### PR TITLE
Add bulk vault save and load controls

### DIFF
--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -343,8 +343,13 @@
       </div>
 
       <div class="input-row">
-        <button id="vault-save" class="primary">Save secret to Gun</button>
-        <button id="vault-load" class="ghost">Load secret from Gun</button>
+        <button id="vault-save" class="primary">Save selected secret</button>
+        <button id="vault-save-all" class="ghost">Save all secrets</button>
+      </div>
+
+      <div class="input-row">
+        <button id="vault-load" class="ghost">Load selected secret</button>
+        <button id="vault-load-all" class="ghost">Load all secrets</button>
       </div>
 
       <div class="auto-sync-row">

--- a/openai-app/styles.css
+++ b/openai-app/styles.css
@@ -125,6 +125,7 @@ label {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .auto-sync-row {


### PR DESCRIPTION
## Summary
- allow the vault to merge per-target secrets instead of overwriting, with new save-all and load-all actions
- apply loaded secrets to all matching inputs/storage and refresh usage tracking
- wrap vault action rows for better mobile handling

## Testing
- npm test *(fails: missing Playwright browser binaries and existing finance test assertion)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418d4027f08320aacc2f42e21b71d6)