### PR TITLE
Improve Stellar Drift performance on mobile and low-power devices

### DIFF
--- a/stellar-flight.html
+++ b/stellar-flight.html
@@ -731,9 +731,53 @@
   const camera = new THREE.PerspectiveCamera(72, window.innerWidth / window.innerHeight, 0.2, 3000);
   camera.position.set(0, 0, 20);
 
+  const coarsePointerQuery = window.matchMedia('(pointer: coarse)');
+  const finePointerQuery = window.matchMedia('(pointer: fine)');
+  const hasTouchPoints = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+  let usingTouchControls = coarsePointerQuery.matches || (!finePointerQuery.matches && hasTouchPoints);
+  let manualControlPreference = false;
+
+  function calculatePerformanceProfile() {
+    const cores = navigator.hardwareConcurrency || 4;
+    const minDimension = Math.min(window.innerWidth, window.innerHeight);
+    let penalty = 0;
+    if (cores <= 4) {
+      penalty += 0.2;
+      if (cores <= 2) {
+        penalty += 0.15;
+      }
+    }
+    if (minDimension < 900) {
+      penalty += 0.15;
+      if (minDimension < 700) {
+        penalty += 0.15;
+      }
+      if (minDimension < 540) {
+        penalty += 0.05;
+      }
+    }
+    const density = Math.max(0.4, 1 - penalty);
+    const animationScale = 0.7 + density * 0.3;
+    return { density, animationScale };
+  }
+
+  let performanceProfile = calculatePerformanceProfile();
+
+  function refreshPerformanceProfile() {
+    performanceProfile = calculatePerformanceProfile();
+  }
+
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-  renderer.setSize(window.innerWidth, window.innerHeight);
-  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+  function updateRendererViewport() {
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    const basePixelRatio = window.devicePixelRatio || 1;
+    const highDensity = basePixelRatio > 1.5;
+    const maxRatio = usingTouchControls || highDensity ? 1.5 : 2;
+    renderer.setPixelRatio(Math.min(basePixelRatio, maxRatio));
+  }
+
+  updateRendererViewport();
   document.body.appendChild(renderer.domElement);
 
   const ambient = new THREE.AmbientLight(0x7dd3fc, 0.38);
@@ -757,7 +801,8 @@
     });
 
     const nebulae = [];
