### PR TITLE
Include stat-only users in award search

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -1173,6 +1173,11 @@ function subscribeToUserDirectory() {
         knownStats.delete(key);
       } else {
         knownStats.set(key, { ...data });
+        if (!knownUsers.has(key)) {
+          const username = (data.username || '').trim() || key.replace('@3dvr', '');
+          const lastLogin = data.lastUpdated || 0;
+          ensureKnownUser(key, username, { lastLogin });
+        }
       }
       renderUserResults(userSearchInput ? userSearchInput.value.trim().toLowerCase() : '');
     });


### PR DESCRIPTION
## Summary
- ensure admin award search backfills user entries from live stats when directory records are missing
- keep leaderboard participants visible to the award tool even if only stats exist

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69379ff9b1cc832089235e7769aeae69)