### PR TITLE
Adjust VDO.Ninja data saver link for lower bitrate

### DIFF
--- a/portal.3dvr.tech/video/index.html
+++ b/portal.3dvr.tech/video/index.html
@@ -51,7 +51,7 @@
     <div class="actions">
       <!-- Default data-saver link (shows usernames) -->
       <a class="button" target="_blank" rel="noopener"
-        href="https://vdo.ninja/?room=3dvrtech&label&showlabels&codec=h264&vb=300&ab=32&fps=10&scale=180p&stereo=0&buffer=100">
+        href="https://vdo.ninja/?room=3dvrtech&label&showlabels&codec=h264&vb=220&ab=24&fps=10&scale=144p&stereo=0&buffer=200">
         🎥 Join (Data Saver)
       </a>
       <!-- Higher bandwidth option -->
@@ -72,7 +72,7 @@
         <li>When prompted, enter your display name — it will show under your video for everyone.</li>
         <li>Use headphones to avoid echo. Close other apps on mobile for best performance.</li>
         <li>Need louder playback on mobile? Tap the menu ⋮ → <em>Audio Output</em> and select <strong>Speaker</strong>.</li>
-        <li>Both links now use a modest 100ms buffer to smooth over jitter while staying responsive.</li>
+        <li>Data Saver now uses a 200ms buffer to stay smooth even on spotty networks; Standard Quality remains at 100ms.</li>
         <li>Need more clarity? Switch to <em>Standard Quality</em> (240p/15fps/500kbps).</li>
         <li>Use <em>Director Mode</em> if you want to manage participants or record streams.</li>
       </ul>


### PR DESCRIPTION
## Summary
- lower the VDO.Ninja data saver link bitrate, resolution, and audio rate for a more compressed stream
- bump the data saver buffer to 200ms and update the tip copy to describe the new buffering behavior

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69168beba0348320b0cdf7c6d96d99f9)