-    for (let i = 0; i < 7; i++) {
+    const nebulaCount = Math.max(4, Math.round(7 * performanceProfile.density));
+    for (let i = 0; i < nebulaCount; i++) {
       const nebulaGeometry = new THREE.IcosahedronGeometry(140 + Math.random() * 90, 2);
       const nebula = new THREE.Mesh(nebulaGeometry, nebulaMaterial.clone());
       nebula.position.set((Math.random() - 0.5) * 1200, (Math.random() - 0.5) * 640, -220 - Math.random() * 1800);
@@ -811,23 +856,24 @@
   }
 
   const nebulae = createNebulae();
+  const starDensity = performanceProfile.density;
   const starLayers = [
     createStarField({
-      count: 1800,
+      count: Math.max(600, Math.round(1800 * starDensity)),
       spread: new THREE.Vector3(2600, 1800, 2600),
       size: 1.6,
       twinkle: 0.14,
       rotationSpeed: 0.006
     }),
     createStarField({
-      count: 1200,
+      count: Math.max(420, Math.round(1200 * starDensity)),
       spread: new THREE.Vector3(1800, 1200, 1800),
       size: 2.1,
       twinkle: 0.18,
       rotationSpeed: 0.01
     }),
     createStarField({
-      count: 800,
+      count: Math.max(320, Math.round(800 * starDensity)),
       spread: new THREE.Vector3(900, 720, 900),
       size: 2.6,
       twinkle: 0.22,
@@ -852,7 +898,8 @@
 
   const anomalyTexture = createGlowTexture();
   const anomalies = [];
-  for (let i = 0; i < 12; i++) {
+  const anomalyCount = Math.max(6, Math.round(12 * starDensity));
+  for (let i = 0; i < anomalyCount; i++) {
     const spriteMaterial = new THREE.SpriteMaterial({
       map: anomalyTexture,
       color: new THREE.Color().setHSL(0.52 + Math.random() * 0.16, 0.8, 0.6),
@@ -870,7 +917,7 @@
       sprite,
       pulse: Math.random() * Math.PI * 2,
       baseOpacity: spriteMaterial.opacity,
-      speed: 0.6 + Math.random() * 0.5
+      baseSpeed: 0.6 + Math.random() * 0.5
     });
   }
 
@@ -960,7 +1007,7 @@
     metalness: 0.1,
     roughness: 0.85
   });
-  const asteroidCount = 110;
+  const asteroidCount = Math.max(60, Math.round(110 * starDensity));
   const asteroids = new THREE.InstancedMesh(asteroidGeometry, asteroidMaterial, asteroidCount);
   const asteroidInfos = [];
   const tempMatrix = new THREE.Matrix4();
@@ -1018,11 +1065,12 @@
     depthWrite: false
   });
   const streaks = [];
-  for (let i = 0; i < 140; i++) {
+  const streakCount = Math.max(60, Math.round(140 * (0.6 + starDensity * 0.4)));
+  for (let i = 0; i < streakCount; i++) {
     const streak = new THREE.Mesh(streakGeometry, streakMaterial);
     resetStreak(streak);
     streakGroup.add(streak);
-    streaks.push({ mesh: streak, speed: 18 + Math.random() * 26 });
+    streaks.push({ mesh: streak, baseSpeed: 18 + Math.random() * 26 });
   }
 
   function resetStreak(mesh) {
@@ -1079,12 +1127,6 @@
     strafeRight: false
   };
   let paused = false;
-
-  const coarsePointerQuery = window.matchMedia('(pointer: coarse)');
-  const finePointerQuery = window.matchMedia('(pointer: fine)');
-  const hasTouchPoints = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-  let usingTouchControls = coarsePointerQuery.matches || (!finePointerQuery.matches && hasTouchPoints);
-  let manualControlPreference = false;
 
   if (overlayToggle) {
     overlayToggle.setAttribute('aria-hidden', 'true');
@@ -1152,7 +1194,7 @@
         ].join(' ');
       secondaryInstructions.innerHTML =
         [
-          'Hold Boost to surge forward, Strafe or Ascend/Descend to slide and climb, and Re-center to reset orientation.',
+          'Hold the Boost pad to surge forward, Strafe or Ascend/Descend to slide and climb, and Re-center to reset orientation.',
           'Pause freezes the ship without leaving the session. Attach a keyboard or toggle controls to return to mouse + WASD flight.'
         ].join(' ');
     } else {
@@ -1198,6 +1240,9 @@
         touchGestureHint.classList.remove('touch-gesture-hint-hidden');
       }
     }
+    updateRendererViewport();
+    refreshPerformanceProfile();
+    updateStatus(velocity.length());
     updateInstructionCopy();
   }
 
@@ -1403,7 +1448,14 @@
 
   function updateStatus(speed) {
     const boostEngaged = touchActions.boost || keys.has('ShiftLeft') || keys.has('ShiftRight');
-    const modeLabel = paused ? 'PAUSED' : boostEngaged ? 'BOOST CHANNEL' : 'CRUISE MODE';
+    let modeLabel = 'CRUISE MODE';
+    if (paused) {
+      modeLabel = 'PAUSED';
+    } else if (boostEngaged) {
+      modeLabel = usingTouchControls ? 'BOOST PAD ACTIVE' : 'BOOST CHANNEL';
+    } else if (usingTouchControls) {
+      modeLabel = 'CRUISE — TAP BOOST TO SURGE';
+    }
     const displayedSpeed = paused ? 0 : speed;
     statusEl.innerHTML = `VELOCITY <span>${displayedSpeed.toFixed(1)}</span> U/S<br>${modeLabel}`;
   }
@@ -1576,15 +1628,16 @@
     requestAnimationFrame(animate);
     const delta = clock.getDelta();
     updateMovement(delta);
