### PR TITLE
Streamline OpenAI workbench account-first layout

### DIFF
--- a/openai-app/app.js
+++ b/openai-app/app.js
@@ -256,7 +256,7 @@ function attemptStoredAuth() {
   const storedPassword = (localStorage.getItem('password') || '').trim();
 
   if (!storedAlias || !storedPassword) {
-    updateAccountStatus('Not signed in. Data stays device-local until you sign in.');
+    updateAccountStatus('Not signed in. Keys stay with this device until you connect your account.');
     return;
   }
 
@@ -276,16 +276,16 @@ function updateStorageModeNotice(context) {
 
   const mode = storage.mode();
   if (mode === 'localStorage') {
-    storageModeNotice.textContent = context || 'Keys persist with localStorage. They should survive refreshes in most browsers, including Brave when shields allow storage.';
+    storageModeNotice.textContent = context || 'Keys save to your Gun account when signed in; otherwise they persist in localStorage on this device.';
     return;
   }
 
   if (mode === 'sessionStorage') {
-    storageModeNotice.textContent = context || 'Local storage is blocked, so keys are stored in sessionStorage. They will survive refreshes but not closing the tab. Try lowering Brave shields to allow local storage.';
+    storageModeNotice.textContent = context || 'Signed-in users sync to Gun; otherwise keys sit in sessionStorage until the tab closes.';
     return;
   }
 
-  storageModeNotice.textContent = context || 'Persistent storage is blocked. Keys stay only for this page load. Adjust Brave Shields or enable storage to keep your key across refreshes.';
+  storageModeNotice.textContent = context || 'Storage is blocked. Keys remain for this page load unless you sign in so Gun can hold them for you.';
 }
 
 function setDefaultKeyStatus(message) {
@@ -313,6 +313,7 @@ async function saveSecretToAccount(field, value) {
           resolve(false);
           return;
         }
+        updateAccountStatus('Saved to your Gun account.');
         resolve(true);
       });
     });
@@ -1132,10 +1133,13 @@ saveKeyBtn.addEventListener('click', () => {
     return;
   }
   const mode = storage.setItem(apiKeyStorageKey, key);
-  updateStorageModeNotice(`API key saved to ${mode}.`);
-  outputBox.textContent = mode === 'memory'
-    ? 'API key saved for this page only. Adjust Brave Shields or storage settings to persist across refreshes.'
-    : `API key saved to ${mode}.`;
+  const savedMessage = user?.is
+    ? 'API key saved to your Gun account and cached locally.'
+    : mode === 'memory'
+      ? 'API key saved for this page only. Adjust Brave Shields or storage settings to persist across refreshes.'
+      : `API key saved to ${mode}.`;
+  updateStorageModeNotice(savedMessage);
+  outputBox.textContent = savedMessage;
   saveSecretToAccount('openaiApiKey', key);
   autoSyncSecret('openai', key);
 });
@@ -1195,10 +1199,13 @@ saveVercelBtn.addEventListener('click', () => {
   }
 
   const mode = storage.setItem(vercelTokenStorageKey, token);
-  updateStorageModeNotice();
-  setVercelStatus(mode === 'memory'
-    ? 'Vercel token saved for this page only. Allow storage for persistence.'
-    : `Vercel token saved to ${mode}.`);
+  const status = user?.is
+    ? 'Vercel token saved to your Gun account and cached locally.'
+    : mode === 'memory'
+      ? 'Vercel token saved for this page only. Allow storage for persistence.'
+      : `Vercel token saved to ${mode}.`;
+  updateStorageModeNotice(status);
+  setVercelStatus(status);
   saveSecretToAccount('vercelToken', token);
   autoSyncSecret('vercel', token);
 });
