### PR TITLE
Improve workbench shared defaults UI

### DIFF
--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -59,8 +59,34 @@
 
     <section class="card" id="api-key-panel" aria-label="API key configuration">
       <div class="card-header">
-        <h2>Account-linked keys</h2>
-        <p class="meta">Keys follow your Gun account when signed in and fall back to secure, device-local storage.</p>
+        <div>
+          <h2>Shared defaults + account keys</h2>
+          <p class="meta">Load team defaults fast, then swap in personal tokens when you are ready.</p>
+        </div>
+      </div>
+      <div class="defaults-panel" aria-label="Shared defaults">
+        <div>
+          <p class="eyebrow">Quick start</p>
+          <h3>Use shared defaults</h3>
+          <p class="meta">Admins can publish shared OpenAI, Vercel, and GitHub keys. Apply them here to start building fast.</p>
+          <ul class="defaults-status" id="defaults-status" aria-live="polite"></ul>
+        </div>
+        <div class="defaults-actions">
+          <label for="default-passphrase">Shared passphrase</label>
+          <input id="default-passphrase" type="password" placeholder="Passphrase from admin">
+          <div class="input-row">
+            <button id="load-default" class="primary">Use shared defaults</button>
+          </div>
+          <label class="checkbox-row" for="default-remember-passphrase">
+            <input id="default-remember-passphrase" type="checkbox">
+            <span>Remember passphrase for this session</span>
+          </label>
+          <label class="checkbox-row" for="default-auto-load">
+            <input id="default-auto-load" type="checkbox">
+            <span>Auto-apply defaults when no keys are set</span>
+          </label>
+          <p id="default-key-status" class="meta" aria-live="polite"></p>
+        </div>
       </div>
       <div class="guide-links">
         <a class="guide-link" href="../deployment-guides/index.html" target="_blank" rel="noreferrer">Guide: setup checklist</a>
@@ -75,11 +101,6 @@
       <p id="api-key-help" class="meta">Saved to your Gun account first when available; otherwise stored on this device.</p>
       <p id="storage-mode" class="meta" aria-live="polite"></p>
       <p id="account-status" class="status" aria-live="polite">Sign in so keys attach to your account instead of this device.</p>
-      <div class="input-row">
-        <input type="password" id="default-passphrase" placeholder="Passphrase for admin default key">
-        <button id="load-default" class="ghost">Use defaults</button>
-      </div>
-      <p id="default-key-status" class="meta" aria-live="polite"></p>
       <p id="shared-usage-status" class="meta" aria-live="polite">Shared keys are rate limited: guests 2/day, accounts 5/day, supporters 20/day, pro members 100/day.</p>
     </section>
 

--- a/openai-app/styles.css
+++ b/openai-app/styles.css
@@ -128,6 +128,72 @@ label {
   flex-wrap: wrap;
 }
 
+.defaults-panel {
+  display: grid;
+  gap: 16px;
+  margin: 12px 0 8px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--ghost);
+}
+
+.defaults-panel h3 {
+  margin: 6px 0;
+}
+
+.defaults-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.defaults-status {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.defaults-status li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  font-weight: 600;
+}
+
+.status-badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.status-badge.ready {
+  background: rgba(122, 91, 210, 0.18);
+  color: var(--accent);
+  border: 1px solid rgba(122, 91, 210, 0.3);
+}
+
+.status-badge.applied {
+  background: rgba(46, 204, 113, 0.16);
+  color: #b9f5ce;
+  border: 1px solid rgba(46, 204, 113, 0.3);
+}
+
+.status-badge.missing {
+  background: rgba(231, 111, 81, 0.12);
+  color: #ffb8a7;
+  border: 1px solid rgba(231, 111, 81, 0.3);
+}
+
 .auto-sync-row {
   display: flex;
   flex-direction: column;
@@ -359,6 +425,11 @@ iframe {
 
   .compact-grid {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .defaults-panel {
+    grid-template-columns: 1.1fr 1fr;
+    align-items: start;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Make shared admin defaults for OpenAI, Vercel, and GitHub easier to discover and apply from the Workbench UI.
- Provide safe, ergonomic defaults so teammates can start building with minimal friction before swapping in personal tokens.
- Allow passphrase remembering per-session and optional auto-apply when no personal keys are present.

### Description
- Added a quick-start `defaults-panel` to `openai-app/index.html` with inputs for a shared passphrase, `default-remember-passphrase`, and `default-auto-load` toggles, plus a `defaults-status` list for per-service badges.
- Introduced styles in `openai-app/styles.css` to support the new panel and status badges with `.defaults-panel` and `.status-badge` variants for `ready`, `applied`, and `missing` states.
- Extended `openai-app/app.js` with a `transientStorage` helper and new storage keys (`defaultPassphraseStorageKey`, `defaultRememberPassphraseKey`, `defaultAutoLoadKey`), UI bindings, and functions: `updateDefaultsStatusList`, `saveDefaultPreferences`, `restoreDefaultPreferences`, and `maybeAutoLoadDefaults` to persist and optionally auto-apply defaults.
- Wire-up changes so defaults status refreshes (`updateDefaultsStatusList`) when defaults are subscribed, when secrets change, and after applying defaults, and added event listeners to persist preferences on user interaction.

### Testing
- Started a local dev server using `python -m http.server 8000` and confirmed it served the app successfully. (succeeded)
- Ran a Playwright script to open `http://127.0.0.1:8000/openai-app/` and capture a screenshot of the updated Workbench UI as a visual smoke test, which completed and produced an artifact. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694893066d848320bc9bc467b9a5646d)