### PR TITLE
Refine chat page styling

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -8,190 +8,116 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="score.js"></script>
   <link rel="stylesheet" href="styles/global.css">
-  <style>
-    body {
-      font-family: 'Poppins', sans-serif;
-      background: #e9f0f5;
-      color: #222;
-      min-height: 100vh;
-      margin: 0;
-      padding: 20px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-
-    header {
-      text-align: center;
-      margin-bottom: 20px;
-    }
-
-    header h1 {
-      font-size: 2.5rem;
-      margin: 0;
-    }
-
-    header p {
-      color: #555;
-      font-size: 1.1rem;
-    }
-
-    #profile-mini {
-      background: #fff;
-      border-radius: 12px;
-      padding: 15px;
-      box-shadow: 0 4px 15px rgba(0,0,0,0.05);
-      text-align: center;
-      width: 100%;
-      max-width: 500px;
-      margin-bottom: 20px;
-    }
-
-    #notification-settings {
-      background: #fff;
-      border-radius: 12px;
-      padding: 15px;
-      box-shadow: 0 4px 15px rgba(0,0,0,0.05);
-      text-align: center;
-      width: 100%;
-      max-width: 500px;
-      margin-bottom: 20px;
-    }
-
-    #notification-settings button {
-      margin-top: 10px;
-    }
-
-    #notification-status {
-      display: block;
-      margin-top: 5px;
-      color: #555;
-      font-size: 0.95rem;
-    }
-
-    #room-select {
-      margin-bottom: 20px;
-      text-align: center;
-    }
-
-    #room-select select {
-      padding: 10px;
-      border-radius: 8px;
-      font-size: 1rem;
-    }
-
-    #new-message {
-      display: flex;
-      gap: 10px;
-      justify-content: center;
-      margin-bottom: 20px;
-      width: 100%;
-      max-width: 700px;
-    }
-
-    input[type="text"], button {
-      padding: 10px;
-      font-size: 1rem;
-      border-radius: 8px;
-      border: none;
-    }
-
-    input[type="text"] {
-      flex-grow: 1;
-    }
-
-    button {
-      background: #66c2b0;
-      color: white;
-      font-weight: bold;
-      cursor: pointer;
-      transition: 0.3s;
-    }
-
-    button:hover {
-      background: #5ca0d3;
-    }
-
-    #messages {
-      flex-grow: 1;
-      overflow-y: auto;
-      max-width: 700px;
-      width: 100%;
-    }
-
-    .message {
-      background: #ffffff;
-      border-radius: 12px;
-      padding: 15px;
-      margin-bottom: 10px;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.05);
-      color: #333;
-    }
-
-    .meta {
-      font-size: 0.8rem;
-      color: #888;
-      margin-top: 5px;
-    }
-
-    footer {
-      margin-top: 40px;
-      margin-bottom: 10px;
-      font-size: 0.8rem;
-      color: #888;
-      text-align: center;
-    }
-
-    footer a {
-      color: #5ca0d3;
-      text-decoration: underline;
-    }
-  </style>
+  <link rel="stylesheet" href="styles/chat.css">
 </head>
-<body>
+<body class="theme-dark chat-page">
+  <a class="skip-link" href="#chatMain">Skip to chat</a>
 
-<div class="top-buttons">
-  <a href="index.html">🏠 Portal Home</a>
-  <a href="profile.html">🧑 Profile</a>
-  <a href="https://3dvr.tech/#subscribe" target="_blank">⭐ Subscribe</a>
-  <a href="https://github.com/tmsteph/3dvr-portal" target="_blank">🚀 Contribute on GitHub</a>
-</div>
+  <div class="top-buttons" role="navigation" aria-label="3DVR quick links">
+    <a href="index.html">🏠 Portal Home</a>
+    <a href="profile.html">🧑 Profile</a>
+    <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">⭐ Subscribe</a>
+    <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">🚀 Contribute on GitHub</a>
+  </div>
 
