### PR TITLE
fix(contacts): stabilize subdomain auth and initial contact hydration

### DIFF
--- a/contacts/contacts-core.js
+++ b/contacts/contacts-core.js
@@ -175,11 +175,16 @@ export function resolveSpaceNode({
 
   if (normalizedSpace === 'personal') {
     if (userHasSession && user && typeof user.get === 'function') {
+      const personalRoot = user.get('contacts');
+      const legacyPersonalContacts = personalRoot && typeof personalRoot.get === 'function'
+        ? personalRoot.get('contacts')
+        : null;
       return {
-        node: user.get('contacts'),
+        node: personalRoot,
         requiresAuth: false,
         shouldClearAuth: true,
-        legacyNodes: [],
+        // Keep listening to the old child collection until all personal data migrates.
+        legacyNodes: legacyPersonalContacts ? [legacyPersonalContacts] : [],
       };
     }
     if (signedIn) {
@@ -193,11 +198,16 @@ export function resolveSpaceNode({
     if (guestId && guestsRoot && typeof guestsRoot.get === 'function') {
       const guestNode = guestsRoot.get(guestId);
       if (guestNode && typeof guestNode.get === 'function') {
+        const guestContactsRoot = guestNode.get('contacts');
+        const legacyGuestContacts = guestContactsRoot && typeof guestContactsRoot.get === 'function'
+          ? guestContactsRoot.get('contacts')
+          : null;
         return {
-          node: guestNode.get('contacts'),
+          node: guestContactsRoot,
           requiresAuth: false,
           shouldClearAuth: false,
-          legacyNodes: [],
+          // Keep listening to the old child collection until all guest data migrates.
+          legacyNodes: legacyGuestContacts ? [legacyGuestContacts] : [],
         };
       }
     }

--- a/contacts/index.html
+++ b/contacts/index.html
@@ -6,11 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" href="https://fav.farm/🧠" />
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
-  <script src="/gun-init.js"></script>
+  <script src="./gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/axe.js"></script>
-  <script src="/auth-identity.js"></script>
-  <script src="/score.js"></script>
+  <script src="./auth-identity.js"></script>
+  <script src="./score.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script
     src="./pwa-install.js"
@@ -1509,7 +1509,35 @@ function sanitizeScoreDisplay(value) {
 }
 
 function hasActiveUserSession() {
-  return !!(user && user.is && user.is.pub && user._ && user._.sea);
+  return !!(user && user.is && user.is.pub);
+}
+
+function waitForUserSessionReady({ timeoutMs = 6000, pollMs = 120 } = {}) {
+  if (hasActiveUserSession()) {
+    return Promise.resolve(true);
+  }
+  return new Promise(resolve => {
+    const startedAt = Date.now();
+    let timer = null;
+    const finish = value => {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      resolve(!!value);
+    };
+    const check = () => {
+      if (hasActiveUserSession()) {
+        finish(true);
+        return;
+      }
+      if ((Date.now() - startedAt) >= timeoutMs) {
+        finish(false);
+      }
+    };
+    timer = setInterval(check, pollMs);
+    check();
+  });
 }
 
 function showAuthStatus(message) {
@@ -1698,6 +1726,7 @@ async function handleContactsAuthSubmit(event) {
   setAuthFormStatus('');
   try {
     const result = await signInOrCreateAccount(aliasInput, nextPassword);
+    const sessionReady = await waitForUserSessionReady();
     const nextUsername = deriveUsernameForAuth(rawIdentity, aliasInput);
     password = nextPassword;
     try {
@@ -1716,11 +1745,17 @@ async function handleContactsAuthSubmit(event) {
     const statusMessage = result.created
       ? 'Account created and signed in.'
       : 'Signed in on this device.';
+    const resolvedStatusMessage = sessionReady
+      ? statusMessage
+      : `${statusMessage} Sync session is still warming up.`;
     finalizeSignedInState({
       alias: aliasInput,
       username: nextUsername,
-      statusMessage,
+      statusMessage: resolvedStatusMessage,
     });
+    if (!sessionReady) {
+      ensurePersonalAuthRecovery();
+    }
   } catch (err) {
     const reason = err && err.message ? err.message : String(err || '');
     if (reason && isAlreadyCreatedError(reason)) {
@@ -1768,6 +1803,7 @@ function ensurePersonalAuthRecovery() {
   }
   personalAuthPromise = new Promise(resolve => {
     let settled = false;
+    const sessionWaitPromise = waitForUserSessionReady({ timeoutMs: 8000 });
     const finish = success => {
       if (settled) return;
       settled = true;
@@ -1787,10 +1823,6 @@ function ensurePersonalAuthRecovery() {
           console.warn('Personal auth recovery failed', ack.err);
           showAuthStatus('Could not restore your private space automatically. Please sign in again.');
           finish(false);
-          return;
-        }
-        if (hasActiveUserSession()) {
-          finish(true);
         }
       });
     } catch (err) {
@@ -1799,13 +1831,14 @@ function ensurePersonalAuthRecovery() {
       finish(false);
       return;
     }
-    setTimeout(() => {
-      if (hasActiveUserSession()) {
+    sessionWaitPromise.then(sessionReady => {
+      if (sessionReady) {
         finish(true);
-      } else {
+      } else if (!settled) {
+        showAuthStatus('Could not restore your private space automatically. Please sign in again.');
         finish(false);
       }
-    }, 2000);
+    });
   });
   return personalAuthPromise;
 }
@@ -2360,22 +2393,43 @@ function attachSpace(){
     .filter(candidate => candidate && typeof candidate.map === 'function');
 
   if (node && typeof node.map === 'function') {
-    const sub = node.map().on((data, id) => {
-      ingestContactFromSource(currentSpace, data, id);
-    });
-    unsubscribers.push(() => {
-      try {
-        sub.off();
-      } catch (err) {
-        console.warn('Failed to detach contacts subscription', err);
-      }
-    });
+    const primaryMap = node.map();
+    if (primaryMap && typeof primaryMap.once === 'function') {
+      primaryMap.once((data, id) => {
+        ingestContactFromSource(currentSpace, data, id);
+      });
+    }
+    const sub = primaryMap && typeof primaryMap.on === 'function'
+      ? primaryMap.on((data, id) => {
+          ingestContactFromSource(currentSpace, data, id);
+        })
+      : null;
+    if (sub && typeof sub.off === 'function') {
+      unsubscribers.push(() => {
+        try {
+          sub.off();
+        } catch (err) {
+          console.warn('Failed to detach contacts subscription', err);
+        }
+      });
+    }
   }
 
   legacyNodes.forEach(legacyNode => {
-    const legacySub = legacyNode.map().on((data, id) => {
-      ingestContactFromSource(currentSpace, data, id, { isLegacy: true, primaryNode: node });
-    });
+    const legacyMap = legacyNode.map();
+    if (legacyMap && typeof legacyMap.once === 'function') {
+      legacyMap.once((data, id) => {
+        ingestContactFromSource(currentSpace, data, id, { isLegacy: true, primaryNode: node });
+      });
+    }
+    const legacySub = legacyMap && typeof legacyMap.on === 'function'
+      ? legacyMap.on((data, id) => {
+          ingestContactFromSource(currentSpace, data, id, { isLegacy: true, primaryNode: node });
+        })
+      : null;
+    if (!legacySub || typeof legacySub.off !== 'function') {
+      return;
+    }
     unsubscribers.push(() => {
       try {
         legacySub.off();

--- a/tests/contacts-core.test.js
+++ b/tests/contacts-core.test.js
@@ -204,7 +204,11 @@ describe('contacts core helpers', () => {
     };
 
     it('returns the user contacts node when a session is active', () => {
-      const userContacts = { kind: 'user-contacts' };
+      const legacyUserContacts = { kind: 'legacy-user-contacts' };
+      const userContacts = {
+        kind: 'user-contacts',
+        get: mock.fn(() => legacyUserContacts),
+      };
       const user = { get: mock.fn(() => userContacts) };
 
       const result = resolveSpaceNode({
@@ -217,8 +221,11 @@ describe('contacts core helpers', () => {
       assert.equal(result.node, userContacts);
       assert.equal(result.requiresAuth, false);
       assert.equal(result.shouldClearAuth, true);
+      assert.deepEqual(result.legacyNodes, [legacyUserContacts]);
       assert.equal(user.get.mock.calls.length, 1);
       assert.deepEqual(user.get.mock.calls[0].arguments, ['contacts']);
+      assert.equal(userContacts.get.mock.calls.length, 1);
+      assert.deepEqual(userContacts.get.mock.calls[0].arguments, ['contacts']);
     });
 
     it('indicates that personal space requires auth when signed in without a session', () => {
@@ -233,9 +240,14 @@ describe('contacts core helpers', () => {
     });
 
     it('resolves guest storage from the shared guests root', () => {
-      const guestContacts = { kind: 'guest-contacts' };
+      const legacyGuestContacts = { kind: 'legacy-guest-contacts' };
+      const guestContacts = {
+        kind: 'guest-contacts',
+        get: mock.fn(() => legacyGuestContacts),
+      };
+      const guestRoot = { get: mock.fn(() => guestContacts) };
       const guestsRoot = {
-        get: mock.fn(() => ({ get: mock.fn(() => guestContacts) })),
+        get: mock.fn(() => guestRoot),
       };
 
       const result = resolveSpaceNode({
@@ -248,7 +260,10 @@ describe('contacts core helpers', () => {
 
       assert.equal(result.node, guestContacts);
       assert.equal(result.requiresAuth, false);
+      assert.deepEqual(result.legacyNodes, [legacyGuestContacts]);
       assert.equal(guestsRoot.get.mock.calls[0].arguments[0], 'guest_abc');
+      assert.equal(guestRoot.get.mock.calls[0].arguments[0], 'contacts');
+      assert.equal(guestContacts.get.mock.calls[0].arguments[0], 'contacts');
     });
 
     it('uses org and public Gun nodes for shared spaces', () => {

--- a/tests/contacts-pwa-config.test.js
+++ b/tests/contacts-pwa-config.test.js
@@ -67,12 +67,12 @@ describe('contacts PWA configuration', () => {
     assert.match(pwaInstallSource, /updatefound/);
   });
 
-  it('keeps shared runtime scripts root-absolute for portal and standalone roots', async () => {
+  it('keeps standalone runtime scripts local to the contacts app root', async () => {
     const html = await readProjectFile('contacts/index.html');
 
-    assert.match(html, /<script src="\/gun-init\.js"><\/script>/);
-    assert.match(html, /<script src="\/auth-identity\.js"><\/script>/);
-    assert.match(html, /<script src="\/score\.js"><\/script>/);
+    assert.match(html, /<script src="\.\/gun-init\.js"><\/script>/);
+    assert.match(html, /<script src="\.\/auth-identity\.js"><\/script>/);
+    assert.match(html, /<script src="\.\/score\.js"><\/script>/);
   });
 
   it('ships a standalone score runtime with portal sync capabilities', async () => {


### PR DESCRIPTION
## Summary
- switch Contacts standalone runtime script imports to local relative paths (`./gun-init.js`, `./auth-identity.js`, `./score.js`) so subdomain and folder deploys load the same runtime
- relax and harden session readiness checks so personal sync does not depend on `user._.sea`, and wait for session readiness before finalizing auth recovery
- hydrate contacts more reliably on first load by priming each space with `map().once(...)` before live `map().on(...)`
- include legacy nested personal nodes (`contacts/contacts`) for user and guest spaces to avoid missing records during migration
- update contacts core + PWA config tests for the new behavior

## Verification
- `node --test tests/contacts-core.test.js tests/contacts-pwa-config.test.js` (pass)
- full `npm test` in the clean worktree was not run end-to-end because that worktree does not have all dependencies installed (`playwright`, `stripe`, `nodemailer`)
