### PR TITLE
Move chat composer above messages

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -86,13 +86,6 @@
         </div>
 
         <div class="chat-card chat-main__body">
-          <div
-            id="messages"
-            class="chat-messages"
-            role="log"
-            aria-live="polite"
-            aria-relevant="additions"
-          ></div>
           <form
             id="new-message"
             class="chat-composer"
@@ -110,6 +103,13 @@
             />
             <button type="submit" class="chat-button chat-button--primary">Send</button>
           </form>
+          <div
+            id="messages"
+            class="chat-messages"
+            role="log"
+            aria-live="polite"
+            aria-relevant="additions"
+          ></div>
         </div>
       </section>
     </section>


### PR DESCRIPTION
## Summary
- move the chat composer form ahead of the message log so the input appears directly under the "Now chatting" header

## Testing
- python3 -m http.server 4173 (manual)


------
https://chatgpt.com/codex/tasks/task_e_68d829f744008320b57eb74a892f2658