### PR TITLE
Add Workbench Dev Lab and portal entry card

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,11 @@
             <span class="app-card__title">Wellness</span>
             <span class="app-card__meta">Explore mindfulness, nutrition, and lifestyle resources.</span>
           </a>
+          <a href="workbench-dev-lab/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🧪</span>
+            <span class="app-card__title">Workbench Dev Lab</span>
+            <span class="app-card__meta">Test prompts and site builder runs side-by-side with shared checklists.</span>
+          </a>
           <a href="workbench-site-builder/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🏗️</span>
             <span class="app-card__title">Workbench Site Builder</span>

--- a/workbench-dev-lab/app.js
+++ b/workbench-dev-lab/app.js
@@ -1,0 +1,138 @@
+(function initLab() {
+  const gun = Gun(window.__GUN_PEERS__ || [
+    'wss://relay.3dvr.tech/gun',
+    'wss://gun-relay-3dvr.fly.dev/gun'
+  ]);
+  const labRoot = gun.get('3dvr-portal').get('workbench-dev-lab');
+
+  const runForm = document.getElementById('runForm');
+  const runList = document.getElementById('runList');
+  const formStatus = document.getElementById('formStatus');
+  const historyStatus = document.getElementById('historyStatus');
+  const keyStatus = document.getElementById('keyStatus');
+  const resetButton = document.getElementById('resetForm');
+
+  const runs = new Map();
+
+  function formatDate(timestamp) {
+    try {
+      return new Intl.DateTimeFormat('en', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit'
+      }).format(new Date(timestamp));
+    } catch (err) {
+      return new Date(timestamp).toLocaleString();
+    }
+  }
+
+  function syncKeyStatus() {
+    const storedKey = localStorage.getItem('openai-api-key');
+    if (storedKey) {
+      keyStatus.textContent = '🔑 Workbench key found — you can jump straight into runs.';
+      keyStatus.setAttribute('data-state', 'ready');
+    } else {
+      keyStatus.textContent = '🔒 No Workbench key detected yet. Set it in the Workbench or Site Builder.';
+      keyStatus.setAttribute('data-state', 'missing');
+    }
+  }
+
+  function renderRuns() {
+    if (!runList) return;
+
+    const validRuns = Array.from(runs.entries())
+      .filter(([id, data]) => Boolean(id && data && data.title))
+      .sort(([, a], [, b]) => (b?.updatedAt || 0) - (a?.updatedAt || 0));
+
+    runList.innerHTML = '';
+
+    if (validRuns.length === 0) {
+      historyStatus.textContent = 'No runs saved yet.';
+      return;
+    }
+
+    historyStatus.textContent = '';
+
+    validRuns.forEach(([id, data]) => {
+      const item = document.createElement('li');
+      const title = document.createElement('strong');
+      title.textContent = data.title || 'Untitled run';
+
+      const meta = document.createElement('p');
+      meta.className = 'meta';
+      meta.textContent = `${formatDate(data.updatedAt || Date.now())} · ${data.goal || 'Goal pending'}`;
+
+      const prompt = document.createElement('p');
+      prompt.textContent = data.prompt || 'No prompt captured yet.';
+
+      const badges = document.createElement('p');
+      badges.className = 'meta';
+      const shareText = data.shareStatus ? 'Shared' : 'Private';
+      const mockText = data.needsMocks ? 'Mocks on' : 'Live data';
+      const traceText = data.traceSteps ? 'Replays tracked' : 'Replays off';
+      badges.textContent = `${shareText} · ${mockText} · ${traceText}`;
+
+      item.appendChild(title);
+      item.appendChild(meta);
+      item.appendChild(prompt);
+      item.appendChild(badges);
+      runList.appendChild(item);
+    });
+  }
+
+  function saveRun(event) {
+    event.preventDefault();
+    if (!runForm || !labRoot) return;
+
+    const title = runForm.runTitle.value.trim() || 'Untitled run';
+    const goal = runForm.runGoal.value.trim();
+    const prompt = runForm.runPrompt.value.trim();
+    const shareStatus = runForm.shareStatus.checked;
+    const needsMocks = runForm.needsMocks.checked;
+    const traceSteps = runForm.traceSteps.checked;
+
+    const runId = `run-${Date.now()}`;
+    const payload = {
+      title,
+      goal,
+      prompt,
+      shareStatus,
+      needsMocks,
+      traceSteps,
+      updatedAt: Date.now()
+    };
+
+    formStatus.textContent = 'Saving to Gun...';
+    labRoot.get(runId).put(payload, (ack) => {
+      if (ack?.err) {
+        formStatus.textContent = `Save failed: ${ack.err}`;
+        return;
+      }
+      formStatus.textContent = 'Saved. Reload the Workbench or Builder to continue.';
+      runs.set(runId, payload);
+      renderRuns();
+    });
+  }
+
+  function resetFormFields() {
+    runForm.reset();
+    formStatus.textContent = '';
+  }
+
+  if (runForm) {
+    runForm.addEventListener('submit', saveRun);
+  }
+
+  if (resetButton) {
+    resetButton.addEventListener('click', resetFormFields);
+  }
+
+  labRoot.map().on((data, id) => {
+    if (!data || typeof data !== 'object' || !id) return;
+    runs.set(id, data);
+    renderRuns();
+  });
+
+  syncKeyStatus();
+})();

