### PR TITLE
Add timestamps to tasks on task board

### DIFF
--- a/old-tasks.html
+++ b/old-tasks.html
@@ -86,6 +86,12 @@ button:hover {
   color: red;
   font-weight: bold;
 }
+
+.task .meta {
+  margin-top: 8px;
+  color: #666;
+  font-size: 0.95rem;
+}
 </style>
 </head>
 <body>
@@ -117,6 +123,24 @@ const gun = Gun({
 
 const tasks = gun.get('3dvr-tasks');
 
+function timeAgoOrFullDate(timestamp) {
+  const now = Date.now();
+  const diff = Math.floor((now - timestamp) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  const mins = Math.floor(diff / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const date = new Date(timestamp);
+  return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function getCreatedAt(task) {
+  return typeof task.createdAt === 'number' && Number.isFinite(task.createdAt)
+    ? task.createdAt
+    : 0;
+}
+
 // Add new task
 function addTask() {
   const text = document.getElementById('task-input').value.trim();
@@ -142,12 +166,18 @@ function renderTasks() {
   const container = document.getElementById('tasks');
   container.innerHTML = '';
   Object.entries(taskList)
-    .sort((a, b) => b[1].createdAt - a[1].createdAt)
+    .sort((a, b) => getCreatedAt(b[1]) - getCreatedAt(a[1]))
     .forEach(([id, task]) => {
       const div = document.createElement('div');
       div.className = 'task';
       div.id = id;
-      div.innerHTML = `${task.text}<span class="delete">🗑</span>`;
+      const createdAt = getCreatedAt(task);
+      const timestamp = createdAt ? timeAgoOrFullDate(createdAt) : 'Just now';
+      div.innerHTML = `
+        <div class="task-text">${task.text}</div>
+        <div class="meta">Added ${timestamp}</div>
+        <span class="delete">🗑</span>
+      `;
       div.querySelector('.delete').onclick = () => tasks.get(id).put(null);
       container.appendChild(div);
     });


### PR DESCRIPTION
## Summary
- add human-friendly timestamps to tasks using existing createdAt values
- improve task sorting robustness when createdAt is missing
- style task metadata to display timestamp beneath task text

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69337f791bd08320a7b460e5eda4105c)