### PR TITLE
Fix desktop shortcut clicks on wide screens

### DIFF
--- a/home/script.js
+++ b/home/script.js
@@ -97,6 +97,11 @@ const apps = {
 let zIndex = 10;
 let activeWindowId = null;
 
+function updateWindowLayerInteractivity() {
+  const hasWindows = windowLayer.querySelector('.window') !== null;
+  windowLayer.style.pointerEvents = hasWindows ? 'auto' : 'none';
+}
+
 function isMobileLayout() {
   return mobileQuery.matches;
 }
@@ -173,6 +178,7 @@ function createWindow(appKey) {
   attachWindowEvents(windowEl);
   addToTaskbar(appKey, app);
   focusWindow(windowEl);
+  updateWindowLayerInteractivity();
   return windowEl;
 }
 
@@ -211,6 +217,7 @@ function closeWindow(appKey) {
   if (activeWindowId === appKey) {
     activeWindowId = null;
   }
+  updateWindowLayerInteractivity();
 }
 
 function addToTaskbar(appKey, app) {
@@ -359,3 +366,4 @@ if (typeof mobileQuery.addEventListener === 'function') {
 
 window.addEventListener('resize', applyResponsiveWindowLayout);
 applyResponsiveWindowLayout();
+updateWindowLayerInteractivity();

--- a/home/style.css
+++ b/home/style.css
@@ -227,6 +227,7 @@ body {
   position: absolute;
   inset: 0;
   z-index: 2;
+  pointer-events: none;
 }
 
 .window {


### PR DESCRIPTION
## Summary
- prevent the desktop window layer from blocking shortcut clicks on wide layouts
- toggle the window layer's pointer events as windows are opened and closed so desktop shortcuts remain usable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a8f1388b08320983e0e3fabe9ea99