### PR TITLE
Use 3DVR Gun relay for calendar event storage

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -230,6 +230,7 @@
     </li>
   </template>
 
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/calendar/calendar.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- instantiate the Gun client on the calendar page and scope data to the current user or guest
- synchronize local calendar CRUD operations with the 3DVR relay and consume remote updates safely
- load the Gun script in the calendar shell and update the ready message to reflect relay support

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d84960d150832090c528214385fafe