### PR TITLE
Add CRM quick link to contacts header

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -19,6 +19,7 @@
   <header class="sticky top-0 z-10 backdrop-blur bg-gray-900/90 border-b border-white/10">
     <div class="max-w-6xl mx-auto px-4 py-3 flex items-center gap-3">
       <a href="../index.html" class="text-sm text-gray-300 hover:text-white">← Portal</a>
+      <a href="../crm/index.html" class="text-sm text-gray-300 hover:text-white">CRM</a>
       <h1 class="text-xl sm:text-2xl font-bold">Contacts <span class="text-teal-400">· 3DVR</span></h1>
       <span id="spaceBadge" class="hidden text-xs px-2 py-1 rounded bg-white/10">personal</span>
       <div class="ms-auto flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add a CRM navigation link to the contacts header so users can switch quickly

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69112eafbe948320b6b6f4f0d1dc55be)