### PR TITLE
Soften social command center palette

### DIFF
--- a/social/styles.css
+++ b/social/styles.css
@@ -1,9 +1,10 @@
 :root {
   color-scheme: light dark;
-  --bg-page: #f5f7fb;
-  --bg-card: rgba(255, 255, 255, 0.94);
+  --bg-page: #eef2f6;
+  --bg-card: rgba(245, 247, 250, 0.96);
   --bg-card-dark: rgba(20, 24, 29, 0.85);
-  --bg-soft: rgba(31, 122, 109, 0.08);
+  --bg-soft: rgba(31, 122, 109, 0.1);
+  --bg-input: #f3f6f9;
   --text-primary: #14232d;
   --text-muted: rgba(20, 35, 45, 0.72);
   --accent: #1f7a6d;
@@ -24,7 +25,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(180deg, #f5f7fb 0%, #eef4f1 45%, #f6fbff 100%);
+  background: linear-gradient(180deg, var(--bg-page) 0%, #e7eff2 45%, #edf3f8 100%);
   color: var(--text-primary);
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   padding: clamp(16px, 4vw, 48px);
@@ -195,7 +196,7 @@ select {
   padding: 12px 14px;
   border-radius: 12px;
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.8);
+  background: var(--bg-input);
   font: inherit;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }


### PR DESCRIPTION
### Motivation
- Reduce eye-strain from the Social Media Command Center by replacing stark whites with softer page, card, and form backgrounds for a calmer, more readable UI.

### Description
- Update `social/styles.css` palette variables by changing `--bg-page` and `--bg-card`, increasing `--bg-soft` opacity, and adding a new `--bg-input` variable.
- Replace the body background gradient to use `--bg-page` and gentler mid tones.
- Use `--bg-input` for `input`, `textarea`, and `select` backgrounds to remove the blinding white fields and match the softened card tone.

### Testing
- Launched a local static server with `python -m http.server 8000` and confirmed `/social/index.html` served successfully.
- Ran a Playwright script to capture a visual verification screenshot saved as `artifacts/social-command-softened.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e6fab16c832086bc0b4c5bd4aab3)