### PR TITLE
Remove Gun Relay Test tile from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,11 +158,6 @@
             <span class="app-card__title">Games</span>
             <span class="app-card__meta">Compete, sharpen skills, and earn bonus points.</span>
           </a>
-          <a href="gun-demo.html" class="app-card">
-            <span class="app-card__icon" aria-hidden="true">🧪</span>
-            <span class="app-card__title">Gun Relay Test</span>
-            <span class="app-card__meta">Validate relay connectivity with a shared counter demo.</span>
-          </a>
           <a href="home/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🖥️</span>
             <span class="app-card__title">Home</span>


### PR DESCRIPTION
## Summary
- remove the Gun Relay Test card from the homepage app grid to reduce confusion

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916b74ea554832096d81295dd7c8999)