### PR TITLE
Add Gun migration script and update admin relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,20 @@ You can sign up, join the chat, and start contributing right now — no download
 git clone https://github.com/tmsteph/3dvr-portal.git
 cd 3dvr-portal
 open index.html
+```
+
+### Backfill legacy Gun data
+
+The admin dashboard now relies on the Fly.io Gun relay. If you need to migrate
+historical records from the legacy Manhattan relay, run the provided script:
+
+```bash
+npm install
+npm run migrate:gun
+```
+
+The script connects to both relays, copies the `3dvr-portal` collections used by
+the admin dashboard (user profiles, stats, admin roster, and admin requests),
+and reports how many records were moved. After the migration completes, reload
+the admin dashboard to confirm historical users appear via the Fly.io relay
+only.

--- a/admin/index.html
+++ b/admin/index.html
@@ -355,7 +355,7 @@
   </div>
 
   <script>
-  const gun = Gun(['https://gun-manhattan.herokuapp.com/gun']);
+  const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
   const user = gun.user();
   const portalRoot = gun.get('3dvr-portal');
   const portalAdmins = portalRoot.get('admins');

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "vercel dev",
-    "test": "node --test"
+    "test": "node --test",
+    "migrate:gun": "node scripts/migrate-gun-users.js"
   },
   "dependencies": {
     "stripe": "^12.17.0",
-    "nodemailer": "^6.9.8"
+    "nodemailer": "^6.9.8",
+    "gun": "^0.2020.1237"
   }
 }

--- a/scripts/migrate-gun-users.js
+++ b/scripts/migrate-gun-users.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import Gun from 'gun';
+
+const SOURCE_PEER = 'https://gun-manhattan.herokuapp.com/gun';
+const TARGET_PEER = 'https://gun-relay-3dvr.fly.dev/gun';
+const ROOT_KEY = '3dvr-portal';
+const TIMEOUT_MS = 20000;
+
+const COLLECTIONS = [
+  { key: 'userIndex', label: 'user profiles' },
+  { key: 'userStats', label: 'user statistics' },
+  { key: 'admins', label: 'admin roster' },
+  { key: 'adminRequests', label: 'admin requests' }
+];
+
+const sourceGun = Gun({ peers: [SOURCE_PEER] });
+const targetGun = Gun({ peers: [TARGET_PEER] });
+
+const sourceRoot = sourceGun.get(ROOT_KEY);
+const targetRoot = targetGun.get(ROOT_KEY);
+
+function onceWithTimeout(node, description, timeout = TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout while attempting to ${description}`));
+    }, timeout);
+
+    node.once(data => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+  });
+}
+
+function putWithAck(node, value, description, timeout = TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout while writing ${description}`));
+    }, timeout);
+
+    node.put(value, ack => {
+      clearTimeout(timer);
+      if (ack && ack.err) {
+        reject(new Error(`Failed to write ${description}: ${ack.err}`));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function cleanData(data) {
+  if (!data || typeof data !== 'object') {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map(item => cleanData(item));
+  }
+
+  const result = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!key || key === '_' || typeof value === 'function') {
+      continue;
+    }
+
+    if (value && typeof value === 'object') {
+      const cleaned = cleanData(value);
+      if (cleaned === undefined) {
+        continue;
+      }
+      result[key] = cleaned;
+    } else if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function hasContent(data) {
+  if (data === null || data === undefined) {
+    return false;
+  }
+
+  if (typeof data !== 'object') {
+    return true;
+  }
+
+  if (Array.isArray(data)) {
+    return data.length > 0;
+  }
+
+  return Object.keys(data).length > 0;
+}
+
+async function migrateCollection({ key, label }) {
+  console.log(`\n⏳ Loading ${label} (${key}) from Manhattan...`);
+  const raw = await onceWithTimeout(sourceRoot.get(key), `read ${key} from Manhattan`);
+  const entryKeys = Object.keys(raw || {}).filter(entryKey => entryKey && entryKey !== '_' && entryKey !== '#');
+
+  if (!entryKeys.length) {
+    console.log(`ℹ️ No records found for ${key}.`);
+    return { key, count: 0 };
+  }
+
+  console.log(`📦 Migrating ${entryKeys.length} records for ${key} to Fly.io...`);
+  let count = 0;
+
+  for (const entryKey of entryKeys) {
+    const entryRaw = await onceWithTimeout(sourceRoot.get(key).get(entryKey), `read ${key}/${entryKey}`);
+    const entryData = cleanData(entryRaw);
+
+    if (!hasContent(entryData)) {
+      continue;
+    }
+
+    await putWithAck(targetRoot.get(key).get(entryKey), entryData, `${key}/${entryKey}`);
+    count += 1;
+  }
+
+  console.log(`✅ Finished migrating ${count} ${label}.`);
+  return { key, count };
+}
+
+async function main() {
+  console.log('🚀 Starting Gun data migration from Manhattan to Fly.io...');
+  const summaries = [];
+
+  for (const collection of COLLECTIONS) {
+    const summary = await migrateCollection(collection);
+    summaries.push(summary);
+  }
+
+  console.log('\n📊 Migration summary:');
+  for (const summary of summaries) {
+    console.log(`  • ${summary.key}: ${summary.count} records migrated`);
+  }
+
+  console.log('\n✨ Migration complete.');
+  process.exit(0);
+}
+
+main().catch(error => {
+  console.error('\n❌ Migration failed:', error.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Node-based Gun migration script that copies the 3dvr-portal collections from the Manhattan peer into the Fly.io relay
- point the admin dashboard at the Fly.io relay and document how to run the migration
- expose an npm script for the migration utility and add the gun dependency

## Testing
- npm run migrate:gun *(fails: Cannot find package 'gun' imported from scripts/migrate-gun-users.js because the registry is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fa3a6dc883209f171c2a4b136bca