### PR TITLE
Add dismissible install banner

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -823,13 +823,69 @@ footer a {
   gap: 0.75rem;
 }
 
-.install-btn {
+.install-banner {
   position: fixed;
   right: 1.5rem;
   bottom: 1.5rem;
   display: none;
-  z-index: 9999;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: rgba(7, 13, 26, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1rem;
   box-shadow: 0 36px 90px rgba(4, 9, 20, 0.65);
+  color: #fff;
+  z-index: 9999;
+  max-width: min(90vw, 24rem);
+}
+
+.install-banner--visible {
+  display: flex;
+}
+
+.install-banner__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.install-banner__text {
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.install-banner__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.install-banner__close:hover,
+.install-banner__close:focus-visible {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.install-btn {
+  display: inline-flex;
+  width: fit-content;
+  box-shadow: none;
+}
+
+@media (max-width: 720px) {
+  .install-banner {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+  }
 }
 
 @media (max-width: 720px) {

--- a/index.html
+++ b/index.html
@@ -302,7 +302,20 @@
     </div>
   </div>
 
-  <button id="installBtn" class="install-btn cta primary" type="button">⬇️ Install 3DVR Portal</button>
+  <div id="installPrompt" class="install-banner" hidden>
+    <div class="install-banner__content">
+      <span class="install-banner__text">Install 3DVR Portal for quick access.</span>
+      <button id="installBtn" class="install-btn cta primary" type="button">⬇️ Install 3DVR Portal</button>
+    </div>
+    <button
+      id="installPromptClose"
+      class="install-banner__close"
+      type="button"
+      aria-label="Dismiss install prompt"
+    >
+      ×
+    </button>
+  </div>
 
   <script>
     const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
@@ -766,7 +779,9 @@
   <script src="navbar.js"></script>
 
   <script>
+    const installPrompt = document.getElementById('installPrompt');
     const installBtn = document.getElementById('installBtn');
+    const installPromptClose = document.getElementById('installPromptClose');
 
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
@@ -776,11 +791,36 @@
     }
 
     let deferredPrompt;
+    let installHideTimeout;
+
+    const scheduleInstallHide = () => {
+      clearTimeout(installHideTimeout);
+      installHideTimeout = window.setTimeout(() => {
+        hideInstallPrompt();
+      }, 15000);
+    };
+
+    const hideInstallPrompt = () => {
+      if (!installPrompt) return;
+      clearTimeout(installHideTimeout);
+      installPrompt.classList.remove('install-banner--visible');
+      installPrompt.setAttribute('hidden', '');
+    };
+
+    const showInstallPrompt = () => {
+      if (!installPrompt) return;
+      clearTimeout(installHideTimeout);
+      installPrompt.removeAttribute('hidden');
+      installPrompt.classList.add('install-banner--visible');
+      scheduleInstallHide();
+    };
 
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       deferredPrompt = e;
-      installBtn.style.display = 'inline-flex';
+      if (installBtn) {
+        showInstallPrompt();
+      }
     });
 
     installBtn?.addEventListener('click', async () => {
@@ -788,12 +828,36 @@
       deferredPrompt.prompt();
       const { outcome } = await deferredPrompt.userChoice;
       deferredPrompt = null;
-      installBtn.style.display = 'none';
+      hideInstallPrompt();
       console.log('Install choice:', outcome);
     });
 
     window.addEventListener('appinstalled', () => {
-      installBtn.style.display = 'none';
+      hideInstallPrompt();
+    });
+
+    installPromptClose?.addEventListener('click', () => {
+      hideInstallPrompt();
+    });
+
+    installPrompt?.addEventListener('mouseenter', () => {
+      clearTimeout(installHideTimeout);
+    });
+
+    installPrompt?.addEventListener('mouseleave', () => {
+      if (installPrompt.classList.contains('install-banner--visible')) {
+        scheduleInstallHide();
+      }
+    });
+
+    installPrompt?.addEventListener('focusin', () => {
+      clearTimeout(installHideTimeout);
+    });
+
+    installPrompt?.addEventListener('focusout', (event) => {
+      if (!installPrompt.contains(event.relatedTarget)) {
+        scheduleInstallHide();
+      }
     });
 
     const topNav = document.querySelector('.top-nav');


### PR DESCRIPTION
## Summary
- replace the floating install button with a fixed banner that contains explanatory copy
- add a close affordance and automatic 15-second dismissal for the install prompt
- refresh the related styling for better positioning and accessibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fbe0c0dcf08320a494eea2bfe17428