### PR TITLE
Add v0.0.33 release notes and update releases index/navigation

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -80,18 +80,25 @@
   <div class="section">
     <h2>Latest Release</h2>
     <article class="release-card">
-      <a class="release-link" href="v0.0.31.html">v0.0.31</a>
-      <span class="release-meta">Week of December 22, 2025</span>
+      <a class="release-link" href="v0.0.33.html">v0.0.33</a>
+      <span class="release-meta">Week of January 5, 2026</span>
         <p class="release-summary">
-          <a href="../ideas/index.html">Ideas Lab</a> landing experiments with browser-local stats, a
-          <a href="../projects/index.html">projects directory</a>, and rate-limited shared defaults for
-          <a href="../openai-app/index.html">AI builders</a>
+          Launchpad clarity, refreshed builder guidance, and weekly routing for CRM, rewards, and wellness
+          workspaces
         </p>
     </article>
   </div>
   <div class="section">
     <h2>Release History</h2>
     <ul class="release-grid">
+      <li class="release-card">
+        <a class="release-link" href="v0.0.33.html">v0.0.33</a>
+        <span class="release-meta">Week of January 5, 2026</span>
+        <p class="release-summary">
+          Launchpad clarity, refreshed builder guidance, and weekly routing for CRM, rewards, and wellness
+          workspaces
+        </p>
+      </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.32.html">v0.0.32</a>
         <span class="release-meta">Week of December 29, 2025</span>

--- a/releases/v0.0.32.html
+++ b/releases/v0.0.32.html
@@ -77,7 +77,7 @@
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
     <a class="release-nav-link" href="v0.0.31.html">← Previous release</a>
-    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
+    <a class="release-nav-link" href="v0.0.33.html">Next release →</a>
   </nav>
   <h1>Release v0.0.32</h1>
   <div class="tag">Week of December 29, 2025</div>

--- a/releases/v0.0.33.html
+++ b/releases/v0.0.33.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal – Release v0.0.33 (Week of January 5, 2026)</title>
+  <style>
+    body {
+      margin: 0 auto;
+      font-family: Arial, Helvetica, sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      line-height: 1.65;
+      padding: 20px;
+      max-width: 900px;
+    }
+    h1,
+    h2,
+    h3 {
+      color: #58a6ff;
+    }
+    a {
+      color: #58a6ff;
+    }
+    .section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #161b22;
+      border-radius: 10px;
+      border: 1px solid #30363d;
+    }
+    .tag {
+      background: #1f6feb;
+      padding: 4px 10px;
+      border-radius: 6px;
+      display: inline-block;
+      font-size: 14px;
+      margin-bottom: 20px;
+    }
+    .release-summary {
+      margin: 0 0 24px;
+      font-size: 16px;
+      color: #9ba3b4;
+    }
+    .back-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .back-link:hover {
+      text-decoration: underline;
+    }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
+  </style>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.32.html">← Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
+  </nav>
+  <h1>Release v0.0.33</h1>
+  <div class="tag">Week of January 5, 2026</div>
+  <div class="section">
+    <h2>Overview</h2>
+    <p>
+      This release sharpens the portal's launchpad experience with clearer routing to core workspaces, refreshed
+      planning cues, and expanded weekly tracking across builders, CRM, and wellness flows.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>Portal quick links</h2>
+    <ul>
+      <li><a href="../index.html">Portal home</a> – jump into every workspace, lab, and experiment.</li>
+      <li><a href="../releases/index.html">Release hub</a> – browse weekly milestones and product checkpoints.</li>
+      <li><a href="../openai-app/index.html">OpenAI Workbench</a> – build, preview, and ship with shared defaults.</li>
+      <li><a href="../web-builder-app/index.html">Web Builder</a> – create web experiences with guided launch flows.</li>
+      <li><a href="../crm/index.html">CRM</a> – track leads, notes, and outreach in one place.</li>
+      <li><a href="../rewards.html">Rewards</a> – review point-based incentives and progress.</li>
+      <li><a href="../mindfulness-session.html">Mindfulness Session</a> – keep wellness workflows close by.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Launchpad clarity</h2>
+    <ul>
+      <li>Spotlight the most-used workspaces with direct links from the primary navigation cards.</li>
+      <li>Keep the landing grid consistent by aligning hero messaging with the weekly release focus.</li>
+      <li>Reduce navigation drift by highlighting returning destinations such as CRM, Web Builder, and rewards.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Builder workflow updates</h2>
+    <ul>
+      <li>Reinforce setup guidance in the <a href="../openai-app/index.html">OpenAI Workbench</a> for smoother session
+      starts.</li>
+      <li>Capture new launch intentions in the <a href="../web-builder-app/index.html">Web Builder</a> flow with clearer
+      routing to publish-ready steps.</li>
+      <li>Keep experimentation on track with refreshed prompts inside the
+      <a href="../ideas/index.html">Ideas Lab</a> catalog.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Operations &amp; wellness</h2>
+    <ul>
+      <li>Highlight weekly follow-ups inside the <a href="../crm/index.html">CRM</a> workspace for easier outreach.</li>
+      <li>Keep incentives visible with a refreshed path to <a href="../rewards.html">rewards tracking</a>.</li>
+      <li>Maintain daily wellbeing visibility with the
+      <a href="../mindfulness-session.html">mindfulness session</a> landing.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Publish the weekly release notes for `v0.0.33` to keep the release hub up to date.
- Surface the new release as the latest entry so portal visitors see the most recent changes first.
- Ensure release-to-release navigation links correctly point forward and back through the history.

### Description

- Add a new static release page at `releases/v0.0.33.html` containing the v0.0.33 notes and metadata.
- Update `releases/index.html` to mark `v0.0.33` as the latest release and insert it into the release history list.
- Update `releases/v0.0.32.html` to replace the disabled "Next release" placeholder with a link to `v0.0.33.html`.
- Changes are purely static HTML updates across three files (`releases/v0.0.33.html`, `releases/index.html`, `releases/v0.0.32.html`).

### Testing

- No automated tests were run for this static content update.
- The edits were committed locally with the message `Add v0.0.33 weekly release notes`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e50098a483208b72e4728ab70ec1)