### PR TITLE
Add admin account recovery workflow

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -441,6 +441,27 @@
         </div>
       </div>
 
+      <div class="card" id="recovery-card">
+        <h2>Account Recovery</h2>
+        <p class="text-muted">Reset usernames and issue temporary passwords for users who lost access.</p>
+        <div class="form-group">
+          <label for="recovery-current">Current account</label>
+          <input id="recovery-current" type="text" placeholder="username or alias to recover" />
+        </div>
+        <div class="form-group">
+          <label for="recovery-username">New username</label>
+          <input id="recovery-username" type="text" placeholder="new username (creates a fresh alias)" />
+        </div>
+        <div class="form-group">
+          <label for="recovery-password">Temporary password</label>
+          <input id="recovery-password" type="password" placeholder="share with the user so they can sign in" />
+        </div>
+        <div class="actions" style="margin-top: 10px;">
+          <button id="recovery-button" class="btn-primary" type="button">Reset credentials</button>
+        </div>
+        <p id="recovery-status" class="text-muted"></p>
+      </div>
+
       <div class="card">
         <h2>Current Admins</h2>
         <div id="admin-list" class="list" aria-live="polite"></div>
@@ -480,6 +501,7 @@
   const workbenchDefaults = portalRoot.get('ai-workbench').get('defaults');
   // Stripe subscriber summaries live under finance/stripeCustomers to keep shared totals in GunJS.
   const stripeCustomersNode = portalRoot.get('finance').get('stripeCustomers');
+  const accountRecoveryLog = portalRoot.get('accountRecovery');
 
   const alias = localStorage.getItem('alias');
   const password = localStorage.getItem('password');
@@ -523,6 +545,12 @@
   const defaultStatusEl = document.getElementById('default-status');
   const saveDefaultKeyBtn = document.getElementById('save-default-key');
   const clearDefaultKeyBtn = document.getElementById('clear-default-key');
+  const recoveryCard = document.getElementById('recovery-card');
+  const recoveryCurrentInput = document.getElementById('recovery-current');
+  const recoveryUsernameInput = document.getElementById('recovery-username');
+  const recoveryPasswordInput = document.getElementById('recovery-password');
+  const recoveryButton = document.getElementById('recovery-button');
+  const recoveryStatusEl = document.getElementById('recovery-status');
 
   function init() {
     ensureRootAdmin();
@@ -701,17 +729,19 @@
         points: Number(stats.points || 0),
         lastUpdated: stats.lastUpdated,
         lastLogin: profile.lastLogin,
-        createdAt: profile.createdAt
+        createdAt: profile.createdAt,
+        archived: Boolean(profile.archived || stats.archived)
       };
     });
 
-    rows.sort((a, b) => b.points - a.points);
+    const activeRows = rows.filter(record => !record.archived);
+    activeRows.sort((a, b) => b.points - a.points);
 
-    const totalPoints = rows.reduce((sum, item) => sum + (item.points || 0), 0);
-    totalUsersEl.innerText = aliasSet.size.toString();
+    const totalPoints = activeRows.reduce((sum, item) => sum + (item.points || 0), 0);
+    totalUsersEl.innerText = activeRows.length.toString();
     totalPointsEl.innerText = totalPoints.toString();
 
