### PR TITLE
Ensure PWA short name matches app name

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "3DVR Portal",
-  "short_name": "3DVR",
+  "name": "3dvr Portal",
+  "short_name": "3dvr Portal",
   "description": "Earn points, play games, learn, and build with 3DVR.",
   "start_url": "/?source=pwa",
   "scope": "/",


### PR DESCRIPTION
## Summary
- update the PWA manifest so the installed app displays as "3dvr Portal"
- align the PWA short name with the full app name so search surfaces "3dvr Portal"

## Testing
- not run (manifest change only)

------
https://chatgpt.com/codex/tasks/task_e_68cad6c0b4e88320bb3a0d56d9084d74