### PR TITLE
Fix meditation stretch link path

### DIFF
--- a/meditation/index.html
+++ b/meditation/index.html
@@ -611,7 +611,7 @@
       <p>Take twelve minutes to stand up, loosen your neck, and finish seated without ever needing a mat. The looped
         routine pairs audio and visual breath cues so you can stretch beside your desk and return refreshed.</p>
       <div class="stretch-callout__actions">
-        <a class="stretch-callout__link" href="guided-stretching.html">Open the standing &amp; seated stretch loop</a>
+        <a class="stretch-callout__link" href="./guided-stretching.html">Open the standing &amp; seated stretch loop</a>
         <a class="stretch-callout__link" href="#breathingGuideHeading">See breathing techniques</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- ensure the meditation page's guided stretching link keeps the user inside the meditation directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe800911cc832096bca113f6d9f90e