### PR TITLE
Fix contacts cookie identity sync false signed-in state

### DIFF
--- a/auth-identity.js
+++ b/auth-identity.js
@@ -108,16 +108,32 @@
 
     const nextAlias = identity.alias;
     const nextUsername = identity.username || aliasToDisplay(nextAlias) || 'User';
+    const hasStoredPassword = normalizeText(storage.getItem('password')).length > 0;
+    const nextSignedIn = hasStoredPassword;
     const currentSignedIn = storage.getItem('signedIn') === 'true';
     const currentAlias = normalizeText(storage.getItem('alias'));
     const currentUsername = normalizeText(storage.getItem('username'));
-    const needsWrite = !currentSignedIn || currentAlias !== nextAlias || currentUsername !== nextUsername;
+    const hasGuestMarkers = Boolean(
+      storage.getItem('guest')
+      || storage.getItem('guestId')
+      || storage.getItem('guestDisplayName')
+    );
+    const needsWrite = (
+      currentSignedIn !== nextSignedIn
+      || currentAlias !== nextAlias
+      || currentUsername !== nextUsername
+      || hasGuestMarkers
+    );
 
     if (!needsWrite) {
       return false;
     }
 
-    storage.setItem('signedIn', 'true');
+    if (nextSignedIn) {
+      storage.setItem('signedIn', 'true');
+    } else {
+      storage.removeItem('signedIn');
+    }
     storage.setItem('alias', nextAlias);
     storage.setItem('username', nextUsername);
     storage.removeItem('guest');

--- a/contacts/auth-identity.js
+++ b/contacts/auth-identity.js
@@ -108,16 +108,32 @@
 
     const nextAlias = identity.alias;
     const nextUsername = identity.username || aliasToDisplay(nextAlias) || 'User';
+    const hasStoredPassword = normalizeText(storage.getItem('password')).length > 0;
+    const nextSignedIn = hasStoredPassword;
     const currentSignedIn = storage.getItem('signedIn') === 'true';
     const currentAlias = normalizeText(storage.getItem('alias'));
     const currentUsername = normalizeText(storage.getItem('username'));
-    const needsWrite = !currentSignedIn || currentAlias !== nextAlias || currentUsername !== nextUsername;
+    const hasGuestMarkers = Boolean(
+      storage.getItem('guest')
+      || storage.getItem('guestId')
+      || storage.getItem('guestDisplayName')
+    );
+    const needsWrite = (
+      currentSignedIn !== nextSignedIn
+      || currentAlias !== nextAlias
+      || currentUsername !== nextUsername
+      || hasGuestMarkers
+    );
 
     if (!needsWrite) {
       return false;
     }
 
-    storage.setItem('signedIn', 'true');
+    if (nextSignedIn) {
+      storage.setItem('signedIn', 'true');
+    } else {
+      storage.removeItem('signedIn');
+    }
     storage.setItem('alias', nextAlias);
     storage.setItem('username', nextUsername);
     storage.removeItem('guest');

--- a/tests/auth-identity.test.js
+++ b/tests/auth-identity.test.js
@@ -92,8 +92,9 @@ describe('auth identity helper', () => {
     assert.equal(Number.isFinite(identity.updatedAt), true);
   });
 
-  it('syncs local storage from shared identity cookies', () => {
+  it('syncs local storage from shared identity cookies and preserves signed-in state when credentials exist', () => {
     const { api, localStorage } = loadAuthIdentity();
+    localStorage.setItem('password', 'secret');
     localStorage.setItem('guest', 'true');
     localStorage.setItem('guestId', 'guest_abc');
     localStorage.setItem('guestDisplayName', 'Guest');
@@ -112,6 +113,23 @@ describe('auth identity helper', () => {
     assert.equal(localStorage.getItem('guest'), null);
     assert.equal(localStorage.getItem('guestId'), null);
     assert.equal(localStorage.getItem('guestDisplayName'), null);
+  });
+
+  it('syncs shared identity hints without forcing signed-in mode when no password is stored', () => {
+    const { api, localStorage } = loadAuthIdentity();
+    localStorage.setItem('signedIn', 'true');
+
+    api.writeSharedIdentity({
+      signedIn: true,
+      alias: 'pilot@3dvr',
+      username: 'Pilot',
+    });
+
+    const changed = api.syncStorageFromSharedIdentity(localStorage);
+    assert.equal(changed, true);
+    assert.equal(localStorage.getItem('signedIn'), null);
+    assert.equal(localStorage.getItem('alias'), 'pilot@3dvr');
+    assert.equal(localStorage.getItem('username'), 'Pilot');
   });
 
   it('clears shared identity cookies', () => {


### PR DESCRIPTION
## Summary
- prevent shared identity cookie sync from forcing `signedIn=true` when local credentials are missing
- keep alias/username hints synced from cookie while leaving auth state unsigned on that device
- mirror the auth helper change for standalone contacts runtime
- extend auth identity tests for both credentialed and non-credentialed sync paths

## Why
After the login flow fix, contacts could show a username from shared identity while lacking an authenticated Gun user session on `contacts.3dvr.tech`, which surfaced as points = 0 and no personal contacts.

## Validation
- `node --test tests/auth-identity.test.js`
- `node --test tests/contacts-core.test.js`
