### PR TITLE
Add portal return link to chat

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -27,6 +27,9 @@
       <p class="chat-hero__tagline">
         Sync with the 3DVR community, share quick wins, and keep projects moving without missing a beat.
       </p>
+      <div class="chat-hero__actions">
+        <a class="chat-hero__portal-link" href="index.html">← Back to Portal</a>
+      </div>
       <div class="chat-hero__meta">
         <span class="chat-hero__reward">💬 Earn <strong>+1 point</strong> for every message you send.</span>
         <div

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -48,6 +48,32 @@ body.chat-page {
   box-shadow: 0 30px 68px rgba(15, 23, 42, 0.35);
 }
 
+.chat-hero__actions {
+  display: flex;
+  justify-content: center;
+}
+
+.chat-hero__portal-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.16);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.chat-hero__portal-link:hover,
+.chat-hero__portal-link:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(59, 130, 246, 0.45);
+}
+
 .chat-hero__eyebrow {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a back-to-portal link inside the chat hero to improve navigation
- style the new link to align with the existing chat hero design

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac0a8fef08320a450dad3df7ade49