### PR TITLE
Add troubleshooting guidance for GitHub PAT errors

### DIFF
--- a/deployment-guides/github-token.html
+++ b/deployment-guides/github-token.html
@@ -42,6 +42,26 @@
     </section>
 
     <section class="guide-section">
+      <h2>Troubleshooting “Resource not accessible by personal access token”</h2>
+      <p class="guide-description">
+        GitHub shows this when the token cannot reach the repository. Fix it with the checklist below:
+      </p>
+      <ul class="guide-list">
+        <li>Use a token that targets the correct owner: fine-grained for the org/repo, or classic with the
+          <span class="inline-code">repo</span> scope (and <span class="inline-code">workflow</span> if Actions are used).</li>
+        <li>For fine-grained tokens, set the resource owner to the organization and grant
+          <strong>Contents: Read and write</strong> plus <strong>Metadata: Read-only</strong>. Add explicit repo access if not using
+          “All repositories.”</li>
+        <li>If the org enforces SSO, authorize the token under <strong>Organization → Settings → Personal access tokens</strong>
+          after creating it.</li>
+        <li>Ensure the user account has permission to read/write the repo (or create it) and that stored tokens in CI or the
+          Workbench have been refreshed.</li>
+      </ul>
+      <p class="guide-description">Once updated, retry the API call or publish step — the error should clear when scopes and
+        org access match the repository.</p>
+    </section>
+
+    <section class="guide-section">
       <h2>Use it in OpenAI Workbench</h2>
       <p class="guide-description">
         Jump to the <a href="/openai-app/index.html" target="_blank" rel="noopener">OpenAI Workbench</a> to paste

--- a/openai-app/app.js
+++ b/openai-app/app.js
@@ -1251,7 +1251,14 @@ async function publishToGithub() {
 
     setGithubStatus(data.htmlUrl ? `Committed to ${data.htmlUrl}` : 'Commit created.');
   } catch (error) {
-    setGithubStatus(`Error: ${error.message}`);
+    const details = error?.message || 'GitHub request failed.';
+    const lowerDetails = details.toLowerCase();
+    if (lowerDetails.includes('resource not accessible by personal access token')) {
+      setGithubStatus('Error: Resource not accessible by personal access token. Confirm repo access, contents scope, '
+        + 'and SSO authorization.');
+      return;
+    }
+    setGithubStatus(`Error: ${details}`);
   } finally {
     githubBtn.disabled = false;
   }

--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -163,6 +163,9 @@
           <button id="clear-github" class="ghost">Clear</button>
         </div>
         <p id="github-help" class="meta">Token stays in localStorage; commits use the GitHub contents API. <a href="../deployment-guides/index.html" target="_blank" rel="noreferrer">Open the guide</a> for PAT scopes.</p>
+        <p class="meta">Seeing “Resource not accessible by personal access token”? Confirm the token targets the right owner, has
+          read/write contents scope, and is SSO-authorized in your org. The <a href="../deployment-guides/github-token.html" target="_blank" rel="noreferrer">GitHub token guide</a>
+          lists the full checklist.</p>
 
         <div class="github-create">
           <div class="github-create-header">


### PR DESCRIPTION
## Summary
- add a troubleshooting checklist for "Resource not accessible by personal access token" to the GitHub token guide
- surface PAT access guidance in the OpenAI Workbench GitHub card
- show a targeted status hint when GitHub publishing fails with the PAT access error

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404e04ee208320b1e76faea7f2abef)