### PR TITLE
Add SEO / Visibility Plan workspace and home app card

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
         <a href="free-trial.html" target="_blank" rel="noopener">🎁 Free Plan</a>
         <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">🚀 Contribute on GitHub</a>
         <a href="share.html">Share via QR Code</a>
+        <a href="/seo/">SEO Plan</a>
       </nav>
     </div>
 
@@ -269,6 +270,11 @@
             <span class="app-card__icon" aria-hidden="true">🧪</span>
             <span class="app-card__title">Science Lab</span>
             <span class="app-card__meta">Run experiments, track signals, and publish VR-ready findings.</span>
+          </a>
+          <a href="/seo/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🧭</span>
+            <span class="app-card__title">SEO Plan</span>
+            <span class="app-card__meta">Track visibility rules, indexing strategy, and progress updates.</span>
           </a>
           <a href="score-rewards/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🎯</span>

--- a/seo/index.html
+++ b/seo/index.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SEO / Visibility Plan | 3DVR Portal</title>
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="/seo/seo.css">
+</head>
+<body class="seo-page">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+  <nav class="nav" aria-label="SEO plan navigation">
+    <a href="/index.html">← Portal Home</a>
+    <a href="/seo/">SEO / Visibility Plan</a>
+  </nav>
+
+  <main id="mainContent" class="page">
+    <header class="page-header">
+      <p class="eyebrow">Public Workspace</p>
+      <h1>SEO / Visibility Plan</h1>
+      <p class="lead">
+        Track how the portal will support public discovery while keeping unlisted and private content protected. This page
+        is safe to publish and acts as the shared plan + tracker hub.
+      </p>
+    </header>
+
+    <section class="section" aria-labelledby="status-title">
+      <div class="section-header">
+        <h2 id="status-title">Implementation checklist</h2>
+        <p class="section-subtitle">Status labels align with Not started, In progress, and Done.</p>
+      </div>
+      <div class="table-wrap" role="region" aria-live="polite" aria-label="SEO plan status table">
+        <table class="status-table">
+          <thead>
+            <tr>
+              <th scope="col">Task</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody data-task-table></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="visibility-title">
+      <h2 id="visibility-title">A) Visibility system</h2>
+      <p class="section-intro">
+        Portal content uses a clear visibility flag so the UI, search engines, and snapshotting logic can agree on what
+        is safe to show.
+      </p>
+      <div class="grid">
+        <div class="card">
+          <h3>Definitions</h3>
+          <ul>
+            <li><strong>Public</strong>: discoverable, listed, and indexable.</li>
+            <li><strong>Unlisted</strong>: accessible by direct link, but hidden from listings and search.</li>
+            <li><strong>Private</strong>: requires auth or membership checks before any content is rendered.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Policy engine outputs</h3>
+          <ul>
+            <li><code>canView</code>: viewer has read access.</li>
+            <li><code>canEdit</code>: viewer can edit or moderate.</li>
+            <li><code>canList</code>: show in portal listings or feeds.</li>
+            <li><code>shouldIndex</code>: allow search engine indexing.</li>
+            <li><code>shouldSnapshot</code>: generate HTML snapshot for bots.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="card">
+        <h3>Default rules by content type</h3>
+        <div class="table-wrap" role="region" aria-label="Default visibility rules">
+          <table class="status-table">
+            <thead>
+              <tr>
+                <th scope="col">Content type</th>
+                <th scope="col">Default visibility</th>
+                <th scope="col">Listing behavior</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Notes</td>
+                <td>Private</td>
+                <td>Visible to the author and invited teammates only.</td>
+              </tr>
+              <tr>
+                <td>Discussions</td>
+                <td>Public</td>
+                <td>Public discussions appear in the public index; unlisted threads stay hidden.</td>
+              </tr>
+              <tr>
+                <td>Dashboards</td>
+                <td>Unlisted</td>
+                <td>Direct-link access for shared dashboards, no global listings.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="indexing-title">
+      <h2 id="indexing-title">B) Indexing strategy</h2>
+      <p class="section-intro">Indexing treats public pages like documents, not databases.</p>
+      <div class="grid">
+        <div class="card">
+          <h3>Documents, not databases</h3>
+          <p>
+            Public pages ship as stable HTML snapshots so crawlers see a cohesive document. GunJS then hydrates the live
+            session for humans.
+          </p>
+        </div>
+        <div class="card">
+          <h3>HTML-first + hydration</h3>
+          <ul>
+            <li>Generate HTML snapshots for public routes.</li>
+            <li>Serve snapshots to bots and to first-time visitors.</li>
+            <li>Hydrate with GunJS data after load to keep the UI live.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Snapshot storage options</h3>
+          <ul>
+            <li>Vercel Blob for immutable HTML snapshots.</li>
+            <li>Vercel KV / Redis for cached HTML strings.</li>
+            <li>Static object storage (S3-compatible) for backup snapshots.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="seo-controls-title">
+      <h2 id="seo-controls-title">C) SEO controls</h2>
+      <div class="grid">
+        <div class="card">
+          <h3>Meta robots rules</h3>
+          <ul>
+            <li><strong>Public</strong>: <code>index,follow</code></li>
+            <li><strong>Unlisted</strong>: <code>noindex,nofollow</code></li>
+            <li><strong>Private</strong>: <code>noindex,nofollow</code> + auth gate</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Sitemap rules</h3>
+          <p>Only public routes appear in <code>sitemap.xml</code>. Unlisted and private content never appears.</p>
+        </div>
+        <div class="card">
+          <h3>robots.txt rules</h3>
+          <p>Disallow private and unlisted sections to keep crawlers away from gated paths.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="implementation-title">
+      <h2 id="implementation-title">D) Implementation plan</h2>
+      <div class="timeline">
+        <div class="timeline-step">
+          <h3>Phase 1: Visibility flags + noindex</h3>
+          <p>Introduce the visibility field, policy helper, and meta robots rules.</p>
+        </div>
+        <div class="timeline-step">
+          <h3>Phase 2: Snapshots</h3>
+          <p>Generate HTML snapshots for public pages and hydrate with GunJS on load.</p>
+        </div>
+        <div class="timeline-step">
+          <h3>Phase 3: Sitemap + robots</h3>
+          <p>Publish <code>sitemap.xml</code> and <code>robots.txt</code> for public-only content.</p>
+        </div>
+        <div class="timeline-step">
+          <h3>Phase 4: Analytics</h3>
+          <p>Track public discovery without adding external analytics scripts.</p>
+        </div>
+      </div>
+      <div class="card">
+        <h3>Definition of done</h3>
+        <ul>
+          <li>Visibility flags exist on every content type.</li>
+          <li>Policy helper drives UI gating and indexability decisions.</li>
+          <li>Public routes ship HTML snapshots and hydrate with GunJS.</li>
+          <li>Sitemaps include public routes only.</li>
+          <li>Private/unlisted routes are blocked from indexing.</li>
+          <li>Public pages include canonical URLs and OpenGraph tags.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="progress-title">
+      <div class="section-header">
+        <h2 id="progress-title">Progress tracker</h2>
+        <p class="section-subtitle">Checklist progress is stored in your browser only.</p>
+      </div>
+      <div class="progress-meta">
+        <div class="progress-summary" aria-live="polite">
+          <span data-progress-count>0</span> of <span data-progress-total>0</span> tasks completed
+        </div>
+        <div class="progress-actions">
+          <button type="button" class="ghost" data-export-progress>Export JSON</button>
+          <label class="ghost file-label" for="progressImport">Import JSON</label>
+          <input type="file" id="progressImport" accept="application/json" class="file-input" data-import-progress>
+        </div>
+      </div>
+      <ul class="checklist" data-progress-list></ul>
+      <p class="meta">Storage key: <code>portal_seo_plan_progress_v1</code></p>
+    </section>
+  </main>
+
+  <footer class="footer">3DVR.Tech – SEO / Visibility Plan</footer>
+  <script src="/seo/seo.js"></script>
+</body>
+</html>

