### PR TITLE
Reposition chat layout above hero

### DIFF
--- a/styles/chat.css
+++ b/styles/chat.css
@@ -33,8 +33,14 @@ body.chat-page {
   position: relative;
   z-index: 1;
   width: min(1100px, 100%);
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: clamp(1.75rem, 2vw, 2.5rem);
+}
+
+.chat-layout {
+  /* Bring the chat interface above the hero without changing DOM order */
+  order: -1;
 }
 
 .chat-hero {


### PR DESCRIPTION
## Summary
- switch the chat page shell to a flex layout so the chat interface can be reordered
- move the chat layout ahead of the hero visually to keep messages near the top of the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac1e511288320adbe560812dd3ff2