### PR TITLE
Sync sales training queue with Gun

### DIFF
--- a/cell/index.html
+++ b/cell/index.html
@@ -1,0 +1,690 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cell Network | 3dvr Portal</title>
+  <style>
+    :root {
+      --bg: #08111f;
+      --bg-soft: #0f1b30;
+      --panel: rgba(15, 27, 48, 0.86);
+      --panel-2: rgba(20, 36, 61, 0.9);
+      --text: #eef6ff;
+      --muted: #aac0d7;
+      --line: rgba(146, 183, 255, 0.18);
+      --gold: #f2cf7a;
+      --blue: #84b8ff;
+      --green: #9fe3c1;
+      --danger: #ff9f9f;
+      --shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+      --radius: 22px;
+    }
+
+    * { box-sizing: border-box; }
+
+    html, body {
+      margin: 0;
+      min-height: 100%;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at top, rgba(91, 144, 255, 0.18), transparent 30%),
+        radial-gradient(circle at right, rgba(242, 207, 122, 0.12), transparent 25%),
+        linear-gradient(180deg, #07101c 0%, #091523 35%, #0c1828 100%);
+      color: var(--text);
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(circle at 20% 20%, rgba(255,255,255,0.05), transparent 0.7rem),
+        radial-gradient(circle at 80% 30%, rgba(255,255,255,0.04), transparent 0.6rem),
+        radial-gradient(circle at 50% 80%, rgba(255,255,255,0.03), transparent 0.8rem);
+      background-size: 220px 220px, 280px 280px, 320px 320px;
+      opacity: 0.35;
+    }
+
+    a { color: inherit; }
+
+    .shell {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 24px 0 48px;
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: 1.3fr 0.9fr;
+      gap: 20px;
+      align-items: stretch;
+      margin-bottom: 20px;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(12px);
+    }
+
+    .hero-main {
+      padding: 28px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-main::after {
+      content: "";
+      position: absolute;
+      width: 260px;
+      height: 260px;
+      right: -40px;
+      top: -40px;
+      background: radial-gradient(circle, rgba(132,184,255,0.22), transparent 65%);
+      border-radius: 50%;
+      pointer-events: none;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: rgba(132, 184, 255, 0.1);
+      border: 1px solid rgba(132, 184, 255, 0.16);
+      color: var(--blue);
+      font-size: 0.82rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      margin-bottom: 18px;
+    }
+
+    h1 {
+      font-size: clamp(2.2rem, 4vw, 4.2rem);
+      line-height: 0.98;
+      margin: 0 0 14px;
+      max-width: 11ch;
+    }
+
+    .accent {
+      color: var(--gold);
+    }
+
+    .lead {
+      font-size: 1.02rem;
+      line-height: 1.7;
+      color: var(--muted);
+      max-width: 62ch;
+      margin-bottom: 24px;
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-bottom: 22px;
+    }
+
+    button, .button {
+      border: 0;
+      border-radius: 999px;
+      padding: 12px 16px;
+      font: inherit;
+      cursor: pointer;
+      transition: transform 0.18s ease, opacity 0.18s ease, background 0.18s ease;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+    }
+
+    button:hover, .button:hover { transform: translateY(-1px); }
+
+    .primary {
+      background: linear-gradient(135deg, #f2cf7a, #dbaa36);
+      color: #10141d;
+      font-weight: 700;
+    }
+
+    .secondary {
+      background: rgba(255,255,255,0.04);
+      color: var(--text);
+      border: 1px solid var(--line);
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+    }
+
+    .hero-stat {
+      padding: 14px;
+      border-radius: 18px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.06);
+    }
+
+    .hero-stat strong {
+      display: block;
+      font-size: 1.4rem;
+      margin-bottom: 6px;
+      color: var(--gold);
+    }
+
+    .hero-stat span {
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .hero-side {
+      padding: 22px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      background: var(--panel-2);
+    }
+
+    .network {
+      min-height: 300px;
+      position: relative;
+      border-radius: 18px;
+      border: 1px solid rgba(255,255,255,0.08);
+      background:
+        radial-gradient(circle at center, rgba(132,184,255,0.08), transparent 40%),
+        linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+      overflow: hidden;
+    }
+
+    .network svg {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      opacity: 0.9;
+    }
+
+    .network-node {
+      position: absolute;
+      width: 88px;
+      aspect-ratio: 1;
+      border-radius: 50%;
+      display: grid;
+      place-items: center;
+      text-align: center;
+      padding: 10px;
+      font-size: 0.82rem;
+      line-height: 1.2;
+      background: linear-gradient(180deg, rgba(132,184,255,0.24), rgba(132,184,255,0.08));
+      border: 1px solid rgba(132,184,255,0.35);
+      box-shadow: 0 10px 35px rgba(0,0,0,0.28);
+    }
+
+    .network-node.core {
+      width: 108px;
+      background: linear-gradient(180deg, rgba(242,207,122,0.34), rgba(242,207,122,0.1));
+      border-color: rgba(242,207,122,0.4);
+      color: #fff7e1;
+      font-weight: 700;
+    }
+
+    .meta {
+      display: grid;
+      gap: 10px;
+    }
+
+    .meta-item {
+      display: flex;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 12px 14px;
+      border-radius: 16px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.05);
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .meta-item strong { color: var(--text); }
+
+    .section-grid {
+      display: grid;
+      grid-template-columns: 1.05fr 0.95fr;
+      gap: 20px;
+      margin-bottom: 20px;
+    }
+
+    .panel {
+      padding: 22px;
+    }
+
+    .panel h2 {
+      margin: 0 0 8px;
+      font-size: 1.4rem;
+    }
+
+    .panel p {
+      color: var(--muted);
+      line-height: 1.7;
+      margin-top: 0;
+    }
+
+    .list {
+      display: grid;
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    .list-item {
+      border: 1px solid rgba(255,255,255,0.06);
+      background: rgba(255,255,255,0.025);
+      border-radius: 18px;
+      padding: 14px 16px;
+    }
+
+    .list-item strong {
+      display: block;
+      margin-bottom: 6px;
+    }
+
+    .mini-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    .mini-card {
+      padding: 16px;
+      border-radius: 18px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.06);
+    }
+
+    .mini-card h3 {
+      margin: 0 0 8px;
+      font-size: 1rem;
+    }
+
+    .mini-card p {
+      margin: 0;
+      font-size: 0.94rem;
+    }
+
+    .builder {
+      display: grid;
+      grid-template-columns: 1.1fr 0.9fr;
+      gap: 20px;
+      margin-bottom: 20px;
+    }
+
+    .form-wrap {
+      padding: 22px;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    label {
+      display: block;
+      font-size: 0.92rem;
+      color: var(--muted);
+      margin-bottom: 8px;
+    }
+
+    input, textarea, select {
+      width: 100%;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 14px;
+      color: var(--text);
+      padding: 12px 13px;
+      font: inherit;
+      outline: none;
+    }
+
+    textarea {
+      min-height: 120px;
+      resize: vertical;
+    }
+
+    input:focus, textarea:focus, select:focus {
+      border-color: rgba(132,184,255,0.45);
+      box-shadow: 0 0 0 4px rgba(132,184,255,0.1);
+    }
+
+    .full { grid-column: 1 / -1; }
+
+    .preview {
+      padding: 22px;
+      display: grid;
+      gap: 14px;
+    }
+
+    .preview-card {
+      padding: 18px;
+      border-radius: 18px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.06);
+    }
+
+    .preview-card h3 {
+      margin: 0 0 8px;
+      font-size: 1.1rem;
+    }
+
+    .tag-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    .tag {
+      padding: 7px 10px;
+      border-radius: 999px;
+      font-size: 0.82rem;
+      background: rgba(159, 227, 193, 0.1);
+      border: 1px solid rgba(159, 227, 193, 0.18);
+      color: var(--green);
+    }
+
+    .footer-note {
+      text-align: center;
+      color: var(--muted);
+      padding: 18px;
+      font-size: 0.92rem;
+    }
+
+    @media (max-width: 980px) {
+      .hero,
+      .section-grid,
+      .builder {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 700px) {
+      .shell { width: min(100% - 20px, 1180px); }
+      .hero-main, .hero-side, .panel, .form-wrap, .preview { padding: 18px; }
+      .hero-grid, .mini-grid, .form-grid { grid-template-columns: 1fr; }
+      h1 { max-width: 100%; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation: none !important;
+        transition: none !important;
+        scroll-behavior: auto !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <section class="hero">
+      <div class="card hero-main">
+        <div class="eyebrow">3dvr Portal • Organization App</div>
+        <h1>Build a <span class="accent">cell unit</span> that crosses all lines.</h1>
+        <p class="lead">
+          A Cell is a small, trusted group that helps people organize across jobs, skills, neighborhoods, projects, and communities.
+          It can support rank-and-file committees while also connecting builders, workers, parents, organizers, and entrepreneurs into one living network.
+        </p>
+        <div class="hero-actions">
+          <a class="button primary" href="#builder">Create a Cell</a>
+          <a class="button secondary" href="#model">See the model</a>
+        </div>
+        <div class="hero-grid">
+          <div class="hero-stat">
+            <strong>3–12</strong>
+            <span>ideal members per unit</span>
+          </div>
+          <div class="hero-stat">
+            <strong>4</strong>
+            <span>core rotating roles</span>
+          </div>
+          <div class="hero-stat">
+            <strong>∞</strong>
+            <span>networked expansion</span>
+          </div>
+        </div>
+      </div>
+
+      <aside class="card hero-side">
+        <div class="network" aria-label="Cell network illustration">
+          <svg viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+            <line x1="50" y1="28" x2="20" y2="22" stroke="rgba(132,184,255,0.4)" stroke-width="0.5" />
+            <line x1="50" y1="28" x2="78" y2="22" stroke="rgba(132,184,255,0.4)" stroke-width="0.5" />
+            <line x1="50" y1="28" x2="22" y2="70" stroke="rgba(132,184,255,0.4)" stroke-width="0.5" />
+            <line x1="50" y1="28" x2="76" y2="70" stroke="rgba(132,184,255,0.4)" stroke-width="0.5" />
+            <line x1="22" y1="70" x2="76" y2="70" stroke="rgba(242,207,122,0.28)" stroke-width="0.45" />
+            <line x1="20" y1="22" x2="22" y2="70" stroke="rgba(159,227,193,0.2)" stroke-width="0.4" />
+            <line x1="78" y1="22" x2="76" y2="70" stroke="rgba(159,227,193,0.2)" stroke-width="0.4" />
+          </svg>
+          <div class="network-node core" style="left: calc(50% - 54px); top: 18%;">Core<br />Cell</div>
+          <div class="network-node" style="left: 10%; top: 6%;">Workers</div>
+          <div class="network-node" style="right: 10%; top: 6%;">Builders</div>
+          <div class="network-node" style="left: 12%; bottom: 8%;">Families</div>
+          <div class="network-node" style="right: 12%; bottom: 8%;">Projects</div>
+        </div>
+        <div class="meta">
+          <div class="meta-item"><span>Primary purpose</span><strong>coordination across lines</strong></div>
+          <div class="meta-item"><span>Can support</span><strong>committees, mutual aid, business</strong></div>
+          <div class="meta-item"><span>Portal use</span><strong>CRM + planning + community</strong></div>
+        </div>
+      </aside>
+    </section>
+
+    <section id="model" class="section-grid">
+      <div class="card panel">
+        <h2>How the model works</h2>
+        <p>
+          This app treats organization as a repeatable, portable unit. Each Cell can support one workplace, many workplaces, or no workplace at all.
+          The point is to give people a shared place to identify needs, exchange skills, organize action, and build economic resilience together.
+        </p>
+        <div class="list">
+          <div class="list-item">
+            <strong>1. Form a trusted group</strong>
+            Start with a small circle of people who actually want to show up consistently.
+          </div>
+          <div class="list-item">
+            <strong>2. Define roles and rhythms</strong>
+            Keep it lightweight: organizer, communicator, builder, connector.
+          </div>
+          <div class="list-item">
+            <strong>3. Track needs, offers, and opportunities</strong>
+            Jobs, clients, childcare, rides, tools, skills, money, and shared goals.
+          </div>
+          <div class="list-item">
+            <strong>4. Connect outward</strong>
+            Link Cells together into a distributed network without forcing everyone into one hierarchy.
+          </div>
+        </div>
+      </div>
+
+      <div class="card panel">
+        <h2>Why this goes beyond a committee</h2>
+        <p>
+          Rank-and-file committees are powerful, but usually workplace-centered. A Cell can include workers, freelancers, family members, technologists,
+          and organizers all at once. It becomes a universal unit for cooperation.
+        </p>
+        <div class="mini-grid">
+          <div class="mini-card">
+            <h3>Workplace</h3>
+            <p>Support negotiations, safety issues, schedules, and solidarity.</p>
+          </div>
+          <div class="mini-card">
+            <h3>Economic</h3>
+            <p>Share leads, referrals, gigs, customers, and ways to make money.</p>
+          </div>
+          <div class="mini-card">
+            <h3>Mutual Aid</h3>
+            <p>Coordinate rides, food, childcare, housing, or emergency support.</p>
+          </div>
+          <div class="mini-card">
+            <h3>Builder Culture</h3>
+            <p>Use the portal to launch pages, docs, chats, tools, and local projects.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="builder">
+      <div id="builder" class="card form-wrap">
+        <h2>Cell Builder</h2>
+        <p>
+          Sketch your first unit. This can later connect to portal accounts, private rooms, member lists, notes, payments, or project pages.
+        </p>
+        <form id="cellForm" class="form-grid">
+          <div>
+            <label for="cellName">Cell name</label>
+            <input id="cellName" name="cellName" type="text" placeholder="Example: South Bay Builder Cell" value="3dvr Builder Cell" />
+          </div>
+          <div>
+            <label for="focus">Primary focus</label>
+            <select id="focus" name="focus">
+              <option>Cross-line organization</option>
+              <option>Workplace support</option>
+              <option>Builder community</option>
+              <option>Mutual aid</option>
+              <option>Lead generation</option>
+            </select>
+          </div>
+          <div>
+            <label for="size">Target size</label>
+            <input id="size" name="size" type="text" placeholder="3–12 people" value="6 people" />
+          </div>
+          <div>
+            <label for="rhythm">Meeting rhythm</label>
+            <input id="rhythm" name="rhythm" type="text" placeholder="Weekly, biweekly, daily" value="Weekly" />
+          </div>
+          <div class="full">
+            <label for="purpose">Shared purpose</label>
+            <textarea id="purpose" name="purpose" placeholder="What is this unit for?">Support workers, builders, and friends across different lines of life while sharing opportunities, organizing action, and helping each other make progress.</textarea>
+          </div>
+          <div class="full">
+            <label for="pillars">Core pillars</label>
+            <input id="pillars" name="pillars" type="text" placeholder="e.g. support, projects, leads, care" value="support, leads, projects, coordination" />
+          </div>
+          <div class="full" style="display:flex; gap:12px; flex-wrap:wrap; margin-top: 4px;">
+            <button type="submit" class="primary">Generate Preview</button>
+            <button type="button" class="secondary" id="resetBtn">Reset</button>
+          </div>
+        </form>
+      </div>
+
+      <aside class="card preview">
+        <div class="preview-card">
+          <h3 id="previewTitle">3dvr Builder Cell</h3>
+          <p id="previewPurpose">
+            Support workers, builders, and friends across different lines of life while sharing opportunities, organizing action, and helping each other make progress.
+          </p>
+          <div class="tag-row" id="previewTags">
+            <span class="tag">support</span>
+            <span class="tag">leads</span>
+            <span class="tag">projects</span>
+            <span class="tag">coordination</span>
+          </div>
+        </div>
+        <div class="preview-card">
+          <h3>Operational Snapshot</h3>
+          <div class="meta">
+            <div class="meta-item"><span>Focus</span><strong id="previewFocus">Cross-line organization</strong></div>
+            <div class="meta-item"><span>Size</span><strong id="previewSize">6 people</strong></div>
+            <div class="meta-item"><span>Rhythm</span><strong id="previewRhythm">Weekly</strong></div>
+          </div>
+        </div>
+        <div class="preview-card">
+          <h3>Portal directions</h3>
+          <p>
+            Next version ideas: member roster, shared needs board, opportunity pipeline, notes, map, chat, and links to project apps across the portal.
+          </p>
+        </div>
+      </aside>
+    </section>
+
+    <div class="footer-note">
+      Built as a concept app for the 3dvr Portal — a universal organizing unit for people, projects, and power.
+    </div>
+  </main>
+
+  <script>
+    const form = document.getElementById('cellForm');
+    const resetBtn = document.getElementById('resetBtn');
+
+    const defaults = {
+      cellName: '3dvr Builder Cell',
+      focus: 'Cross-line organization',
+      size: '6 people',
+      rhythm: 'Weekly',
+      purpose: 'Support workers, builders, and friends across different lines of life while sharing opportunities, organizing action, and helping each other make progress.',
+      pillars: 'support, leads, projects, coordination'
+    };
+
+    function updatePreview() {
+      const cellName = document.getElementById('cellName').value.trim() || defaults.cellName;
+      const focus = document.getElementById('focus').value;
+      const size = document.getElementById('size').value.trim() || defaults.size;
+      const rhythm = document.getElementById('rhythm').value.trim() || defaults.rhythm;
+      const purpose = document.getElementById('purpose').value.trim() || defaults.purpose;
+      const pillars = document.getElementById('pillars').value.trim() || defaults.pillars;
+
+      document.getElementById('previewTitle').textContent = cellName;
+      document.getElementById('previewFocus').textContent = focus;
+      document.getElementById('previewSize').textContent = size;
+      document.getElementById('previewRhythm').textContent = rhythm;
+      document.getElementById('previewPurpose').textContent = purpose;
+
+      const tagsEl = document.getElementById('previewTags');
+      tagsEl.innerHTML = '';
+      pillars
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(Boolean)
+        .slice(0, 8)
+        .forEach(tag => {
+          const span = document.createElement('span');
+          span.className = 'tag';
+          span.textContent = tag;
+          tagsEl.appendChild(span);
+        });
+
+      if (!tagsEl.children.length) {
+        ['support', 'projects', 'coordination'].forEach(tag => {
+          const span = document.createElement('span');
+          span.className = 'tag';
+          span.textContent = tag;
+          tagsEl.appendChild(span);
+        });
+      }
+    }
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      updatePreview();
+    });
+
+    resetBtn.addEventListener('click', () => {
+      document.getElementById('cellName').value = defaults.cellName;
+      document.getElementById('focus').value = defaults.focus;
+      document.getElementById('size').value = defaults.size;
+      document.getElementById('rhythm').value = defaults.rhythm;
+      document.getElementById('purpose').value = defaults.purpose;
+      document.getElementById('pillars').value = defaults.pillars;
+      updatePreview();
+    });
+
+    updatePreview();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -121,6 +121,11 @@
             <span class="app-card__title">Calendar</span>
             <span class="app-card__meta">Connect Google or Outlook and manage events.</span>
           </a>
+          <a href="cell/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🧫</span>
+            <span class="app-card__title">Cell</span>
+            <span class="app-card__meta">Build a portable organizing unit for people, projects, and mutual support.</span>
+          </a>
           <a href="/chat/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">💬</span>
             <span class="app-card__title">Chat</span>

--- a/sales/index.html
+++ b/sales/index.html
@@ -87,7 +87,7 @@
         <a href="training/" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
           <p class="text-xs uppercase tracking-wide text-blue-300">Skills</p>
           <h3 class="text-lg font-semibold mt-2">Sales Training</h3>
-          <p class="text-sm text-slate-300 mt-3">Build your rapid pitch, sharpen offers, and rehearse follow-up flows in one workspace.</p>
+          <p class="text-sm text-slate-300 mt-3">Start the reach-out desk, sharpen the pitch, and keep follow-up moving in one workspace.</p>
         </a>
         <a href="../contacts/index.html" class="block rounded-2xl bg-slate-900/70 border border-white/5 p-5 shadow-lg transition hover:border-blue-400">
           <p class="text-xs uppercase tracking-wide text-blue-300">Network</p>

--- a/sales/training/index.html
+++ b/sales/training/index.html
@@ -3,8 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>3dvr.tech • Training Model (Hormozi-inspired)</title>
-  <meta name="description" content="A single-file training system to craft offers, generate leads, close sales, deliver value, and retain customers. Inspired by Alex Hormozi’s style—original content, not quotes." />
+  <title>3dvr.tech • Reach-Out Desk</title>
+  <meta name="description" content="A short daily outreach method for contacting leads, tightening the pitch, logging follow-up, and keeping the pipeline clean." />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <style>
     :root{
       --bg:#0b0d10; --panel:#12161c; --ink:#e9edf1; --muted:#aeb7c2; --accent:#6ee7ff; --ok:#8cffd3; --warn:#ffd37a; --bad:#ff7a7a;
@@ -83,7 +85,7 @@
         <div class="logo" aria-hidden="true"></div>
         <div>
           <h1>3dvr.tech Training</h1>
-          <div class="muted">Hormozi-inspired, builder-first</div>
+          <div class="muted">One lead. One message. One follow-up.</div>
         </div>
       </div>
       <div class="search">
@@ -106,8 +108,8 @@
             <span aria-hidden="true">›</span>
             <span>Training</span>
           </nav>
-          <div class="muted">Foundation → Offer → Leads → Sales → Delivery → Retention → Flywheel</div>
-          <h2 id="title">Select a module</h2>
+          <div class="muted">Reach-out → Pitch → Follow-up → Pipeline</div>
+          <h2 id="title">Select a step</h2>
         </div>
         <div class="actions">
           <button id="focusToggle" class="btn" type="button">Focus Mode</button>
@@ -127,10 +129,28 @@
     </main>
   </div>
   <script>
-  // --- Simple training data model (inspired by Hormozi principles, original wording) ---
+  // --- Simple training data model (built for daily outreach) ---
   const MODEL = [
-    { id:"pitch", name:"Rapid Pitch System", time:"~20m", items:[
-      {type:"text", title:"Why Start Here", body:"People give you seconds, not minutes. Lead with a one-line promise that ties outcomes to proof and an easy next step."},
+    { id:"reachout", name:"Reach-Out Method", time:"~15m", items:[
+      {type:"text", title:"Start here", body:"Do one real reach-out before you do anything else. The goal is a human touch, a clear next step, and a logged follow-up."},
+      {type:"text", title:"The method", body:"1) Pick one warm lead. 2) Send one short personal message. 3) Ask one clear question. 4) Log the touch in CRM and contacts. 5) Set the next follow-up before you leave."},
+      {type:"form", title:"Outreach queue", fields:[
+        {k:"lead", label:"Lead or account", type:"text"},
+        {k:"source", label:"Where did they come from?", type:"text"},
+        {k:"reason", label:"Why now?", type:"text"},
+        {k:"message", label:"Message draft", type:"text"},
+        {k:"next", label:"Next step / follow-up date", type:"text"}
+      ]},
+      {type:"check", title:"Done for the day", list:[
+        "Picked one lead to contact",
+        "Sent one human message",
+        "Logged the touch in CRM",
+        "Set the next follow-up",
+        "Asked for one clear next step"
+      ]}
+    ]},
+    { id:"pitch", name:"Rapid Pitch System", time:"~15m", items:[
+      {type:"text", title:"Say it in one breath", body:"People give you seconds, not minutes. Lead with a one-line promise that ties outcome to proof and an easy next step."},
       {type:"form", title:"One-Line Pitch", fields:[
         {k:"audience", label:"Audience (who are you speaking to?)", type:"text"},
         {k:"pain", label:"Pain or urgent priority", type:"text"},
@@ -150,141 +170,55 @@
         "Practiced twice with a peer or mirror"
       ]}
     ]},
-    { id:"foundation", name:"0) Foundation & Avatar", time:"~30m", items:[
-      {type:"text", title:"Define One Avatar", body:"Pick one audience you can win for in 90 days. Niche down until your offers become obvious."},
-      {type:"form", title:"Avatar Sketch", fields:[
-        {k:"who", label:"Who are they? (role, stage)", type:"text"},
-        {k:"pains", label:"Top 3 pains/frictions", type:"text"},
-        {k:"dream", label:"Desired outcome in numbers", type:"text"},
-        {k:"where", label:"Where do they hang out? (platforms, groups)", type:"text"}
+    { id:"followup", name:"Follow-Up Loop", time:"~10m", items:[
+      {type:"text", title:"Stay warm", body:"If the answer is not now, set the next step before you close the page. No lead should leave without a date or reason."},
+      {type:"form", title:"Follow-up plan", fields:[
+        {k:"lead", label:"Lead or account", type:"text"},
+        {k:"why", label:"Why are we following up?", type:"text"},
+        {k:"next", label:"Next step", type:"text"},
+        {k:"when", label:"Follow-up date", type:"text"}
       ]},
       {type:"check", title:"Checklist", list:[
-        "Narrowed to one clear avatar",
-        "Defined quantifiable dream outcome",
-        "Listed top frictions and constraints",
-        "Identified watering holes (traffic sources)"
-      ]},
-    ]},
-
-    { id:"offer", name:"1) Grand-Slam Offer (Value Equation)", time:"~45m", items:[
-      {type:"text", title:"Value Equation", body:"Value increases with perceived dream outcome &amp; likelihood of achievement, and decreases with time delay &amp; effort/sacrifice. Design the offer to maximize value without brute-forcing price cuts."},
-      {type:"form", title:"Offer Builder", fields:[
-        {k:"dream", label:"Dream Outcome (specific numbers)", type:"text"},
-        {k:"likelihood", label:"Proof &amp; Mechanisms (why it will work)", type:"text"},
-        {k:"delay", label:"Time to Value (how fast?)", type:"text"},
-        {k:"effort", label:"Effort/Sacrifice removed via done-for-you, templates, or coaching", type:"text"},
-        {k:"bonuses", label:"Stacked Bonuses (deliverables)", type:"text"},
-        {k:"guarantee", label:"Risk Reversal (terms)", type:"text"},
-        {k:"price", label:"Price &amp; Terms (monthly, setup, pay-in-full)", type:"text"}
-      ]},
-      {type:"check", title:"Checklist", list:[
-        "Clear promise and timeline",
-        "3-5 bonuses tied to bottlenecks",
-        "Risk reversal that feels unfair (to you)",
-        "Price linked to value, not cost"
+        "Next step is calendar-bound",
+        "CRM stage is current",
+        "Reply path is clear",
+        "Nothing left in a vague state"
       ]}
     ]},
-
-    { id:"leads", name:"2) Lead Engine (Organic → Paid)", time:"~45m", items:[
-      {type:"text", title:"Daily Inputs", body:"Ship one piece of content, make five direct touches, and one collaboration outreach daily. Compounds faster than waiting for perfect ads."},
-      {type:"form", title:"Lead Magnet", fields:[
-        {k:"hook", label:"Hook (pattern interrupt)", type:"text"},
-        {k:"promise", label:"Result in advance (what do they get?)", type:"text"},
-        {k:"cta", label:"CTA (what action?)", type:"text"},
-        {k:"link", label:"URL (optional)", type:"url"}
-      ]},
-      {type:"check", title:"Checklist", list:[
-        "Setup tracking sheet (inputs, leads, calls)",
-        "Defined 3 content pillars",
-        "Outbound script prepared",
-        "Calendar link live"
-      ]}
-    ]},
-
-    { id:"sales", name:"3) Sales Calls (Diagnose → Prescribe)", time:"~45m", items:[
-      {type:"text", title:"Call Flow", body:"Frame → Probe → Diagnose → Prescribe → Align on consequences → Ask. Stay in control with empathy; sell the outcome, not the tool."},
-      {type:"form", title:"Script Notes", fields:[
-        {k:"opening", label:"Opening frame (agenda, time check)", type:"text"},
-        {k:"probe", label:"Problem &amp; cost probes (numbers)", type:"text"},
-        {k:"prescribe", label:"Prescription (offer mapping)", type:"text"},
-        {k:"objections", label:"Likely objections + resolves", type:"text"}
-      ]},
-      {type:"check", title:"Checklist", list:[
-        "Booked with context (form/DM)",
-        "Disqualified poor fits early",
-        "Quoted price after value recap",
-        "Clear next step (pay or plan)"
-      ]}
-    ]},
-
-    { id:"delivery", name:"4) Delivery &amp; Proof", time:"~30m", items:[
-      {type:"text", title:"Fast Wins", body:"Engineer a 24- to 72-hour quick win to reinforce belief. Capture proof (before/after metrics, testimonials)."},
-      {type:"form", title:"Onboarding", fields:[
-        {k:"kickoff", label:"Kickoff checklist / first tasks", type:"text"},
-        {k:"metrics", label:"North-star metrics &amp; cadence", type:"text"}
-      ]},
-      {type:"check", title:"Checklist", list:[
-        "Client dashboard created",
-        "Quick-win delivered",
-        "Weekly cadence locked",
-        "Proof captured (metrics, quote, video)"
-      ]}
-    ]},
-
-    { id:"retention", name:"5) Retention, Ascension, Referrals", time:"~30m", items:[
-      {type:"text", title:"Keep &amp; Grow", body:"Prevent churn with proactive success calls, roadmap reveals, and milestone celebrations. Invite referrals after wins."},
-      {type:"form", title:"Ascension Plan", fields:[
-        {k:"next", label:"Next-step offers (what &amp; when)", type:"text"},
-        {k:"ref", label:"Referral moment &amp; ask script", type:"text"}
-      ]},
-      {type:"check", title:"Checklist", list:[
-        "Churn reasons logged",
-        "NPS/CSAT touchpoints",
-        "Referral mechanism live",
-        "Case study pipeline"
-      ]}
-    ]},
-
-    { id:"metrics", name:"6) Metrics &amp; Targets", time:"~20m", items:[
-      {type:"text", title:"Simple Funnel Math", body:"Track Inputs → Leads → Calls → Shows → Closes → Revenue → Profit. Improve one constraint at a time."},
-      {type:"kpi", title:"Weekly Snapshot", fields:[
-        {k:"inputs", label:"Content/Outbound inputs", type:"number"},
-        {k:"leads", label:"Leads", type:"number"},
+    { id:"pipeline", name:"Pipeline Hygiene", time:"~10m", items:[
+      {type:"text", title:"Keep the queue clean", body:"The goal is not more tabs. The goal is a pipeline where every active deal has a stage, a note, and a next action."},
+      {type:"kpi", title:"Weekly snapshot", fields:[
+        {k:"touches", label:"Touches sent", type:"number"},
+        {k:"replies", label:"Replies received", type:"number"},
         {k:"calls", label:"Booked calls", type:"number"},
-        {k:"shows", label:"Show rate (%)", type:"number"},
-        {k:"closes", label:"Closed deals", type:"number"},
-        {k:"mrr", label:"MRR ($)", type:"number"}
+        {k:"wins", label:"Closed deals", type:"number"}
+      ]},
+      {type:"check", title:"Checklist", list:[
+        "Every active deal has a next step",
+        "Stale records are archived or revived",
+        "Notes are readable in under 10 seconds",
+        "Open CRM queue is current"
       ]}
     ]}
   ];
 
   const TOOLKIT = {
+    reachout: [
+      { href: '../lead-generation.html', label: 'Lead Capture', desc: 'Use the inbox path that turns interest into a real record.' },
+      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Log the touch, stage the deal, and set the next follow-up.' },
+      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Keep the person, relationship, and follow-up context together.' },
+      { href: '../scripts.html', label: 'Scripts & objections', desc: 'Pull the exact talk track needed for the next message or call.' }
+    ],
     pitch: [
       { href: 'marketing.html', label: 'Marketing dashboard', desc: 'Drop the refined pitch into top content slots.' },
-      { href: 'leads.html', label: 'Leads tracker', desc: 'Log outreach reps and note which pitch variant converts.' }
+      { href: '../crm/index.html', label: 'CRM dashboard', desc: 'Use live opportunities to pressure-test the promise.' }
     ],
-    foundation: [
-      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Map real people to your avatar notes.' },
-      { href: 'leads.html', label: 'Leads tracker', desc: 'Pair avatar research with pipeline commitments.' }
+    followup: [
+      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Update stage, next step, and ownership while the conversation is current.' },
+      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Keep the person and follow-up history together.' }
     ],
-    offer: [
-      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Validate pricing and guarantees against live deals.' }
-    ],
-    leads: [
-      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Segment outreach lists with tags and follow-ups.' },
-      { href: 'marketing.html', label: 'Marketing dashboard', desc: 'Line up campaigns that feed the lead engine.' }
-    ],
-    sales: [
-      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Log call outcomes and next steps while momentum is high.' },
-      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Update buyer committees and warm introductions.' }
-    ],
-    delivery: [
-      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Track onboarding milestones and proof artifacts.' }
-    ],
-    retention: [
-      { href: '../../contacts/index.html', label: 'Contacts workspace', desc: 'Tag promoters for referral asks and milestone gifts.' }
-    ],
-    metrics: [
+    pipeline: [
+      { href: '../../crm/index.html', label: 'CRM dashboard', desc: 'Audit stale records, queue priorities, and active opportunities.' },
       { href: 'analytics.html', label: 'Analytics & reporting', desc: 'Compare weekly snapshot entries with live dashboards.' }
     ],
     default: [
@@ -295,16 +229,119 @@
   // --- State ---
   const SKEY = 'training.v1';
   const BASE_TITLE = document.title;
+  const GUN_QUEUE_NODE_PATH = ['3dvr-portal', 'sales-training', 'today-queue'];
   let STATE = JSON.parse(localStorage.getItem(SKEY) || '{}');
   let focusMode = localStorage.getItem(`${SKEY}.focus`) === '1';
   let activeModule = localStorage.getItem(`${SKEY}.active`) || null;
+  let trainingGun = null;
+  let reachoutQueueNode = null;
+  let reachoutQueueSnapshot = '';
 
-  function save() {
+  function createTrainingGun() {
+    if (typeof window === 'undefined' || typeof window.Gun !== 'function') {
+      return null;
+    }
+
+    const peers = window.__GUN_PEERS__ || [
+      'wss://relay.3dvr.tech/gun',
+      'wss://gun-relay-3dvr.fly.dev/gun'
+    ];
+
+    try {
+      return window.Gun({ peers });
+    } catch (error) {
+      console.warn('Sales training Gun init failed', error);
+      try {
+        return window.Gun({ peers, radisk: false, localStorage: false });
+      } catch (fallbackError) {
+        console.warn('Sales training Gun fallback failed', fallbackError);
+        return null;
+      }
+    }
+  }
+
+  function normalizeQueueEntry(item = {}) {
+    return {
+      id: String(item.id || Date.now()),
+      lead: String(item.lead || '').trim(),
+      message: String(item.message || '').trim(),
+      next: String(item.next || '').trim(),
+      done: Boolean(item.done)
+    };
+  }
+
+  function normalizeQueue(list = []) {
+    return Array.isArray(list)
+      ? list.map(normalizeQueueEntry).filter(item => item.lead && item.message && item.next)
+      : [];
+  }
+
+  function queueSignature(list = []) {
+    return JSON.stringify(normalizeQueue(list));
+  }
+
+  function getReachoutQueue() {
+    return normalizeQueue(STATE.reachoutQueue || []);
+  }
+
+  function persistReachoutQueueToGun() {
+    if (!reachoutQueueNode) {
+      return;
+    }
+
+    reachoutQueueNode.put({
+      items: getReachoutQueue(),
+      updatedAt: new Date().toISOString()
+    }, ack => {
+      if (ack && ack.err) {
+        console.warn('Sales training queue sync failed', ack.err);
+      }
+    });
+  }
+
+  function setReachoutQueue(next, options = {}) {
+    STATE.reachoutQueue = normalizeQueue(next);
+    reachoutQueueSnapshot = queueSignature(STATE.reachoutQueue);
+    save(false);
+    if (!options.fromGun) {
+      persistReachoutQueueToGun();
+    }
+  }
+
+  function hydrateReachoutQueueFromGun() {
+    if (!reachoutQueueNode) {
+      return;
+    }
+
+    const applyRemoteQueue = (data) => {
+      if (!data || !data.updatedAt) {
+        return;
+      }
+
+      const nextQueue = normalizeQueue(data.items || []);
+      const nextSignature = queueSignature(nextQueue);
+      if (nextSignature === reachoutQueueSnapshot) {
+        return;
+      }
+
+      reachoutQueueSnapshot = nextSignature;
+      STATE.reachoutQueue = nextQueue;
+      save(false);
+    };
+
+    reachoutQueueNode.once(applyRemoteQueue);
+    reachoutQueueNode.on(applyRemoteQueue);
+  }
+
+  function save(syncReachoutQueue = false) {
     localStorage.setItem(SKEY, JSON.stringify(STATE));
     renderSidebar();
     if (activeModule) {
       const current = MODEL.find(m => m.id === activeModule);
       if (current) renderOverview(current);
+    }
+    if (syncReachoutQueue) {
+      persistReachoutQueueToGun();
     }
   }
   function pctDone(id) {
@@ -314,6 +351,95 @@
     const done = STATE[id]?.checks || {};
     const completed = checks.filter(label => done[label]).length;
     return checks.length ? Math.round((100 * completed) / checks.length) : 0;
+  }
+  function getQueueSyncLabel() {
+    return reachoutQueueNode ? 'Shared with Gun' : 'Local only';
+  }
+
+  function renderReachoutQueueCard() {
+    const card = document.createElement('div');
+    card.className = 'card';
+
+    function render() {
+      const queue = getReachoutQueue();
+      const active = queue.filter(item => !item.done).length;
+      const done = queue.length - active;
+      const activeLabel = active === 1 ? 'lead' : 'leads';
+      const syncLabel = getQueueSyncLabel();
+
+      let html = `
+        <h3>Today's queue</h3>
+        <p class="muted">Keep the queue small. Add one lead, write one message, and set one next step before you move on.</p>
+        <div class="tiny" style="margin-top:8px">${syncLabel} • ${GUN_QUEUE_NODE_PATH.join(' / ')}</div>
+        <form data-queue-form class="grid" style="margin-top:12px">
+          <input name="lead" type="text" placeholder="Lead or account" required>
+          <input name="message" type="text" placeholder="Message or angle" required>
+          <input name="next" type="text" placeholder="Next step or follow-up date" required>
+          <button class="btn-ok" type="submit">Add to queue</button>
+        </form>
+        <div class="tiny" style="margin-top:10px">${active} active ${activeLabel}${done ? `, ${done} done` : ''}</div>
+        <div class="queue-list" style="margin-top:12px">`;
+
+      if (!queue.length) {
+        html += '<p class="tiny">No leads in the queue yet.</p>';
+      } else {
+        queue.forEach((item) => {
+          html += `
+            <div class="queue-item ${item.done ? 'done' : ''}">
+              <div>
+                <strong>${item.lead}</strong>
+                <div class="tiny">${item.message}</div>
+              </div>
+              <div class="queue-meta">
+                <span class="pill">${item.next}</span>
+                ${item.done ? '<span class="pill">Done</span>' : '<span class="pill">Active</span>'}
+              </div>
+              <div class="queue-actions">
+                <button type="button" class="btn" data-queue-toggle="${item.id}">${item.done ? 'Reopen' : 'Mark done'}</button>
+                <button type="button" class="btn-warn" data-queue-remove="${item.id}">Remove</button>
+              </div>
+            </div>`;
+        });
+      }
+
+      html += '</div>';
+      card.innerHTML = html;
+
+      const form = card.querySelector('[data-queue-form]');
+      if (form) {
+        form.addEventListener('submit', (event) => {
+          event.preventDefault();
+          const data = new FormData(form);
+          const lead = String(data.get('lead') || '').trim();
+          const message = String(data.get('message') || '').trim();
+          const next = String(data.get('next') || '').trim();
+          if (!lead || !message || !next) return;
+          setReachoutQueue([
+            ...getReachoutQueue(),
+            { id: String(Date.now()), lead, message, next, done: false }
+          ]);
+          form.reset();
+        });
+      }
+
+      card.querySelectorAll('[data-queue-toggle]').forEach((button) => {
+        button.addEventListener('click', () => {
+          const queue = getReachoutQueue().map((item) => (
+            item.id === button.dataset.queueToggle ? { ...item, done: !item.done } : item
+          ));
+          setReachoutQueue(queue);
+        });
+      });
+
+      card.querySelectorAll('[data-queue-remove]').forEach((button) => {
+        button.addEventListener('click', () => {
+          setReachoutQueue(getReachoutQueue().filter((item) => item.id !== button.dataset.queueRemove));
+        });
+      });
+    }
+
+    render();
+    return card;
   }
 
   // --- Sidebar ---
@@ -357,7 +483,7 @@
     localStorage.setItem(`${SKEY}.active`, id);
     localStorage.setItem(`${SKEY}.opened`, '1');
     document.getElementById('title').textContent = m.name;
-    document.title = `${m.name} • 3dvr Training`;
+    document.title = `${m.name} • Reach-Out Desk`;
     renderOverview(m);
     const root = document.getElementById('content');
     root.innerHTML = '';
@@ -439,7 +565,7 @@
     if (!module) {
       const card = document.createElement('div');
       card.className = 'card';
-      card.innerHTML = '<h3>Pick a module</h3><p class="muted">Choose a stage to see checklists, forms, and linked tools.</p>';
+      card.innerHTML = '<h3>Pick a step</h3><p class="muted">Choose a step to see the checklist, the form, and the tools that keep the deal moving.</p>';
       board.appendChild(card);
       document.title = BASE_TITLE;
       updateFocusButton();
@@ -471,6 +597,10 @@
       });
       stack.appendChild(list);
       board.appendChild(stack);
+    }
+
+    if (module.id === 'reachout') {
+      board.appendChild(renderReachoutQueueCard());
     }
 
     updateFocusButton();
@@ -520,13 +650,13 @@
   function resetProgress() {
     if (confirm('Reset all local progress?')) {
       STATE = {};
-      save();
+      setReachoutQueue([]);
       activeModule = null;
       localStorage.removeItem(`${SKEY}.active`);
       localStorage.removeItem(`${SKEY}.opened`);
       renderSidebar();
       document.getElementById('content').innerHTML = '';
-      document.getElementById('title').textContent = 'Select a module';
+      document.getElementById('title').textContent = 'Select a step';
       renderOverview(null);
       document.title = BASE_TITLE;
       applyFocus();
@@ -545,6 +675,15 @@
   }
 
   // --- Init ---
+  trainingGun = createTrainingGun();
+  if (trainingGun) {
+    window.gun = trainingGun;
+    reachoutQueueNode = trainingGun
+      .get(GUN_QUEUE_NODE_PATH[0])
+      .get(GUN_QUEUE_NODE_PATH[1])
+      .get(GUN_QUEUE_NODE_PATH[2]);
+    hydrateReachoutQueueFromGun();
+  }
   renderSidebar();
   applyFocus();
   const stored = activeModule && MODEL.find(m => m.id === activeModule);

--- a/tests/cell.test.js
+++ b/tests/cell.test.js
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const baseDir = new URL('../cell/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+describe('cell hub', () => {
+  it('ships the cell concept page in its own directory', async () => {
+    const indexUrl = new URL('index.html', baseDir);
+    assert.equal(await fileExists(indexUrl), true, 'index.html should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    assert.match(html, /Cell Network \| 3dvr Portal/);
+    assert.match(html, /Build a <span class="accent">cell unit<\/span> that crosses all lines\./);
+    assert.match(html, /Create a Cell/);
+    assert.match(html, /id="cellForm"/);
+    assert.match(html, /id="previewTitle"/);
+    assert.match(html, /id="previewTags"/);
+    assert.match(html, /Cell Builder/);
+    assert.match(html, /Core(?:<br\s*\/?>)?Cell/);
+    assert.ok(!html.includes('Node Builder'), 'the page should be branded as Cell, not Node');
+  });
+
+  it('registers the Cell workspace in the portal app grid', async () => {
+    const portalIndex = new URL('../index.html', baseDir);
+    assert.equal(await fileExists(portalIndex), true, 'root index.html should exist');
+
+    const html = await readFile(portalIndex, 'utf8');
+    const calendarIndex = html.indexOf('>Calendar<');
+    const cellIndex = html.indexOf('>Cell<');
+    const chatIndex = html.indexOf('>Chat<');
+    assert.ok(calendarIndex !== -1, 'Calendar app card should still be present');
+    assert.ok(cellIndex !== -1, 'Cell app card should be listed on the portal');
+    assert.ok(chatIndex !== -1, 'Chat app card should still be present');
+    assert.ok(calendarIndex < cellIndex, 'Cell should appear after Calendar');
+    assert.ok(cellIndex < chatIndex, 'Cell should appear before Chat');
+    assert.match(html, /href="cell\/(?:index\.html)?"/);
+  });
+});

--- a/tests/sales-training.test.js
+++ b/tests/sales-training.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('sales training leads with the outreach method and shared queue', async () => {
+  const salesHubHtml = await readFile(new URL('../sales/index.html', import.meta.url), 'utf8');
+  const html = await readFile(new URL('../sales/training/index.html', import.meta.url), 'utf8');
+
+  assert.match(salesHubHtml, /Start the reach-out desk, sharpen the pitch, and keep follow-up moving in one workspace\./);
+  assert.match(html, /Reach-Out Desk/);
+  assert.match(html, /One lead\. One message\. One follow-up\./);
+  assert.match(html, /https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+  assert.match(html, /\/gun-init\.js/);
+  assert.match(html, /Reach-Out Method/);
+  assert.match(html, /The method/);
+  assert.match(html, /Today's queue/);
+  assert.match(html, /Shared with Gun/);
+  assert.match(html, /today-queue/);
+  assert.match(html, /Outreach queue/);
+  assert.match(html, /Done for the day/);
+  assert.match(html, /Lead Capture/);
+  assert.match(html, /CRM dashboard/);
+  assert.match(html, /Follow-Up Loop/);
+  assert.match(html, /Pipeline Hygiene/);
+});


### PR DESCRIPTION
Sales Training now keeps the today's queue in a shared Gun node so the outreach list follows you across devices. The page still works locally, but it now hydrates from and persists to gun.get('3dvr-portal').get('sales-training').get('today-queue'), and the regression test guards the queue, Gun bootstrap, and Sales Hub copy.