### PR TITLE
Slow meditation room point accrual cadence

### DIFF
--- a/meditation/index.html
+++ b/meditation/index.html
@@ -1095,6 +1095,7 @@
     const breathVolumeControl = document.getElementById('breathVolume');
     const breathVolumeValue = document.getElementById('breathVolumeValue');
 
+    const SCORE_TICK_INTERVAL_MS = 5000;
     let currentPaceKey = paceControl.value;
     let phases = phasesByPace[currentPaceKey];
     let phaseIndex = 0;
@@ -1660,7 +1661,7 @@
         } catch (err) {
           console.warn('Unable to increment meditation score', err);
         }
-      }, 1000);
+      }, SCORE_TICK_INTERVAL_MS);
     }
 
     function stopScoreTicker() {

--- a/points.html
+++ b/points.html
@@ -64,7 +64,7 @@
               <li>Complete quests, tasks, and sprints inside the portal.</li>
               <li>Host or contribute to community events and workshops.</li>
               <li>Ship new features, tutorials, or docs that help the ecosystem grow.</li>
-              <li>Stay present in wellbeing spaces &mdash; every second on a meditation page adds a point automatically.</li>
+              <li>Stay present in wellbeing spaces &mdash; every five seconds spent on a meditation page adds a point automatically.</li>
             </ul>
             <p class="info-note">Each activity awards a set number of points that appear in your rewards dashboard.</p>
           </article>
@@ -134,7 +134,7 @@
           <article class="info-card">
             <h3>Meditation &amp; wellbeing leadership</h3>
             <ul>
-              <li>Earn 1 point per second you remain in a live or on-demand meditation experience.</li>
+              <li>Earn 1 point for every five seconds you remain in a live or on-demand meditation experience.</li>
               <li>Host a weekly community meditation: 8 bonus points per guided session you lead.</li>
               <li>Create new breathwork or focus scripts for the library: 12 points per approved upload.</li>
               <li>Log participant feedback and improvements: 3 points for each published recap.</li>


### PR DESCRIPTION
## Summary
- slow the meditation room score ticker so points accrue every five seconds
- update points documentation to match the new meditation payout cadence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69011eadcb1c8320b612728173caa855