-<header>
-  <h1>Group Chat</h1>
-  <p>💬 You earn <strong>+1 point</strong> for every message you send!</p>
-</header>
+  <main id="chatMain" class="chat-shell" aria-labelledby="chatTitle">
+    <header class="chat-hero">
+      <span class="chat-hero__eyebrow">Community Hub</span>
+      <h1 id="chatTitle">Group Chat</h1>
+      <p class="chat-hero__tagline">
+        Sync with the 3DVR community, share quick wins, and keep projects moving without missing a beat.
+      </p>
+      <div class="chat-hero__meta">
+        <span class="chat-hero__reward">💬 Earn <strong>+1 point</strong> for every message you send.</span>
+      </div>
+    </header>
 
-<div id="notification-settings">
-  <strong>🔔 Chat notifications</strong>
-  <span id="notification-status">Checking permissions…</span>
-  <button id="notification-toggle" onclick="toggleNotifications()">Enable Notifications</button>
-</div>
+    <section class="chat-layout">
+      <aside class="chat-sidebar" aria-label="Chat preferences">
+        <div id="notification-settings" class="chat-card chat-card--accent">
+          <div class="chat-card__header">
+            <span class="chat-card__eyebrow">Notifications</span>
+            <h2 class="chat-card__title">Stay in the loop</h2>
+          </div>
+          <p id="notification-status" class="chat-card__muted">Checking permissions…</p>
+          <button
+            id="notification-toggle"
+            class="chat-button"
+            type="button"
+            onclick="toggleNotifications()"
+          >Enable Notifications</button>
+        </div>
 
-<div id="profile-mini">
-  <p><strong>Username:</strong> <span id="current-username">Loading...</span></p>
-</div>
+        <div id="profile-mini" class="chat-card" aria-live="polite">
+          <div class="chat-card__header">
+            <span class="chat-card__eyebrow">Profile</span>
+            <h2 class="chat-card__title">Your identity</h2>
+          </div>
+          <p class="chat-card__muted">Signed in as</p>
+          <p class="chat-card__value"><span id="current-username">Loading...</span></p>
+          <p class="chat-card__hint">Visit your <a href="profile.html">profile</a> to update details.</p>
+        </div>
 
-<div id="room-select">
-  <label for="room">Select Room:</label>
-  <select id="room" onchange="changeRoom()">
-    <option value="general">🌎 General</option>
-    <option value="ideas">💡 Ideas</option>
-    <option value="support">🛟 Support</option>
-    <option value="random">🎲 Random</option>
-  </select>
-</div>
+        <div id="room-select" class="chat-card">
+          <div class="chat-card__header">
+            <span class="chat-card__eyebrow">Rooms</span>
+            <h2 class="chat-card__title">Choose a channel</h2>
+          </div>
+          <label class="chat-card__muted" for="room">Switch between focused conversations.</label>
+          <div class="chat-room-select">
+            <select id="room" onchange="changeRoom()">
+              <option value="general">🌎 General</option>
+              <option value="ideas">💡 Ideas</option>
+              <option value="support">🛟 Support</option>
+              <option value="random">🎲 Random</option>
+            </select>
+          </div>
+          <p id="room-description" class="chat-card__hint">All-hands updates and daily announcements.</p>
+        </div>
+      </aside>
 
-<div id="new-message">
-  <input type="text" id="message-input" placeholder="Type your message..." />
-  <button onclick="sendMessage()">Send</button>
-</div>
+      <section class="chat-main" aria-label="Chat messages">
+        <div class="chat-card chat-main__header">
+          <div class="chat-main__header-text">
+            <h2 class="chat-main__title">Now chatting</h2>
+            <p class="chat-main__room" id="active-room-name">#general</p>
+          </div>
+          <p class="chat-main__subtitle" id="active-room-description">All-hands updates and daily announcements.</p>
+        </div>
 
-<div id="messages"></div>
+        <div class="chat-card chat-main__body">
+          <div
+            id="messages"
+            class="chat-messages"
+            role="log"
+            aria-live="polite"
+            aria-relevant="additions"
+          ></div>
+          <form
+            id="new-message"
+            class="chat-composer"
+            onsubmit="sendMessage(); return false;"
+            aria-label="Send a message"
+          >
+            <label class="sr-only" for="message-input">Message</label>
+            <input
+              type="text"
+              id="message-input"
+              name="message"
+              placeholder="Type your message..."
+              autocomplete="off"
+              required
+            />
+            <button type="submit" class="chat-button chat-button--primary">Send</button>
+          </form>
+        </div>
+      </section>
+    </section>
+  </main>
 
