### PR TITLE
Add payables tracking to finance hub

### DIFF
--- a/finance/app.js
+++ b/finance/app.js
@@ -115,6 +115,9 @@ const gun = gunContext.gun;
 const financeLedger = gun && typeof gun.get === 'function'
   ? gun.get('finance').get('expenditures')
   : createLocalGunNodeStub();
+const financePayables = gun && typeof gun.get === 'function'
+  ? gun.get('finance').get('payables')
+  : createLocalGunNodeStub();
 
 if (window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
   try {
@@ -135,8 +138,19 @@ const ledgerList = document.getElementById('finance-ledger');
 const emptyState = document.getElementById('finance-empty');
 const totalAmount = document.getElementById('total-amount');
 const latestEntry = document.getElementById('latest-entry');
+const outstandingAmount = document.getElementById('outstanding-amount');
+const nextPayable = document.getElementById('next-payable');
+
+const payableForm = document.getElementById('payable-form');
+const payeeInput = document.getElementById('payee');
+const payableAmountInput = document.getElementById('payable-amount');
+const dueDateInput = document.getElementById('due-date');
+const payableNotesInput = document.getElementById('payable-notes');
+const payablesList = document.getElementById('payables-list');
+const payablesEmptyState = document.getElementById('payables-empty');
 
 const entries = new Map();
+const payables = new Map();
 const numberFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
@@ -147,11 +161,22 @@ if (dateInput) {
   dateInput.value = defaultDate();
 }
 
+if (dueDateInput) {
+  dueDateInput.value = defaultDate();
+}
+
 if (form) {
   form.addEventListener('submit', handleSubmit);
 }
 if (financeLedger && typeof financeLedger.map === 'function' && typeof financeLedger.map().on === 'function') {
   financeLedger.map().on(handleLedgerUpdate);
+}
+
+if (payableForm) {
+  payableForm.addEventListener('submit', handlePayableSubmit);
+}
+if (financePayables && typeof financePayables.map === 'function' && typeof financePayables.map().on === 'function') {
+  financePayables.map().on(handlePayableUpdate);
 }
 
 function defaultDate() {
@@ -198,6 +223,31 @@ function handleLedgerUpdate(data, key) {
   renderEntries();
 }
 
+function handlePayableUpdate(data, key) {
+  if (!key || key === '_') {
+    return;
+  }
+
+  if (!data) {
+    payables.delete(key);
+    renderPayables();
+    return;
+  }
+
+  const record = sanitizeRecord(data);
+  if (!record) {
+    payables.delete(key);
+    renderPayables();
+    return;
+  }
+
+  payables.set(key, {
+    ...record,
+    id: key
+  });
+  renderPayables();
+}
+
 function handleSubmit(event) {
   event.preventDefault();
 
@@ -233,6 +283,54 @@ function handleSubmit(event) {
   }
   form.reset();
   dateInput.value = record.date;
+}
+
+function handlePayableSubmit(event) {
+  event.preventDefault();
+
+  if (!payeeInput || !payableAmountInput || !dueDateInput || !payableNotesInput) {
+    return;
+  }
+
+  const payee = payeeInput.value.trim();
+  if (!payee) {
+    payeeInput.focus();
+    payeeInput.setCustomValidity('Please enter who the payment is for.');
+    payeeInput.reportValidity();
+    return;
+  }
+  payeeInput.setCustomValidity('');
+
+  const amount = normalizeAmount(payableAmountInput.value);
+  if (amount <= 0) {
+    payableAmountInput.focus();
+    payableAmountInput.setCustomValidity('Please enter an amount greater than 0.');
+    payableAmountInput.reportValidity();
+    return;
+  }
+  payableAmountInput.setCustomValidity('');
+
+  const payableId = typeof Gun !== 'undefined' && Gun.text && typeof Gun.text.random === 'function'
+    ? Gun.text.random(16)
+    : Math.random().toString(36).slice(2, 10);
+  const now = new Date();
+  const record = {
+    payee,
+    amount,
+    dueDate: dueDateInput.value || defaultDate(),
+    notes: payableNotesInput.value.trim(),
+    createdAt: now.toISOString(),
+    settledAt: null
+  };
+
+  const payableNode = typeof financePayables.get === 'function' ? financePayables.get(payableId) : null;
+  if (payableNode && typeof payableNode.put === 'function') {
+    payableNode.put(record);
+  }
+
+  payableForm.reset();
+  payeeInput.focus();
+  dueDateInput.value = record.dueDate;
 }
 
 function normalizeAmount(value) {
@@ -326,5 +424,154 @@ function renderEntries() {
     if (latestEntry) {
       latestEntry.textContent = `${formatted} • ${numberFormatter.format(normalizeAmount(latest.amount))}`;
     }
+  }
+}
+
+function renderPayables() {
+  if (!payablesList) {
+    return;
+  }
+
+  const sorted = Array.from(payables.values()).sort((a, b) => {
+    const aSettled = Boolean(a.settledAt);
+    const bSettled = Boolean(b.settledAt);
+    if (aSettled !== bSettled) {
+      return aSettled ? 1 : -1;
+    }
+    const aStamp = Date.parse(a.dueDate || a.createdAt || 0);
+    const bStamp = Date.parse(b.dueDate || b.createdAt || 0);
+    if (Number.isNaN(aStamp) || Number.isNaN(bStamp)) {
+      const aCreated = Date.parse(a.createdAt || 0);
+      const bCreated = Date.parse(b.createdAt || 0);
+      if (Number.isNaN(aCreated) || Number.isNaN(bCreated)) {
+        return 0;
+      }
+      return aCreated - bCreated;
+    }
+    return aStamp - bStamp;
+  });
+
+  payablesList.innerHTML = '';
+
+  if (sorted.length === 0) {
+    if (payablesEmptyState) {
+      payablesEmptyState.hidden = false;
+      payablesList.append(payablesEmptyState);
+    }
+    if (outstandingAmount) {
+      outstandingAmount.textContent = numberFormatter.format(0);
+    }
+    if (nextPayable) {
+      nextPayable.textContent = 'No payables logged';
+    }
+    return;
+  }
+
+  if (payablesEmptyState) {
+    payablesEmptyState.hidden = true;
+  }
+
+  let outstandingTotal = 0;
+  let upcoming = null;
+
+  sorted.forEach(entry => {
+    const container = document.createElement('article');
+    container.className = 'finance-entry finance-payable';
+    if (entry.settledAt) {
+      container.classList.add('finance-payable--settled');
+    }
+    container.setAttribute('role', 'listitem');
+
+    const header = document.createElement('div');
+    header.className = 'finance-entry__header';
+
+    const title = document.createElement('h3');
+    title.className = 'finance-entry__title';
+    title.textContent = entry.payee || 'Unnamed payee';
+
+    const amountLabel = document.createElement('span');
+    amountLabel.className = 'finance-entry__amount';
+    amountLabel.textContent = numberFormatter.format(normalizeAmount(entry.amount));
+
+    header.append(title, amountLabel);
+
+    const meta = document.createElement('p');
+    meta.className = 'finance-entry__meta';
+    const dueDate = entry.dueDate ? new Date(entry.dueDate) : new Date(entry.createdAt || Date.now());
+    const formattedDue = Number.isNaN(dueDate.getTime()) ? 'No due date' : dueDate.toLocaleDateString();
+    if (entry.settledAt) {
+      const settledDate = new Date(entry.settledAt);
+      const formattedSettled = Number.isNaN(settledDate.getTime()) ? 'Settled' : `Settled ${settledDate.toLocaleDateString()}`;
+      meta.textContent = `${formattedDue} • ${formattedSettled}`;
+    } else {
+      meta.textContent = `${formattedDue} • Pending payment`;
+    }
+
+    container.append(header, meta);
+
+    if (entry.notes) {
+      const notes = document.createElement('p');
+      notes.className = 'finance-entry__notes';
+      notes.textContent = entry.notes;
+      container.append(notes);
+    }
+
+    if (!entry.settledAt) {
+      const actions = document.createElement('div');
+      actions.className = 'finance-payable__actions';
+      const settleButton = document.createElement('button');
+      settleButton.type = 'button';
+      settleButton.className = 'finance-button finance-button--secondary';
+      settleButton.textContent = 'Mark as paid';
+      settleButton.addEventListener('click', () => {
+        markPayableSettled(entry.id);
+      });
+      actions.append(settleButton);
+      container.append(actions);
+      if (!upcoming) {
+        upcoming = entry;
+      }
+      outstandingTotal += normalizeAmount(entry.amount);
+    }
+
+    payablesList.append(container);
+  });
+
+  if (outstandingAmount) {
+    outstandingAmount.textContent = numberFormatter.format(outstandingTotal);
+  }
+
+  if (nextPayable) {
+    if (!upcoming) {
+      nextPayable.textContent = 'All payables settled';
+    } else {
+      const dueDate = upcoming.dueDate ? new Date(upcoming.dueDate) : new Date(upcoming.createdAt || Date.now());
+      const formattedDue = Number.isNaN(dueDate.getTime()) ? 'Due soon' : dueDate.toLocaleDateString();
+      nextPayable.textContent = `${upcoming.payee || 'Unnamed payee'} • ${formattedDue} • ${numberFormatter.format(normalizeAmount(upcoming.amount))}`;
+    }
+  }
+}
+
+function markPayableSettled(identifier) {
+  if (!identifier) {
+    return;
+  }
+
+  const entry = payables.get(identifier);
+  if (!entry) {
+    return;
+  }
+
+  const { id, ...rest } = entry;
+  if (rest.settledAt) {
+    return;
+  }
+
+  const node = typeof financePayables.get === 'function' ? financePayables.get(id) : null;
+  if (node && typeof node.put === 'function') {
+    node.put({
+      ...rest,
+      settledAt: new Date().toISOString()
+    });
   }
 }

--- a/finance/index.html
+++ b/finance/index.html
@@ -33,6 +33,14 @@
             <dt>Latest entry</dt>
             <dd id="latest-entry">No entries yet</dd>
           </div>
+          <div class="finance-summary__stat">
+            <dt>Outstanding payables</dt>
+            <dd id="outstanding-amount">$0.00</dd>
+          </div>
+          <div class="finance-summary__stat">
+            <dt>Next payment</dt>
+            <dd id="next-payable">No payables logged</dd>
+          </div>
         </dl>
       </div>
 
@@ -66,6 +74,46 @@
           </label>
           <button type="submit" class="finance-button">Log expenditure</button>
         </form>
+      </div>
+    </section>
+
+    <section class="finance-layout" aria-labelledby="payables-title">
+      <div class="finance-card finance-card--form" aria-labelledby="payable-form-title">
+        <div class="finance-card__header">
+          <h2 id="payable-form-title" class="finance-card__title">Schedule a payment</h2>
+          <p class="finance-card__subhead">Track payables</p>
+        </div>
+        <form id="payable-form" class="finance-form" autocomplete="off" novalidate>
+          <div class="finance-form__grid">
+            <label class="finance-field">
+              <span class="finance-field__label">Payee</span>
+              <input id="payee" name="payee" type="text" placeholder="Who is owed" required>
+            </label>
+            <label class="finance-field">
+              <span class="finance-field__label">Amount (USD)</span>
+              <input id="payable-amount" name="payableAmount" type="number" step="0.01" min="0" inputmode="decimal" required>
+            </label>
+            <label class="finance-field">
+              <span class="finance-field__label">Due date</span>
+              <input id="due-date" name="dueDate" type="date" required>
+            </label>
+          </div>
+          <label class="finance-field">
+            <span class="finance-field__label">Notes</span>
+            <textarea id="payable-notes" name="payableNotes" rows="3" placeholder="Context or project details"></textarea>
+          </label>
+          <button type="submit" class="finance-button">Add payable</button>
+        </form>
+      </div>
+
+      <div class="finance-card finance-card--ledger" aria-labelledby="payables-title">
+        <div class="finance-card__header">
+          <h2 id="payables-title" class="finance-card__title">Payables</h2>
+          <span class="finance-card__subhead">Upcoming obligations</span>
+        </div>
+        <div id="payables-list" class="finance-ledger finance-payables" role="list">
+          <p id="payables-empty" class="finance-ledger__empty">No payables yet. Log a payment schedule to get started.</p>
+        </div>
       </div>
     </section>
 

--- a/finance/styles.css
+++ b/finance/styles.css
@@ -256,6 +256,10 @@ body {
   gap: 1.25rem;
 }
 
+.finance-payables {
+  gap: 1.5rem;
+}
+
 .finance-ledger__empty {
   margin: 0;
   padding: 1.75rem;
@@ -276,6 +280,54 @@ body {
   display: grid;
   gap: 0.75rem;
   transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.finance-payable {
+  position: relative;
+  overflow: hidden;
+}
+
+.finance-payable::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(14, 165, 233, 0.05));
+}
+
+.finance-payable:hover::before,
+.finance-payable:focus-within::before {
+  opacity: 1;
+}
+
+.finance-payable--settled {
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.25);
+  opacity: 0.8;
+}
+
+.finance-payable--settled .finance-entry__amount {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.finance-payable__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.finance-button--secondary {
+  background: rgba(15, 23, 42, 0.85);
+  color: #38bdf8;
+  border: 1px solid rgba(56, 189, 248, 0.6);
+  box-shadow: none;
+}
+
+.finance-button--secondary:hover,
+.finance-button--secondary:focus {
+  box-shadow: 0 12px 28px rgba(14, 165, 233, 0.25);
 }
 
 .finance-entry:hover,


### PR DESCRIPTION
## Summary
- add a payables form and ledger to schedule upcoming payments in the finance hub
- surface outstanding totals and next payment details in the overview metrics
- support marking payables as paid while keeping styling aligned with existing entries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907a1fa04548320817d7e1ead5817cd