### PR TITLE
Add points overview page and update CTA links

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
         <p class="hero-tagline">Launch straight into the apps that power the community and keep everyone in sync.</p>
         <div class="hero-actions">
           <button type="button" class="cta primary" data-app-search-trigger>Browse apps</button>
-          <a href="sign-in.html" class="cta ghost">Start earning</a>
-          <a href="free-trial.html" class="cta ghost" target="_blank" rel="noopener">Explore plans</a>
+          <a href="points.html" class="cta ghost">Start earning</a>
+          <a href="https://3dvr.tech/subscribe" class="cta ghost" target="_blank" rel="noopener">Explore plans</a>
         </div>
       </section>
 

--- a/points.html
+++ b/points.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>3dvr.tech Points Overview</title>
+    <link rel="stylesheet" href="styles/global.css" />
+    <link rel="stylesheet" href="styles/points.css" />
+  </head>
+  <body class="points-page">
+    <a class="skip-link" href="#mainContent">Skip to main content</a>
+    <div class="top-buttons" role="navigation" aria-label="Primary">
+      <a href="index.html">🏠 Portal home</a>
+      <a href="sign-in.html">🔑 Sign in</a>
+      <a href="rewards.html">🏆 See live rewards</a>
+      <a href="mailto:hello@3dvr.tech">💬 Chat with the team</a>
+    </div>
+    <header class="points-hero">
+      <div class="points-shell">
+        <p class="points-eyebrow">3dvr.tech Rewards</p>
+        <h1>How the 3dvr.tech point system works</h1>
+        <p class="points-intro">
+          We are building a transparent way to reward every contribution. Points track your impact today and will soon
+          convert into a share of the revenue that flows through our Stripe account.
+        </p>
+        <div class="points-cta">
+          <a class="cta primary" href="sign-in.html">Sign in to track your points</a>
+          <a class="cta ghost" href="https://3dvr.tech/subscribe" target="_blank" rel="noopener">Become a supporter</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="mainContent" class="points-main">
+      <section class="points-section">
+        <div class="section-card">
+          <h2>Points are a percentage of the Stripe pool</h2>
+          <p>
+            Every point you earn represents a slice of the monthly revenue collected through the 3dvr.tech Stripe account.
+            When redemptions launch, we will publish the pool size, calculate the value per point, and let you cash in or
+            roll points forward for future drops.
+          </p>
+          <dl class="points-stats">
+            <div>
+              <dt>Current status</dt>
+              <dd>In design &mdash; tracking contributions only</dd>
+            </div>
+            <div>
+              <dt>Redemption model</dt>
+              <dd>Points × percentage share of monthly Stripe revenue</dd>
+            </div>
+            <div>
+              <dt>Launch target</dt>
+              <dd>Stripe redemption beta in Q1 2025</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section class="points-section">
+        <div class="section-grid">
+          <article class="info-card">
+            <h3>How you earn points today</h3>
+            <ul>
+              <li>Complete quests, tasks, and sprints inside the portal.</li>
+              <li>Host or contribute to community events and workshops.</li>
+              <li>Ship new features, tutorials, or docs that help the ecosystem grow.</li>
+            </ul>
+            <p class="info-note">Each activity awards a set number of points that appear in your rewards dashboard.</p>
+          </article>
+          <article class="info-card">
+            <h3>What happens next</h3>
+            <ol>
+              <li>Finalize our contribution rubric and publish the point table.</li>
+              <li>Connect Stripe webhooks so the monthly revenue pool updates automatically.</li>
+              <li>Enable in-app redemption with options to cash out or reinvest in future projects.</li>
+            </ol>
+            <p class="info-note">We will share progress updates in the community Discord and via email.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="points-section">
+        <div class="section-card">
+          <h2>Transparency &amp; trust</h2>
+          <div class="transparency-grid">
+            <article>
+              <h3>Monthly statements</h3>
+              <p>We will publish Stripe summaries so everyone can verify the pool before redemptions open.</p>
+            </article>
+            <article>
+              <h3>Community governance</h3>
+              <p>Point holders help shape new perks, bonus multipliers, and how we reinvest surplus funds.</p>
+            </article>
+            <article>
+              <h3>Opt-in flexibility</h3>
+              <p>Keep points for long-term rewards or redeem them during seasonal cash-out windows.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="points-section">
+        <div class="section-card">
+          <h2>Frequently asked questions</h2>
+          <div class="faq-list">
+            <details>
+              <summary>Can I redeem my points right now?</summary>
+              <p>Not yet. We are currently tracking points while we finish the Stripe integration and legal review.</p>
+            </details>
+            <details>
+              <summary>How will the point value be calculated?</summary>
+              <p>
+                We will divide the Stripe revenue pool by the total active points. Your payout equals the number of points
+                you redeem multiplied by that value.
+              </p>
+            </details>
+            <details>
+              <summary>Will there be bonuses?</summary>
+              <p>
+                Yes. Early adopters and community hosts will receive seasonal boosters once the beta opens. We will also run
+                surprise drops tied to special events.
+              </p>
+            </details>
+            <details>
+              <summary>How can I stay informed?</summary>
+              <p>
+                Join our newsletter via the subscribe link above or message <a href="mailto:hello@3dvr.tech">hello@3dvr.tech</a>
+                to receive development updates.
+              </p>
+            </details>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="points-footer">
+      <p>Questions or ideas? Email <a href="mailto:hello@3dvr.tech">hello@3dvr.tech</a> and we will get back to you.</p>
+    </footer>
+  </body>
+</html>

