### PR TITLE
Recall Gun session before deriving contacts identity

### DIFF
--- a/contacts/contacts-core.js
+++ b/contacts/contacts-core.js
@@ -14,26 +14,35 @@ export function deriveIdentityState({
   aliasFromSession = '',
   usernameFromSession = '',
 } = {}) {
+  const normalize = value => (typeof value === 'string' ? value.trim() : '');
   const mode = authState?.mode || 'anon';
+  const sessionAlias = normalize(aliasFromSession);
+  const sessionUsername = normalize(usernameFromSession);
+  const storedAliasNormalized = normalize(storedAlias);
+  const storedUsernameNormalized = normalize(storedUsername);
+
   let signedIn = mode === 'user';
   let guest = mode === 'guest';
   let alias = '';
   let username = '';
 
-  const normalize = value => (typeof value === 'string' ? value.trim() : '');
+  if (!signedIn && (sessionAlias || sessionUsername)) {
+    signedIn = true;
+    guest = false;
+  }
 
   if (signedIn) {
-    alias = normalize(authState?.alias) || normalize(aliasFromSession) || normalize(storedAlias);
-    username = normalize(authState?.username) || normalize(usernameFromSession) || normalize(storedUsername);
+    alias = normalize(authState?.alias) || sessionAlias || storedAliasNormalized;
+    username = normalize(authState?.username) || sessionUsername || storedUsernameNormalized;
     if (!username) {
       username = aliasToDisplay(alias) || 'User';
     }
   } else if (guest) {
-    alias = normalize(storedAlias);
-    username = normalize(storedUsername) || 'Guest';
+    alias = storedAliasNormalized;
+    username = storedUsernameNormalized || 'Guest';
   } else {
-    alias = normalize(storedAlias);
-    username = normalize(storedUsername);
+    alias = storedAliasNormalized;
+    username = storedUsernameNormalized;
   }
 
   const displayName = signedIn

--- a/contacts/index.html
+++ b/contacts/index.html
@@ -255,6 +255,20 @@ const authState = window.ScoreSystem && typeof window.ScoreSystem.computeAuthSta
     : (legacyGuest
       ? { mode: 'guest' }
       : { mode: 'anon' }));
+
+// Keep session alive across standalone/browser contexts before deriving identity:
+const recallUsed = window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function'
+  ? window.ScoreSystem.recallUserSession(user)
+  : (() => {
+      try {
+        user.recall({ sessionStorage: true, localStorage: true });
+        return true;
+      } catch (err) {
+        console.warn('Unable to recall user session', err);
+        return false;
+      }
+    })();
+
 const identitySnapshot = deriveIdentityState({
   authState,
   storedAlias,
@@ -311,19 +325,6 @@ function ensureGuestContactsId() {
   guestContactsId = resolved;
   return guestContactsId;
 }
-
-// Keep session alive across standalone/browser contexts:
-const recallUsed = window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function'
-  ? window.ScoreSystem.recallUserSession(user)
-  : (() => {
-      try {
-        user.recall({ sessionStorage: true, localStorage: true });
-        return true;
-      } catch (err) {
-        console.warn('Unable to recall user session', err);
-        return false;
-      }
-    })();
 
 const userDisplay = document.getElementById('userDisplay');
 const btnLogout = document.getElementById('btnLogout');

--- a/tests/contacts-core.test.js
+++ b/tests/contacts-core.test.js
@@ -42,6 +42,37 @@ describe('contacts core helpers', () => {
       assert.equal(state.guest, true);
       assert.equal(state.displayName, 'Guest');
     });
+
+    it('treats an active Gun session as signed in even without stored flags', () => {
+      const state = deriveIdentityState({
+        authState: { mode: 'guest' },
+        storedAlias: '',
+        storedUsername: '',
+        aliasFromSession: 'agent@3dvr.tech',
+        usernameFromSession: 'Agent 47',
+      });
+
+      assert.equal(state.signedIn, true);
+      assert.equal(state.guest, false);
+      assert.equal(state.alias, 'agent@3dvr.tech');
+      assert.equal(state.username, 'Agent 47');
+      assert.equal(state.displayName, 'Agent 47');
+    });
+
+    it('falls back to an alias-based name when the session lacks a username', () => {
+      const state = deriveIdentityState({
+        authState: { mode: 'anon' },
+        storedAlias: '',
+        storedUsername: '',
+        aliasFromSession: 'alias@example.com',
+        usernameFromSession: '',
+      });
+
+      assert.equal(state.signedIn, true);
+      assert.equal(state.guest, false);
+      assert.equal(state.username, 'alias');
+      assert.equal(state.displayName, 'alias');
+    });
   });
 
   describe('deriveFloatingIdentityDisplay', () => {


### PR DESCRIPTION
## Summary
- recall the Gun user session before deriving contacts identity so restored sessions immediately expose alias and username details
- ensure the contacts UI initializes with the recalled session state prior to applying identity fallbacks

## Testing
- node --test tests/contacts-core.test.js
- npm test *(fails: Playwright package is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69039a2eef4083208b7bb1703b131d61