### PR TITLE
Add mobile web app capable meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="index-style.css">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#0e1116">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="apple-touch-icon" href="/icons/icon-192.png">


### PR DESCRIPTION
## Summary
- include the standard mobile-web-app-capable meta tag in the landing page head to satisfy modern installability checks while keeping the existing Apple-specific tag for compatibility

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5c06ff0188320892b2f63f25a45e6