### PR TITLE
Add News Lounge hub with RSS feeds

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,11 @@
             <span class="app-card__title">Notes</span>
             <span class="app-card__meta">Collaborate in real time with the community.</span>
           </a>
+          <a href="newsroom/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">📰</span>
+            <span class="app-card__title">News Lounge</span>
+            <span class="app-card__meta">Scroll tech, XR, and social feeds without leaving the portal.</span>
+          </a>
           <a href="openai-app/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🤖</span>
             <span class="app-card__title">OpenAI Workbench</span>

--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>News & Social Lounge | 3DVR Portal</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="./newsroom.css">
+</head>
+<body class="newsroom theme-dark">
+  <a class="skip-link" href="#newsroomMain">Skip to news and social feed</a>
+  <div class="newsroom-shell">
+    <header class="newsroom-hero" aria-labelledby="newsroomTitle">
+      <p class="newsroom-hero__eyebrow">News &amp; Social</p>
+      <h1 id="newsroomTitle" class="newsroom-hero__title">Signal Lounge</h1>
+      <p class="newsroom-hero__lead">
+        Catch the latest tech, XR, and community headlines in one calm scroll. Each feed updates live from trusted RSS sources
+        so you can read, react, and share without leaving the portal.
+      </p>
+      <div class="newsroom-hero__actions">
+        <a class="cta primary" href="../index.html">⬅️ Back to portal</a>
+        <button class="cta ghost" type="button" data-refresh-all>🔄 Refresh all feeds</button>
+      </div>
+    </header>
+
+    <main id="newsroomMain" class="newsroom-grid" aria-label="News and social feeds">
+      <article class="feed-card" data-feed="open-web">
+        <header class="feed-card__header">
+          <div>
+            <p class="feed-card__eyebrow">Open web pulse</p>
+            <h2 class="feed-card__title">Tech headlines</h2>
+            <p class="feed-card__summary">Fresh drops from The Verge, Engadget, and friends.</p>
+          </div>
+          <button class="feed-card__refresh" type="button" data-feed-refresh>
+            <span aria-hidden="true">⟳</span>
+            <span class="sr-only">Refresh tech headlines</span>
+          </button>
+        </header>
+        <p class="feed-card__status" data-feed-status aria-live="polite">Loading latest stories…</p>
+        <ol class="feed-card__list" data-feed-list></ol>
+      </article>
+
+      <article class="feed-card" data-feed="immersive">
+        <header class="feed-card__header">
+          <div>
+            <p class="feed-card__eyebrow">VR + Play</p>
+            <h2 class="feed-card__title">Immersive culture</h2>
+            <p class="feed-card__summary">Road to VR, UploadVR, and XR creators in one lane.</p>
+          </div>
+          <button class="feed-card__refresh" type="button" data-feed-refresh>
+            <span aria-hidden="true">⟳</span>
+            <span class="sr-only">Refresh immersive stories</span>
+          </button>
+        </header>
+        <p class="feed-card__status" data-feed-status aria-live="polite">Loading immersive drops…</p>
+        <ol class="feed-card__list" data-feed-list></ol>
+      </article>
+
+      <article class="feed-card" data-feed="community">
+        <header class="feed-card__header">
+          <div>
+            <p class="feed-card__eyebrow">Community chatter</p>
+            <h2 class="feed-card__title">Social stream</h2>
+            <p class="feed-card__summary">Reddit and HN threads that keep builders laughing and thinking.</p>
+          </div>
+          <button class="feed-card__refresh" type="button" data-feed-refresh>
+            <span aria-hidden="true">⟳</span>
+            <span class="sr-only">Refresh community stream</span>
+          </button>
+        </header>
+        <p class="feed-card__status" data-feed-status aria-live="polite">Loading social threads…</p>
+        <ol class="feed-card__list" data-feed-list></ol>
+      </article>
+    </main>
+  </div>
+
+  <script src="./newsroom.js"></script>
+</body>
+</html>

