### PR TITLE
Fix floating identity showing guest for signed-in contacts users

### DIFF
--- a/contacts/contacts-core.js
+++ b/contacts/contacts-core.js
@@ -45,6 +45,36 @@ export function deriveIdentityState({
   return { signedIn, guest, alias, username, displayName };
 }
 
+export function deriveFloatingIdentityDisplay({
+  latestDisplayName = '',
+  signedIn = false,
+  guest = false,
+  username = '',
+  storedUsername = '',
+  alias = '',
+  guestDisplayName = '',
+} = {}) {
+  const normalizedHint = typeof latestDisplayName === 'string' ? latestDisplayName.trim() : '';
+  if (normalizedHint) {
+    return normalizedHint;
+  }
+
+  const aliasDisplay = aliasToDisplay(alias);
+
+  if (signedIn) {
+    const normalizedUsername = typeof username === 'string' ? username.trim() : '';
+    const normalizedStored = typeof storedUsername === 'string' ? storedUsername.trim() : '';
+    return normalizedUsername || normalizedStored || aliasDisplay || 'User';
+  }
+
+  if (guest) {
+    const normalizedGuest = typeof guestDisplayName === 'string' ? guestDisplayName.trim() : '';
+    return normalizedGuest || aliasDisplay || 'Guest';
+  }
+
+  return aliasDisplay || 'Guest';
+}
+
 export function resolveSpaceNode({
   space,
   signedIn,
@@ -124,6 +154,7 @@ if (typeof window !== 'undefined') {
   window.ContactsCore = {
     aliasToDisplay,
     deriveIdentityState,
+    deriveFloatingIdentityDisplay,
     resolveSpaceNode,
   };
 }

--- a/contacts/index.html
+++ b/contacts/index.html
@@ -204,7 +204,12 @@
   </footer>
 
 <script type="module">
-import { aliasToDisplay, deriveIdentityState, resolveSpaceNode } from './contacts-core.js';
+import {
+  aliasToDisplay,
+  deriveIdentityState,
+  deriveFloatingIdentityDisplay,
+  resolveSpaceNode,
+} from './contacts-core.js';
 /* ---------- Gun & session reuse ---------- */
 const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
 const user = gun.user();
@@ -793,25 +798,22 @@ try {
 if (floatingIdentity && floatingIdentityName && floatingIdentityScore) {
   let identitySignedIn = signedIn;
   let identityGuest = !identitySignedIn && guest;
-  let latestDisplayName = '';
-  let aliasDisplay = aliasToDisplay(alias);
+  let latestDisplayName = identitySnapshot.displayName || '';
   let signedIdentityListenersAttached = false;
   let guestIdentityInitialized = false;
 
   function updateIdentityName() {
-    let display = '';
-    if (latestDisplayName) {
-      display = latestDisplayName;
-    } else if (identitySignedIn) {
-      const stored = (localStorage.getItem('username') || '').trim();
-      const fallback = (username || '').trim();
-      display = fallback || stored || aliasDisplay || 'Guest';
-    } else if (identityGuest) {
-      const guestStored = (localStorage.getItem('guestDisplayName') || '').trim();
-      display = guestStored || aliasDisplay || 'Guest';
-    } else {
-      display = aliasDisplay || 'Guest';
-    }
+    const stored = (localStorage.getItem('username') || '').trim();
+    const guestStored = (localStorage.getItem('guestDisplayName') || '').trim();
+    const display = deriveFloatingIdentityDisplay({
+      latestDisplayName,
+      signedIn: identitySignedIn,
+      guest: identityGuest,
+      username,
+      storedUsername: stored,
+      alias,
+      guestDisplayName: guestStored,
+    });
     floatingIdentityName.textContent = `👤 ${display}`;
   }
 
@@ -830,7 +832,6 @@ if (floatingIdentity && floatingIdentityName && floatingIdentityScore) {
         if (normalized) {
           alias = normalized;
         }
-        aliasDisplay = aliasToDisplay(normalized || alias);
         updateIdentityName();
         refreshSignedInDisplay();
       });
@@ -873,9 +874,7 @@ if (floatingIdentity && floatingIdentityName && floatingIdentityScore) {
 
   updateIdentityForSignedIn = ({ aliasHint, usernameHint } = {}) => {
     if (typeof aliasHint === 'string' && aliasHint.trim()) {
-      aliasDisplay = aliasToDisplay(aliasHint);
-    } else {
-      aliasDisplay = aliasToDisplay(alias);
+      alias = aliasHint.trim();
     }
     if (typeof usernameHint === 'string' && usernameHint.trim()) {
       latestDisplayName = usernameHint.trim();

--- a/tests/contacts-core.test.js
+++ b/tests/contacts-core.test.js
@@ -1,6 +1,11 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { aliasToDisplay, deriveIdentityState, resolveSpaceNode } from '../contacts/contacts-core.js';
+import {
+  aliasToDisplay,
+  deriveIdentityState,
+  deriveFloatingIdentityDisplay,
+  resolveSpaceNode,
+} from '../contacts/contacts-core.js';
 
 describe('contacts core helpers', () => {
   describe('aliasToDisplay', () => {
@@ -36,6 +41,35 @@ describe('contacts core helpers', () => {
       assert.equal(state.signedIn, false);
       assert.equal(state.guest, true);
       assert.equal(state.displayName, 'Guest');
+    });
+  });
+
+  describe('deriveFloatingIdentityDisplay', () => {
+    it('uses the most recent explicit display name when provided', () => {
+      const display = deriveFloatingIdentityDisplay({
+        latestDisplayName: 'Agent Smith',
+        signedIn: true,
+        username: 'agent',
+        storedUsername: 'smith',
+        alias: 'agent@3dvr.tech',
+      });
+
+      assert.equal(display, 'Agent Smith');
+    });
+
+    it('falls back to a generic user label when signed in data is missing', () => {
+      const display = deriveFloatingIdentityDisplay({ signedIn: true });
+
+      assert.equal(display, 'User');
+    });
+
+    it('prefers stored guest names when available', () => {
+      const display = deriveFloatingIdentityDisplay({
+        guest: true,
+        guestDisplayName: 'Visitor 42',
+      });
+
+      assert.equal(display, 'Visitor 42');
     });
   });
 


### PR DESCRIPTION
## Summary
- add a core helper to normalize floating identity display labels for contacts
- ensure the contacts UI uses the helper and initial snapshot so signed-in users no longer appear as guests
- extend the contacts core test suite to cover the new helper and signed-in fallback behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69039556a6f0832086e9a8d73b43f649