+    const animationScale = performanceProfile.animationScale;
 
     starLayers.forEach((layer, index) => {
-      layer.points.rotation.y += delta * layer.rotationSpeed * (index + 1);
-      layer.points.rotation.x += delta * layer.rotationSpeed * 0.5;
+      layer.points.rotation.y += delta * layer.rotationSpeed * (index + 1) * animationScale;
+      layer.points.rotation.x += delta * layer.rotationSpeed * 0.5 * animationScale;
     });
 
     nebulae.forEach((item) => {
-      item.mesh.rotation.y += delta * 0.02;
-      item.mesh.position.addScaledVector(item.drift, delta * 0.5);
+      item.mesh.rotation.y += delta * 0.02 * animationScale;
+      item.mesh.position.addScaledVector(item.drift, delta * 0.5 * animationScale);
       if (item.mesh.position.z > 200) {
         item.mesh.position.copy(new THREE.Vector3(
           (Math.random() - 0.5) * 1200,
@@ -1595,9 +1648,9 @@
     });
 
     anomalies.forEach((anomaly) => {
-      anomaly.pulse += delta * anomaly.speed;
+      anomaly.pulse += delta * anomaly.baseSpeed * animationScale;
       anomaly.sprite.material.opacity = anomaly.baseOpacity + Math.sin(anomaly.pulse) * 0.18;
-      anomaly.sprite.position.z += delta * 14;
+      anomaly.sprite.position.z += delta * 14 * animationScale;
       if (anomaly.sprite.position.z > 120) {
         anomaly.sprite.position.set(
           (Math.random() - 0.5) * 1100,
@@ -1608,24 +1661,24 @@
     });
 
     planets.forEach((planet, index) => {
-      planet.rotation.y += delta * (0.04 + index * 0.018);
-      planet.userData.floatPhase += delta * 0.6;
+      planet.rotation.y += delta * (0.04 + index * 0.018) * animationScale;
+      planet.userData.floatPhase += delta * 0.6 * animationScale;
       planet.position.y = planet.userData.baseY + Math.sin(planet.userData.floatPhase) * 8;
       if (planet.userData.ring) {
-        planet.userData.ring.rotation.z += delta * 0.05;
+        planet.userData.ring.rotation.z += delta * 0.05 * animationScale;
         planet.userData.ring.position.y = planet.position.y;
       }
     });
 
     planetPivots.forEach((pivot, index) => {
-      pivot.rotation.y += delta * (0.02 + index * 0.01);
+      pivot.rotation.y += delta * (0.02 + index * 0.01) * animationScale;
     });
 
     asteroidInfos.forEach((info, instanceIndex) => {
-      info.rotation.x += delta * info.rotationDelta.x;
-      info.rotation.y += delta * info.rotationDelta.y;
-      info.rotation.z += delta * info.rotationDelta.z;
-      info.position.addScaledVector(info.drift, delta * 0.6);
+      info.rotation.x += delta * info.rotationDelta.x * animationScale;
+      info.rotation.y += delta * info.rotationDelta.y * animationScale;
+      info.rotation.z += delta * info.rotationDelta.z * animationScale;
+      info.position.addScaledVector(info.drift, delta * 0.6 * animationScale);
       info.position.z += delta * (velocity.length() * 0.45);
       if (info.position.z > 140) {
         info.position.copy(randomAsteroidPosition());
@@ -1637,7 +1690,7 @@
     asteroids.instanceMatrix.needsUpdate = true;
 
     streaks.forEach((streak) => {
-      streak.mesh.position.z += delta * (velocity.length() * 0.9 + streak.speed);
+      streak.mesh.position.z += delta * (velocity.length() * 0.9 + streak.baseSpeed * animationScale);
       if (streak.mesh.position.z > -2) {
         resetStreak(streak.mesh);
       }
@@ -1648,10 +1701,24 @@
 
   animate();
 
-  window.addEventListener('resize', () => {
+  function handleViewportChange() {
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
-    renderer.setSize(window.innerWidth, window.innerHeight);
+    updateRendererViewport();
+    refreshPerformanceProfile();
+    if (usingTouchControls) {
+      requestAnimationFrame(() => setThrottleValue(throttleValue));
+    }
+    updateStatus(velocity.length());
+  }
+
+  window.addEventListener('resize', handleViewportChange);
+  window.addEventListener('orientationchange', () => {
+    setTimeout(() => {
+      handleViewportChange();
+      updateInstructionCopy();
+      evaluatePointerPreference();
+    }, 150);
   });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- clamp the WebGL renderer pixel ratio more aggressively when touch controls or high-DPR displays are detected
- scale starfield, anomaly, asteroid, and streak densities plus animation speeds based on device capability hints
- refresh touch-oriented status messaging and handle resize/orientation changes so touch controls and camera stay in sync

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69128e9183848320adf65820d900f475)