### PR TITLE
Add navigation controls between release notes

### DIFF
--- a/releases/v0.0.1.html
+++ b/releases/v0.0.1.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
   </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <span class="release-nav-link is-disabled" aria-disabled="true">← Previous release</span>
+    <a class="release-nav-link" href="v0.0.2.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.1</h1>
   <div class="tag">Initial Milestone · April 2025</div>
   <p class="release-summary">First public development build of the 3dvr Portal ecosystem.</p>

--- a/releases/v0.0.10.html
+++ b/releases/v0.0.10.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.9.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.11.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.10</h1>
   <div class="tag">Week of July 10, 2025</div>
   <p class="release-summary">Personalized builder conversations</p>

--- a/releases/v0.0.11.html
+++ b/releases/v0.0.11.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.10.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.12.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.11</h1>
   <div class="tag">Week of July 16, 2025</div>
   <p class="release-summary">Admin security &amp; sales suite</p>

--- a/releases/v0.0.12.html
+++ b/releases/v0.0.12.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.11.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.13.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.12</h1>
   <div class="tag">Week of July 22, 2025</div>
   <p class="release-summary">Free-trial polish &amp; share page</p>

--- a/releases/v0.0.13.html
+++ b/releases/v0.0.13.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.12.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.14.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.13</h1>
   <div class="tag">Week of July 30, 2025</div>
   <p class="release-summary">Share workspace discovery</p>

--- a/releases/v0.0.14.html
+++ b/releases/v0.0.14.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.13.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.15.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.14</h1>
   <div class="tag">Week of August 7, 2025</div>
   <p class="release-summary">CRM indexing &amp; homepage resilience</p>

--- a/releases/v0.0.15.html
+++ b/releases/v0.0.15.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.14.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.16.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.15</h1>
   <div class="tag">Week of August 11, 2025</div>
   <p class="release-summary">Legacy tasks revival</p>

--- a/releases/v0.0.16.html
+++ b/releases/v0.0.16.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.15.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.17.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.16</h1>
   <div class="tag">Week of September 13, 2025</div>
   <p class="release-summary">Contacts hub launch</p>

--- a/releases/v0.0.17.html
+++ b/releases/v0.0.17.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.16.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.18.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.17</h1>
   <div class="tag">Week of September 15, 2025</div>
   <p class="release-summary">PWA &amp; navigation refresh</p>

--- a/releases/v0.0.18.html
+++ b/releases/v0.0.18.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.17.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.19.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.18</h1>
   <div class="tag">Week of September 22, 2025</div>
   <p class="release-summary">Platform overhaul</p>

--- a/releases/v0.0.19.html
+++ b/releases/v0.0.19.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.18.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.20.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.19</h1>
   <div class="tag">Week of September 29, 2025</div>
   <p class="release-summary">Chat identity &amp; notes overhaul</p>

--- a/releases/v0.0.2.html
+++ b/releases/v0.0.2.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.1.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.3.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.2</h1>
   <div class="tag">Week of April 26, 2025</div>
   <p class="release-summary">Portal foundations land</p>

--- a/releases/v0.0.20.html
+++ b/releases/v0.0.20.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.19.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.21.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.20</h1>
   <div class="tag">Week of October 21, 2025</div>
   <p class="release-summary">Ecosystem expansion</p>

--- a/releases/v0.0.21.html
+++ b/releases/v0.0.21.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.20.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.22.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.21</h1>
   <div class="tag">Week of October 27, 2025</div>
   <p class="release-summary">Meetings, identity fixes, &amp; finance ledger</p>

--- a/releases/v0.0.22.html
+++ b/releases/v0.0.22.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.21.html">← Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
+  </nav>
   <h1>🚀 Release v0.0.22</h1>
   <div class="tag">Week of November 3, 2025</div>
   <p class="release-summary">Release hub &amp; stability</p>

--- a/releases/v0.0.3.html
+++ b/releases/v0.0.3.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.2.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.4.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.3</h1>
   <div class="tag">Week of April 28, 2025</div>
   <p class="release-summary">Portal styling sprint</p>

--- a/releases/v0.0.4.html
+++ b/releases/v0.0.4.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.3.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.5.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.4</h1>
   <div class="tag">Week of May 5, 2025</div>
   <p class="release-summary">Authentication &amp; rewards</p>

--- a/releases/v0.0.5.html
+++ b/releases/v0.0.5.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.4.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.6.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.5</h1>
   <div class="tag">Week of May 15, 2025</div>
   <p class="release-summary">Recovery flows &amp; task depth</p>

--- a/releases/v0.0.6.html
+++ b/releases/v0.0.6.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.5.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.7.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.6</h1>
   <div class="tag">Week of May 20, 2025</div>
   <p class="release-summary">Async auth &amp; billing</p>

--- a/releases/v0.0.7.html
+++ b/releases/v0.0.7.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.6.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.8.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.7</h1>
   <div class="tag">Week of June 5, 2025</div>
   <p class="release-summary">AI chatbot &amp; free trials</p>

--- a/releases/v0.0.8.html
+++ b/releases/v0.0.8.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.7.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.9.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.8</h1>
   <div class="tag">Week of June 10, 2025</div>
   <p class="release-summary">Website builder debut</p>

--- a/releases/v0.0.9.html
+++ b/releases/v0.0.9.html
@@ -50,10 +50,35 @@
     .back-link:hover {
       text-decoration: underline;
     }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
 </style>
 </head>
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.8.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.10.html">Next release →</a>
+  </nav>
   <h1>🚀 Release v0.0.9</h1>
   <div class="tag">Week of June 16, 2025</div>
   <p class="release-summary">Builder upgrades &amp; history sync</p>


### PR DESCRIPTION
## Summary
- add shared navigation styling to each release notes page
- link every release to its previous and next version with disabled states at the boundaries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c0734ca5083209cbf88e9a48e31a9