### PR TITLE
Improve session recall for installed PWA

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -147,8 +147,12 @@ const alias = ls.getItem('alias') || '';
 const username = ls.getItem('username') || '';
 const password = ls.getItem('password') || '';
 
-// Keep tab session alive if already authed in this tab:
-user.recall({ sessionStorage: true });
+// Keep session alive across standalone/browser contexts:
+try {
+  user.recall({ sessionStorage: true, localStorage: true });
+} catch (err) {
+  console.warn('Unable to recall user session', err);
+}
 
 const userDisplay = document.getElementById('userDisplay');
 const btnLogout = document.getElementById('btnLogout');

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>3DVR Portal</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script src="score.js"></script>
   <link rel="stylesheet" href="styles/global.css">
   <link rel="stylesheet" href="index-style.css">
   <link rel="manifest" href="/manifest.webmanifest">
@@ -167,7 +168,15 @@
   <script>
     const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
     const user = gun.user();
-    user.recall({ sessionStorage: true });
+    if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function') {
+      window.ScoreSystem.recallUserSession(user);
+    } else {
+      try {
+        user.recall({ sessionStorage: true, localStorage: true });
+      } catch (err) {
+        console.warn('Unable to recall user session', err);
+      }
+    }
 
     function ensureGuestId() {
       const legacyId = localStorage.getItem('userId');
@@ -247,7 +256,6 @@
     }
   </script>
 
-  <script src="score.js"></script>
   <script src="navbar.js"></script>
 
   <script>

--- a/navbar.js
+++ b/navbar.js
@@ -12,10 +12,14 @@ function aliasToDisplay(alias) {
 }
 
 function createNavbar() {
-  try {
-    user.recall({ sessionStorage: true });
-  } catch (err) {
-    console.warn('Unable to recall user session', err);
+  if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function') {
+    window.ScoreSystem.recallUserSession(user);
+  } else {
+    try {
+      user.recall({ sessionStorage: true, localStorage: true });
+    } catch (err) {
+      console.warn('Unable to recall user session', err);
+    }
   }
 
   const nav = document.createElement('div');

--- a/profile.html
+++ b/profile.html
@@ -127,6 +127,16 @@ const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
 const user = gun.user();
 const portalRoot = gun.get('3dvr-portal');
 
+if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function') {
+  window.ScoreSystem.recallUserSession(user);
+} else {
+  try {
+    user.recall({ sessionStorage: true, localStorage: true });
+  } catch (err) {
+    console.warn('Unable to recall user session', err);
+  }
+}
+
 let isSignedIn = localStorage.getItem('signedIn') === 'true';
 if (!isSignedIn && window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
   window.ScoreSystem.ensureGuestIdentity();
@@ -292,10 +302,14 @@ function initializeSignedInProfile() {
   guestStoredName = '';
   activeProfile = user;
 
-  try {
-    user.recall({ sessionStorage: true });
-  } catch (err) {
-    console.warn('Unable to recall user session', err);
+  if (!window.ScoreSystem || typeof window.ScoreSystem.recallUserSession !== 'function') {
+    try {
+      user.recall({ sessionStorage: true, localStorage: true });
+    } catch (err) {
+      console.warn('Unable to recall user session', err);
+    }
+  } else {
+    window.ScoreSystem.recallUserSession(user);
   }
 
   user.get('alias').on(value => {


### PR DESCRIPTION
## Summary
- add a shared helper in `score.js` to recall Gun sessions from both localStorage and sessionStorage with a safe fallback
- update the portal shell, profile, and navbar scripts to reuse the helper so installed PWAs retain the signed-in session
- align the contacts app with the same recall strategy to keep private spaces available across contexts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c478c1148320bb5606997db89fee