--- a/newsroom/newsroom.css
+++ b/newsroom/newsroom.css
@@ -1,0 +1,208 @@
+:root {
+  --newsroom-accent: #8b5cf6;
+  --newsroom-surface: rgba(17, 24, 39, 0.75);
+  --newsroom-surface-strong: rgba(30, 41, 59, 0.92);
+  --newsroom-border: rgba(148, 163, 184, 0.25);
+}
+
+.newsroom {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(140% 140% at 16% 0%, #0f172a 0%, #0b1220 55%, #05070c 100%);
+  color: #e2e8f0;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--newsroom-surface-strong);
+  color: #e2e8f0;
+  border-radius: 8px;
+  border: 1px solid var(--newsroom-border);
+  transform: translateY(-120%);
+  transition: transform 0.2s ease;
+  z-index: 2;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.newsroom-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.newsroom-hero {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(168, 85, 247, 0.14));
+  border: 1px solid var(--newsroom-border);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(10px);
+}
+
+.newsroom-hero__eyebrow {
+  font-size: 0.9rem;
+  color: #cbd5e1;
+  margin: 0 0 0.5rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.newsroom-hero__title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  color: #f8fafc;
+}
+
+.newsroom-hero__lead {
+  margin: 0 0 1.5rem;
+  max-width: 720px;
+  color: #cbd5e1;
+}
+
+.newsroom-hero__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.newsroom-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.feed-card {
+  background: var(--newsroom-surface);
+  border-radius: 16px;
+  border: 1px solid var(--newsroom-border);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+.feed-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.feed-card__eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #a5b4fc;
+  letter-spacing: 0.04em;
+}
+
+.feed-card__title {
+  margin: 0.2rem 0;
+  font-size: 1.4rem;
+  color: #f8fafc;
+}
+
+.feed-card__summary {
+  margin: 0;
+  color: #cbd5e1;
+}
+
+.feed-card__refresh {
+  background: rgba(139, 92, 246, 0.18);
+  border: 1px solid rgba(139, 92, 246, 0.35);
+  color: #ede9fe;
+  border-radius: 12px;
+  padding: 0.5rem 0.6rem;
+  cursor: pointer;
+  transition: transform var(--transition-base), background var(--transition-base);
+}
+
+.feed-card__refresh:hover {
+  transform: translateY(-2px);
+  background: rgba(139, 92, 246, 0.28);
+}
+
+.feed-card__refresh:focus-visible {
+  outline: 2px solid #c084fc;
+  outline-offset: 2px;
+}
+
+.feed-card__status {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+.feed-card__list {
+  list-style: decimal;
+  padding-left: 1.25rem;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.feed-card__item {
+  background: var(--newsroom-surface-strong);
+  border-radius: 12px;
+  border: 1px solid var(--newsroom-border);
+  padding: 0.75rem 0.85rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.feed-card__item a {
+  color: #e0e7ff;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.feed-card__item a:hover {
+  color: #c084fc;
+}
+
+.feed-card__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+}
+
+.feed-card__tag {
+  padding: 0.25rem 0.6rem;
+  background: rgba(139, 92, 246, 0.18);
+  border-radius: 999px;
+  color: #e9d5ff;
+  border: 1px solid rgba(139, 92, 246, 0.32);
+  font-size: 0.85rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .newsroom-hero__actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .feed-card__meta {
+    flex-direction: column;
+  }
+}

--- a/newsroom/newsroom.js
+++ b/newsroom/newsroom.js
@@ -1,0 +1,140 @@
+const feedSources = {
+  'open-web': {
+    label: 'Tech',
+    url: 'https://api.rss2json.com/v1/api.json?rss_url=' +
+      encodeURIComponent('https://www.theverge.com/rss/index.xml')
+  },
+  immersive: {
+    label: 'XR & Play',
+    url: 'https://api.rss2json.com/v1/api.json?rss_url=' +
+      encodeURIComponent('https://www.roadtovr.com/feed/')
+  },
+  community: {
+    label: 'Community',
+    url: 'https://api.rss2json.com/v1/api.json?rss_url=' +
+      encodeURIComponent('https://hnrss.org/frontpage')
+  }
+};
+
+const feedCards = Array.from(document.querySelectorAll('[data-feed]'));
+
+function formatDate(dateString) {
+  if (!dateString) return 'Just now';
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return 'Just now';
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+function setStatus(card, message) {
+  const status = card.querySelector('[data-feed-status]');
+  if (status) {
+    status.textContent = message;
+  }
+}
+
+function renderItems(card, items = []) {
+  const list = card.querySelector('[data-feed-list]');
+  if (!list) return;
+  list.innerHTML = '';
+
+  if (!items.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No stories found yet. Try refreshing in a moment.';
+    empty.className = 'feed-card__status';
+    list.appendChild(empty);
+    return;
+  }
+
+  items.slice(0, 8).forEach((item) => {
+    const listItem = document.createElement('li');
+    listItem.className = 'feed-card__item';
+
+    const link = document.createElement('a');
+    link.href = item.link;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = item.title || 'Untitled story';
+
+    const meta = document.createElement('div');
+    meta.className = 'feed-card__meta';
+
+    const date = document.createElement('span');
+    date.textContent = formatDate(item.pubDate);
+
+    const tag = document.createElement('span');
+    tag.className = 'feed-card__tag';
+    tag.textContent = item.tag || feedSources[card.dataset.feed]?.label || 'Feed';
+
+    meta.appendChild(date);
+    meta.appendChild(tag);
+
+    listItem.appendChild(link);
+    if (item.description) {
+      const description = document.createElement('p');
+      description.className = 'feed-card__summary';
+      description.textContent = item.description.replace(/<[^>]+>/g, '').slice(0, 140) + '…';
+      listItem.appendChild(description);
+    }
+    listItem.appendChild(meta);
+    list.appendChild(listItem);
+  });
+}
+
+function fetchFeed(card) {
+  const feedKey = card.dataset.feed;
+  const source = feedSources[feedKey];
+  if (!source) {
+    setStatus(card, 'Unknown feed.');
+    return;
+  }
+
+  setStatus(card, 'Fetching fresh stories…');
+
+  fetch(source.url)
+    .then((response) => response.json())
+    .then((data) => {
+      if (!data || !Array.isArray(data.items)) {
+        throw new Error('No items returned');
+      }
+      const cleanedItems = data.items.map((item) => ({
+        title: item.title,
+        link: item.link,
+        pubDate: item.pubDate,
+        description: item.description,
+        tag: source.label
+      }));
+      renderItems(card, cleanedItems);
+      setStatus(card, `Updated · ${new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`);
+    })
+    .catch((error) => {
+      console.error('Feed error', error);
+      setStatus(card, 'Feed is quiet right now. Try again in a moment.');
+      renderItems(card, []);
+    });
+}
+
+function attachRefreshHandlers() {
+  document.querySelectorAll('[data-feed-refresh]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const card = button.closest('[data-feed]');
+      if (card) {
+        fetchFeed(card);
+      }
+    });
+  });
+
+  const refreshAll = document.querySelector('[data-refresh-all]');
+  if (refreshAll) {
+    refreshAll.addEventListener('click', () => {
+      feedCards.forEach(fetchFeed);
+    });
+  }
+}
+
+if (feedCards.length) {
+  feedCards.forEach(fetchFeed);
+  attachRefreshHandlers();
+}


### PR DESCRIPTION
## Summary
- create a News Lounge page that pulls tech, XR, and community updates from RSS sources
- add styling and refresh controls for quickly reloading feed content without leaving the portal
- link the new lounge from the main app grid so it’s easy to find

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693648258880832095ead146b1b52db5)