### PR TITLE
Make newsroom feed items clickable

### DIFF
--- a/newsroom/newsroom.css
+++ b/newsroom/newsroom.css
@@ -157,6 +157,21 @@
   gap: 0.35rem;
 }
 
+.feed-card__item--linked {
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.feed-card__item--linked:hover {
+  border-color: rgba(139, 92, 246, 0.45);
+  background: rgba(30, 41, 59, 0.88);
+}
+
+.feed-card__item--linked:focus-visible {
+  outline: 2px solid #c084fc;
+  outline-offset: 2px;
+}
+
 .feed-card__item a {
   color: #e0e7ff;
   font-weight: 600;

--- a/newsroom/newsroom.js
+++ b/newsroom/newsroom.js
@@ -52,6 +52,21 @@ function renderItems(card, items = []) {
     const listItem = document.createElement('li');
     listItem.className = 'feed-card__item';
 
+    if (item.link) {
+      listItem.classList.add('feed-card__item--linked');
+      listItem.tabIndex = 0;
+      listItem.addEventListener('click', (event) => {
+        if (event.target instanceof Element && event.target.closest('a')) return;
+        window.open(item.link, '_blank', 'noopener,noreferrer');
+      });
+      listItem.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          window.open(item.link, '_blank', 'noopener,noreferrer');
+        }
+      });
+    }
+
     const link = document.createElement('a');
     link.href = item.link;
     link.target = '_blank';


### PR DESCRIPTION
## Summary
- make newsroom feed entries clickable across the entire item with keyboard support
- add hover and focus states to clarify links

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f34da0dc83209745d44fedc5b522)