### PR TITLE
Auto-load vault secrets with account alias

### DIFF
--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -105,6 +105,14 @@
           <input id="vault-remember-passphrase" type="checkbox">
           <span>Remember passphrase for this session</span>
         </label>
+        <label class="checkbox-row" for="vault-use-account-alias">
+          <input id="vault-use-account-alias" type="checkbox" checked>
+          <span>Use my username as the vault label</span>
+        </label>
+        <label class="checkbox-row" for="vault-auto-load">
+          <input id="vault-auto-load" type="checkbox" checked>
+          <span>Auto-load secrets after signing in</span>
+        </label>
       </div>
 
       <p id="vault-auto-status" class="meta" aria-live="polite">Enable auto-sync to encrypt secrets immediately after you save them.</p>


### PR DESCRIPTION
## Summary
- add options to use the signed-in username as the vault label and auto-load secrets after login
- store new vault preferences for account alias usage and auto-loading alongside passphrase handling
- trigger silent auto-loads on sign-in and when passphrases are entered for smoother cross-device restores

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd5803e1c8320948ccebfbb30448c)