### PR TITLE
Move shared transcript section below publishing tools

### DIFF
--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -100,17 +100,6 @@
       </section>
     </section>
 
-    <section class="card" id="history-panel" aria-label="Shared transcript">
-      <div class="card-header">
-        <div>
-          <p class="eyebrow">Reuse</p>
-          <h2>Shared transcript</h2>
-          <p class="meta">Entries are stored at <code>ai/workbench/&lt;sessionId&gt;</code> in Gun so teammates can find successful prompts.</p>
-        </div>
-      </div>
-      <ul id="history"></ul>
-    </section>
-
     <section class="grid">
       <section class="card" id="vercel-panel" aria-label="Vercel deployment">
         <div class="card-header">
@@ -275,6 +264,17 @@
         </div>
         <ul id="github-history"></ul>
       </section>
+    </section>
+
+    <section class="card" id="history-panel" aria-label="Shared transcript">
+      <div class="card-header">
+        <div>
+          <p class="eyebrow">Reuse</p>
+          <h2>Shared transcript</h2>
+          <p class="meta">Entries are stored at <code>ai/workbench/&lt;sessionId&gt;</code> in Gun so teammates can find successful prompts.</p>
+        </div>
+      </div>
+      <ul id="history"></ul>
     </section>
 
     <section class="card" id="vault-panel" aria-label="Gun key vault">


### PR DESCRIPTION
## Summary
- move the shared transcript card beneath the deployment and GitHub panels to reduce its prominence

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f8bb32bb883208b4ebb20d5a69fb4)