### PR TITLE
Add live point-to-dollar ratio preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,6 +265,11 @@
             <span class="app-card__title">Score Rewards</span>
             <span class="app-card__meta">Review the Stripe-linked score model, guardrails, and incentives.</span>
           </a>
+          <a href="points-ratio/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">💱</span>
+            <span class="app-card__title">Live Point Value</span>
+            <span class="app-card__meta">Watch the Stripe pool and leaderboard drive point-to-dollar value.</span>
+          </a>
           <a href="website-builder.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🛠️</span>
             <span class="app-card__title">Sites</span>

--- a/points-ratio/index.html
+++ b/points-ratio/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Live Point Value • 3dvr.tech</title>
+    <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+    <script src="../gun-init.js"></script>
+    <link rel="stylesheet" href="../styles/global.css" />
+    <link rel="stylesheet" href="../styles/points.css" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body class="points-page">
+    <a class="skip-link" href="#mainContent">Skip to main content</a>
+
+    <header class="points-hero">
+      <div class="points-shell">
+        <p class="points-eyebrow">Live payout preview</p>
+        <h1>See the real point-to-dollar ratio</h1>
+        <p class="points-intro">
+          This dashboard pulls the current Stripe pool and total leaderboard points to estimate how much each point is worth
+          right now. Refresh anytime to watch the value change as supporters subscribe and contributors earn.
+        </p>
+        <div class="points-cta">
+          <a class="cta primary" href="../points.html">Back to points overview</a>
+          <button class="cta ghost" type="button" id="ratioRefresh">Refresh live data</button>
+        </div>
+        <p class="ratio-live__status" id="ratioStatus" aria-live="polite">Loading live pool and leaderboard data...</p>
+      </div>
+    </header>
+
+    <main id="mainContent" class="points-main">
+      <section class="points-section">
+        <div class="section-card ratio-card" aria-labelledby="liveRatioHeading">
+          <div class="ratio-header">
+            <div>
+              <p class="points-eyebrow">Real-time math</p>
+              <h2 id="liveRatioHeading">Point-to-dollar value</h2>
+              <p class="info-note">
+                Values update automatically when Stripe or the leaderboard changes. You can still adjust the numbers to model
+                future growth scenarios.
+              </p>
+            </div>
+            <div class="ratio-badge" aria-live="polite">
+              <p class="ratio-badge-label">Dollar value per point</p>
+              <p class="ratio-badge-value" id="ratioHighlight">$0.00</p>
+            </div>
+          </div>
+
+          <div class="ratio-grid ratio-grid--condensed">
+            <div class="ratio-stat">
+              <p class="ratio-label">Stripe pool (USD)</p>
+              <p class="ratio-value" id="poolDisplay">$0.00</p>
+              <p class="ratio-hint" id="poolBreakdown">Waiting for Stripe to respond...</p>
+            </div>
+            <div class="ratio-stat">
+              <p class="ratio-label">Total active points</p>
+              <p class="ratio-value" id="totalPointsDisplay">0</p>
+              <p class="ratio-hint">Summed from the live leaderboard</p>
+            </div>
+            <div class="ratio-stat">
+              <p class="ratio-label">Updated at</p>
+              <p class="ratio-value" id="liveUpdatedAt">—</p>
+              <p class="ratio-hint">Timestamp of the last successful sync</p>
+            </div>
+          </div>
+
+          <form class="ratio-form" aria-label="Point to dollar calculator">
+            <div class="ratio-input">
+              <label for="totalPoints">Total active points</label>
+              <input id="totalPoints" name="totalPoints" type="number" min="0" step="1" value="0" />
+            </div>
+            <div class="ratio-input">
+              <label for="poolDollars">Stripe pool (USD)</label>
+              <input id="poolDollars" name="poolDollars" type="number" min="0" step="1" value="0" />
+            </div>
+            <div class="ratio-input">
+              <label for="yourPoints">Your points to redeem</label>
+              <input id="yourPoints" name="yourPoints" type="number" min="0" step="1" value="0" />
+            </div>
+          </form>
+
+          <div class="ratio-grid" aria-live="polite">
+            <div class="ratio-stat">
+              <p class="ratio-label">Dollar value per point</p>
+              <p class="ratio-value" id="dollarPerPoint">$0.00</p>
+              <p class="ratio-hint">Pool divided by total active points</p>
+            </div>
+            <div class="ratio-stat">
+              <p class="ratio-label">Points needed per dollar</p>
+              <p class="ratio-value" id="pointsPerDollar">0</p>
+              <p class="ratio-hint">Total points divided by pool</p>
+            </div>
+            <div class="ratio-stat">
+              <p class="ratio-label">Potential cash-out</p>
+              <p class="ratio-value" id="cashoutEstimate">$0.00</p>
+              <p class="ratio-hint">Your points × dollar value per point</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="points-section">
+        <div class="section-grid live-leaderboard">
+          <article class="info-card">
+            <h3>Top contributors</h3>
+            <ol id="liveLeaderboard" class="leaderboard-list" aria-live="polite">
+              <li class="leaderboard-list__item">Waiting for leaderboard data...</li>
+            </ol>
+          </article>
+          <article class="info-card">
+            <h3>How the live pool is calculated</h3>
+            <ul>
+              <li>Stripe balances come directly from <code>/api/stripe/metrics</code> and prefer USD when available.</li>
+              <li>We add available and pending funds together to show the full pool backing point redemptions.</li>
+              <li>Total points reflect the latest leaderboard entries stored in Gun.</li>
+            </ul>
+            <p class="info-note">If a currency other than USD is active, the page will display that currency code.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="points-footer">
+      <p>Questions or ideas? Email <a href="mailto:hello@3dvr.tech">hello@3dvr.tech</a> and we will get back to you.</p>
+    </footer>
+
+    <script src="./pool-ratio.js" defer></script>
+  </body>
+</html>

