### PR TITLE
Fix contacts score updates and add e2e coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,5 @@ These instructions apply to the entire repository.
 ## Testing & Verification
 - Prefer automated tests for new logic, especially around Gun node selection, identity management, and sync flows.
 - If you modify any server-side code under `api/`, start the development server with `npm run dev` to ensure it boots without errors.
+- Capture test coverage or add new checks whenever you touch core flows so we continuously prevent regressions in score, identity, and contact management features.
+- Perform and document manual UI/UX and functional walkthroughs for any changes that impact the customer experience, including VR and touch interactions.

--- a/contacts/index.html
+++ b/contacts/index.html
@@ -448,6 +448,7 @@ function attachScoreManager(manager) {
     scoreManagerUnsubscribe = scoreManager.subscribe(value => {
       notifyScoreSubscribers(value);
     });
+    notifyScoreSubscribers(currentScoreValue());
   } else {
     notifyScoreSubscribers(currentScoreValue());
   }
@@ -468,7 +469,6 @@ function refreshScoreManager({ forceReset = false } = {}) {
   attachScoreManager(window.ScoreSystem.getManager({ gun, user, portalRoot }));
 }
 
-refreshScoreManager();
 const CACHE_PREFIX = 'contacts:cache:';
 const QUEUE_PREFIX = 'contacts:pending:';
 const CONTACT_FIELDS = [
@@ -575,6 +575,12 @@ function ensureGuestContactsId() {
   guestContactsId = resolved;
   return guestContactsId;
 }
+
+if (!signedIn) {
+  ensureGuestContactsId();
+}
+
+refreshScoreManager();
 
 const userDisplay = document.getElementById('userDisplay');
 const btnLogout = document.getElementById('btnLogout');

--- a/tests/contacts-score.e2e.test.js
+++ b/tests/contacts-score.e2e.test.js
@@ -1,0 +1,142 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { resolve, extname, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.webmanifest': 'application/manifest+json',
+};
+
+describe('contacts score integration', () => {
+  let server;
+  let baseUrl;
+
+  before(async () => {
+    server = createServer(async (req, res) => {
+      try {
+        const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+        let filePath = resolve(projectRoot, `.${requestUrl.pathname}`);
+        if (requestUrl.pathname.endsWith('/')) {
+          filePath = resolve(filePath, 'index.html');
+        }
+        const data = await readFile(filePath);
+        const type = MIME_TYPES[extname(filePath).toLowerCase()] || 'application/octet-stream';
+        res.writeHead(200, { 'Content-Type': type });
+        res.end(data);
+      } catch (err) {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Not found');
+      }
+    });
+
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  after(async () => {
+    if (server) {
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+
+  async function launchChromium(t) {
+    try {
+      return await chromium.launch();
+    } catch (error) {
+      const message = error && typeof error.message === 'string' ? error.message : String(error);
+      if (message.includes('dependencies to run browsers') || message.includes('Executable doesn\'t exist')) {
+        t.skip('Playwright browser dependencies are not installed in this environment.');
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  it('updates the floating identity score when the score manager changes', async t => {
+    const browser = await launchChromium(t);
+    if (!browser) {
+      return;
+    }
+
+    try {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await page.goto(`${baseUrl}/contacts/index.html`, { waitUntil: 'networkidle' });
+      await page.waitForSelector('#floatingIdentityScore');
+
+      const initialScore = await page.textContent('#floatingIdentityScore');
+
+      await page.evaluate(() => {
+        const manager = window.ScoreSystem && window.ScoreSystem.getManager ? window.ScoreSystem.getManager() : null;
+        if (manager) {
+          manager.increment(7);
+        }
+      });
+
+      await page.waitForFunction(() => {
+        const el = document.getElementById('floatingIdentityScore');
+        return el && /\b7\b/.test(el.textContent || '');
+      });
+
+      const updatedScore = await page.textContent('#floatingIdentityScore');
+      assert.notStrictEqual(updatedScore, initialScore);
+      assert.match(updatedScore, /\b7\b/);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it('persists score across reloads', async t => {
+    const browser = await launchChromium(t);
+    if (!browser) {
+      return;
+    }
+
+    try {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await page.goto(`${baseUrl}/contacts/index.html`, { waitUntil: 'networkidle' });
+      await page.waitForSelector('#floatingIdentityScore');
+
+      await page.click('#openCreateContact');
+      await page.fill('#name', 'Reload Test');
+      await page.fill('#email', 'reload@example.com');
+      await page.fill('#company', 'Persistence Inc');
+      await page.click('#contactForm button[type="submit"]');
+
+      await page.waitForFunction(() => {
+        const el = document.getElementById('floatingIdentityScore');
+        return el && /\b10\b/.test(el.textContent || '');
+      });
+
+      await page.reload({ waitUntil: 'networkidle' });
+      await page.waitForTimeout(500);
+
+      const persistedScore = await page.textContent('#floatingIdentityScore');
+      assert.match(persistedScore || '', /\b10\b/);
+
+      const managerScore = await page.evaluate(() => {
+        return window.ScoreSystem && window.ScoreSystem.getManager
+          ? window.ScoreSystem.getManager().getCurrent()
+          : null;
+      });
+      assert.equal(managerScore, 10);
+    } finally {
+      await browser.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the contacts score manager notifies listeners immediately and initializes guest identity before refreshing
- add Playwright end-to-end coverage for floating identity score updates and persistence
- document required regression and manual UI testing practices in the main AGENTS guidelines

## Testing
- not run (Playwright browsers unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6903baef2590832097144565faf8a485