### PR TITLE
Workbench: auto-suggest and auto-create GitHub repos

### DIFF
--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -180,7 +180,8 @@
             <div>
               <p class="eyebrow">New repo</p>
               <h3>Create directly from the Workbench</h3>
-              <p class="meta">Use the same token to spin up a GitHub repository without leaving this page.</p>
+              <p class="meta">Use the same token to spin up a GitHub repository without leaving this page. Leave the name
+                blank to auto-generate one.</p>
             </div>
             <div class="pill-row" role="radiogroup" aria-label="Repository owner">
               <label class="pill">
@@ -198,7 +199,8 @@
             <div>
               <label for="repo-name">Repository name</label>
               <input id="repo-name" type="text" placeholder="my-new-repo" aria-describedby="repo-name-help">
-              <p id="repo-name-help" class="meta">Letters, numbers, and dashes. Owner comes from the radio buttons above.</p>
+              <p id="repo-name-help" class="meta">Letters, numbers, and dashes. Owner comes from the radio buttons above.
+                Leave empty to auto-name.</p>
             </div>
             <div>
               <label for="repo-org">Organization (if selected)</label>


### PR DESCRIPTION
### Motivation
- Improve ergonomics of the OpenAI Workbench GitHub flow by reducing manual steps required to name and create repositories.
- Let the Workbench derive a sensible repository name from the current prompt or deploy note to speed up publish workflows.
- Persist repo creation settings with the rest of the publish form so users don't re-enter options repeatedly.
- Allow publishing to proceed by auto-creating a repository when no `owner/name` is provided.

### Description
- Added new defaults to `defaultFormState` and extended persisted form payload to include repo creation fields such as `repoName`, `repoOwner`, `repoOrg`, `repoVisibility`, `repoDescription`, `repoReadme`, and `repoBranchCleanup` in `openai-app/app.js`.
- Implemented `slugifyRepoName`, `buildRepoNameSeed`, and `suggestRepoName` helpers to auto-generate a safe repo name from the current `messageInput` or `deployNoteInput`, and wire suggestions to input events and initial hydration.
- Reworked the repo creation flow into `createGithubRepoRequest({ autoName })` which attempts generated names (and fallbacks) and returns created repo metadata, and added `createGithubRepo` wrapper to call it from the UI.
- Updated `publishToGithub` to auto-create a repo when `githubRepo` is empty and adjusted UI copy in `openai-app/index.html` to explain auto-naming behavior.

### Testing
- Started a local static server with `python -m http.server 8000` and confirmed the Workbench page loads successfully in-browser (succeeded).
- Captured a screenshot using Playwright to validate the updated repo creation UI and auto-name copy (artifact generated successfully).
- No new unit tests were added in this change set.
- No automated API/GitHub integration tests were run against live services in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947734952688320808ba9bb36925b75)