### PR TITLE
Disable Brave diagnostics by default

### DIFF
--- a/gun-init.js
+++ b/gun-init.js
@@ -9,6 +9,13 @@
   const mergedPeers = Array.from(new Set([...defaultPeers, ...existingPeers].filter(Boolean)));
   global.__GUN_PEERS__ = mergedPeers;
 
+  const braveDiagnosticsEnabled = (() => {
+    if (typeof global.__ENABLE_BRAVE_DIAGNOSTICS__ === 'boolean') {
+      return global.__ENABLE_BRAVE_DIAGNOSTICS__;
+    }
+    return false;
+  })();
+
   function showBraveShieldNotice(reason) {
     if (typeof console === 'undefined') {
       return;
@@ -49,6 +56,10 @@
   }
 
   function runDiagnostics() {
+    if (!braveDiagnosticsEnabled) {
+      return;
+    }
+
     if (typeof global.Gun !== 'function' || global.__GUN_BRAVE_DIAGNOSTICS__) {
       return;
     }


### PR DESCRIPTION
## Summary
- gate the Brave diagnostics helper in `gun-init.js` behind a feature flag so it stays off in production by default
- ensure the diagnostics early-return unless `window.__ENABLE_BRAVE_DIAGNOSTICS__` is explicitly set, preventing the pop-up from appearing for Brave users

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f112e838832098997a5d1f5ae597)