### PR TITLE
Normalize reward point totals

### DIFF
--- a/rewards.html
+++ b/rewards.html
@@ -61,12 +61,30 @@
       return Math.max(0, Math.round(numeric));
     }
 
+    function getStoredTotal(callback) {
+      user.get('score').once(score => {
+        if (score === undefined || score === null) {
+          user.get('points').once(points => {
+            callback(normalizePoints(points));
+          });
+          return;
+        }
+        callback(normalizePoints(score));
+      });
+    }
+
+    function persistUserTotals(total) {
+      const safeTotal = normalizePoints(total);
+      user.get('score').put(safeTotal);
+      user.get('points').put(safeTotal);
+      syncPublicPoints(safeTotal);
+      return safeTotal;
+    }
+
     function completeTask() {
-      user.get('points').once(p => {
-        const currentPoints = normalizePoints(p);
-        const newPoints = currentPoints + 100;
-        user.get('points').put(newPoints);
-        syncPublicPoints(newPoints);
+      getStoredTotal(currentPoints => {
+        const updatedTotal = currentPoints + 100;
+        persistUserTotals(updatedTotal);
         user.get('log').set({
           task: 'Completed task',
           time: Date.now()
@@ -78,8 +96,7 @@
     function updateLog() {
       logDiv.innerHTML = '<strong>Your Task History:</strong><br>';
 
-      user.get('points').once(p => {
-        const total = normalizePoints(p);
+      getStoredTotal(total => {
         logDiv.innerHTML += `Total Points: ${total}<br><br>`;
         syncPublicPoints(total);
       });

--- a/rewards.html
+++ b/rewards.html
@@ -63,13 +63,15 @@
 
     function getStoredTotal(callback) {
       user.get('score').once(score => {
-        if (score === undefined || score === null) {
-          user.get('points').once(points => {
-            callback(normalizePoints(points));
-          });
+        if (score !== undefined && score !== null) {
+          callback(normalizePoints(score));
           return;
         }
-        callback(normalizePoints(score));
+        user.get('points').once(points => {
+          const fallbackTotal = normalizePoints(points);
+          persistUserTotals(fallbackTotal);
+          callback(fallbackTotal);
+        });
       });
     }
 

--- a/rewards.html
+++ b/rewards.html
@@ -53,9 +53,18 @@
     const portalRoot = gun.get('3dvr-portal');
     const logDiv = document.getElementById('log');
 
+    function normalizePoints(value) {
+      const numeric = typeof value === 'number' ? value : Number(value);
+      if (!Number.isFinite(numeric)) {
+        return 0;
+      }
+      return Math.max(0, Math.round(numeric));
+    }
+
     function completeTask() {
       user.get('points').once(p => {
-        const newPoints = (p || 0) + 100;
+        const currentPoints = normalizePoints(p);
+        const newPoints = currentPoints + 100;
         user.get('points').put(newPoints);
         syncPublicPoints(newPoints);
         user.get('log').set({
@@ -70,7 +79,7 @@
       logDiv.innerHTML = '<strong>Your Task History:</strong><br>';
 
       user.get('points').once(p => {
-        const total = p || 0;
+        const total = normalizePoints(p);
         logDiv.innerHTML += `Total Points: ${total}<br><br>`;
         syncPublicPoints(total);
       });
@@ -92,13 +101,14 @@
     });
 
     function syncPublicPoints(totalPoints) {
+      const safeTotal = normalizePoints(totalPoints);
       const alias = localStorage.getItem('alias');
       if (!alias) return;
       const displayName = localStorage.getItem('username') || alias.replace('@3dvr', '');
       portalRoot.get('userStats').get(alias).put({
         alias,
         username: displayName,
-        points: totalPoints,
+        points: safeTotal,
         lastUpdated: Date.now()
       });
     }

--- a/sign-in.html
+++ b/sign-in.html
@@ -117,6 +117,10 @@ function finishLogin(username, alias, password) {
     .catch(err => {
       console.error('Guest migration failed', err);
     })
+    .then(() => ensureUserTotalsConsistency())
+    .catch(err => {
+      console.error('Failed to sync user totals', err);
+    })
     .then(() => {
       recordUserProfile(username, alias);
       window.location.href = 'index.html';
@@ -134,6 +138,46 @@ function sanitizeScore(value) {
   const numeric = typeof value === 'number' ? value : Number(value);
   if (!Number.isFinite(numeric)) return 0;
   return Math.max(0, Math.round(numeric));
+}
+
+function ensureUserTotalsConsistency() {
+  return new Promise(resolve => {
+    let scoreValue;
+    let pointsValue;
+    let resolved = false;
+
+    function safeResolve() {
+      if (resolved) return;
+      resolved = true;
+      resolve();
+    }
+
+    function trySync() {
+      if (scoreValue === undefined || pointsValue === undefined) return;
+      const normalizedScore = sanitizeScore(scoreValue);
+      const normalizedPoints = sanitizeScore(pointsValue);
+      const best = Math.max(normalizedScore, normalizedPoints);
+      if (normalizedScore !== best) {
+        user.get('score').put(best);
+      }
+      if (normalizedPoints !== best) {
+        user.get('points').put(best);
+      }
+      safeResolve();
+    }
+
+    user.get('score').once(value => {
+      scoreValue = value;
+      trySync();
+    });
+
+    user.get('points').once(value => {
+      pointsValue = value;
+      trySync();
+    });
+
+    setTimeout(safeResolve, 1500);
+  });
 }
 
 function migrateGuestProgress() {


### PR DESCRIPTION
## Summary
- ensure reward point math uses normalized numeric values before updating totals
- persist sanitized totals to the shared user stats node for consistent cross-browser display

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d36988dab88320a16759e721c5886d