### PR TITLE
Add immersive 3D logo experience to landing page

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -123,6 +123,65 @@ body.landing {
   align-items: center;
 }
 
+.hero-logo-wrapper {
+  display: grid;
+  gap: 0.85rem;
+  justify-items: center;
+}
+
+.hero-logo {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: min(220px, 48vw);
+  aspect-ratio: 1 / 1;
+  padding: 1.5rem;
+  border-radius: 32px;
+  background: radial-gradient(circle at 30% 30%, rgba(34, 211, 238, 0.4), rgba(8, 15, 35, 0.9));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 40px 90px rgba(8, 15, 35, 0.5);
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+}
+
+.hero-logo:hover,
+.hero-logo:focus-visible {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 48px 110px rgba(34, 211, 238, 0.55);
+  border-color: rgba(56, 189, 248, 0.55);
+  outline: none;
+}
+
+.hero-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 1;
+  filter: drop-shadow(0 12px 24px rgba(15, 23, 42, 0.45));
+}
+
+.hero-logo__glow {
+  position: absolute;
+  inset: 14%;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.6), transparent 65%);
+  filter: blur(12px);
+  opacity: 0.75;
+  z-index: 0;
+  transition: opacity var(--transition-base);
+}
+
+.hero-logo:hover .hero-logo__glow,
+.hero-logo:focus-visible .hero-logo__glow {
+  opacity: 1;
+}
+
+.hero-logo__caption {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
 .hero-eyebrow {
   display: inline-flex;
   align-items: center;
@@ -182,6 +241,118 @@ body.landing {
   gap: 1rem;
   justify-content: center;
   margin-top: 0.75rem;
+}
+
+.logo-viewer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 2000;
+}
+
+.logo-viewer[hidden] {
+  display: none;
+}
+
+.logo-viewer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.6), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(34, 211, 238, 0.45), transparent 60%),
+    rgba(2, 6, 23, 0.86);
+  backdrop-filter: blur(24px);
+}
+
+.logo-viewer__dialog {
+  position: relative;
+  width: min(960px, 100%);
+  max-height: min(92vh, 720px);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 80px 160px rgba(2, 6, 23, 0.75);
+  color: #e2e8f0;
+  overflow: hidden;
+}
+
+.logo-viewer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.logo-viewer__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.logo-viewer__close {
+  border: none;
+  background: rgba(148, 163, 184, 0.16);
+  color: inherit;
+  border-radius: 999px;
+  width: 2.5rem;
+  height: 2.5rem;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background var(--transition-base), transform var(--transition-base);
+}
+
+.logo-viewer__close:hover,
+.logo-viewer__close:focus-visible {
+  background: rgba(56, 189, 248, 0.32);
+  transform: scale(1.05);
+  outline: none;
+}
+
+.logo-viewer model-viewer {
+  width: 100%;
+  height: clamp(320px, 60vh, 520px);
+  border-radius: 20px;
+  overflow: hidden;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.7));
+}
+
+.logo-viewer__hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+  text-align: center;
+}
+
+.logo-viewer__fallback {
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+body.logo-viewer-open {
+  overflow: hidden;
+}
+
+@media (max-width: 640px) {
+  .logo-viewer {
+    padding: 1rem;
+  }
+
+  .logo-viewer__dialog {
+    padding: 1.25rem;
+    border-radius: 20px;
+  }
+
+  .logo-viewer__header h2 {
+    font-size: 1.2rem;
+  }
 }
 
 .cta {

--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
   <script src="score.js"></script>
   <link rel="stylesheet" href="styles/global.css">
   <link rel="stylesheet" href="index-style.css">
+  <script
+    type="module"
+    src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"
+  ></script>
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#0e1116">
   <meta name="mobile-web-app-capable" content="yes">
@@ -44,6 +48,18 @@
         <span class="hero-eyebrow">Open Metaverse Community</span>
         <h1 id="landing-title">Welcome to the 3DVR Portal</h1>
         <p class="hero-tagline">Launch straight into the apps that power the community and keep everyone in sync.</p>
+        <div class="hero-logo-wrapper">
+          <button
+            type="button"
+            class="hero-logo"
+            data-logo-viewer-trigger
+            aria-label="Open interactive 3D logo"
+          >
+            <img src="icons/icon-512.png" alt="3DVR Portal logo" loading="lazy" />
+            <span class="hero-logo__glow" aria-hidden="true"></span>
+          </button>
+          <p class="hero-logo__caption">Tap the emblem to explore the logo in 3D.</p>
+        </div>
         <div class="hero-actions">
           <button type="button" class="cta primary" data-app-search-trigger>Browse apps</button>
           <a href="points.html" class="cta ghost">Start earning</a>
@@ -279,6 +295,48 @@
 
   <button id="installBtn" class="install-btn cta primary" type="button">⬇️ Install 3DVR Portal</button>
 
+  <div
+    class="logo-viewer"
+    data-logo-viewer
+    role="presentation"
+    hidden
+    aria-hidden="true"
+  >
+    <div class="logo-viewer__backdrop" data-logo-viewer-backdrop aria-hidden="true"></div>
+    <div
+      class="logo-viewer__dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="logoViewerTitle"
+      data-logo-viewer-dialog
+    >
+      <header class="logo-viewer__header">
+        <h2 id="logoViewerTitle">3DVR logo playground</h2>
+        <button
+          type="button"
+          class="logo-viewer__close"
+          data-logo-viewer-close
+          aria-label="Close 3D logo experience"
+        >
+          ✕
+        </button>
+      </header>
+      <model-viewer
+        src="media/3dvr-logo.glb"
+        camera-controls
+        autoplay
+        ar
+        shadow-intensity="1"
+        exposure="1"
+        interaction-prompt="none"
+      >
+        <div class="logo-viewer__fallback" slot="fallback">
+          <p>Your browser can't display the 3D model yet. Try updating or switching to a modern browser.</p>
+        </div>
+      </model-viewer>
+      <p class="logo-viewer__hint">Drag to orbit, pinch or scroll to zoom, and double-tap to reset the view.</p>
+    </div>
+  </div>
   <script>
     const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
     const user = gun.user();
@@ -1060,6 +1118,97 @@
 
     const initialSearchValue = searchInput?.value ?? '';
     updateAppFilter(initialSearchValue);
+    const logoViewer = document.querySelector('[data-logo-viewer]');
+    const logoViewerDialog = logoViewer?.querySelector('[data-logo-viewer-dialog]') ?? null;
+    const logoViewerClose = logoViewer?.querySelector('[data-logo-viewer-close]') ?? null;
+    const logoViewerBackdrop = logoViewer?.querySelector('[data-logo-viewer-backdrop]') ?? null;
+    const logoViewerTrigger = document.querySelector('[data-logo-viewer-trigger]');
+    const focusableSelector = [
+      'a[href]',
+      'area[href]',
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(',');
+    let previousActiveElement = null;
+
+    const getFocusableElements = () => {
+      if (!logoViewerDialog) return [];
+      return Array.from(logoViewerDialog.querySelectorAll(focusableSelector)).filter(
+        (element) => element.offsetParent !== null || element === document.activeElement
+      );
+    };
+
+    const trapFocus = (event) => {
+      if (event.key !== 'Tab') return;
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey) {
+        if (document.activeElement === first || document.activeElement === logoViewerDialog) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    function closeLogoViewer() {
+      if (!logoViewer) return;
+      logoViewer.setAttribute('hidden', '');
+      logoViewer.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('logo-viewer-open');
+      document.removeEventListener('keydown', handleLogoViewerKeydown);
+      if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
+        previousActiveElement.focus();
+      }
+    }
+
+    function openLogoViewer() {
+      if (!logoViewer) return;
+      previousActiveElement = document.activeElement;
+      logoViewer.removeAttribute('hidden');
+      logoViewer.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('logo-viewer-open');
+      document.addEventListener('keydown', handleLogoViewerKeydown);
+      window.requestAnimationFrame(() => {
+        const focusTarget = logoViewerClose ?? getFocusableElements()[0];
+        focusTarget?.focus();
+      });
+    }
+
+    function handleLogoViewerKeydown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeLogoViewer();
+        return;
+      }
+
+      trapFocus(event);
+    }
+
+    logoViewerTrigger?.addEventListener('click', () => {
+      openLogoViewer();
+    });
+
+    logoViewerClose?.addEventListener('click', () => {
+      closeLogoViewer();
+    });
+
+    logoViewerBackdrop?.addEventListener('click', () => {
+      closeLogoViewer();
+    });
+
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dedicated hero logo trigger that invites visitors to open the 3D logo experience
- introduce a full-screen modal with the new logo model powered by `<model-viewer>` and accessibility-friendly controls
- style the hero call-to-action and modal for a polished glow treatment that matches the dark theme

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efda6584a48320aa941d51e9ab4ea2