--- a/seo/seo.css
+++ b/seo/seo.css
@@ -1,0 +1,232 @@
+:root {
+  color-scheme: light dark;
+}
+
+.seo-page {
+  background: #0f141b;
+  color: #e9eef5;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+.seo-page .nav {
+  display: flex;
+  gap: 1rem;
+  padding: 1.5rem 1.5rem 0;
+  font-size: 0.95rem;
+}
+
+.seo-page .nav a {
+  color: inherit;
+  text-decoration: none;
+  opacity: 0.8;
+}
+
+.seo-page .nav a:hover,
+.seo-page .nav a:focus {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.page-header {
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: #9fb3c8;
+}
+
+.lead {
+  font-size: 1.05rem;
+  max-width: 720px;
+}
+
+.section {
+  margin-bottom: 2.5rem;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.section-subtitle,
+.section-intro {
+  color: #c3d1e3;
+  margin: 0;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: #141b24;
+  border: 1px solid #223043;
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border-radius: 12px;
+  border: 1px solid #223043;
+  background: #121821;
+}
+
+.status-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+.status-table th,
+.status-table td {
+  text-align: left;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #223043;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.status-pill--not-started {
+  background: rgba(237, 189, 77, 0.15);
+  color: #f6d68a;
+}
+
+.status-pill--in-progress {
+  background: rgba(82, 171, 252, 0.15);
+  color: #98c8ff;
+}
+
+.status-pill--done {
+  background: rgba(87, 212, 139, 0.15);
+  color: #98f0c0;
+}
+
+.timeline {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.timeline-step {
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid #223043;
+  background: #121821;
+}
+
+.progress-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.progress-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ghost {
+  background: transparent;
+  color: inherit;
+  border: 1px solid #3a4b63;
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.ghost:focus,
+.ghost:hover {
+  border-color: #6f86a6;
+}
+
+.file-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.file-label {
+  cursor: pointer;
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.checklist li {
+  background: #141b24;
+  border: 1px solid #223043;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.checklist input[type="checkbox"] {
+  margin-top: 0.2rem;
+  width: 1rem;
+  height: 1rem;
+}
+
+.meta {
+  color: #9fb3c8;
+  font-size: 0.85rem;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1.5rem 2.5rem;
+  color: #9fb3c8;
+}
+
+@media (min-width: 760px) {
+  .grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  .progress-meta {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    scroll-behavior: auto;
+  }
+}

--- a/seo/seo.js
+++ b/seo/seo.js
@@ -1,0 +1,236 @@
+const STORAGE_KEY = 'portal_seo_plan_progress_v1';
+
+const tasks = [
+  {
+    id: 'visibility-field',
+    label: 'Add visibility field to content objects (public/unlisted/private)',
+    status: 'Not started'
+  },
+  {
+    id: 'policy-helper',
+    label: 'Add policy helper: getPolicy(viewer, doc)',
+    status: 'Not started'
+  },
+  {
+    id: 'public-routes',
+    label: 'Public routes: ensure index,follow + included in sitemap',
+    status: 'Not started'
+  },
+  {
+    id: 'unlisted-routes',
+    label: 'Unlisted routes: noindex,nofollow + not in sitemap',
+    status: 'Not started'
+  },
+  {
+    id: 'private-routes',
+    label: 'Private routes: auth-gated + noindex + disallowed in robots.txt',
+    status: 'Not started'
+  },
+  {
+    id: 'robots-txt',
+    label: 'Add robots.txt',
+    status: 'Not started'
+  },
+  {
+    id: 'sitemap-xml',
+    label: 'Add sitemap.xml (public only)',
+    status: 'Not started'
+  },
+  {
+    id: 'snapshot-endpoint',
+    label: 'Add snapshot endpoint (generate HTML for public pages)',
+    status: 'Not started'
+  },
+  {
+    id: 'snapshot-storage',
+    label: 'Add snapshot storage (Blob/KV)',
+    status: 'Not started'
+  },
+  {
+    id: 'discussion-index',
+    label: 'Add discuss index page that lists public threads',
+    status: 'Not started'
+  },
+  {
+    id: 'canonical-urls',
+    label: 'Add canonical URLs & slugs for public content',
+    status: 'Not started'
+  },
+  {
+    id: 'opengraph-tags',
+    label: 'Add OpenGraph tags for public pages',
+    status: 'Not started'
+  },
+  {
+    id: 'publish-action',
+    label: 'Add “Publish” action that triggers snapshot',
+    status: 'Not started'
+  }
+];
+
+const defaultProgress = tasks.reduce((acc, task) => {
+  acc[task.id] = false;
+  return acc;
+}, {});
+
+function loadProgress() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) {
+    return { ...defaultProgress };
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    const items = parsed && typeof parsed === 'object' ? parsed.items : null;
+    return {
+      ...defaultProgress,
+      ...(items && typeof items === 'object' ? items : {})
+    };
+  } catch (error) {
+    console.warn('Unable to parse progress data', error);
+    return { ...defaultProgress };
+  }
+}
+
+function saveProgress(items) {
+  const payload = {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    items
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+function statusClass(status) {
+  if (status === 'Done') return 'status-pill status-pill--done';
+  if (status === 'In progress') return 'status-pill status-pill--in-progress';
+  return 'status-pill status-pill--not-started';
+}
+
+function renderTable(progress) {
+  const tableBody = document.querySelector('[data-task-table]');
+  if (!tableBody) return;
+  tableBody.innerHTML = '';
+
+  tasks.forEach(task => {
+    const row = document.createElement('tr');
+    const taskCell = document.createElement('td');
+    const statusCell = document.createElement('td');
+
+    taskCell.textContent = task.label;
+    const statusValue = progress[task.id] ? 'Done' : task.status;
+    const statusSpan = document.createElement('span');
+    statusSpan.className = statusClass(statusValue);
+    statusSpan.textContent = statusValue;
+    statusSpan.dataset.statusId = task.id;
+    statusCell.appendChild(statusSpan);
+
+    row.appendChild(taskCell);
+    row.appendChild(statusCell);
+    tableBody.appendChild(row);
+  });
+}
+
+function updateProgressSummary(progress) {
+  const countEl = document.querySelector('[data-progress-count]');
+  const totalEl = document.querySelector('[data-progress-total]');
+  const total = tasks.length;
+  const completed = tasks.reduce((sum, task) => sum + (progress[task.id] ? 1 : 0), 0);
+
+  if (countEl) countEl.textContent = completed;
+  if (totalEl) totalEl.textContent = total;
+}
+
+function renderChecklist(progress) {
+  const list = document.querySelector('[data-progress-list]');
+  if (!list) return;
+  list.innerHTML = '';
+
+  tasks.forEach(task => {
+    const item = document.createElement('li');
+    const checkbox = document.createElement('input');
+    const label = document.createElement('label');
+
+    checkbox.type = 'checkbox';
+    checkbox.id = `progress-${task.id}`;
+    checkbox.checked = Boolean(progress[task.id]);
+    checkbox.addEventListener('change', () => {
+      progress[task.id] = checkbox.checked;
+      saveProgress(progress);
+      updateProgressSummary(progress);
+      renderTable(progress);
+    });
+
+    label.setAttribute('for', checkbox.id);
+    label.textContent = task.label;
+
+    item.appendChild(checkbox);
+    item.appendChild(label);
+    list.appendChild(item);
+  });
+}
+
+function handleExport(progress) {
+  const payload = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    items: progress
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'seo-plan-progress.json';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function handleImport(file, progress) {
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = event => {
+    try {
+      const parsed = JSON.parse(event.target.result);
+      const items = parsed && typeof parsed === 'object' ? parsed.items : null;
+      if (!items || typeof items !== 'object') {
+        throw new Error('Missing items');
+      }
+      tasks.forEach(task => {
+        if (typeof items[task.id] === 'boolean') {
+          progress[task.id] = items[task.id];
+        }
+      });
+      saveProgress(progress);
+      updateProgressSummary(progress);
+      renderChecklist(progress);
+      renderTable(progress);
+    } catch (error) {
+      console.warn('Unable to import progress file', error);
+    }
+  };
+  reader.readAsText(file);
+}
+
+function initProgressTracker() {
+  const progress = loadProgress();
+  renderTable(progress);
+  renderChecklist(progress);
+  updateProgressSummary(progress);
+
+  const exportButton = document.querySelector('[data-export-progress]');
+  if (exportButton) {
+    exportButton.addEventListener('click', () => handleExport(progress));
+  }
+
+  const importInput = document.querySelector('[data-import-progress]');
+  if (importInput) {
+    importInput.addEventListener('change', event => {
+      const file = event.target.files && event.target.files[0];
+      handleImport(file, progress);
+      event.target.value = '';
+    });
+  }
+}
+
+window.addEventListener('DOMContentLoaded', initProgressTracker);


### PR DESCRIPTION
### Motivation
- Provide a safe-to-publish, human-readable plan and tracker for implementing public / unlisted / private visibility and an HTML-first indexing approach.
- Keep changes minimal and consistent with the existing static site structure and styling without adding new frameworks or external services.
- Give maintainers a lightweight, browser-local progress checklist to track implementation steps and move it between devices.

### Description
- Add a new workspace at `seo/index.html` documenting the visibility system, indexing strategy, SEO controls, implementation plan, and definition-of-done.
- Add supporting assets `seo/seo.css` (accessible, mobile-first styles; `prefers-reduced-motion` respected) and `seo/seo.js` (local progress tracker using key `portal_seo_plan_progress_v1` with export/import JSON).
- Add an `SEO Plan` link to the top nav in `index.html` and an `SEO Plan` app card in the home app grid (inserted alphabetically in the grid).
- Ensure no external network calls or analytics were introduced and the tracker persists only to `localStorage` and supports JSON export/import.

### Testing
- Launched a local static server with `python -m http.server 8000` and confirmed the page loads at `/seo/` (server ran successfully).
- Captured screenshots via Playwright for the `/seo/` page and the updated home page to verify layout and the new app card (Playwright run succeeded and produced artifacts).
- Files were staged and committed; commits completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944f94765408320b15bc1bfc6d84fe8)