--- a/points-ratio/pool-ratio.js
+++ b/points-ratio/pool-ratio.js
@@ -1,0 +1,247 @@
+(function initPoolRatio(global) {
+  const totalPointsInput = document.getElementById('totalPoints');
+  const poolDollarsInput = document.getElementById('poolDollars');
+  const yourPointsInput = document.getElementById('yourPoints');
+  const dollarPerPointEl = document.getElementById('dollarPerPoint');
+  const pointsPerDollarEl = document.getElementById('pointsPerDollar');
+  const cashoutEstimateEl = document.getElementById('cashoutEstimate');
+  const ratioHighlightEl = document.getElementById('ratioHighlight');
+  const ratioStatusEl = document.getElementById('ratioStatus');
+  const poolDisplayEl = document.getElementById('poolDisplay');
+  const poolBreakdownEl = document.getElementById('poolBreakdown');
+  const totalPointsDisplayEl = document.getElementById('totalPointsDisplay');
+  const liveUpdatedAtEl = document.getElementById('liveUpdatedAt');
+  const leaderboardListEl = document.getElementById('liveLeaderboard');
+  const refreshButtons = Array.from(document.querySelectorAll('#ratioRefresh'));
+
+  if (!totalPointsInput || !poolDollarsInput || !yourPointsInput) {
+    return;
+  }
+
+  const ratioState = {
+    currency: 'USD',
+    poolCents: 0,
+    totalPoints: Number(totalPointsInput.value) || 0,
+    leaderboard: new Map(),
+    stripeAvailable: {},
+    stripePending: {}
+  };
+
+  function formatCurrency(amount, currency = ratioState.currency) {
+    const value = Number.isFinite(amount) ? amount : 0;
+    try {
+      return value.toLocaleString(undefined, {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      });
+    } catch (err) {
+      return `${currency} ${value.toFixed(2)}`;
+    }
+  }
+
+  function formatNumber(value, options = {}) {
+    const numeric = Number.isFinite(value) ? value : 0;
+    return numeric.toLocaleString(undefined, options);
+  }
+
+  function setStatus(message, isError = false) {
+    if (!ratioStatusEl) return;
+    ratioStatusEl.textContent = message;
+    ratioStatusEl.classList.toggle('is-error', !!isError);
+  }
+
+  function escapeHtml(value) {
+    if (typeof value !== 'string') return '';
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function safeNumber(input) {
+    const value = Number(input?.value || 0);
+    if (!Number.isFinite(value) || value < 0) return 0;
+    return value;
+  }
+
+  function updateRatios() {
+    const totalPoints = safeNumber(totalPointsInput);
+    const poolDollars = safeNumber(poolDollarsInput);
+    const yourPoints = safeNumber(yourPointsInput);
+
+    const hasPool = totalPoints > 0 && poolDollars > 0;
+    const dollarPerPoint = hasPool ? poolDollars / totalPoints : 0;
+    const pointsPerDollar = hasPool ? totalPoints / poolDollars : 0;
+    const cashoutEstimate = hasPool ? dollarPerPoint * yourPoints : 0;
+
+    const currency = ratioState.currency || 'USD';
+    dollarPerPointEl && (dollarPerPointEl.textContent = hasPool ? formatCurrency(dollarPerPoint, currency) : '$0.00');
+    pointsPerDollarEl && (pointsPerDollarEl.textContent = hasPool ? formatNumber(pointsPerDollar, { maximumFractionDigits: 2 }) : '0');
+    cashoutEstimateEl && (cashoutEstimateEl.textContent = hasPool ? formatCurrency(cashoutEstimate, currency) : '$0.00');
+    ratioHighlightEl && (ratioHighlightEl.textContent = hasPool ? formatCurrency(dollarPerPoint, currency) : '$0.00');
+  }
+
+  function describePoolBreakdown(currency) {
+    if (!poolBreakdownEl) return;
+    const available = ratioState.stripeAvailable[currency] || 0;
+    const pending = ratioState.stripePending[currency] || 0;
+    poolBreakdownEl.textContent = `Available ${formatCurrency(available / 100, currency)} • Pending ${formatCurrency(pending / 100, currency)}`;
+  }
+
+  function applyLiveNumbers({ poolCents, currency, totalPoints, updatedAt }) {
+    const nextTotalPoints = Number.isFinite(totalPoints) ? Math.max(0, Math.round(totalPoints)) : ratioState.totalPoints;
+    const nextPoolCents = Number.isFinite(poolCents) && poolCents >= 0 ? poolCents : ratioState.poolCents;
+    const nextCurrency = currency || ratioState.currency || 'USD';
+
+    ratioState.totalPoints = nextTotalPoints;
+    ratioState.poolCents = nextPoolCents;
+    ratioState.currency = nextCurrency;
+
+    totalPointsInput.value = nextTotalPoints;
+    poolDollarsInput.value = (nextPoolCents / 100).toFixed(2);
+    totalPointsDisplayEl && (totalPointsDisplayEl.textContent = formatNumber(nextTotalPoints));
+    poolDisplayEl && (poolDisplayEl.textContent = formatCurrency(nextPoolCents / 100, nextCurrency));
+    describePoolBreakdown(nextCurrency);
+
+    if (updatedAt && liveUpdatedAtEl) {
+      liveUpdatedAtEl.textContent = new Date(updatedAt).toLocaleString();
+    }
+
+    updateRatios();
+  }
+
+  function pickCurrency(available = {}, pending = {}) {
+    if (available.USD || pending.USD) return 'USD';
+    const availableKeys = Object.keys(available);
+    if (availableKeys.length) return availableKeys[0].toUpperCase();
+    const pendingKeys = Object.keys(pending);
+    if (pendingKeys.length) return pendingKeys[0].toUpperCase();
+    return 'USD';
+  }
+
+  async function refreshStripeMetrics() {
+    setStatus('Refreshing live Stripe metrics...');
+    try {
+      const response = await fetch('/api/stripe/metrics');
+      if (!response.ok) {
+        throw new Error(`Stripe API responded with ${response.status}`);
+      }
+
+      const payload = await response.json();
+      ratioState.stripeAvailable = payload.available || {};
+      ratioState.stripePending = payload.pending || {};
+      const currency = pickCurrency(payload.available, payload.pending);
+      const poolCents = (payload.available?.[currency] || 0) + (payload.pending?.[currency] || 0);
+
+      applyLiveNumbers({
+        poolCents,
+        currency,
+        totalPoints: ratioState.totalPoints,
+        updatedAt: payload.updatedAt || new Date().toISOString()
+      });
+      setStatus('Live data synced from Stripe and the leaderboard.');
+    } catch (err) {
+      setStatus(`Unable to load Stripe metrics: ${err.message}`, true);
+    }
+  }
+
+  function updateLeaderboardUI() {
+    if (!leaderboardListEl) return;
+    const records = Array.from(ratioState.leaderboard.values())
+      .filter(record => Number.isFinite(record.points))
+      .sort((a, b) => b.points - a.points)
+      .slice(0, 5);
+
+    if (!records.length) {
+      leaderboardListEl.innerHTML = '<li class="leaderboard-list__item">No leaderboard data yet.</li>';
+      return;
+    }
+
+    leaderboardListEl.innerHTML = records.map((record, index) => {
+      const rank = index + 1;
+      const badge = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `#${rank}`;
+      const safeName = escapeHtml(record.username);
+      const safeAlias = escapeHtml(record.alias);
+      return `
+        <li class="leaderboard-list__item">
+          <div class="leaderboard-list__left">
+            <span class="leaderboard-rank">${badge}</span>
+            <div>
+              <p class="leaderboard-name">${safeName}</p>
+              <p class="leaderboard-alias">${safeAlias}</p>
+            </div>
+          </div>
+          <p class="leaderboard-points">${formatNumber(record.points)} pts</p>
+        </li>
+      `;
+    }).join('');
+  }
+
+  function handleLeaderboardUpdate(data, key) {
+    if (!key) return;
+    if (!data) {
+      ratioState.leaderboard.delete(key);
+    } else {
+      const points = Number(data.points);
+      const username = data.username || key.replace('@3dvr', '');
+      ratioState.leaderboard.set(key, {
+        alias: key,
+        username,
+        points: Number.isFinite(points) ? points : 0
+      });
+    }
+
+    const totalPoints = Array.from(ratioState.leaderboard.values())
+      .reduce((sum, record) => sum + (Number.isFinite(record.points) ? record.points : 0), 0);
+
+    applyLiveNumbers({ poolCents: ratioState.poolCents, currency: ratioState.currency, totalPoints });
+    updateLeaderboardUI();
+  }
+
+  function subscribeToLeaderboard() {
+    if (typeof global.Gun !== 'function') {
+      setStatus('Gun is unavailable. Enter totals manually or try again later.', true);
+      return null;
+    }
+
+    const peers = Array.isArray(global.__GUN_PEERS__) && global.__GUN_PEERS__.length
+      ? global.__GUN_PEERS__
+      : [
+        'wss://relay.3dvr.tech/gun',
+        'wss://gun-relay-3dvr.fly.dev/gun'
+      ];
+
+    const gun = global.Gun({ peers, axe: true });
+    const portalRoot = gun.get('3dvr-portal');
+    const userStats = portalRoot.get('userStats');
+
+    if (typeof userStats.map !== 'function') {
+      setStatus('Unable to reach the leaderboard. Enter totals manually or retry.', true);
+      return null;
+    }
+
+    return userStats.map().on(handleLeaderboardUpdate);
+  }
+
+  function init() {
+    totalPointsInput.addEventListener('input', updateRatios);
+    poolDollarsInput.addEventListener('input', updateRatios);
+    yourPointsInput.addEventListener('input', updateRatios);
+
+    refreshButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        refreshStripeMetrics();
+      });
+    });
+
+    subscribeToLeaderboard();
+    refreshStripeMetrics();
+    updateRatios();
+  }
+
+  init();
+})(window);