-<footer>
-  3DVR.Tech &copy; 2025 - Open Web for Everyone | Visit <a href="https://3dvr.tech">3DVR.Tech</a> | <a href="https://github.com/tmsteph/3dvr-portal">Contribute on GitHub</a>
-</footer>
+  <footer class="chat-footer">
+    3DVR.Tech &copy; 2025 - Open Web for Everyone | Visit <a href="https://3dvr.tech">3DVR.Tech</a> | <a href="https://github.com/tmsteph/3dvr-portal">Contribute on GitHub</a>
+  </footer>
 
 <script>
 const gun = Gun([
@@ -209,6 +135,29 @@ const scoreManager = window.ScoreSystem && typeof window.ScoreSystem.getManager 
   : null;
 let currentRoom = 'general';
 let chat = gun.get('3dvr-chat').get(currentRoom);
+
+const activeRoomNameEl = document.getElementById('active-room-name');
+const activeRoomDescriptionEl = document.getElementById('active-room-description');
+const roomDescriptionEl = document.getElementById('room-description');
+const roomSelectEl = document.getElementById('room');
+const ROOM_DETAILS = {
+  general: {
+    label: '#general',
+    description: 'All-hands updates and daily announcements.'
+  },
+  ideas: {
+    label: '#ideas',
+    description: 'Brainstorm new concepts and pitch future experiments.'
+  },
+  support: {
+    label: '#support',
+    description: 'Request a hand, squash bugs, and keep teammates unblocked.'
+  },
+  random: {
+    label: '#random',
+    description: 'Celebrate wins, share memes, and connect between sprints.'
+  }
+};
 
 const notificationToggleButton = document.getElementById('notification-toggle');
 const notificationStatusText = document.getElementById('notification-status');
@@ -349,6 +298,22 @@ function fetchSenderUsername(senderId, handler) {
       handler(fallbackName || '');
     });
   });
