### PR TITLE
Allow mindfulness page to scroll vertically

### DIFF
--- a/mindfulness-session.html
+++ b/mindfulness-session.html
@@ -20,7 +20,8 @@
         radial-gradient(circle at 80% 30%, rgba(94, 234, 212, 0.18), transparent 55%),
         #05070c;
       color: #f8fafc;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
     body::before,
     body::after {


### PR DESCRIPTION
## Summary
- allow vertical scrolling on the mindfulness session page so content is accessible when it exceeds the viewport
- keep horizontal overflow hidden to preserve layout effects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa390c054883208c35fbe08a0f7c81