### PR TITLE
Avoid writing private contacts to guest storage before auth

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -544,6 +544,7 @@ const ORG_SPACE_KEY = 'org-3dvr-demo'; // shared demo node
 function spaceNode(space = currentSpace) {
   if (space === 'personal') {
     if (user.is) return user.get('contacts');
+    if (signedIn) return null;
     const guestId = ensureGuestContactsId();
     if (guestId && guestsRoot) {
       return guestsRoot.get(guestId).get('contacts');


### PR DESCRIPTION
## Summary
- prevent the contacts page from saving personal records to the guest graph while a signed-in session is still restoring
- allow pending operations to queue until the authenticated Gun user is ready so they flush to the private space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690279a27ae0832099e7b773fef68eb9