### PR TITLE
Clarify contacts auth fallback messaging

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -296,8 +296,13 @@ if (signedIn) {
       handleSignedIn();
       return;
     }
-    signedStatus.textContent = 'Signed-in data detected. Using Public demo space until you sign in again.';
+    signedStatus.textContent = 'Couldn\'t reconnect to your private contacts automatically. Viewing Public demo space until you sign in again.';
     btnGoSignIn.classList.remove('hidden');
+    setTimeout(() => {
+      if (typeof changeSpace === 'function') {
+        changeSpace('public-demo', { force: true });
+      }
+    }, 0);
   }
 
   if (user.is) {


### PR DESCRIPTION
## Summary
- clarify the fallback message shown when reconnecting to private contacts fails
- automatically switch to the Public demo space after an auth failure so the UI matches the message

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_6902630db1948320a2909371f1e6074e