### PR TITLE
Revamp landing page styling and unify shared navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/chat.html
+++ b/chat.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3DVR - Group Chat</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <link rel="stylesheet" href="styles/global.css">
   <style>
     body {
       font-family: 'Poppins', sans-serif;
@@ -16,28 +17,6 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-    }
-
-    .top-buttons {
-      display: flex;
-      gap: 15px;
-      margin-bottom: 20px;
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-
-    .top-buttons a {
-      background: #66c2b0;
-      color: #fff;
-      padding: 10px 20px;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: bold;
-      transition: background 0.3s ease;
-    }
-
-    .top-buttons a:hover {
-      background: #5ca0d3;
     }
 
     header {

--- a/chatbot.html
+++ b/chatbot.html
@@ -6,6 +6,7 @@
   <title>AI Chatbot</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <link rel="stylesheet" href="styles/global.css">
   <style>
     body {
       font-family: 'Poppins', sans-serif;
@@ -17,28 +18,6 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-    }
-
-    .top-buttons {
-      display: flex;
-      gap: 15px;
-      margin-bottom: 20px;
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-
-    .top-buttons a {
-      background: #66c2b0;
-      color: #fff;
-      padding: 10px 20px;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: bold;
-      transition: background 0.3s ease;
-    }
-
-    .top-buttons a:hover {
-      background: #5ca0d3;
     }
 
     header {

--- a/games.html
+++ b/games.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>3DVR - Mini Game Hub</title>
+<link rel="stylesheet" href="styles/global.css">
 <style>
 body {
   background: #e9f0f5;
@@ -19,28 +20,6 @@ h1 {
   margin-top: 0;
   font-size: 2.4rem;
   color: #333;
-}
-
-.top-buttons {
-  display: flex;
-  gap: 15px;
-  margin-bottom: 30px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.top-buttons a {
-  background: #66c2b0;
-  color: white;
-  padding: 10px 20px;
-  border-radius: 8px;
-  text-decoration: none;
-  font-weight: bold;
-  transition: background 0.3s ease;
-}
-
-.top-buttons a:hover {
-  background: #5ca0d3;
 }
 
 .game-grid {

--- a/index-style.css
+++ b/index-style.css
@@ -1,172 +1,367 @@
-body {
-      margin: 0;
-      font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: #e9f0f5;
-      color: #222;
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: start;
-      padding: 20px;
-    }
+body.landing {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
 
-    .top-buttons {
-      display: flex;
-      gap: 15px;
-      margin-bottom: 20px;
-      flex-wrap: wrap;
-      justify-content: center;
-    }
+.landing-shell {
+  position: relative;
+  z-index: 1;
+  width: min(1120px, 100%);
+  padding: 6rem 1.5rem 4rem;
+}
 
-    .top-buttons a {
-      background: #66c2b0;
-      color: #fff;
-      padding: 10px 20px;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: bold;
-      transition: background 0.3s ease;
-    }
+.landing-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+}
 
-    .top-buttons a:hover {
-      background: #5ca0d3;
-    }
+.hero {
+  display: grid;
+  gap: 1.6rem;
+  text-align: center;
+  align-items: center;
+}
 
-    header {
-      text-align: center;
-      margin-top: 20px;
-      margin-bottom: 20px;
-    }
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.16);
+  color: rgba(226, 232, 240, 0.75);
+  width: fit-content;
+  margin: 0 auto;
+}
 
-    header h1 {
-      font-size: 2.8rem;
-      color: #333;
-      margin: 0;
-    }
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.8rem, 4vw + 1rem, 3.8rem);
+  line-height: 1.05;
+}
 
-    header p {
-      font-size: 1.2rem;
-      color: #555;
-    }
+.hero-tagline {
+  margin: 0 auto;
+  max-width: 640px;
+  color: var(--color-text-muted);
+  font-size: 1.15rem;
+}
 
-    .info {
-      background: #fff;
-      border-radius: 12px;
-      padding: 25px;
-      margin-top: 20px;
-      margin-bottom: 30px;
-      width: 100%;
-      max-width: 800px;
-      text-align: center;
-      box-shadow: 0 4px 15px rgba(0,0,0,0.05);
-    }
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 0.75rem;
+}
 
-    .info h2 {
-      margin-bottom: 10px;
-      font-size: 1.8rem;
-      color: #444;
-    }
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform var(--transition-base),
+    box-shadow var(--transition-base),
+    background var(--transition-base),
+    color var(--transition-base),
+    border-color var(--transition-base);
+  text-decoration: none;
+}
 
-    .info p {
-      margin-bottom: 10px;
-      color: #666;
-      font-size: 1rem;
-      line-height: 1.6;
-    }
+.cta.primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  box-shadow: 0 32px 70px rgba(34, 211, 238, 0.4);
+}
 
