### PR TITLE
Fix PWA install cache behavior for Contacts

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,4 +1,5 @@
 {
+  "id": "/",
   "name": "3dvr Portal",
   "short_name": "3dvr Portal",
   "description": "Earn points, play games, learn, and build with 3DVR.",

--- a/tests/contacts-pwa-config.test.js
+++ b/tests/contacts-pwa-config.test.js
@@ -10,7 +10,23 @@ const projectRoot = resolve(__dirname, '..');
 const readProjectFile = async (path) =>
   readFile(resolve(projectRoot, path), 'utf8');
 
+const findHeaderValue = (headers, key) => {
+  const match = headers.find((header) => header.key === key);
+  return match ? match.value : null;
+};
+
 describe('contacts PWA configuration', () => {
+  it('keeps portal and contacts manifest identities distinct', async () => {
+    const rootManifestText = await readProjectFile('manifest.webmanifest');
+    const rootManifest = JSON.parse(rootManifestText);
+    const contactsManifestText = await readProjectFile('app-manifests/contacts.webmanifest');
+    const contactsManifest = JSON.parse(contactsManifestText);
+
+    assert.equal(rootManifest.id, '/');
+    assert.equal(contactsManifest.id, '/contacts/');
+    assert.notEqual(rootManifest.id, contactsManifest.id);
+  });
+
   it('uses a contacts-scoped webmanifest identity', async () => {
     const manifestText = await readProjectFile('app-manifests/contacts.webmanifest');
     const manifest = JSON.parse(manifestText);
@@ -36,5 +52,42 @@ describe('contacts PWA configuration', () => {
     assert.match(workerSource, /contacts-html-/);
     assert.match(workerSource, /\/contacts\/index\.html/);
     assert.match(workerSource, /self\.addEventListener\('fetch'/);
+  });
+
+  it('marks install-critical files as no-cache in Vercel headers', async () => {
+    const vercelText = await readProjectFile('vercel.json');
+    const config = JSON.parse(vercelText);
+    const rules = Array.isArray(config.headers) ? config.headers : [];
+
+    const staticAssetsIndex = rules.findIndex(
+      (rule) => rule.source === '/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|woff2?)'
+    );
+    const pwaInstallIndex = rules.findIndex((rule) => rule.source === '/pwa-install.js');
+    const rootWorkerIndex = rules.findIndex((rule) => rule.source === '/service-worker.js');
+    const contactsWorkerIndex = rules.findIndex(
+      (rule) => rule.source === '/contacts/service-worker.js'
+    );
+
+    assert.notEqual(staticAssetsIndex, -1);
+    assert.notEqual(pwaInstallIndex, -1);
+    assert.notEqual(rootWorkerIndex, -1);
+    assert.notEqual(contactsWorkerIndex, -1);
+
+    assert.equal(staticAssetsIndex < pwaInstallIndex, true);
+    assert.equal(staticAssetsIndex < rootWorkerIndex, true);
+    assert.equal(staticAssetsIndex < contactsWorkerIndex, true);
+
+    const pwaInstallRule = rules[pwaInstallIndex];
+    const rootWorkerRule = rules[rootWorkerIndex];
+    const contactsWorkerRule = rules[contactsWorkerIndex];
+
+    assert.equal(findHeaderValue(pwaInstallRule.headers, 'Cache-Control'), 'no-cache');
+    assert.equal(findHeaderValue(rootWorkerRule.headers, 'Cache-Control'), 'no-cache');
+    assert.equal(findHeaderValue(rootWorkerRule.headers, 'Service-Worker-Allowed'), '/');
+    assert.equal(findHeaderValue(contactsWorkerRule.headers, 'Cache-Control'), 'no-cache');
+    assert.equal(
+      findHeaderValue(contactsWorkerRule.headers, 'Service-Worker-Allowed'),
+      '/contacts/'
+    );
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,30 @@
   ],
   "headers": [
     {
+      "source": "/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|woff2?)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/manifest.webmanifest",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/app-manifests/(.*)\\.webmanifest",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/pwa-install.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    },
+    {
       "source": "/service-worker.js",
       "headers": [
         { "key": "Cache-Control", "value": "no-cache" },
@@ -18,12 +42,6 @@
       "headers": [
         { "key": "Cache-Control", "value": "no-cache" },
         { "key": "Service-Worker-Allowed", "value": "/contacts/" }
-      ]
-    },
-    {
-      "source": "/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|woff2?)",
-      "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- prevent stale install logic by setting `no-cache` for `/pwa-install.js`, `/service-worker.js`, and `/contacts/service-worker.js`
- keep manifest updates fresh with explicit `must-revalidate` headers for `/manifest.webmanifest` and `/app-manifests/*.webmanifest`
- add an explicit root manifest `id` (`/`) so root and contacts app identities stay distinct
- add test coverage to lock these PWA config invariants

## Why
Chrome can keep old install behavior when install-critical JS/SW files are cached as immutable. This hotfix ensures new manifest/service-worker changes are picked up quickly and improves app identity separation.

## Testing
- npm test -- tests/contacts-pwa-config.test.js
