### PR TITLE
Add jetpack corridor game to hub

### DIFF
--- a/games.html
+++ b/games.html
@@ -67,6 +67,7 @@ h1 {
   <a class="game-card" href="memory.html">Memory Match</a>
   <a class="game-card" href="tribes-flight.html">Zero-G Ski Range</a>
   <a class="game-card" href="stellar-flight.html">Stellar Drift Flight</a>
+  <a class="game-card" href="jetpack.html">Jetpack Corridor</a>
 </div>
 
 </body>

--- a/jetpack.html
+++ b/jetpack.html
@@ -1,0 +1,532 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>3DVR - Jetpack Corridor</title>
+  <link rel="stylesheet" href="styles/global.css">
+  <style>
+  body {
+    margin: 0;
+    overflow: hidden;
+    background: radial-gradient(circle at top, #0a2540, #050f1f 65%, #02060c 100%);
+    color: #fff;
+    font-family: 'Poppins', sans-serif;
+  }
+
+  canvas {
+    position: fixed;
+    inset: 0;
+    display: block;
+  }
+
+  .top-buttons {
+    position: fixed;
+    top: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 50;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(94, 234, 212, 0.35);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(14px);
+  }
+
+  #hud {
+    position: fixed;
+    top: 100px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(10, 25, 50, 0.7);
+    color: #e2f1ff;
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-size: 1rem;
+    letter-spacing: 0.05em;
+    z-index: 40;
+  }
+
+  #loading,
+  #winMessage {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    font-weight: 600;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    z-index: 60;
+  }
+
+  #winMessage {
+    display: none;
+    font-size: clamp(2rem, 3vw, 3.5rem);
+    text-align: center;
+  }
+
+  #winMessage button {
+    margin-top: 1.5rem;
+    padding: 0.65rem 1.4rem;
+    border-radius: 999px;
+    border: none;
+    background: rgba(56, 189, 248, 0.25);
+    color: #f8fafc;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease;
+  }
+
+  #winMessage button:hover {
+    transform: translateY(-2px);
+    background: rgba(56, 189, 248, 0.35);
+  }
+
+  #dpad {
+    position: fixed;
+    bottom: 2.5rem;
+    left: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    z-index: 45;
+  }
+
+  #dpad > div {
+    display: flex;
+    gap: 0.35rem;
+  }
+
+  #dpad button,
+  #fly-btn {
+    width: 60px;
+    height: 60px;
+    font-size: 1.6rem;
+    border-radius: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.5);
+    background: rgba(15, 23, 42, 0.55);
+    color: #f8fafc;
+    cursor: pointer;
+    opacity: 0.85;
+    transition: transform 0.15s ease, background 0.15s ease, opacity 0.15s ease;
+    touch-action: none;
+  }
+
+  #dpad button:active,
+  #fly-btn:active {
+    transform: scale(0.96);
+    background: rgba(56, 189, 248, 0.3);
+    opacity: 1;
+  }
+
+  #fly-btn {
+    position: fixed;
+    bottom: 2.5rem;
+    right: 2.5rem;
+    width: 80px;
+    height: 80px;
+    font-size: 1.3rem;
+    border-radius: 999px;
+    z-index: 45;
+  }
+
+  @media (max-width: 720px) {
+    #hud {
+      top: 5.5rem;
+      font-size: 0.9rem;
+    }
+
+    .top-buttons {
+      top: 0.75rem;
+      transform: translate(-50%, 0);
+    }
+  }
+  </style>
+</head>
+<body class="theme-dark">
+  <div class="top-buttons">
+    <a href="index.html">🏠 Portal</a>
+    <a href="games.html">🎮 Game Hub</a>
+    <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">⭐ Subscribe</a>
+    <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">🚀 GitHub</a>
+  </div>
+
+  <div id="loading">Loading jetpack pilot...</div>
+  <div id="hud">Score: 0</div>
+  <div id="winMessage">
+    <div>Mission Complete!<br>Corridor secured.</div>
+    <button id="restart-btn" type="button">Fly Again</button>
+  </div>
+
+  <div id="dpad" aria-hidden="true">
+    <button id="up-btn" aria-label="Move forward">↑</button>
+    <div>
+      <button id="left-btn" aria-label="Turn left">←</button>
+      <button id="down-btn" aria-label="Move backward">↓</button>
+      <button id="right-btn" aria-label="Turn right">→</button>
+    </div>
+  </div>
+  <button id="fly-btn" aria-label="Use jetpack">Fly</button>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
+  <script>
+  let scene;
+  let camera;
+  let renderer;
+  let clock;
+  let player;
+  let defaultCameraTarget;
+  const playerVelocity = new THREE.Vector3();
+  const keys = {};
+  let score = 0;
+  let gameActive = true;
+  const pathBillboards = [];
+  const hitEffects = [];
+  const winZ = 200;
+  const COLLISION_THRESHOLD = 4;
+  const rotationSpeed = 2;
+  const moveSpeed = 5;
+  const jetpackSpeed = 10;
+  const gravity = -9.8;
+  const groundLevel = 1;
+
+  function init() {
+    scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x06142a);
+    camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.set(0, 5, 15);
+    defaultCameraTarget = new THREE.Vector3(0, 2, 100);
+
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    document.body.appendChild(renderer.domElement);
+
+    clock = new THREE.Clock();
+
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+    scene.add(ambientLight);
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
+    directionalLight.position.set(12, 18, 8);
+    scene.add(directionalLight);
+
+    const groundGeo = new THREE.PlaneGeometry(500, 500);
+    const groundMat = new THREE.MeshStandardMaterial({ color: 0x102e44 });
+    const ground = new THREE.Mesh(groundGeo, groundMat);
+    ground.rotation.x = -Math.PI / 2;
+    ground.position.y = 0;
+    ground.receiveShadow = true;
+    scene.add(ground);
+
+    createPath();
+
+    window.addEventListener('resize', onWindowResize);
+    window.addEventListener('keydown', onKeyDown, { passive: false });
+    window.addEventListener('keyup', onKeyUp);
+
+    initControls();
+    animate();
+    loadPlayer();
+  }
+
+  function initControls() {
+    const mapping = [
+      ['left-btn', 'ArrowLeft'],
+      ['right-btn', 'ArrowRight'],
+      ['up-btn', 'ArrowUp'],
+      ['down-btn', 'ArrowDown'],
+      ['fly-btn', ' ']
+    ];
+
+    mapping.forEach(([id, key]) => {
+      const button = document.getElementById(id);
+      if (!button) return;
+
+      const activate = event => {
+        event.preventDefault();
+        keys[key] = true;
+      };
+
+      const deactivate = event => {
+        event.preventDefault();
+        keys[key] = false;
+      };
+
+      button.addEventListener('pointerdown', activate);
+      button.addEventListener('pointerup', deactivate);
+      button.addEventListener('pointerleave', deactivate);
+      button.addEventListener('pointercancel', deactivate);
+    });
+
+    document.getElementById('restart-btn').addEventListener('click', resetGame);
+  }
+
+  function onKeyDown(event) {
+    const key = event.key;
+    if (key === 'ArrowUp' || key === 'ArrowDown' || key === 'ArrowLeft' || key === 'ArrowRight' || key === ' ' || key === 'Spacebar') {
+      event.preventDefault();
+      keys[key === 'Spacebar' ? ' ' : key] = true;
+    }
+  }
+
+  function onKeyUp(event) {
+    const key = event.key;
+    if (key === 'ArrowUp' || key === 'ArrowDown' || key === 'ArrowLeft' || key === 'ArrowRight' || key === ' ' || key === 'Spacebar') {
+      keys[key === 'Spacebar' ? ' ' : key] = false;
+    }
+  }
+
+  function loadPlayer() {
+    const loader = new THREE.GLTFLoader();
+    loader.load(
+      'https://threejs.org/examples/models/gltf/RobotExpressive/RobotExpressive.glb',
+      gltf => {
+        player = gltf.scene;
+        player.scale.set(0.5, 0.5, 0.5);
+        player.position.set(0, groundLevel, 0);
+        player.rotation.y = 0;
+        attachJetpack(player);
+        addPlayerBranding();
+        scene.add(player);
+        hideLoading();
+      },
+      undefined,
+      () => {
+        const fallback = new THREE.Object3D();
+        const bodyGeo = new THREE.SphereGeometry(0.5, 16, 16);
+        const bodyMat = new THREE.MeshStandardMaterial({ color: 0xff3366 });
+        const bodyMesh = new THREE.Mesh(bodyGeo, bodyMat);
+        fallback.add(bodyMesh);
+        attachJetpack(fallback);
+        addPlayerBranding(fallback);
+        fallback.position.set(0, groundLevel, 0);
+        player = fallback;
+        scene.add(player);
+        hideLoading();
+      }
+    );
+  }
+
+  function attachJetpack(object3d) {
+    const flameGeo = new THREE.ConeGeometry(0.2, 0.5, 8);
+    const flameMat = new THREE.MeshBasicMaterial({ color: 0xffa500 });
+    const flameMesh = new THREE.Mesh(flameGeo, flameMat);
+    flameMesh.position.set(0, -0.8, 0);
+    flameMesh.rotation.x = Math.PI;
+    flameMesh.visible = false;
+    flameMesh.name = 'flame';
+    object3d.add(flameMesh);
+  }
+
+  function addPlayerBranding(target = player) {
+    if (!target) return;
+    const branding = createBillboard('3dvr.tech');
+    branding.scale.set(0.5, 0.5, 0.5);
+    branding.position.set(0, 2, 0);
+    branding.name = 'branding';
+    target.add(branding);
+  }
+
+  function createBillboard(text) {
+    const size = 256;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    const gradient = ctx.createRadialGradient(size / 2, size / 2, size / 8, size / 2, size / 2, size / 2);
+    gradient.addColorStop(0, '#ffcc00');
+    gradient.addColorStop(1, '#ff6600');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, size, size);
+    ctx.font = 'bold 50px Arial';
+    ctx.fillStyle = '#ffffff';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(text, size / 2, size / 2);
+    ctx.lineWidth = 4;
+    ctx.strokeStyle = '#000000';
+    ctx.strokeText(text, size / 2, size / 2);
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.needsUpdate = true;
+    const material = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide, transparent: true });
+    const geometry = new THREE.PlaneGeometry(5, 5);
+    return new THREE.Mesh(geometry, material);
+  }
+
+  function createPath() {
+    const numBoards = 30;
+    for (let i = 0; i < numBoards; i += 1) {
+      const t = i / (numBoards - 1);
+      const z = 20 + t * 180;
+      const x = 5 * Math.sin(2 * Math.PI * t);
+      const y = 2;
+      const billboard = createBillboard('3dvr.tech');
+      billboard.position.set(x, y, z);
+      scene.add(billboard);
+      pathBillboards.push(billboard);
+    }
+  }
+
+  function createHitEffect(position) {
+    const ringGeom = new THREE.RingGeometry(0.5, 0.6, 32);
+    const ringMat = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      side: THREE.DoubleSide,
+      transparent: true,
+      opacity: 1,
+      blending: THREE.AdditiveBlending
+    });
+    const ring = new THREE.Mesh(ringGeom, ringMat);
+    ring.position.copy(position);
+    ring.rotation.x = Math.PI / 2;
+    ring.userData.startTime = clock.getElapsedTime();
+    ring.userData.duration = 0.5;
+    scene.add(ring);
+    hitEffects.push(ring);
+  }
+
+  function checkCollisions() {
+    if (!player) return;
+    const playerPos = player.position;
+    for (let i = pathBillboards.length - 1; i >= 0; i -= 1) {
+      const billboard = pathBillboards[i];
+      const distance = playerPos.distanceTo(billboard.position);
+      if (distance < COLLISION_THRESHOLD) {
+        createHitEffect(billboard.position);
+        scene.remove(billboard);
+        pathBillboards.splice(i, 1);
+        score += 10;
+        updateHUD();
+      }
+    }
+  }
+
+  function checkWin() {
+    if (player && player.position.z >= winZ && gameActive) {
+      winLevel();
+    }
+  }
+
+  function winLevel() {
+    gameActive = false;
+    document.getElementById('winMessage').style.display = 'flex';
+  }
+
+  function updateHUD() {
+    document.getElementById('hud').textContent = `Score: ${score}`;
+  }
+
+  function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  }
+
+  function updatePlayer(delta) {
+    if (!player) {
+      camera.position.lerp(new THREE.Vector3(0, 5, 15), 0.08);
+      camera.lookAt(defaultCameraTarget);
+      return;
+    }
+
+    if (keys.ArrowLeft) {
+      player.rotation.y += rotationSpeed * delta;
+    }
+    if (keys.ArrowRight) {
+      player.rotation.y -= rotationSpeed * delta;
+    }
+
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(player.quaternion);
+    forward.y = 0;
+    forward.normalize();
+
+    if (keys.ArrowUp) {
+      player.position.addScaledVector(forward, moveSpeed * delta);
+    }
+    if (keys.ArrowDown) {
+      player.position.addScaledVector(forward, -moveSpeed * delta);
+    }
+
+    const flame = player.getObjectByName('flame');
+    if (keys[' ']) {
+      playerVelocity.y = jetpackSpeed;
+      if (flame) flame.visible = true;
+    } else {
+      playerVelocity.y += gravity * delta;
+      if (flame) flame.visible = false;
+    }
+
+    player.position.y += playerVelocity.y * delta;
+
+    if (player.position.y < groundLevel) {
+      player.position.y = groundLevel;
+      playerVelocity.y = 0;
+    }
+
+    const desiredCameraPos = new THREE.Vector3().copy(player.position);
+    const backward = new THREE.Vector3(0, 0, 1).applyQuaternion(player.quaternion);
+    backward.y = 0;
+    backward.normalize();
+    desiredCameraPos.addScaledVector(backward, 10);
+    desiredCameraPos.y += 5;
+    camera.position.lerp(desiredCameraPos, 0.1);
+    camera.lookAt(player.position.clone().add(new THREE.Vector3(0, 2, 0)));
+  }
+
+  function animate() {
+    requestAnimationFrame(animate);
+    const delta = clock.getDelta();
+    if (gameActive) {
+      updatePlayer(delta);
+      checkCollisions();
+      checkWin();
+    }
+
+    for (let i = hitEffects.length - 1; i >= 0; i -= 1) {
+      const effect = hitEffects[i];
+      const elapsed = clock.getElapsedTime() - effect.userData.startTime;
+      const t = elapsed / effect.userData.duration;
+      if (t >= 1) {
+        scene.remove(effect);
+        hitEffects.splice(i, 1);
+      } else {
+        effect.scale.setScalar(1 + t * 2);
+        effect.material.opacity = 1 - t;
+      }
+    }
+
+    pathBillboards.forEach(billboard => billboard.lookAt(camera.position));
+    renderer.render(scene, camera);
+  }
+
+  function hideLoading() {
+    const loader = document.getElementById('loading');
+    if (loader) loader.style.display = 'none';
+  }
+
+  function resetGame() {
+    score = 0;
+    updateHUD();
+    gameActive = true;
+    playerVelocity.set(0, 0, 0);
+    Object.keys(keys).forEach(key => {
+      keys[key] = false;
+    });
+    document.getElementById('winMessage').style.display = 'none';
+    if (player) {
+      player.position.set(0, groundLevel, 0);
+      player.rotation.y = 0;
+      const flame = player.getObjectByName('flame');
+      if (flame) flame.visible = false;
+    }
+    pathBillboards.splice(0, pathBillboards.length).forEach(billboard => scene.remove(billboard));
+    createPath();
+  }
+
+  init();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Jetpack Corridor Three.js experience with mobile controls and restart support
- style the scene with overlay HUD and top navigation for consistency with the portal
- link the new adventure from the mini game hub

## Testing
- manual: loaded jetpack.html via `python3 -m http.server 8000`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915271e04b48320a79c1d8961a25830)