-    .grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 20px;
-      width: 100%;
-      max-width: 900px;
-      margin-top: 10px;
-    }
+.cta.primary:hover {
+  transform: translateY(-2px);
+  background: var(--accent-strong);
+  box-shadow: 0 38px 80px rgba(34, 211, 238, 0.5);
+}
 
-    .card {
-      background: #ffffff;
-      border-radius: 12px;
-      padding: 25px;
-      text-align: center;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-      cursor: pointer;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.05);
-      color: #333;
-      text-decoration: none;
-      font-size: 1.1rem;
-      font-weight: 500;
-    }
+.cta.ghost {
+  background: rgba(148, 163, 184, 0.08);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--color-text);
+}
 
-    .card:hover {
-      transform: scale(1.04);
-      box-shadow: 0 6px 20px rgba(0,0,0,0.1);
-      background: #f9fbfc;
-    }
+.cta.ghost:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent-strong);
+  color: var(--accent-strong);
+  background: rgba(56, 189, 248, 0.18);
+}
 
-    footer {
-      margin-top: 40px;
-      margin-bottom: 10px;
-      font-size: 0.8rem;
-      color: #888;
-      text-align: center;
-    }
+.section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
 
-    footer a {
-      color: #5ca0d3;
-      text-decoration: underline;
-    }
+.section-heading h2 {
+  margin: 0.35rem 0 0;
+  font-size: clamp(2rem, 1.6vw + 1.3rem, 2.6rem);
+}
 
-    #auth-modal {
-      position: fixed;
-      top: 0; left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(0,0,0,0.7);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      z-index: 9999;
-      color: #fff;
-      padding: 20px;
-      text-align: center;
-    }
+.section-heading p {
+  margin: 0;
+  max-width: 420px;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+}
 
-    #auth-modal button {
-      margin: 10px;
-      padding: 12px 24px;
-      border-radius: 8px;
-      border: none;
-      background: #66c2b0;
-      color: #fff;
-      font-weight: bold;
-      font-size: 1rem;
-      cursor: pointer;
-      transition: background 0.3s ease;
-    }
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.75);
+  background: rgba(148, 163, 184, 0.16);
+}
 
-    #auth-modal button:hover {
-      background: #5ca0d3;
-    }
+.app-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.6rem;
+}
 
-    #auth-modal h2 {
-      margin-bottom: 10px;
-      font-size: 2rem;
-    }
+.app-card {
+  position: relative;
+  display: grid;
+  align-content: start;
+  gap: 0.9rem;
+  padding: 1.65rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  color: var(--color-text);
+  text-decoration: none;
+  box-shadow: 0 28px 70px rgba(5, 10, 25, 0.55);
+  overflow: hidden;
+  isolation: isolate;
+  transition: transform var(--transition-base),
+    box-shadow var(--transition-base),
+    border-color var(--transition-base),
+    background var(--transition-base);
+}
 
-    #auth-modal p {
-      margin-bottom: 20px;
-      font-size: 1.1rem;
-    }
+.app-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top left, rgba(34, 211, 238, 0.25), transparent 60%);
+  opacity: 0;
+  transition: opacity var(--transition-base);
+  z-index: -1;
+}
 
-    #auth-modal .guest-btn {
-      background: transparent;
-      border: 2px solid #66c2b0;
-      color: #66c2b0;
-    }
+.app-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: 0 38px 90px rgba(4, 9, 20, 0.65);
+}
 