--- a/workbench-dev-lab/index.html
+++ b/workbench-dev-lab/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Workbench Dev Lab</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+</head>
+<body class="lab-shell">
+  <div class="top-buttons">
+    <a href="../index.html">🏠 Portal</a>
+    <a href="../openai-app/">🤖 Workbench</a>
+    <a href="../workbench-site-builder/">🏗️ Site Builder</a>
+    <a href="../notes/">📝 Shared Notes</a>
+  </div>
+
+  <header class="lab-header">
+    <p class="eyebrow">Rapid experiments</p>
+    <h1>Workbench Dev Lab</h1>
+    <p class="lede">
+      Prototype prompts, site templates, and QA checklists side-by-side. Everything stays simple so you can swap between
+      Workbench chats and the Site Builder without losing your place.
+    </p>
+    <div class="status-row" id="keyStatus" aria-live="polite"></div>
+  </header>
+
+  <main class="lab-grid">
+    <section class="card" aria-label="Set up a run">
+      <header>
+        <p class="eyebrow">Plan</p>
+        <h2>Set up a run</h2>
+        <p class="meta">Capture the essentials before you hop into the Workbench or Builder.</p>
+      </header>
+      <form id="runForm" class="form-grid">
+        <label for="runTitle">Run title</label>
+        <input id="runTitle" name="runTitle" type="text" placeholder="e.g., Builder QA flow for onboarding">
+
+        <label for="runGoal">Outcome to validate</label>
+        <input id="runGoal" name="runGoal" type="text" placeholder="Generate a stable landing page + publishable copy">
+
+        <label for="runPrompt">Prompt or context</label>
+        <textarea
+          id="runPrompt"
+          name="runPrompt"
+          rows="3"
+          placeholder="Paste a Workbench prompt or builder note"
+        ></textarea>
+
+        <div class="input-row">
+          <label class="checkbox">
+            <input type="checkbox" id="needsMocks" name="needsMocks">
+            <span>Use mock data</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" id="shareStatus" name="shareStatus" checked>
+            <span>Share with teammates in Gun</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" id="traceSteps" name="traceSteps" checked>
+            <span>Track steps for replays</span>
+          </label>
+        </div>
+
+        <div class="input-row">
+          <button type="submit" class="primary">Save to lab</button>
+          <button type="button" id="resetForm" class="ghost">Reset</button>
+        </div>
+        <p class="status" id="formStatus" aria-live="polite"></p>
+      </form>
+    </section>
+
+    <section class="card" aria-label="Checklist and shortcuts">
+      <header>
+        <p class="eyebrow">Flow</p>
+        <h2>Checklist</h2>
+        <p class="meta">Stay oriented and jump where you need to.</p>
+      </header>
+      <ul class="checklist">
+        <li>
+          <span class="dot" aria-hidden="true"></span>
+          Open the <a href="../openai-app/">Workbench</a> with your saved API key.
+        </li>
+        <li>
+          <span class="dot" aria-hidden="true"></span>
+          If you need a page, hop to the <a href="../workbench-site-builder/">Site Builder</a> and reuse the same key.
+        </li>
+        <li>
+          <span class="dot" aria-hidden="true"></span>
+          Paste generated HTML back here to compare runs or hand off to teammates.
+        </li>
+        <li>
+          <span class="dot" aria-hidden="true"></span>
+          Mark mock data and replay traces so QA knows what to expect.
+        </li>
+      </ul>
+    </section>
+
+    <section class="card" aria-label="Recent lab runs">
+      <header>
+        <p class="eyebrow">History</p>
+        <h2>Recent runs</h2>
+        <p class="meta">Shared to Gun at <code>3dvr-portal/workbench-dev-lab</code>. Newest first.</p>
+      </header>
+      <ul id="runList" class="history"></ul>
+      <p class="meta" id="historyStatus" aria-live="polite">No runs saved yet.</p>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/workbench-dev-lab/styles.css
+++ b/workbench-dev-lab/styles.css
@@ -1,0 +1,194 @@
+body.lab-shell {
+  background: radial-gradient(circle at 10% 20%, rgba(87, 122, 255, 0.1), transparent 20%),
+    radial-gradient(circle at 90% 10%, rgba(124, 255, 216, 0.08), transparent 25%),
+    #05070d;
+  color: #e8ecf8;
+  min-height: 100vh;
+  padding: 16px;
+}
+
+.top-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.top-buttons a {
+  color: #e8ecf8;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 8px 10px;
+  border-radius: 10px;
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+.top-buttons a:hover,
+.top-buttons a:focus {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.lab-header {
+  max-width: 960px;
+  margin: 0 auto 20px;
+  text-align: center;
+}
+
+.lab-header h1 {
+  margin: 8px 0 12px;
+}
+
+.status-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #bcd3ff;
+}
+
+.status-row[data-state="ready"] {
+  color: #d6fff2;
+  background: rgba(108, 243, 232, 0.1);
+}
+
+.status-row[data-state="missing"] {
+  color: #ffd6d6;
+  background: rgba(255, 120, 120, 0.08);
+}
+
+.lab-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.card {
+  background: rgba(15, 21, 34, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+.card header {
+  margin-bottom: 12px;
+}
+
+.card .meta {
+  color: #9fb4d9;
+}
+
+.form-grid {
+  display: grid;
+  gap: 10px;
+}
+
+textarea,
+input[type="text"] {
+  background: rgba(255, 255, 255, 0.04);
+  color: #e8ecf8;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.input-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #dfe7ff;
+}
+
+.primary {
+  background: linear-gradient(135deg, #5f8bff, #6cf3e8);
+  color: #05070d;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ghost {
+  background: transparent;
+  color: #e8ecf8;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.status {
+  margin-top: 4px;
+  color: #bcd3ff;
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.checklist li {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 10px 12px;
+  border-radius: 10px;
+}
+
+.checklist a {
+  color: #c2e4ff;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  background: #6cf3e8;
+  border-radius: 50%;
+  box-shadow: 0 0 8px #6cf3e8;
+}
+
+.history {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.history li {
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.history strong {
+  display: block;
+  color: #e8ecf8;
+}
+
+.history .meta {
+  color: #9fb4d9;
+}
+
+@media (min-width: 900px) {
+  .lab-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- add a Workbench Dev Lab page that reuses Workbench/Site Builder keys and saves shared runs to Gun
- style the lab for quick planning, checklists, and history with clear status cues
- expose the lab from the main portal grid with an alphabetized card

## Testing
- npm test (fails: playwright browsers unavailable; finance form expectation not met)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1c7e0d088320b9d9c6ae94797f77)