### PR TITLE
Add onboarding start landing page

### DIFF
--- a/start/index.html
+++ b/start/index.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Start with 3dvr.tech</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="top-nav" aria-label="Main navigation">
+        <a class="brand" href="../index.html">3dvr.tech</a>
+        <div class="nav-links">
+          <a href="#discover">Discover Yourself</a>
+          <a href="#fast-track">Fast-Track</a>
+          <a href="#support">Support</a>
+          <a href="#resources">Resources</a>
+        </div>
+      </nav>
+      <div class="hero-content">
+        <span class="tag">Welcome</span>
+        <h1>Begin your 3dvr.tech journey</h1>
+        <p>
+          Unsure where to start? This hub helps you uncover what lights you up, map a
+          business or community around it, and build the digital foundation that brings it
+          to life.
+        </p>
+        <div class="hero-actions">
+          <a class="button primary" href="#discover">Find Your Path</a>
+          <a class="button secondary" href="#fast-track">Already Have an Idea?</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="discover" class="section">
+        <div class="section-heading">
+          <span class="tag">Step 1</span>
+          <h2>Discover what you love doing every day</h2>
+          <p>
+            Choose the activities that energize you. We will co-create opportunities that
+            let you thrive.
+          </p>
+        </div>
+        <div class="path-grid">
+          <article class="card">
+            <h3>Creative Builder</h3>
+            <p>
+              Design immersive experiences, XR spaces, and rich visuals that wow audiences.
+            </p>
+            <ul>
+              <li>3D/VR art &amp; worldbuilding</li>
+              <li>Storytelling &amp; narrative design</li>
+              <li>Brand identity &amp; media production</li>
+            </ul>
+            <a class="button tertiary" href="../website-builder.html">Explore tools</a>
+          </article>
+          <article class="card">
+            <h3>Community Catalyst</h3>
+            <p>
+              Bring people together for learning, wellness, and shared growth in digital and
+              real worlds.
+            </p>
+            <ul>
+              <li>Membership spaces &amp; events</li>
+              <li>Coaching, mentoring, and masterminds</li>
+              <li>Nonprofit and social impact missions</li>
+            </ul>
+            <a class="button tertiary" href="../calendar/index.html">Plan gatherings</a>
+          </article>
+          <article class="card">
+            <h3>Product &amp; Systems Architect</h3>
+            <p>
+              Craft services, automations, and scalable products that support your audience.
+            </p>
+            <ul>
+              <li>No-code &amp; low-code experiences</li>
+              <li>Automations and CRM flows</li>
+              <li>Subscription &amp; revenue models</li>
+            </ul>
+            <a class="button tertiary" href="../crm.html">Map your systems</a>
+          </article>
+        </div>
+        <div class="callout">
+          <h3>Not seeing your passion?</h3>
+          <p>
+            Tell us what you love. We will design custom collaborations, partnerships, or
+            unique revenue pathways tailored to you.
+          </p>
+          <a class="button primary" href="mailto:hello@3dvr.tech">Start a conversation</a>
+        </div>
+      </section>
+
+      <section id="fast-track" class="section alt">
+        <div class="section-heading">
+          <span class="tag">Step 2</span>
+          <h2>Fast-track your idea into a thriving offer</h2>
+          <p>
+            Already have a concept? Use these guided sprints to evolve from idea to
+            subscribers and sustainable revenue.
+          </p>
+        </div>
+        <div class="journey">
+          <div class="journey-step">
+            <span class="step-number">0</span>
+            <div>
+              <h3>Vision sync</h3>
+              <p>Clarify your goals, audience, and success metrics in a 30-minute session.</p>
+            </div>
+          </div>
+          <div class="journey-step">
+            <span class="step-number">5</span>
+            <div>
+              <h3>Prototype &amp; pilot</h3>
+              <p>Launch a minimum viable experience and onboard your first 5 subscribers.</p>
+            </div>
+          </div>
+          <div class="journey-step">
+            <span class="step-number">20+</span>
+            <div>
+              <h3>Scale &amp; optimize</h3>
+              <p>Refine your offer, introduce automations, and grow beyond 20 monthly members.</p>
+            </div>
+          </div>
+        </div>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Launchpad</h3>
+            <p>Choose templates, copy frameworks, and onboarding flows tailored to your idea.</p>
+            <a class="button secondary" href="../website-builder.html">Build your site</a>
+          </article>
+          <article class="card">
+            <h3>Revenue runway</h3>
+            <p>
+              Shape your pricing, launch plan, and marketing rhythms with our sales playbooks.
+            </p>
+            <a class="button secondary" href="../sales/index.html">Plan your launch</a>
+          </article>
+          <article class="card">
+            <h3>Growth stack</h3>
+            <p>
+              Connect CRM, analytics, and automation tools so every interaction feels personal.
+            </p>
+            <a class="button secondary" href="../crm/index.html">Activate systems</a>
+          </article>
+        </div>
+      </section>
+
+      <section id="support" class="section">
+        <div class="section-heading">
+          <span class="tag">Step 3</span>
+          <h2>Get the support you need</h2>
+          <p>
+            We collaborate across strategy, design, and technology to help you build a living
+            you love.
+          </p>
+        </div>
+        <div class="support-grid">
+          <article class="support-card">
+            <h3>Co-creation sessions</h3>
+            <p>
+              Weekly or bi-weekly workshops where we brainstorm, prototype, and keep momentum
+              strong.
+            </p>
+          </article>
+          <article class="support-card">
+            <h3>Done-with-you builds</h3>
+            <p>
+              Pair with 3dvr.tech makers to design and ship websites, automations, and content.
+            </p>
+          </article>
+          <article class="support-card">
+            <h3>Community collaborations</h3>
+            <p>
+              Join forces with aligned partners, cross-promote, and unlock funding
+              opportunities.
+            </p>
+          </article>
+        </div>
+        <div class="callout">
+          <h3>Ready to begin?</h3>
+          <p>Share your vision and we will craft the roadmap together.</p>
+          <a class="button primary" href="https://cal.com/3dvr/intro">Book an intro call</a>
+        </div>
+      </section>
+
+      <section id="resources" class="section alt">
+        <div class="section-heading">
+          <span class="tag">Keep Exploring</span>
+          <h2>Resources to guide your next move</h2>
+          <p>Browse templates, guides, and inspiration curated for creators, founders, and community leaders.</p>
+        </div>
+        <div class="resource-grid">
+          <article class="resource-card">
+            <h3>Idea workshop prompts</h3>
+            <p>Unlock clarity with reflection questions and daily practice ideas.</p>
+            <a class="button tertiary" href="../notes.html">Open notes hub</a>
+          </article>
+          <article class="resource-card">
+            <h3>Success stories</h3>
+            <p>See how others turned passion into sustainable offerings with 3dvr.tech.</p>
+            <a class="button tertiary" href="../profile.html">Meet the community</a>
+          </article>
+          <article class="resource-card">
+            <h3>Growth systems</h3>
+            <p>Review CRM, analytics, and outreach frameworks to scale with confidence.</p>
+            <a class="button tertiary" href="../sales/index.html">Open sales hub</a>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Made with care by 3dvr.tech &bull; <a href="mailto:hello@3dvr.tech">hello@3dvr.tech</a>
+      </p>
+    </footer>
+  </body>
+</html>

