### PR TITLE
Simplify sales directory to core workspace tools

### DIFF
--- a/sales/index.html
+++ b/sales/index.html
@@ -11,12 +11,13 @@
     <div class="max-w-6xl mx-auto px-6 py-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
       <div>
         <p class="uppercase tracking-[0.3em] text-xs text-blue-200">3dvr.tech</p>
-        <h1 class="text-3xl font-bold mt-2">Revenue Operations Command Center</h1>
-        <p class="text-sm text-blue-100 mt-1">Everything the team needs to attract, close, and delight customers.</p>
+        <h1 class="text-3xl font-bold mt-2">Founder Revenue Launchpad</h1>
+        <p class="text-sm text-blue-100 mt-1">Coordinate calendar, contacts, CRM, and daily habits in one place.</p>
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../contacts/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Contacts Workspace</a>
         <a href="../crm/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">CRM</a>
+        <a href="../calendar" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Calendar</a>
         <a href="../index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Main Portal</a>
       </nav>
     </div>
@@ -25,25 +26,25 @@
   <main class="max-w-6xl mx-auto px-6 py-10 space-y-10">
     <section>
       <div class="flex items-center justify-between flex-wrap gap-4 mb-6">
-        <h2 class="text-xl font-semibold">This Week's Revenue Priorities</h2>
-        <span class="text-xs uppercase tracking-[0.3em] text-blue-300">Grounded in live systems</span>
+        <h2 class="text-xl font-semibold">This Week's Launch Priorities</h2>
+        <span class="text-xs uppercase tracking-[0.3em] text-blue-300">Run inside your workspace</span>
       </div>
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <article class="rounded-2xl bg-gradient-to-br from-blue-700 to-blue-500 p-4 shadow-lg">
-          <p class="text-xs uppercase tracking-wide text-blue-100">Inbound demand</p>
-          <p class="text-sm text-blue-100 mt-2">Review the "New Demo Requests" view in HubSpot and assign owners before noon.</p>
+          <p class="text-xs uppercase tracking-wide text-blue-100">Calendar rhythm</p>
+          <p class="text-sm text-blue-100 mt-2">Lock focus blocks for sales calls, product work, and review them in the calendar daily.</p>
         </article>
         <article class="rounded-2xl bg-gradient-to-br from-purple-700 to-purple-500 p-4 shadow-lg">
-          <p class="text-xs uppercase tracking-wide text-purple-100">Outbound follow-through</p>
-          <p class="text-sm text-purple-100 mt-2">Advance contacts in Apollo step 3 with custom loom recaps—log responses back to the CRM.</p>
+          <p class="text-xs uppercase tracking-wide text-purple-100">Pipeline momentum</p>
+          <p class="text-sm text-purple-100 mt-2">Move deals forward in the CRM and jot next-step notes so nothing slips through.</p>
         </article>
         <article class="rounded-2xl bg-gradient-to-br from-emerald-600 to-emerald-500 p-4 shadow-lg">
-          <p class="text-xs uppercase tracking-wide text-emerald-100">Warm referrals</p>
-          <p class="text-sm text-emerald-100 mt-2">Check the partner Slack channel for introductions and capture each in the "Referrals" pipeline.</p>
+          <p class="text-xs uppercase tracking-wide text-emerald-100">Relationship follow-up</p>
+          <p class="text-sm text-emerald-100 mt-2">Review contacts tagged as warm and send personal check-ins before week's end.</p>
         </article>
         <article class="rounded-2xl bg-gradient-to-br from-slate-700 to-slate-600 p-4 shadow-lg">
-          <p class="text-xs uppercase tracking-wide text-slate-200">Response discipline</p>
-          <p class="text-sm text-slate-200 mt-2">Triage unanswered emails tagged <span class="font-semibold text-white">#hot</span> before EOD using the shared inbox view.</p>
+          <p class="text-xs uppercase tracking-wide text-slate-200">Execution discipline</p>
+          <p class="text-sm text-slate-200 mt-2">Clear the day's task queue and capture new ideas in notes while they're fresh.</p>
         </article>
       </div>
     </section>
@@ -51,37 +52,37 @@
     <section>
       <div class="flex items-center justify-between flex-wrap gap-4 mb-6">
         <h2 class="text-xl font-semibold">Mission Control</h2>
-        <a href="../calendar" class="text-xs uppercase tracking-[0.3em] text-blue-300 hover:text-blue-200">View calendar →</a>
+        <a href="../calendar" class="text-xs uppercase tracking-[0.3em] text-blue-300 hover:text-blue-200">Open calendar →</a>
       </div>
       <div class="grid gap-6 lg:grid-cols-[1.4fr,1fr]">
         <article class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 shadow-lg space-y-6">
           <header class="flex items-center justify-between">
-            <h3 class="text-lg font-semibold">Pipeline Board</h3>
-            <a href="leads.html" class="text-blue-300 text-sm hover:text-blue-200">Open leads workspace →</a>
+            <h3 class="text-lg font-semibold">Daily Revenue Workflow</h3>
+            <a href="../crm/index.html" class="text-blue-300 text-sm hover:text-blue-200">Jump into CRM →</a>
           </header>
           <div class="grid gap-4 md:grid-cols-3">
             <div class="rounded-xl bg-slate-900 border border-white/5 p-4">
