### PR TITLE
Fix Pong GunJS init by loading SEA module

### DIFF
--- a/pong.html
+++ b/pong.html
@@ -6,6 +6,7 @@
 <title>3DVR - Pong</title>
 <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
 <script src="gun-init.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
 <script src="score.js"></script>
 <link rel="stylesheet" href="styles/global.css">
 <style>


### PR DESCRIPTION
## Summary
- load the Gun SEA module on pong.html so the page can call `gun.user()` without throwing
- confirm the game renders by visiting the page in a browser

## Testing
- Manual verification

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691525cfce48832099a210b72919bd7e)