### PR TITLE
Add navigation links to finance hub

### DIFF
--- a/finance/index.html
+++ b/finance/index.html
@@ -13,6 +13,13 @@
 </head>
 <body class="finance-body">
   <a href="#page-main" class="finance-skip-link">Skip to finance content</a>
+  <nav class="finance-nav" aria-label="Portal navigation">
+    <a class="finance-nav__link" href="../index.html">Main portal</a>
+    <a class="finance-nav__link" href="../rewards.html">Rewards</a>
+    <a class="finance-nav__link" href="../tasks.html">Tasks</a>
+    <a class="finance-nav__link" href="../contacts/index.html">Contacts</a>
+    <a class="finance-nav__link" href="../crm/index.html">CRM</a>
+  </nav>
   <main id="page-main" class="finance-shell" aria-labelledby="page-title">
     <header class="finance-hero">
       <p class="finance-hero__eyebrow">Finance workspace</p>

--- a/finance/styles.css
+++ b/finance/styles.css
@@ -41,6 +41,34 @@ body {
   box-shadow: 0 12px 30px rgba(8, 47, 73, 0.3);
 }
 
+.finance-nav {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem 0;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.finance-nav__link {
+  color: #e0f2fe;
+  text-decoration: none;
+  background: rgba(14, 165, 233, 0.14);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: background 150ms ease, transform 150ms ease, border-color 150ms ease;
+}
+
+.finance-nav__link:focus-visible,
+.finance-nav__link:hover {
+  background: rgba(14, 165, 233, 0.2);
+  border-color: rgba(125, 211, 252, 0.9);
+  transform: translateY(-1px);
+}
+
 .finance-shell {
   max-width: 1120px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- add a portal navigation bar to the finance hub linking to key pages
- style the navigation links to match the finance aesthetic and remain accessible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934b787d0d88320a5342c556dfa06c1)