### PR TITLE
Add Workbench Ideas automation hub (GunJS-backed)

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,11 @@
             <span class="app-card__title">Ideas Lab</span>
             <span class="app-card__meta">Test lightweight landing pages with local view and CTA stats.</span>
           </a>
+          <a href="workbench-ideas/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🧰</span>
+            <span class="app-card__title">Workbench Ideas</span>
+            <span class="app-card__meta">Automate Workbench idea briefs and promotion checklists.</span>
+          </a>
           <a href="job-tracker/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🧭</span>
             <span class="app-card__title">Job Tracker</span>

--- a/workbench-ideas/app.js
+++ b/workbench-ideas/app.js
@@ -1,0 +1,322 @@
+const TOOL_OPTIONS = [
+  {
+    key: 'brief-builder',
+    label: 'Idea brief builder',
+    description: 'Structure the problem, audience, and success metrics.'
+  },
+  {
+    key: 'page-generator',
+    label: 'Idea page generator',
+    description: 'Turn briefs into an idea landing page draft.'
+  },
+  {
+    key: 'cta-optimizer',
+    label: 'CTA optimizer',
+    description: 'Tune headers, body copy, and calls-to-action.'
+  },
+  {
+    key: 'share-pack',
+    label: 'Share pack creator',
+    description: 'Generate social copy, email blurbs, and QR captions.'
+  },
+  {
+    key: 'analytics-notes',
+    label: 'Analytics notes',
+    description: 'Capture what to measure after launch.'
+  }
+];
+
+const CHANNEL_OPTIONS = [
+  {
+    key: 'portal',
+    label: 'Portal announcement',
+    description: 'Add to portal updates and dashboards.'
+  },
+  {
+    key: 'community-chat',
+    label: 'Community chat',
+    description: 'Share in the 3DVR chat and Discord spaces.'
+  },
+  {
+    key: 'email',
+    label: 'Email or newsletter',
+    description: 'Push to subscribers and partners.'
+  },
+  {
+    key: 'social',
+    label: 'Social media thread',
+    description: 'Post on X, LinkedIn, or similar channels.'
+  },
+  {
+    key: 'partner',
+    label: 'Partner outreach',
+    description: 'Coordinate cross-promo with allies.'
+  }
+];
+
+const PROMO_STEPS = [
+  { key: 'publish', label: 'Publish idea page draft' },
+  { key: 'share-chat', label: 'Share in community chat' },
+  { key: 'share-social', label: 'Post social thread' },
+  { key: 'email-blast', label: 'Send email or newsletter' },
+  { key: 'metrics', label: 'Record first-week results' }
+];
+
+const ideasById = {};
+
+function createOption({ key, label, description }, groupName) {
+  const wrapper = document.createElement('label');
+  wrapper.className = 'option-item';
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.name = groupName;
+  checkbox.value = key;
+
+  const textWrapper = document.createElement('span');
+  const labelEl = document.createElement('strong');
+  labelEl.textContent = label;
+  const descriptionEl = document.createElement('span');
+  descriptionEl.textContent = description;
+
+  textWrapper.appendChild(labelEl);
+  textWrapper.appendChild(document.createElement('br'));
+  textWrapper.appendChild(descriptionEl);
+
+  wrapper.appendChild(checkbox);
+  wrapper.appendChild(textWrapper);
+
+  return wrapper;
+}
+
+function renderOptions(container, options, groupName) {
+  const list = document.createElement('div');
+  list.className = 'option-list';
+
+  options.forEach(option => {
+    list.appendChild(createOption(option, groupName));
+  });
+
+  container.appendChild(list);
+}
+
+function buildSelectionObject(form, name, options) {
+  const selected = Array.from(form.querySelectorAll(`input[name="${name}"]:checked`));
+  if (!selected.length) {
+    return {};
+  }
+
+  return selected.reduce((acc, input) => {
+    const match = options.find(option => option.key === input.value);
+    const label = match ? match.label : input.value;
+    acc[label] = true;
+    return acc;
+  }, {});
+}
+
+function formatTimestamp(value) {
+  if (!value) {
+    return 'Just now';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Just now';
+  }
+
+  return date.toLocaleString();
+}
+
+function renderIdeas(container, ideaRoot) {
+  container.innerHTML = '';
+
+  const ideas = Object.values(ideasById).sort((a, b) => {
+    return new Date(b.createdAt || 0) - new Date(a.createdAt || 0);
+  });
+
+  if (!ideas.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No idea pages yet. Add one above to start automation.';
+    container.appendChild(empty);
+    return;
+  }
+
+  ideas.forEach(idea => {
+    const card = document.createElement('article');
+    card.className = 'idea-card';
+
+    const header = document.createElement('div');
+    header.className = 'idea-card__header';
+
+    const title = document.createElement('h3');
+    title.textContent = idea.title;
+
+    const meta = document.createElement('div');
+    meta.className = 'idea-card__meta';
+    meta.textContent = `Created ${formatTimestamp(idea.createdAt)}`;
+
+    header.appendChild(title);
+    header.appendChild(meta);
+
+    if (idea.pageUrl) {
+      const link = document.createElement('a');
+      link.href = idea.pageUrl;
+      link.textContent = 'Open idea page';
+      link.target = '_blank';
+      link.rel = 'noopener';
+      header.appendChild(link);
+    }
+
+    card.appendChild(header);
+
+    const summary = document.createElement('p');
+    summary.textContent = idea.problem;
+    card.appendChild(summary);
+
+    if (idea.audience) {
+      const audience = document.createElement('p');
+      audience.className = 'idea-card__meta';
+      audience.textContent = `Audience: ${idea.audience}`;
+      card.appendChild(audience);
+    }
+
+    const badges = document.createElement('div');
+    badges.className = 'idea-card__badges';
+    Object.keys(idea.tools || {}).forEach(label => {
+      const badge = document.createElement('span');
+      badge.className = 'badge';
+      badge.textContent = label;
+      badges.appendChild(badge);
+    });
+    Object.keys(idea.channels || {}).forEach(label => {
+      const badge = document.createElement('span');
+      badge.className = 'badge';
+      badge.textContent = label;
+      badges.appendChild(badge);
+    });
+
+    if (badges.children.length) {
+      card.appendChild(badges);
+    }
+
+    const checklistSection = document.createElement('div');
+    checklistSection.className = 'idea-card__section';
+
+    const checklistTitle = document.createElement('h4');
+    checklistTitle.textContent = 'Promotion checklist';
+    checklistSection.appendChild(checklistTitle);
+
+    const checklist = document.createElement('div');
+    checklist.className = 'promo-checklist';
+
+    PROMO_STEPS.forEach(step => {
+      const item = document.createElement('div');
+      item.className = 'promo-item';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.id = `${idea.id}-${step.key}`;
+      input.checked = idea.promoProgress?.[step.key] === true;
+
+      input.addEventListener('change', () => {
+        ideaRoot
+          .get(idea.id)
+          .get('promoProgress')
+          .get(step.key)
+          .put(input.checked);
+      });
+
+      const label = document.createElement('label');
+      label.setAttribute('for', input.id);
+      label.textContent = step.label;
+
+      item.appendChild(input);
+      item.appendChild(label);
+      checklist.appendChild(item);
+    });
+
+    checklistSection.appendChild(checklist);
+    card.appendChild(checklistSection);
+
+    container.appendChild(card);
+  });
+}
+
+function initIdeaBoard() {
+  const form = document.querySelector('[data-idea-form]');
+  const status = document.querySelector('[data-form-status]');
+  const ideaList = document.querySelector('[data-idea-list]');
+  const toolOptions = document.querySelector('[data-tool-options]');
+  const channelOptions = document.querySelector('[data-channel-options]');
+
+  renderOptions(toolOptions, TOOL_OPTIONS, 'workbenchTools');
+  renderOptions(channelOptions, CHANNEL_OPTIONS, 'promoChannels');
+
+  const gun = Gun({
+    peers: window.__GUN_PEERS__ || [],
+    localStorage: false,
+    radisk: false
+  });
+
+  // Node shape: workbench/idea-pages/{ideaId} -> { title, problem, audience, success, pageUrl, tools, channels, createdAt }
+  const ideaRoot = gun.get('workbench').get('idea-pages');
+
+  ideaRoot.map().on((data, key) => {
+    if (!data || key?.startsWith('_')) {
+      return;
+    }
+
+    ideasById[key] = {
+      id: key,
+      title: data.title,
+      problem: data.problem,
+      audience: data.audience,
+      success: data.success,
+      pageUrl: data.pageUrl,
+      tools: data.tools || {},
+      channels: data.channels || {},
+      promoProgress: data.promoProgress || {},
+      createdAt: data.createdAt
+    };
+
+    renderIdeas(ideaList, ideaRoot);
+  });
+
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+
+    const title = form.elements.ideaTitle.value.trim();
+    const problem = form.elements.ideaProblem.value.trim();
+    const audience = form.elements.ideaAudience.value.trim();
+    const success = form.elements.ideaSuccess.value.trim();
+    const pageUrl = form.elements.ideaUrl.value.trim();
+
+    if (!title || !problem) {
+      status.textContent = 'Add a title and problem statement to save the idea.';
+      return;
+    }
+
+    const tools = buildSelectionObject(form, 'workbenchTools', TOOL_OPTIONS);
+    const channels = buildSelectionObject(form, 'promoChannels', CHANNEL_OPTIONS);
+    const createdAt = new Date().toISOString();
+    const ideaId = `idea-${Date.now()}`;
+
+    ideaRoot.get(ideaId).put({
+      title,
+      problem,
+      audience,
+      success,
+      pageUrl,
+      tools,
+      channels,
+      createdAt
+    });
+
+    form.reset();
+    status.textContent = 'Idea saved and synced to Gun.';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initIdeaBoard();
+});

