### PR TITLE
Add Brave-friendly Gun peer defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The portal is live and hosted at:
 
 You can sign up, join the chat, and start contributing right now — no downloads or installs required.
 
+### Brave browser setup
+
+Brave shields can block realtime sync. Click the 🛡️ icon and either turn Shields off for `portal.3dvr.tech` and `relay.3dvr.tech`, or set **Cross-site cookies** to *Allow* and **Fingerprinting** to *Standard*. Use a regular window (not Tor or private mode) for the most reliable GunJS connection.
+
 ### Run Locally
 
 ```bash

--- a/admin/index.html
+++ b/admin/index.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <style>
   :root {
@@ -356,8 +357,9 @@
 
   <script>
   const gun = Gun({
-    peers: [
-      'https://gun-relay-3dvr.fly.dev/gun'
+    peers: window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
     ]
   });
   const user = gun.user();

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -58,8 +58,11 @@ const calendarState = {
   dayEvents: new Map()
 };
 
-const GUN_RELAY_URL = 'https://gun-relay-3dvr.fly.dev/gun';
-const gun = typeof Gun === 'function' ? Gun([GUN_RELAY_URL]) : null;
+const GUN_PEERS = (typeof window !== 'undefined' && window.__GUN_PEERS__) || [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+];
+const gun = typeof Gun === 'function' ? Gun(GUN_PEERS) : null;
 const portalRoot = gun ? gun.get('3dvr-portal') : null;
 const calendarRoot = portalRoot ? portalRoot.get('calendar') : null;
 const calendarOwnerKey = calendarRoot ? resolveCalendarOwnerKey() : null;

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -273,6 +273,7 @@
   </template>
 
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <script src="/calendar/calendar.js" type="module"></script>
 </body>
 </html>

--- a/chat.html
+++ b/chat.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3DVR - Group Chat</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="score.js"></script>
   <link rel="stylesheet" href="styles/global.css">
@@ -148,8 +149,9 @@
   </footer>
 
 <script>
-const gun = Gun([
-  'https://gun-relay-3dvr.fly.dev/gun',          // 👈 primary
+const gun = Gun(window.__GUN_PEERS__ || [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
 ]);
 const portalRoot = gun.get('3dvr-portal');
 const gunSupportsUser = typeof gun.user === 'function';

--- a/compat.html
+++ b/compat.html
@@ -5,7 +5,12 @@
 <pre id="log" style="white-space:pre-wrap;padding:12px;font:13px/1.4 ui-monospace,Consolas,monospace"></pre>
 <script type="module">
   // ---- CONFIG (Codex replaces {{WSS_RELAY_URL}}) ----
-  const PEERS = ['{{WSS_RELAY_URL}}']; // e.g. wss://relay.3dvr.tech/gun
+  const PEERS = (window.__GUN_PEERS__ && window.__GUN_PEERS__.length)
+    ? window.__GUN_PEERS__
+    : [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ];
 
   // ---- UTIL ----
   const log = document.getElementById('log');

--- a/contacts/index.html
+++ b/contacts/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" href="https://fav.farm/🧠" />
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/axe.js"></script>
   <script src="../score.js"></script>
@@ -386,7 +387,12 @@ function ensureGunContext(factory, label) {
 }
 
 const gunContext = ensureGunContext(
-  () => (typeof Gun === 'function' ? Gun(['https://gun-relay-3dvr.fly.dev/gun']) : null),
+  () => (typeof Gun === 'function'
+    ? Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ])
+    : null),
   'contacts'
 );
 const gun = gunContext.gun;

--- a/crm/index.html
+++ b/crm/index.html
@@ -7,6 +7,7 @@
   <link rel="icon" href="https://fav.farm/🧠" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/axe.js"></script>
   <script src="../score.js"></script>
@@ -153,7 +154,10 @@
   </div>
 
   <script>
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
     const user = gun.user();
     const portalRoot = gun.get('3dvr-portal');
     const guestsRoot = gun.get('3dvr-guests');

--- a/education.html
+++ b/education.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>3DVR Education Portal</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <style>
     body {
       font-family: 'Segoe UI', Tahoma, sans-serif;
@@ -91,7 +92,10 @@
 
 <script>
 // Init Gun
-const gun = Gun();
+const gun = Gun(window.__GUN_PEERS__ || [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+]);
 
 // UI Elements
 const lessonList = document.getElementById('lesson-list');

--- a/finance/app.js
+++ b/finance/app.js
@@ -108,7 +108,12 @@ function ensureGunContext(factory, label) {
 }
 
 const gunContext = ensureGunContext(
-  () => (typeof Gun === 'function' ? Gun(['https://gun-relay-3dvr.fly.dev/gun']) : null),
+  () => (typeof Gun === 'function'
+    ? Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ])
+    : null),
   'finance'
 );
 const gun = gunContext.gun;

--- a/finance/index.html
+++ b/finance/index.html
@@ -6,6 +6,7 @@
   <title>3dvr Finance Hub</title>
   <link rel="stylesheet" href="./styles.css">
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/axe.js"></script>
   <script src="../score.js"></script>

--- a/gun-init.js
+++ b/gun-init.js
@@ -1,0 +1,49 @@
+(function initGunPeers(global) {
+  const defaultPeers = [
+    'wss://relay.3dvr.tech/gun',
+    'wss://gun-relay-3dvr.fly.dev/gun'
+  ];
+  const existingPeers = Array.isArray(global.__GUN_PEERS__)
+    ? global.__GUN_PEERS__
+    : [];
+  const mergedPeers = Array.from(new Set([...defaultPeers, ...existingPeers].filter(Boolean)));
+  global.__GUN_PEERS__ = mergedPeers;
+
+  function runDiagnostics() {
+    if (typeof global.Gun !== 'function' || global.__GUN_BRAVE_DIAGNOSTICS__) {
+      return;
+    }
+    global.__GUN_BRAVE_DIAGNOSTICS__ = true;
+
+    (async () => {
+      try {
+        const isBrave = !!navigator.brave && (await navigator.brave.isBrave?.());
+        console.log('Brave?', isBrave);
+      } catch (err) {
+        console.warn('Brave detection failed', err);
+      }
+
+      const diagGun = global.Gun({
+        peers: mergedPeers,
+        axe: true,
+        radisk: false,
+        localStorage: false
+      });
+
+      diagGun.on('hi', peer => console.log('[GUN] HI', peer?.url || peer));
+      diagGun.on('bye', peer => console.warn('[GUN] BYE', peer?.url || peer));
+
+      const testNode = diagGun.get('brave_sync_test');
+      testNode.put({ now: Date.now() }, ack => console.log('PUT ack:', ack));
+      testNode.once(data => console.log('READ:', data));
+    })();
+  }
+
+  if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', runDiagnostics, { once: true });
+    } else {
+      runDiagnostics();
+    }
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>3DVR Portal</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="score.js"></script>
   <link rel="stylesheet" href="styles/global.css">
@@ -389,7 +390,10 @@
   </div>
 
   <script>
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
     const user = gun.user();
     const portalRoot = gun.get('3dvr-portal');
     if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function') {

--- a/lead-generation.html
+++ b/lead-generation.html
@@ -7,6 +7,7 @@
   <link rel="icon" href="https://fav.farm/🧲" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <meta name="description" content="Collect inbound leads for 3DVR and sync them instantly with the contacts workspace and CRM." />
 </head>
 <body class="bg-gray-950 text-white min-h-screen">
@@ -139,7 +140,10 @@
 
   <script>
     const SOURCE_LABEL = 'Lead generation page';
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
     const orgContacts = gun.get('org-3dvr-demo').get('contacts');
     const crm = gun.get('3dvr-crm');
 

--- a/magic-link.html
+++ b/magic-link.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Set New Password - 3DVR Portal</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <style>
     body {
@@ -54,7 +55,10 @@
   <div id="status"></div>
 
   <script>
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
     const user = gun.user();
 
     const params = new URLSearchParams(window.location.search);

--- a/meditation/index.html
+++ b/meditation/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mindfulness Breathing Room | 3DVR Portal</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="../score.js"></script>
   <link rel="stylesheet" href="../styles/global.css">
@@ -832,7 +833,10 @@
     Tip: Use background audio to keep the rhythm going even if you dim the screen or switch apps.
   </footer>
   <script>
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
     const user = gun.user();
     const portalRoot = gun.get('3dvr-portal');
 

--- a/memory.html
+++ b/memory.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>3DVR - Memory Match</title>
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+<script src="gun-init.js"></script>
 <script src="score.js"></script>
 <link rel="stylesheet" href="styles/global.css">
 <style>
@@ -106,7 +107,10 @@ footer {
 </footer>
 
 <script>
-const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+const gun = Gun(window.__GUN_PEERS__ || [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+]);
 const portalUser = gun.user();
 const portalRoot = gun.get('3dvr-portal');
 const scoreManager = window.ScoreSystem

--- a/notes/index.html
+++ b/notes/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>📝 3DVR Notes</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <link rel="stylesheet" href="../style.css?v=notes-refresh-20240204">
 </head>
 <body class="notes-page">
@@ -88,7 +89,10 @@
   </div>
 
   <script>
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
     const folders = gun.get('simple-folders');
     const notes = gun.get('simple-notes');
 

--- a/old-tasks.html
+++ b/old-tasks.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>3DVR - Task Board</title>
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+<script src="gun-init.js"></script>
 <link rel="stylesheet" href="styles/global.css">
 <style>
 body {
@@ -108,8 +109,9 @@ button:hover {
 <script>
 // Setup GUN with the 3DVR relay
 const gun = Gun({
-  peers: [
-    'https://gun-relay-3dvr.fly.dev/gun'
+  peers: window.__GUN_PEERS__ || [
+    'wss://relay.3dvr.tech/gun',
+    'wss://gun-relay-3dvr.fly.dev/gun'
   ]
 });
 

--- a/password-reset.html
+++ b/password-reset.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Password Reset - 3DVR Portal</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <style>
     body {
@@ -48,7 +49,10 @@
   <div id="status"></div>
 
   <script>
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
 
     async function sendResetLink() {
       const email = document.getElementById('email').value.trim().toLowerCase();

--- a/pong.html
+++ b/pong.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>3DVR - Pong</title>
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+<script src="gun-init.js"></script>
 <script src="score.js"></script>
 <link rel="stylesheet" href="styles/global.css">
 <style>
@@ -67,7 +68,10 @@ footer {
 </footer>
 
 <script>
-const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+const gun = Gun(window.__GUN_PEERS__ || [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+]);
 const portalUser = gun.user();
 const portalRoot = gun.get('3dvr-portal');
 const scoreManager = window.ScoreSystem

--- a/profile.html
+++ b/profile.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>3DVR - Profile</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="score.js"></script>
   <link rel="stylesheet" href="styles/global.css">
@@ -123,7 +124,10 @@
 </div>
 
 <script>
-const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+const gun = Gun(window.__GUN_PEERS__ || [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+]);
 const user = gun.user();
 const portalRoot = gun.get('3dvr-portal');
 

--- a/rewards.html
+++ b/rewards.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3DVR Rewards</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="score.js"></script>
   <style>
@@ -49,7 +50,10 @@
   <div class="log" id="log">Loading your log...</div>
 
   <script>
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
     const user = gun.user();
     const portalRoot = gun.get('3dvr-portal');
     const scoreManager = window.ScoreSystem

--- a/sign-in.html
+++ b/sign-in.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3DVR Portal – Sign In or Sign Up</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <style>
     :root {
@@ -473,7 +474,14 @@
     }
 
     const gunContext = ensureGunContext(
-      () => (typeof Gun === 'function' ? Gun({ peers: ['https://gun-relay-3dvr.fly.dev/gun'] }) : null),
+      () => (typeof Gun === 'function'
+        ? Gun({
+          peers: window.__GUN_PEERS__ || [
+            'wss://relay.3dvr.tech/gun',
+            'wss://gun-relay-3dvr.fly.dev/gun'
+          ]
+        })
+        : null),
       'sign-in'
     );
     const gun = gunContext.gun;

--- a/src/gun/adapter.js
+++ b/src/gun/adapter.js
@@ -5,9 +5,17 @@ import { getEnvInfo } from './env.js';
 export function createGun() {
   return import('https://cdn.jsdelivr.net/npm/gun/gun.js').then(({ default: Gun }) => {
     const { RELAY, ROOT, cacheEnabled } = getEnvInfo();
+    const fallbackPeers = [
+      RELAY,
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ].filter(Boolean);
+    const peers = (typeof window !== 'undefined' && Array.isArray(window.__GUN_PEERS__))
+      ? window.__GUN_PEERS__
+      : Array.from(new Set(fallbackPeers));
 
     const gun = Gun({
-      peers: [RELAY],
+      peers,
       axe: true,                 // better WAN performance
       radisk: cacheEnabled,      // disable in previews to avoid stale state
       localStorage: cacheEnabled // disable in previews to avoid stale state

--- a/tasks.html
+++ b/tasks.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>3DVR - Advanced Task Board</title>
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+<script src="gun-init.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles/global.css">
@@ -1099,8 +1100,9 @@ function init() {
 function setupGun() {
   try {
     gun = Gun({
-      peers: [
-        'https://gun-relay-3dvr.fly.dev/gun'
+      peers: window.__GUN_PEERS__ || [
+        'wss://relay.3dvr.tech/gun',
+        'wss://gun-relay-3dvr.fly.dev/gun'
       ]
     });
     

--- a/test-gun.html
+++ b/test-gun.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>GunJS Relay Test</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <style>
     body { font-family: sans-serif; padding: 2rem; background: #f4f4f4; }
     input, button { font-size: 1rem; padding: 0.5rem; }
@@ -23,7 +24,10 @@
   </div>
 
   <script>
-    const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+    const gun = Gun(window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ]);
     const messages = gun.get('test/messages');
 
     function send() {

--- a/tests/finance.test.js
+++ b/tests/finance.test.js
@@ -45,7 +45,7 @@ describe('finance ledger hub', () => {
     assert.equal(await fileExists(scriptUrl), true, 'app.js should exist');
 
     const js = await readFile(scriptUrl, 'utf8');
-    assert.ok(js.includes("Gun(['https://gun-relay-3dvr.fly.dev/gun'])"));
+    assert.match(js, /Gun\(window\.__GUN_PEERS__ \|\| \[/);
     assert.ok(js.includes("gun.get('finance').get('expenditures')"));
     assert.match(js, /financeLedger\.get\(/);
     assert.match(js, /form\.addEventListener\('submit'/);

--- a/website-builder.html
+++ b/website-builder.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Website Builder</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="gun-init.js"></script>
   <link rel="stylesheet" href="styles/global.css">
  <style>
     body {
@@ -78,7 +79,10 @@
 <button id="submit-btn">Send</button>
 
 <script>
-  const gun = Gun(['https://gun-relay-3dvr.fly.dev/gun']);
+  const gun = Gun(window.__GUN_PEERS__ || [
+    'wss://relay.3dvr.tech/gun',
+    'wss://gun-relay-3dvr.fly.dev/gun'
+  ]);
   let threadId = null;
   let openAiAssistantUrl = null;
   


### PR DESCRIPTION
## Summary
- add a shared gun-init helper that prefers the new relay.3dvr.tech peer, provides a Fly fallback, and logs Brave diagnostics
- update portal pages and the shared adapter to consume the merged peer list via window.__GUN_PEERS__
- document Brave shield settings so users can keep realtime sync working in Brave

## Testing
- npm test *(fails: Playwright browser binaries are not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691113fb8bd48320a78352a2b747f084)