-    #auth-modal .guest-btn:hover {
-      background: #5ca0d3;
-      color: white;
-    }
+.app-card:hover::before {
+  opacity: 1;
+}
+
+.app-card__icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.6rem;
+  background: rgba(34, 211, 238, 0.22);
+  color: var(--accent-strong);
+}
+
+.app-card__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.app-card__meta {
+  font-size: 0.96rem;
+  color: var(--color-text-muted);
+}
+
+.info-panels {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.info-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-lg);
+  padding: 1.9rem;
+  box-shadow: 0 32px 80px rgba(4, 9, 20, 0.6);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.info-card h3 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.info-card p {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+}
+
+.info-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.info-card li {
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.info-card__footer {
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+footer {
+  margin-top: 4rem;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+footer a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.auth-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  padding: 2rem;
+  background: rgba(4, 7, 16, 0.78);
+  backdrop-filter: blur(24px);
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.auth-modal__panel {
+  background: var(--surface-alt);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  padding: 2.5rem 2.2rem;
+  max-width: 420px;
+  width: min(100%, 420px);
+  text-align: center;
+  box-shadow: 0 40px 90px rgba(3, 7, 18, 0.65);
+}
+
+.auth-modal__panel h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.75rem;
+}
+
+.auth-modal__panel p {
+  margin: 0 0 1.5rem;
+  color: var(--color-text-muted);
+}
+
+.auth-modal__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.install-btn {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  display: none;
+  z-index: 9999;
+  box-shadow: 0 36px 90px rgba(4, 9, 20, 0.65);
+}
+
+@media (max-width: 960px) {
+  .landing-shell {
+    padding-top: 5.5rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.4rem, 6vw, 3.2rem);
+  }
+}
+
+@media (min-width: 960px) {
+  .hero {
+    text-align: left;
+  }
+
+  .hero-eyebrow {
+    margin-left: 0;
+  }
+
+  .hero-tagline {
+    margin-left: 0;
+    max-width: 520px;
+  }
+
+  .hero-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .landing-shell {
+    padding: 5rem 1rem 3.5rem;
+  }
+
+  .hero-eyebrow {
+    width: 100%;
+  }
+
+  .auth-modal {
+    padding: 1.5rem;
+  }
+
+  .auth-modal__panel {
+    padding: 2rem 1.5rem;
+  }
+
+  .install-btn {
+    left: 1rem;
+    right: 1rem;
+    width: calc(100% - 2rem);
+    justify-content: center;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>3DVR Portal</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <link rel="stylesheet" href="styles/global.css">
   <link rel="stylesheet" href="index-style.css">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#0e1116">
@@ -13,118 +14,179 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="apple-touch-icon" href="/icons/icon-192.png">
   <link rel="apple-touch-icon" sizes="512x512" href="/icons/icon-512.png">
-  
 </head>
+<body class="landing theme-dark">
+  <div class="landing-shell">
+    <nav class="top-buttons" aria-label="3DVR quick links">
+      <a href="https://3dvr.tech">🏠 3DVR Home</a>
+      <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">⭐ Subscribe</a>
+      <a href="https://3dvr-portal.vercel.app/free-trial.html" target="_blank" rel="noopener">🎁 Free Plan</a>
+      <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">🚀 Contribute on GitHub</a>
+      <a href="https://portal.3dvr.tech/share.html">Share via QR Code</a>
+    </nav>
 
-<body>
+    <main class="landing-content">
+      <section class="hero" aria-labelledby="landing-title">
+        <span class="hero-eyebrow">Open Metaverse Community</span>
+        <h1 id="landing-title">Welcome to the 3DVR Portal</h1>
+        <p class="hero-tagline">Earn, play, and build the future of the web together.</p>
+        <div class="hero-actions">
+          <a href="sign-in.html" class="cta primary">Start earning</a>
+          <a href="free-trial.html" class="cta ghost" target="_blank" rel="noopener">Explore plans</a>
+        </div>
+      </section>
 
-<div class="top-buttons">
-  <a href="https://3dvr.tech">🏠 3DVR Home</a>
-  <a href="https://3dvr.tech/#subscribe" target="_blank">⭐ Subscribe</a>
-  <a href="https://3dvr-portal.vercel.app/free-trial.html" target="_blank">🎁 Free Plan</a>
-  <a href="https://github.com/tmsteph/3dvr-portal" target="_blank">🚀 Contribute on GitHub</a>
-  <a href="https://portal.3dvr.tech/share.html">Share via QR Code</a>
-</div>
+      <section class="app-hub" aria-labelledby="app-hub-title">
+        <div class="section-heading">
+          <div>
+            <span class="eyebrow">Launchpad</span>
+            <h2 id="app-hub-title">Your apps, ready to go</h2>
+          </div>
+          <p>Everything you need to collaborate, compete, and grow lives here. Pick an app to get started in seconds.</p>
+        </div>
+        <div class="app-grid">
+          <a href="notes.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">📝</span>
+            <span class="app-card__title">Shared Notes</span>
+            <span class="app-card__meta">Collaborate in real time with the community.</span>
+          </a>
+          <a href="chat.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">💬</span>
+            <span class="app-card__title">Group Chat</span>
+            <span class="app-card__meta">Stay in the loop and ship ideas faster.</span>
+          </a>
+          <a href="tasks.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">✅</span>
+            <span class="app-card__title">Task Board</span>
+            <span class="app-card__meta">Plan, assign, and celebrate team wins.</span>
+          </a>
+          <a href="games.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🎮</span>
+            <span class="app-card__title">Mini Game Hub</span>
+            <span class="app-card__meta">Compete, sharpen skills, and earn bonus points.</span>
+          </a>
+          <a href="profile.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">👤</span>
+            <span class="app-card__title">Profile Wallet</span>
+            <span class="app-card__meta">Track your progress and manage your rewards.</span>
+          </a>
+          <a href="education.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🎓</span>
+            <span class="app-card__title">Education Hub</span>
+            <span class="app-card__meta">Unlock new lessons and level up your skills.</span>
+          </a>
+          <a href="rewards.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🏆</span>
+            <span class="app-card__title">Earn Points</span>
+            <span class="app-card__meta">Complete challenges to unlock real perks.</span>
+          </a>
+          <a href="website-builder.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🛠️</span>
+            <span class="app-card__title">Website Builder</span>
+            <span class="app-card__meta">Launch lightweight pages for your projects.</span>
+          </a>
+          <a href="https://portal.3dvr.tech/contacts" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">📇</span>
+            <span class="app-card__title">Contacts</span>
+            <span class="app-card__meta">Keep teammates and partners close.</span>
+          </a>
+        </div>
+      </section>
 
-<header>
-  <h1>Welcome to the 3DVR Portal</h1>
-  <p>Earn, Play, and Build the Future!</p>
-</header>
+      <section class="info-panels" aria-label="How points work">
+        <article class="info-card">
+          <h3>🌟 Earn Points. Unlock Rewards.</h3>
+          <p>At 3DVR, everything you do helps you grow. Play, learn, and contribute while your progress syncs across every device.</p>
+          <p>Use your points to unlock exclusive educational content, special services, and even future cash-out opportunities.</p>
+        </article>
+        <article class="info-card">
+          <h3>How to build momentum</h3>
+          <ul>
+            <li><strong>Play</strong> games in the hub to sharpen skills and climb the leaderboard.</li>
+            <li><strong>Collaborate</strong> in shared notes, chat, and tasks to support the mission.</li>
+            <li><strong>Subscribe</strong> or share the portal to unlock pro tools and new rewards.</li>
+          </ul>
+          <p class="info-card__footer">🎯 Build your profile, contribute to the community, and be rewarded along the way.</p>
+        </article>
+      </section>
+    </main>
 
-<div class="info">
-  <h2>🌟 Earn Points. Unlock Rewards.</h2>
-  <p>At 3DVR, everything you do helps you grow!</p>
-  <p><strong>Earn points</strong> by playing games, participating in chats, and subscribing to support our mission.</p>
-  <p>Use your points to unlock exclusive educational content, special services, and even future cash-out opportunities!</p>
-  <p>🎯 Build your profile, contribute to the community, and be rewarded along the way.</p>
-</div>
+    <footer>
+      3DVR.Tech &copy; 2025 - Open Web for Everyone | Visit <a href="https://3dvr.tech">3DVR.Tech</a> | <a href="https://github.com/tmsteph/3dvr-portal">Contribute on GitHub</a>
+    </footer>
+  </div>
 
-<div class="grid">
-  <a href="notes.html" class="card">Shared Notes</a>
-  <a href="chat.html" class="card">Group Chat</a>
-  <a href="tasks.html" class="card">Task Board</a>
-  <a href="games.html" class="card">Mini Game Hub</a>
-  <a href="profile.html" class="card">Profile Wallet</a>
-  <a href="education.html" class="card">Education Hub</a>
-  <a href="rewards.html" class="card">Earn Points</a>
-  <a href="website-builder.html" class="card">Website Builder</a>
-  <a href="https://portal.3dvr.tech/contacts" class="card">Contacts</a>
-</div>
+  <div id="auth-modal" class="auth-modal" aria-hidden="true">
+    <div class="auth-modal__panel" role="dialog" aria-modal="true" aria-labelledby="auth-modal-title">
+      <h2 id="auth-modal-title">Sign in to save your progress</h2>
+      <p>Create an account to sync your points across all your devices.</p>
+      <div class="auth-modal__actions">
+        <button type="button" class="cta primary" onclick="window.location.href='sign-in.html'">Sign in / Create account</button>
+        <button type="button" class="cta ghost" onclick="continueAsGuest()">Continue as guest</button>
+      </div>
+    </div>
+  </div>
 
-<footer>
-  3DVR.Tech &copy; 2025 - Open Web for Everyone | Visit <a href="https://3dvr.tech">3DVR.Tech</a> | <a href="https://github.com/tmsteph/3dvr-portal">Contribute on GitHub</a>
-</footer>
+  <button id="installBtn" class="install-btn cta primary" type="button">⬇️ Install 3DVR Portal</button>
 
-<div id="auth-modal" style="display: none;">
-  <h2>Sign In to Save Your Progress</h2>
-  <p>Create an account to sync your points across all your devices!</p>
-  <button onclick="window.location.href='sign-in.html'">Sign In / Create Account</button>
-  <button class="guest-btn" onclick="continueAsGuest()">Continue as Guest</button>
-</div>
+  <script>
+    const gun = Gun(['https://gun-manhattan.herokuapp.com/gun']);
+    const user = gun.user();
 
-<script>
-  const gun = Gun(['https://gun-manhattan.herokuapp.com/gun']);
-  const user = gun.user();
-
-  window.addEventListener('load', () => {
-    const signedIn = localStorage.getItem('signedIn');
-    const guest = localStorage.getItem('guest');
-    const username = localStorage.getItem('username');
-    const password = localStorage.getItem('password');
-
-    if (!signedIn && !guest) {
-      document.getElementById('auth-modal').style.display = 'flex';
-    }
-  });
-
-  function continueAsGuest() {
-    localStorage.setItem('guest', 'true');
-    document.getElementById('auth-modal').style.display = 'none';
-  }
-</script>
-
-<script src="navbar.js"></script>
-
-
-  <!-- PWA install button (hidden until eligible) -->
-<button id="installBtn" style="position:fixed;right:1rem;bottom:1rem;display:none;z-index:9999;">
-  ⬇️ Install 3DVR Portal
-</button>
-
-<script>
-  // Register service worker
-  if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-      navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
-        .catch(err => console.error('SW registration failed:', err));
+      const signedIn = localStorage.getItem('signedIn');
+      const guest = localStorage.getItem('guest');
+      const authModal = document.getElementById('auth-modal');
+
+      if (!signedIn && !guest) {
+        authModal.style.display = 'flex';
+        authModal.setAttribute('aria-hidden', 'false');
+      } else {
+        authModal.style.display = 'none';
+        authModal.setAttribute('aria-hidden', 'true');
+      }
     });
-  }
 