-    userTable.innerHTML = rows.map(record => `
+    userTable.innerHTML = activeRows.map(record => `
       <tr>
         <td>${escapeHtml(record.username)}</td>
         <td>${escapeHtml(record.alias)}</td>
@@ -721,7 +751,7 @@
       </tr>
     `).join('');
 
-    renderLeaderboard(rows);
+    renderLeaderboard(activeRows);
   }
 
   function renderLeaderboard(rows) {
@@ -883,6 +913,158 @@
     if (defaultStatusEl) {
       defaultStatusEl.innerText = message;
     }
+  }
+
+  function setRecoveryStatus(message, tone = 'muted') {
+    if (!recoveryStatusEl) return;
+    recoveryStatusEl.innerText = message;
+    if (tone === 'error') {
+      recoveryStatusEl.style.color = 'var(--danger)';
+    } else if (tone === 'success') {
+      recoveryStatusEl.style.color = 'var(--success)';
+    } else {
+      recoveryStatusEl.style.color = 'var(--text-secondary)';
+    }
+  }
+
+  function sanitizePointsValue(value) {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(numeric)) return 0;
+    return Math.max(0, Math.round(numeric));
+  }
+
+  function readNodeValue(node, key) {
+    return new Promise(resolve => {
+      if (!node || typeof node.get !== 'function') {
+        resolve(null);
+        return;
+      }
+      node.get(key).once(data => resolve(data || null));
+    });
+  }
+
+  async function handleAccountRecovery() {
+    if (!recoveryButton) return;
+    if (!isAdmin) {
+      setRecoveryStatus('Only admins can reset credentials.', 'error');
+      return;
+    }
+
+    const targetAlias = normalizeAlias((recoveryCurrentInput.value || '').trim());
+    const nextUsername = (recoveryUsernameInput.value || '').trim();
+    const nextAlias = normalizeAlias(nextUsername);
+    const tempPassword = (recoveryPasswordInput.value || '').trim();
+
+    if (!targetAlias) {
+      setRecoveryStatus('Enter the existing username or alias to recover.', 'error');
+      return;
+    }
+    if (!nextUsername) {
+      setRecoveryStatus('Add the new username you want to issue.', 'error');
+      return;
+    }
+    if (!tempPassword || tempPassword.length < 6) {
+      setRecoveryStatus('Use a temporary password with at least 6 characters.', 'error');
+      return;
+    }
+    if (!gun || gun.__isGunStub) {
+      setRecoveryStatus('Gun peers are offline. Try again once connected.', 'error');
+      return;
+    }
+    if (targetAlias === nextAlias) {
+      setRecoveryStatus('Choose a new username so a fresh alias can be created.', 'error');
+      return;
+    }
+
+    setRecoveryStatus('Looking up the account and preparing a reset...');
+    recoveryButton.disabled = true;
+
+    const [profile, stats] = await Promise.all([
+      readNodeValue(userIndex, targetAlias),
+      readNodeValue(userStats, targetAlias)
+    ]);
+
+    if (!profile && !stats) {
+      setRecoveryStatus('No account metadata found for that user.', 'error');
+      recoveryButton.disabled = false;
+      return;
+    }
+
+    const issuedAt = Date.now();
+    const currentUsername = profile?.username || stats?.username || targetAlias.replace('@3dvr', '');
+    const points = sanitizePointsValue(stats?.points);
+    const lastUpdated = stats?.lastUpdated || issuedAt;
+    const createdAt = profile?.createdAt || issuedAt;
+    const lastLogin = profile?.lastLogin || 0;
+
+    setRecoveryStatus('Creating the new account and transferring metadata...');
+    const creationUser = typeof gun.user === 'function' ? gun.user() : null;
+    if (!creationUser || typeof creationUser.create !== 'function') {
+      setRecoveryStatus('Gun user instance unavailable. Refresh and try again.', 'error');
+      recoveryButton.disabled = false;
+      return;
+    }
+
+    const creationAck = await new Promise(resolve => {
+      try {
+        creationUser.create(nextAlias, tempPassword, ack => resolve(ack || {}));
+      } catch (error) {
+        resolve({ err: error?.message || 'account-creation-failed' });
+      }
+    });
+
+    if (creationAck && creationAck.err) {
+      const message = String(creationAck.err || '').includes('User already created')
+        ? 'That new username already exists. Pick a different username.'
+        : `Could not create the new account: ${creationAck.err}`;
+      setRecoveryStatus(message, 'error');
+      recoveryButton.disabled = false;
+      return;
+    }
+
+    userIndex.get(nextAlias).put({
+      username: nextUsername,
+      alias: nextAlias,
+      createdAt,
+      lastLogin,
+      recoveredFrom: targetAlias,
+      recoveredAt: issuedAt
+    });
+
+    userStats.get(nextAlias).put({
+      username: nextUsername,
+      alias: nextAlias,
+      points,
+      lastUpdated,
+      recoveredFrom: targetAlias,
+      recoveredAt: issuedAt
+    });
+
+    userIndex.get(targetAlias).put({
+      archived: true,
+      recoveredTo: nextAlias,
+      recoveredAt: issuedAt
+    });
+    userStats.get(targetAlias).put({
+      archived: true,
+      recoveredTo: nextAlias,
+      recoveredAt: issuedAt
+    });
+
+    accountRecoveryLog.get(`${targetAlias}-${issuedAt}`).put({
+      targetAlias,
+      newAlias: nextAlias,
+      issuedBy: alias,
+      issuedAt,
+      pointsTransferred: points,
+      previousUsername: currentUsername
+    });
+
+    setRecoveryStatus(`New credentials ready. Username: ${nextUsername}. Temporary password: ${tempPassword}.`, 'success');
+    recoveryButton.disabled = false;
+    recoveryCurrentInput.value = '';
+    recoveryUsernameInput.value = '';
+    recoveryPasswordInput.value = '';
   }
 
   async function saveDefaultKey() {
@@ -1151,6 +1333,9 @@
     setStatus(`${displayName} promoted to admin.`);
   });
 
+  if (recoveryButton) {
+    recoveryButton.addEventListener('click', handleAccountRecovery);
+  }
   saveDefaultKeyBtn.addEventListener('click', saveDefaultKey);
   clearDefaultKeyBtn.addEventListener('click', clearDefaultKey);
   stripeRefreshBtn.addEventListener('click', refreshStripeCustomers);


### PR DESCRIPTION
## Summary
- add an account recovery card so admins can reset usernames and issue temporary passwords
- archive recovered aliases, log recovery actions, and migrate stats to the new account
- filter archived profiles out of user totals and the leaderboard

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937a29090c08320a8f16844a12c2355)