### PR TITLE
Auto-start stretching flow and add portal navigation

### DIFF
--- a/meditation/guided-stretching.html
+++ b/meditation/guided-stretching.html
@@ -717,6 +717,7 @@
       <span>A desk-friendly routine that releases computer tension without leaving your chair and keeps the breath pacing in
         sync with gentle music and looping animation cues.</span>
       <div class="cta-row">
+        <a href="../index.html">Return to 3DVR Portal</a>
         <a href="index.html">Return to breathing room</a>
         <a href="#stretchFlow">Jump to routine</a>
       </div>
@@ -1350,6 +1351,7 @@
     }
 
     updateStep(currentStepIndex, false);
+    startLoop();
   </script>
   <footer>
     Listen inward, honor your edge, and revisit this loop whenever screen time tightens your posture.

--- a/meditation/index.html
+++ b/meditation/index.html
@@ -80,6 +80,34 @@
       font-size: 1.05rem;
       line-height: 1.7;
     }
+    .header-links {
+      margin-top: 24px;
+      display: flex;
+      justify-content: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .header-links a {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 20px;
+      border-radius: 999px;
+      border: 1px solid rgba(94, 234, 212, 0.35);
+      background: rgba(15, 23, 42, 0.55);
+      color: #f8fafc;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+      text-decoration: none;
+    }
+    .header-links a:hover,
+    .header-links a:focus {
+      transform: translateY(-2px);
+      background: rgba(56, 189, 248, 0.22);
+      border-color: rgba(94, 234, 212, 0.6);
+      outline: none;
+    }
     .breathing-space {
       position: relative;
       width: clamp(320px, 38vw, 760px);
@@ -604,6 +632,9 @@
       <h1>Mindfulness Breathing Room</h1>
       <span>Follow the gentle cues for as many rounds as you need. Set your cadence, press play, and let the cycle guide you
         back to center.</span>
+      <div class="header-links" role="navigation" aria-label="Meditation quick links">
+        <a href="../index.html">Return to 3DVR Portal</a>
+      </div>
     </header>
     <section class="stretch-callout" aria-label="Guided stretch reminder">
       <span class="stretch-callout__tag">screen break reset</span>


### PR DESCRIPTION
## Summary
- automatically start the guided stretching loop on load so users receive continuous pacing without a manual click
- add quick links back to the main 3DVR portal from both the guided stretching and meditation experiences for easier navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe87f464688320a22033f0375cf1de