-  // Handle install prompt (Android/Desktop)
-  let deferredPrompt;
-  const installBtn = document.getElementById('installBtn');
+    function continueAsGuest() {
+      const authModal = document.getElementById('auth-modal');
+      localStorage.setItem('guest', 'true');
+      authModal.style.display = 'none';
+      authModal.setAttribute('aria-hidden', 'true');
+    }
+  </script>
 
-  window.addEventListener('beforeinstallprompt', (e) => {
-    e.preventDefault();
-    deferredPrompt = e;
-    installBtn.style.display = 'inline-block';
-  });
+  <script src="navbar.js"></script>
 
-  installBtn?.addEventListener('click', async () => {
-    if (!deferredPrompt) return;
-    deferredPrompt.prompt();
-    const { outcome } = await deferredPrompt.userChoice;
-    deferredPrompt = null;
-    installBtn.style.display = 'none';
-    console.log('Install choice:', outcome);
-  });
+  <script>
+    const installBtn = document.getElementById('installBtn');
 
-  // Optional: hide button if already installed
-  window.addEventListener('appinstalled', () => {
-    installBtn.style.display = 'none';
-  });
-</script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
+          .catch(err => console.error('SW registration failed:', err));
+      });
+    }
 
+    let deferredPrompt;
 
+    window.addEventListener('beforeinstallprompt', (e) => {
+      e.preventDefault();
+      deferredPrompt = e;
+      installBtn.style.display = 'inline-flex';
+    });
+
+    installBtn?.addEventListener('click', async () => {
+      if (!deferredPrompt) return;
+      deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      deferredPrompt = null;
+      installBtn.style.display = 'none';
+      console.log('Install choice:', outcome);
+    });
+
+    window.addEventListener('appinstalled', () => {
+      installBtn.style.display = 'none';
+    });
+  </script>
 </body>
 </html>

