### PR TITLE
Add two Ideas Lab audience test pages with Gun-backed signup handling

### DIFF
--- a/ideas/ai-leverage.html
+++ b/ideas/ai-leverage.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Leverage · Ideas Lab</title>
+  <meta name="description" content="AI can reduce the grind for solopreneurs by handling admin, planning, and follow-ups.">
+  <link rel="icon" href="https://fav.farm/⚡">
+  <link rel="stylesheet" href="audience-leads.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+  <script src="audience-leads.js" defer></script>
+</head>
+<body>
+  <div class="page">
+    <nav class="top-nav" aria-label="Ideas Lab navigation">
+      <a href="/ideas/">← Ideas Lab</a>
+      <a href="/index.html">Portal Home</a>
+    </nav>
+
+    <main class="layout">
+      <section class="panel" aria-labelledby="headline">
+        <p class="kicker">Audience test · v1</p>
+        <h1 id="headline">You’re doing five jobs. AI can do four of them.</h1>
+        <p class="subhead">Stop drowning in admin, marketing, planning, and follow-ups. Use AI to create leverage
+          instead of grinding harder.</p>
+
+        <div class="body-text">
+          <p>Most solopreneurs don’t need motivation. They need <strong>systems</strong>.</p>
+          <p>AI can:</p>
+          <ul>
+            <li>handle repetitive thinking</li>
+            <li>draft, organize, and follow up</li>
+            <li>help you package your skills into cleaner offers</li>
+            <li>reduce context switching and burnout</li>
+          </ul>
+          <p>We’re testing a more humane way to work: less chaos, more clarity, more breathing room.</p>
+        </div>
+
+        <h2 class="section-title">What You’ll Get (later)</h2>
+        <div class="body-text">
+          <ul>
+            <li>real AI workflows for solo operators</li>
+            <li>templates you can reuse</li>
+            <li>simple systems instead of tool overload</li>
+            <li>help turning effort into repeatable income</li>
+          </ul>
+        </div>
+      </section>
+
+      <aside class="panel form-panel" aria-label="Stay in the loop">
+        <h2>I want leverage, not burnout. Keep me posted.</h2>
+        <p>Share your name and email so we can deliver the next steps and workflow experiments.</p>
+        <form
+          class="form-grid"
+          data-audience-form
+          data-audience-key="ai-leverage"
+          data-audience-label="Solopreneurs and freelancers"
+          data-source-label="Ideas Lab · AI leverage"
+          data-question-label="What eats most of your time right now?"
+        >
+          <label>
+            <span>Name</span>
+            <input name="name" type="text" autocomplete="name" required placeholder="Morgan Chen">
+          </label>
+          <label>
+            <span>Email</span>
+            <input name="email" type="email" autocomplete="email" required placeholder="you@example.com">
+          </label>
+          <label>
+            <span>Optional: What eats most of your time right now?</span>
+            <textarea name="prompt" placeholder="Admin, outreach, planning, follow-ups, etc."></textarea>
+          </label>
+          <button type="submit">I want leverage</button>
+          <p class="status" data-form-status role="status" aria-live="polite"></p>
+        </form>
+      </aside>
+    </main>
+
+    <footer class="footer-note">
+      Submissions sync to the 3DVR Gun relay so we can share experiments with the right audience.
+    </footer>
+  </div>
+</body>
+</html>

