### PR TITLE
Move Jetpack entrypoint into folder with backward-compatible redirect

### DIFF
--- a/games.html
+++ b/games.html
@@ -67,7 +67,7 @@ h1 {
   <a class="game-card" href="memory.html">Memory Match</a>
   <a class="game-card" href="tribes-flight.html">Zero-G Ski Range</a>
   <a class="game-card" href="stellar-flight.html">Stellar Drift Flight</a>
-  <a class="game-card" href="jetpack.html">Jetpack Corridor (Arrows/WASD + Jetpack)</a>
+  <a class="game-card" href="jetpack/">Jetpack Corridor (Arrows/WASD + Jetpack)</a>
 </div>
 
 </body>

--- a/jetpack.html
+++ b/jetpack.html
@@ -3,97 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>3dvr.tech Jetpack Corridor</title>
-  <link rel="stylesheet" href="styles/global.css">
-  <link rel="stylesheet" href="jetpack/style.css">
+  <title>Redirecting to Jetpack Corridor</title>
+  <meta http-equiv="refresh" content="0; url=jetpack/">
+  <link rel="canonical" href="jetpack/">
+  <script>
+    window.location.replace('jetpack/');
+  </script>
 </head>
 <body>
-  <button id="menu-toggle" type="button" aria-controls="game-nav" aria-expanded="false">Menu</button>
-
-  <nav id="game-nav" class="top-buttons" aria-label="Game links">
-    <a href="index.html">Portal</a>
-    <a href="games.html">Game Hub</a>
-    <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">Subscribe</a>
-    <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">GitHub</a>
-  </nav>
-
-  <div id="loading" role="status" aria-live="polite">Loading Corridor...</div>
-
-  <aside id="hud" aria-live="polite">
-    <div class="hud-header">
-      <span class="hud-title">Run Score</span>
-      <strong id="hud-score" class="hud-value">0</strong>
-    </div>
-
-    <div class="hud-grid">
-      <div class="hud-item">
-        <span class="hud-item-label">Shield</span>
-        <strong id="hud-shield" class="hud-item-value">100%</strong>
-      </div>
-      <div class="hud-item">
-        <span class="hud-item-label">Boost</span>
-        <strong id="hud-boost" class="hud-item-value">Ready</strong>
-      </div>
-    </div>
-
-    <div class="hud-meter">
-      <div class="hud-meter-label">
-        <span>Fuel</span>
-        <span id="hud-fuel">100%</span>
-      </div>
-      <div class="meter-track">
-        <div id="fuel-meter-fill" class="meter-fill fuel"></div>
-      </div>
-    </div>
-
-    <div class="hud-meter">
-      <div class="hud-meter-label">
-        <span>Distance</span>
-        <span id="hud-distance">0%</span>
-      </div>
-      <div class="meter-track">
-        <div id="distance-meter-fill" class="meter-fill distance"></div>
-      </div>
-    </div>
-
-    <div class="hud-meter">
-      <div class="hud-meter-label">
-        <span>Shield Integrity</span>
-        <span aria-hidden="true">Tracked</span>
-      </div>
-      <div class="meter-track">
-        <div id="shield-meter-fill" class="meter-fill shield"></div>
-      </div>
-    </div>
-  </aside>
-
-  <section id="overlay" hidden aria-hidden="true">
-    <div class="overlay-card" role="dialog" aria-modal="true" aria-labelledby="overlay-title">
-      <h2 id="overlay-title">Jetpack Corridor</h2>
-      <p id="overlay-message">Prepare to launch.</p>
-      <button id="overlay-action" type="button">Launch</button>
-    </div>
-  </section>
-
-  <p id="instruction-chip">
-    WASD/Arrows steer. Hold Space or Fly to climb. On touch, joystick X turns and strafes while Y drives forward/back.
-  </p>
-
-  <div id="controls" aria-label="Touch controls">
-    <div id="joystick-zone" aria-hidden="true">
-      <div id="joystick-base">
-        <div id="joystick-knob"></div>
-      </div>
-    </div>
-
-    <div id="action-buttons">
-      <button id="fly-btn" class="control-btn fly" type="button" aria-label="Use jetpack">Fly</button>
-      <button id="pause-btn" class="control-btn small" type="button" aria-label="Pause run">Pause</button>
-    </div>
-  </div>
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
-  <script type="module" src="jetpack/main.js"></script>
+  <p>Redirecting to <a href="jetpack/">Jetpack Corridor</a>...</p>
 </body>
 </html>

--- a/jetpack/index.html
+++ b/jetpack/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3dvr.tech Jetpack Corridor</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button id="menu-toggle" type="button" aria-controls="game-nav" aria-expanded="false">Menu</button>
+
+  <nav id="game-nav" class="top-buttons" aria-label="Game links">
+    <a href="../index.html">Portal</a>
+    <a href="../games.html">Game Hub</a>
+    <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">Subscribe</a>
+    <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">GitHub</a>
+  </nav>
+
+  <div id="loading" role="status" aria-live="polite">Loading Corridor...</div>
+
+  <aside id="hud" aria-live="polite">
+    <div class="hud-header">
+      <span class="hud-title">Run Score</span>
+      <strong id="hud-score" class="hud-value">0</strong>
+    </div>
+
+    <div class="hud-grid">
+      <div class="hud-item">
+        <span class="hud-item-label">Shield</span>
+        <strong id="hud-shield" class="hud-item-value">100%</strong>
+      </div>
+      <div class="hud-item">
+        <span class="hud-item-label">Boost</span>
+        <strong id="hud-boost" class="hud-item-value">Ready</strong>
+      </div>
+    </div>
+
+    <div class="hud-meter">
+      <div class="hud-meter-label">
+        <span>Fuel</span>
+        <span id="hud-fuel">100%</span>
+      </div>
+      <div class="meter-track">
+        <div id="fuel-meter-fill" class="meter-fill fuel"></div>
+      </div>
+    </div>
+
+    <div class="hud-meter">
+      <div class="hud-meter-label">
+        <span>Distance</span>
+        <span id="hud-distance">0%</span>
+      </div>
+      <div class="meter-track">
+        <div id="distance-meter-fill" class="meter-fill distance"></div>
+      </div>
+    </div>
+
+    <div class="hud-meter">
+      <div class="hud-meter-label">
+        <span>Shield Integrity</span>
+        <span aria-hidden="true">Tracked</span>
+      </div>
+      <div class="meter-track">
+        <div id="shield-meter-fill" class="meter-fill shield"></div>
+      </div>
+    </div>
+  </aside>
+
+  <section id="overlay" hidden aria-hidden="true">
+    <div class="overlay-card" role="dialog" aria-modal="true" aria-labelledby="overlay-title">
+      <h2 id="overlay-title">Jetpack Corridor</h2>
+      <p id="overlay-message">Prepare to launch.</p>
+      <button id="overlay-action" type="button">Launch</button>
+    </div>
+  </section>
+
+  <p id="instruction-chip">
+    WASD/Arrows steer. Hold Space or Fly to climb. On touch, joystick X turns and strafes while Y drives forward/back.
+  </p>
+
+  <div id="controls" aria-label="Touch controls">
+    <div id="joystick-zone" aria-hidden="true">
+      <div id="joystick-base">
+        <div id="joystick-knob"></div>
+      </div>
+    </div>
+
+    <div id="action-buttons">
+      <button id="fly-btn" class="control-btn fly" type="button" aria-label="Use jetpack">Fly</button>
+      <button id="pause-btn" class="control-btn small" type="button" aria-label="Pause run">Pause</button>
+    </div>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
+  <script type="module" src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move the Jetpack page entrypoint from `jetpack.html` to `jetpack/index.html`
- update `games.html` to link to `jetpack/`
- keep a lightweight `jetpack.html` redirect so existing links continue to work

## Testing
- node --test tests/jetpack-game-state.test.js
