### PR TITLE
Add floating profile badge to chat page

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -13,12 +13,11 @@
 <body class="theme-dark chat-page">
   <a class="skip-link" href="#chatMain">Skip to chat</a>
 
-  <div
+  <a
     id="chat-floating-meta"
     class="chat-floating-meta"
-    role="status"
+    href="profile.html"
     aria-live="polite"
-    aria-label="Your chat info"
   >
     <span id="chat-floating-username" class="chat-floating-meta__name">Guest</span>
     <span class="chat-floating-meta__divider" aria-hidden="true">•</span>
@@ -26,7 +25,8 @@
       <span class="sr-only">Score</span>
       <span id="chat-floating-score-value" aria-hidden="true">0</span>
     </span>
-  </div>
+    <span class="sr-only">Open profile</span>
+  </a>
 
   <div class="top-buttons" role="navigation" aria-label="3DVR quick links">
     <a href="index.html">🏠 Portal Home</a>

--- a/chat.html
+++ b/chat.html
@@ -13,6 +13,21 @@
 <body class="theme-dark chat-page">
   <a class="skip-link" href="#chatMain">Skip to chat</a>
 
+  <div
+    id="chat-floating-meta"
+    class="chat-floating-meta"
+    role="status"
+    aria-live="polite"
+    aria-label="Your chat info"
+  >
+    <span id="chat-floating-username" class="chat-floating-meta__name">Guest</span>
+    <span class="chat-floating-meta__divider" aria-hidden="true">•</span>
+    <span class="chat-floating-meta__score">
+      <span class="sr-only">Score</span>
+      <span id="chat-floating-score-value" aria-hidden="true">0</span>
+    </span>
+  </div>
+
   <div class="top-buttons" role="navigation" aria-label="3DVR quick links">
     <a href="index.html">🏠 Portal Home</a>
     <a href="profile.html">🧑 Profile</a>
@@ -155,6 +170,9 @@ const roomDescriptionEl = document.getElementById('room-description');
 const roomSelectEl = document.getElementById('room');
 const chatScoreContainer = document.getElementById('chat-score');
 const chatScoreValueEl = document.getElementById('chat-score-value');
+const chatFloatingMetaEl = document.getElementById('chat-floating-meta');
+const chatFloatingUsernameEl = document.getElementById('chat-floating-username');
+const chatFloatingScoreValueEl = document.getElementById('chat-floating-score-value');
 const ROOM_DETAILS = {
   general: {
     label: '#general',
@@ -184,13 +202,18 @@ function sanitizeScoreDisplay(value) {
 }
 
 function updateChatScoreDisplay(value) {
-  if (!chatScoreValueEl) {
-    return;
-  }
   const safeScore = sanitizeScoreDisplay(value);
-  chatScoreValueEl.innerText = safeScore;
+  if (chatScoreValueEl) {
+    chatScoreValueEl.innerText = safeScore;
+  }
   if (chatScoreContainer) {
     chatScoreContainer.setAttribute('data-ready', 'true');
+  }
+  if (chatFloatingScoreValueEl) {
+    chatFloatingScoreValueEl.innerText = safeScore;
+  }
+  if (chatFloatingMetaEl) {
+    chatFloatingMetaEl.setAttribute('data-ready', 'true');
   }
 }
 
@@ -613,8 +636,12 @@ function applyUsernameToUI(name) {
       safeRemoveStorage('username');
     }
   }
-  if (!currentUsernameEl) return;
-  currentUsernameEl.innerText = finalName;
+  if (currentUsernameEl) {
+    currentUsernameEl.innerText = finalName;
+  }
+  if (chatFloatingUsernameEl) {
+    chatFloatingUsernameEl.innerText = finalName;
+  }
 }
 
 function derivePreferredUsername(existingName) {

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -45,11 +45,22 @@ body.chat-page {
   z-index: 24;
   pointer-events: none;
   backdrop-filter: blur(16px);
+  text-decoration: none;
 }
 
 .chat-floating-meta[data-ready="true"] {
   opacity: 1;
   transform: translateY(0);
+  pointer-events: auto;
+}
+
+.chat-floating-meta:hover {
+  color: inherit;
+}
+
+.chat-floating-meta:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.45);
 }
 
 .chat-floating-meta__name {

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -24,6 +24,77 @@ body.chat-page {
   z-index: 12;
 }
 
+.chat-floating-meta {
+  position: fixed;
+  top: clamp(1rem, 2vw + 1rem, 2.6rem);
+  right: clamp(1rem, 2vw + 1rem, 2.8rem);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.48);
+  color: var(--color-text-primary, #e2e8f0);
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity var(--transition-base, 0.3s ease),
+    transform var(--transition-base, 0.3s ease);
+  z-index: 24;
+  pointer-events: none;
+  backdrop-filter: blur(16px);
+}
+
+.chat-floating-meta[data-ready="true"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.chat-floating-meta__name {
+  max-width: 14ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-floating-meta__divider {
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.chat-floating-meta__score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  color: #5eead4;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-floating-meta__score .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .chat-floating-meta {
+    font-size: 0.85rem;
+    padding: 0.55rem 1.05rem;
+    gap: 0.35rem;
+  }
+
+  .chat-floating-meta__name {
+    max-width: 11ch;
+  }
+}
+
 .skip-link:focus-visible {
   transform: translateY(0);
   opacity: 1;


### PR DESCRIPTION
## Summary
- add a floating chat meta widget that keeps the current username and score visible
- synchronize the widget with existing identity and score updates
- style the floating badge for readability on desktop and smaller screens

## Testing
- python3 -m http.server 3000

------
https://chatgpt.com/codex/tasks/task_e_68dac37110708320ad87e7ff5d446a33