--- a/start/style.css
+++ b/start/style.css
@@ -1,0 +1,327 @@
+:root {
+  --bg: #0f172a;
+  --bg-alt: #131c34;
+  --surface: #ffffff;
+  --surface-alt: #f1f5f9;
+  --accent: #6366f1;
+  --accent-strong: #4338ca;
+  --text: #0f172a;
+  --text-light: #475569;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Outfit', 'Segoe UI', Tahoma, sans-serif;
+  background: linear-gradient(160deg, var(--bg) 0%, #1e293b 100%);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.hero {
+  position: relative;
+  padding: 60px 24px 120px;
+  color: #fff;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.6), transparent 55%),
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.35), transparent 45%);
+  z-index: 0;
+}
+
+.top-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+  margin-bottom: 40px;
+}
+
+.brand {
+  font-size: 1.2rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav-links a {
+  margin-left: 18px;
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  color: #fff;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+}
+
+.tag {
+  display: inline-block;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 16px 0;
+  font-size: clamp(2.5rem, 5vw, 3.4rem);
+  line-height: 1.1;
+}
+
+.hero p {
+  margin-bottom: 28px;
+  font-size: 1.1rem;
+  max-width: 600px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 24px;
+  border-radius: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.primary {
+  background: #fff;
+  color: var(--bg);
+  box-shadow: var(--shadow);
+}
+
+.button.secondary {
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  color: #fff;
+}
+
+.button.tertiary {
+  color: var(--accent);
+  border: 1px solid rgba(99, 102, 241, 0.24);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.15);
+}
+
+main {
+  background: #fff;
+}
+
+.section {
+  padding: 96px 24px;
+}
+
+.section.alt {
+  background: var(--surface-alt);
+}
+
+.section-heading {
+  max-width: 760px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+
+.section-heading h2 {
+  margin-top: 12px;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  color: var(--bg);
+}
+
+.section-heading p {
+  color: var(--text-light);
+  margin: 16px auto 0;
+  max-width: 640px;
+}
+
+.path-grid,
+.card-grid,
+.resource-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--bg);
+}
+
+.card p {
+  margin: 0;
+  color: var(--text-light);
+}
+
+.card ul {
+  padding-left: 16px;
+  margin: 0;
+  color: var(--text-light);
+}
+
+.card li {
+  margin-bottom: 8px;
+}
+
+.callout {
+  margin: 72px auto 0;
+  max-width: 760px;
+  padding: 36px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(14, 165, 233, 0.12));
+  text-align: center;
+  box-shadow: 0 15px 30px rgba(15, 23, 42, 0.12);
+}
+
+.callout h3 {
+  margin-top: 0;
+  color: var(--bg);
+}
+
+.callout p {
+  color: var(--text-light);
+}
+
+.journey {
+  max-width: 820px;
+  margin: 0 auto 64px;
+  display: grid;
+  gap: 20px;
+}
+
+.journey-step {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  background: #fff;
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.step-number {
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+}
+
+.support-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  max-width: 900px;
+  margin: 0 auto 64px;
+}
+
+.support-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: var(--shadow);
+  color: var(--text-light);
+}
+
+.support-card h3 {
+  margin-top: 0;
+  color: var(--bg);
+}
+
+.resource-grid {
+  max-width: 960px;
+}
+
+.resource-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: var(--shadow);
+  color: var(--text-light);
+}
+
+.footer {
+  padding: 28px;
+  text-align: center;
+  background: var(--bg);
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.footer a {
+  color: #fff;
+  text-decoration: none;
+}
+
+@media (max-width: 720px) {
+  .nav-links {
+    display: none;
+  }
+
+  .hero {
+    padding-bottom: 80px;
+  }
+
+  .journey-step {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .step-number {
+    width: 54px;
+    height: 54px;
+    font-size: 1.2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated /start landing page that guides visitors from discovery to launch
- provide curated journeys for passion discovery, idea fast-tracking, and support options
- style the page with a new gradient-driven theme and responsive layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97744bd98832097628ab0319faa71