--- a/points-ratio/style.css
+++ b/points-ratio/style.css
@@ -1,0 +1,79 @@
+.points-page {
+  background: radial-gradient(circle at 20% 20%, rgba(91, 108, 255, 0.1), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(94, 234, 212, 0.08), transparent 35%),
+    var(--page-bg, #0b0e13);
+}
+
+.ratio-grid--condensed {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: start;
+}
+
+.live-leaderboard {
+  align-items: start;
+}
+
+.leaderboard-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.leaderboard-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  background: var(--surface-alt);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.06);
+}
+
+.leaderboard-list__left {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.leaderboard-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  font-weight: 700;
+}
+
+.leaderboard-name {
+  margin: 0;
+  font-weight: 700;
+}
+
+.leaderboard-alias {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.leaderboard-points {
+  margin: 0;
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .leaderboard-list__item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .leaderboard-points {
+    font-size: 1.1rem;
+  }
+}

--- a/points.html
+++ b/points.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>3dvr.tech Points Overview</title>
+    <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+    <script src="gun-init.js"></script>
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/points.css" />
   </head>
@@ -81,18 +83,23 @@
             </div>
           </div>
 
+          <div class="ratio-live">
+            <p class="ratio-live__status" id="ratioStatus" aria-live="polite">Loading live pool and leaderboard data...</p>
+            <button class="cta ghost" type="button" id="ratioRefresh">Refresh live data</button>
+          </div>
+
           <form class="ratio-form" aria-label="Point to dollar calculator">
             <div class="ratio-input">
               <label for="totalPoints">Total active points</label>
-              <input id="totalPoints" name="totalPoints" type="number" min="0" step="1" value="100000" />
+              <input id="totalPoints" name="totalPoints" type="number" min="0" step="1" value="0" />
             </div>
             <div class="ratio-input">
               <label for="poolDollars">Stripe pool (USD)</label>
-              <input id="poolDollars" name="poolDollars" type="number" min="0" step="50" value="25000" />
+              <input id="poolDollars" name="poolDollars" type="number" min="0" step="50" value="0" />
             </div>
             <div class="ratio-input">
               <label for="yourPoints">Your points to redeem</label>
-              <input id="yourPoints" name="yourPoints" type="number" min="0" step="50" value="5000" />
+              <input id="yourPoints" name="yourPoints" type="number" min="0" step="50" value="0" />
             </div>
           </form>
 
@@ -280,58 +287,7 @@
       </section>
     </main>
 
-    <script>
-      (function() {
-        const totalPointsInput = document.getElementById('totalPoints');
-        const poolDollarsInput = document.getElementById('poolDollars');
-        const yourPointsInput = document.getElementById('yourPoints');
-        const dollarPerPointEl = document.getElementById('dollarPerPoint');
-        const pointsPerDollarEl = document.getElementById('pointsPerDollar');
-        const cashoutEstimateEl = document.getElementById('cashoutEstimate');
-        const ratioHighlightEl = document.getElementById('ratioHighlight');
-
-        function formatCurrency(value) {
-          return `$${value.toLocaleString(undefined, {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2
-          })}`;
-        }
-
-        function formatNumber(value) {
-          return value.toLocaleString(undefined, {
-            maximumFractionDigits: 2
-          });
-        }
-
-        function safeNumber(input) {
-          const value = Number(input?.value || 0);
-          if (!Number.isFinite(value) || value < 0) return 0;
-          return value;
-        }
-
-        function updateRatios() {
-          const totalPoints = safeNumber(totalPointsInput);
-          const poolDollars = safeNumber(poolDollarsInput);
-          const yourPoints = safeNumber(yourPointsInput);
-
-          const hasPool = totalPoints > 0 && poolDollars > 0;
-          const dollarPerPoint = hasPool ? poolDollars / totalPoints : 0;
-          const pointsPerDollar = hasPool ? totalPoints / poolDollars : 0;
-          const cashoutEstimate = hasPool ? dollarPerPoint * yourPoints : 0;
-
-          dollarPerPointEl.textContent = hasPool ? formatCurrency(dollarPerPoint) : '$0.00';
-          pointsPerDollarEl.textContent = hasPool ? formatNumber(pointsPerDollar) : '0';
-          cashoutEstimateEl.textContent = hasPool ? formatCurrency(cashoutEstimate) : '$0.00';
-          ratioHighlightEl.textContent = hasPool ? formatCurrency(dollarPerPoint) : '$0.00';
-        }
-
-        totalPointsInput?.addEventListener('input', updateRatios);
-        poolDollarsInput?.addEventListener('input', updateRatios);
-        yourPointsInput?.addEventListener('input', updateRatios);
-
-        updateRatios();
-      })();
-    </script>
+      <script src="/points-ratio/pool-ratio.js" defer></script>
 
     <footer class="points-footer">
       <p>Questions or ideas? Email <a href="mailto:hello@3dvr.tech">hello@3dvr.tech</a> and we will get back to you.</p>

--- a/styles/points.css
+++ b/styles/points.css
@@ -118,6 +118,23 @@
   gap: 1rem;
 }
 
+.ratio-live {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.ratio-live__status {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.ratio-live__status.is-error {
+  color: #f43f5e;
+}
+
 .ratio-badge {
   min-width: 220px;
   background: var(--surface-alt);


### PR DESCRIPTION
## Summary
- add a live calculator section that previews point-to-dollar conversions on the points page
- surface calculated dollar-per-point, points-per-dollar, and cash-out estimate outputs with accessible labels
- apply styling for the new ratio form, badge, and stats grid to match the existing design

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693656fc914c8320b5af3145797a7581)