### PR TITLE
Prevent mindfulness breathing session screen sleep

### DIFF
--- a/mindfulness-session.html
+++ b/mindfulness-session.html
@@ -446,6 +446,39 @@
     let counterAnimationId = null;
     let counterTimeoutId = null;
     let lastDisplayedSecond = 0;
+    const wakeLockSupported = 'wakeLock' in navigator;
+    let wakeLock = null;
+
+    async function requestWakeLock() {
+      if (!wakeLockSupported || wakeLock) {
+        return;
+      }
+      try {
+        wakeLock = await navigator.wakeLock.request('screen');
+        wakeLock.addEventListener('release', () => {
+          wakeLock = null;
+          if (isRunning && !document.hidden) {
+            requestWakeLock();
+          }
+        });
+      } catch (error) {
+        wakeLock = null;
+        console.warn('Unable to acquire screen wake lock', error);
+      }
+    }
+
+    async function releaseWakeLock() {
+      if (!wakeLockSupported || !wakeLock) {
+        return;
+      }
+      try {
+        await wakeLock.release();
+      } catch (error) {
+        console.warn('Unable to release screen wake lock', error);
+      } finally {
+        wakeLock = null;
+      }
+    }
 
     function updateCountText(value, animate = true) {
       if (!countValue) {
@@ -566,6 +599,7 @@
       isRunning = true;
       hasStarted = true;
       setToggleLabel();
+      requestWakeLock();
       scheduleNextPhase();
     }
 
@@ -574,6 +608,7 @@
       clearTimeout(timeoutId);
       stopCounter();
       setToggleLabel();
+      releaseWakeLock();
     }
 
     toggleSession.addEventListener('click', () => {
@@ -600,6 +635,8 @@
     document.addEventListener('visibilitychange', () => {
       if (document.hidden) {
         pauseSession();
+      } else if (isRunning) {
+        requestWakeLock();
       }
     });
 
@@ -625,6 +662,9 @@
     } else if (typeof motionPreference.addListener === 'function') {
       motionPreference.addListener(handleMotionPreference);
     }
+
+    window.addEventListener('pagehide', releaseWakeLock);
+    window.addEventListener('beforeunload', releaseWakeLock);
 
     showIdlePhase();
     updateCycleDuration();


### PR DESCRIPTION
## Summary
- keep the mindfulness breathing room active by requesting a screen wake lock while the session runs
- release the wake lock when the session pauses or the page is hidden to avoid leaving the screen on unnecessarily

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa37c887d48320be223ff136659b8e