### PR TITLE
Improve OpenAI key persistence fallback

### DIFF
--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -38,6 +38,7 @@
         <button id="clear-key" class="ghost">Clear</button>
       </div>
       <p id="api-key-help" class="meta">Stored only in localStorage on this device.</p>
+      <p id="storage-mode" class="meta" aria-live="polite"></p>
     </section>
 
     <section class="grid">


### PR DESCRIPTION
## Summary
- add a resilient storage helper that falls back to sessionStorage or memory when localStorage is blocked
- surface the active storage mode so Brave users understand how their keys are retained across refreshes
- route OpenAI, Vercel, and GitHub token saves through the fallback storage to improve persistence

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a6eab2af8832087a2d66e96320730)