### PR TITLE
Add weekly release v0.0.32 (landing refresh, new labs, workbench hubs)

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -93,6 +93,14 @@
     <h2>Release History</h2>
     <ul class="release-grid">
       <li class="release-card">
+        <a class="release-link" href="v0.0.32.html">v0.0.32</a>
+        <span class="release-meta">Week of December 29, 2025</span>
+        <p class="release-summary">
+          Workbench workflow hubs, new labs for XR motion and decentralized cloud, and a refreshed landing page
+          focused on discovery
+        </p>
+      </li>
+      <li class="release-card">
         <a class="release-link" href="v0.0.31.html">v0.0.31</a>
         <span class="release-meta">Week of December 22, 2025</span>
         <p class="release-summary">

--- a/releases/v0.0.31.html
+++ b/releases/v0.0.31.html
@@ -77,7 +77,7 @@
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
     <a class="release-nav-link" href="v0.0.30.html">← Previous release</a>
-    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
+    <a class="release-nav-link" href="v0.0.32.html">Next release →</a>
   </nav>
   <h1>Release v0.0.31</h1>
   <div class="tag">Week of December 22, 2025</div>

--- a/releases/v0.0.32.html
+++ b/releases/v0.0.32.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal – Release v0.0.32 (Week of December 29, 2025)</title>
+  <style>
+    body {
+      margin: 0 auto;
+      font-family: Arial, Helvetica, sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      line-height: 1.65;
+      padding: 20px;
+      max-width: 900px;
+    }
+    h1,
+    h2,
+    h3 {
+      color: #58a6ff;
+    }
+    a {
+      color: #58a6ff;
+    }
+    .section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #161b22;
+      border-radius: 10px;
+      border: 1px solid #30363d;
+    }
+    .tag {
+      background: #1f6feb;
+      padding: 4px 10px;
+      border-radius: 6px;
+      display: inline-block;
+      font-size: 14px;
+      margin-bottom: 20px;
+    }
+    .release-summary {
+      margin: 0 0 24px;
+      font-size: 16px;
+      color: #9ba3b4;
+    }
+    .back-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .back-link:hover {
+      text-decoration: underline;
+    }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
+  </style>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.31.html">← Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
+  </nav>
+  <h1>Release v0.0.32</h1>
+  <div class="tag">Week of December 29, 2025</div>
+  <div class="section">
+    <h2>Overview</h2>
+    <p>
+      The portal focused on discoverability and builder productivity this week, with a refreshed landing flow, new
+      workbench hubs, and fresh labs covering XR motion, decentralized cloud, and local model setup.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>Portal quick links</h2>
+    <ul>
+      <li><a href="../index.html">Portal home</a> – jump into every workspace, lab, and experiment.</li>
+      <li><a href="../releases/index.html">Release hub</a> – browse weekly milestones and product checkpoints.</li>
+      <li><a href="../openai-app/index.html">OpenAI Workbench</a> – build, preview, and ship with shared defaults.</li>
+      <li><a href="../web-builder-app/index.html">Web Builder</a> – create web experiences with guided launch
+      flows.</li>
+      <li><a href="../xr-motion-lab/index.html">XR Motion Lab</a> – prototype VR/AR motion controls from the
+      browser.</li>
+      <li><a href="../cloud/index.html">Decentralized Cloud</a> – explore the open cloud roadmap and architecture.</li>
+      <li><a href="../local-models-on-phones/index.html">Local Models</a> – track on-device setup notes and
+      experiments.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Landing page refresh</h2>
+    <ul>
+      <li>Refocus the <a href="../index.html">portal home</a> hero on app discovery with updated layout and
+      messaging.</li>
+      <li>Retire the breathing demo headline link so the primary CTA stays on exploration and launch.</li>
+      <li>Highlight new app cards for <a href="../local-models-on-phones/index.html">local models</a> and the
+      <a href="../seo/index.html">SEO planning workspace</a> to keep the landing grid current.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Workbench workflow hubs</h2>
+    <ul>
+      <li>Add setup, preview, and logs hubs inside the <a href="../openai-app/index.html">OpenAI Workbench</a> so
+      builders can navigate the full flow without losing context.</li>
+      <li>Improve workbench shared default key management with clearer UI guidance and stronger hints.</li>
+      <li>Smooth mobile editing and repo creation experiences with ergonomic layout updates.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>New labs and directories</h2>
+    <ul>
+      <li>Launch the <a href="../xr-motion-lab/index.html">XR Motion Lab</a> prototype for accelerometer- and
+      camera-driven VR/AR control exploration.</li>
+      <li>Introduce the <a href="../cloud/index.html">Decentralized Cloud</a> landing page and directory structure.</li>
+      <li>Move <a href="../tinymark/index.html">TinyMark</a> into its own home and link it from the portal
+      navigation.</li>
+      <li>Add a <a href="../deployment-guides/self-hosted.html">self-hosted deployment guide</a> for GitHub and Vercel
+      setups.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Ideas Lab audience testing</h2>
+    <ul>
+      <li>Add audience-focused experiment pages in the <a href="../ideas/index.html">Ideas Lab</a> to support future
+      A/B testing across the concept portfolio.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Document the latest weekly work by adding a release note for the Week of December 29, 2025 to track recent changes.
- Surface new experiments and app hubs (XR Motion Lab, Decentralized Cloud, Local Models) so contributors can discover them from the release hub.
- Link the new release into the release history and keep navigation between adjacent release pages accurate.
- Ensure release files adhere to repository formatting rules (wrap long lines under 120 characters).

### Description
- Create `releases/v0.0.32.html` containing the v0.0.32 release notes covering landing refresh, workbench hubs, and new labs. 
- Insert a `v0.0.32` entry into `releases/index.html` so the release appears in the release history grid. 
- Update `releases/v0.0.31.html` to wire the "Next release" navigation to `v0.0.32.html`. 
- Wrap long lines in the new release HTML to comply with the repository style guidelines and avoid >120 character lines.

### Testing
- No unit or integration tests were run because this change is documentation-only (release notes only). 
- Verified and fixed long-line occurrences using `rg` to ensure no lines exceed 120 characters. 
- Files were added and committed successfully with `git commit` creating the release snapshot. 
- No automated test failures occurred because no automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5f09db8883208f225150a5493de4)