### PR TITLE
Fix sales training workspace path

### DIFF
--- a/crm/index.html
+++ b/crm/index.html
@@ -18,7 +18,7 @@
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../sales/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Sales home</a>
-        <a href="../sales/training.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Training playbook</a>
+        <a href="../sales/training/" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Training playbook</a>
         <a href="../contacts/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Contacts workspace</a>
       </nav>
     </div>
@@ -31,7 +31,7 @@
         <p class="text-sm text-gray-300">This CRM uses the same 3DVR GUN relay as the contacts workspace. Tag people the same way so both apps stay aligned.</p>
         <div class="mt-4 flex flex-wrap gap-2">
           <a href="../contacts/index.html" class="bg-teal-600 hover:bg-teal-500 text-white px-3 py-2 rounded">Open contacts</a>
-          <a href="../sales/training.html" class="bg-sky-600 hover:bg-sky-500 text-white px-3 py-2 rounded">Review training</a>
+          <a href="../sales/training/" class="bg-sky-600 hover:bg-sky-500 text-white px-3 py-2 rounded">Review training</a>
         </div>
       </div>
       <div class="bg-gray-800/60 border border-white/10 rounded-xl p-5">

--- a/sales/index.html
+++ b/sales/index.html
@@ -36,7 +36,7 @@
           <h3 class="text-lg font-semibold mt-2">CRM</h3>
           <p class="text-sm text-slate-300 mt-3">Track opportunities, assign stages, and record progress in real time.</p>
         </a>
-        <a href="training.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
+        <a href="training/" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
           <p class="text-xs uppercase tracking-wide text-blue-300">Skills</p>
           <h3 class="text-lg font-semibold mt-2">Sales Training</h3>
           <p class="text-sm text-slate-300 mt-3">Build your rapid pitch, sharpen offers, and rehearse follow-up flows in one workspace.</p>

--- a/sales/scripts.html
+++ b/sales/scripts.html
@@ -19,7 +19,7 @@
           <h1 class="text-3xl font-bold">Sales Scripts &amp; Talk Tracks</h1>
           <p class="text-sm text-blue-100">Modular messaging for discovery calls, demos, and post-meeting follow-ups.</p>
         </div>
-        <a href="training.html" class="inline-flex items-center justify-center rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20">Open training model</a>
+        <a href="training/" class="inline-flex items-center justify-center rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20">Open training model</a>
       </div>
     </div>
   </header>

--- a/sales/team.html
+++ b/sales/team.html
@@ -57,7 +57,7 @@
     <section class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 space-y-5">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Weekly Commitments</h2>
-        <a href="training.html" class="text-sm text-blue-300 hover:text-blue-200">Link to enablement plan →</a>
+        <a href="training/" class="text-sm text-blue-300 hover:text-blue-200">Link to enablement plan →</a>
       </div>
       <div class="grid gap-4 md:grid-cols-3 text-sm text-slate-300">
         <article class="rounded-xl border border-white/5 bg-slate-900 p-4 space-y-2">

--- a/sales/training/index.html
+++ b/sales/training/index.html
@@ -100,7 +100,7 @@
       <header class="top">
         <div>
           <nav class="crumbs" aria-label="Breadcrumb">
-            <a href="index.html">Sales Directory</a>
+            <a href="../index.html">Sales Directory</a>
             <span aria-hidden="true">›</span>
             <span>Training</span>
           </nav>
@@ -109,8 +109,8 @@
         </div>
         <div class="actions">
           <button id="focusToggle" class="btn" type="button">Focus Mode</button>
-          <a href="../contacts/index.html" class="btn inline">Contacts</a>
-          <a href="../crm/index.html" class="btn inline">CRM</a>
+          <a href="../../contacts/index.html" class="btn inline">Contacts</a>
+          <a href="../../crm/index.html" class="btn inline">CRM</a>
           <button onclick="exportData()" class="btn" type="button">Export</button>
           <label class="btn" for="importer">Import<input id="importer" type="file" accept="application/json" hidden onchange="importData(event)"></label>
           <button onclick="window.print()" class="btn-warn" type="button">Print / PDF</button>
@@ -262,31 +262,31 @@
       { href: 'leads.html', label: 'Leads tracker', desc: 'Log outreach reps and note which pitch variant converts.' }
     ],
     foundation: [
-      { href: '../contacts/index.html', label: 'Contacts workspace', desc: 'Map real people to your avatar notes.' },
+      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Map real people to your avatar notes.' },
       { href: 'leads.html', label: 'Leads tracker', desc: 'Pair avatar research with pipeline commitments.' }
     ],
     offer: [
-      { href: '../crm/index.html', label: 'CRM dashboard', desc: 'Validate pricing and guarantees against live deals.' }
+      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Validate pricing and guarantees against live deals.' }
     ],
     leads: [
-      { href: '../contacts/index.html', label: 'Contacts workspace', desc: 'Segment outreach lists with tags and follow-ups.' },
+      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Segment outreach lists with tags and follow-ups.' },
       { href: 'marketing.html', label: 'Marketing dashboard', desc: 'Line up campaigns that feed the lead engine.' }
     ],
     sales: [
-      { href: '../crm/index.html', label: 'CRM dashboard', desc: 'Log call outcomes and next steps while momentum is high.' },
-      { href: '../contacts/index.html', label: 'Contacts workspace', desc: 'Update buyer committees and warm introductions.' }
+      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Log call outcomes and next steps while momentum is high.' },
+      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Update buyer committees and warm introductions.' }
     ],
     delivery: [
-      { href: '../crm/index.html', label: 'CRM dashboard', desc: 'Track onboarding milestones and proof artifacts.' }
+      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Track onboarding milestones and proof artifacts.' }
     ],
     retention: [
-      { href: '../contacts/index.html', label: 'Contacts workspace', desc: 'Tag promoters for referral asks and milestone gifts.' }
+      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Tag promoters for referral asks and milestone gifts.' }
     ],
     metrics: [
       { href: 'analytics.html', label: 'Analytics & reporting', desc: 'Compare weekly snapshot entries with live dashboards.' }
     ],
     default: [
-      { href: '../contacts/index.html', label: 'Contacts workspace', desc: 'Keep everyone aligned on who we serve next.' }
+      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Keep everyone aligned on who we serve next.' }
     ]
   };
 


### PR DESCRIPTION
## Summary
- move the sales training workspace into its own folder so `/sales/training/` resolves correctly
- update all navigation links in sales and CRM pages to point to the new route
- adjust breadcrumb and cross-links inside the training workspace for the deeper path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68faebf2717083208187527088fe4e76