--- a/ideas/audience-leads.css
+++ b/ideas/audience-leads.css
@@ -1,0 +1,185 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #101827, #070a12 55%);
+  color: #e2e8f0;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 24px 20px 48px;
+}
+
+.top-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  font-size: 0.9rem;
+}
+
+.top-nav a {
+  color: #94a3b8;
+  text-decoration: none;
+}
+
+.top-nav a:hover,
+.top-nav a:focus {
+  color: #38bdf8;
+}
+
+.layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+}
+
+.kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.7rem;
+  color: #67e8f9;
+  font-weight: 600;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 12px 0 12px;
+  color: #f8fafc;
+}
+
+.subhead {
+  font-size: 1.1rem;
+  color: #cbd5f5;
+  margin-bottom: 20px;
+}
+
+.body-text {
+  display: grid;
+  gap: 16px;
+  font-size: 1rem;
+  color: #cbd5e1;
+}
+
+.body-text ul {
+  padding-left: 20px;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.section-title {
+  margin-top: 24px;
+  font-size: 1.1rem;
+  color: #f8fafc;
+}
+
+.form-panel h2 {
+  margin-top: 0;
+  font-size: 1.4rem;
+  color: #f8fafc;
+}
+
+.form-panel p {
+  color: #cbd5e1;
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+  font-size: 0.95rem;
+}
+
+input,
+textarea {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(8, 11, 18, 0.9);
+  color: #f8fafc;
+  padding: 12px;
+  font-size: 1rem;
+}
+
+input:focus,
+textarea:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.8);
+  outline-offset: 2px;
+}
+
+textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  background: #38bdf8;
+  color: #0f172a;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 12px 20px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover,
+button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.3);
+}
+
+.status {
+  min-height: 22px;
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+.status[data-tone='success'] {
+  color: #6ee7b7;
+}
+
+.status[data-tone='error'] {
+  color: #f87171;
+}
+
+.footer-note {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+@media (min-width: 900px) {
+  .page {
+    padding: 32px 40px 60px;
+  }
+
+  .layout {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+    align-items: start;
+  }
+}

--- a/ideas/audience-leads.js
+++ b/ideas/audience-leads.js
@@ -1,0 +1,92 @@
+const DEFAULT_PEERS = [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+];
+
+function setupAudienceForm() {
+  const form = document.querySelector('[data-audience-form]');
+  if (!form) {
+    return;
+  }
+
+  const status = document.querySelector('[data-form-status]');
+  const audienceKey = form.dataset.audienceKey;
+  const audienceLabel = form.dataset.audienceLabel || audienceKey;
+  const sourceLabel = form.dataset.sourceLabel || 'Ideas Lab audience test';
+  const questionLabel = form.dataset.questionLabel || 'Optional prompt';
+
+  const gun = Gun(window.__GUN_PEERS__ || DEFAULT_PEERS);
+
+  // Node shape:
+  // 3dvr-audience-tests/v1/{audienceKey}/signups -> { id, name, email, prompt, promptLabel, source, audienceLabel, createdAt }
+  const signups = gun
+    .get('3dvr-audience-tests')
+    .get('v1')
+    .get(audienceKey)
+    .get('signups');
+
+  function setStatus(message, tone = 'info') {
+    if (!status) {
+      return;
+    }
+    status.textContent = message;
+    status.dataset.tone = tone;
+  }
+
+  function trim(value) {
+    return String(value || '').trim();
+  }
+
+  function putAsync(node, data) {
+    return new Promise((resolve, reject) => {
+      node.set(data, ack => {
+        if (ack && ack.err) {
+          reject(new Error(ack.err));
+        } else {
+          resolve(ack);
+        }
+      });
+    });
+  }
+
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const name = trim(formData.get('name'));
+    const email = trim(formData.get('email'));
+    const prompt = trim(formData.get('prompt'));
+
+    if (!name || !email) {
+      setStatus('Please add your name and email so we can keep you in the loop.', 'error');
+      return;
+    }
+
+    const payload = {
+      id: crypto.randomUUID ? crypto.randomUUID() : `audience-${Date.now()}`,
+      name,
+      email,
+      prompt,
+      promptLabel: questionLabel,
+      source: sourceLabel,
+      audienceKey,
+      audienceLabel,
+      createdAt: new Date().toISOString(),
+      referrer: document.referrer || 'direct'
+    };
+
+    setStatus('Sending your note…', 'info');
+
+    putAsync(signups, payload)
+      .then(() => {
+        form.reset();
+        setStatus('Thanks. You are on the early list.', 'success');
+      })
+      .catch(error => {
+        console.error('Audience signup failed', error);
+        setStatus('Something went wrong. Please try again in a moment.', 'error');
+      });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', setupAudienceForm);

--- a/ideas/freedom-from-work.html
+++ b/ideas/freedom-from-work.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Freedom From Work · Ideas Lab</title>
+  <meta name="description" content="AI can help build options and agency without quitting your job or burning out.">
+  <link rel="icon" href="https://fav.farm/🕊️">
+  <link rel="stylesheet" href="audience-leads.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+  <script src="audience-leads.js" defer></script>
+</head>
+<body>
+  <div class="page">
+    <nav class="top-nav" aria-label="Ideas Lab navigation">
+      <a href="/ideas/">← Ideas Lab</a>
+      <a href="/index.html">Portal Home</a>
+    </nav>
+
+    <main class="layout">
+      <section class="panel" aria-labelledby="headline">
+        <p class="kicker">Audience test · v1</p>
+        <h1 id="headline">You don’t hate work. You hate being trapped.</h1>
+        <p class="subhead">AI makes it possible for one person to build income, skills, and options — without
+          quitting your job or burning out.</p>
+
+        <div class="body-text">
+          <p>Most people aren’t lazy. They’re tired of depending on a system that doesn’t care about them.</p>
+          <p>We’re exploring practical ways to use AI to:</p>
+          <ul>
+            <li>build side income without hustle culture</li>
+            <li>learn skills faster than traditional paths</li>
+            <li>reduce dependence on bosses, schedules, and permission</li>
+          </ul>
+          <p>This isn’t a course. This isn’t a guru funnel. It’s an experiment in <strong>regaining agency</strong>.</p>
+        </div>
+
+        <h2 class="section-title">What You’ll Get (later)</h2>
+        <div class="body-text">
+          <ul>
+            <li>simple AI workflows normal people can use</li>
+            <li>examples of small, realistic income systems</li>
+            <li>open tools you actually control</li>
+            <li>guidance without pressure</li>
+          </ul>
+        </div>
+      </section>
+
+      <aside class="panel form-panel" aria-label="Stay in the loop">
+        <h2>I want more freedom. Keep me in the loop.</h2>
+        <p>Leave your name and email so we can share the next steps as soon as they are ready.</p>
+        <form
+          class="form-grid"
+          data-audience-form
+          data-audience-key="freedom-from-work"
+          data-audience-label="People stuck in jobs"
+          data-source-label="Ideas Lab · Freedom from work"
+          data-question-label="What makes work feel unbearable right now?"
+        >
+          <label>
+            <span>Name</span>
+            <input name="name" type="text" autocomplete="name" required placeholder="Jordan Lee">
+          </label>
+          <label>
+            <span>Email</span>
+            <input name="email" type="email" autocomplete="email" required placeholder="you@example.com">
+          </label>
+          <label>
+            <span>Optional: What makes work feel unbearable right now?</span>
+            <textarea name="prompt" placeholder="What part feels most draining?"></textarea>
+          </label>
+          <button type="submit">I want more freedom</button>
+          <p class="status" data-form-status role="status" aria-live="polite"></p>
+        </form>
+      </aside>
+    </main>
+
+    <footer class="footer-note">
+      Submissions sync to the 3DVR Gun relay so the team can listen and respond with care.
+    </footer>
+  </div>
+</body>
+</html>

--- a/ideas/index.html
+++ b/ideas/index.html
@@ -13,7 +13,7 @@
   </nav>
   <main class="page">
     <h1>Ideas Lab</h1>
-    <p class="lead">Three quick landing experiments with simple, browser-local stats.</p>
+    <p class="lead">Five quick landing experiments with simple, browser-local stats.</p>
     <div class="cards">
       <div class="card" data-idea-card data-idea-path="/ideas/websites.html">
         <h2>Websites, Fast</h2>
@@ -71,6 +71,44 @@
           </div>
         </div>
         <a class="cta" href="/ideas/support.html">Open idea</a>
+      </div>
+      <div class="card" data-idea-card data-idea-path="/ideas/freedom-from-work.html">
+        <h2>Freedom From Work</h2>
+        <p>You don’t hate work. You hate being trapped. Explore AI as a path to agency.</p>
+        <div class="stats">
+          <div class="stat">
+            <span class="label">Page views</span>
+            <span class="value" data-idea-views>0</span>
+          </div>
+          <div class="stat">
+            <span class="label">CTA clicks</span>
+            <span class="value" data-idea-cta-count>0</span>
+          </div>
+          <div class="stat">
+            <span class="label">Last seen</span>
+            <span class="value" data-idea-last>Never</span>
+          </div>
+        </div>
+        <a class="cta" href="/ideas/freedom-from-work.html">Open idea</a>
+      </div>
+      <div class="card" data-idea-card data-idea-path="/ideas/ai-leverage.html">
+        <h2>AI Leverage</h2>
+        <p>Solopreneur systems that reduce the grind and create reusable leverage.</p>
+        <div class="stats">
+          <div class="stat">
+            <span class="label">Page views</span>
+            <span class="value" data-idea-views>0</span>
+          </div>
+          <div class="stat">
+            <span class="label">CTA clicks</span>
+            <span class="value" data-idea-cta-count>0</span>
+          </div>
+          <div class="stat">
+            <span class="label">Last seen</span>
+            <span class="value" data-idea-last>Never</span>
+          </div>
+        </div>
+        <a class="cta" href="/ideas/ai-leverage.html">Open idea</a>
       </div>
     </div>
     <div class="actions">


### PR DESCRIPTION
### Motivation

- Add two lightweight landing pages to test distinct audiences (people stuck in jobs and solopreneurs/freelancers) using the existing Ideas Lab A/B-style suite.  
- Capture early-signal signups centrally via GunJS so submissions sync to the shared relay and can be analyzed.  
- Keep the change small, reuseable, and easy to iterate on by introducing a shared style and form handling module.  
- Surface the experiments on the Ideas Lab dashboard so page views and CTA counts can be tracked locally.

### Description

- Added two new pages: `ideas/freedom-from-work.html` and `ideas/ai-leverage.html` with the exact copy and CTAs requested.  
- Added shared styles in `ideas/audience-leads.css` and a reusable form handler `ideas/audience-leads.js` that writes signups to the Gun node path `3dvr-audience-tests/v1/{audienceKey}/signups`.  
- Updated `ideas/index.html` to list the two new experiments and bumped the dashboard copy to reflect five experiments.  
- Kept the data node shape and network peers explicit in the form handler and used `putAsync`/`set` promises for reliable acknowledgements.

### Testing

- Started a local static server with `python -m http.server 8000` and rendered both pages in a headless browser via Playwright, capturing screenshots of `freedom-from-work` and `ai-leverage` (succeeded).  
- Verified pages load without runtime errors in the browser render run (no JS exceptions observed during the screenshot run).  
- No automated unit tests were added for this change (per incremental rollout plan).  
- Commit created and files staged; no CI/unit test failures reported during this local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cc6c6d7f08320a038d7e5ed3f4748)