### PR TITLE
Add sales and meditation point milestones to rewards page

### DIFF
--- a/points.html
+++ b/points.html
@@ -64,6 +64,7 @@
               <li>Complete quests, tasks, and sprints inside the portal.</li>
               <li>Host or contribute to community events and workshops.</li>
               <li>Ship new features, tutorials, or docs that help the ecosystem grow.</li>
+              <li>Stay present in wellbeing spaces &mdash; every second on a meditation page adds a point automatically.</li>
             </ul>
             <p class="info-note">Each activity awards a set number of points that appear in your rewards dashboard.</p>
           </article>
@@ -101,7 +102,7 @@
 
       <section class="points-section">
         <div class="section-card">
-          <h2>Sales milestones that earn points</h2>
+          <h2>Sales &amp; CRM milestones that earn points</h2>
           <p>
             Sales activity fuels the revenue pool directly, so we assign clear point values to every stage of the pipeline.
             Track your progress in the CRM and submit close notes to make sure your contributions are counted.
@@ -119,6 +120,10 @@
               <dt>Closed revenue</dt>
               <dd>Points equal to 10% of first-month MRR, with multipliers for annual agreements.</dd>
             </div>
+            <div>
+              <dt>CRM touches</dt>
+              <dd>1 point for every new contact created, update logged, or follow-up completed in the sales workspace.</dd>
+            </div>
           </dl>
           <p class="info-note">Bonus: partner referrals that convert within 90 days earn a 2× multiplier on closing points.</p>
         </div>
@@ -129,7 +134,8 @@
           <article class="info-card">
             <h3>Meditation &amp; wellbeing leadership</h3>
             <ul>
-              <li>Host a weekly community meditation: 8 points per guided session.</li>
+              <li>Earn 1 point per second you remain in a live or on-demand meditation experience.</li>
+              <li>Host a weekly community meditation: 8 bonus points per guided session you lead.</li>
               <li>Create new breathwork or focus scripts for the library: 12 points per approved upload.</li>
               <li>Log participant feedback and improvements: 3 points for each published recap.</li>
             </ul>


### PR DESCRIPTION
## Summary
- add a sales milestone breakdown so revenue contributions have clear point values
- highlight meditation leadership and mindfulness integration tasks that earn rewards

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_69011731dec08320b62cb0c9b786397b