### PR TITLE
Add calendar hub prototype with calendar API proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you believe in empowering people to create together and own what they build �
 - **Realtime Group Chat:** Connect with the community and collaborate live.
 - **Task & Notes Apps:** Plan, discuss, and organize project work together.
 - **Mini Games & Demos:** Explore multiplayer-first coding through fun experiments.
+- **Calendar Hub (beta):** Connect Google and Outlook calendars using OAuth tokens and sync events in one place.
 - **Membership Support (coming soon):** Fund the platform and unlock rewards with our $20/month supporter plan.
 
 Everything is **100% open-source using HTML, CSS, and JS** — forkable, hackable, remixable.
@@ -63,3 +64,15 @@ You can sign up, join the chat, and start contributing right now — no download
 git clone https://github.com/tmsteph/3dvr-portal.git
 cd 3dvr-portal
 open index.html
+```
+
+### Calendar Hub developer preview
+
+The new calendar prototype lives at `calendar/index.html`. To experiment with Google or Outlook:
+
+1. Generate OAuth tokens using your own developer accounts (Google Cloud or Azure).
+2. Open the Calendar Hub page locally and paste the access tokens into the connection cards.
+3. Use the **Fetch events** button to call the lightweight proxy in `/api/calendar` and list your upcoming events.
+4. Use the **Create quick events** form to push meetings back to the connected provider.
+
+Tokens are stored in `localStorage` only, making it easy to iterate while you wire up a production-ready OAuth flow.

--- a/api/calendar/google.js
+++ b/api/calendar/google.js
@@ -1,0 +1,137 @@
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function validateIsoDate(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+async function listEvents(body) {
+  const accessToken = body.accessToken?.trim();
+  if (!accessToken) {
+    return { status: 400, payload: { error: 'Access token is required.' } };
+  }
+  const calendarId = body.calendarId?.trim() || 'primary';
+  const params = new URLSearchParams({
+    singleEvents: 'true',
+    orderBy: 'startTime'
+  });
+  if (body.timeMin) {
+    const timeMin = validateIsoDate(body.timeMin);
+    if (!timeMin) {
+      return { status: 400, payload: { error: 'Invalid timeMin value.' } };
+    }
+    params.set('timeMin', timeMin);
+  }
+  if (body.timeMax) {
+    const timeMax = validateIsoDate(body.timeMax);
+    if (!timeMax) {
+      return { status: 400, payload: { error: 'Invalid timeMax value.' } };
+    }
+    params.set('timeMax', timeMax);
+  }
+  if (body.maxResults) {
+    const limit = Math.min(Math.max(Number(body.maxResults) || 1, 1), 100);
+    params.set('maxResults', String(limit));
+  }
+  const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = data?.error?.message || 'Unable to load Google events.';
+    return { status: response.status, payload: { error } };
+  }
+  return {
+    status: 200,
+    payload: {
+      events: Array.isArray(data.items) ? data.items : [],
+      nextSyncToken: data.nextSyncToken || null
+    }
+  };
+}
+
+function prepareEventDates(start, end) {
+  const normalizedStart = validateIsoDate(start);
+  const normalizedEnd = validateIsoDate(end);
+  if (!normalizedStart || !normalizedEnd) {
+    return null;
+  }
+  if (new Date(normalizedEnd) <= new Date(normalizedStart)) {
+    return null;
+  }
+  return { start: normalizedStart, end: normalizedEnd };
+}
+
+async function createEvent(body) {
+  const accessToken = body.accessToken?.trim();
+  if (!accessToken) {
+    return { status: 400, payload: { error: 'Access token is required.' } };
+  }
+  const { start, end } = prepareEventDates(body.start, body.end) || {};
+  if (!start || !end) {
+    return { status: 400, payload: { error: 'Valid start and end datetimes are required.' } };
+  }
+  const calendarId = body.calendarId?.trim() || 'primary';
+  const eventPayload = {
+    summary: body.title || 'Untitled event',
+    description: body.description || '',
+    start: {
+      dateTime: start,
+      timeZone: body.timeZone || 'UTC'
+    },
+    end: {
+      dateTime: end,
+      timeZone: body.timeZone || 'UTC'
+    }
+  };
+  const response = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(eventPayload)
+    }
+  );
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = data?.error?.message || 'Unable to create Google event.';
+    return { status: response.status, payload: { error } };
+  }
+  return { status: 200, payload: { event: data } };
+}
+
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+  const action = req.body?.action;
+  try {
+    if (action === 'listEvents') {
+      const result = await listEvents(req.body || {});
+      return res.status(result.status).json(result.payload);
+    }
+    if (action === 'createEvent') {
+      const result = await createEvent(req.body || {});
+      return res.status(result.status).json(result.payload);
+    }
+    return res.status(400).json({ error: 'Unknown action.' });
+  } catch (err) {
+    console.error('Google calendar proxy error', err);
+    return res.status(500).json({ error: 'Unexpected server error.' });
+  }
+}

--- a/api/calendar/outlook.js
+++ b/api/calendar/outlook.js
@@ -1,0 +1,143 @@
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function validateIsoDate(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function prepareEventDates(start, end) {
+  const normalizedStart = validateIsoDate(start);
+  const normalizedEnd = validateIsoDate(end);
+  if (!normalizedStart || !normalizedEnd) {
+    return null;
+  }
+  if (new Date(normalizedEnd) <= new Date(normalizedStart)) {
+    return null;
+  }
+  return { start: normalizedStart, end: normalizedEnd };
+}
+
+function getBaseUrl(mailbox) {
+  const suffix = mailbox ? `users/${encodeURIComponent(mailbox)}` : 'me';
+  return `https://graph.microsoft.com/v1.0/${suffix}`;
+}
+
+async function listEvents(body) {
+  const accessToken = body.accessToken?.trim();
+  if (!accessToken) {
+    return { status: 400, payload: { error: 'Access token is required.' } };
+  }
+  const params = new URLSearchParams({
+    $orderby: 'start/dateTime'
+  });
+  if (body.maxResults) {
+    const limit = Math.min(Math.max(Number(body.maxResults) || 1, 1), 100);
+    params.set('$top', String(limit));
+  }
+  let url = `${getBaseUrl(body.mailbox?.trim())}/events`;
+  if (body.timeMin && body.timeMax) {
+    const start = validateIsoDate(body.timeMin);
+    const end = validateIsoDate(body.timeMax);
+    if (!start || !end) {
+      return { status: 400, payload: { error: 'Invalid time range provided.' } };
+    }
+    const rangeParams = new URLSearchParams({
+      startDateTime: start,
+      endDateTime: end
+    });
+    if (params.has('$top')) {
+      rangeParams.set('$top', params.get('$top'));
+    }
+    rangeParams.set('$orderby', 'start/dateTime');
+    url = `${getBaseUrl(body.mailbox?.trim())}/calendarView?${rangeParams.toString()}`;
+  } else if (params.toString()) {
+    url = `${url}?${params.toString()}`;
+  }
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = data?.error?.message || 'Unable to load Outlook events.';
+    return { status: response.status, payload: { error } };
+  }
+  return {
+    status: 200,
+    payload: {
+      events: Array.isArray(data.value) ? data.value : []
+    }
+  };
+}
+
+async function createEvent(body) {
+  const accessToken = body.accessToken?.trim();
+  if (!accessToken) {
+    return { status: 400, payload: { error: 'Access token is required.' } };
+  }
+  const range = prepareEventDates(body.start, body.end);
+  if (!range) {
+    return { status: 400, payload: { error: 'Valid start and end datetimes are required.' } };
+  }
+  const eventPayload = {
+    subject: body.title || 'Untitled event',
+    body: {
+      contentType: 'HTML',
+      content: body.description || ''
+    },
+    start: {
+      dateTime: range.start,
+      timeZone: body.timeZone || 'UTC'
+    },
+    end: {
+      dateTime: range.end,
+      timeZone: body.timeZone || 'UTC'
+    }
+  };
+  const response = await fetch(`${getBaseUrl(body.mailbox?.trim())}/events`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+      Prefer: `outlook.timezone="${body.timeZone || 'UTC'}"`
+    },
+    body: JSON.stringify(eventPayload)
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = data?.error?.message || 'Unable to create Outlook event.';
+    return { status: response.status, payload: { error } };
+  }
+  return { status: 200, payload: { event: data } };
+}
+
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+  const action = req.body?.action;
+  try {
+    if (action === 'listEvents') {
+      const result = await listEvents(req.body || {});
+      return res.status(result.status).json(result.payload);
+    }
+    if (action === 'createEvent') {
+      const result = await createEvent(req.body || {});
+      return res.status(result.status).json(result.payload);
+    }
+    return res.status(400).json({ error: 'Unknown action.' });
+  } catch (err) {
+    console.error('Outlook calendar proxy error', err);
+    return res.status(500).json({ error: 'Unexpected server error.' });
+  }
+}

