### PR TITLE
Add meditation shortcut card to app list

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,11 @@
             <span class="app-card__title">Wellness</span>
             <span class="app-card__meta">Explore mindfulness, nutrition, and lifestyle resources.</span>
           </a>
+          <a href="mindfulness-session.html#meditationFlow" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🧘</span>
+            <span class="app-card__title">Meditation</span>
+            <span class="app-card__meta">Jump into the breathing room for guided calming cycles.</span>
+          </a>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add a dedicated Meditation app card to the home app grid
- link the shortcut directly to the breathing room section for quick access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa3532d4008320885077bc4ddb4021