@@ -1220,10 +1227,13 @@ saveGithubBtn.addEventListener('click', () => {
   }
 
   const mode = storage.setItem(githubTokenStorageKey, token);
-  updateStorageModeNotice();
-  setGithubStatus(mode === 'memory'
-    ? 'GitHub token saved for this page only. Allow storage for persistence.'
-    : `GitHub token saved to ${mode}.`);
+  const githubMessage = user?.is
+    ? 'GitHub token saved to your Gun account and cached locally.'
+    : mode === 'memory'
+      ? 'GitHub token saved for this page only. Allow storage for persistence.'
+      : `GitHub token saved to ${mode}.`;
+  updateStorageModeNotice(githubMessage);
+  setGithubStatus(githubMessage);
   saveSecretToAccount('githubToken', token);
   autoSyncSecret('github', token);
 });

--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -41,8 +41,8 @@
 
     <section class="card" id="api-key-panel" aria-label="API key configuration">
       <div class="card-header">
-        <h2>Bring your own key</h2>
-        <p class="meta">Keys stay in your browser; prompts and responses sync to GunDB so teams can reuse what worked.</p>
+        <h2>Account-linked keys</h2>
+        <p class="meta">Keys follow your Gun account when signed in and fall back to secure, device-local storage.</p>
       </div>
       <label for="api-key">OpenAI API key</label>
       <div class="input-row">
@@ -50,73 +50,14 @@
         <button id="save-key" class="primary">Save</button>
         <button id="clear-key" class="ghost">Clear</button>
       </div>
-      <p id="api-key-help" class="meta">Stored only in localStorage on this device.</p>
+      <p id="api-key-help" class="meta">Saved to your Gun account first when available; otherwise stored on this device.</p>
       <p id="storage-mode" class="meta" aria-live="polite"></p>
-      <p id="account-status" class="status" aria-live="polite">Connect your Gun account to sync keys across browsers.</p>
+      <p id="account-status" class="status" aria-live="polite">Sign in so keys attach to your account instead of this device.</p>
       <div class="input-row">
         <input type="password" id="default-passphrase" placeholder="Passphrase for admin default key">
         <button id="load-default" class="ghost">Use default key</button>
       </div>
       <p id="default-key-status" class="meta" aria-live="polite"></p>
-    </section>
-
-    <section class="card" id="vault-panel" aria-label="Gun key vault">
-      <div class="card-header">
-        <div>
-          <p class="eyebrow">Sync</p>
-          <h2>Gun secret vault</h2>
-          <p class="meta">Encrypt any Workbench secret with a passphrase and keep it in Gun so it follows you across previews and devices.</p>
-        </div>
-      </div>
-
-      <div class="grid compact-grid">
-        <div>
-          <label for="vault-alias">Vault label</label>
-          <input id="vault-alias" type="text" placeholder="workbench-default" aria-describedby="vault-alias-help">
-          <p id="vault-alias-help" class="meta">Letters, numbers, and dashes only. Use the same label on every device.</p>
-        </div>
-        <div>
-          <label for="vault-passphrase">Passphrase</label>
-          <input id="vault-passphrase" type="password" placeholder="Required to encrypt/decrypt" aria-describedby="vault-passphrase-help">
-          <p id="vault-passphrase-help" class="meta">Passphrase never leaves the browser; it only decrypts your secret locally.</p>
-        </div>
-        <div>
-          <label for="vault-target">Secret type</label>
-          <select id="vault-target" aria-describedby="vault-target-help">
-            <option value="openai">OpenAI API key</option>
-            <option value="vercel">Vercel token</option>
-            <option value="github">GitHub token</option>
-          </select>
-          <p id="vault-target-help" class="meta">Choose which field to pull from and where the decrypted secret should be applied.</p>
-        </div>
-      </div>
-
-      <div class="input-row">
-        <button id="vault-save" class="primary">Save secret to Gun</button>
-        <button id="vault-load" class="ghost">Load secret from Gun</button>
-      </div>
-
-      <div class="auto-sync-row">
-        <label class="checkbox-row" for="vault-auto-sync">
-          <input id="vault-auto-sync" type="checkbox">
-          <span>Auto-sync secrets to Gun after saving</span>
-        </label>
-        <label class="checkbox-row" for="vault-remember-passphrase">
-          <input id="vault-remember-passphrase" type="checkbox">
-          <span>Remember passphrase for this session</span>
-        </label>
-        <label class="checkbox-row" for="vault-use-account-alias">
-          <input id="vault-use-account-alias" type="checkbox" checked>
-          <span>Use my username as the vault label</span>
-        </label>
-        <label class="checkbox-row" for="vault-auto-load">
-          <input id="vault-auto-load" type="checkbox" checked>
-          <span>Auto-load secrets after signing in</span>
-        </label>
-      </div>
-
-      <p id="vault-auto-status" class="meta" aria-live="polite">Enable auto-sync to encrypt secrets immediately after you save them.</p>
-      <p id="vault-status" class="status" aria-live="polite">Use the vault to keep keys, tokens, and other secrets handy when Vercel preview URLs change.</p>
     </section>
 
     <section class="grid">
