### PR TITLE
Add Vercel analytics snippet to portal pages

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="/styles/install-banner.css">
   <link rel="manifest" href="/app-manifests/calendar.webmanifest">
   <meta name="theme-color" content="#0e1116">
+  <script defer src="/_vercel/insights/script.js"></script>
   <script src="/pwa-install.js" defer></script>
 </head>
 <body>

--- a/deployment-guides/dev-alias.html
+++ b/deployment-guides/dev-alias.html
@@ -6,6 +6,7 @@
   <title>Stable Dev Alias | 3DVR Portal</title>
   <link rel="stylesheet" href="/styles/global.css">
   <link rel="stylesheet" href="/styles/guides.css">
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="guide-page">
   <div class="guide-shell">

--- a/deployment-guides/github-token.html
+++ b/deployment-guides/github-token.html
@@ -6,6 +6,7 @@
   <title>GitHub Token Guide | 3DVR Portal</title>
   <link rel="stylesheet" href="/styles/global.css">
   <link rel="stylesheet" href="/styles/guides.css">
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="guide-page">
   <div class="guide-shell">

--- a/deployment-guides/index.html
+++ b/deployment-guides/index.html
@@ -6,6 +6,7 @@
   <title>Deployment Guides | 3DVR Portal</title>
   <link rel="stylesheet" href="/styles/global.css">
   <link rel="stylesheet" href="/styles/guides.css">
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="guide-page">
   <div class="guide-shell">

--- a/deployment-guides/secrets-and-workflow.html
+++ b/deployment-guides/secrets-and-workflow.html
@@ -6,6 +6,7 @@
   <title>Secrets &amp; Workflow | 3DVR Portal</title>
   <link rel="stylesheet" href="/styles/global.css">
   <link rel="stylesheet" href="/styles/guides.css">
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="guide-page">
   <div class="guide-shell">

--- a/deployment-guides/vercel-token.html
+++ b/deployment-guides/vercel-token.html
@@ -6,6 +6,7 @@
   <title>Vercel Token &amp; IDs | 3DVR Portal</title>
   <link rel="stylesheet" href="/styles/global.css">
   <link rel="stylesheet" href="/styles/guides.css">
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="guide-page">
   <div class="guide-shell">

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="score.js"></script>
   <script src="/pwa-install.js" defer></script>
+  <script defer src="/_vercel/insights/script.js"></script>
   <link rel="stylesheet" href="styles/global.css">
   <link rel="stylesheet" href="index-style.css">
   <link rel="manifest" href="/manifest.webmanifest">


### PR DESCRIPTION
## Summary
- add the Vercel Web Analytics script to the main portal landing page
- include analytics coverage on calendar hub and deployment guide pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934ad9c43b083208c8a9fa774c9a2e9)