### PR TITLE
Revamp landing navigation

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -13,250 +13,101 @@ body.landing {
 
 .skip-link {
   position: absolute;
-  top: -100vh;
-  left: 50%;
-  transform: translateX(-50%);
-  padding: 0.75rem 1.35rem;
-  border-radius: 999px;
+  top: 1.5rem;
+  left: 1.5rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: 0.75rem;
   background: var(--accent);
   color: var(--accent-contrast);
   font-weight: 600;
-  text-decoration: none;
-  box-shadow: 0 22px 44px rgba(34, 211, 238, 0.4);
-  transition: top var(--transition-base), box-shadow var(--transition-base);
-  z-index: 1200;
+  transform: translateY(-150%);
+  transition: transform var(--transition-base),
+    opacity var(--transition-base);
+  opacity: 0;
+  z-index: 12;
 }
 
 .skip-link:focus-visible {
-  top: 1.5rem;
-  outline: none;
-  box-shadow: 0 28px 60px rgba(34, 211, 238, 0.5);
+  transform: translateY(0);
+  opacity: 1;
 }
 
-.landing-header {
-  width: min(1020px, 100%);
-  margin: 0 auto 3rem;
-  position: relative;
-  z-index: 2;
-}
-
-.landing-header__inner {
-  display: flex;
-  align-items: center;
-  gap: 1.25rem;
-  padding: 0.85rem 1.35rem;
-  border-radius: 999px;
-  background: var(--top-button-container-bg);
-  border: 1px solid var(--top-button-container-border);
-  box-shadow: var(--top-button-container-shadow);
-  backdrop-filter: blur(12px);
-}
-
-.landing-header__brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.85rem;
-  text-decoration: none;
-  color: var(--top-button-text);
-  transition: color var(--transition-base);
-}
-
-.landing-header__brand:hover {
-  color: var(--top-button-text-hover);
-}
-
-.landing-header__logo {
-  display: grid;
-  place-items: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: var(--top-button-bg);
-  border: 1px solid var(--top-button-border);
-  box-shadow: var(--top-button-shadow);
-  font-size: 1.2rem;
-}
-
-.landing-header__text {
+.top-nav {
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
-  line-height: 1.1;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  margin-bottom: 2.5rem;
 }
 
-.landing-header__title {
-  font-size: 1.1rem;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-}
-
-.landing-header__subtitle {
-  font-size: 0.75rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-
-.landing-header__toggle {
+.top-nav__toggle {
   display: none;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.6rem 0.9rem;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1.2rem;
   border-radius: 999px;
   border: 1px solid var(--top-button-border);
   background: var(--top-button-bg);
   color: var(--top-button-text);
   font-weight: 600;
-  margin-left: auto;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  transition: background var(--transition-base),
-    color var(--transition-base),
+  transition: transform var(--transition-base),
+    background var(--transition-base),
     border-color var(--transition-base),
+    color var(--transition-base),
     box-shadow var(--transition-base);
 }
 
-.landing-header__toggle:hover,
-.landing-header__toggle:focus-visible {
+.top-nav__toggle:hover,
+.top-nav__toggle:focus-visible {
+  transform: translateY(-2px);
   background: var(--top-button-bg-hover);
   border-color: var(--top-button-border-hover);
   color: var(--top-button-text-hover);
   box-shadow: var(--top-button-shadow-hover);
+}
+
+.top-nav__toggle:focus-visible {
   outline: none;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.35);
 }
 
-.landing-header__toggle-icon {
+.top-nav__toggle-icon {
   position: relative;
-  width: 1.35rem;
+  width: 1.25rem;
   height: 0.12rem;
-  border-radius: 999px;
   background: currentColor;
-  transition: background var(--transition-base);
+  border-radius: 999px;
 }
 
-.landing-header__toggle-icon::before,
-.landing-header__toggle-icon::after {
+.top-nav__toggle-icon::before,
+.top-nav__toggle-icon::after {
   content: '';
   position: absolute;
   left: 0;
-  width: 1.35rem;
-  height: 0.12rem;
-  border-radius: 999px;
+  width: 100%;
+  height: 100%;
   background: currentColor;
-  transition: transform var(--transition-base),
-    top var(--transition-base),
-    opacity var(--transition-base);
-}
-
-.landing-header__toggle-icon::before {
-  top: -0.4rem;
-}
-
-.landing-header__toggle-icon::after {
-  top: 0.4rem;
-}
-
-.landing-header--open .landing-header__toggle-icon {
-  background: transparent;
-}
-
-.landing-header--open .landing-header__toggle-icon::before {
-  top: 0;
-  transform: rotate(45deg);
-}
-
-.landing-header--open .landing-header__toggle-icon::after {
-  top: 0;
-  transform: rotate(-45deg);
-}
-
-.landing-header__nav {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  margin-left: auto;
-}
-
-.landing-header__links {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.landing-header__link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.55rem 1rem;
   border-radius: 999px;
-  border: 1px solid transparent;
-  font-weight: 500;
-  color: var(--top-button-text);
-  background: transparent;
-  transition: background var(--transition-base),
-    color var(--transition-base),
-    border-color var(--transition-base);
 }
 
-.landing-header__link:hover,
-.landing-header__link:focus-visible {
-  background: var(--top-button-bg-hover);
-  border-color: var(--top-button-border-hover);
-  color: var(--top-button-text-hover);
-  outline: none;
+.top-nav__toggle-icon::before {
+  top: -0.36rem;
 }
 
-.landing-header__actions {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+.top-nav__toggle-icon::after {
+  top: 0.36rem;
 }
 
-.landing-header__action-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.55rem 1.1rem;
-  border-radius: 999px;
-  border: 1px solid var(--top-button-border);
-  font-weight: 600;
-  color: var(--top-button-text);
-  transition: background var(--transition-base),
-    color var(--transition-base),
-    border-color var(--transition-base),
-    box-shadow var(--transition-base);
-}
-
-.landing-header__action-link:hover,
-.landing-header__action-link:focus-visible {
-  background: rgba(56, 189, 248, 0.18);
-  color: var(--top-button-text-hover);
-  border-color: var(--top-button-border-hover);
-  box-shadow: var(--top-button-shadow-hover);
-  outline: none;
-}
-
-.landing-header__actions .cta {
-  padding: 0.65rem 1.45rem;
+.top-nav__toggle-text {
   font-size: 0.95rem;
 }
 
-.landing-header__actions .cta.primary {
-  box-shadow: 0 26px 54px rgba(34, 211, 238, 0.45);
-}
-
-.landing-header__actions .cta.primary:hover {
-  box-shadow: 0 32px 64px rgba(34, 211, 238, 0.55);
-}
-
-.landing-header__link:focus-visible,
-.landing-header__action-link:focus-visible,
-.landing-header__toggle:focus-visible,
-.landing-header__actions .cta:focus-visible {
-  outline: 2px solid var(--accent-strong);
-  outline-offset: 3px;
+.top-nav--collapsed .top-buttons {
+  display: none;
 }
 
 .landing-content {
@@ -610,89 +461,29 @@ footer a {
   box-shadow: 0 36px 90px rgba(4, 9, 20, 0.65);
 }
 
-@media (max-width: 1080px) {
-  .landing-header {
+@media (max-width: 720px) {
+  .top-nav {
     width: 100%;
+    align-items: stretch;
   }
 
-  .landing-header__inner {
-    flex-wrap: wrap;
-    row-gap: 1rem;
-  }
-
-  .landing-header__nav {
-    width: 100%;
-    margin-left: 0;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    row-gap: 0.75rem;
-  }
-
-  .landing-header__actions {
-    flex-wrap: wrap;
-    justify-content: flex-end;
-  }
-}
-
-@media (max-width: 900px) {
-  .landing-header__nav {
-    justify-content: flex-start;
-    gap: 1rem;
-  }
-
-  .landing-header__actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-}
-
-@media (max-width: 768px) {
-  .landing-header__inner {
-    align-items: flex-start;
-  }
-
-  .landing-header__toggle {
+  .top-nav__toggle {
     display: inline-flex;
   }
 
-  .landing-header__nav {
-    display: none;
-    flex-direction: column;
-    align-items: stretch;
-    width: 100%;
-    margin-left: 0;
-    padding-top: 1rem;
-    margin-top: 0.5rem;
-    border-top: 1px solid var(--top-button-container-border);
-    gap: 1rem;
+  .top-nav .top-buttons {
+    margin-bottom: 0;
   }
 
-  .landing-header__nav--open {
+  .top-nav--expanded .top-buttons {
     display: flex;
   }
+}
 
-  .landing-header__links {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.6rem;
-  }
-
-  .landing-header__link {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .landing-header__actions {
-    flex-direction: column;
-    align-items: stretch;
-    width: 100%;
-    gap: 0.6rem;
-  }
-
-  .landing-header__actions .cta,
-  .landing-header__action-link {
-    width: 100%;
-    justify-content: center;
+@media (min-width: 721px) {
+  .top-nav--collapsed .top-buttons,
+  .top-nav--expanded .top-buttons {
+    display: flex;
   }
 }
 

--- a/index-style.css
+++ b/index-style.css
@@ -11,6 +11,254 @@ body.landing {
   padding: 6rem 1.5rem 4rem;
 }
 
+.skip-link {
+  position: absolute;
+  top: -100vh;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 22px 44px rgba(34, 211, 238, 0.4);
+  transition: top var(--transition-base), box-shadow var(--transition-base);
+  z-index: 1200;
+}
+
+.skip-link:focus-visible {
+  top: 1.5rem;
+  outline: none;
+  box-shadow: 0 28px 60px rgba(34, 211, 238, 0.5);
+}
+
+.landing-header {
+  width: min(1020px, 100%);
+  margin: 0 auto 3rem;
+  position: relative;
+  z-index: 2;
+}
+
+.landing-header__inner {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.85rem 1.35rem;
+  border-radius: 999px;
+  background: var(--top-button-container-bg);
+  border: 1px solid var(--top-button-container-border);
+  box-shadow: var(--top-button-container-shadow);
+  backdrop-filter: blur(12px);
+}
+
+.landing-header__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  text-decoration: none;
+  color: var(--top-button-text);
+  transition: color var(--transition-base);
+}
+
+.landing-header__brand:hover {
+  color: var(--top-button-text-hover);
+}
+
+.landing-header__logo {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--top-button-bg);
+  border: 1px solid var(--top-button-border);
+  box-shadow: var(--top-button-shadow);
+  font-size: 1.2rem;
+}
+
+.landing-header__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  line-height: 1.1;
+}
+
+.landing-header__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.landing-header__subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.landing-header__toggle {
+  display: none;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--top-button-border);
+  background: var(--top-button-bg);
+  color: var(--top-button-text);
+  font-weight: 600;
+  margin-left: auto;
+  cursor: pointer;
+  transition: background var(--transition-base),
+    color var(--transition-base),
+    border-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.landing-header__toggle:hover,
+.landing-header__toggle:focus-visible {
+  background: var(--top-button-bg-hover);
+  border-color: var(--top-button-border-hover);
+  color: var(--top-button-text-hover);
+  box-shadow: var(--top-button-shadow-hover);
+  outline: none;
+}
+
+.landing-header__toggle-icon {
+  position: relative;
+  width: 1.35rem;
+  height: 0.12rem;
+  border-radius: 999px;
+  background: currentColor;
+  transition: background var(--transition-base);
+}
+
+.landing-header__toggle-icon::before,
+.landing-header__toggle-icon::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 1.35rem;
+  height: 0.12rem;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform var(--transition-base),
+    top var(--transition-base),
+    opacity var(--transition-base);
+}
+
+.landing-header__toggle-icon::before {
+  top: -0.4rem;
+}
+
+.landing-header__toggle-icon::after {
+  top: 0.4rem;
+}
+
+.landing-header--open .landing-header__toggle-icon {
+  background: transparent;
+}
+
+.landing-header--open .landing-header__toggle-icon::before {
+  top: 0;
+  transform: rotate(45deg);
+}
+
+.landing-header--open .landing-header__toggle-icon::after {
+  top: 0;
+  transform: rotate(-45deg);
+}
+
+.landing-header__nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-left: auto;
+}
+
+.landing-header__links {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.landing-header__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 500;
+  color: var(--top-button-text);
+  background: transparent;
+  transition: background var(--transition-base),
+    color var(--transition-base),
+    border-color var(--transition-base);
+}
+
+.landing-header__link:hover,
+.landing-header__link:focus-visible {
+  background: var(--top-button-bg-hover);
+  border-color: var(--top-button-border-hover);
+  color: var(--top-button-text-hover);
+  outline: none;
+}
+
+.landing-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.landing-header__action-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid var(--top-button-border);
+  font-weight: 600;
+  color: var(--top-button-text);
+  transition: background var(--transition-base),
+    color var(--transition-base),
+    border-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.landing-header__action-link:hover,
+.landing-header__action-link:focus-visible {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--top-button-text-hover);
+  border-color: var(--top-button-border-hover);
+  box-shadow: var(--top-button-shadow-hover);
+  outline: none;
+}
+
+.landing-header__actions .cta {
+  padding: 0.65rem 1.45rem;
+  font-size: 0.95rem;
+}
+
+.landing-header__actions .cta.primary {
+  box-shadow: 0 26px 54px rgba(34, 211, 238, 0.45);
+}
+
+.landing-header__actions .cta.primary:hover {
+  box-shadow: 0 32px 64px rgba(34, 211, 238, 0.55);
+}
+
+.landing-header__link:focus-visible,
+.landing-header__action-link:focus-visible,
+.landing-header__toggle:focus-visible,
+.landing-header__actions .cta:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 3px;
+}
+
 .landing-content {
   display: flex;
   flex-direction: column;
@@ -360,6 +608,92 @@ footer a {
   display: none;
   z-index: 9999;
   box-shadow: 0 36px 90px rgba(4, 9, 20, 0.65);
+}
+
+@media (max-width: 1080px) {
+  .landing-header {
+    width: 100%;
+  }
+
+  .landing-header__inner {
+    flex-wrap: wrap;
+    row-gap: 1rem;
+  }
+
+  .landing-header__nav {
+    width: 100%;
+    margin-left: 0;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    row-gap: 0.75rem;
+  }
+
+  .landing-header__actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 900px) {
+  .landing-header__nav {
+    justify-content: flex-start;
+    gap: 1rem;
+  }
+
+  .landing-header__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 768px) {
+  .landing-header__inner {
+    align-items: flex-start;
+  }
+
+  .landing-header__toggle {
+    display: inline-flex;
+  }
+
+  .landing-header__nav {
+    display: none;
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    margin-left: 0;
+    padding-top: 1rem;
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--top-button-container-border);
+    gap: 1rem;
+  }
+
+  .landing-header__nav--open {
+    display: flex;
+  }
+
+  .landing-header__links {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.6rem;
+  }
+
+  .landing-header__link {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .landing-header__actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: 0.6rem;
+  }
+
+  .landing-header__actions .cta,
+  .landing-header__action-link {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 @media (max-width: 960px) {

--- a/index.html
+++ b/index.html
@@ -18,61 +18,24 @@
 <body class="landing theme-dark">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <div class="landing-shell">
-    <header class="landing-header" role="banner">
-      <div class="landing-header__inner">
-        <a class="landing-header__brand" href="index.html">
-          <span class="landing-header__logo" aria-hidden="true">🌌</span>
-          <span class="landing-header__text">
-            <span class="landing-header__title">3DVR Portal</span>
-            <span class="landing-header__subtitle">Open Metaverse Community</span>
-          </span>
-        </a>
-        <button
-          class="landing-header__toggle"
-          type="button"
-          aria-expanded="false"
-          aria-controls="landing-navigation"
-        >
-          <span class="landing-header__toggle-icon" aria-hidden="true"></span>
-          <span class="landing-header__toggle-text">Menu</span>
-        </button>
-        <nav class="landing-header__nav" id="landing-navigation" aria-label="Main navigation">
-          <ul class="landing-header__links">
-            <li><a class="landing-header__link" href="#apps">Apps</a></li>
-            <li>
-              <a class="landing-header__link" href="https://portal.3dvr.tech/contacts">Contacts</a>
-            </li>
-            <li><a class="landing-header__link" href="share.html">Share</a></li>
-            <li>
-              <a
-                class="landing-header__link"
-                href="https://3dvr.tech"
-                target="_blank"
-                rel="noopener"
-              >3DVR.Tech</a>
-            </li>
-            <li>
-              <a
-                class="landing-header__link"
-                href="https://github.com/tmsteph/3dvr-portal"
-                target="_blank"
-                rel="noopener"
-              >GitHub</a>
-            </li>
-          </ul>
-          <div class="landing-header__actions">
-            <a
-              class="landing-header__action-link"
-              href="https://3dvr.tech/#subscribe"
-              target="_blank"
-              rel="noopener"
-            >Subscribe</a>
-            <a class="cta ghost" href="free-trial.html" target="_blank" rel="noopener">Free Plan</a>
-            <a class="cta primary" href="sign-in.html">Sign in</a>
-          </div>
-        </nav>
-      </div>
-    </header>
+    <div class="top-nav top-nav--expanded">
+      <button
+        class="top-nav__toggle"
+        type="button"
+        aria-expanded="true"
+        aria-controls="landingQuickLinks"
+      >
+        <span class="top-nav__toggle-icon" aria-hidden="true"></span>
+        <span class="top-nav__toggle-text">Menu</span>
+      </button>
+      <nav class="top-buttons" id="landingQuickLinks" aria-label="3DVR quick links">
+        <a href="https://3dvr.tech">🏠 3DVR Home</a>
+        <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">⭐ Subscribe</a>
+        <a href="https://3dvr-portal.vercel.app/free-trial.html" target="_blank" rel="noopener">🎁 Free Plan</a>
+        <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">🚀 Contribute on GitHub</a>
+        <a href="https://portal.3dvr.tech/share.html">Share via QR Code</a>
+      </nav>
+    </div>
 
     <main id="mainContent" class="landing-content">
       <section class="hero" aria-labelledby="landing-title">
@@ -85,7 +48,7 @@
         </div>
       </section>
 
-      <section id="apps" class="app-hub" aria-labelledby="app-hub-title">
+      <section class="app-hub" aria-labelledby="app-hub-title">
         <div class="section-heading">
           <div>
             <span class="eyebrow">Launchpad</span>
@@ -251,47 +214,45 @@
       installBtn.style.display = 'none';
     });
 
-    const landingHeader = document.querySelector('.landing-header');
-    const landingNav = document.getElementById('landing-navigation');
-    const landingNavToggle = document.querySelector('.landing-header__toggle');
+    const topNav = document.querySelector('.top-nav');
+    const topNavToggle = document.querySelector('.top-nav__toggle');
+    const topNavLinks = document.getElementById('landingQuickLinks');
+    const desktopQuery = window.matchMedia('(min-width: 721px)');
 
-    if (landingNav && landingNavToggle) {
-      const toggleText = landingNavToggle.querySelector('.landing-header__toggle-text');
-
+    if (topNav && topNavToggle && topNavLinks) {
       const setNavExpanded = (expanded) => {
-        landingNavToggle.setAttribute('aria-expanded', String(expanded));
-        if (toggleText) {
-          toggleText.textContent = expanded ? 'Close' : 'Menu';
+        topNavToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        topNav.classList.toggle('top-nav--expanded', expanded);
+        topNav.classList.toggle('top-nav--collapsed', !expanded);
+
+        if (expanded || desktopQuery.matches) {
+          topNavLinks.removeAttribute('hidden');
+        } else {
+          topNavLinks.setAttribute('hidden', '');
         }
-        landingNav.classList.toggle('landing-header__nav--open', expanded);
-        landingHeader?.classList.toggle('landing-header--open', expanded);
       };
 
-      landingNavToggle.addEventListener('click', () => {
-        const isExpanded = landingNavToggle.getAttribute('aria-expanded') === 'true';
-        setNavExpanded(!isExpanded);
-      });
-
-      window.addEventListener('resize', () => {
-        if (window.innerWidth > 768) {
-          setNavExpanded(false);
+      const syncNavWithViewport = () => {
+        if (desktopQuery.matches) {
+          setNavExpanded(true);
+        } else {
+          const expanded = topNavToggle.getAttribute('aria-expanded') === 'true';
+          setNavExpanded(expanded);
         }
+      };
+
+      topNavToggle.addEventListener('click', () => {
+        const expanded = topNavToggle.getAttribute('aria-expanded') === 'true';
+        setNavExpanded(!expanded);
       });
 
-      window.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && landingNav.classList.contains('landing-header__nav--open')) {
-          setNavExpanded(false);
-          landingNavToggle.focus();
-        }
-      });
+      syncNavWithViewport();
 
-      landingNav.querySelectorAll('a').forEach((link) => {
-        link.addEventListener('click', () => {
-          if (landingNav.classList.contains('landing-header__nav--open')) {
-            setNavExpanded(false);
-          }
-        });
-      });
+      if (typeof desktopQuery.addEventListener === 'function') {
+        desktopQuery.addEventListener('change', syncNavWithViewport);
+      } else if (typeof desktopQuery.addListener === 'function') {
+        desktopQuery.addListener(syncNavWithViewport);
+      }
     }
 
     const appSearchInput = document.getElementById('appSearch');

--- a/index.html
+++ b/index.html
@@ -18,11 +18,11 @@
 <body class="landing theme-dark">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <div class="landing-shell">
-    <div class="top-nav top-nav--expanded">
+    <div class="top-nav top-nav--collapsed">
       <button
         class="top-nav__toggle"
         type="button"
-        aria-expanded="true"
+        aria-expanded="false"
         aria-controls="landingQuickLinks"
       >
         <span class="top-nav__toggle-icon" aria-hidden="true"></span>

--- a/index.html
+++ b/index.html
@@ -16,16 +16,65 @@
   <link rel="apple-touch-icon" sizes="512x512" href="/icons/icon-512.png">
 </head>
 <body class="landing theme-dark">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
   <div class="landing-shell">
-    <nav class="top-buttons" aria-label="3DVR quick links">
-      <a href="https://3dvr.tech">🏠 3DVR Home</a>
-      <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">⭐ Subscribe</a>
-      <a href="https://3dvr-portal.vercel.app/free-trial.html" target="_blank" rel="noopener">🎁 Free Plan</a>
-      <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">🚀 Contribute on GitHub</a>
-      <a href="https://portal.3dvr.tech/share.html">Share via QR Code</a>
-    </nav>
+    <header class="landing-header" role="banner">
+      <div class="landing-header__inner">
+        <a class="landing-header__brand" href="index.html">
+          <span class="landing-header__logo" aria-hidden="true">🌌</span>
+          <span class="landing-header__text">
+            <span class="landing-header__title">3DVR Portal</span>
+            <span class="landing-header__subtitle">Open Metaverse Community</span>
+          </span>
+        </a>
+        <button
+          class="landing-header__toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="landing-navigation"
+        >
+          <span class="landing-header__toggle-icon" aria-hidden="true"></span>
+          <span class="landing-header__toggle-text">Menu</span>
+        </button>
+        <nav class="landing-header__nav" id="landing-navigation" aria-label="Main navigation">
+          <ul class="landing-header__links">
+            <li><a class="landing-header__link" href="#apps">Apps</a></li>
+            <li>
+              <a class="landing-header__link" href="https://portal.3dvr.tech/contacts">Contacts</a>
+            </li>
+            <li><a class="landing-header__link" href="share.html">Share</a></li>
+            <li>
+              <a
+                class="landing-header__link"
+                href="https://3dvr.tech"
+                target="_blank"
+                rel="noopener"
+              >3DVR.Tech</a>
+            </li>
+            <li>
+              <a
+                class="landing-header__link"
+                href="https://github.com/tmsteph/3dvr-portal"
+                target="_blank"
+                rel="noopener"
+              >GitHub</a>
+            </li>
+          </ul>
+          <div class="landing-header__actions">
+            <a
+              class="landing-header__action-link"
+              href="https://3dvr.tech/#subscribe"
+              target="_blank"
+              rel="noopener"
+            >Subscribe</a>
+            <a class="cta ghost" href="free-trial.html" target="_blank" rel="noopener">Free Plan</a>
+            <a class="cta primary" href="sign-in.html">Sign in</a>
+          </div>
+        </nav>
+      </div>
+    </header>
 
-    <main class="landing-content">
+    <main id="mainContent" class="landing-content">
       <section class="hero" aria-labelledby="landing-title">
         <span class="hero-eyebrow">Open Metaverse Community</span>
         <h1 id="landing-title">Welcome to the 3DVR Portal</h1>
@@ -36,7 +85,7 @@
         </div>
       </section>
 
-      <section class="app-hub" aria-labelledby="app-hub-title">
+      <section id="apps" class="app-hub" aria-labelledby="app-hub-title">
         <div class="section-heading">
           <div>
             <span class="eyebrow">Launchpad</span>
@@ -201,6 +250,49 @@
     window.addEventListener('appinstalled', () => {
       installBtn.style.display = 'none';
     });
+
+    const landingHeader = document.querySelector('.landing-header');
+    const landingNav = document.getElementById('landing-navigation');
+    const landingNavToggle = document.querySelector('.landing-header__toggle');
+
+    if (landingNav && landingNavToggle) {
+      const toggleText = landingNavToggle.querySelector('.landing-header__toggle-text');
+
+      const setNavExpanded = (expanded) => {
+        landingNavToggle.setAttribute('aria-expanded', String(expanded));
+        if (toggleText) {
+          toggleText.textContent = expanded ? 'Close' : 'Menu';
+        }
+        landingNav.classList.toggle('landing-header__nav--open', expanded);
+        landingHeader?.classList.toggle('landing-header--open', expanded);
+      };
+
+      landingNavToggle.addEventListener('click', () => {
+        const isExpanded = landingNavToggle.getAttribute('aria-expanded') === 'true';
+        setNavExpanded(!isExpanded);
+      });
+
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 768) {
+          setNavExpanded(false);
+        }
+      });
+
+      window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && landingNav.classList.contains('landing-header__nav--open')) {
+          setNavExpanded(false);
+          landingNavToggle.focus();
+        }
+      });
+
+      landingNav.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => {
+          if (landingNav.classList.contains('landing-header__nav--open')) {
+            setNavExpanded(false);
+          }
+        });
+      });
+    }
 
     const appSearchInput = document.getElementById('appSearch');
     const appCards = Array.from(document.querySelectorAll('.app-card'));

--- a/navbar.js
+++ b/navbar.js
@@ -37,10 +37,13 @@ function createNavbar() {
   nav.appendChild(button);
 
   const topButtons = document.querySelector('.top-buttons');
+  const landingHeader = document.querySelector('.landing-header');
   const landingShell = document.querySelector('.landing-shell');
 
   if (topButtons) {
     topButtons.insertAdjacentElement('afterend', nav);
+  } else if (landingHeader) {
+    landingHeader.insertAdjacentElement('afterend', nav);
   } else if (landingShell) {
     landingShell.insertAdjacentElement('afterbegin', nav);
   } else {


### PR DESCRIPTION
## Summary
- replace the landing page button strip with a branded header that includes quick links and calls to action, plus a skip link for keyboard users
- add responsive styles and JavaScript to handle a collapsible mobile navigation and ensure the floating identity widget anchors beneath the new header

## Testing
- not run (manual verification recommended)

------
https://chatgpt.com/codex/tasks/task_e_68cdba052dac8320a253551563bfeeb7