### PR TITLE
Add Vercel dev preview workflow with stable alias option

### DIFF
--- a/.github/workflows/vercel-dev-preview.yml
+++ b/.github/workflows/vercel-dev-preview.yml
@@ -5,7 +5,16 @@ on:
     branches:
       - main
       - dev
+  pull_request:
+    branches:
+      - main
+      - dev
   workflow_dispatch:
+    inputs:
+      set_alias:
+        description: 'Alias this deployment to the stable dev URL (uses VERCEL_DEV_ALIAS)'
+        required: false
+        default: 'false'
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -18,6 +27,11 @@ jobs:
     name: Deploy preview alias
     runs-on: ubuntu-latest
     if: ${{ env.VERCEL_TOKEN != '' && env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != '' }}
+    env:
+      SHOULD_ALIAS: ${{
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.set_alias == 'true')
+      }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -45,7 +59,8 @@ jobs:
         run: |
           DEPLOY_URL=$(vercel deploy --prebuilt --target=preview --token=$VERCEL_TOKEN --yes)
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
+          echo "Preview URL: $DEPLOY_URL"
 
       - name: Alias deployment to stable dev URL
-        if: ${{ env.VERCEL_DEV_ALIAS != '' }}
+        if: ${{ env.VERCEL_DEV_ALIAS != '' && env.SHOULD_ALIAS == 'true' }}
         run: vercel alias set ${{ steps.deploy.outputs.url }} $VERCEL_DEV_ALIAS --token=$VERCEL_TOKEN

--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ origin or cookie sensitive.
 1. In your repository settings, add the following secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` (from the
    Vercel dashboard). Optional: set `VERCEL_DEV_ALIAS` to the `.vercel.app` or custom domain you want the workflow to point at
    (for example `dev-3dvr-portal.vercel.app`).
-2. Enable the "Vercel Dev Preview" workflow in GitHub Actions and trigger it with a push to `main` or `dev`, or run it manually
-   via **Run workflow**.
-3. Each run pulls preview env settings, builds the site, deploys a preview, and—if `VERCEL_DEV_ALIAS` is set—aliases that
-   deployment to the stable dev URL so you can reuse the same link across sessions and team members.
+2. Enable the "Vercel Dev Preview" workflow in GitHub Actions. It now runs on push to `main`/`dev`, pull requests targeting
+   those branches, and manual dispatch via **Run workflow**.
+3. Pull request runs always publish a preview URL so you can test before merging. To also alias that preview to your stable
+   dev URL from a manual run, set the `set_alias` input to `true` when triggering the workflow. Pushes to `main`/`dev` alias
+   automatically when `VERCEL_DEV_ALIAS` is configured.
+4. Each run pulls preview env settings, builds the site, deploys a preview, and—if aliasing is enabled—points the stable dev
+   URL at the new preview so you can reuse the same link across sessions and team members.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and deploys preview builds to Vercel with an optional stable alias for dev testing
- document the required Vercel secrets and how to trigger the workflow to keep a consistent dev URL

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214db3e1d0832094a3dc8f3516038b)