### PR TITLE
Add npm start script alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vercel dev",
+    "start": "vercel dev",
     "test": "node --test"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- Provide a conventional entrypoint so contributors can start the dev server with `npm start` (aliases the existing `npm run dev`).

### Description
- Add a `start` script to `package.json` that runs `vercel dev`, matching the current `dev` script.

### Testing
- No automated tests were run for this single-line `package.json` update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697384c2e3fc8320adc1624b5d16a774)