### PR TITLE
Move TinyMark into directory and add portal link

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,11 @@
             <span class="app-card__title">Tasks</span>
             <span class="app-card__meta">Plan, assign, and celebrate team wins.</span>
           </a>
+          <a href="tinymark/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">✍️</span>
+            <span class="app-card__title">TinyMark</span>
+            <span class="app-card__meta">Draft outline-style notes and render clean HTML.</span>
+          </a>
           <a href="video/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🎥</span>
             <span class="app-card__title">Video Chat</span>

--- a/tinymark/index.html
+++ b/tinymark/index.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>TinyMark v0.1</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      margin: 24px;
+    }
+    textarea {
+      width: 100%;
+      height: 40vh;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .wrap {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: 1fr;
+    }
+    @media (min-width: 900px) {
+      .wrap {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+    .panel {
+      border: 1px solid #ddd;
+      border-radius: 12px;
+      padding: 12px;
+    }
+    .panel h2 {
+      margin: 0 0 8px;
+      font-size: 16px;
+    }
+    #out {
+      max-width: 75ch;
+    }
+    h1,
+    h2,
+    h3,
+    h4 {
+      margin: 0.9em 0 0.35em;
+    }
+    p {
+      margin: 0 0 0.9em;
+      line-height: 1.5;
+    }
+    .muted {
+      color: #666;
+      font-size: 12px;
+    }
+    button {
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid #ddd;
+      background: #fff;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <h1 style="margin-top:0">TinyMark v0.1 — outline → HTML</h1>
+  <p class="muted">
+    Rules: first line = H1 • blank line = new paragraph • indented line ending with ":" = heading (2 spaces per
+    level).
+  </p>
+
+  <div style="display:flex; gap:12px; align-items:center; margin: 12px 0 18px;">
+    <button id="renderBtn">Render</button>
+    <button id="copyBtn">Copy HTML</button>
+    <span class="muted" id="status"></span>
+  </div>
+
+  <div class="wrap">
+    <div class="panel">
+      <h2>Input (TinyMark)</h2>
+      <textarea id="src"></textarea>
+    </div>
+    <div class="panel">
+      <h2>Output (HTML render)</h2>
+      <div id="out"></div>
+    </div>
+  </div>
+
+  <script>
+    function escapeHtml(s) {
+      return s.replace(/[&<>"']/g, (c) => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        "\"": "&quot;",
+        "'": "&#39;"
+      }[c]));
+    }
+
+    function countLeadingSpaces(line) {
+      let i = 0;
+      while (i < line.length && line[i] === " ") i++;
+      return i;
+    }
+
+    // TinyMark v0.1: first non-empty line = H1; blank lines split paragraphs;
+    // headings are indented lines ending with ":"; 2 spaces per level -> h2,h3,...
+    function tinyMarkToHtml(input) {
+      const lines = input.replace(/\r\n/g, "\n").split("\n");
+
+      // find title
+      let title = null;
+      let idx = 0;
+      while (idx < lines.length) {
+        const t = lines[idx].trim();
+        if (t !== "") {
+          title = t;
+          idx++;
+          break;
+        }
+        idx++;
+      }
+
+      let html = "";
+      if (title) html += `<h1>${escapeHtml(title)}</h1>\n`;
+
+      let paragraph = [];
+      const flushParagraph = () => {
+        if (paragraph.length === 0) return;
+        const text = paragraph.join(" ").replace(/\s+/g, " ").trim();
+        if (text) html += `<p>${escapeHtml(text)}</p>\n`;
+        paragraph = [];
+      };
+
+      for (; idx < lines.length; idx++) {
+        const raw = lines[idx];
+        const trimmed = raw.trim();
+
+        // blank line => paragraph break
+        if (trimmed === "") {
+          flushParagraph();
+          continue;
+        }
+
+        // heading detection: ends with ":" AND has indentation >= 2
+        const lead = countLeadingSpaces(raw);
+        const isHeading = trimmed.endsWith(":") && lead >= 2;
+
+        if (isHeading) {
+          flushParagraph();
+          const levelFromIndent = Math.floor(lead / 2) + 1; // 2 spaces => level 2
+          const tagLevel = Math.min(Math.max(levelFromIndent, 2), 6); // clamp h2..h6
+          const headingText = trimmed.slice(0, -1).trim();
+          html += `<h${tagLevel}>${escapeHtml(headingText)}</h${tagLevel}>\n`;
+          continue;
+        }
+
+        // normal text: accumulate into current paragraph
+        paragraph.push(trimmed);
+      }
+
+      flushParagraph();
+      return html.trim();
+    }
+
+    const src = document.getElementById("src");
+    const out = document.getElementById("out");
+    const status = document.getElementById("status");
+
+    function render() {
+      const html = tinyMarkToHtml(src.value);
+      out.innerHTML = html;
+      status.textContent = "Rendered.";
+      setTimeout(() => {
+        status.textContent = "";
+      }, 1200);
+    }
+
+    document.getElementById("renderBtn").addEventListener("click", render);
+
+    document.getElementById("copyBtn").addEventListener("click", async () => {
+      const html = tinyMarkToHtml(src.value);
+      try {
+        await navigator.clipboard.writeText(html);
+        status.textContent = "Copied HTML to clipboard.";
+      } catch (e) {
+        status.textContent = "Clipboard blocked (try HTTPS or manual copy).";
+      }
+      setTimeout(() => {
+        status.textContent = "";
+      }, 1600);
+    });
+
+    // starter text
+    src.value =
+`My Doc Title
+
+  Section One:
+This is the first paragraph.
+It wraps across lines.
+
+    Subsection:
+Another paragraph.
+
+  Section Two:
+More stuff here.`;
+
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Place the TinyMark demo in its own directory so it follows the portal's content structure and is easier to extend. 
- Make the demo discoverable from the main portal by adding an app card in the app grid in alphabetical order. 
- Keep the demo self-contained and human-readable for quick authoring and testing. 

### Description
- Move the demo file into `tinymark/index.html` and include the full TinyMark v0.1 demo with `tinyMarkToHtml`, `escapeHtml`, and `countLeadingSpaces` helpers. 
- Add a new app card linking to `tinymark/index.html` in `index.html` with an icon, title `TinyMark`, and short meta text so it appears in the portal grid. 
- Preserve mobile-first layout, controls (`Render` / `Copy HTML`), starter text, and clipboard/status feedback in the demo page. 

### Testing
- Served the site with `python -m http.server 8000` and verified the demo and portal index load successfully. 
- Ran Playwright scripts to open `/tinymark/index.html` and `/index.html` and captured screenshots which completed successfully. 
- No unit tests were added for this static demo in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948b91d84d88320a87047a53b0b4538)