--- a/styles/points.css
+++ b/styles/points.css
@@ -1,0 +1,228 @@
+.points-page {
+  background: var(--page-background);
+  color: var(--color-text);
+}
+
+.points-cta .cta,
+.points-shell .cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.points-shell .cta.primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  box-shadow: 0 16px 36px rgba(37, 99, 235, 0.28);
+}
+
+.points-shell .cta.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 44px rgba(37, 99, 235, 0.35);
+}
+
+.points-shell .cta.ghost {
+  background: transparent;
+  border: 1px solid var(--surface-border);
+  color: var(--color-text);
+}
+
+.points-shell .cta.ghost:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.points-page .top-buttons {
+  margin-top: 2rem;
+}
+
+.points-hero {
+  padding: 4rem 1.5rem 2rem;
+}
+
+.points-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.points-eyebrow {
+  display: inline-flex;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: var(--surface-alt);
+  border: 1px solid var(--surface-border);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.points-hero h1 {
+  margin: 1.5rem 0 1rem;
+  font-size: clamp(2.2rem, 5vw, 3rem);
+}
+
+.points-intro {
+  margin: 0 auto 2rem;
+  max-width: 680px;
+  color: var(--color-text-muted);
+}
+
+.points-cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.points-main {
+  padding: 2rem 1.5rem 4rem;
+}
+
+.points-section {
+  max-width: 1000px;
+  margin: 0 auto 2.5rem;
+}
+
+.section-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.08);
+}
+
+.section-card h2 {
+  margin-top: 0;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.section-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.info-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.08);
+}
+
+.info-card h3 {
+  margin-top: 0;
+}
+
+.info-card ul,
+.info-card ol {
+  margin: 0 0 1.25rem 1.25rem;
+  color: var(--color-text-muted);
+}
+
+.info-note {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.points-stats {
+  display: grid;
+  gap: 1.25rem;
+  margin: 2rem 0 0;
+}
+
+.points-stats div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.points-stats dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.points-stats dd {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.transparency-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.transparency-grid article {
+  background: var(--surface-alt);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.06);
+}
+
+.transparency-grid h3 {
+  margin-top: 0;
+}
+
+.faq-list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.faq-list details {
+  background: var(--surface-alt);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md);
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.06);
+}
+
+.faq-list summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.faq-list p {
+  margin: 0.75rem 0 0;
+  color: var(--color-text-muted);
+}
+
+.points-footer {
+  text-align: center;
+  padding: 2rem 1.5rem 3rem;
+  color: var(--color-text-muted);
+}
+
+.points-footer a {
+  color: inherit;
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .section-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .transparency-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .section-card {
+    padding: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a points overview page that outlines the upcoming Stripe-connected rewards system
- style the new page with dedicated components for stats, roadmap, and FAQs
- update the landing hero CTAs to open the overview and send Explore plans to 3dvr.tech/subscribe

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dca0bdce1c83208f940dc216cecc52