+}
+
+function updateRoomUI(room) {
+  const details = ROOM_DETAILS[room] || {};
+  if (activeRoomNameEl) {
+    activeRoomNameEl.textContent = details.label || `#${room}`;
+  }
+  if (activeRoomDescriptionEl) {
+    activeRoomDescriptionEl.textContent = details.description || 'Chat with the community.';
+  }
+  if (roomDescriptionEl) {
+    roomDescriptionEl.textContent = details.description || 'Chat with the community.';
+  }
+  if (roomSelectEl && roomSelectEl.value !== room) {
+    roomSelectEl.value = room;
+  }
 }
 
 function loadNotificationState() {
@@ -724,6 +689,13 @@ function displayMessages() {
     msgDiv.innerHTML = `<div><strong>${username}:</strong> ${message.text}</div><div class="meta">${time}</div>`;
     messagesDiv.appendChild(msgDiv);
   }
+
+  if (!sorted.length) {
+    const emptyState = document.createElement('p');
+    emptyState.className = 'chat-empty';
+    emptyState.textContent = 'No messages yet. Start the conversation!';
+    messagesDiv.appendChild(emptyState);
+  }
 }
 
 function loadRoom(roomName) {
@@ -772,10 +744,13 @@ function loadRoom(roomName) {
 }
 
 function changeRoom() {
-  currentRoom = document.getElementById('room').value;
+  const select = roomSelectEl || document.getElementById('room');
+  currentRoom = select ? select.value : currentRoom;
+  updateRoomUI(currentRoom);
   loadRoom(currentRoom);
 }
 
+updateRoomUI(currentRoom);
 loadRoom(currentRoom);
 
 function initNotifications() {

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1,0 +1,413 @@
+body.chat-page {
+  position: relative;
+  min-height: 100vh;
+  padding: clamp(2rem, 4vw + 1rem, 4.5rem) 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.skip-link {
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: 0.75rem;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+  transform: translateY(-150%);
+  transition: transform var(--transition-base),
+    opacity var(--transition-base);
+  opacity: 0;
+  z-index: 12;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.chat-shell {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 100%);
+  display: grid;
+  gap: clamp(1.75rem, 2vw, 2.5rem);
+}
+
+.chat-hero {
+  display: grid;
+  gap: 1.25rem;
+  text-align: center;
+  padding: clamp(2.25rem, 4vw, 3rem);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: 0 30px 68px rgba(15, 23, 42, 0.35);
+}
+
+.chat-hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.26em;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.16);
+  color: rgba(226, 232, 240, 0.75);
+  width: fit-content;
+  margin: 0 auto;
+}
+
+.chat-hero__tagline {
+  margin: 0 auto;
+  max-width: 640px;
+  color: var(--color-text-muted);
+  font-size: 1.1rem;
+}
+
+.chat-hero__meta {
+  display: flex;
+  justify-content: center;
+}
+
+.chat-hero__reward {
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  background: rgba(34, 211, 238, 0.14);
+  border: 1px solid rgba(34, 211, 238, 0.32);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.chat-layout {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2rem);
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+}
+
+.chat-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.chat-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.chat-card {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  padding: 1.75rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: 0 24px 54px rgba(15, 23, 42, 0.28);
+}
+
+.chat-card--accent {
+  background: linear-gradient(155deg, rgba(34, 211, 238, 0.15), rgba(59, 130, 246, 0.08));
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: 0 36px 72px rgba(8, 17, 38, 0.45);
+}
+
+.chat-card__header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.chat-card__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.chat-card__title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.chat-card__muted {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.chat-card__value {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.chat-card__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.chat-card__hint a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.chat-room-select {
+  display: flex;
+  margin-top: 0.5rem;
+}
+
+.chat-room-select select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--color-text);
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.chat-room-select select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.chat-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform var(--transition-base),
+    box-shadow var(--transition-base),
+    background var(--transition-base),
+    border-color var(--transition-base),
+    color var(--transition-base);
+  color: var(--color-text);
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.chat-button:hover,
+.chat-button:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(148, 163, 184, 0.24);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.chat-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.chat-button--primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: rgba(37, 99, 235, 0.65);
+  box-shadow: 0 20px 40px rgba(14, 116, 144, 0.4);
+}
+
+.chat-button--primary:hover,
+.chat-button--primary:focus-visible {
+  background: var(--accent-strong);
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 28px 52px rgba(14, 116, 144, 0.52);
+}
+
+.chat-main__header {
+  gap: 0.75rem;
+}
+
+.chat-main__header-text {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.chat-main__title {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.chat-main__room {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.chat-main__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.chat-main__body {
+  gap: 1.25rem;
+}
+
+.chat-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: clamp(360px, 60vh, 520px);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.chat-messages::-webkit-scrollbar {
+  width: 0.55rem;
+}
+
+.chat-messages::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.25);
+  border-radius: 999px;
+}
+
+.chat-messages::-webkit-scrollbar-thumb {
+  background: rgba(56, 189, 248, 0.55);
+  border-radius: 999px;
+}
+
+.message {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  box-shadow: 0 16px 36px rgba(8, 17, 38, 0.35);
+}
+
+.message strong {
+  color: var(--accent);
+}
+
+.meta {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.chat-empty {
+  margin: 0;
+  padding: 2rem 1.5rem;
+  border-radius: var(--radius-md);
+  text-align: center;
+  background: rgba(15, 23, 42, 0.25);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.chat-composer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.chat-composer input[type="text"] {
+  flex: 1;
+  min-width: 220px;
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--color-text);
+  font-size: 1rem;
+  transition: border-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.chat-composer input[type="text"]::placeholder {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.chat-composer input[type="text"]:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.chat-footer {
+  width: min(1100px, 100%);
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.chat-footer a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+@media (max-width: 960px) {
+  .chat-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-sidebar {
+    order: 2;
+  }
+
+  .chat-main {
+    order: 1;
+  }
+}
+
+@media (max-width: 640px) {
+  body.chat-page {
+    padding: 1.75rem 1rem 3rem;
+  }
+
+  .chat-card {
+    padding: 1.5rem;
+  }
+
+  .chat-main__header-text {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chat-composer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .chat-composer input[type="text"] {
+    width: 100%;
+  }
+
+  .chat-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the chat page markup to mirror the landing experience and highlight navigation, notifications, and identity info
- add a dedicated chat stylesheet with gradient surfaces, responsive layout, and refreshed components that align with portal branding
- enhance chat scripts to keep room metadata in sync and surface an empty-state prompt when no messages are present

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8264031688320aff696c0f3e54928