### PR TITLE
Add app search and shorten app labels on portal

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -126,6 +126,56 @@ body.landing {
   font-size: 1rem;
 }
 
+.app-search {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.6rem 0 0;
+}
+
+.app-search__input {
+  flex: 1 1 260px;
+  min-width: 220px;
+  padding: 0.85rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid var(--surface-border);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--color-text);
+  font-size: 1rem;
+  box-shadow: 0 24px 60px rgba(4, 9, 20, 0.45);
+  transition: border-color var(--transition-base),
+    box-shadow var(--transition-base),
+    background var(--transition-base);
+}
+
+.app-search__input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.app-search__input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.75);
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.25);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.app-search__hint {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  opacity: 0.85;
+}
+
+.app-search__empty {
+  margin: 0.75rem 0 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.app-card[hidden] {
+  display: none;
+}
+
 .eyebrow {
   display: inline-flex;
   align-items: center;
@@ -344,6 +394,10 @@ footer a {
 @media (max-width: 640px) {
   .landing-shell {
     padding: 5rem 1rem 3.5rem;
+  }
+
+  .app-search__hint {
+    width: 100%;
   }
 
   .hero-eyebrow {

--- a/index.html
+++ b/index.html
@@ -44,45 +44,58 @@
           </div>
           <p>Everything you need to collaborate, compete, and grow lives here. Pick an app to get started in seconds.</p>
         </div>
+        <div class="app-search" role="search">
+          <input
+            type="search"
+            id="appSearch"
+            class="app-search__input"
+            placeholder="Search apps…"
+            aria-label="Search apps"
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <span class="app-search__hint" aria-hidden="true">Press / or Ctrl + K to jump here</span>
+        </div>
+        <p id="appSearchEmpty" class="app-search__empty" role="status" aria-live="polite" hidden>No apps match your search yet.</p>
         <div class="app-grid">
           <a href="notes.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">📝</span>
-            <span class="app-card__title">Shared Notes</span>
+            <span class="app-card__title">Notes</span>
             <span class="app-card__meta">Collaborate in real time with the community.</span>
           </a>
           <a href="chat.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">💬</span>
-            <span class="app-card__title">Group Chat</span>
+            <span class="app-card__title">Chat</span>
             <span class="app-card__meta">Stay in the loop and ship ideas faster.</span>
           </a>
           <a href="tasks.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">✅</span>
-            <span class="app-card__title">Task Board</span>
+            <span class="app-card__title">Tasks</span>
             <span class="app-card__meta">Plan, assign, and celebrate team wins.</span>
           </a>
           <a href="games.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🎮</span>
-            <span class="app-card__title">Mini Game Hub</span>
+            <span class="app-card__title">Games</span>
             <span class="app-card__meta">Compete, sharpen skills, and earn bonus points.</span>
           </a>
           <a href="profile.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">👤</span>
-            <span class="app-card__title">Profile Wallet</span>
+            <span class="app-card__title">Profile</span>
             <span class="app-card__meta">Track your progress and manage your rewards.</span>
           </a>
           <a href="education.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🎓</span>
-            <span class="app-card__title">Education Hub</span>
+            <span class="app-card__title">Learn</span>
             <span class="app-card__meta">Unlock new lessons and level up your skills.</span>
           </a>
           <a href="rewards.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🏆</span>
-            <span class="app-card__title">Earn Points</span>
+            <span class="app-card__title">Rewards</span>
             <span class="app-card__meta">Complete challenges to unlock real perks.</span>
           </a>
           <a href="website-builder.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🛠️</span>
-            <span class="app-card__title">Website Builder</span>
+            <span class="app-card__title">Sites</span>
             <span class="app-card__meta">Launch lightweight pages for your projects.</span>
           </a>
           <a href="https://portal.3dvr.tech/contacts" class="app-card">
@@ -187,6 +200,64 @@
     window.addEventListener('appinstalled', () => {
       installBtn.style.display = 'none';
     });
+
+    const appSearchInput = document.getElementById('appSearch');
+    const appCards = Array.from(document.querySelectorAll('.app-card'));
+    const appSearchEmpty = document.getElementById('appSearchEmpty');
+
+    const updateAppFilter = (value = '') => {
+      const query = value.trim().toLowerCase();
+      let visibleCount = 0;
+
+      appCards.forEach((card) => {
+        const titleText = card
+          .querySelector('.app-card__title')
+          ?.textContent?.toLowerCase() ?? '';
+        const metaText = card
+          .querySelector('.app-card__meta')
+          ?.textContent?.toLowerCase() ?? '';
+        const matches = !query || titleText.includes(query) || metaText.includes(query);
+
+        card.hidden = !matches;
+        if (matches) {
+          visibleCount += 1;
+        }
+      });
+
+      if (appSearchEmpty) {
+        appSearchEmpty.hidden = visibleCount > 0;
+      }
+    };
+
+    const focusSearch = () => {
+      if (!appSearchInput) return;
+      appSearchInput.focus();
+      appSearchInput.select();
+    };
+
+    appSearchInput?.addEventListener('input', (event) => {
+      updateAppFilter(event.target.value);
+    });
+
+    appSearchInput?.addEventListener('search', (event) => {
+      updateAppFilter(event.target.value);
+    });
+
+    appSearchInput?.addEventListener('focus', (event) => {
+      event.target.select();
+    });
+
+    window.addEventListener('keydown', (event) => {
+      const isSlash = event.key === '/' && !event.ctrlKey && !event.metaKey && !event.altKey;
+      const isCommandK = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
+
+      if ((isSlash || isCommandK) && document.activeElement !== appSearchInput) {
+        event.preventDefault();
+        focusSearch();
+      }
+    });
+
+    updateAppFilter(appSearchInput?.value ?? '');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- shorten the primary app card labels so it is faster to recognize each tool
- add a launchpad search bar with keyboard shortcuts and auto-selection when focused
- filter app cards in real time and show an empty state when nothing matches

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68cda1e0c5648320a678101555cdd641