### PR TITLE
Add Personal Debian Server landing page and link from portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,11 @@
             <span class="app-card__title">Debian Browser Lab</span>
             <span class="app-card__meta">Explore the Debian-in-browser experiment with VM and streaming paths.</span>
           </a>
+          <a href="personal-debian-server/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🖧</span>
+            <span class="app-card__title">Personal Debian Server</span>
+            <span class="app-card__meta">Learn how a Debian laptop runs local-first hosting and databases.</span>
+          </a>
           <a href="finance/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">💰</span>
             <span class="app-card__title">Finance</span>

--- a/personal-debian-server/index.html
+++ b/personal-debian-server/index.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Personal Debian Server – Local-First Hosting</title>
+  <meta name="description" content="Running websites and databases from a Debian laptop: a practical, sovereign, local-first approach to infrastructure." />
+  <style>
+    :root {
+      --bg: #0e1117;
+      --fg: #e6edf3;
+      --muted: #9da7b3;
+      --accent: #00ffc8;
+      --card: #161b22;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: linear-gradient(180deg, #0e1117, #0b0f14);
+      color: var(--fg);
+      line-height: 1.6;
+    }
+
+    header {
+      padding: 4rem 1.5rem 3rem;
+      max-width: 900px;
+      margin: auto;
+    }
+
+    h1 {
+      font-size: clamp(2rem, 5vw, 3rem);
+      margin-bottom: 1rem;
+    }
+
+    h2 {
+      margin-top: 3rem;
+      color: var(--accent);
+    }
+
+    p {
+      color: var(--fg);
+    }
+
+    .subtitle {
+      color: var(--muted);
+      font-size: 1.1rem;
+      max-width: 700px;
+    }
+
+    .home-link {
+      color: var(--accent);
+      display: inline-flex;
+      gap: 0.5rem;
+      align-items: center;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .home-link:hover,
+    .home-link:focus {
+      text-decoration: underline;
+    }
+
+    main {
+      max-width: 900px;
+      margin: auto;
+      padding: 0 1.5rem 4rem;
+    }
+
+    section {
+      margin-top: 3rem;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid #222;
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-top: 1.5rem;
+    }
+
+    ul,
+    ol {
+      padding-left: 1.25rem;
+    }
+
+    li {
+      margin-bottom: 0.5rem;
+    }
+
+    code {
+      background: #000;
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      color: var(--accent);
+    }
+
+    footer {
+      border-top: 1px solid #222;
+      padding: 2rem 1.5rem;
+      color: var(--muted);
+      font-size: 0.9rem;
+      text-align: center;
+    }
+
+    .accent {
+      color: var(--accent);
+    }
+  </style>
+</head>
+<body>
+
+  <header>
+    <a class="home-link" href="/">← Back to 3DVR Portal</a>
+    <h1>Running Websites & Databases from a Debian Laptop</h1>
+    <p class="subtitle">
+      A local-first, sovereign approach to hosting — using a machine you already own,
+      designed for learning, resilience, and long-term decentralization.
+    </p>
+  </header>
+
+  <main>
+
+    <section>
+      <h2>What This Is</h2>
+      <p>
+        This machine is a <strong>Debian-based laptop</strong> that stays at home most of the time
+        and functions as a personal server.
+      </p>
+      <p>
+        It runs real websites and real databases — not as a gimmick, but as an intentional
+        alternative to cloud-only infrastructure.
+      </p>
+
+      <div class="card">
+        <strong>Think of it as:</strong>
+        <ul>
+          <li>A personal development server</li>
+          <li>A staging environment</li>
+          <li>A low-traffic production server</li>
+          <li>A learning platform for real infrastructure</li>
+          <li>A foundation for decentralized hosting</li>
+        </ul>
+      </div>
+    </section>
+
+    <section>
+      <h2>What’s Technically Possible</h2>
+      <div class="card">
+        <ul>
+          <li>Serve static sites (HTML / CSS / JS)</li>
+          <li>Run dynamic applications (Node, PHP, Python, etc.)</li>
+          <li>Host multiple sites from one machine</li>
+          <li>Run databases like PostgreSQL or MariaDB</li>
+          <li>Use containers (Docker / Podman)</li>
+          <li>Expose services securely to the internet</li>
+        </ul>
+      </div>
+
+      <p>
+        Debian is widely used on professional servers.
+        There is no meaningful difference between this laptop and a cloud VM —
+        only context and responsibility.
+      </p>
+    </section>
+
+    <section>
+      <h2>What Actually Matters (The Real Constraints)</h2>
+
+      <div class="card">
+        <strong>🌍 Internet Access</strong>
+        <ul>
+          <li>Home machines are usually behind NAT</li>
+          <li>Inbound traffic must be intentionally enabled</li>
+          <li>Solutions include port forwarding, tunnels, or VPN ingress</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <strong>🔐 Security</strong>
+        <ul>
+          <li>Firewall configuration is mandatory</li>
+          <li>SSH keys only (no passwords)</li>
+          <li>Services run as non-root users</li>
+          <li>Databases are never exposed directly</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <strong>⚡ Power & Uptime</strong>
+        <ul>
+          <li>Occasional outages are expected</li>
+          <li>Systemd handles auto-restarts</li>
+          <li>This is acceptable for personal and low-traffic use</li>
+        </ul>
+      </div>
+    </section>
+
+    <section>
+      <h2>Why Do This Instead of “Just Using the Cloud”?</h2>
+      <p>
+        Cloud platforms are convenient — but they hide how infrastructure actually works.
+      </p>
+
+      <div class="card">
+        <ul>
+          <li>Deeper understanding of servers and networking</li>
+          <li>Lower long-term costs</li>
+          <li>Privacy and data ownership</li>
+          <li>Ability to run anywhere</li>
+          <li>No platform lock-in</li>
+        </ul>
+      </div>
+
+      <p>
+        This approach treats infrastructure as <strong>a skill</strong>, not a service dependency.
+      </p>
+    </section>
+
+    <section>
+      <h2>How This Evolves</h2>
+      <div class="card">
+        <ol>
+          <li>Single Debian machine (this)</li>
+          <li>Containerized services</li>
+          <li>Hybrid model (home + VPS ingress)</li>
+          <li>Replication and backups</li>
+          <li>Federated / decentralized nodes</li>
+        </ol>
+      </div>
+
+      <p>
+        This laptop is not the final destination.
+        It is the <span class="accent">starting node</span>.
+      </p>
+    </section>
+
+    <section>
+      <h2>Philosophy</h2>
+      <p>
+        Modern computing doesn’t have to mean:
+        centralized, opaque, disposable, and fragile.
+      </p>
+      <p>
+        A single machine — thoughtfully configured — can be:
+      </p>
+
+      <div class="card">
+        <ul>
+          <li>Understandable</li>
+          <li>Repairable</li>
+          <li>Portable</li>
+          <li>Sovereign</li>
+          <li>Expandable</li>
+        </ul>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>
+    <p>
+      Built on Debian • Local-First • Infrastructure as Knowledge
+    </p>
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated landing page that explains how to run a personal Debian laptop as a local-first hosting node.
- Make the new content discoverable from the portal app grid so users can jump directly to the guide.
- Keep the portal consistent and human-readable by reusing the supplied standalone HTML and styling.

### Description
- Added `personal-debian-server/index.html` with the provided responsive HTML, styles, and a back link to the portal (`/`).
- Linked the new page from the main portal app grid by adding an `app-card` entry in `index.html` that points to `personal-debian-server/index.html`.
- Ensured the new page uses the portal color variables and simple accessible layout to match existing pages.

### Testing
- Served the site locally with `python -m http.server 8000` and confirmed the server started successfully.
- Loaded `http://127.0.0.1:8000/personal-debian-server/index.html` with a Playwright script and captured a full-page screenshot, which completed successfully.
- Performed a smoke check in the browser to verify the back link and the new app card are present and load as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c94d21b1c8320a0c01ba69489b635)