### PR TITLE
Rename installed app label to 3DVR Contacts

### DIFF
--- a/app-manifests/contacts.webmanifest
+++ b/app-manifests/contacts.webmanifest
@@ -1,7 +1,7 @@
 {
   "id": "/contacts/",
   "name": "3DVR Contacts",
-  "short_name": "Contacts",
+  "short_name": "3DVR Contacts",
   "description": "Manage your 3DVR relationships and invite collaborators.",
   "start_url": "/contacts/?source=pwa",
   "scope": "/contacts/",

--- a/contacts/contacts.webmanifest
+++ b/contacts/contacts.webmanifest
@@ -1,7 +1,7 @@
 {
   "id": "./",
   "name": "3DVR Contacts",
-  "short_name": "Contacts",
+  "short_name": "3DVR Contacts",
   "description": "Manage your 3DVR relationships and invite collaborators.",
   "start_url": "./?source=pwa",
   "scope": "./",

--- a/tests/contacts-pwa-config.test.js
+++ b/tests/contacts-pwa-config.test.js
@@ -32,6 +32,7 @@ describe('contacts PWA configuration', () => {
     const manifest = JSON.parse(manifestText);
 
     assert.equal(manifest.id, '/contacts/');
+    assert.equal(manifest.short_name, '3DVR Contacts');
     assert.equal(manifest.scope, '/contacts/');
     assert.match(manifest.start_url, /^\/contacts\//);
     assert.equal(manifest.display, 'standalone');
@@ -42,6 +43,7 @@ describe('contacts PWA configuration', () => {
     const manifest = JSON.parse(manifestText);
 
     assert.equal(manifest.id, './');
+    assert.equal(manifest.short_name, '3DVR Contacts');
     assert.equal(manifest.scope, './');
     assert.equal(manifest.start_url, './?source=pwa');
     assert.equal(manifest.display, 'standalone');


### PR DESCRIPTION
## Summary
- change contacts app manifest `short_name` to `3DVR Contacts` for both deploy modes
  - `app-manifests/contacts.webmanifest`
  - `contacts/contacts.webmanifest`
- extend contacts PWA config test assertions to enforce the new label

## Why
This avoids confusion with a device's default Contacts app by showing a distinct launcher label.

## Testing
- npm test -- tests/contacts-pwa-config.test.js
