### PR TITLE
Make Contacts a standalone downloadable PWA

### DIFF
--- a/app-manifests/contacts.webmanifest
+++ b/app-manifests/contacts.webmanifest
@@ -1,9 +1,10 @@
 {
+  "id": "/contacts/",
   "name": "3DVR Contacts",
   "short_name": "Contacts",
   "description": "Manage your 3DVR relationships and invite collaborators.",
   "start_url": "/contacts/?source=pwa",
-  "scope": "/",
+  "scope": "/contacts/",
   "display": "standalone",
   "background_color": "#0e1116",
   "theme_color": "#0e1116",

--- a/contacts/index.html
+++ b/contacts/index.html
@@ -11,7 +11,12 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/axe.js"></script>
   <script src="../score.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script src="/pwa-install.js" defer></script>
+  <script
+    src="/pwa-install.js"
+    data-sw-url="/contacts/service-worker.js"
+    data-sw-scope="/contacts/"
+    defer
+  ></script>
   <meta name="color-scheme" content="dark light">
   <link rel="stylesheet" href="/styles/install-banner.css">
   <link rel="manifest" href="/app-manifests/contacts.webmanifest">

--- a/pwa-install.js
+++ b/pwa-install.js
@@ -1,10 +1,33 @@
 (() => {
+  const scriptEl = document.currentScript;
+  const configuredWorkerUrl = scriptEl?.dataset?.swUrl || '/service-worker.js';
+  const configuredScope = scriptEl?.dataset?.swScope || '/';
+  const resolvedWorkerUrl = new URL(configuredWorkerUrl, window.location.origin);
+  const resolvedScopeUrl = new URL(configuredScope, window.location.origin);
+  const scopePath = resolvedScopeUrl.pathname.endsWith('/')
+    ? resolvedScopeUrl.pathname
+    : `${resolvedScopeUrl.pathname}/`;
+  const scopeHref = new URL(scopePath, window.location.origin).href;
+
+  const toPathname = (url) => {
+    if (!url) return '';
+    try {
+      return new URL(url, window.location.origin).pathname;
+    } catch (error) {
+      console.warn('Unable to parse service worker URL', error);
+      return '';
+    }
+  };
+
   const registerServiceWorker = async () => {
     if (!('serviceWorker' in navigator)) return null;
 
     try {
-      const registration = await navigator.serviceWorker.getRegistration('/');
-      const isExpectedWorker = registration?.active?.scriptURL?.endsWith('/service-worker.js');
+      const registration = await navigator.serviceWorker.getRegistration(scopePath);
+      const activeScriptPath = toPathname(registration?.active?.scriptURL);
+      const isExpectedWorker = Boolean(registration)
+        && activeScriptPath === resolvedWorkerUrl.pathname
+        && registration.scope === scopeHref;
 
       if (isExpectedWorker) {
         registration.update().catch((error) => {
@@ -13,7 +36,10 @@
         return registration;
       }
 
-      return navigator.serviceWorker.register('/service-worker.js', { scope: '/' });
+      return navigator.serviceWorker.register(
+        `${resolvedWorkerUrl.pathname}${resolvedWorkerUrl.search}`,
+        { scope: scopePath }
+      );
     } catch (error) {
       console.error('Service worker registration failed', error);
       return null;

--- a/tests/contacts-pwa-config.test.js
+++ b/tests/contacts-pwa-config.test.js
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+
+const readProjectFile = async (path) =>
+  readFile(resolve(projectRoot, path), 'utf8');
+
+describe('contacts PWA configuration', () => {
+  it('uses a contacts-scoped webmanifest identity', async () => {
+    const manifestText = await readProjectFile('app-manifests/contacts.webmanifest');
+    const manifest = JSON.parse(manifestText);
+
+    assert.equal(manifest.id, '/contacts/');
+    assert.equal(manifest.scope, '/contacts/');
+    assert.match(manifest.start_url, /^\/contacts\//);
+    assert.equal(manifest.display, 'standalone');
+  });
+
+  it('registers the contacts service worker with contacts scope', async () => {
+    const html = await readProjectFile('contacts/index.html');
+
+    assert.match(html, /src="\/pwa-install\.js"/);
+    assert.match(html, /data-sw-url="\/contacts\/service-worker\.js"/);
+    assert.match(html, /data-sw-scope="\/contacts\/"/);
+  });
+
+  it('ships an app-specific contacts service worker', async () => {
+    const workerSource = await readProjectFile('contacts/service-worker.js');
+
+    assert.match(workerSource, /contacts-static-/);
+    assert.match(workerSource, /contacts-html-/);
+    assert.match(workerSource, /\/contacts\/index\.html/);
+    assert.match(workerSource, /self\.addEventListener\('fetch'/);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,13 @@
       ]
     },
     {
+      "source": "/contacts/service-worker.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" },
+        { "key": "Service-Worker-Allowed", "value": "/contacts/" }
+      ]
+    },
+    {
       "source": "/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|woff2?)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Summary
- scope the Contacts manifest identity to `/contacts/` so it installs as its own app
- register a Contacts-specific service worker via configurable `pwa-install.js` data attributes
- add `contacts/service-worker.js` with Contacts-focused caching strategies
- add Vercel headers for `/contacts/service-worker.js` to keep worker updates fresh
- add a regression test for Contacts PWA configuration

## Testing
- npm test -- tests/contacts-core.test.js tests/contacts-pwa-config.test.js
