### PR TITLE
Fix sign-in overflow and clarify username field

### DIFF
--- a/sign-in.html
+++ b/sign-in.html
@@ -24,6 +24,10 @@
       box-sizing: border-box;
     }
 
+    html {
+      overflow-x: hidden;
+    }
+
     body {
       margin: 0;
       min-height: 100dvh;
@@ -321,8 +325,8 @@
         </div>
         <form onsubmit="event.preventDefault(); signIn();" aria-describedby="auth-title">
           <div>
-            <label for="username">Display name</label>
-            <input type="text" id="username" name="username" placeholder="e.g. cosmic-explorer" autocomplete="username" required>
+            <label for="username">Username</label>
+            <input type="text" id="username" name="username" placeholder="Enter your username" autocomplete="username" required>
           </div>
           <div>
             <label for="password">Password</label>


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on the sign-in page by hiding overflow on the root element
- clarify the username field label and placeholder text

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d4931018bc832096d3608520bfd59e