### PR TITLE
Add tests for trial API handler

### DIFF
--- a/api/trial.js
+++ b/api/trial.js
@@ -1,117 +1,130 @@
 import Stripe from 'stripe';
 import nodemailer from 'nodemailer';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-10-16',
-});
-
-// Allow external calls (you can restrict this to your frontend domain later)
 function setCorsHeaders(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 }
 
-// Email setup
-const transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.GMAIL_USER,
-    pass: process.env.GMAIL_APP_PASSWORD,
-  },
-});
-
-// Send welcome email
-async function sendWelcomeEmail(to) {
-  await transporter.sendMail({
-    from: `"Thomas @ 3DVR.Tech" <${process.env.GMAIL_USER}>`,
-    to,
-    subject: 'Welcome to 3DVR.Tech!',
-    html: `
-      <div style="font-family: sans-serif; font-size: 16px;">
-        <h2>Welcome to 3DVR.Tech!</h2>
-        <p>You’ve started your free trial — no credit card required. Excited to have you on board!</p>
-        <p>Let’s build something amazing together. If you have questions, reply to this email anytime.</p>
-        <p>– Thomas</p>
-      </div>
-    `,
+function createStripeClient(secretKey) {
+  return new Stripe(secretKey, {
+    apiVersion: '2023-10-16',
   });
 }
 
-// Notify team
-async function notifyTeam(email) {
-  const teamEmails = [
-    'tmsteph1290@gmail.com',
-    'abrandon055@gmail.com',
-    'gamboaesai@gmail.com',
-    'mark.wells3050@gmail.com',
-    'davidmartinezr@hotmail.com'
-  ];
-
-  await transporter.sendMail({
-    from: `"3DVR.Tech Bot" <${process.env.GMAIL_USER}>`,
-    to: process.env.GMAIL_USER,
-    bcc: teamEmails,
-    subject: `New Free Trial Started: ${email}`,
-    html: `<p><strong>${email}</strong> just signed up for a free trial.</p>`
+function createMailTransport(config) {
+  return nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: config.GMAIL_USER,
+      pass: config.GMAIL_APP_PASSWORD,
+    },
   });
 }
 
-// Main route handler
-export default async function handler(req, res) {
-  setCorsHeaders(res);
+export function createTrialHandler(options = {}) {
+  const {
+    stripeClient,
+    mailTransport,
+    config = process.env,
+  } = options;
 
-  if (req.method === 'OPTIONS') return res.status(200).end();
-  if (req.method !== 'POST') return res.status(405).json({ error: 'Method Not Allowed' });
+  const stripe = stripeClient || (config.STRIPE_SECRET_KEY ? createStripeClient(config.STRIPE_SECRET_KEY) : null);
+  const transporter = mailTransport || createMailTransport(config);
 
-  const { email } = req.body;
-
-  if (!email || !email.includes('@')) {
-    return res.status(400).json({ error: 'A valid email address is required.' });
-  }
-
-  if (!process.env.STRIPE_SECRET_KEY || !process.env.STRIPE_PRICE_ID) {
-    return res.status(500).json({ error: 'Stripe configuration is missing.' });
-  }
-
-  try {
-    console.log('📩 Creating customer for:', email);
-
-    // Check for existing customer
-    const existingCustomers = await stripe.customers.list({ email, limit: 1 });
-    const customer = existingCustomers.data[0] || await stripe.customers.create({ email });
-
-    // Check if the customer already has an active subscription
-    const subs = await stripe.subscriptions.list({
-      customer: customer.id,
-      status: 'all',
-      limit: 1,
+  async function sendWelcomeEmail(to) {
+    await transporter.sendMail({
+      from: `"Thomas @ 3DVR.Tech" <${config.GMAIL_USER}>`,
+      to,
+      subject: 'Welcome to 3DVR.Tech!',
+      html: `
+        <div style="font-family: sans-serif; font-size: 16px;">
+          <h2>Welcome to 3DVR.Tech!</h2>
+          <p>You’ve started your free trial — no credit card required. Excited to have you on board!</p>
+          <p>Let’s build something amazing together. If you have questions, reply to this email anytime.</p>
+          <p>– Thomas</p>
+        </div>
+      `,
     });
+  }
 
-    const alreadySubscribed = subs.data.some(sub => sub.status === 'active' || sub.status === 'trialing');
+  async function notifyTeam(email) {
+    const teamEmails = [
+      'tmsteph1290@gmail.com',
+      'abrandon055@gmail.com',
+      'gamboaesai@gmail.com',
+      'mark.wells3050@gmail.com',
+      'davidmartinezr@hotmail.com'
+    ];
 
-    if (alreadySubscribed) {
-      return res.status(409).json({ error: 'You already have an active or trialing subscription.' });
+    await transporter.sendMail({
+      from: `"3DVR.Tech Bot" <${config.GMAIL_USER}>`,
+      to: config.GMAIL_USER,
+      bcc: teamEmails,
+      subject: `New Free Trial Started: ${email}`,
+      html: `<p><strong>${email}</strong> just signed up for a free trial.</p>`
+    });
+  }
+
+  return async function handler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
     }
 
-    // Create new trial subscription
-    const subscription = await stripe.subscriptions.create({
-      customer: customer.id,
-      items: [{ price: process.env.STRIPE_PRICE_ID }],
-      trial_period_days: 14,
-      payment_behavior: 'default_incomplete',
-    });
+    if (req.method !== 'POST') {
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
 
-    console.log('✅ Trial started:', subscription.id);
+    const { email } = req.body;
 
-    // Notify user + team
-    await sendWelcomeEmail(email);
-    await notifyTeam(email);
+    if (!email || !email.includes('@')) {
+      return res.status(400).json({ error: 'A valid email address is required.' });
+    }
 
-    res.status(200).json({ success: true, subscriptionId: subscription.id });
+    if (!config.STRIPE_SECRET_KEY || !config.STRIPE_PRICE_ID) {
+      return res.status(500).json({ error: 'Stripe configuration is missing.' });
+    }
 
-  } catch (err) {
-    console.error('🔥 FINAL ERROR:', err);
-    res.status(500).json({ error: err.message || 'Unexpected error occurred.' });
-  }
+    try {
+      console.log('📩 Creating customer for:', email);
+
+      const existingCustomers = await stripe.customers.list({ email, limit: 1 });
+      const customer = existingCustomers.data[0] || await stripe.customers.create({ email });
+
+      const subs = await stripe.subscriptions.list({
+        customer: customer.id,
+        status: 'all',
+        limit: 1,
+      });
+
+      const alreadySubscribed = subs.data.some(sub => sub.status === 'active' || sub.status === 'trialing');
+
+      if (alreadySubscribed) {
+        return res.status(409).json({ error: 'You already have an active or trialing subscription.' });
+      }
+
+      const subscription = await stripe.subscriptions.create({
+        customer: customer.id,
+        items: [{ price: config.STRIPE_PRICE_ID }],
+        trial_period_days: 14,
+        payment_behavior: 'default_incomplete',
+      });
+
+      console.log('✅ Trial started:', subscription.id);
+
+      await sendWelcomeEmail(email);
+      await notifyTeam(email);
+
+      return res.status(200).json({ success: true, subscriptionId: subscription.id });
+    } catch (err) {
+      console.error('🔥 FINAL ERROR:', err);
+      return res.status(500).json({ error: err.message || 'Unexpected error occurred.' });
+    }
+  };
 }
+
+const handler = createTrialHandler();
+export default handler;

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "3dvr-portal",
   "version": "1.0.0",
   "description": "Main portal for 3dvr.tech with Stripe webhooks and email notifications",
+  "type": "module",
   "scripts": {
-    "dev": "vercel dev"
+    "dev": "vercel dev",
+    "test": "node --test"
   },
   "dependencies": {
     "stripe": "^12.17.0",

--- a/tests/trial.test.js
+++ b/tests/trial.test.js
@@ -1,0 +1,159 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTrialHandler } from '../api/trial.js';
+
+const baseConfig = {
+  STRIPE_SECRET_KEY: 'sk_test_key',
+  STRIPE_PRICE_ID: 'price_123',
+  GMAIL_USER: 'bot@example.com',
+  GMAIL_APP_PASSWORD: 'app_password',
+};
+
+function createMockStripe(overrides = {}) {
+  const stripe = {
+    customers: {
+      list: mock.fn(async () => ({ data: [] })),
+      create: mock.fn(async ({ email }) => ({ id: 'cus_test', email })),
+    },
+    subscriptions: {
+      list: mock.fn(async () => ({ data: [] })),
+      create: mock.fn(async () => ({ id: 'sub_test' })),
+    },
+  };
+
+  if (overrides.customers?.list) stripe.customers.list = overrides.customers.list;
+  if (overrides.customers?.create) stripe.customers.create = overrides.customers.create;
+  if (overrides.subscriptions?.list) stripe.subscriptions.list = overrides.subscriptions.list;
+  if (overrides.subscriptions?.create) stripe.subscriptions.create = overrides.subscriptions.create;
+
+  return stripe;
+}
+
+function createMailTransport() {
+  return {
+    sendMail: mock.fn(async () => ({})),
+  };
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+    ended: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end(payload) {
+      this.ended = true;
+      if (payload !== undefined) {
+        this.body = payload;
+      }
+      return this;
+    },
+    setHeader(key, value) {
+      this.headers[key] = value;
+    },
+  };
+}
+
+describe('trial handler', () => {
+  it('responds to OPTIONS requests without processing', async () => {
+    const stripe = createMockStripe();
+    const mailTransport = createMailTransport();
+    const handler = createTrialHandler({ stripeClient: stripe, mailTransport, config: baseConfig });
+
+    const req = { method: 'OPTIONS', body: {} };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.ended, true);
+    assert.equal(stripe.customers.list.mock.calls.length, 0);
+    assert.equal(mailTransport.sendMail.mock.calls.length, 0);
+  });
+
+  it('rejects invalid email payloads', async () => {
+    const handler = createTrialHandler({
+      stripeClient: createMockStripe(),
+      mailTransport: createMailTransport(),
+      config: baseConfig,
+    });
+
+    const req = { method: 'POST', body: {} };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, { error: 'A valid email address is required.' });
+  });
+
+  it('returns a server error when Stripe config is incomplete', async () => {
+    const handler = createTrialHandler({
+      stripeClient: createMockStripe(),
+      mailTransport: createMailTransport(),
+      config: {
+        ...baseConfig,
+        STRIPE_PRICE_ID: undefined,
+      },
+    });
+
+    const req = { method: 'POST', body: { email: 'user@example.com' } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 500);
+    assert.deepEqual(res.body, { error: 'Stripe configuration is missing.' });
+  });
+
+  it('prevents duplicate trial subscriptions', async () => {
+    const stripe = createMockStripe({
+      subscriptions: {
+        list: mock.fn(async () => ({ data: [{ status: 'active' }] })),
+        create: mock.fn(),
+      },
+    });
+    const mailTransport = createMailTransport();
+    const handler = createTrialHandler({ stripeClient: stripe, mailTransport, config: baseConfig });
+
+    const req = { method: 'POST', body: { email: 'existing@example.com' } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(stripe.subscriptions.create.mock.calls.length, 0);
+    assert.equal(mailTransport.sendMail.mock.calls.length, 0);
+    assert.equal(res.statusCode, 409);
+    assert.deepEqual(res.body, { error: 'You already have an active or trialing subscription.' });
+  });
+
+  it('creates a trial and notifies the user and team', async () => {
+    const stripe = createMockStripe();
+    const mailTransport = createMailTransport();
+    const handler = createTrialHandler({ stripeClient: stripe, mailTransport, config: baseConfig });
+
+    const req = { method: 'POST', body: { email: 'new-user@example.com' } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.deepEqual(stripe.customers.list.mock.calls[0].arguments[0], { email: 'new-user@example.com', limit: 1 });
+    assert.deepEqual(stripe.subscriptions.create.mock.calls[0].arguments[0], {
+      customer: 'cus_test',
+      items: [{ price: baseConfig.STRIPE_PRICE_ID }],
+      trial_period_days: 14,
+      payment_behavior: 'default_incomplete',
+    });
+    assert.equal(mailTransport.sendMail.mock.calls.length, 2);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, { success: true, subscriptionId: 'sub_test' });
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the Stripe trial API to allow injecting Stripe and mail transports for easier testing
- cover common trial request scenarios with node:test mocks and assertions
- add a package.json test script using Node's built-in test runner and mark the project as ESM

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda7a360f08320bb1a41aff601869d