--- a/memory.html
+++ b/memory.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>3DVR - Memory Match</title>
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+<link rel="stylesheet" href="styles/global.css">
 <style>
 body {
   margin: 0;
@@ -20,28 +21,6 @@ h1 {
   color: #333;
   font-size: 2.4rem;
   margin-top: 0;
-}
-
-.top-buttons {
-  display: flex;
-  gap: 15px;
-  margin-bottom: 30px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.top-buttons a {
-  background: #66c2b0;
-  color: white;
-  padding: 10px 20px;
-  border-radius: 8px;
-  text-decoration: none;
-  font-weight: bold;
-  transition: background 0.3s ease;
-}
-
-.top-buttons a:hover {
-  background: #5ca0d3;
 }
 
 .board {

--- a/navbar.js
+++ b/navbar.js
@@ -4,31 +4,24 @@
 
 function createNavbar() {
   const nav = document.createElement('div');
-  nav.style.position = 'fixed';
-  nav.style.top = '10px';
-  nav.style.right = '10px';
-  nav.style.background = 'rgba(255, 215, 0, 0.1)';
-  nav.style.border = '1px solid gold';
-  nav.style.borderRadius = '8px';
-  nav.style.padding = '10px 15px';
-  nav.style.zIndex = '9999';
-  nav.style.display = 'flex';
-  nav.style.alignItems = 'center';
-  nav.style.gap = '10px';
-  nav.style.fontSize = '1rem';
+  nav.className = 'floating-identity';
+  nav.setAttribute('aria-label', 'Account status');
+
+  const stats = document.createElement('div');
+  stats.className = 'floating-identity__stats';
 
   const usernameSpan = document.createElement('span');
-  const scoreSpan = document.createElement('span');
-  const button = document.createElement('button');
+  usernameSpan.className = 'floating-identity__label';
 
-  button.style.background = 'gold';
-  button.style.color = '#003366';
-  button.style.border = 'none';
-  button.style.borderRadius = '6px';
-  button.style.padding = '5px 10px';
-  button.style.cursor = 'pointer';
-  button.style.fontWeight = 'bold';
-  button.style.transition = '0.3s ease';
+  const scoreSpan = document.createElement('span');
+  scoreSpan.className = 'floating-identity__value';
+
+  stats.appendChild(usernameSpan);
+  stats.appendChild(scoreSpan);
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'floating-identity__button';
   button.innerText = 'Sign Out';
 
   button.addEventListener('click', () => {
@@ -40,8 +33,7 @@ function createNavbar() {
     window.location.href = 'index.html';
   });
 
-  nav.appendChild(usernameSpan);
-  nav.appendChild(scoreSpan);
+  nav.appendChild(stats);
   nav.appendChild(button);
   document.body.appendChild(nav);
 

--- a/old-tasks.html
+++ b/old-tasks.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>3DVR - Task Board</title>
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+<link rel="stylesheet" href="styles/global.css">
 <style>
 body {
   font-family: 'Poppins', sans-serif;
@@ -27,28 +28,6 @@ h1 {
   color: #333;
   margin-top: 0;
   font-size: 2.4rem;
-}
-
-.top-buttons {
-  display: flex;
-  gap: 15px;
-  margin-bottom: 20px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.top-buttons a {
-  background: #66c2b0;
-  color: white;
-  padding: 10px 20px;
-  border-radius: 8px;
-  text-decoration: none;
-  font-weight: bold;
-  transition: background 0.3s ease;
-}
-
-.top-buttons a:hover {
-  background: #5ca0d3;
 }
 
 #new-task {

--- a/pong.html
+++ b/pong.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>3DVR - Pong</title>
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+<link rel="stylesheet" href="styles/global.css">
 <style>
 body {
   margin: 0;
@@ -20,28 +21,6 @@ h1 {
   color: #333;
   font-size: 2.4rem;
   margin-top: 0;
-}
-
-.top-buttons {
-  display: flex;
-  gap: 15px;
-  margin-bottom: 30px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.top-buttons a {
-  background: #66c2b0;
-  color: white;
-  padding: 10px 20px;
-  border-radius: 8px;
-  text-decoration: none;
-  font-weight: bold;
-  transition: background 0.3s ease;
-}
-
-.top-buttons a:hover {
-  background: #5ca0d3;
 }
 
 canvas {

--- a/profile.html
+++ b/profile.html
@@ -6,6 +6,7 @@
   <title>3DVR - Profile</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <link rel="stylesheet" href="styles/global.css">
   <style>
     body {
       background: #e9f0f5;
@@ -20,25 +21,6 @@
       color: #333;
       font-size: 2.4rem;
       margin-top: 0;
-    }
-    .top-buttons {
-      display: flex;
-      gap: 15px;
-      margin-bottom: 30px;
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-    .top-buttons a {
-      background: #66c2b0;
-      color: white;
-      padding: 10px 20px;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: bold;
-      transition: background 0.3s ease;
-    }
-    .top-buttons a:hover {
-      background: #5ca0d3;
     }
     #profile {
       background: #ffffff;

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,13 +1,14 @@
 /* service-worker.js */
 
 // Increment this to bust old caches when you deploy
-const STATIC_CACHE = '3dvr-static-v1';
+const STATIC_CACHE = '3dvr-static-v2';
 const HTML_CACHE = '3dvr-html-v1';
 
 // What to cache at install (add your CSS/JS/assets here)
 const STATIC_ASSETS = [
   '/',                     // App shell (Start URL)
   '/index-style.css',
+  '/styles/global.css',
   '/navbar.js',
   '/manifest.webmanifest',
   '/icons/icon-192.png',

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,0 +1,231 @@
+:root {
+  --page-background: #f5f7fb;
+  --surface: #ffffff;
+  --surface-alt: #eef2ff;
+  --surface-border: rgba(148, 163, 184, 0.18);
+  --color-text: #0f172a;
+  --color-text-muted: #475569;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --accent-contrast: #f8fafc;
+  --radius-sm: 10px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --transition-base: 0.25s ease;
+  --top-button-container-bg: rgba(255, 255, 255, 0.9);
+  --top-button-container-border: rgba(148, 163, 184, 0.35);
+  --top-button-container-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  --top-button-bg: rgba(37, 99, 235, 0.12);
+  --top-button-bg-hover: rgba(37, 99, 235, 0.18);
+  --top-button-border: rgba(37, 99, 235, 0.24);
+  --top-button-border-hover: rgba(37, 99, 235, 0.35);
+  --top-button-text: #1e293b;
+  --top-button-text-hover: #0f172a;
+  --top-button-shadow: 0 10px 26px rgba(37, 99, 235, 0.15);
+  --top-button-shadow-hover: 0 16px 36px rgba(37, 99, 235, 0.2);
+  --identity-bg: rgba(255, 255, 255, 0.92);
+  --identity-border: rgba(148, 163, 184, 0.35);
+  --identity-text: #0f172a;
+  --identity-shadow: 0 24px 46px rgba(15, 23, 42, 0.12);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--page-background);
+  color: var(--color-text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--transition-base);
+}
+
+a:hover {
+  color: var(--accent-strong);
+}
+
+.top-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0 auto 2.5rem;
+  padding: 0.75rem 1rem;
+  max-width: min(960px, calc(100% - 2rem));
+  border-radius: 999px;
+  background: var(--top-button-container-bg);
+  border: 1px solid var(--top-button-container-border);
+  box-shadow: var(--top-button-container-shadow);
+  backdrop-filter: blur(12px);
+}
+
+.top-buttons a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: var(--top-button-bg);
+  color: var(--top-button-text);
+  border: 1px solid var(--top-button-border);
+  box-shadow: var(--top-button-shadow);
+  transition: transform var(--transition-base),
+    background var(--transition-base),
+    box-shadow var(--transition-base),
+    border-color var(--transition-base),
+    color var(--transition-base);
+}
+
+.top-buttons a:hover {
+  transform: translateY(-2px);
+  background: var(--top-button-bg-hover);
+  box-shadow: var(--top-button-shadow-hover);
+  border-color: var(--top-button-border-hover);
+  color: var(--top-button-text-hover);
+}
+
+body:not(.landing) .top-buttons {
+  padding: 0;
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+body:not(.landing) .top-buttons a {
+  box-shadow: none;
+}
+
+body.theme-dark {
+  position: relative;
+  overflow-x: hidden;
+  --page-background: radial-gradient(140% 140% at 16% 0%, #1c2640 0%, #0b1220 55%, #05070c 100%);
+  --surface: rgba(17, 24, 39, 0.75);
+  --surface-alt: rgba(30, 41, 59, 0.85);
+  --surface-border: rgba(148, 163, 184, 0.24);
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --accent: #22d3ee;
+  --accent-strong: #38bdf8;
+  --accent-contrast: #04111d;
+  --top-button-container-bg: rgba(15, 23, 42, 0.65);
+  --top-button-container-border: rgba(94, 234, 212, 0.35);
+  --top-button-container-shadow: 0 30px 60px rgba(7, 11, 23, 0.55);
+  --top-button-bg: rgba(34, 211, 238, 0.18);
+  --top-button-bg-hover: rgba(56, 189, 248, 0.28);
+  --top-button-border: rgba(45, 212, 191, 0.45);
+  --top-button-border-hover: rgba(56, 189, 248, 0.6);
+  --top-button-text: #e2e8f0;
+  --top-button-text-hover: #f8fafc;
+  --top-button-shadow: 0 24px 54px rgba(8, 15, 35, 0.45);
+  --top-button-shadow-hover: 0 32px 68px rgba(8, 15, 35, 0.6);
+  --identity-bg: rgba(15, 23, 42, 0.7);
+  --identity-border: rgba(148, 163, 184, 0.32);
+  --identity-text: #e2e8f0;
+  --identity-shadow: 0 36px 68px rgba(5, 10, 25, 0.65);
+}
+
+body.theme-dark::before,
+body.theme-dark::after {
+  content: '';
+  position: fixed;
+  width: min(55vw, 620px);
+  height: min(55vw, 620px);
+  filter: blur(120px);
+  opacity: 0.45;
+  z-index: 0;
+  pointer-events: none;
+}
+
+body.theme-dark::before {
+  top: -18vh;
+  left: -12vw;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.4), transparent 60%);
+}
+
+body.theme-dark::after {
+  bottom: -22vh;
+  right: -12vw;
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.32), transparent 60%);
+}
+
+.floating-identity {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--identity-bg);
+  border: 1px solid var(--identity-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--identity-shadow);
+  color: var(--identity-text);
+  backdrop-filter: blur(18px);
+  z-index: 1000;
+}
+
+.floating-identity__stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.floating-identity__label {
+  font-weight: 600;
+}
+
+.floating-identity__value {
+  opacity: 0.8;
+}
+
+.floating-identity__button {
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+  padding: 0.55rem 1.1rem;
+  cursor: pointer;
+  transition: transform var(--transition-base),
+    box-shadow var(--transition-base),
+    background var(--transition-base);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.25);
+}
+
+.floating-identity__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 44px rgba(37, 99, 235, 0.3);
+  background: var(--accent-strong);
+}
+
+@media (max-width: 640px) {
+  .floating-identity {
+    position: static;
+    margin: 1rem auto 0;
+    width: min(100%, 420px);
+    justify-content: space-between;
+  }
+
+  .top-buttons {
+    max-width: calc(100% - 1rem);
+    margin-bottom: 2rem;
+  }
+}

--- a/tasks.html
+++ b/tasks.html
@@ -7,6 +7,7 @@
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles/global.css">
 <style>
 * {
   box-sizing: border-box;
@@ -33,28 +34,6 @@ h1 {
   color: #333;
   margin-top: 0;
   font-size: 2.4rem;
-}
-
-.top-buttons {
-  display: flex;
-  gap: 15px;
-  margin-bottom: 20px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.top-buttons a {
-  background: #66c2b0;
-  color: white;
-  padding: 10px 20px;
-  border-radius: 8px;
-  text-decoration: none;
-  font-weight: bold;
-  transition: background 0.3s ease;
-}
-
-.top-buttons a:hover {
-  background: #5ca0d3;
 }
 
 .controls {

--- a/website-builder.html
+++ b/website-builder.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Website Builder</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <link rel="stylesheet" href="styles/global.css">
  <style>
     body {
       font-family: Arial, sans-serif;
@@ -17,25 +18,6 @@
     h1 {
       text-align: center;
       color: #444;
-    }
-    .top-buttons {
-      display: flex;
-      gap: 15px;
-      margin-bottom: 30px;
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-    .top-buttons a {
-      background: #66c2b0;
-      color: white;
-      padding: 10px 20px;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: bold;
-      transition: background 0.3s ease;
-    }
-    .top-buttons a:hover {
-      background: #5ca0d3;
     }
     label {
       font-weight: bold;


### PR DESCRIPTION
## Summary
- redesign the landing page with a dark hero, quick launch app grid, and refreshed rewards messaging
- add a shared global stylesheet and convert the floating identity widget to class-based styling
- point feature pages to the shared top-button styles, bump the service worker cache, and ignore node_modules

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68cd7bc265cc83209ecd33ac0f34022c