### PR TITLE
Add iframe portfolio previews to landing

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -541,6 +541,80 @@ body.landing {
   color: var(--color-text-muted);
 }
 
+.portfolio {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.portfolio__header {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 720px;
+}
+
+.portfolio__header h2 {
+  margin: 0;
+  font-size: clamp(2rem, 1.4vw + 1.4rem, 2.6rem);
+}
+
+.portfolio__header p {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+}
+
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.4rem;
+}
+
+.portfolio-card {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.2rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: 0 26px 64px rgba(5, 10, 25, 0.5);
+}
+
+.portfolio-card__frame {
+  position: relative;
+  border-radius: calc(var(--radius-lg) - 4px);
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.portfolio-card iframe {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 0;
+  background: #0e1116;
+}
+
+.portfolio-card__meta {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.portfolio-card__meta h3 {
+  margin: 0;
+}
+
+.portfolio-card__meta p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.portfolio-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.35rem;
+}
+
 .gamified-dashboard {
   display: grid;
   gap: 2.5rem;

--- a/index.html
+++ b/index.html
@@ -272,6 +272,55 @@
         </div>
       </section>
 
+      <section class="portfolio" aria-labelledby="portfolio-title">
+        <div class="portfolio__header">
+          <span class="eyebrow">Work Samples</span>
+          <h2 id="portfolio-title">Explore live portfolio builds</h2>
+          <p>
+            View real experiences in motion. Each preview runs as an embedded page so you can see how the layouts
+            behave without leaving the portal.
+          </p>
+        </div>
+        <div class="portfolio-grid">
+          <article class="portfolio-card" aria-labelledby="portfolio-start-title">
+            <div class="portfolio-card__frame">
+              <iframe src="start/" title="Start experience preview" loading="lazy"></iframe>
+            </div>
+            <div class="portfolio-card__meta">
+              <h3 id="portfolio-start-title">Start Experience</h3>
+              <p>Guided onboarding flow that highlights how we structure multi-step journeys for new members.</p>
+              <div class="portfolio-card__actions">
+                <a class="cta ghost" href="start/" target="_blank" rel="noopener">Open live page</a>
+              </div>
+            </div>
+          </article>
+          <article class="portfolio-card" aria-labelledby="portfolio-wellness-title">
+            <div class="portfolio-card__frame">
+              <iframe src="wellness.html" title="Wellness hub preview" loading="lazy"></iframe>
+            </div>
+            <div class="portfolio-card__meta">
+              <h3 id="portfolio-wellness-title">Wellness Hub</h3>
+              <p>Mindfulness, nutrition, and stretch routines woven together with calming visuals.</p>
+              <div class="portfolio-card__actions">
+                <a class="cta ghost" href="wellness.html" target="_blank" rel="noopener">Open live page</a>
+              </div>
+            </div>
+          </article>
+          <article class="portfolio-card" aria-labelledby="portfolio-video-title">
+            <div class="portfolio-card__frame">
+              <iframe src="portal.3dvr.tech/video/" title="Video meeting preview" loading="lazy"></iframe>
+            </div>
+            <div class="portfolio-card__meta">
+              <h3 id="portfolio-video-title">Video Meeting</h3>
+              <p>Lightweight VDO.Ninja landing that demonstrates our event-ready communication cards.</p>
+              <div class="portfolio-card__actions">
+                <a class="cta ghost" href="portal.3dvr.tech/video/" target="_blank" rel="noopener">Open live page</a>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
       <section class="gamified-dashboard" aria-labelledby="gamified-dashboard-title">
         <div class="gamified-dashboard__header">
           <span class="eyebrow">Play to progress</span>


### PR DESCRIPTION
## Summary
- add a portfolio showcase section to the landing page with live iframe previews
- style the new portfolio grid to match existing card aesthetics and responsive layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a63e33ee483208dfe56b09c245a7f)