### PR TITLE
Ensure guest scores persist via relay identity restoration

### DIFF
--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -49,6 +49,21 @@ const GUN_RELAY_URL = 'https://gun-relay-3dvr.fly.dev/gun';
 const gun = typeof Gun === 'function' ? Gun([GUN_RELAY_URL]) : null;
 const portalRoot = gun ? gun.get('3dvr-portal') : null;
 const calendarRoot = portalRoot ? portalRoot.get('calendar') : null;
+
+if (window.ScoreSystem) {
+  if (typeof window.ScoreSystem.restoreGuestIdentity === 'function') {
+    window.ScoreSystem.restoreGuestIdentity({ gun, portalRoot })
+      .catch(err => {
+        console.warn('Failed to restore guest identity for calendar', err);
+        if (typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
+          window.ScoreSystem.ensureGuestIdentity();
+        }
+      });
+  } else if (typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
+    window.ScoreSystem.ensureGuestIdentity();
+  }
+}
+
 const calendarOwnerKey = calendarRoot ? resolveCalendarOwnerKey() : null;
 const gunEvents = calendarOwnerKey ? calendarRoot.get('users').get(calendarOwnerKey).get('events') : null;
 let isGunApplying = false;

--- a/chat.html
+++ b/chat.html
@@ -154,13 +154,7 @@ const gun = Gun([
 const portalRoot = gun.get('3dvr-portal');
 const gunSupportsUser = typeof gun.user === 'function';
 const portalUser = gunSupportsUser ? gun.user() : null;
-const scoreManager = window.ScoreSystem && typeof window.ScoreSystem.getManager === 'function'
-  ? window.ScoreSystem.getManager({
-      gun: gunSupportsUser ? gun : null,
-      user: portalUser,
-      portalRoot
-    })
-  : null;
+let scoreManager = null;
 let currentRoom = 'general';
 let chat = gun.get('3dvr-chat').get(currentRoom);
 
@@ -217,13 +211,26 @@ function updateChatScoreDisplay(value) {
   }
 }
 
-if (chatScoreContainer && chatScoreValueEl) {
+function setupScoreTracking() {
+  if (!chatScoreContainer || !chatScoreValueEl) {
+    return;
+  }
+
   if (scoreManager && typeof scoreManager.subscribe === 'function') {
     scoreManager.subscribe(updateChatScoreDisplay);
+    if (typeof scoreManager.whenReady === 'function') {
+      scoreManager.whenReady()
+        .then(value => updateChatScoreDisplay(value))
+        .catch(err => {
+          console.warn('Failed to await score manager readiness', err);
+        });
+    }
   } else {
     updateChatScoreDisplay(0);
   }
 }
+
+setupScoreTracking();
 
 const notificationToggleButton = document.getElementById('notification-toggle');
 const notificationStatusText = document.getElementById('notification-status');
@@ -581,42 +588,47 @@ if ('serviceWorker' in navigator) {
 const currentUsernameEl = document.getElementById('current-username');
 let cachedUsername = '';
 
-const chatIdentity = resolveChatIdentity();
-const userId = chatIdentity.id;
-const isGuestIdentity = chatIdentity.type === 'guest';
-const chatProfile = gun.get(chatIdentity.profileRoot).get(userId);
+let chatIdentity = null;
+let userId = '';
+let isGuestIdentity = false;
+let chatProfile = null;
 
-// Auto import old chats into General (only runs if in General and no messages exist)
-if (currentRoom === 'general') {
-  gun.get('3dvr-chat').map().once((message, id) => {
-    if (!message) return;
-    chat.get(id).once(existing => {
-      if (!existing) {
-        chat.get(id).put(message);
-        console.log('Imported old message:', id);
+function initializeChatProfile() {
+  if (!chatIdentity) {
+    return;
+  }
+
+  if (currentRoom === 'general') {
+    gun.get('3dvr-chat').map().once((message, id) => {
+      if (!message) return;
+      chat.get(id).once(existing => {
+        if (!existing) {
+          chat.get(id).put(message);
+          console.log('Imported old message:', id);
+        }
+      });
+    });
+  }
+
+  const initialUsername = derivePreferredUsername();
+  applyUsernameToUI(initialUsername);
+
+  if (chatProfile && typeof chatProfile.get === 'function') {
+    chatProfile.get('username').once(existingName => {
+      const resolvedName = derivePreferredUsername(existingName);
+      applyUsernameToUI(resolvedName);
+      const normalizedExisting = typeof existingName === 'string' ? existingName.trim() : '';
+      if (normalizedExisting !== resolvedName) {
+        chatProfile.get('username').put(resolvedName);
       }
     });
-  });
-}
 
-const initialUsername = derivePreferredUsername();
-applyUsernameToUI(initialUsername);
-
-if (chatProfile && typeof chatProfile.get === 'function') {
-  chatProfile.get('username').once(existingName => {
-    const resolvedName = derivePreferredUsername(existingName);
-    applyUsernameToUI(resolvedName);
-    const normalizedExisting = typeof existingName === 'string' ? existingName.trim() : '';
-    if (normalizedExisting !== resolvedName) {
-      chatProfile.get('username').put(resolvedName);
-    }
-  });
-
-  chatProfile.get('username').on(name => {
-    const normalized = typeof name === 'string' ? name.trim() : '';
-    if (!normalized) return;
-    applyUsernameToUI(normalized);
-  });
+    chatProfile.get('username').on(name => {
+      const normalized = typeof name === 'string' ? name.trim() : '';
+      if (!normalized) return;
+      applyUsernameToUI(normalized);
+    });
+  }
 }
 
 function applyUsernameToUI(name) {
@@ -1072,6 +1084,40 @@ function maybeNotifyNewMessage(message, id) {
   updateRoomStateWithMessage(roomState, effectiveTimestamp, id);
   persistNotificationState();
 }
+
+async function initializeChat() {
+  if (window.ScoreSystem && typeof window.ScoreSystem.restoreGuestIdentity === 'function') {
+    try {
+      await window.ScoreSystem.restoreGuestIdentity({ gun: gunSupportsUser ? gun : null, portalRoot });
+    } catch (err) {
+      console.warn('Failed to restore guest identity for chat', err);
+      if (typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
+        window.ScoreSystem.ensureGuestIdentity();
+      }
+    }
+  } else if (window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
+    window.ScoreSystem.ensureGuestIdentity();
+  }
+
+  scoreManager = window.ScoreSystem && typeof window.ScoreSystem.getManager === 'function'
+    ? window.ScoreSystem.getManager({
+        gun: gunSupportsUser ? gun : null,
+        user: portalUser,
+        portalRoot
+      })
+    : null;
+
+  setupScoreTracking();
+
+  chatIdentity = resolveChatIdentity();
+  userId = chatIdentity.id;
+  isGuestIdentity = chatIdentity.type === 'guest';
+  chatProfile = gun.get(chatIdentity.profileRoot).get(userId);
+
+  initializeChatProfile();
+}
+
+initializeChat();
 
 initNotifications();
 </script>

--- a/profile.html
+++ b/profile.html
@@ -138,24 +138,10 @@ if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'funct
 }
 
 let isSignedIn = localStorage.getItem('signedIn') === 'true';
-if (!isSignedIn && window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
-  window.ScoreSystem.ensureGuestIdentity();
-}
-
-const scoreManager = window.ScoreSystem
-  ? window.ScoreSystem.getManager({ gun, user, portalRoot })
-  : null;
-
-let authState = scoreManager
-  ? scoreManager.getState()
-  : (window.ScoreSystem && typeof window.ScoreSystem.computeAuthState === 'function'
-    ? window.ScoreSystem.computeAuthState()
-    : { mode: 'anon' });
-
-isSignedIn = authState.mode === 'user';
-let isGuest = authState.mode === 'guest';
-
-let activeProfile = scoreManager ? scoreManager.getNode() : null;
+let isGuest = false;
+let scoreManager = null;
+let authState = { mode: 'anon' };
+let activeProfile = null;
 let latestProfileName = '';
 let aliasName = '';
 let portalStoredName = (localStorage.getItem('username') || '').trim();
@@ -326,36 +312,68 @@ function initializeGuestProfile() {
   isSignedIn = false;
   isGuest = true;
   aliasName = '';
-  activeProfile = ensureGuestProfileNode();
+  const managerGuestNode = scoreManager ? scoreManager.getNode() : null;
+  activeProfile = managerGuestNode || ensureGuestProfileNode();
   watchUsername(activeProfile);
   applyDisplayName();
   subscribeToScore();
 }
 
-const signedInAlias = (localStorage.getItem('alias') || '').trim();
-const signedInPassword = localStorage.getItem('password');
-
-if (isSignedIn && signedInAlias && signedInPassword) {
-  aliasName = aliasToDisplay(signedInAlias);
-  if (user.is) {
-    initializeSignedInProfile();
-  } else {
-    user.auth(signedInAlias, signedInPassword, ack => {
-      if (ack && ack.err) {
-        alert('Session expired. Please sign in again.');
-        localStorage.removeItem('signedIn');
-        localStorage.removeItem('alias');
-        localStorage.removeItem('username');
-        localStorage.removeItem('password');
-        initializeGuestProfile();
-      } else {
-        initializeSignedInProfile();
+async function startProfile() {
+  if (window.ScoreSystem && typeof window.ScoreSystem.restoreGuestIdentity === 'function') {
+    try {
+      await window.ScoreSystem.restoreGuestIdentity({ gun, portalRoot });
+    } catch (err) {
+      console.warn('Failed to restore guest identity from relay', err);
+      if (typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
+        window.ScoreSystem.ensureGuestIdentity();
       }
-    });
+    }
+  } else if (window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
+    window.ScoreSystem.ensureGuestIdentity();
   }
-} else {
-  initializeGuestProfile();
+
+  scoreManager = window.ScoreSystem
+    ? window.ScoreSystem.getManager({ gun, user, portalRoot })
+    : null;
+
+  authState = scoreManager
+    ? scoreManager.getState()
+    : (window.ScoreSystem && typeof window.ScoreSystem.computeAuthState === 'function'
+      ? window.ScoreSystem.computeAuthState()
+      : { mode: 'anon' });
+
+  isSignedIn = authState.mode === 'user';
+  isGuest = authState.mode === 'guest';
+  activeProfile = scoreManager ? scoreManager.getNode() : null;
+
+  const signedInAlias = (localStorage.getItem('alias') || '').trim();
+  const signedInPassword = localStorage.getItem('password');
+
+  if (isSignedIn && signedInAlias && signedInPassword) {
+    aliasName = aliasToDisplay(signedInAlias);
+    if (user.is) {
+      initializeSignedInProfile();
+    } else {
+      user.auth(signedInAlias, signedInPassword, ack => {
+        if (ack && ack.err) {
+          alert('Session expired. Please sign in again.');
+          localStorage.removeItem('signedIn');
+          localStorage.removeItem('alias');
+          localStorage.removeItem('username');
+          localStorage.removeItem('password');
+          initializeGuestProfile();
+        } else {
+          initializeSignedInProfile();
+        }
+      });
+    }
+  } else {
+    initializeGuestProfile();
+  }
 }
+
+startProfile();
 
 function saveUsername() {
   const nameInput = document.getElementById('name-input');


### PR DESCRIPTION
## Summary
- add relay-backed guest identity restoration and fingerprint mapping to the shared score system so guest progress survives storage resets
- update profile, chat, navbar, and calendar flows to await guest identity restoration before using Gun nodes or guest state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e06c4727448320b88194753ecce22f