### PR TITLE
Add release notes for v0.0.31

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -83,8 +83,9 @@
       <a class="release-link" href="v0.0.31.html">v0.0.31</a>
       <span class="release-meta">Week of December 22, 2025</span>
         <p class="release-summary">
-          Ideas Lab landing experiments with browser-local stats, a projects directory, and rate-limited shared
-          defaults for AI builders
+          <a href="../ideas/index.html">Ideas Lab</a> landing experiments with browser-local stats, a
+          <a href="../projects/index.html">projects directory</a>, and rate-limited shared defaults for
+          <a href="../openai-app/index.html">AI builders</a>
         </p>
     </article>
   </div>
@@ -95,8 +96,9 @@
         <a class="release-link" href="v0.0.31.html">v0.0.31</a>
         <span class="release-meta">Week of December 22, 2025</span>
         <p class="release-summary">
-          Ideas Lab landing experiments with browser-local stats, a projects directory, and rate-limited shared
-          defaults for AI builders
+          <a href="../ideas/index.html">Ideas Lab</a> landing experiments with browser-local stats, a
+          <a href="../projects/index.html">projects directory</a>, and rate-limited shared defaults for
+          <a href="../openai-app/index.html">AI builders</a>
         </p>
       </li>
       <li class="release-card">

--- a/releases/v0.0.31.html
+++ b/releases/v0.0.31.html
@@ -84,8 +84,10 @@
   <div class="section">
     <h2>Overview</h2>
     <p>
-      Ideas Lab launches with trackable experiments, the portal gains a project directory for active explorations, and
-      shared defaults across the AI builders pick up clearer vault imports plus rate limits for default keys.
+      The new <a href="../ideas/index.html">Ideas Lab</a> launches with trackable experiments, the portal gains a
+      <a href="../projects/index.html">project directory</a> for active explorations, and shared defaults across the
+      <a href="../openai-app/index.html">AI builders</a> pick up clearer vault imports plus rate limits for
+      default keys.
     </p>
   </div>
 
@@ -105,22 +107,24 @@
   <div class="section">
     <h2>Ideas Lab experiments</h2>
     <ul>
-      <li>Launch an Ideas Lab dashboard with per-card stats for page views, CTA clicks, last-seen timestamps, and a
-      manual reset that stores data in localStorage per landing page.</li>
-      <li>Add three idea landers—Websites, Systems, and Tech Support—with prefilled mailto CTAs that include the idea
-      name and URL while logging CTA clicks per visitor.</li>
-      <li>Keep portal navigation close at hand so visitors can hop back home or review other experiments without losing
-      their local stats.</li>
+      <li>Launch an <a href="../ideas/index.html">Ideas Lab dashboard</a> with per-card stats for page views, CTA
+      clicks, last-seen timestamps, and a manual reset that stores data in localStorage per landing page.</li>
+      <li>Add three idea landers—<a href="../ideas/websites.html">Websites</a>,
+      <a href="../ideas/systems.html">Systems</a>, and <a href="../ideas/support.html">Tech Support</a>—with
+      prefilled mailto CTAs that include the idea name and URL while logging CTA clicks per visitor.</li>
+      <li>Keep portal navigation close at hand so visitors can hop back to <a href="../index.html">home</a> or review
+      other experiments without losing their local stats.</li>
     </ul>
   </div>
 
   <div class="section">
     <h2>Project directory &amp; navigation</h2>
     <ul>
-      <li>Introduce a Projects directory that highlights the wearable input kit exploration, spells out the GunJS data
-      paths for concepts and handoff artifacts, and links to shared notes and tasks.</li>
-      <li>Surface new Projects and Ideas Lab entry points on the portal home so contributors can find experiments and
-      explorations alongside existing tools.</li>
+      <li>Introduce a <a href="../projects/index.html">Projects directory</a> that highlights the wearable input kit
+      exploration, spells out the GunJS data paths for concepts and handoff artifacts, and links to shared notes and
+      tasks.</li>
+      <li>Surface new Projects and Ideas Lab entry points on the <a href="../index.html">portal home</a> so
+      contributors can find experiments and explorations alongside existing tools.</li>
       <li>Retain dark-theme readability with mobile-friendly grids and skip links that jump directly to project
       content.</li>
     </ul>
@@ -133,8 +137,8 @@
       generating or publishing sites, with Gun-backed counters that reset daily.</li>
       <li>Harden OpenAI Workbench defaults by aligning cipher fields for OpenAI, Vercel, and GitHub tokens so shared
       keys unlock reliably across vault imports and passphrase hints.</li>
-      <li>Let admins import their saved workbench secrets—or vault backups when needed—directly into the shared defaults
-      form before re-encrypting them for the team.</li>
+      <li>Let <a href="../admin/index.html">admins</a> import their saved workbench secrets—or vault backups when
+      needed—directly into the shared defaults form before re-encrypting them for the team.</li>
     </ul>
   </div>
 


### PR DESCRIPTION
## Summary
- add release page for v0.0.31 covering Ideas Lab experiments, projects directory, and AI builder guardrails
- update release hub to feature v0.0.31 as the latest weekly milestone

## Testing
- not run (not needed for release copy)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69430dc37bd48320b266f35a5168b63c)