-              <p class="text-xs uppercase tracking-wide text-slate-400">New</p>
+              <p class="text-xs uppercase tracking-wide text-slate-400">Plan</p>
               <ul class="mt-3 text-sm text-slate-300 space-y-1">
-                <li>• Assign every fresh inbound form submission in HubSpot.</li>
-                <li>• Run the "VR-curious" intent list and drop priority notes into the CRM.</li>
-                <li>• Book discovery within 48 hours using the Calendly round-robin.</li>
+                <li>• Review today's meetings and prep agendas inside the calendar.</li>
+                <li>• Capture fresh leads directly in the CRM's new pipeline column.</li>
+                <li>• Schedule one founder outreach block before noon.</li>
               </ul>
             </div>
             <div class="rounded-xl bg-slate-900 border border-white/5 p-4">
-              <p class="text-xs uppercase tracking-wide text-blue-400">In Progress</p>
+              <p class="text-xs uppercase tracking-wide text-blue-400">Engage</p>
               <ul class="mt-3 text-sm text-slate-300 space-y-1">
-                <li>• Align solution fit in Notion deal room before demos.</li>
-                <li>• Capture technical requirements in the "Implementation" custom object.</li>
-                <li>• Share curated immersive project reels for their vertical.</li>
+                <li>• Update deal notes after every call while it's top of mind.</li>
+                <li>• Add new decision makers to contacts with quick context tags.</li>
+                <li>• Drop action items into the task list before you leave the page.</li>
               </ul>
             </div>
             <div class="rounded-xl bg-slate-900 border border-white/5 p-4">
-              <p class="text-xs uppercase tracking-wide text-emerald-400">Ready to Close</p>
+              <p class="text-xs uppercase tracking-wide text-emerald-400">Review</p>
               <ul class="mt-3 text-sm text-slate-300 space-y-1">
-                <li>• Confirm procurement checklist items are attached in CRM files.</li>
-                <li>• Loop success manager for onboarding timeline alignment.</li>
-                <li>• Send dual-option proposal template from PandaDoc.</li>
+                <li>• Check tasks marked "waiting" and unblock anything stalled.</li>
+                <li>• Summarize wins and lessons learned in your notes hub.</li>
+                <li>• Confirm tomorrow's meetings are prepped and resourced.</li>
               </ul>
             </div>
           </div>
@@ -90,16 +91,16 @@
           <h3 class="text-lg font-semibold">Key Updates</h3>
           <ul class="space-y-3 text-sm text-slate-300">
             <li>
-              <p class="font-medium text-slate-100">Launch: immersive buyer kit</p>
-              <p class="text-xs text-slate-400">Assets drop Friday @ 10:00 AM PST</p>
+              <p class="font-medium text-slate-100">New task templates</p>
+              <p class="text-xs text-slate-400">Use the "Launch Checklist" list to guide your next sprint.</p>
             </li>
             <li>
-              <p class="font-medium text-slate-100">Marketing sync</p>
-              <p class="text-xs text-slate-400">Tuesday @ 2:00 PM — finalize Q2 campaigns</p>
+              <p class="font-medium text-slate-100">Notes workspace refresh</p>
+              <p class="text-xs text-slate-400">Capture meeting minutes with the new decision + follow-up fields.</p>
             </li>
             <li>
-              <p class="font-medium text-slate-100">Product spotlight</p>
-              <p class="text-xs text-slate-400">Live VR configurator shipping to beta clients</p>
+              <p class="font-medium text-slate-100">Calendar sync tips</p>
+              <p class="text-xs text-slate-400">Keep recurring founder sessions blocked so momentum stays high.</p>
             </li>
           </ul>
         </aside>
@@ -109,55 +110,45 @@
     <section>
       <h2 class="text-xl font-semibold mb-6">Explore Tools</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
-        <a href="leads.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
-          <p class="text-xs uppercase tracking-wide text-blue-300">Prospecting</p>
-          <h3 class="text-lg font-semibold mt-2">Leads & Prospects</h3>
-          <p class="text-sm text-slate-300 mt-3">Daily playbooks, lead capture forms, and the prioritized follow-up queue.</p>
-        </a>
-        <a href="marketing.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
-          <p class="text-xs uppercase tracking-wide text-blue-300">Growth Engine</p>
-          <h3 class="text-lg font-semibold mt-2">Marketing Dashboard</h3>
-          <p class="text-sm text-slate-300 mt-3">Coordinate with marketing on live campaigns that produce fresh conversations.</p>
-        </a>
         <a href="../crm/index.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
-          <p class="text-xs uppercase tracking-wide text-blue-300">Relationships</p>
+          <p class="text-xs uppercase tracking-wide text-blue-300">Deals</p>
           <h3 class="text-lg font-semibold mt-2">CRM</h3>
