### PR TITLE
Bust cached notes stylesheet

### DIFF
--- a/notes/index.html
+++ b/notes/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>📝 3DVR Notes</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
-  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../style.css?v=notes-refresh-20240204">
 </head>
 <body class="notes-page">
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 /* service-worker.js */
 
 // Increment this to bust old caches when you deploy
-const CACHE_VERSION = 'v5';
+const CACHE_VERSION = 'v6';
 const STATIC_CACHE = `3dvr-static-${CACHE_VERSION}`;
 const HTML_CACHE = `3dvr-html-${CACHE_VERSION}`;
 
@@ -10,6 +10,7 @@ const STATIC_ASSETS = [
   '/',                     // App shell (Start URL)
   '/index-style.css',
   '/styles/global.css',
+  '/style.css?v=notes-refresh-20240204',
   '/navbar.js',
   '/score.js',
   '/manifest.webmanifest',


### PR DESCRIPTION
## Summary
- append a cache-busting version query to the notes stylesheet link so browsers fetch the refreshed styles
- bump the service worker cache version and pre-cache the versioned stylesheet to refresh existing installs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0682efcc88320a4f62e4eb3e780f8