### PR TITLE
Fix sign-in overflow and clarify username field

### DIFF
--- a/sign-in.html
+++ b/sign-in.html
@@ -24,6 +24,10 @@
       box-sizing: border-box;
     }
 
+    html {
+      overflow-x: hidden;
+    }
+
     body {
       margin: 0;
       min-height: 100dvh;
@@ -321,12 +325,12 @@
         </div>
         <form onsubmit="event.preventDefault(); signIn();" aria-describedby="auth-title">
           <div>
-            <label for="username">Display name</label>
-            <input type="text" id="username" name="username" placeholder="e.g. cosmic-explorer" autocomplete="username" required>
+            <label for="username">Username</label>
+            <input type="text" id="username" name="username" placeholder="Enter your username" autocomplete="username" required>
           </div>
           <div>
             <label for="password">Password</label>
-            <input type="password" id="password" name="password" placeholder="Create a secure passphrase" autocomplete="current-password" required>
+            <input type="password" id="password" name="password" placeholder="Enter your password or passphrase" autocomplete="current-password" required>
           </div>
           <div class="actions">
             <button type="submit" class="primary-button">Sign in or sign up</button>

--- a/sign-in.html
+++ b/sign-in.html
@@ -330,7 +330,7 @@
           </div>
           <div>
             <label for="password">Password</label>
-            <input type="password" id="password" name="password" placeholder="Enter your password or passphrase" autocomplete="current-password" required>
+            <input type="password" id="password" name="password" placeholder="Enter your password" autocomplete="current-password" required>
           </div>
           <div class="actions">
             <button type="submit" class="primary-button">Sign in or sign up</button>


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on the sign-in page by hiding overflow on the root element
- clarify the username field label and placeholder text
- update the password placeholder copy so it applies to both signing in and signing up

## Testing
- not run (static HTML change)

------
https://chatgpt.com/codex/tasks/task_e_68d4931018bc832096d3608520bfd59e