### PR TITLE
Enable editing local calendar events

### DIFF
--- a/calendar/calendar.css
+++ b/calendar/calendar.css
@@ -469,6 +469,19 @@ button:hover {
   white-space: pre-line;
 }
 
+.calendar-view__details-item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  margin: 4px 0 0;
+}
+
+.calendar-view__details-edit {
+  font-size: 0.85rem;
+  padding: 8px 14px;
+}
+
 .event-results__empty {
   color: var(--calendar-muted);
   margin: 0;
@@ -546,10 +559,19 @@ button:hover {
 .event-card__footer {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   justify-content: space-between;
 }
 
+.event-card__footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.event-card__edit,
 .event-card__delete {
   font-size: 0.9rem;
   padding: 10px 16px;

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -36,6 +36,8 @@
           data-action="toggle-create-event"
           data-label-open="Add event"
           data-label-close="Hide event form"
+          data-label-edit-open="Editing event"
+          data-label-edit-close="Cancel edit"
           aria-expanded="false"
           aria-controls="create-event-form"
         >Add event</button>
@@ -43,6 +45,7 @@
 
       <div class="create-event-form__container" data-create-event-container hidden>
         <form class="create-event-form" id="create-event-form">
+          <input type="hidden" name="eventId">
           <div class="create-event-form__row">
             <label class="field">
               <span class="field__label">Title</span>
@@ -267,7 +270,10 @@
       <p class="event-card__description" data-field="description"></p>
       <div class="event-card__footer">
         <a class="event-card__link" data-field="link" href="#" target="_blank" rel="noreferrer noopener">Open in calendar</a>
-        <button type="button" class="event-card__delete button-secondary" data-action="delete-event">Remove</button>
+        <div class="event-card__footer-actions">
+          <button type="button" class="event-card__edit button-secondary" data-action="edit-event">Edit</button>
+          <button type="button" class="event-card__delete button-secondary" data-action="delete-event">Remove</button>
+        </div>
       </div>
     </li>
   </template>


### PR DESCRIPTION
## Summary
- add support for editing existing events by wiring hidden IDs, edit/cancel labels, and opening the form in edit mode
- surface edit actions in the event list and day detail view with updated layout styling
- update the calendar script to load events into the form, apply edits, and manage create/edit mode transitions

## Testing
- npm test *(fails: Playwright browser dependencies are not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916b6ad5b70832086bda801e81822b1)