### PR TITLE
Update weekly video links

### DIFF
--- a/portal.3dvr.tech/video/index.html
+++ b/portal.3dvr.tech/video/index.html
@@ -49,10 +49,15 @@
     <p class="sub">One simple link. Names visible. Mobile‑ready.</p>
 
     <div class="actions">
-      <!-- Default data-saver link (shows usernames) -->
+      <!-- This week's data-saver link with extra compression and lower buffer for latency -->
       <a class="button" target="_blank" rel="noopener"
+        href="https://vdo.ninja/?room=3dvrtech&label&showlabels&codec=h264&vb=180&ab=20&fps=9&scale=144p&stereo=0&buffer=140">
+        🎥 Join (This Week: Faster Data Saver)
+      </a>
+      <!-- Saved link from last week -->
+      <a class="button secondary" target="_blank" rel="noopener"
         href="https://vdo.ninja/?room=3dvrtech&label&showlabels&codec=h264&vb=220&ab=24&fps=10&scale=144p&stereo=0&buffer=200">
-        🎥 Join (Data Saver)
+        🕒 Last Week's Link
       </a>
       <!-- Higher bandwidth option -->
       <a class="button secondary" target="_blank" rel="noopener"
@@ -72,8 +77,9 @@
         <li>When prompted, enter your display name — it will show under your video for everyone.</li>
         <li>Use headphones to avoid echo. Close other apps on mobile for best performance.</li>
         <li>Need louder playback on mobile? Tap the menu ⋮ → <em>Audio Output</em> and select <strong>Speaker</strong>.</li>
-        <li>Data Saver now uses a 200ms buffer to stay smooth even on spotty networks; Standard Quality remains at 100ms.</li>
-        <li>Need more clarity? Switch to <em>Standard Quality</em> (240p/15fps/500kbps).</li>
+        <li>This week's Data Saver is extra compressed (180 kbps video, 20 kbps audio, 9 fps, 144p) with a 140ms buffer for lower delay.</li>
+        <li>Last week's link is saved above if you want the smoother 200ms buffer instead.</li>
+        <li>Need more clarity? Switch to <em>Standard Quality</em> (240p/15fps/500kbps) — buffer stays at 100ms.</li>
         <li>Use <em>Director Mode</em> if you want to manage participants or record streams.</li>
       </ul>
       <div style="margin-top:.4rem">Admin note: avoid <code>&cleanoutput</code> or <code>&cleanviewer</code> if you want names visible.</div>


### PR DESCRIPTION
## Summary
- add a new data-saver link for this week with lower audio/video bitrates and reduced buffer for less delay
- preserve last week's data-saver link alongside the existing standard and director options
- update usage tips to reflect the current and previous weekly presets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5fde6a9883208905707607f1c97b)