### PR TITLE
Fix pointer mode initialization on Stellar Drift

### DIFF
--- a/stellar-flight.html
+++ b/stellar-flight.html
@@ -1085,6 +1085,9 @@
   const hasTouchPoints = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
   let usingTouchControls = coarsePointerQuery.matches || (!finePointerQuery.matches && hasTouchPoints);
   let manualControlPreference = false;
+  let touchLookPointer = null;
+  let lastLookX = 0;
+  let lastLookY = 0;
 
   if (overlayToggle) {
     overlayToggle.setAttribute('aria-hidden', 'true');
@@ -1390,9 +1393,6 @@
   let pitch = 0;
   let pointerLocked = false;
   const pitchLimit = Math.PI / 2 - 0.08;
-  let touchLookPointer = null;
-  let lastLookX = 0;
-  let lastLookY = 0;
 
   function recenterShip() {
     camera.position.set(0, 0, 20);


### PR DESCRIPTION
## Summary
- declare the touch look pointer state before the control mode logic runs so desktops no longer throw a ReferenceError
- keep the later input handling logic unchanged while avoiding duplicate declarations

## Testing
- Manual verification in headless Chromium (desktop)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134ba2e4f88320a69e2ad426369bf1)