### PR TITLE
Improve cross-device score sync reliability

### DIFF
--- a/navbar.js
+++ b/navbar.js
@@ -63,6 +63,7 @@ function createNavbar() {
     localStorage.removeItem('guestId');
     localStorage.removeItem('guestDisplayName');
     localStorage.removeItem('userId');
+    localStorage.removeItem('userPubKey');
     window.location.href = 'index.html';
   });
 


### PR DESCRIPTION
## Summary
- persist and reuse a user's public key so score updates can be matched across devices
- stream portal score updates by both alias and pub key with automatic reattachment on identity changes
- clear stored pub key on sign out and manager reset for a clean session state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fc0b54179c8320868d124e65dd04a0