### PR TITLE
Add chat score display

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -29,6 +29,16 @@
       </p>
       <div class="chat-hero__meta">
         <span class="chat-hero__reward">💬 Earn <strong>+1 point</strong> for every message you send.</span>
+        <div
+          id="chat-score"
+          class="chat-hero__score"
+          role="status"
+          aria-live="polite"
+          aria-label="Your current score"
+        >
+          <span class="chat-hero__score-label">Your Score</span>
+          <span id="chat-score-value" class="chat-hero__score-value">0</span>
+        </div>
       </div>
     </header>
 
@@ -140,6 +150,8 @@ const activeRoomNameEl = document.getElementById('active-room-name');
 const activeRoomDescriptionEl = document.getElementById('active-room-description');
 const roomDescriptionEl = document.getElementById('room-description');
 const roomSelectEl = document.getElementById('room');
+const chatScoreContainer = document.getElementById('chat-score');
+const chatScoreValueEl = document.getElementById('chat-score-value');
 const ROOM_DETAILS = {
   general: {
     label: '#general',
@@ -158,6 +170,34 @@ const ROOM_DETAILS = {
     description: 'Celebrate wins, share memes, and connect between sprints.'
   }
 };
+
+function sanitizeScoreDisplay(value) {
+  if (window.ScoreSystem && typeof window.ScoreSystem.sanitizeScore === 'function') {
+    return window.ScoreSystem.sanitizeScore(value);
+  }
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.round(numeric));
+}
+
+function updateChatScoreDisplay(value) {
+  if (!chatScoreValueEl) {
+    return;
+  }
+  const safeScore = sanitizeScoreDisplay(value);
+  chatScoreValueEl.innerText = safeScore;
+  if (chatScoreContainer) {
+    chatScoreContainer.setAttribute('data-ready', 'true');
+  }
+}
+
+if (chatScoreContainer && chatScoreValueEl) {
+  if (scoreManager && typeof scoreManager.subscribe === 'function') {
+    scoreManager.subscribe(updateChatScoreDisplay);
+  } else {
+    updateChatScoreDisplay(0);
+  }
+}
 
 const notificationToggleButton = document.getElementById('notification-toggle');
 const notificationStatusText = document.getElementById('notification-status');

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -74,7 +74,36 @@ body.chat-page {
 
 .chat-hero__meta {
   display: flex;
+  align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.chat-hero__score {
+  display: grid;
+  gap: 0.2rem;
+  justify-items: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: var(--radius-md);
+  background: rgba(45, 212, 191, 0.18);
+  border: 1px solid rgba(45, 212, 191, 0.35);
+  box-shadow: 0 24px 42px rgba(4, 11, 24, 0.45);
+  text-align: center;
+  min-width: 180px;
+}
+
+.chat-hero__score-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.chat-hero__score-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #5eead4;
 }
 
 .chat-hero__reward {


### PR DESCRIPTION
## Summary
- add a score badge to the chat hero so members can see their progress immediately
- subscribe the badge to the shared score manager for live updates while chatting

## Testing
- Manual QA: Loaded chat.html locally


------
https://chatgpt.com/codex/tasks/task_e_68d82a89ab6c8320a8c79f7836e9bdd7