### PR TITLE
Add portal directory landing page

### DIFF
--- a/directory/index.html
+++ b/directory/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3DVR Portal Directory</title>
+  <meta
+    name="description"
+    content="Explore the 3DVR Portal directory — a decentralized hub for building, hosting, and thinking."
+  />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="stylesheet" href="/styles/global.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>3DVR Portal Directory</h1>
+    <p>
+      A living directory for the 3DVR ecosystem — launch core workspaces, creator tools, and community spaces without
+      leaving the portal.
+    </p>
+  </header>
+
+  <main>
+    <section>
+      <h2>Core Spaces</h2>
+      <div class="grid">
+        <a class="card" href="/home">
+          <h3>Home</h3>
+          <p>Your personal dashboard and entry point.</p>
+        </a>
+        <a class="card" href="/notes">
+          <h3>Notes</h3>
+          <p>Thoughts, drafts, and living documents.</p>
+        </a>
+        <a class="card" href="/tasks">
+          <h3>Tasks</h3>
+          <p>Lightweight planning and execution.</p>
+        </a>
+        <a class="card" href="/chat">
+          <h3>Chat</h3>
+          <p>Decentralized discussion and coordination.</p>
+        </a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Builders &amp; Infrastructure</h2>
+      <div class="grid">
+        <a class="card" href="/deploy">
+          <h3>Deploy</h3>
+          <p>Self-hosted deployments and experiments.</p>
+        </a>
+        <a class="card" href="/repos">
+          <h3>Repos</h3>
+          <p>Distributed code, projects, and history.</p>
+        </a>
+        <a class="card" href="/compute">
+          <h3>Compute</h3>
+          <p>Local and shared processing power.</p>
+        </a>
+        <a class="card" href="/ai">
+          <h3>Intelligence</h3>
+          <p>Local-first AI and experimentation.</p>
+        </a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Community &amp; Learning</h2>
+      <div class="grid">
+        <a class="card" href="/newsroom">
+          <h3>Newsroom</h3>
+          <p>Track ecosystem updates and shared milestones.</p>
+        </a>
+        <a class="card" href="/education.html">
+          <h3>Learning</h3>
+          <p>Unlock lessons, documentation, and skill builders.</p>
+        </a>
+        <a class="card" href="/science">
+          <h3>Science Lab</h3>
+          <p>Experiment tracking, signal reviews, and VR-ready findings.</p>
+        </a>
+        <a class="card" href="/wellness.html">
+          <h3>Wellness</h3>
+          <p>Mindfulness, recovery, and flow-state reset tools.</p>
+        </a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Vision</h2>
+      <p class="directory-note">
+        The 3DVR Portal is not a product — it is a pattern. A place where the lines between user, builder, host, and
+        thinker blur. Everything here is designed to work locally first, federate naturally, and respect human scale.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <p>
+      Built openly by 3DVR.tech · No lock-in · No black boxes · Always evolving
+    </p>
+  </footer>
+</body>
+</html>

--- a/directory/style.css
+++ b/directory/style.css
@@ -1,0 +1,107 @@
+:root {
+  --directory-bg: #0b1020;
+  --directory-fg: #e8ecff;
+  --directory-muted: #9aa4ff;
+  --directory-accent: #00ffc8;
+  --directory-card: #141a33;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at top, #141a33, var(--directory-bg));
+  color: var(--directory-fg);
+  line-height: 1.6;
+}
+
+header {
+  padding: 4rem 1.5rem 3rem;
+  text-align: center;
+}
+
+header h1 {
+  font-size: clamp(2.2rem, 6vw, 3.2rem);
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.04em;
+}
+
+header p {
+  color: var(--directory-muted);
+  max-width: 720px;
+  margin: 0.5rem auto 0;
+  font-size: 1.05rem;
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+section {
+  margin-bottom: 3.5rem;
+}
+
+section h2 {
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+  color: var(--directory-accent);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+}
+
+.card {
+  background: var(--directory-card);
+  border-radius: 14px;
+  padding: 1.2rem 1.3rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover,
+.card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.35);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.4rem;
+  font-size: 1.15rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--directory-muted);
+  font-size: 0.95rem;
+}
+
+.directory-note {
+  max-width: 760px;
+  color: var(--directory-muted);
+}
+
+footer {
+  text-align: center;
+  padding: 2.5rem 1.5rem 3rem;
+  color: var(--directory-muted);
+  font-size: 0.9rem;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--directory-accent);
+  outline-offset: 4px;
+}

--- a/index.html
+++ b/index.html
@@ -151,6 +151,11 @@
             <span class="app-card__title">CRM</span>
             <span class="app-card__meta">Track deals and sync with contacts seamlessly.</span>
           </a>
+          <a href="directory/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🗂️</span>
+            <span class="app-card__title">Directory</span>
+            <span class="app-card__meta">Browse the portal map and jump into core spaces.</span>
+          </a>
           <a href="deployment-guides/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🛠️</span>
             <span class="app-card__title">Deploy Guides</span>


### PR DESCRIPTION
### Motivation
- Provide a simple, human-readable directory page that mirrors the supplied landing layout for easier discovery of portal apps.
- Make core workspaces and community tools easier to find by surfacing a dedicated Directory entry in the main app grid.
- Keep the change small and focused so it can be reviewed and iterated on quickly.
- Isolate directory-specific visual rules to avoid duplicating or polluting global styles.

### Description
- Add `directory/index.html` which contains curated sections for Core Spaces, Builders & Infrastructure, and Community & Learning.
- Add `directory/style.css` with CSS variables, responsive grid rules, accessible focus states, and card styles used by the new page.
- Surface the directory in the main app grid by adding a `Directory` app-card entry to `index.html`.
- Commit includes the three files: `directory/index.html`, `directory/style.css`, and the updated `index.html`.

### Testing
- Started a local static server with `python -m http.server 8000` and confirmed the new page loads at `/directory/index.html`.
- Captured a visual validation screenshot using Playwright saved to `artifacts/directory-page.png` for review.
- No automated unit or integration tests were added or executed for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c9269ffc832088c5682895c02aba)