### PR TITLE
Remove Brave Shields warning overlay

### DIFF
--- a/gun-init.js
+++ b/gun-init.js
@@ -10,68 +10,15 @@
   global.__GUN_PEERS__ = mergedPeers;
 
   function showBraveShieldNotice(reason) {
-    if (typeof document === 'undefined') {
+    if (typeof console === 'undefined') {
       return;
     }
 
-    if (document.getElementById('brave-shield-warning')) {
-      const details = document.querySelector('#brave-shield-warning [data-reason]');
-      if (details && reason && !details.textContent.includes(reason)) {
-        details.textContent += `, ${reason}`;
-      }
-      return;
-    }
+    const message = reason
+      ? `Brave diagnostic: ${reason}`
+      : 'Brave diagnostic: Brave Shields likely active.';
 
-    const wrapper = document.createElement('div');
-    wrapper.id = 'brave-shield-warning';
-    wrapper.setAttribute('role', 'status');
-    wrapper.setAttribute('aria-live', 'polite');
-    wrapper.style.position = 'fixed';
-    wrapper.style.zIndex = '2147483647';
-    wrapper.style.right = '16px';
-    wrapper.style.bottom = '16px';
-    wrapper.style.maxWidth = '360px';
-    wrapper.style.padding = '16px';
-    wrapper.style.borderRadius = '12px';
-    wrapper.style.background = 'rgba(21, 21, 21, 0.92)';
-    wrapper.style.color = '#fff';
-    wrapper.style.boxShadow = '0 12px 32px rgba(0, 0, 0, 0.35)';
-    wrapper.style.fontFamily = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
-    wrapper.style.lineHeight = '1.4';
-
-    const heading = document.createElement('strong');
-    heading.textContent = 'Brave Shields are blocking realtime sync';
-
-    const description = document.createElement('p');
-    description.style.margin = '8px 0 0 0';
-    description.textContent = 'GunJS needs cross-site cookies and WebSocket access. Turn the Brave shield off or set Cross-site cookies to Allow and Fingerprinting to Standard for portal.3dvr.tech and relay.3dvr.tech.';
-
-    const details = document.createElement('p');
-    details.style.margin = '8px 0 0 0';
-    details.dataset.reason = 'true';
-    details.textContent = reason ? `Detected issue: ${reason}` : 'Detected issue: Brave Shields likely active.';
-
-    const close = document.createElement('button');
-    close.type = 'button';
-    close.textContent = 'Dismiss';
-    close.style.marginTop = '12px';
-    close.style.padding = '6px 12px';
-    close.style.border = 'none';
-    close.style.borderRadius = '8px';
-    close.style.cursor = 'pointer';
-    close.style.fontWeight = '600';
-    close.style.background = '#ff8a00';
-    close.style.color = '#151515';
-    close.addEventListener('click', () => {
-      wrapper.remove();
-    });
-
-    wrapper.appendChild(heading);
-    wrapper.appendChild(description);
-    wrapper.appendChild(details);
-    wrapper.appendChild(close);
-
-    document.body.appendChild(wrapper);
+    console.info(message);
   }
 
   function runDiagnostics() {


### PR DESCRIPTION
## Summary
- replace the Brave Shields warning overlay with a console info message so the CRM no longer shows a blocking prompt

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69113a31c098832096d7476e7558f5ab)