### PR TITLE
Adjust meditation breathing audio timbre

### DIFF
--- a/mindfulness-session.html
+++ b/mindfulness-session.html
@@ -489,36 +489,36 @@
     };
 
     const phaseAudioSettings = {
-      inhale: { frequency: 238, intensity: 0.36, releaseLevel: 0.04, padLevel: 0.09 },
+      inhale: { frequency: 228, intensity: 0.32, releaseLevel: 0.05, padLevel: 0.08 },
       hold: { frequency: 284, intensity: 0.22, releaseLevel: 0.05, padLevel: 0.07 },
-      exhale: { frequency: 166, intensity: 0.3, releaseLevel: 0.02, padLevel: 0.08 },
+      exhale: { frequency: 184, intensity: 0.28, releaseLevel: 0.03, padLevel: 0.07 },
       rest: { frequency: 148, intensity: 0.16, releaseLevel: 0.02, padLevel: 0.06 },
       default: { frequency: 196, intensity: 0.24, releaseLevel: 0.02, padLevel: 0.07 }
     };
 
     const breathCueSettings = {
       inhale: {
-        filter: { start: 280, end: 640 },
-        q: 0.95,
-        peak: 0.52,
-        sustain: 0.28,
-        release: 0.9,
+        filter: { start: 260, end: 480 },
+        q: 0.75,
+        peak: 0.45,
+        sustain: 0.26,
+        release: 1.1,
         attackRatio: 0.5
       },
       exhale: {
-        filter: { start: 540, end: 260 },
-        q: 1.05,
-        peak: 0.48,
-        sustain: 0.16,
-        release: 1.4,
-        attackRatio: 0.32
+        filter: { start: 360, end: 240 },
+        q: 0.78,
+        peak: 0.4,
+        sustain: 0.18,
+        release: 1.3,
+        attackRatio: 0.38
       }
     };
 
     const toneCueSettings = {
-      inhale: { type: 'sine', start: 392, end: 622, peak: 0.22, sustain: 0.12, duration: 1.6 },
+      inhale: { type: 'triangle', start: 340, end: 460, peak: 0.18, sustain: 0.1, duration: 1.7 },
       hold: { type: 'triangle', start: 320, end: 320, peak: 0.12, sustain: 0.08, duration: 1.2 },
-      exhale: { type: 'sawtooth', start: 262, end: 180, peak: 0.24, sustain: 0.14, duration: 1.8 },
+      exhale: { type: 'triangle', start: 300, end: 220, peak: 0.17, sustain: 0.1, duration: 1.8 },
       rest: { type: 'sine', start: 220, end: 196, peak: 0.1, sustain: 0.06, duration: 1 }
     };
 


### PR DESCRIPTION
## Summary
- retune breathing phase oscillator frequencies and gain levels to reduce tonal contrast
- adjust inhale and exhale noise filter settings for a softer texture
- align tone cue waveforms and envelopes for smoother transitions between phases

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa4cc73a008320b99903ae3e94b407