### PR TITLE
Add Supabase Test Lab entry point and link from portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,11 @@
             <span class="app-card__title">Gun Sync Lab</span>
             <span class="app-card__meta">Monitor relays, run the shared counter, and capture backups.</span>
           </a>
+          <a href="tests/supabase/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🧪</span>
+            <span class="app-card__title">Supabase Test Lab</span>
+            <span class="app-card__meta">Prototype Supabase workflows before migrating portal apps.</span>
+          </a>
           <a href="home/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🖥️</span>
             <span class="app-card__title">Home</span>

--- a/tests/supabase/README.md
+++ b/tests/supabase/README.md
@@ -1,0 +1,29 @@
+# Supabase test sandbox
+
+This folder is a small, dedicated space for Supabase-focused tests without touching GunJS flows.
+It keeps Supabase connectivity experiments isolated from existing test suites.
+
+## Setup
+
+1. Create a Supabase project (or reuse an existing one).
+2. Export the connection details before running tests:
+
+```bash
+export SUPABASE_URL="https://your-project.supabase.co"
+export SUPABASE_ANON_KEY="your_anon_key"
+```
+
+## Running
+
+```bash
+node --test tests/supabase
+```
+
+## Browser access
+
+Open `tests/supabase/index.html` from the portal home page to use the Supabase Test Lab UI.
+
+## Notes
+
+- Tests in this folder are designed to skip automatically when credentials are missing.
+- Add new tests here as we expand Supabase coverage.

--- a/tests/supabase/index.html
+++ b/tests/supabase/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Supabase Test Lab</title>
+  <link rel="stylesheet" href="/styles/global.css">
+  <style>
+    body {
+      background: #0e1116;
+      color: #f5f7ff;
+      font-family: "Inter", "Segoe UI", sans-serif;
+      margin: 0;
+      min-height: 100vh;
+    }
+
+    .page-shell {
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+      margin: 0 auto;
+      max-width: 900px;
+      padding: 2.5rem 1.5rem 4rem;
+    }
+
+    .page-header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .page-header a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .page-header a:focus,
+    .page-header a:hover {
+      text-decoration: underline;
+    }
+
+    .status-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .status-card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 16px;
+      padding: 1.25rem;
+    }
+
+    .status-card h2 {
+      font-size: 1.05rem;
+      margin: 0 0 0.5rem;
+    }
+
+    .status-card p {
+      color: rgba(245, 247, 255, 0.8);
+      margin: 0;
+    }
+
+    .next-steps {
+      background: rgba(15, 92, 255, 0.12);
+      border: 1px solid rgba(15, 92, 255, 0.3);
+      border-radius: 16px;
+      padding: 1.5rem;
+    }
+
+    .next-steps ol {
+      margin: 0.75rem 0 0;
+      padding-left: 1.2rem;
+    }
+
+    .pill {
+      background: rgba(255, 255, 255, 0.12);
+      border-radius: 999px;
+      display: inline-flex;
+      font-size: 0.85rem;
+      padding: 0.25rem 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="page-shell">
+    <header class="page-header">
+      <a href="/index.html">← Back to portal</a>
+      <span class="pill">Supabase Test Lab</span>
+      <h1>Supabase Test App</h1>
+      <p>
+        Use this space to validate Supabase workflows before migrating larger apps. The goal is to keep
+        experiments isolated from GunJS while keeping notes and next steps in one place.
+      </p>
+    </header>
+
+    <section class="status-grid" aria-label="Supabase test status">
+      <article class="status-card">
+        <h2>Connection</h2>
+        <p>Waiting on credentials and project setup.</p>
+      </article>
+      <article class="status-card">
+        <h2>Data Model</h2>
+        <p>Define tables and policies before wiring UI flows.</p>
+      </article>
+      <article class="status-card">
+        <h2>Auth</h2>
+        <p>Plan sign-in routes (magic link, OAuth, or email + password).</p>
+      </article>
+    </section>
+
+    <section class="next-steps" aria-label="Next steps">
+      <h2>Suggested next steps</h2>
+      <ol>
+        <li>Create the Supabase project and enable Row Level Security.</li>
+        <li>Decide which app feature to migrate first and sketch the schema.</li>
+        <li>Add Supabase client logic and small UI panels here before wiring into the portal.</li>
+      </ol>
+    </section>
+  </main>
+</body>
+</html>

--- a/tests/supabase/supabase-env.test.js
+++ b/tests/supabase/supabase-env.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+// Keeping this focused on configuration validation until we wire in @supabase/supabase-js.
+// This ensures early feedback without forcing secrets into the repo.
+
+test('supabase credentials are available', { skip: !supabaseUrl || !supabaseAnonKey }, () => {
+  assert.ok(supabaseUrl, 'SUPABASE_URL is required to run Supabase tests');
+  assert.ok(supabaseAnonKey, 'SUPABASE_ANON_KEY is required to run Supabase tests');
+});


### PR DESCRIPTION
### Motivation

- Provide a lightweight browser-accessible Supabase Test Lab so Supabase workflows can be prototyped before migrating larger portal apps.
- Keep Supabase experiments isolated from GunJS tests to avoid cross-test interference and browser-specific GunJS issues.
- Make it easy to reach the test sandbox from the main portal UI for iterative UI-driven development.

### Description

- Add `tests/supabase/index.html` as a Supabase Test Lab landing page with status cards and next steps for prototyping.
- Link the new Test Lab into the portal app grid by adding an entry in `index.html` pointing to `tests/supabase/index.html`.
- Update `tests/supabase/README.md` to document browser access and running tests via `node --test tests/supabase`.
- Add a small env validation test `tests/supabase/supabase-env.test.js` that asserts presence of `SUPABASE_URL` and `SUPABASE_ANON_KEY` and is skipped automatically when those vars are absent.

### Testing

- Started a local static server with `python -m http.server 8000` and ran a Playwright script that loaded `/index.html` and `/tests/supabase/index.html` and produced screenshots, which completed successfully.
- The new `supabase-env.test.js` is present but not executed as part of this change; it is configured to skip when credentials are missing.
- No `node --test` suite was run as part of this change beyond the env-check test being added (it will skip without secrets).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b24096aa4832086ccbedbd1e3fd41)