### PR TITLE
Remove launch priorities and mission control panels from sales hub

### DIFF
--- a/sales/index.html
+++ b/sales/index.html
@@ -12,7 +12,7 @@
       <div>
         <p class="uppercase tracking-[0.3em] text-xs text-blue-200">3dvr.tech</p>
         <h1 class="text-3xl font-bold mt-2">Founder Revenue Launchpad</h1>
-        <p class="text-sm text-blue-100 mt-1">Coordinate calendar, contacts, CRM, and daily habits in one place.</p>
+        <p class="text-sm text-blue-100 mt-1">Jump straight into CRM, contacts, calendar, and more to keep momentum high.</p>
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../contacts/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Contacts Workspace</a>
@@ -26,89 +26,10 @@
   <main class="max-w-6xl mx-auto px-6 py-10 space-y-10">
     <section>
       <div class="flex items-center justify-between flex-wrap gap-4 mb-6">
-        <h2 class="text-xl font-semibold">This Week's Launch Priorities</h2>
-        <span class="text-xs uppercase tracking-[0.3em] text-blue-300">Run inside your workspace</span>
+        <h2 class="text-xl font-semibold">Explore Tools</h2>
+        <p class="text-xs uppercase tracking-[0.3em] text-blue-300">Choose a workspace to dive in</p>
       </div>
-      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <article class="rounded-2xl bg-gradient-to-br from-blue-700 to-blue-500 p-4 shadow-lg">
-          <p class="text-xs uppercase tracking-wide text-blue-100">Calendar rhythm</p>
-          <p class="text-sm text-blue-100 mt-2">Lock focus blocks for sales calls, product work, and review them in the calendar daily.</p>
-        </article>
-        <article class="rounded-2xl bg-gradient-to-br from-purple-700 to-purple-500 p-4 shadow-lg">
-          <p class="text-xs uppercase tracking-wide text-purple-100">Pipeline momentum</p>
-          <p class="text-sm text-purple-100 mt-2">Move deals forward in the CRM and jot next-step notes so nothing slips through.</p>
-        </article>
-        <article class="rounded-2xl bg-gradient-to-br from-emerald-600 to-emerald-500 p-4 shadow-lg">
-          <p class="text-xs uppercase tracking-wide text-emerald-100">Relationship follow-up</p>
-          <p class="text-sm text-emerald-100 mt-2">Review contacts tagged as warm and send personal check-ins before week's end.</p>
-        </article>
-        <article class="rounded-2xl bg-gradient-to-br from-slate-700 to-slate-600 p-4 shadow-lg">
-          <p class="text-xs uppercase tracking-wide text-slate-200">Execution discipline</p>
-          <p class="text-sm text-slate-200 mt-2">Clear the day's task queue and capture new ideas in notes while they're fresh.</p>
-        </article>
-      </div>
-    </section>
-
-    <section>
-      <div class="flex items-center justify-between flex-wrap gap-4 mb-6">
-        <h2 class="text-xl font-semibold">Mission Control</h2>
-        <a href="../calendar" class="text-xs uppercase tracking-[0.3em] text-blue-300 hover:text-blue-200">Open calendar →</a>
-      </div>
-      <div class="grid gap-6 lg:grid-cols-[1.4fr,1fr]">
-        <article class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 shadow-lg space-y-6">
-          <header class="flex items-center justify-between">
-            <h3 class="text-lg font-semibold">Daily Revenue Workflow</h3>
-            <a href="../crm/index.html" class="text-blue-300 text-sm hover:text-blue-200">Jump into CRM →</a>
-          </header>
-          <div class="grid gap-4 md:grid-cols-3">
-            <div class="rounded-xl bg-slate-900 border border-white/5 p-4">
-              <p class="text-xs uppercase tracking-wide text-slate-400">Plan</p>
-              <ul class="mt-3 text-sm text-slate-300 space-y-1">
-                <li>• Review today's meetings and prep agendas inside the calendar.</li>
-                <li>• Capture fresh leads directly in the CRM's new pipeline column.</li>
-                <li>• Schedule one founder outreach block before noon.</li>
-              </ul>
-            </div>
-            <div class="rounded-xl bg-slate-900 border border-white/5 p-4">
-              <p class="text-xs uppercase tracking-wide text-blue-400">Engage</p>
-              <ul class="mt-3 text-sm text-slate-300 space-y-1">
-                <li>• Update deal notes after every call while it's top of mind.</li>
-                <li>• Add new decision makers to contacts with quick context tags.</li>
-                <li>• Drop action items into the task list before you leave the page.</li>
-              </ul>
-            </div>
-            <div class="rounded-xl bg-slate-900 border border-white/5 p-4">
-              <p class="text-xs uppercase tracking-wide text-emerald-400">Review</p>
-              <ul class="mt-3 text-sm text-slate-300 space-y-1">
-                <li>• Check tasks marked "waiting" and unblock anything stalled.</li>
-                <li>• Summarize wins and lessons learned in your notes hub.</li>
-                <li>• Confirm tomorrow's meetings are prepped and resourced.</li>
-              </ul>
-            </div>
-          </div>
-        </article>
-        <aside class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 shadow-lg space-y-4">
-          <h3 class="text-lg font-semibold">Key Updates</h3>
-          <ul class="space-y-3 text-sm text-slate-300">
-            <li>
-              <p class="font-medium text-slate-100">New task templates</p>
-              <p class="text-xs text-slate-400">Use the "Launch Checklist" list to guide your next sprint.</p>
-            </li>
-            <li>
-              <p class="font-medium text-slate-100">Notes workspace refresh</p>
-              <p class="text-xs text-slate-400">Capture meeting minutes with the new decision + follow-up fields.</p>
-            </li>
-            <li>
-              <p class="font-medium text-slate-100">Calendar sync tips</p>
-              <p class="text-xs text-slate-400">Keep recurring founder sessions blocked so momentum stays high.</p>
-            </li>
-          </ul>
-        </aside>
-      </div>
-    </section>
-
-    <section>
-      <h2 class="text-xl font-semibold mb-6">Explore Tools</h2>
+      <p class="text-sm text-slate-300 max-w-3xl mb-6">Pick the workspace that matches what you need to move forward right now—manage deals, coordinate your calendar, organize contacts, and capture notes without losing momentum.</p>
       <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
         <a href="../crm/index.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
           <p class="text-xs uppercase tracking-wide text-blue-300">Deals</p>


### PR DESCRIPTION
## Summary
- remove the Launch Priorities and Mission Control sections from the sales landing page
- refresh the hero copy to highlight quick access to core workspaces
- expand the Explore Tools section with guiding copy so contributors jump directly into the right app

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f93548677c8320b2fe5ad9b51e4938