### PR TITLE
Fix start page stylesheet path

### DIFF
--- a/start/index.html
+++ b/start/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Start with 3dvr.tech</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="./style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/start/index.html
+++ b/start/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Start with 3dvr.tech</title>
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="/start/style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Summary
- update the Start page to reference its stylesheet with a relative path that works when the page is requested without a trailing slash

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97ad7b930832084ae6423dffbf5cc