### PR TITLE
Make floating identity username link to profile

### DIFF
--- a/navbar.js
+++ b/navbar.js
@@ -26,8 +26,11 @@ function createNavbar() {
   nav.className = 'floating-identity';
   nav.setAttribute('aria-label', 'Account status');
 
-  const stats = document.createElement('div');
+  const stats = document.createElement('a');
   stats.className = 'floating-identity__stats';
+  stats.href = 'profile.html#profile';
+  stats.setAttribute('aria-label', 'View your profile details');
+  stats.title = 'Go to your profile';
 
   const usernameSpan = document.createElement('span');
   usernameSpan.className = 'floating-identity__label';

--- a/styles/global.css
+++ b/styles/global.css
@@ -186,6 +186,9 @@ body.theme-dark::after {
   flex-direction: column;
   gap: 0.25rem;
   font-size: 0.95rem;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 .floating-identity__label {
@@ -194,6 +197,11 @@ body.theme-dark::after {
 
 .floating-identity__value {
   opacity: 0.8;
+}
+
+.floating-identity__stats:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .floating-identity__button {


### PR DESCRIPTION
## Summary
- convert the floating identity username display into a link that targets the profile section
- tweak global styles so the identity link keeps its visual treatment while supporting focus outlines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5c6998a9c83209a1d983ddc94bdae