### PR TITLE
Document GitHub admin permission for Workbench repo creation

### DIFF
--- a/deployment-guides/create-repo.html
+++ b/deployment-guides/create-repo.html
@@ -26,6 +26,8 @@
         <li>For personal repos, use a classic token with <span class="inline-code">repo</span> (or
           <span class="inline-code">public_repo</span> for public only) scope, or a fine-grained token that allows
           repository creation.</li>
+        <li>When using a fine-grained token, enable <strong>Administration: Read and write</strong> so the Workbench can
+          create repositories through the GitHub API.</li>
         <li>For organization repos, grant the token access to the org and enable <strong>Repository creation</strong>
           permissions.</li>
         <li>Keep the token handy — we only use it in this tab and never persist or log it.</li>

--- a/deployment-guides/github-token.html
+++ b/deployment-guides/github-token.html
@@ -25,6 +25,8 @@
         <li>Open <strong>GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens</strong>.</li>
         <li>Select <strong>Generate new token</strong> and scope it to this repository.</li>
         <li>Under <strong>Repository permissions</strong>, grant at least <strong>Contents: Read</strong> and <strong>Actions: Write</strong>.</li>
+        <li>If you plan to create repositories from the OpenAI Workbench, also enable <strong>Administration: Read and write</strong>
+          so GitHub accepts repository creation requests.</li>
         <li>Name the token (for example <span class="inline-code">3dvr-portal-ci</span>), set an expiration, and generate it.</li>
         <li>Copy the token and store it as a repository secret such as <span class="inline-code">GH_PAT</span> if
           you need more than the default <span class="inline-code">GITHUB_TOKEN</span> provides.


### PR DESCRIPTION
## Summary
- note the Administration: Read and write permission required for creating repos via the OpenAI Workbench
- update the GitHub token guide with the same instruction for fine-grained tokens

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940e8908cd8832099b4dea80691636b)