### PR TITLE
Adjust contacts auth fallback messaging

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -296,7 +296,7 @@ if (signedIn) {
       handleSignedIn();
       return;
     }
-    signedStatus.textContent = 'Signed-in data present but auth failed. You can still use Public demo space.';
+    signedStatus.textContent = 'Signed-in data detected. Using Public demo space until you sign in again.';
     btnGoSignIn.classList.remove('hidden');
   }
 


### PR DESCRIPTION
## Summary
- soften the silent auth failure status so it no longer shows an alarming error message

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69025d6f394c8320bc76d88b6a164d43