### PR TITLE
Fix contacts standalone deployment links on Vercel

### DIFF
--- a/contacts/gun-init.js
+++ b/contacts/gun-init.js
@@ -1,0 +1,12 @@
+(function initGunPeers(global) {
+  const defaultPeers = [
+    'wss://relay.3dvr.tech/gun',
+    'wss://gun-relay-3dvr.fly.dev/gun'
+  ];
+  const existingPeers = Array.isArray(global.__GUN_PEERS__)
+    ? global.__GUN_PEERS__
+    : [];
+  global.__GUN_PEERS__ = Array.from(
+    new Set([...defaultPeers, ...existingPeers].filter(Boolean))
+  );
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/contacts/index.html
+++ b/contacts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-portal-origin="https://3dvr-portal.vercel.app">
 <head>
   <meta charset="UTF-8" />
   <title>3DVR Contacts</title>
@@ -9,7 +9,7 @@
   <script src="/gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/axe.js"></script>
-  <script src="../score.js"></script>
+  <script src="/score.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script
     src="./pwa-install.js"
@@ -27,8 +27,8 @@
   <!-- Header -->
   <header class="sticky top-0 z-10 backdrop-blur bg-gray-900/90 border-b border-white/10">
     <div class="max-w-6xl mx-auto px-4 py-3 flex items-center gap-3">
-      <a href="../index.html" class="text-sm text-gray-300 hover:text-white">← Portal</a>
-      <a href="../crm/index.html" class="text-sm text-gray-300 hover:text-white">CRM</a>
+      <a id="portalHomeLink" href="https://3dvr-portal.vercel.app/index.html" class="text-sm text-gray-300 hover:text-white">← Portal</a>
+      <a id="portalCrmLink" href="https://3dvr-portal.vercel.app/crm/index.html" class="text-sm text-gray-300 hover:text-white">CRM</a>
       <h1 class="text-xl sm:text-2xl font-bold">Contacts <span class="text-teal-400">· 3DVR</span></h1>
       <span id="spaceBadge" class="hidden text-xs px-2 py-1 rounded bg-white/10">personal</span>
       <div class="ms-auto flex items-center gap-2">
@@ -40,7 +40,7 @@
 
   <a
     id="floatingIdentity"
-    href="../profile.html#profile"
+    href="https://3dvr-portal.vercel.app/profile.html#profile"
     title="View your profile"
     class="fixed bottom-4 right-4 sm:top-4 sm:bottom-auto sm:right-4 z-30 inline-flex items-center gap-3 rounded-2xl border border-white/15 bg-gray-900/90 px-4 py-3 text-sm text-white shadow-xl shadow-black/30 backdrop-blur"
   >
@@ -304,7 +304,9 @@ import {
   aliasToDisplay,
   deriveIdentityState,
   deriveFloatingIdentityDisplay,
+  resolvePortalOrigin,
   resolveSpaceNode,
+  toPortalHref,
 } from './contacts-core.js';
 /* ---------- Gun & session reuse ---------- */
 function createLocalGunSubscriptionStub() {
@@ -563,6 +565,36 @@ function ensureLocalStorage() {
     console.warn('LocalStorage unavailable for contacts; using memory fallback', err);
   }
   return { storage: createMemoryStorage(), native: null };
+}
+
+function readConfiguredPortalOrigin() {
+  // Standalone deploys can point cross-app links back to the main portal origin.
+  const explicit = typeof window.__CONTACTS_PORTAL_ORIGIN__ === 'string'
+    ? window.__CONTACTS_PORTAL_ORIGIN__
+    : '';
+  if (explicit.trim()) {
+    return explicit.trim();
+  }
+  const fromHtml = document.documentElement?.dataset?.portalOrigin || '';
+  return fromHtml.trim();
+}
+
+const resolvedPortalOrigin = resolvePortalOrigin({
+  configuredOrigin: readConfiguredPortalOrigin(),
+  currentOrigin: window.location.origin,
+  pathname: window.location.pathname,
+});
+
+function portalHref(path = '/') {
+  return toPortalHref(path, { configuredOrigin: resolvedPortalOrigin });
+}
+
+function crmContactHref(contactId = '') {
+  const id = typeof contactId === 'string' ? contactId : String(contactId || '');
+  if (!id) {
+    return portalHref('/crm/index.html');
+  }
+  return portalHref(`/crm/index.html?contact=${encodeURIComponent(id)}`);
 }
 
 const { storage: ls, native: nativeLocalStorage } = ensureLocalStorage();
@@ -1076,6 +1108,8 @@ const duplicateSummaryEl = document.getElementById('duplicateSummary');
 const prevPageBtn = document.getElementById('prevPage');
 const nextPageBtn = document.getElementById('nextPage');
 const pageInfo = document.getElementById('pageInfo');
+const portalHomeLink = document.getElementById('portalHomeLink');
+const portalCrmLink = document.getElementById('portalCrmLink');
 const floatingIdentity = document.getElementById('floatingIdentity');
 const floatingIdentityName = document.getElementById('floatingIdentityName');
 const floatingIdentityScore = document.getElementById('floatingIdentityScore');
@@ -1095,6 +1129,16 @@ const contactDetailActions = document.getElementById('contactDetailActions');
 const closeContactDetailBtn = document.getElementById('closeContactDetail');
 const openCreateContactBtn = document.getElementById('openCreateContact');
 const closeCreateContactBtn = document.getElementById('closeCreateContact');
+
+if (portalHomeLink) {
+  portalHomeLink.href = portalHref('/index.html');
+}
+if (portalCrmLink) {
+  portalCrmLink.href = portalHref('/crm/index.html');
+}
+if (floatingIdentity) {
+  floatingIdentity.href = portalHref('/profile.html#profile');
+}
 
 let lastFocusedBeforeCreate = null;
 
@@ -2386,7 +2430,7 @@ function renderCard(c){
   const email = c.email ? `<a class="underline hover:no-underline" href="mailto:${encodeURIComponent(c.email)}">${hx(c.email)}</a>` : '';
   const phone = c.phone ? `<a class="underline hover:no-underline" href="tel:${encodeURIComponent(c.phone)}">${hx(c.phone)}</a>` : '';
   const crmAction = hasCrmLink
-    ? `<a href="../crm/index.html?contact=${encodeURIComponent(c.crmId)}" class="bg-sky-700/60 hover:bg-sky-600 px-3 py-1.5 rounded text-sm border border-sky-300/40 text-sky-100 transition" title="Open this contact in the CRM" target="_blank" rel="noopener">Open CRM</a>`
+    ? `<a href="${crmContactHref(c.crmId)}" class="bg-sky-700/60 hover:bg-sky-600 px-3 py-1.5 rounded text-sm border border-sky-300/40 text-sky-100 transition" title="Open this contact in the CRM" target="_blank" rel="noopener">Open CRM</a>`
     : `<button type="button" id="crm-${c.id}" class="bg-sky-600 hover:bg-sky-500 px-3 py-1.5 rounded text-sm border border-sky-300/40 text-white transition">Add to CRM</button>`;
   const duplicateInfo = duplicateMetaById.get(c.id);
   const duplicateBadge = duplicateInfo
@@ -2565,7 +2609,7 @@ function openContactDetail(id){
         <p class="text-sm font-semibold text-sky-200">Linked CRM record</p>
         <p class="text-xs text-sky-100/80 mt-1">Synced as <code>${hx(contact.crmId)}</code></p>
         <div class="mt-3 flex flex-wrap gap-2">
-          <a href="../crm/index.html?contact=${encodeURIComponent(contact.crmId)}" target="_blank" rel="noopener" class="bg-sky-600 hover:bg-sky-500 text-white text-sm px-3 py-1.5 rounded">Open CRM</a>
+          <a href="${crmContactHref(contact.crmId)}" target="_blank" rel="noopener" class="bg-sky-600 hover:bg-sky-500 text-white text-sm px-3 py-1.5 rounded">Open CRM</a>
         </div>
       </div>
     `;

--- a/contacts/score.js
+++ b/contacts/score.js
@@ -1,0 +1,368 @@
+(function initContactsScore(global) {
+  if (global.ScoreSystem && typeof global.ScoreSystem.getManager === 'function') {
+    return;
+  }
+
+  const SCORE_CACHE_PREFIX = '3dvr:score:';
+  const GUN_OFFLINE_ERROR = { err: 'gun-unavailable' };
+
+  function createGunSubscriptionStub() {
+    return {
+      off() {}
+    };
+  }
+
+  function createGunNodeStub() {
+    const node = {
+      __isGunStub: true,
+      get() {
+        return createGunNodeStub();
+      },
+      put(_value, callback) {
+        if (typeof callback === 'function') {
+          setTimeout(() => callback(GUN_OFFLINE_ERROR), 0);
+        }
+        return node;
+      },
+      once(callback) {
+        if (typeof callback === 'function') {
+          setTimeout(() => callback(undefined), 0);
+        }
+        return node;
+      },
+      on(_listener) {
+        return createGunSubscriptionStub();
+      },
+      off() {},
+      map() {
+        return {
+          __isGunStub: true,
+          on() {
+            return createGunSubscriptionStub();
+          }
+        };
+      },
+      set() {
+        return node;
+      }
+    };
+    return node;
+  }
+
+  function createGunUserStub() {
+    const node = createGunNodeStub();
+    return {
+      ...node,
+      is: null,
+      _: {},
+      recall() {},
+      auth(_alias, _password, callback) {
+        if (typeof callback === 'function') {
+          setTimeout(() => callback(GUN_OFFLINE_ERROR), 0);
+        }
+      },
+      leave() {},
+      create(_alias, _password, callback) {
+        if (typeof callback === 'function') {
+          setTimeout(() => callback(GUN_OFFLINE_ERROR), 0);
+        }
+      }
+    };
+  }
+
+  function createGunStub() {
+    return {
+      __isGunStub: true,
+      user() {
+        return createGunUserStub();
+      },
+      get() {
+        return createGunNodeStub();
+      }
+    };
+  }
+
+  function ensureGun(factory, { label = 'gun' } = {}) {
+    if (typeof factory === 'function') {
+      try {
+        const instance = factory();
+        if (instance) {
+          const resolvedUser = typeof instance.user === 'function'
+            ? instance.user()
+            : createGunUserStub();
+          return {
+            gun: instance,
+            user: resolvedUser,
+            isStub: !!instance.__isGunStub
+          };
+        }
+      } catch (err) {
+        console.warn(`Failed to initialize ${label} Gun instance`, err);
+      }
+    }
+    console.warn(`Gun.js is unavailable for ${label}; running in offline mode.`);
+    const stub = createGunStub();
+    return {
+      gun: stub,
+      user: stub.user(),
+      isStub: true
+    };
+  }
+
+  function sanitizeScore(value) {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(numeric)) return 0;
+    return Math.max(0, Math.round(numeric));
+  }
+
+  function readStorage(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  function writeStorage(key, value) {
+    try {
+      if (value == null) {
+        localStorage.removeItem(key);
+      } else {
+        localStorage.setItem(key, String(value));
+      }
+      return true;
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  function ensureGuestIdentity() {
+    try {
+      const legacyId = localStorage.getItem('userId');
+      if (legacyId && !localStorage.getItem('guestId')) {
+        localStorage.setItem('guestId', legacyId);
+      }
+      if (legacyId) {
+        localStorage.removeItem('userId');
+      }
+      let guestId = localStorage.getItem('guestId');
+      if (!guestId) {
+        guestId = `guest_${Math.random().toString(36).slice(2, 11)}`;
+        localStorage.setItem('guestId', guestId);
+      }
+      if (!localStorage.getItem('guestDisplayName')) {
+        localStorage.setItem('guestDisplayName', 'Guest');
+      }
+      localStorage.setItem('guest', 'true');
+      return guestId;
+    } catch (err) {
+      console.warn('Failed to ensure guest identity', err);
+      return '';
+    }
+  }
+
+  function computeAuthState() {
+    try {
+      const signedIn = localStorage.getItem('signedIn') === 'true';
+      const alias = (localStorage.getItem('alias') || '').trim();
+      let username = (localStorage.getItem('username') || '').trim();
+      if (username.toLowerCase() === 'guest') {
+        username = '';
+      }
+      if (signedIn) {
+        return {
+          mode: 'user',
+          alias,
+          username
+        };
+      }
+      const isGuest = localStorage.getItem('guest') === 'true';
+      if (isGuest) {
+        return {
+          mode: 'guest',
+          guestId: ensureGuestIdentity(),
+          guestDisplayName: (localStorage.getItem('guestDisplayName') || '').trim()
+        };
+      }
+      return { mode: 'anon' };
+    } catch (_err) {
+      return { mode: 'anon' };
+    }
+  }
+
+  function recallUserSession(targetUser, { useLocal = true, useSession = true } = {}) {
+    const user = targetUser;
+    if (!user || typeof user.recall !== 'function') {
+      return false;
+    }
+    const options = {};
+    if (useSession) options.sessionStorage = true;
+    if (useLocal) options.localStorage = true;
+    if (!Object.keys(options).length) {
+      return false;
+    }
+    try {
+      user.recall(options);
+      return true;
+    } catch (err) {
+      console.warn('Failed to recall user session', err);
+      return false;
+    }
+  }
+
+  function scoreKeyForState(state) {
+    if (!state || state.mode === 'anon') {
+      return `${SCORE_CACHE_PREFIX}anon`;
+    }
+    if (state.mode === 'user') {
+      const alias = typeof state.alias === 'string' ? state.alias.trim().toLowerCase() : '';
+      return `${SCORE_CACHE_PREFIX}user:${alias || 'default'}`;
+    }
+    const guestId = typeof state.guestId === 'string' ? state.guestId.trim() : '';
+    return `${SCORE_CACHE_PREFIX}${guestId || 'guest'}`;
+  }
+
+  class ScoreManager {
+    constructor(_context = {}) {
+      this.state = computeAuthState();
+      this.storageKey = scoreKeyForState(this.state);
+      this.current = sanitizeScore(readStorage(this.storageKey));
+      this.listeners = new Set();
+      this._handleStorage = event => {
+        if (!event || event.key !== this.storageKey) {
+          return;
+        }
+        const next = sanitizeScore(event.newValue);
+        if (next !== this.current) {
+          this.current = next;
+          this._notify();
+        }
+      };
+      if (typeof window !== 'undefined') {
+        window.addEventListener('storage', this._handleStorage);
+      }
+    }
+
+    _notify() {
+      this.listeners.forEach(handler => {
+        try {
+          handler(this.current);
+        } catch (err) {
+          console.error('Score listener failed', err);
+        }
+      });
+    }
+
+    _setCurrent(value, { persist = false } = {}) {
+      const normalized = sanitizeScore(value);
+      if (normalized === this.current) {
+        return this.current;
+      }
+      this.current = normalized;
+      if (persist) {
+        writeStorage(this.storageKey, this.current);
+      }
+      this._notify();
+      return this.current;
+    }
+
+    subscribe(handler) {
+      if (typeof handler !== 'function') {
+        return () => {};
+      }
+      this.listeners.add(handler);
+      try {
+        handler(this.current);
+      } catch (err) {
+        console.error('Score listener failed during subscribe', err);
+      }
+      return () => {
+        this.listeners.delete(handler);
+      };
+    }
+
+    increment(amount) {
+      const delta = Number(amount);
+      if (!Number.isFinite(delta) || delta === 0) {
+        return this.current;
+      }
+      return this._setCurrent(this.current + Math.round(delta), { persist: true });
+    }
+
+    decrement(amount, { floor = 0, maxDrop } = {}) {
+      const delta = Number(amount);
+      if (!Number.isFinite(delta) || delta === 0) {
+        return this.current;
+      }
+      const desiredDrop = Math.max(0, Math.round(Math.abs(delta)));
+      const cappedDrop = Number.isFinite(maxDrop) ? Math.max(0, Math.round(maxDrop)) : desiredDrop;
+      const appliedDrop = Math.min(desiredDrop, cappedDrop);
+      const floorValue = sanitizeScore(floor);
+      const next = Math.max(floorValue, this.current - appliedDrop);
+      return this._setCurrent(next, { persist: true });
+    }
+
+    set(value) {
+      return this._setCurrent(value, { persist: true });
+    }
+
+    ensureMinimum(value) {
+      const minimum = sanitizeScore(value);
+      if (minimum <= this.current) {
+        return this.current;
+      }
+      return this._setCurrent(minimum, { persist: true });
+    }
+
+    getCurrent() {
+      return this.current;
+    }
+
+    whenReady() {
+      return Promise.resolve(this.current);
+    }
+
+    getState() {
+      return { ...this.state };
+    }
+
+    getNode() {
+      return createGunNodeStub();
+    }
+
+    dispose() {
+      this.listeners.clear();
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('storage', this._handleStorage);
+      }
+    }
+  }
+
+  const ScoreSystem = {
+    sanitizeScore,
+    ensureGuestIdentity,
+    computeAuthState,
+    recallUserSession,
+    ensureGun,
+    createGunUserStub,
+    createGunNodeStub,
+    getManager(context = {}) {
+      if (!this._manager) {
+        this._manager = new ScoreManager(context);
+      }
+      return this._manager;
+    },
+    resetManager() {
+      if (this._manager) {
+        try {
+          this._manager.dispose();
+        } catch (err) {
+          console.warn('Failed to dispose score manager', err);
+        }
+      }
+      this._manager = null;
+    }
+  };
+
+  global.ScoreSystem = ScoreSystem;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/contacts/service-worker.js
+++ b/contacts/service-worker.js
@@ -10,6 +10,8 @@ const STATIC_ASSETS = [
   scopeAsset(''),
   scopeAsset('index.html'),
   scopeAsset('contacts-core.js'),
+  scopeAsset('gun-init.js'),
+  scopeAsset('score.js'),
   scopeAsset('pwa-install.js'),
   scopeAsset('install-banner.css'),
   scopeAsset('contacts.webmanifest'),

--- a/contacts/vercel.json
+++ b/contacts/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|woff2?)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/contacts.webmanifest",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/pwa-install.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    },
+    {
+      "source": "/service-worker.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" },
+        { "key": "Service-Worker-Allowed", "value": "/" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- make `contacts/index.html` portable across `/contacts/` and standalone-root deployments by resolving portal/CRM/profile links at runtime
- switch contacts to root-absolute shared script paths and add standalone `contacts/gun-init.js` + `contacts/score.js` so Vercel root-directory deploys still load required runtimes
- add standalone `contacts/vercel.json` cache headers for manifest/install/service-worker files
- extend contacts tests for portal-origin URL resolution, standalone Vercel config, and updated runtime script/service-worker expectations

## Testing
- `npm test`