### PR TITLE
Reorder Social Planning card into alphabetical app list

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,11 +148,6 @@
             <span class="app-card__title">CRM</span>
             <span class="app-card__meta">Track deals and sync with contacts seamlessly.</span>
           </a>
-          <a href="social/index.html" class="app-card">
-            <span class="app-card__icon" aria-hidden="true">📣</span>
-            <span class="app-card__title">Social Planning</span>
-            <span class="app-card__meta">Organize campaigns, credentials, and automation plans.</span>
-          </a>
           <a href="finance/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">💰</span>
             <span class="app-card__title">Finance</span>
@@ -217,6 +212,11 @@
             <span class="app-card__icon" aria-hidden="true">🛠️</span>
             <span class="app-card__title">Sites</span>
             <span class="app-card__meta">Launch lightweight pages for your projects.</span>
+          </a>
+          <a href="social/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">📣</span>
+            <span class="app-card__title">Social Planning</span>
+            <span class="app-card__meta">Organize campaigns, credentials, and automation plans.</span>
           </a>
           <a href="tasks.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">✅</span>


### PR DESCRIPTION
## Summary
- move the Social Planning app card to follow Sites so the app grid stays alphabetical

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691523a3d18c8320a54238bb7f4583e8)