--- a/calendar/calendar.css
+++ b/calendar/calendar.css
@@ -1,0 +1,363 @@
+:root {
+  --calendar-bg: #f3f6fb;
+  --calendar-surface: #ffffff;
+  --calendar-border: #d4deee;
+  --calendar-primary: #5ca0d3;
+  --calendar-primary-dark: #3f79a2;
+  --calendar-muted: #5f6c7b;
+  --calendar-radius: 16px;
+  --calendar-shadow: 0 20px 60px rgba(15, 46, 81, 0.08);
+}
+
+body {
+  background: radial-gradient(circle at top left, rgba(92, 160, 211, 0.25), transparent 50%),
+    radial-gradient(circle at top right, rgba(102, 194, 176, 0.2), transparent 45%),
+    var(--calendar-bg);
+  color: #141a26;
+  font-family: 'Poppins', sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  padding: 40px 20px 80px;
+}
+
+.calendar-header {
+  margin: 0 auto 40px;
+  max-width: 1100px;
+  text-align: center;
+}
+
+.calendar-header__back {
+  color: var(--calendar-primary-dark);
+  display: inline-block;
+  font-weight: 500;
+  margin-bottom: 10px;
+  text-decoration: none;
+}
+
+.calendar-header__title {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0;
+}
+
+.calendar-header__subtitle {
+  color: var(--calendar-muted);
+  font-size: 1.1rem;
+  margin: 10px auto 0;
+  max-width: 720px;
+}
+
+.calendar-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  margin: 0 auto;
+  max-width: 1100px;
+}
+
+.panel {
+  background: var(--calendar-surface);
+  border: 1px solid rgba(212, 222, 238, 0.6);
+  border-radius: var(--calendar-radius);
+  box-shadow: var(--calendar-shadow);
+  padding: 32px;
+}
+
+.panel__header {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.panel__intro {
+  color: var(--calendar-muted);
+  margin: 0;
+  max-width: 680px;
+}
+
+.connection-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.connection-card {
+  border: 1px solid rgba(212, 222, 238, 0.8);
+  border-radius: calc(var(--calendar-radius) - 6px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+}
+
+.connection-card__header {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.connection-card__status {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 6px 12px;
+}
+
+.connection-card__status[data-connected="false"] {
+  background: rgba(92, 160, 211, 0.1);
+  color: var(--calendar-primary-dark);
+}
+
+.connection-card__status[data-connected="true"] {
+  background: rgba(102, 194, 176, 0.2);
+  color: #166e5c;
+}
+
+.connection-card__form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.connection-card__actions {
+  display: flex;
+  gap: 10px;
+}
+
+.connection-card__details {
+  color: var(--calendar-muted);
+  font-size: 0.95rem;
+}
+
+.connection-card__details summary {
+  color: var(--calendar-primary-dark);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.connection-card__details ol {
+  margin: 12px 0 0 20px;
+  padding: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field__label {
+  color: #1b2433;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.field__help {
+  color: var(--calendar-muted);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+input,
+select,
+textarea,
+button {
+  border: 1px solid var(--calendar-border);
+  border-radius: 12px;
+  font-family: 'Poppins', sans-serif;
+  font-size: 1rem;
+  padding: 12px 14px;
+}
+
+textarea {
+  resize: vertical;
+}
+
+button {
+  background: var(--calendar-primary);
+  border: none;
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button:hover {
+  background: var(--calendar-primary-dark);
+  transform: translateY(-1px);
+}
+
+.button-secondary {
+  background: rgba(92, 160, 211, 0.12);
+  color: var(--calendar-primary-dark);
+}
+
+.button-secondary:hover {
+  background: rgba(92, 160, 211, 0.22);
+}
+
+.sync-controls {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.sync-controls__group {
+  border: 1px solid rgba(212, 222, 238, 0.8);
+  border-radius: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 0;
+  padding: 16px;
+}
+
+.sync-controls__group legend {
+  font-weight: 600;
+  padding: 0 6px;
+}
+
+.sync-controls__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.chip {
+  align-items: center;
+  background: rgba(92, 160, 211, 0.12);
+  border-radius: 999px;
+  color: var(--calendar-primary-dark);
+  cursor: pointer;
+  display: inline-flex;
+  font-weight: 600;
+  gap: 6px;
+  padding: 4px 14px;
+}
+
+.chip input {
+  accent-color: var(--calendar-primary);
+}
+
+.event-results {
+  border: 1px dashed rgba(212, 222, 238, 0.8);
+  border-radius: 14px;
+  margin-top: 24px;
+  min-height: 140px;
+  padding: 20px;
+}
+
+.event-results__empty {
+  color: var(--calendar-muted);
+  margin: 0;
+  text-align: center;
+}
+
+.event-results__list {
+  display: grid;
+  gap: 18px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.event-card {
+  background: rgba(92, 160, 211, 0.08);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 18px;
+}
+
+.event-card__header {
+  align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.event-card__provider {
+  background: rgba(92, 160, 211, 0.15);
+  border-radius: 999px;
+  color: var(--calendar-primary-dark);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  text-transform: uppercase;
+}
+
+.event-card__meta {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin: 0;
+}
+
+.event-card__meta dt {
+  color: var(--calendar-muted);
+  font-size: 0.8rem;
+  margin: 0 0 4px;
+  text-transform: uppercase;
+}
+
+.event-card__meta dd {
+  margin: 0;
+}
+
+.event-card__description {
+  color: #1f2d3d;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.event-card__link {
+  color: var(--calendar-primary-dark);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.event-card__link:hover {
+  text-decoration: underline;
+}
+
+.create-event-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.create-event-form__row {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.log {
+  background: rgba(20, 26, 38, 0.75);
+  border-radius: 14px;
+  color: white;
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.95rem;
+  margin-top: 18px;
+  padding: 16px;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 24px 16px 60px;
+  }
+
+  .panel {
+    padding: 24px;
+  }
+
+  .calendar-header__subtitle {
+    font-size: 1rem;
+  }
+}

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -1,0 +1,351 @@
+const PROVIDERS = {
+  google: {
+    label: 'Google Calendar',
+    storageKey: 'calendar.google.connection',
+    endpoint: '/api/calendar/google',
+    defaults: { calendarId: 'primary' }
+  },
+  outlook: {
+    label: 'Outlook',
+    storageKey: 'calendar.outlook.connection',
+    endpoint: '/api/calendar/outlook',
+    defaults: { mailbox: '' }
+  }
+};
+
+const state = {
+  connections: new Map()
+};
+
+const statusElements = new Map(
+  Array.from(document.querySelectorAll('[data-status]')).map(el => [el.dataset.status, el])
+);
+
+const eventList = document.querySelector('[data-event-list]');
+const emptyState = document.querySelector('[data-empty]');
+const logPanel = document.querySelector('[data-log]');
+const eventTemplate = document.getElementById('event-template');
+const syncForm = document.getElementById('event-sync-form');
+const createEventForm = document.getElementById('create-event-form');
+
+function readConnection(provider) {
+  const config = PROVIDERS[provider];
+  if (!config) return null;
+  try {
+    const stored = localStorage.getItem(config.storageKey);
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (!parsed.accessToken) return null;
+    return parsed;
+  } catch (err) {
+    console.warn('Unable to parse stored connection', provider, err);
+    return null;
+  }
+}
+
+function writeConnection(provider, payload) {
+  const config = PROVIDERS[provider];
+  if (!config) return;
+  const record = {
+    ...config.defaults,
+    ...payload,
+    updatedAt: new Date().toISOString()
+  };
+  localStorage.setItem(config.storageKey, JSON.stringify(record));
+  state.connections.set(provider, record);
+  updateStatus(provider, true);
+}
+
+function removeConnection(provider) {
+  const config = PROVIDERS[provider];
+  if (!config) return;
+  localStorage.removeItem(config.storageKey);
+  state.connections.delete(provider);
+  updateStatus(provider, false);
+}
+
+function updateStatus(provider, isConnected) {
+  const el = statusElements.get(provider);
+  if (!el) return;
+  el.dataset.connected = String(Boolean(isConnected));
+  el.textContent = isConnected ? 'Connected' : 'Disconnected';
+}
+
+function hydrateForms() {
+  Object.keys(PROVIDERS).forEach(provider => {
+    const form = document.querySelector(`form[data-provider="${provider}"]`);
+    if (!form) return;
+    const connection = state.connections.get(provider);
+    const config = PROVIDERS[provider];
+    const controls = new FormData(form);
+    controls.forEach((_, key) => {
+      const field = form.elements.namedItem(key);
+      if (!(field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement)) {
+        return;
+      }
+      if (connection && typeof connection[key] === 'string') {
+        field.value = connection[key];
+      } else if (config.defaults[key]) {
+        field.value = config.defaults[key];
+      } else {
+        field.value = '';
+      }
+    });
+  });
+}
+
+function hydrateState() {
+  state.connections.clear();
+  Object.keys(PROVIDERS).forEach(provider => {
+    const stored = readConnection(provider);
+    if (stored) {
+      state.connections.set(provider, stored);
+    }
+    updateStatus(provider, Boolean(stored));
+  });
+  hydrateForms();
+}
+
+function showLog(message, type = 'info') {
+  if (!logPanel) return;
+  const prefix = type === 'error' ? '⚠️' : type === 'success' ? '✅' : 'ℹ️';
+  logPanel.textContent = `${prefix} ${message}`;
+}
+
+function clearEvents() {
+  if (eventList) {
+    eventList.innerHTML = '';
+  }
+  if (emptyState) {
+    emptyState.hidden = false;
+  }
+}
+
+function renderEvents(provider, events = []) {
+  if (!eventList || !eventTemplate) return;
+  eventList.innerHTML = '';
+  const normalized = events.map(event => normalizeEvent(provider, event)).filter(Boolean);
+  if (!normalized.length) {
+    if (emptyState) {
+      emptyState.hidden = false;
+    }
+    return;
+  }
+  if (emptyState) {
+    emptyState.hidden = true;
+  }
+  normalized.forEach(entry => {
+    const fragment = eventTemplate.content.cloneNode(true);
+    fragment.querySelector('[data-field="title"]').textContent = entry.title;
+    fragment.querySelector('[data-field="provider"]').textContent = entry.providerLabel;
+    fragment.querySelector('[data-field="start"]').textContent = entry.start;
+    fragment.querySelector('[data-field="end"]').textContent = entry.end;
+    fragment.querySelector('[data-field="description"]').textContent = entry.description;
+    const link = fragment.querySelector('[data-field="link"]');
+    if (entry.link) {
+      link.href = entry.link;
+      link.hidden = false;
+    } else {
+      link.hidden = true;
+    }
+    eventList.appendChild(fragment);
+  });
+}
+
+function normalizeEvent(provider, raw) {
+  if (!raw) return null;
+  if (provider === 'google') {
+    const start = raw.start?.dateTime || raw.start?.date;
+    const end = raw.end?.dateTime || raw.end?.date;
+    return {
+      providerLabel: 'Google',
+      title: raw.summary || 'Untitled event',
+      description: raw.description || '',
+      start: formatDateTime(start),
+      end: formatDateTime(end),
+      link: raw.htmlLink || null
+    };
+  }
+  if (provider === 'outlook') {
+    return {
+      providerLabel: 'Outlook',
+      title: raw.subject || 'Untitled event',
+      description: raw.bodyPreview || '',
+      start: formatDateTime(raw.start?.dateTime, raw.start?.timeZone),
+      end: formatDateTime(raw.end?.dateTime, raw.end?.timeZone),
+      link: raw.webLink || null
+    };
+  }
+  return null;
+}
+
+function formatDateTime(value, timeZone) {
+  if (!value) return '—';
+  try {
+    const date = new Date(value);
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone
+    });
+    return formatter.format(date);
+  } catch (err) {
+    console.warn('Unable to format date', value, err);
+    return value;
+  }
+}
+
+async function callProvider(provider, payload) {
+  const config = PROVIDERS[provider];
+  if (!config) throw new Error('Unknown provider');
+  const response = await fetch(config.endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const message = data?.error || data?.message || 'Request failed';
+    throw new Error(message);
+  }
+  return data;
+}
+
+function getSelectedProvider() {
+  const formData = new FormData(syncForm);
+  return formData.get('provider') || 'google';
+}
+
+function getConnectionOrWarn(provider) {
+  const connection = state.connections.get(provider);
+  if (!connection) {
+    showLog(`${PROVIDERS[provider].label} is not connected yet. Save a token first.`, 'error');
+    return null;
+  }
+  return connection;
+}
+
+async function handleFetchEvents() {
+  const provider = getSelectedProvider();
+  const connection = getConnectionOrWarn(provider);
+  if (!connection) {
+    clearEvents();
+    return;
+  }
+  const params = new FormData(syncForm);
+  const payload = {
+    action: 'listEvents',
+    accessToken: connection.accessToken
+  };
+  if (provider === 'google') {
+    payload.calendarId = connection.calendarId || PROVIDERS.google.defaults.calendarId;
+  }
+  if (provider === 'outlook' && connection.mailbox) {
+    payload.mailbox = connection.mailbox;
+  }
+  const timeMin = params.get('timeMin');
+  const timeMax = params.get('timeMax');
+  const maxResults = params.get('maxResults');
+  if (timeMin) payload.timeMin = new Date(timeMin).toISOString();
+  if (timeMax) payload.timeMax = new Date(timeMax).toISOString();
+  if (maxResults) payload.maxResults = Number(maxResults);
+  try {
+    showLog(`Fetching ${PROVIDERS[provider].label} events…`);
+    const data = await callProvider(provider, payload);
+    renderEvents(provider, data.events || []);
+    showLog(`Loaded ${data.events?.length || 0} events from ${PROVIDERS[provider].label}.`, 'success');
+  } catch (err) {
+    clearEvents();
+    showLog(err.message || 'Unable to fetch events.', 'error');
+  }
+}
+
+async function handleCreateEvent(event) {
+  event.preventDefault();
+  const formData = new FormData(createEventForm);
+  const provider = formData.get('provider');
+  const connection = getConnectionOrWarn(provider);
+  if (!connection) {
+    return;
+  }
+  const payload = {
+    action: 'createEvent',
+    accessToken: connection.accessToken,
+    title: formData.get('title'),
+    description: formData.get('description'),
+    start: formData.get('start'),
+    end: formData.get('end'),
+    timeZone: formData.get('timeZone') || 'UTC'
+  };
+  if (!payload.title || !payload.start || !payload.end) {
+    showLog('Please provide a title, start, and end time.', 'error');
+    return;
+  }
+  if (provider === 'google') {
+    payload.calendarId = connection.calendarId || PROVIDERS.google.defaults.calendarId;
+  }
+  if (provider === 'outlook' && connection.mailbox) {
+    payload.mailbox = connection.mailbox;
+  }
+  try {
+    showLog(`Creating event in ${PROVIDERS[provider].label}…`);
+    const result = await callProvider(provider, payload);
+    showLog(`Event created successfully (${result.event?.id || 'no id returned'}).`, 'success');
+    createEventForm.reset();
+  } catch (err) {
+    showLog(err.message || 'Unable to create event.', 'error');
+  }
+}
+
+function onConnectionSubmit(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const provider = form.dataset.provider;
+  const formData = new FormData(form);
+  const accessToken = formData.get('accessToken')?.trim();
+  if (!accessToken) {
+    showLog('Access token is required.', 'error');
+    return;
+  }
+  const record = { accessToken };
+  if (provider === 'google') {
+    record.calendarId = formData.get('calendarId')?.trim() || PROVIDERS.google.defaults.calendarId;
+  }
+  if (provider === 'outlook') {
+    record.mailbox = formData.get('mailbox')?.trim();
+  }
+  writeConnection(provider, record);
+  showLog(`${PROVIDERS[provider].label} connection stored locally.`, 'success');
+}
+
+function handleDisconnect(event) {
+  const button = event.currentTarget;
+  const provider = button.dataset.provider;
+  removeConnection(provider);
+  const form = document.querySelector(`form[data-provider="${provider}"]`);
+  if (form) {
+    form.reset();
+  }
+  hydrateForms();
+  showLog(`${PROVIDERS[provider].label} tokens removed from this browser.`, 'info');
+}
+
+function bindEvents() {
+  document
+    .querySelectorAll('.connection-card__form')
+    .forEach(form => form.addEventListener('submit', onConnectionSubmit));
+
+  document
+    .querySelectorAll('button[data-action="disconnect"]')
+    .forEach(button => button.addEventListener('click', handleDisconnect));
+
+  syncForm.querySelector('[data-action="fetch-events"]').addEventListener('click', handleFetchEvents);
+  syncForm.querySelector('[data-action="refresh-status"]').addEventListener('click', hydrateState);
+  createEventForm.addEventListener('submit', handleCreateEvent);
+}
+
+hydrateState();
+bindEvents();
+clearEvents();
+showLog('Ready to connect a provider and sync events.');

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3DVR Portal – Calendar Hub</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="calendar.css">
+</head>
+<body>
+  <header class="calendar-header">
+    <a class="calendar-header__back" href="../index.html">⬅ Back to Portal</a>
+    <h1 class="calendar-header__title">Calendar Hub</h1>
+    <p class="calendar-header__subtitle">
+      Connect your Google and Outlook calendars, manage events, and keep your schedule in sync.
+    </p>
+  </header>
+
+  <main class="calendar-shell">
+    <section class="panel" aria-labelledby="connections-title">
+      <div class="panel__header">
+        <h2 id="connections-title">Account Connections</h2>
+        <p class="panel__intro">
+          Authenticate with Google or Outlook using OAuth and paste the access token below. We store the
+          values locally so you can quickly reconnect while developing the integration.
+        </p>
+      </div>
+
+      <div class="connection-grid">
+        <article class="connection-card" aria-labelledby="google-connection-title">
+          <div class="connection-card__header">
+            <h3 id="google-connection-title">Google Calendar</h3>
+            <span class="connection-card__status" data-status="google">Disconnected</span>
+          </div>
+          <form class="connection-card__form" data-provider="google">
+            <label class="field">
+              <span class="field__label">Access token</span>
+              <textarea name="accessToken" rows="3" required placeholder="ya29.a0AWY..." aria-describedby="google-token-help"></textarea>
+            </label>
+            <label class="field">
+              <span class="field__label">Calendar ID (optional)</span>
+              <input type="text" name="calendarId" placeholder="primary">
+            </label>
+            <p class="field__help" id="google-token-help">
+              Generate tokens via Google OAuth 2.0. Use a test project and enable the Calendar API. Tokens
+              are saved in your browser only.
+            </p>
+            <div class="connection-card__actions">
+              <button type="submit">Save connection</button>
+              <button type="button" class="button-secondary" data-action="disconnect" data-provider="google">Disconnect</button>
+            </div>
+          </form>
+          <details class="connection-card__details">
+            <summary>Need help?</summary>
+            <ol>
+              <li>Create an OAuth 2.0 client in the Google Cloud console.</li>
+              <li>Authorize the playground or your dev app with the <code>https://www.googleapis.com/auth/calendar</code> scope.</li>
+              <li>Paste the returned <strong>access_token</strong> here. Refresh tokens can be rotated manually for now.</li>
+            </ol>
+          </details>
+        </article>
+
+        <article class="connection-card" aria-labelledby="outlook-connection-title">
+          <div class="connection-card__header">
+            <h3 id="outlook-connection-title">Outlook / Microsoft 365</h3>
+            <span class="connection-card__status" data-status="outlook">Disconnected</span>
+          </div>
+          <form class="connection-card__form" data-provider="outlook">
+            <label class="field">
+              <span class="field__label">Access token</span>
+              <textarea name="accessToken" rows="3" required placeholder="EwBwA8l6B..." aria-describedby="outlook-token-help"></textarea>
+            </label>
+            <label class="field">
+              <span class="field__label">Mailbox (optional)</span>
+              <input type="email" name="mailbox" placeholder="user@contoso.com">
+            </label>
+            <p class="field__help" id="outlook-token-help">
+              Create an Azure AD app registration with Calendars.ReadWrite delegated permissions and paste the
+              access token here. Microsoft Graph endpoints are proxied through our API folder.
+            </p>
+            <div class="connection-card__actions">
+              <button type="submit">Save connection</button>
+              <button type="button" class="button-secondary" data-action="disconnect" data-provider="outlook">Disconnect</button>
+            </div>
+          </form>
+          <details class="connection-card__details">
+            <summary>Need help?</summary>
+            <ol>
+              <li>Register a single-page application in Azure.</li>
+              <li>Grant delegated permissions for <code>Calendars.ReadWrite</code> and <code>offline_access</code>.</li>
+              <li>Use the OAuth 2.0 authorization code flow to fetch tokens, then paste the <strong>access_token</strong> here.</li>
+            </ol>
+          </details>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel" aria-labelledby="event-sync-title">
+      <div class="panel__header">
+        <h2 id="event-sync-title">Event Sync</h2>
+        <p class="panel__intro">
+          Fetch events from connected providers and push new ones back. Choose a provider below to get
+          started.
+        </p>
+      </div>
+
+      <form class="sync-controls" id="event-sync-form">
+        <fieldset class="sync-controls__group">
+          <legend>Provider</legend>
+          <label class="chip">
+            <input type="radio" name="provider" value="google" checked>
+            <span>Google</span>
+          </label>
+          <label class="chip">
+            <input type="radio" name="provider" value="outlook">
+            <span>Outlook</span>
+          </label>
+        </fieldset>
+
+        <fieldset class="sync-controls__group">
+          <legend>Time range</legend>
+          <label class="field">
+            <span class="field__label">From</span>
+            <input type="datetime-local" name="timeMin">
+          </label>
+          <label class="field">
+            <span class="field__label">To</span>
+            <input type="datetime-local" name="timeMax">
+          </label>
+          <label class="field">
+            <span class="field__label">Max events</span>
+            <input type="number" name="maxResults" min="1" max="100" value="20">
+          </label>
+        </fieldset>
+
+        <div class="sync-controls__actions">
+          <button type="button" data-action="fetch-events">Fetch events</button>
+          <button type="button" data-action="refresh-status">Refresh status</button>
+        </div>
+      </form>
+
+      <div class="event-results" aria-live="polite">
+        <div class="event-results__empty" data-empty>
+          <p>No events yet. Fetch from Google or Outlook to preview them here.</p>
+        </div>
+        <ul class="event-results__list" data-event-list></ul>
+      </div>
+    </section>
+
+    <section class="panel" aria-labelledby="create-event-title">
+      <div class="panel__header">
+        <h2 id="create-event-title">Create quick events</h2>
+        <p class="panel__intro">
+          Use the form below to push a single event to the selected provider. We will use the stored access token
+          when calling our lightweight API proxy.
+        </p>
+      </div>
+
+      <form class="create-event-form" id="create-event-form">
+        <div class="create-event-form__row">
+          <label class="field">
+            <span class="field__label">Title</span>
+            <input type="text" name="title" required placeholder="Sprint planning">
+          </label>
+          <label class="field">
+            <span class="field__label">Provider</span>
+            <select name="provider">
+              <option value="google">Google</option>
+              <option value="outlook">Outlook</option>
+            </select>
+          </label>
+        </div>
+        <div class="create-event-form__row">
+          <label class="field">
+            <span class="field__label">Start</span>
+            <input type="datetime-local" name="start" required>
+          </label>
+          <label class="field">
+            <span class="field__label">End</span>
+            <input type="datetime-local" name="end" required>
+          </label>
+          <label class="field">
+            <span class="field__label">Timezone</span>
+            <input type="text" name="timeZone" value="UTC" required>
+          </label>
+        </div>
+        <label class="field">
+          <span class="field__label">Description</span>
+          <textarea name="description" rows="3" placeholder="Add agenda and dial-in details"></textarea>
+        </label>
+        <button type="submit">Create event</button>
+      </form>
+
+      <div class="log" aria-live="polite" data-log></div>
+    </section>
+  </main>
+
+  <template id="event-template">
+    <li class="event-card">
+      <div class="event-card__header">
+        <h3 data-field="title"></h3>
+        <span class="event-card__provider" data-field="provider"></span>
+      </div>
+      <dl class="event-card__meta">
+        <div>
+          <dt>Starts</dt>
+          <dd data-field="start"></dd>
+        </div>
+        <div>
+          <dt>Ends</dt>
+          <dd data-field="end"></dd>
+        </div>
+      </dl>
+      <p class="event-card__description" data-field="description"></p>
+      <a class="event-card__link" data-field="link" href="#" target="_blank" rel="noreferrer noopener">Open in calendar</a>
+    </li>
+  </template>
+
+  <script src="calendar.js" type="module"></script>
+</body>
+</html>

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -7,8 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../styles/global.css">
-  <link rel="stylesheet" href="calendar.css">
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="/calendar/calendar.css">
 </head>
 <body>
   <header class="calendar-header">
@@ -219,6 +219,6 @@
     </li>
   </template>
 
-  <script src="calendar.js" type="module"></script>
+  <script src="/calendar/calendar.js" type="module"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -96,6 +96,11 @@
             <span class="app-card__title">Tasks</span>
             <span class="app-card__meta">Plan, assign, and celebrate team wins.</span>
           </a>
+          <a href="calendar/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">📅</span>
+            <span class="app-card__title">Calendar</span>
+            <span class="app-card__meta">Connect Google or Outlook and manage events.</span>
+          </a>
           <a href="games.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🎮</span>
             <span class="app-card__title">Games</span>


### PR DESCRIPTION
## Summary
- add a Calendar Hub workspace that lets users connect Google or Outlook calendars and manage events
- style the new page with a dedicated theme and build client-side logic for storing tokens and syncing events
- add Google Calendar and Microsoft Graph proxy endpoints plus README guidance for testing the developer preview

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82c75b9ec83209ab3c8c4d4b0f2c6