@@ -271,6 +212,65 @@
         </div>
         <ul id="github-history"></ul>
       </section>
+    </section>
+
+    <section class="card" id="vault-panel" aria-label="Gun key vault">
+      <div class="card-header">
+        <div>
+          <p class="eyebrow">Backup</p>
+          <h2>Gun secret vault</h2>
+          <p class="meta">Optional encrypted vault for when you need a passphrase-based backup beyond your account.</p>
+        </div>
+      </div>
+
+      <div class="grid compact-grid">
+        <div>
+          <label for="vault-alias">Vault label</label>
+          <input id="vault-alias" type="text" placeholder="workbench-default" aria-describedby="vault-alias-help">
+          <p id="vault-alias-help" class="meta">Letters, numbers, and dashes only. Defaults to your account handle when signed in.</p>
+        </div>
+        <div>
+          <label for="vault-passphrase">Passphrase</label>
+          <input id="vault-passphrase" type="password" placeholder="Required to encrypt/decrypt" aria-describedby="vault-passphrase-help">
+          <p id="vault-passphrase-help" class="meta">Passphrase never leaves the browser; it only decrypts your secret locally.</p>
+        </div>
+        <div>
+          <label for="vault-target">Secret type</label>
+          <select id="vault-target" aria-describedby="vault-target-help">
+            <option value="openai">OpenAI API key</option>
+            <option value="vercel">Vercel token</option>
+            <option value="github">GitHub token</option>
+          </select>
+          <p id="vault-target-help" class="meta">Choose which field to pull from and where the decrypted secret should be applied.</p>
+        </div>
+      </div>
+
+      <div class="input-row">
+        <button id="vault-save" class="primary">Save secret to Gun</button>
+        <button id="vault-load" class="ghost">Load secret from Gun</button>
+      </div>
+
+      <div class="auto-sync-row">
+        <label class="checkbox-row" for="vault-auto-sync">
+          <input id="vault-auto-sync" type="checkbox">
+          <span>Auto-sync secrets to Gun after saving</span>
+        </label>
+        <label class="checkbox-row" for="vault-remember-passphrase">
+          <input id="vault-remember-passphrase" type="checkbox">
+          <span>Remember passphrase for this session</span>
+        </label>
+        <label class="checkbox-row" for="vault-use-account-alias">
+          <input id="vault-use-account-alias" type="checkbox" checked>
+          <span>Use my username as the vault label</span>
+        </label>
+        <label class="checkbox-row" for="vault-auto-load">
+          <input id="vault-auto-load" type="checkbox" checked>
+          <span>Auto-load secrets after signing in</span>
+        </label>
+      </div>
+
+      <p id="vault-auto-status" class="meta" aria-live="polite">Enable auto-sync to encrypt secrets immediately after you save them.</p>
+      <p id="vault-status" class="status" aria-live="polite">Use the vault when you need a passphrase-protected backup alongside your account.</p>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- move the Gun vault panel to the bottom of the workbench and clarify copy
- emphasize account-linked key handling with updated instructions and statuses
- surface account-first messaging when saving API, Vercel, and GitHub tokens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693df58b54d48320a892e345fffd00d0)