### PR TITLE
Force CSS fetches to bypass cached copies

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -22,9 +22,9 @@ const STATIC_ASSETS = [
 const createReloadedRequests = (assets) =>
   assets.map((asset) => new Request(asset, { cache: 'reload' }));
 
-const networkFirst = async (req) => {
+const networkFirst = async (req, { cacheMode = 'default' } = {}) => {
   try {
-    const fresh = await fetch(req);
+    const fresh = await fetch(req, { cache: cacheMode });
     if (fresh && fresh.ok) {
       const cache = await caches.open(STATIC_CACHE);
       cache.put(req, fresh.clone());
@@ -105,7 +105,7 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (isStyleRequest(req)) {
-    event.respondWith(networkFirst(req));
+    event.respondWith(networkFirst(req, { cacheMode: 'reload' }));
     return;
   }
 


### PR DESCRIPTION
## Summary
- ensure service worker fetches stylesheet updates with cache reload semantics
- pass cache mode to the existing network-first helper so CSS always refreshes

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_690180ef9a1c8320a36617ca60c22e0d