### PR TITLE
Add potato mode video link

### DIFF
--- a/portal.3dvr.tech/video/index.html
+++ b/portal.3dvr.tech/video/index.html
@@ -49,10 +49,10 @@
     <p class="sub">One simple link. Names visible. Mobile‑ready.</p>
 
     <div class="actions">
-      <!-- This week's data-saver link with extra compression and lower buffer for latency -->
+      <!-- Potato mode: ultra-lean bandwidth with visible labels -->
       <a class="button" target="_blank" rel="noopener"
-        href="https://vdo.ninja/?room=3dvrtech&label&showlabels&codec=h264&vb=180&ab=20&fps=9&scale=144p&stereo=0&buffer=140">
-        🎥 Join (This Week: Faster Data Saver)
+        href="https://vdo.ninja/?room=3dvrtech&codec=h264&vb=90&ab=32&fps=6&scale=144p&stereo=0&buffer=100&showlabels">
+        🥔 Join (Potato Mode)
       </a>
       <!-- Saved link from last week -->
       <a class="button secondary" target="_blank" rel="noopener"
@@ -77,8 +77,8 @@
         <li>When prompted, enter your display name — it will show under your video for everyone.</li>
         <li>Use headphones to avoid echo. Close other apps on mobile for best performance.</li>
         <li>Need louder playback on mobile? Tap the menu ⋮ → <em>Audio Output</em> and select <strong>Speaker</strong>.</li>
-        <li>This week's Data Saver is extra compressed (180 kbps video, 20 kbps audio, 9 fps, 144p) with a 140ms buffer for lower delay.</li>
-        <li>Last week's link is saved above if you want the smoother 200ms buffer instead.</li>
+        <li>Potato Mode leans way down on bandwidth (90 kbps video, 32 kbps audio, 6 fps, 144p) with a 100ms buffer for lower delay.</li>
+        <li>Last week's link is saved above if you want the smoother 200ms buffer instead of Potato Mode.</li>
         <li>Need more clarity? Switch to <em>Standard Quality</em> (240p/15fps/500kbps) — buffer stays at 100ms.</li>
         <li>Use <em>Director Mode</em> if you want to manage participants or record streams.</li>
       </ul>


### PR DESCRIPTION
## Summary
- replace the main join button with the new potato mode VDO.Ninja link
- document potato mode bandwidth details and keep last week’s option for smoother playback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692287ee315c83208902786bcc7caeaa)