--- a/workbench-ideas/index.html
+++ b/workbench-ideas/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Workbench Idea Automations</title>
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <script src="app.js" defer></script>
+</head>
+<body class="theme-dark workbench-ideas">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+  <header class="page-header">
+    <div class="page-header__content">
+      <div>
+        <p class="page-header__eyebrow">OpenAI Workbench</p>
+        <h1>Idea page automation + promotion hub</h1>
+        <p class="page-header__summary">
+          Coordinate the Workbench tools, publish idea pages, and track promotion steps with GunJS as the shared
+          source of truth.
+        </p>
+      </div>
+      <div class="page-header__actions">
+        <a class="button ghost" href="/index.html">Back to portal</a>
+        <a class="button" href="/ideas/index.html">Ideas Lab</a>
+      </div>
+    </div>
+  </header>
+
+  <main id="mainContent" class="page-content">
+    <section class="panel" aria-labelledby="automation-title">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Automation flow</p>
+          <h2 id="automation-title">Use Workbench tools to ship idea pages fast</h2>
+        </div>
+      </div>
+      <div class="flow-grid">
+        <article class="flow-card">
+          <h3>1. Shape the idea</h3>
+          <p>Draft the problem, audience, and success metric with Workbench prompts so every page has a crisp story.</p>
+        </article>
+        <article class="flow-card">
+          <h3>2. Generate the page</h3>
+          <p>Use tool templates to translate the brief into an idea page and save the URL for promotion.</p>
+        </article>
+        <article class="flow-card">
+          <h3>3. Promote everywhere</h3>
+          <p>Pick promotion channels, assign owners, and track progress in the shared GunJS checklist below.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel" aria-labelledby="create-title">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Idea intake</p>
+          <h2 id="create-title">Create a Workbench-backed idea page</h2>
+          <p>Store each idea in Gun so the team can coordinate promotion from any device.</p>
+        </div>
+      </div>
+      <form class="idea-form" data-idea-form>
+        <div class="field-grid">
+          <label class="field">
+            <span class="field__label">Idea title</span>
+            <input type="text" name="ideaTitle" required placeholder="AI onboarding concierge" />
+          </label>
+          <label class="field">
+            <span class="field__label">Target audience</span>
+            <input type="text" name="ideaAudience" placeholder="New portal members, startup founders" />
+          </label>
+          <label class="field field--full">
+            <span class="field__label">Problem statement</span>
+            <textarea name="ideaProblem" rows="3" required placeholder="Describe the core problem and why it matters."></textarea>
+          </label>
+          <label class="field field--full">
+            <span class="field__label">Success metric</span>
+            <input type="text" name="ideaSuccess" placeholder="15 qualified signups in week one" />
+          </label>
+          <label class="field field--full">
+            <span class="field__label">Idea page URL</span>
+            <input type="url" name="ideaUrl" placeholder="https://3dvr.tech/ideas/your-idea" />
+          </label>
+        </div>
+
+        <div class="option-grid">
+          <div class="option-block" data-tool-options>
+            <h3>Workbench tools</h3>
+          </div>
+          <div class="option-block" data-channel-options>
+            <h3>Promotion channels</h3>
+          </div>
+        </div>
+
+        <div class="form-footer">
+          <button class="button" type="submit">Save idea</button>
+          <p class="form-status" data-form-status role="status" aria-live="polite"></p>
+        </div>
+      </form>
+    </section>
+
+    <section class="panel" aria-labelledby="board-title">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Promotion board</p>
+          <h2 id="board-title">Track idea pages and promotion progress</h2>
+          <p>Every checklist update syncs through the shared Gun node for the Workbench automation stream.</p>
+        </div>
+      </div>
+      <div class="idea-board" data-idea-list></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/workbench-ideas/styles.css
+++ b/workbench-ideas/styles.css
@@ -1,0 +1,256 @@
+.workbench-ideas {
+  background: radial-gradient(circle at top, #111827 0%, #0b0f1a 55%, #070b13 100%);
+  color: #f8fafc;
+  min-height: 100vh;
+}
+
+.page-header {
+  padding: 48px 20px 24px;
+}
+
+.page-header__content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin: 0 auto;
+  max-width: 1100px;
+}
+
+.page-header__eyebrow {
+  color: #93c5fd;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 8px 0 12px;
+}
+
+.page-header__summary {
+  color: #cbd5f5;
+  max-width: 720px;
+}
+
+.page-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  margin: 0 auto 56px;
+  max-width: 1100px;
+  padding: 0 20px 40px;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: 0 22px 60px rgba(15, 23, 42, 0.35);
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.eyebrow {
+  color: #7dd3fc;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.flow-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.flow-card {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 18px;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.flow-card h3 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  color: #fef3c7;
+}
+
+.idea-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.field-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field--full {
+  grid-column: 1 / -1;
+}
+
+.field__label {
+  color: #e2e8f0;
+  font-weight: 600;
+}
+
+.field input,
+.field textarea {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  color: #f8fafc;
+  font-size: 0.95rem;
+  padding: 12px 14px;
+}
+
+.field input:focus,
+.field textarea:focus {
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.3);
+  outline: none;
+}
+
+.option-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.option-block {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(10, 15, 28, 0.5);
+}
+
+.option-block h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.option-list {
+  display: grid;
+  gap: 10px;
+}
+
+.option-item {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.option-item input {
+  margin-top: 4px;
+}
+
+.form-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+}
+
+.form-status {
+  color: #93c5fd;
+}
+
+.idea-board {
+  display: grid;
+  gap: 18px;
+}
+
+.idea-card {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 18px;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.idea-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.idea-card__header h3 {
+  margin: 0;
+  color: #f8fafc;
+}
+
+.idea-card__meta {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.idea-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.badge {
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  border-radius: 999px;
+  color: #bfdbfe;
+  font-size: 0.75rem;
+  padding: 4px 10px;
+}
+
+.idea-card__section {
+  margin-top: 12px;
+}
+
+.idea-card__section h4 {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+  color: #fef3c7;
+}
+
+.promo-checklist {
+  display: grid;
+  gap: 8px;
+}
+
+.promo-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.promo-item label {
+  color: #e2e8f0;
+  font-size: 0.9rem;
+}
+
+@media (min-width: 900px) {
+  .page-header__content {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
### Motivation
- Automate the flow for turning Workbench briefs into idea landing pages and coordinating promotion steps. 
- Provide a shared, real-time source of truth for ideas and promotion progress using GunJS. 
- Expose Workbench tool selections and promotion channels so owners can pick and track steps. 
- Make the new automation hub discoverable from the main portal landing grid.

### Description
- Added a new app under `workbench-ideas/` with `index.html`, `app.js`, and `styles.css` implementing intake form, tool/channel selectors, and a promotion board. 
- Integrated GunJS and wired the app to the shared node `workbench/idea-pages` (node shape documented in code comment). 
- Promotion checklist items are written back to Gun with per-step `.get(...).put(...)` operations so progress syncs across clients. 
- Linked the new app from the portal by adding a `Workbench Ideas` app card to `index.html`.

### Testing
- Served the site locally with `python -m http.server` on port 8000 and the server started successfully. 
- Ran a Playwright smoke test that loaded `workbench-ideas/index.html` and captured a full-page screenshot successfully. 
- No automated unit or integration tests were added for the new JS logic in this change. 
- Live Gun sync scenarios were not exercised by automated tests in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec6219c588320affd26831f56d967)