### PR TITLE
Enable auto-sync for Workbench vault secrets

### DIFF
--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -96,6 +96,18 @@
         <button id="vault-load" class="ghost">Load secret from Gun</button>
       </div>
 
+      <div class="auto-sync-row">
+        <label class="checkbox-row" for="vault-auto-sync">
+          <input id="vault-auto-sync" type="checkbox">
+          <span>Auto-sync secrets to Gun after saving</span>
+        </label>
+        <label class="checkbox-row" for="vault-remember-passphrase">
+          <input id="vault-remember-passphrase" type="checkbox">
+          <span>Remember passphrase for this session</span>
+        </label>
+      </div>
+
+      <p id="vault-auto-status" class="meta" aria-live="polite">Enable auto-sync to encrypt secrets immediately after you save them.</p>
       <p id="vault-status" class="status" aria-live="polite">Use the vault to keep keys, tokens, and other secrets handy when Vercel preview URLs change.</p>
     </section>
 

--- a/openai-app/styles.css
+++ b/openai-app/styles.css
@@ -102,6 +102,24 @@ label {
   gap: 8px;
 }
 
+.auto-sync-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.checkbox-row span {
+  color: var(--text);
+}
+
 input[type="password"],
 textarea,
 select {


### PR DESCRIPTION
## Summary
- add vault auto-sync controls and session passphrase memory in the Workbench UI
- persist vault preferences and restore secrets automatically when enabled
- auto-encrypt API, Vercel, and GitHub tokens to Gun after saving so they follow devices

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dc76c93388320bafa83a5c7f9e08f)