### PR TITLE
Fix notes redirect to relative path

### DIFF
--- a/notes.html
+++ b/notes.html
@@ -2,15 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="refresh" content="0; url=/notes/" />
+  <meta http-equiv="refresh" content="0; url=notes/" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Redirecting to 3DVR Notes</title>
-  <link rel="canonical" href="/notes/" />
+  <link rel="canonical" href="notes/" />
   <script>
-    window.location.replace('/notes/');
+    window.location.replace('notes/');
   </script>
 </head>
 <body>
-  <p>Redirecting to <a href="/notes/">3DVR Notes</a>...</p>
+  <p>Redirecting to <a href="notes/">3DVR Notes</a>...</p>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 /* service-worker.js */
 
 // Increment this to bust old caches when you deploy
-const CACHE_VERSION = 'v4';
+const CACHE_VERSION = 'v5';
 const STATIC_CACHE = `3dvr-static-${CACHE_VERSION}`;
 const HTML_CACHE = `3dvr-html-${CACHE_VERSION}`;
 


### PR DESCRIPTION
## Summary
- update notes.html redirect to use a relative path so the notes CSS loads when the site is served from a subdirectory
- bump the service worker cache version so existing clients fetch the updated redirect

## Testing
- Not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68e062e93da88320976d82754f241d8d