### PR TITLE
feat: make calendar local-first

### DIFF
--- a/calendar/calendar.css
+++ b/calendar/calendar.css
@@ -325,6 +325,18 @@ button:hover {
   text-decoration: underline;
 }
 
+.event-card__footer {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.event-card__delete {
+  font-size: 0.9rem;
+  padding: 10px 16px;
+}
+
 .create-event-form {
   display: flex;
   flex-direction: column;
@@ -335,6 +347,28 @@ button:hover {
   display: grid;
   gap: 18px;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.create-event-form__sync {
+  border: 1px solid rgba(212, 222, 238, 0.8);
+  border-radius: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 0;
+  padding: 16px;
+}
+
+.create-event-form__sync legend {
+  font-weight: 600;
+  padding: 0 6px;
+}
+
+.create-event-form__sync p {
+  color: var(--calendar-muted);
+  flex-basis: 100%;
+  font-size: 0.9rem;
+  margin: 0;
 }
 
 .log {

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -13,8 +13,18 @@ const PROVIDERS = {
   }
 };
 
+const LOCAL_EVENTS_KEY = 'calendar.local.events';
+const PROVIDER_LABELS = {
+  local: 'Local',
+  google: 'Google',
+  outlook: 'Outlook'
+};
+
+const DEFAULT_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 const state = {
-  connections: new Map()
+  connections: new Map(),
+  localEvents: []
 };
 
 const statusElements = new Map(
@@ -113,19 +123,93 @@ function showLog(message, type = 'info') {
   logPanel.textContent = `${prefix} ${message}`;
 }
 
-function clearEvents() {
-  if (eventList) {
-    eventList.innerHTML = '';
+function parseEventDate(value) {
+  if (!value) return Number.MAX_SAFE_INTEGER;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
+}
+
+function normalizeStoredEvent(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
   }
-  if (emptyState) {
-    emptyState.hidden = false;
+  const provider = raw.provider === 'google' || raw.provider === 'outlook' ? raw.provider : 'local';
+  const now = new Date().toISOString();
+  const base = {
+    id: typeof raw.id === 'string' ? raw.id : generateLocalId(provider),
+    provider,
+    title: typeof raw.title === 'string' && raw.title.trim() ? raw.title.trim() : 'Untitled event',
+    description: typeof raw.description === 'string' ? raw.description : '',
+    start: typeof raw.start === 'string' ? raw.start : raw.start === null ? null : '',
+    end: typeof raw.end === 'string' ? raw.end : raw.end === null ? null : '',
+    timeZone: typeof raw.timeZone === 'string' ? raw.timeZone : '',
+    link: typeof raw.link === 'string' ? raw.link : '',
+    metadata: raw.metadata && typeof raw.metadata === 'object' ? raw.metadata : {},
+    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : now,
+    updatedAt: typeof raw.updatedAt === 'string' ? raw.updatedAt : now
+  };
+  return base;
+}
+
+function sortEvents(events) {
+  return events
+    .slice()
+    .sort((a, b) => {
+      const startA = parseEventDate(a.start);
+      const startB = parseEventDate(b.start);
+      if (startA !== startB) {
+        return startA - startB;
+      }
+      return a.title.localeCompare(b.title);
+    });
+}
+
+function readLocalEvents() {
+  try {
+    const stored = localStorage.getItem(LOCAL_EVENTS_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map(normalizeStoredEvent)
+      .filter(Boolean);
+  } catch (err) {
+    console.warn('Unable to parse local events', err);
+    return [];
   }
 }
 
-function renderEvents(provider, events = []) {
+function writeLocalEvents(events) {
+  const normalized = Array.isArray(events)
+    ? events.map(normalizeStoredEvent).filter(Boolean)
+    : [];
+  const sorted = sortEvents(normalized);
+  state.localEvents = sorted;
+  try {
+    localStorage.setItem(LOCAL_EVENTS_KEY, JSON.stringify(sorted));
+  } catch (err) {
+    console.warn('Unable to persist local events', err);
+  }
+  renderEvents();
+}
+
+function hydrateLocalEvents() {
+  const events = sortEvents(readLocalEvents());
+  state.localEvents = events;
+  renderEvents();
+}
+
+function withTimeZoneLabel(text, timeZone) {
+  if (!timeZone || !text || text === '—') {
+    return text;
+  }
+  return `${text} (${timeZone})`;
+}
+
+function renderEvents(events = state.localEvents) {
   if (!eventList || !eventTemplate) return;
   eventList.innerHTML = '';
-  const normalized = events.map(event => normalizeEvent(provider, event)).filter(Boolean);
+  const normalized = events.map(normalizeEvent).filter(Boolean);
   if (!normalized.length) {
     if (emptyState) {
       emptyState.hidden = false;
@@ -143,47 +227,61 @@ function renderEvents(provider, events = []) {
     fragment.querySelector('[data-field="end"]').textContent = entry.end;
     fragment.querySelector('[data-field="description"]').textContent = entry.description;
     const link = fragment.querySelector('[data-field="link"]');
-    if (entry.link) {
-      link.href = entry.link;
-      link.hidden = false;
-    } else {
-      link.hidden = true;
+    if (link) {
+      if (entry.link) {
+        link.href = entry.link;
+        link.hidden = false;
+      } else {
+        link.hidden = true;
+      }
+    }
+    const deleteButton = fragment.querySelector('[data-action="delete-event"]');
+    if (deleteButton) {
+      deleteButton.dataset.eventId = entry.id;
     }
     eventList.appendChild(fragment);
   });
 }
 
-function normalizeEvent(provider, raw) {
-  if (!raw) return null;
-  if (provider === 'google') {
-    const start = raw.start?.dateTime || raw.start?.date;
-    const end = raw.end?.dateTime || raw.end?.date;
-    return {
-      providerLabel: 'Google',
-      title: raw.summary || 'Untitled event',
-      description: raw.description || '',
-      start: formatDateTime(start),
-      end: formatDateTime(end),
-      link: raw.htmlLink || null
-    };
+function normalizeEvent(entry) {
+  if (!entry) return null;
+  const provider = typeof entry.provider === 'string' ? entry.provider : 'local';
+  const baseLabel = PROVIDER_LABELS[provider] || PROVIDER_LABELS.local;
+  const syncedProviders = Array.isArray(entry.metadata?.syncedProviders)
+    ? entry.metadata.syncedProviders
+    : [];
+  let providerLabel = baseLabel;
+  if (provider === 'local' && syncedProviders.length) {
+    const syncedLabels = syncedProviders
+      .map(key => PROVIDER_LABELS[key] || key)
+      .join(', ');
+    providerLabel = `${baseLabel} • Synced to ${syncedLabels}`;
+  } else if (provider !== 'local') {
+    providerLabel = `${baseLabel} • Imported`;
   }
-  if (provider === 'outlook') {
-    return {
-      providerLabel: 'Outlook',
-      title: raw.subject || 'Untitled event',
-      description: raw.bodyPreview || '',
-      start: formatDateTime(raw.start?.dateTime, raw.start?.timeZone),
-      end: formatDateTime(raw.end?.dateTime, raw.end?.timeZone),
-      link: raw.webLink || null
-    };
-  }
-  return null;
+  const title = entry.title || 'Untitled event';
+  const description = entry.description || '';
+  const start = withTimeZoneLabel(formatDateTime(entry.start, entry.timeZone), entry.timeZone);
+  const end = withTimeZoneLabel(formatDateTime(entry.end, entry.timeZone), entry.timeZone);
+  return {
+    id: entry.id,
+    provider,
+    providerLabel,
+    title,
+    description,
+    start,
+    end,
+    link: entry.link || ''
+  };
 }
 
 function formatDateTime(value, timeZone) {
   if (!value) return '—';
   try {
     const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
     const formatter = new Intl.DateTimeFormat(undefined, {
       dateStyle: 'medium',
       timeStyle: 'short',
@@ -192,7 +290,7 @@ function formatDateTime(value, timeZone) {
     return formatter.format(date);
   } catch (err) {
     console.warn('Unable to format date', value, err);
-    return value;
+    return '—';
   }
 }
 
@@ -213,6 +311,7 @@ async function callProvider(provider, payload) {
 }
 
 function getSelectedProvider() {
+  if (!syncForm) return 'google';
   const formData = new FormData(syncForm);
   return formData.get('provider') || 'google';
 }
@@ -226,11 +325,103 @@ function getConnectionOrWarn(provider) {
   return connection;
 }
 
+function toISOStringIfPossible(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function generateLocalId(prefix = 'local') {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return `${prefix}:${crypto.randomUUID()}`;
+  }
+  return `${prefix}:${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function mapRemoteEvent(provider, raw) {
+  if (!raw) return null;
+  if (provider === 'google') {
+    const start = raw.start?.dateTime || raw.start?.date;
+    const end = raw.end?.dateTime || raw.end?.date;
+    const timeZone = raw.start?.timeZone || raw.end?.timeZone || '';
+    return {
+      id: `remote:${provider}:${raw.id || `${start || ''}:${end || ''}`}`,
+      provider,
+      title: raw.summary || 'Untitled event',
+      description: raw.description || '',
+      start: toISOStringIfPossible(start),
+      end: toISOStringIfPossible(end),
+      timeZone,
+      link: raw.htmlLink || '',
+      metadata: {
+        remoteId: raw.id || null
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+  }
+  if (provider === 'outlook') {
+    const start = raw.start?.dateTime;
+    const end = raw.end?.dateTime;
+    const timeZone = raw.start?.timeZone || raw.end?.timeZone || '';
+    return {
+      id: `remote:${provider}:${raw.id || `${start || ''}:${end || ''}`}`,
+      provider,
+      title: raw.subject || 'Untitled event',
+      description: raw.bodyPreview || '',
+      start: toISOStringIfPossible(start),
+      end: toISOStringIfPossible(end),
+      timeZone,
+      link: raw.webLink || '',
+      metadata: {
+        remoteId: raw.id || null
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+  }
+  return null;
+}
+
+function importRemoteEvents(provider, events = []) {
+  if (!Array.isArray(events) || !events.length) {
+    return { added: 0, updated: 0, total: 0 };
+  }
+  const list = [...state.localEvents];
+  let added = 0;
+  let updated = 0;
+  events.forEach(raw => {
+    const mapped = mapRemoteEvent(provider, raw);
+    if (!mapped) {
+      return;
+    }
+    const index = list.findIndex(item => item.id === mapped.id);
+    if (index === -1) {
+      list.push(mapped);
+      added += 1;
+    } else {
+      list[index] = {
+        ...list[index],
+        ...mapped,
+        updatedAt: new Date().toISOString()
+      };
+      updated += 1;
+    }
+  });
+  if (added || updated) {
+    writeLocalEvents(list);
+  } else {
+    renderEvents();
+  }
+  return { added, updated, total: added + updated };
+}
+
 async function handleFetchEvents() {
+  if (!syncForm) return;
   const provider = getSelectedProvider();
   const connection = getConnectionOrWarn(provider);
   if (!connection) {
-    clearEvents();
     return;
   }
   const params = new FormData(syncForm);
@@ -251,51 +442,193 @@ async function handleFetchEvents() {
   if (timeMax) payload.timeMax = new Date(timeMax).toISOString();
   if (maxResults) payload.maxResults = Number(maxResults);
   try {
-    showLog(`Fetching ${PROVIDERS[provider].label} events…`);
+    showLog(`Importing events from ${PROVIDERS[provider].label}…`);
     const data = await callProvider(provider, payload);
-    renderEvents(provider, data.events || []);
-    showLog(`Loaded ${data.events?.length || 0} events from ${PROVIDERS[provider].label}.`, 'success');
+    const imported = importRemoteEvents(provider, data.events || []);
+    if (!imported.total) {
+      showLog(`No new events from ${PROVIDERS[provider].label}.`, 'info');
+      return;
+    }
+    const summary = [];
+    if (imported.added) summary.push(`${imported.added} new`);
+    if (imported.updated) summary.push(`${imported.updated} updated`);
+    const detail = summary.join(' and ');
+    showLog(`Imported ${detail} event${imported.total === 1 ? '' : 's'} from ${PROVIDERS[provider].label}.`, 'success');
   } catch (err) {
-    clearEvents();
-    showLog(err.message || 'Unable to fetch events.', 'error');
+    showLog(err.message || 'Unable to import events.', 'error');
+  }
+}
+
+function updateLocalEvent(eventId, patch) {
+  const list = state.localEvents.map(entry => {
+    if (entry.id !== eventId) {
+      return entry;
+    }
+    const mergedMetadata = {
+      ...(entry.metadata && typeof entry.metadata === 'object' ? entry.metadata : {}),
+      ...(patch.metadata || {})
+    };
+    return {
+      ...entry,
+      ...patch,
+      metadata: mergedMetadata,
+      updatedAt: new Date().toISOString()
+    };
+  });
+  writeLocalEvents(list);
+}
+
+function deleteLocalEvent(id) {
+  if (!id) return;
+  const remaining = state.localEvents.filter(event => event.id !== id);
+  if (remaining.length === state.localEvents.length) {
+    return;
+  }
+  writeLocalEvents(remaining);
+  showLog('Event removed from your local calendar.', 'info');
+}
+
+function handleEventListClick(event) {
+  const button = event.target.closest('button[data-action="delete-event"]');
+  if (!button) return;
+  const { eventId } = button.dataset;
+  if (eventId) {
+    deleteLocalEvent(eventId);
   }
 }
 
 async function handleCreateEvent(event) {
   event.preventDefault();
+  if (!createEventForm) return;
   const formData = new FormData(createEventForm);
-  const provider = formData.get('provider');
-  const connection = getConnectionOrWarn(provider);
-  if (!connection) {
-    return;
-  }
-  const payload = {
-    action: 'createEvent',
-    accessToken: connection.accessToken,
-    title: formData.get('title'),
-    description: formData.get('description'),
-    start: formData.get('start'),
-    end: formData.get('end'),
-    timeZone: formData.get('timeZone') || 'UTC'
-  };
-  if (!payload.title || !payload.start || !payload.end) {
+  const title = formData.get('title')?.toString().trim();
+  const startValue = formData.get('start')?.toString();
+  const endValue = formData.get('end')?.toString();
+  const timeZone = formData.get('timeZone')?.toString().trim() || DEFAULT_TIME_ZONE || 'UTC';
+  const description = formData.get('description')?.toString().trim() || '';
+
+  if (!title || !startValue || !endValue) {
     showLog('Please provide a title, start, and end time.', 'error');
     return;
   }
-  if (provider === 'google') {
-    payload.calendarId = connection.calendarId || PROVIDERS.google.defaults.calendarId;
+
+  const start = toISOStringIfPossible(startValue);
+  const end = toISOStringIfPossible(endValue);
+  if (!start || !end) {
+    showLog('Please provide valid start and end times.', 'error');
+    return;
   }
-  if (provider === 'outlook' && connection.mailbox) {
-    payload.mailbox = connection.mailbox;
+
+  if (new Date(start).getTime() > new Date(end).getTime()) {
+    showLog('End time must be after the start time.', 'error');
+    return;
   }
-  try {
-    showLog(`Creating event in ${PROVIDERS[provider].label}…`);
-    const result = await callProvider(provider, payload);
-    showLog(`Event created successfully (${result.event?.id || 'no id returned'}).`, 'success');
-    createEventForm.reset();
-  } catch (err) {
-    showLog(err.message || 'Unable to create event.', 'error');
+
+  const localEvent = {
+    id: generateLocalId('local'),
+    provider: 'local',
+    title,
+    description,
+    start,
+    end,
+    timeZone,
+    link: '',
+    metadata: { createdFrom: 'local' },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  };
+
+  writeLocalEvents([...state.localEvents, localEvent]);
+
+  const storedEvent = state.localEvents.find(item => item.id === localEvent.id) || localEvent;
+
+  createEventForm.reset();
+  hydrateCreateFormDefaults();
+
+  const messages = ['Event saved to your local calendar.'];
+  let messageType = 'success';
+
+  const syncTargets = Array.from(
+    new Set(
+      formData
+        .getAll('syncProviders')
+        .map(value => value?.toString())
+        .filter(value => value && PROVIDERS[value])
+    )
+  );
+
+  if (syncTargets.length) {
+    const result = await syncEventToProviders(storedEvent, syncTargets);
+    if (result.lines.length) {
+      messages.push(...result.lines);
+    }
+    if (result.type === 'error') {
+      messageType = 'error';
+    }
   }
+
+  showLog(messages.join('\n'), messageType);
+}
+
+async function syncEventToProviders(localEvent, providers) {
+  const lines = [];
+  let overallType = 'success';
+  const syncedProviders = Array.isArray(localEvent.metadata?.syncedProviders)
+    ? [...localEvent.metadata.syncedProviders]
+    : [];
+
+  for (const provider of providers) {
+    const config = PROVIDERS[provider];
+    if (!config) {
+      continue;
+    }
+    const label = config.label;
+    const connection = state.connections.get(provider);
+    if (!connection) {
+      lines.push(`${label} is not connected. Open the section above to add a token and try again.`);
+      overallType = 'error';
+      continue;
+    }
+    const payload = {
+      action: 'createEvent',
+      accessToken: connection.accessToken,
+      title: localEvent.title,
+      description: localEvent.description,
+      start: localEvent.start,
+      end: localEvent.end,
+      timeZone: localEvent.timeZone || DEFAULT_TIME_ZONE || 'UTC'
+    };
+    if (provider === 'google') {
+      payload.calendarId = connection.calendarId || PROVIDERS.google.defaults.calendarId;
+    }
+    if (provider === 'outlook' && connection.mailbox) {
+      payload.mailbox = connection.mailbox;
+    }
+    try {
+      const response = await callProvider(provider, payload);
+      lines.push(`Synced to ${label}${response.event?.id ? ` (id: ${response.event.id})` : ''}.`);
+      if (!syncedProviders.includes(provider)) {
+        syncedProviders.push(provider);
+      }
+    } catch (err) {
+      lines.push(`Failed to sync to ${label}: ${err.message || 'Unknown error.'}`);
+      overallType = 'error';
+    }
+  }
+
+  if (syncedProviders.length !== (localEvent.metadata?.syncedProviders?.length || 0)) {
+    updateLocalEvent(localEvent.id, {
+      metadata: {
+        ...localEvent.metadata,
+        syncedProviders
+      }
+    });
+  }
+
+  return {
+    lines,
+    type: overallType
+  };
 }
 
 function onConnectionSubmit(event) {
@@ -331,6 +664,14 @@ function handleDisconnect(event) {
   showLog(`${PROVIDERS[provider].label} tokens removed from this browser.`, 'info');
 }
 
+function hydrateCreateFormDefaults() {
+  if (!createEventForm) return;
+  const timeZoneField = createEventForm.elements.namedItem('timeZone');
+  if (timeZoneField instanceof HTMLInputElement) {
+    timeZoneField.value = timeZoneField.value || DEFAULT_TIME_ZONE || 'UTC';
+  }
+}
+
 function bindEvents() {
   document
     .querySelectorAll('.connection-card__form')
@@ -340,12 +681,28 @@ function bindEvents() {
     .querySelectorAll('button[data-action="disconnect"]')
     .forEach(button => button.addEventListener('click', handleDisconnect));
 
-  syncForm.querySelector('[data-action="fetch-events"]').addEventListener('click', handleFetchEvents);
-  syncForm.querySelector('[data-action="refresh-status"]').addEventListener('click', hydrateState);
-  createEventForm.addEventListener('submit', handleCreateEvent);
+  if (syncForm) {
+    const fetchButton = syncForm.querySelector('[data-action="fetch-events"]');
+    const refreshButton = syncForm.querySelector('[data-action="refresh-status"]');
+    if (fetchButton) {
+      fetchButton.addEventListener('click', handleFetchEvents);
+    }
+    if (refreshButton) {
+      refreshButton.addEventListener('click', hydrateState);
+    }
+  }
+
+  if (createEventForm) {
+    createEventForm.addEventListener('submit', handleCreateEvent);
+  }
+
+  if (eventList) {
+    eventList.addEventListener('click', handleEventListClick);
+  }
 }
 
 hydrateState();
+hydrateLocalEvents();
+hydrateCreateFormDefaults();
 bindEvents();
-clearEvents();
-showLog('Ready to connect a provider and sync events.');
+showLog('Ready to manage your local calendar. Connect Google or Outlook to sync when needed.');

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -15,14 +15,76 @@
     <a class="calendar-header__back" href="../index.html">⬅ Back to Portal</a>
     <h1 class="calendar-header__title">Calendar Hub</h1>
     <p class="calendar-header__subtitle">
-      Connect your Google and Outlook calendars, manage events, and keep your schedule in sync.
+      Manage your schedule directly in the portal. Events live in your local calendar first, with optional
+      syncs to Google or Outlook when you need them.
     </p>
   </header>
 
   <main class="calendar-shell">
+    <section class="panel" aria-labelledby="local-calendar-title">
+      <div class="panel__header">
+        <h2 id="local-calendar-title">My local calendar</h2>
+        <p class="panel__intro">
+          Add events that stay in this browser by default. When you want to share them with another service,
+          you can trigger an optional sync without leaving this page.
+        </p>
+      </div>
+
+      <form class="create-event-form" id="create-event-form">
+        <div class="create-event-form__row">
+          <label class="field">
+            <span class="field__label">Title</span>
+            <input type="text" name="title" required placeholder="Sprint planning">
+          </label>
+          <label class="field">
+            <span class="field__label">Start</span>
+            <input type="datetime-local" name="start" required>
+          </label>
+          <label class="field">
+            <span class="field__label">End</span>
+            <input type="datetime-local" name="end" required>
+          </label>
+        </div>
+        <div class="create-event-form__row">
+          <label class="field">
+            <span class="field__label">Timezone</span>
+            <input type="text" name="timeZone" required>
+          </label>
+          <label class="field">
+            <span class="field__label">Description</span>
+            <textarea name="description" rows="3" placeholder="Add agenda and dial-in details"></textarea>
+          </label>
+        </div>
+
+        <fieldset class="create-event-form__sync">
+          <legend>Optional sync</legend>
+          <p>Select the services that should also receive this event after it is stored locally.</p>
+          <label class="chip">
+            <input type="checkbox" name="syncProviders" value="google">
+            <span>Google</span>
+          </label>
+          <label class="chip">
+            <input type="checkbox" name="syncProviders" value="outlook">
+            <span>Outlook</span>
+          </label>
+        </fieldset>
+
+        <button type="submit">Save event</button>
+      </form>
+
+      <div class="event-results" aria-live="polite">
+        <div class="event-results__empty" data-empty>
+          <p>No events yet. Add one above or import from Google/Outlook when you're ready.</p>
+        </div>
+        <ul class="event-results__list" data-event-list></ul>
+      </div>
+
+      <div class="log" aria-live="polite" data-log></div>
+    </section>
+
     <section class="panel" aria-labelledby="connections-title">
       <div class="panel__header">
-        <h2 id="connections-title">Account Connections</h2>
+        <h2 id="connections-title">Optional account connections</h2>
         <p class="panel__intro">
           Authenticate with Google or Outlook using OAuth and paste the access token below. We store the
           values locally so you can quickly reconnect while developing the integration.
@@ -100,10 +162,10 @@
 
     <section class="panel" aria-labelledby="event-sync-title">
       <div class="panel__header">
-        <h2 id="event-sync-title">Event Sync</h2>
+        <h2 id="event-sync-title">Import from external calendars</h2>
         <p class="panel__intro">
-          Fetch events from connected providers and push new ones back. Choose a provider below to get
-          started.
+          Pull events from connected providers when you want to copy them into your local calendar. Choose a
+          provider below to start an import.
         </p>
       </div>
 
@@ -137,64 +199,10 @@
         </fieldset>
 
         <div class="sync-controls__actions">
-          <button type="button" data-action="fetch-events">Fetch events</button>
+          <button type="button" data-action="fetch-events">Import events</button>
           <button type="button" data-action="refresh-status">Refresh status</button>
         </div>
       </form>
-
-      <div class="event-results" aria-live="polite">
-        <div class="event-results__empty" data-empty>
-          <p>No events yet. Fetch from Google or Outlook to preview them here.</p>
-        </div>
-        <ul class="event-results__list" data-event-list></ul>
-      </div>
-    </section>
-
-    <section class="panel" aria-labelledby="create-event-title">
-      <div class="panel__header">
-        <h2 id="create-event-title">Create quick events</h2>
-        <p class="panel__intro">
-          Use the form below to push a single event to the selected provider. We will use the stored access token
-          when calling our lightweight API proxy.
-        </p>
-      </div>
-
-      <form class="create-event-form" id="create-event-form">
-        <div class="create-event-form__row">
-          <label class="field">
-            <span class="field__label">Title</span>
-            <input type="text" name="title" required placeholder="Sprint planning">
-          </label>
-          <label class="field">
-            <span class="field__label">Provider</span>
-            <select name="provider">
-              <option value="google">Google</option>
-              <option value="outlook">Outlook</option>
-            </select>
-          </label>
-        </div>
-        <div class="create-event-form__row">
-          <label class="field">
-            <span class="field__label">Start</span>
-            <input type="datetime-local" name="start" required>
-          </label>
-          <label class="field">
-            <span class="field__label">End</span>
-            <input type="datetime-local" name="end" required>
-          </label>
-          <label class="field">
-            <span class="field__label">Timezone</span>
-            <input type="text" name="timeZone" value="UTC" required>
-          </label>
-        </div>
-        <label class="field">
-          <span class="field__label">Description</span>
-          <textarea name="description" rows="3" placeholder="Add agenda and dial-in details"></textarea>
-        </label>
-        <button type="submit">Create event</button>
-      </form>
-
-      <div class="log" aria-live="polite" data-log></div>
     </section>
   </main>
 
@@ -215,7 +223,10 @@
         </div>
       </dl>
       <p class="event-card__description" data-field="description"></p>
-      <a class="event-card__link" data-field="link" href="#" target="_blank" rel="noreferrer noopener">Open in calendar</a>
+      <div class="event-card__footer">
+        <a class="event-card__link" data-field="link" href="#" target="_blank" rel="noreferrer noopener">Open in calendar</a>
+        <button type="button" class="event-card__delete button-secondary" data-action="delete-event">Remove</button>
+      </div>
     </li>
   </template>
 


### PR DESCRIPTION
## Summary
- prioritize the built-in local calendar by moving the create form and event list to the top of the page and updating copy
- add local storage, deletion, and optional provider sync/import logic so events work without Google/Outlook connections
- refresh styles and templates to support the new local-first workflow and action buttons

## Testing
- python3 -m http.server 3000

------
https://chatgpt.com/codex/tasks/task_e_68d832cc01fc83208cdb725aa5ea1241