-          <p class="text-sm text-slate-300 mt-3">Source of truth for deal status, buying teams, and activity logs.</p>
+          <p class="text-sm text-slate-300 mt-3">Track opportunities, assign stages, and record progress in real time.</p>
         </a>
         <a href="../contacts/index.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
           <p class="text-xs uppercase tracking-wide text-blue-300">Network</p>
           <h3 class="text-lg font-semibold mt-2">Contacts Workspace</h3>
-          <p class="text-sm text-slate-300 mt-3">Map stakeholders, note warm paths, and request introductions with context.</p>
+          <p class="text-sm text-slate-300 mt-3">Organize founders, champions, and investors with quick context tags.</p>
         </a>
-        <a href="analytics.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
-          <p class="text-xs uppercase tracking-wide text-blue-300">Signals</p>
-          <h3 class="text-lg font-semibold mt-2">Analytics & Reporting</h3>
-          <p class="text-sm text-slate-300 mt-3">Links to live dashboards plus guidance on interpreting leading indicators.</p>
+        <a href="../calendar" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
+          <p class="text-xs uppercase tracking-wide text-blue-300">Schedule</p>
+          <h3 class="text-lg font-semibold mt-2">Calendar</h3>
+          <p class="text-sm text-slate-300 mt-3">Plan your week, stack critical meetings, and protect focus time.</p>
         </a>
-        <a href="scripts.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
-          <p class="text-xs uppercase tracking-wide text-blue-300">Enablement</p>
-          <h3 class="text-lg font-semibold mt-2">Sales Scripts</h3>
-          <p class="text-sm text-slate-300 mt-3">Industry-specific messaging, proof assets, and objection responses.</p>
+        <a href="../tasks.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
+          <p class="text-xs uppercase tracking-wide text-blue-300">Execution</p>
+          <h3 class="text-lg font-semibold mt-2">Tasks</h3>
+          <p class="text-sm text-slate-300 mt-3">Break goals into next steps and work straight from prioritized lists.</p>
         </a>
-        <a href="team.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
-          <p class="text-xs uppercase tracking-wide text-blue-300">Accountability</p>
-          <h3 class="text-lg font-semibold mt-2">Team Assignments</h3>
-          <p class="text-sm text-slate-300 mt-3">Know the point people for territories, product lines, and enablement tasks.</p>
+        <a href="../notes.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
+          <p class="text-xs uppercase tracking-wide text-blue-300">Knowledge</p>
+          <h3 class="text-lg font-semibold mt-2">Notes</h3>
+          <p class="text-sm text-slate-300 mt-3">Store ideas, meeting takeaways, and playbooks for future launches.</p>
         </a>
-        <a href="training.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
-          <p class="text-xs uppercase tracking-wide text-blue-300">Mastery</p>
-          <h3 class="text-lg font-semibold mt-2">Offer & Sales Training</h3>
-          <p class="text-sm text-slate-300 mt-3">The Hormozi-inspired playbook with built-in progress checkpoints.</p>
+        <a href="../index.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
+          <p class="text-xs uppercase tracking-wide text-blue-300">Hub</p>
+          <h3 class="text-lg font-semibold mt-2">Main Portal</h3>
+          <p class="text-sm text-slate-300 mt-3">Jump to any workspace in the suite and stay aligned with the mission.</p>
         </a>
       </div>
     </section>
 
     <section class="rounded-2xl bg-gradient-to-br from-blue-700 via-blue-600 to-purple-700 p-8 shadow-xl text-center">
-      <h2 class="text-2xl font-semibold">Need Backup on a Deal?</h2>
-      <p class="text-sm text-blue-50 mt-3 max-w-2xl mx-auto">Tap the enablement team for custom decks, ROI models, or technical deep dives. Drop details in the support queue and someone will respond within a business day.</p>
+      <h2 class="text-2xl font-semibold">Ship Faster With the Suite</h2>
+      <p class="text-sm text-blue-50 mt-3 max-w-2xl mx-auto">Set your priorities in tasks, capture insights in notes, and lock time on the calendar so every idea moves closer to launch.</p>
       <div class="mt-6 flex flex-wrap justify-center gap-3">
-        <a href="https://3dvr.tech" class="inline-flex items-center justify-center rounded-lg bg-white text-blue-900 px-5 py-2.5 font-semibold shadow hover:bg-blue-50">Talk to Support</a>
-        <a href="scripts.html" class="inline-flex items-center justify-center rounded-lg bg-blue-900/30 border border-white/30 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-900/40">Download Scripts</a>
+        <a href="../tasks.html" class="inline-flex items-center justify-center rounded-lg bg-white text-blue-900 px-5 py-2.5 font-semibold shadow hover:bg-blue-50">Open Tasks</a>
+        <a href="../notes.html" class="inline-flex items-center justify-center rounded-lg bg-blue-900/30 border border-white/30 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-900/40">Review Notes</a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- refocused the sales landing page messaging on the calendar, CRM, contacts, tasks, and notes tools that are live today
- updated navigation tiles and calls to action so they only link to currently supported workspaces
- refreshed mission control guidance and key updates to match the simplified founder workflow

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68f902af2f4c83208394958f99f89c79