### PR TITLE
Prioritize app name matches in search results

### DIFF
--- a/index.html
+++ b/index.html
@@ -1051,6 +1051,24 @@
       const query = value.trim().toLowerCase();
       let visibleCount = 0;
 
+      if (!query) {
+        appCards.forEach((card) => {
+          card.hidden = false;
+          if (appGrid) {
+            appGrid.appendChild(card);
+          }
+          visibleCount += 1;
+        });
+
+        if (appSearchEmpty) {
+          appSearchEmpty.hidden = visibleCount > 0;
+        }
+        return;
+      }
+
+      const nameMatches = [];
+      const descriptionMatches = [];
+
       appCards.forEach((card) => {
         const titleText = card
           .querySelector('.app-card__title')
@@ -1058,13 +1076,27 @@
         const metaText = card
           .querySelector('.app-card__meta')
           ?.textContent?.toLowerCase() ?? '';
-        const matches = !query || titleText.includes(query) || metaText.includes(query);
+        const titleIncludesQuery = titleText.includes(query);
+        const metaIncludesQuery = metaText.includes(query);
+        const matches = titleIncludesQuery || metaIncludesQuery;
 
         card.hidden = !matches;
         if (matches) {
           visibleCount += 1;
+          if (titleIncludesQuery) {
+            nameMatches.push(card);
+          } else if (metaIncludesQuery) {
+            descriptionMatches.push(card);
+          }
         }
       });
+
+      const orderedResults = [...nameMatches, ...descriptionMatches];
+      if (appGrid) {
+        orderedResults.forEach((card) => {
+          appGrid.appendChild(card);
+        });
+      }
 
       if (appSearchEmpty) {
         appSearchEmpty.hidden = visibleCount > 0;


### PR DESCRIPTION
## Summary
- reorder app search results so name matches appear before description matches
- keep the grid order intact when no search term is provided

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb84f3a088320a0b8b33bbcd1385f)