### PR TITLE
Open meeting cards directly to meeting page

### DIFF
--- a/meeting-notes/index.html
+++ b/meeting-notes/index.html
@@ -242,8 +242,11 @@
       border-radius: 12px;
       padding: 12px;
       background: var(--panel);
+      color: var(--text);
       cursor: pointer;
+      display: block;
       transition: border-color 0.15s ease, transform 0.15s ease;
+      text-decoration: none;
     }
 
     .meeting-card:hover { border-color: var(--accent); transform: translateY(-1px); }
@@ -637,18 +640,22 @@
           return dateB - dateA;
         })
         .forEach(([id, data]) => {
-          const card = document.createElement('article');
+          const card = document.createElement('a');
+          const meetingPageUrl = buildMeetingPageUrl(id);
           card.className = 'meeting-card';
-          card.tabIndex = 0;
-          card.setAttribute('role', 'button');
+          card.href = meetingPageUrl;
           card.setAttribute('data-meeting-id', id);
 
-          const selectMeeting = () => setActiveMeeting(id, meetingsCache.get(id) || data);
-          card.onclick = selectMeeting;
+          const openMeetingPage = (event) => {
+            event.preventDefault();
+            window.location.href = meetingPageUrl;
+          };
+
+          card.onclick = openMeetingPage;
           card.onkeydown = (event) => {
             if (event.key === 'Enter' || event.key === ' ') {
               event.preventDefault();
-              selectMeeting();
+              openMeetingPage(event);
             }
           };
 


### PR DESCRIPTION
## Summary
- update meeting list cards to navigate straight to the dedicated meeting page on click or keyboard activation
- adjust meeting card styling so anchor links keep the existing card appearance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c6c0caa6483209468a762957d2ea2)