### PR TITLE
Add Logic Lab portal app

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Calendar Hub](https://3dvr-portal.vercel.app/calendar/)
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)
 - [Life](https://3dvr-portal.vercel.app/life/)
+- [Logic Lab](https://3dvr-portal.vercel.app/logic-lab/)
 
 Open the page you want and use your browser’s **Install** or **Add to Home Screen** option to pin it like a native app.
 

--- a/index.html
+++ b/index.html
@@ -269,6 +269,11 @@
             <span class="app-card__title">Learn</span>
             <span class="app-card__meta">Unlock new lessons and level up your skills.</span>
           </a>
+          <a href="logic-lab/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">&#9878;</span>
+            <span class="app-card__title">Logic Lab</span>
+            <span class="app-card__meta">Train agents to define terms, test premises, and show their reasoning.</span>
+          </a>
           <a href="meditation/#meditationFlow" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🧘</span>
             <span class="app-card__title">Meditation</span>

--- a/logic-lab/app.js
+++ b/logic-lab/app.js
@@ -1,0 +1,839 @@
+'use strict';
+
+(function initLogicLab(window, document) {
+  if (!window || !document) {
+    return;
+  }
+
+  const STORAGE_KEY = 'portal-logic-lab-sessions';
+  const DRAFT_KEY = 'portal-logic-lab-draft';
+  const MAX_SESSIONS = 12;
+  const SESSION_VERSION = '2026-04-09-logic-lab-v1';
+  const DEFAULT_GUN_PEERS = [
+    'wss://relay.3dvr.tech/gun',
+    'wss://gun-relay-3dvr.fly.dev/gun',
+  ];
+  const LENSES = {
+    logic: {
+      key: 'logic',
+      title: 'Logic',
+      description: 'Check structure first. A valid argument can still rest on weak premises.',
+      checklist: [
+        'Define the key terms before evaluating the claim.',
+        'List the premises in plain language.',
+        'Ask whether the conclusion follows from those premises.',
+        'Look for contradiction, ambiguity, or hidden assumptions.',
+      ],
+    },
+    epistemology: {
+      key: 'epistemology',
+      title: 'Epistemology',
+      description: 'Focus on evidence quality, uncertainty, and what would change the answer.',
+      checklist: [
+        'Separate observation from interpretation.',
+        'Name the evidence that supports or weakens the claim.',
+        'Say what remains unknown.',
+        'Lower confidence when the support is thin or second-hand.',
+      ],
+    },
+    ethics: {
+      key: 'ethics',
+      title: 'Ethics',
+      description: 'Make the value conflict explicit instead of hiding it in the wording.',
+      checklist: [
+        'Identify who is helped, harmed, or ignored.',
+        'Separate factual predictions from moral judgments.',
+        'Name the values in conflict.',
+        'Explain why the chosen tradeoff beats the alternatives.',
+      ],
+    },
+    agency: {
+      key: 'agency',
+      title: 'Agency',
+      description: 'Model goals, incentives, and how an agent could drift from its stated objective.',
+      checklist: [
+        'State the agent goal in operational terms.',
+        'Identify incentives that can distort behavior.',
+        'Check for reward hacking or proxy gaming.',
+        'Describe what the agent should refuse or escalate.',
+      ],
+    },
+  };
+
+  const refs = {
+    form: document.getElementById('reasoning-form'),
+    claimInput: document.getElementById('claim-input'),
+    lensSelect: document.getElementById('lens-select'),
+    depthSelect: document.getElementById('depth-select'),
+    goalInput: document.getElementById('goal-input'),
+    notesInput: document.getElementById('notes-input'),
+    scaffoldOutput: document.getElementById('scaffold-output'),
+    promptOutput: document.getElementById('prompt-output'),
+    connectionBadge: document.getElementById('connection-badge'),
+    identityBadge: document.getElementById('identity-badge'),
+    saveBadge: document.getElementById('save-badge'),
+    disciplineGrid: document.getElementById('discipline-grid'),
+    lensSummaryTitle: document.getElementById('lens-summary-title'),
+    lensSummaryBody: document.getElementById('lens-summary-body'),
+    checklistList: document.getElementById('checklist-list'),
+    drillList: document.getElementById('drill-list'),
+    sessionList: document.getElementById('session-list'),
+    metricDrillCount: document.getElementById('metric-drill-count'),
+    metricSessionCount: document.getElementById('metric-session-count'),
+    metricChecklistCount: document.getElementById('metric-checklist-count'),
+    metricChecklistLabel: document.getElementById('metric-checklist-label'),
+    buildScaffold: document.getElementById('build-scaffold'),
+    saveSession: document.getElementById('save-session'),
+    copyScaffold: document.getElementById('copy-scaffold'),
+    copyPrompt: document.getElementById('copy-prompt'),
+  };
+
+  if (!refs.form || !refs.claimInput || !refs.scaffoldOutput || !refs.promptOutput) {
+    return;
+  }
+
+  const DRILLS = seedDrills();
+  const gunContext = ensureGunContext(() => createLogicLabGun(), 'logic-lab');
+  const gun = gunContext.gun;
+  const portalRoot = gun && typeof gun.get === 'function' ? gun.get('3dvr-portal') : createLocalGunNodeStub();
+  const sessionsNode = portalRoot.get('philosophyLogic').get('sessions');
+  const state = {
+    activeLens: 'logic',
+    activeDrillId: '',
+    activeSessionId: '',
+    author: resolveAuthor(),
+    sessions: readSessions(),
+  };
+
+  hydrateDraft();
+  bindEvents();
+  renderLensDeck();
+  renderDrillList();
+  renderSessions();
+  renderConnectionState();
+  renderIdentity();
+  updateOutputs();
+
+  function normalizeText(value) {
+    return typeof value === 'string' ? value.trim() : '';
+  }
+
+  function safeLocalStorageGet(key) {
+    try {
+      return window.localStorage.getItem(key) || '';
+    } catch (_error) {
+      return '';
+    }
+  }
+
+  function safeLocalStorageSet(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  function safeReadJson(key, fallback) {
+    const raw = safeLocalStorageGet(key);
+    if (!raw) {
+      return fallback;
+    }
+    try {
+      return JSON.parse(raw);
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function safeWriteJson(key, value) {
+    try {
+      return safeLocalStorageSet(key, JSON.stringify(value));
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  function createLocalGunSubscriptionStub() {
+    return {
+      off() {},
+    };
+  }
+
+  function createLocalGunNodeStub() {
+    const node = {
+      __isGunStub: true,
+      get() {
+        return createLocalGunNodeStub();
+      },
+      put(_value, callback) {
+        if (typeof callback === 'function') {
+          setTimeout(() => callback({ err: 'gun-unavailable' }), 0);
+        }
+        return node;
+      },
+      once(callback) {
+        if (typeof callback === 'function') {
+          setTimeout(() => callback(undefined), 0);
+        }
+        return node;
+      },
+      on() {
+        return createLocalGunSubscriptionStub();
+      },
+      map() {
+        return {
+          on() {
+            return createLocalGunSubscriptionStub();
+          },
+        };
+      },
+      off() {},
+    };
+    return node;
+  }
+
+  function createLocalGunUserStub() {
+    const node = createLocalGunNodeStub();
+    return {
+      ...node,
+      is: null,
+      _: {},
+      recall() {},
+    };
+  }
+
+  function createGunStub() {
+    return {
+      __isGunStub: true,
+      get() {
+        return createLocalGunNodeStub();
+      },
+      user() {
+        return createLocalGunUserStub();
+      },
+    };
+  }
+
+  function ensureGunContext(factory, label) {
+    const ensureGun = window.ScoreSystem && typeof window.ScoreSystem.ensureGun === 'function'
+      ? window.ScoreSystem.ensureGun.bind(window.ScoreSystem)
+      : null;
+
+    if (ensureGun) {
+      return ensureGun(factory, { label });
+    }
+
+    if (typeof factory === 'function') {
+      try {
+        const instance = factory();
+        if (instance) {
+          return {
+            gun: instance,
+            user: typeof instance.user === 'function' ? instance.user() : createLocalGunUserStub(),
+            isStub: !!instance.__isGunStub,
+          };
+        }
+      } catch (error) {
+        console.warn(`Failed to initialize ${label || 'gun'} context`, error);
+      }
+    }
+
+    const stub = createGunStub();
+    return {
+      gun: stub,
+      user: stub.user(),
+      isStub: true,
+    };
+  }
+
+  function createLogicLabGun() {
+    if (typeof Gun !== 'function') {
+      return null;
+    }
+
+    const peers = window.__GUN_PEERS__ || DEFAULT_GUN_PEERS;
+
+    try {
+      return Gun({ peers, axe: true });
+    } catch (error) {
+      const message = error && error.message ? error.message : String(error);
+      if (/storage|quota|blocked|third-party/i.test(message)) {
+        try {
+          return Gun({ peers, axe: true, radisk: false, localStorage: false });
+        } catch (fallbackError) {
+          console.warn('Logic Lab Gun fallback init failed', fallbackError);
+        }
+      } else {
+        console.warn('Logic Lab Gun init failed unexpectedly', error);
+      }
+    }
+
+    return null;
+  }
+
+  function resolveAuthor() {
+    if (window.AuthIdentity && typeof window.AuthIdentity.syncStorageFromSharedIdentity === 'function') {
+      try {
+        window.AuthIdentity.syncStorageFromSharedIdentity(window.localStorage);
+      } catch (error) {
+        console.warn('Failed to sync shared identity into local storage', error);
+      }
+    }
+
+    const signedIn = safeLocalStorageGet('signedIn') === 'true';
+    const alias = normalizeText(safeLocalStorageGet('alias'));
+    const username = normalizeText(safeLocalStorageGet('username'));
+    if (signedIn && alias) {
+      return {
+        mode: 'user',
+        key: `user-${alias.toLowerCase()}`,
+        label: username || alias.split('@')[0],
+      };
+    }
+
+    const ensureGuestIdentity = window.ScoreSystem
+      && typeof window.ScoreSystem.ensureGuestIdentity === 'function'
+      ? window.ScoreSystem.ensureGuestIdentity.bind(window.ScoreSystem)
+      : null;
+    const guestId = normalizeText(ensureGuestIdentity ? ensureGuestIdentity() : safeLocalStorageGet('guestId'));
+    return {
+      mode: 'guest',
+      key: guestId || `guest-${Date.now()}`,
+      label: normalizeText(safeLocalStorageGet('guestDisplayName')) || 'Guest',
+    };
+  }
+
+  function seedDrills() {
+    return [
+      {
+        id: 'hidden-premise',
+        title: 'Hidden premise audit',
+        lens: 'logic',
+        depth: 'balanced',
+        claim: 'A bot that answers faster is automatically a better teacher.',
+        goal: 'Expose the hidden premise and test whether speed implies learning quality.',
+        notes: 'Push the model to separate delivery speed from comprehension, retention, and calibration.',
+      },
+      {
+        id: 'evidence-ladder',
+        title: 'Evidence ladder',
+        lens: 'epistemology',
+        depth: 'deep',
+        claim: 'Users say the feature feels better, so the feature definitely improved outcomes.',
+        goal: 'Separate anecdote, proxy metrics, and direct evidence before making a strong claim.',
+        notes: 'Ask what evidence would confirm or overturn the conclusion.',
+      },
+      {
+        id: 'is-ought-split',
+        title: 'Is / ought split',
+        lens: 'ethics',
+        depth: 'balanced',
+        claim: 'Because automation is possible, the team ought to automate customer replies.',
+        goal: 'Force the model to distinguish factual capability from moral or strategic justification.',
+        notes: 'Identify the stakeholders, the failure modes, and the approval boundary.',
+      },
+      {
+        id: 'goal-drift',
+        title: 'Goal drift map',
+        lens: 'agency',
+        depth: 'deep',
+        claim: 'If the bot is rewarded for ticket closure time, it will help customers better.',
+        goal: 'Model the incentive and look for reward hacking or shallow optimization.',
+        notes: 'Push the agent to state what behavior the metric rewards and what it leaves out.',
+      },
+      {
+        id: 'counterexample-builder',
+        title: 'Counterexample builder',
+        lens: 'logic',
+        depth: 'quick',
+        claim: 'Every persuasive answer is also a truthful answer.',
+        goal: 'Generate one clean counterexample and lower confidence accordingly.',
+        notes: 'Avoid rhetoric. Use a compact, concrete case.',
+      },
+      {
+        id: 'value-conflict',
+        title: 'Value conflict map',
+        lens: 'ethics',
+        depth: 'balanced',
+        claim: 'A tutoring bot should always tell the full truth, even if it overwhelms the student.',
+        goal: 'Name the values in conflict and justify a revised practical policy.',
+        notes: 'Balance honesty, clarity, pacing, and learner agency.',
+      },
+    ];
+  }
+
+  function readDraft() {
+    const draft = safeReadJson(DRAFT_KEY, null);
+    if (!draft || typeof draft !== 'object') {
+      return {
+        lens: 'logic',
+        depth: 'balanced',
+        claim: '',
+        goal: '',
+        notes: '',
+      };
+    }
+
+    return {
+      lens: Object.prototype.hasOwnProperty.call(LENSES, draft.lens) ? draft.lens : 'logic',
+      depth: ['quick', 'balanced', 'deep'].includes(draft.depth) ? draft.depth : 'balanced',
+      claim: normalizeText(draft.claim),
+      goal: normalizeText(draft.goal),
+      notes: normalizeText(draft.notes),
+    };
+  }
+
+  function writeDraft() {
+    const draft = {
+      lens: state.activeLens,
+      depth: refs.depthSelect.value,
+      claim: refs.claimInput.value,
+      goal: refs.goalInput.value,
+      notes: refs.notesInput.value,
+    };
+    safeWriteJson(DRAFT_KEY, draft);
+  }
+
+  function readSessions() {
+    const stored = safeReadJson(STORAGE_KEY, []);
+    if (!Array.isArray(stored)) {
+      return [];
+    }
+    return stored
+      .filter(entry => entry && typeof entry === 'object')
+      .slice(0, MAX_SESSIONS);
+  }
+
+  function writeSessions(sessions) {
+    safeWriteJson(STORAGE_KEY, sessions.slice(0, MAX_SESSIONS));
+  }
+
+  function hydrateDraft() {
+    const draft = readDraft();
+    state.activeLens = draft.lens;
+    refs.claimInput.value = draft.claim;
+    refs.lensSelect.value = draft.lens;
+    refs.depthSelect.value = draft.depth;
+    refs.goalInput.value = draft.goal;
+    refs.notesInput.value = draft.notes;
+  }
+
+  function bindEvents() {
+    refs.form.addEventListener('submit', event => {
+      event.preventDefault();
+      writeDraft();
+      updateOutputs();
+      setSaveBadge('Scaffold rebuilt from the current draft.', 'neutral');
+    });
+
+    refs.claimInput.addEventListener('input', handleDraftInput);
+    refs.goalInput.addEventListener('input', handleDraftInput);
+    refs.notesInput.addEventListener('input', handleDraftInput);
+    refs.depthSelect.addEventListener('change', handleDraftInput);
+    refs.lensSelect.addEventListener('change', event => {
+      const value = normalizeText(event.target.value);
+      if (!Object.prototype.hasOwnProperty.call(LENSES, value)) {
+        return;
+      }
+      state.activeLens = value;
+      state.activeDrillId = '';
+      writeDraft();
+      renderLensDeck();
+      renderDrillList();
+      updateOutputs();
+    });
+
+    refs.saveSession.addEventListener('click', saveCurrentSession);
+    refs.copyScaffold.addEventListener('click', () => {
+      copyText(refs.scaffoldOutput.value, 'Scaffold copied to the clipboard.');
+    });
+    refs.copyPrompt.addEventListener('click', () => {
+      copyText(refs.promptOutput.value, 'Prompt copied to the clipboard.');
+    });
+  }
+
+  function handleDraftInput() {
+    writeDraft();
+    updateOutputs();
+  }
+
+  function getCurrentLens() {
+    return LENSES[state.activeLens] || LENSES.logic;
+  }
+
+  function getCurrentDrill() {
+    return DRILLS.find(drill => drill.id === state.activeDrillId) || null;
+  }
+
+  function renderConnectionState() {
+    if (gunContext.isStub) {
+      refs.connectionBadge.textContent = 'Offline draft mode';
+      refs.connectionBadge.className = 'logic-status-badge logic-status-badge--warn';
+      return;
+    }
+
+    refs.connectionBadge.textContent = 'Connected to Gun';
+    refs.connectionBadge.className = 'logic-status-badge';
+  }
+
+  function renderIdentity() {
+    const label = state.author.mode === 'user'
+      ? `Signed in as ${state.author.label}`
+      : `Guest deck for ${state.author.label}`;
+    refs.identityBadge.textContent = label;
+  }
+
+  function renderLensDeck() {
+    const lensEntries = Object.values(LENSES);
+    refs.disciplineGrid.innerHTML = '';
+    lensEntries.forEach(lens => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `discipline-card${lens.key === state.activeLens ? ' is-active' : ''}`;
+      button.setAttribute('role', 'listitem');
+      button.innerHTML = [
+        `<span class="discipline-card__title">${escapeHtml(lens.title)}</span>`,
+        `<span class="discipline-card__meta">${escapeHtml(lens.description)}</span>`,
+      ].join('');
+      button.addEventListener('click', () => {
+        state.activeLens = lens.key;
+        state.activeDrillId = '';
+        refs.lensSelect.value = lens.key;
+        writeDraft();
+        renderLensDeck();
+        renderDrillList();
+        updateOutputs();
+      });
+      refs.disciplineGrid.appendChild(button);
+    });
+  }
+
+  function renderDrillList() {
+    refs.metricDrillCount.textContent = String(DRILLS.length);
+    refs.drillList.innerHTML = '';
+
+    DRILLS.forEach(drill => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      const isActive = drill.id === state.activeDrillId;
+      button.className = `drill-card${isActive ? ' is-active' : ''}`;
+      button.setAttribute('role', 'listitem');
+      button.innerHTML = [
+        `<span class="drill-card__title">${escapeHtml(drill.title)}</span>`,
+        `<span class="drill-card__meta">${escapeHtml(drill.goal)}</span>`,
+      ].join('');
+      button.addEventListener('click', () => applyDrill(drill));
+      refs.drillList.appendChild(button);
+    });
+  }
+
+  function applyDrill(drill) {
+    state.activeDrillId = drill.id;
+    state.activeLens = drill.lens;
+    state.activeSessionId = '';
+    refs.claimInput.value = drill.claim;
+    refs.goalInput.value = drill.goal;
+    refs.notesInput.value = drill.notes;
+    refs.depthSelect.value = drill.depth;
+    refs.lensSelect.value = drill.lens;
+    writeDraft();
+    renderLensDeck();
+    renderDrillList();
+    updateOutputs();
+    setSaveBadge(`Loaded drill: ${drill.title}.`, 'neutral');
+  }
+
+  function renderSessions() {
+    refs.metricSessionCount.textContent = String(state.sessions.length);
+    refs.sessionList.innerHTML = '';
+
+    if (!state.sessions.length) {
+      const empty = document.createElement('p');
+      empty.className = 'logic-empty';
+      empty.textContent = 'No saved sessions yet. Save a scaffold to build a reusable training deck.';
+      refs.sessionList.appendChild(empty);
+      return;
+    }
+
+    state.sessions.forEach(session => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      const isActive = session.sessionId === state.activeSessionId;
+      button.className = `session-card${isActive ? ' is-active' : ''}`;
+      button.setAttribute('role', 'listitem');
+      button.innerHTML = [
+        `<span class="session-card__title">${escapeHtml(session.claim || 'Untitled session')}</span>`,
+        `<span class="session-card__meta">${escapeHtml(session.goal || getLensLabel(session.lens))}</span>`,
+        `<span class="session-card__timestamp">${escapeHtml(formatTimestamp(session.savedAt))}</span>`,
+      ].join('');
+      button.addEventListener('click', () => applySession(session));
+      refs.sessionList.appendChild(button);
+    });
+  }
+
+  function applySession(session) {
+    state.activeSessionId = session.sessionId;
+    state.activeDrillId = normalizeText(session.drillId);
+    state.activeLens = Object.prototype.hasOwnProperty.call(LENSES, session.lens) ? session.lens : 'logic';
+    refs.claimInput.value = normalizeText(session.claim);
+    refs.goalInput.value = normalizeText(session.goal);
+    refs.notesInput.value = normalizeText(session.notes);
+    refs.depthSelect.value = ['quick', 'balanced', 'deep'].includes(session.depth) ? session.depth : 'balanced';
+    refs.lensSelect.value = state.activeLens;
+    writeDraft();
+    renderLensDeck();
+    renderDrillList();
+    renderSessions();
+    updateOutputs();
+    setSaveBadge('Loaded saved session.', 'neutral');
+  }
+
+  function updateOutputs() {
+    const lens = getCurrentLens();
+    const drill = getCurrentDrill();
+    const draft = {
+      claim: normalizeText(refs.claimInput.value),
+      goal: normalizeText(refs.goalInput.value),
+      notes: normalizeText(refs.notesInput.value),
+      depth: normalizeText(refs.depthSelect.value) || 'balanced',
+    };
+
+    refs.scaffoldOutput.value = buildReasoningScaffold(draft, lens, drill);
+    refs.promptOutput.value = buildTrainingPrompt(draft, lens, drill);
+
+    refs.lensSummaryTitle.textContent = lens.title;
+    refs.lensSummaryBody.textContent = lens.description;
+    refs.checklistList.innerHTML = '';
+    lens.checklist.forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      refs.checklistList.appendChild(li);
+    });
+    refs.metricChecklistCount.textContent = String(lens.checklist.length);
+    refs.metricChecklistLabel.textContent = `${lens.title} checklist ready.`;
+  }
+
+  function buildReasoningScaffold(draft, lens, drill) {
+    const claim = draft.claim || 'Add a claim or a question you want the bot to analyze.';
+    const goal = draft.goal || 'Clarify what better reasoning should look like.';
+    const notes = draft.notes || 'Add domain constraints, known risks, or stakeholder context.';
+    const drillTitle = drill ? drill.title : 'Custom session';
+
+    return [
+      '# Question',
+      claim,
+      '',
+      '# Goal',
+      goal,
+      '',
+      '# Lens',
+      `${lens.title}: ${lens.description}`,
+      '',
+      '# Drill',
+      drillTitle,
+      '',
+      '# Definitions',
+      '- Which terms need to be defined before the claim can be judged?',
+      '- Which words are vague, overloaded, or likely to shift meaning?',
+      '',
+      '# Facts vs Values',
+      '- What descriptive claims are being made?',
+      '- What normative or strategic judgments are being assumed?',
+      '',
+      '# Premises',
+      '1. Premise one:',
+      '2. Premise two:',
+      '3. Hidden premise:',
+      '',
+      '# Inference Check',
+      '- Does the conclusion follow from the premises?',
+      '- If not, what leap or missing bridge is present?',
+      '',
+      '# Evidence Check',
+      '- What evidence supports the premises?',
+      '- What evidence is missing or weak?',
+      '',
+      '# Counterexample',
+      '- Give one concrete case that would pressure-test the claim.',
+      '',
+      '# Strongest Objection',
+      '- State the best opposing view without caricature.',
+      '',
+      '# Revision',
+      '- Rewrite the conclusion in a form that survives the objections better.',
+      '',
+      '# Confidence',
+      '- Report a confidence score from 0.0 to 1.0 and explain why.',
+      '',
+      '# Constraints',
+      notes,
+    ].join('\n');
+  }
+
+  function buildTrainingPrompt(draft, lens, drill) {
+    const claim = draft.claim || 'Add a claim or a question first.';
+    const goal = draft.goal || 'Improve reasoning quality.';
+    const notes = draft.notes || 'No extra constraints provided.';
+    const drillLine = drill ? `Drill focus: ${drill.title}.` : 'Drill focus: custom reasoning session.';
+
+    return [
+      `Analyze the following claim using ${lens.title}.`,
+      '',
+      `Claim: ${claim}`,
+      `Goal: ${goal}`,
+      `Depth: ${describeDepth(draft.depth)}`,
+      drillLine,
+      `Context: ${notes}`,
+      '',
+      'Return exactly these sections:',
+      '1. Definitions',
+      '2. Facts vs values',
+      '3. Premises',
+      '4. Validity check',
+      '5. Evidence check',
+      '6. Strongest objection',
+      '7. Counterexample',
+      '8. Revised conclusion',
+      '9. Confidence from 0.0 to 1.0',
+      '',
+      'Rules:',
+      '- Do not hide uncertainty.',
+      '- Name missing definitions.',
+      '- Separate descriptive claims from normative claims.',
+      '- Distinguish validity from truth.',
+      '- Lower confidence when evidence is thin.',
+      '- Prefer short concrete sentences over rhetoric.',
+      '',
+      'Lens checklist:',
+      ...lens.checklist.map(item => `- ${item}`),
+    ].join('\n');
+  }
+
+  function describeDepth(depth) {
+    if (depth === 'quick') {
+      return 'quick pass';
+    }
+    if (depth === 'deep') {
+      return 'deep review';
+    }
+    return 'balanced';
+  }
+
+  function saveCurrentSession() {
+    const claim = normalizeText(refs.claimInput.value);
+    if (!claim) {
+      refs.claimInput.focus();
+      setSaveBadge('Add a question or claim before saving.', 'warn');
+      return;
+    }
+
+    const sessionId = state.activeSessionId || createSessionId();
+    const session = {
+      sessionId,
+      version: SESSION_VERSION,
+      savedAt: new Date().toISOString(),
+      lens: state.activeLens,
+      depth: refs.depthSelect.value,
+      claim,
+      goal: normalizeText(refs.goalInput.value),
+      notes: normalizeText(refs.notesInput.value),
+      drillId: state.activeDrillId,
+      scaffold: refs.scaffoldOutput.value,
+      prompt: refs.promptOutput.value,
+      author: state.author,
+    };
+
+    state.activeSessionId = sessionId;
+    state.sessions = [session]
+      .concat(state.sessions.filter(entry => entry.sessionId !== sessionId))
+      .slice(0, MAX_SESSIONS);
+    writeSessions(state.sessions);
+    renderSessions();
+    setSaveBadge('Saved locally. Syncing to Gun.', 'neutral');
+
+    sessionsNode.get(sessionId).put(session, acknowledgement => {
+      if (acknowledgement && acknowledgement.err) {
+        setSaveBadge('Saved locally. Gun sync will retry when available.', 'warn');
+        return;
+      }
+      setSaveBadge('Saved locally and synced to Gun.', 'neutral');
+    });
+  }
+
+  function createSessionId() {
+    const randomPart = Math.random().toString(36).slice(2, 8);
+    return `logic-${Date.now()}-${randomPart}`;
+  }
+
+  async function copyText(value, successMessage) {
+    const text = normalizeText(value);
+    if (!text) {
+      setSaveBadge('Nothing to copy yet.', 'warn');
+      return;
+    }
+
+    if (window.navigator && window.navigator.clipboard && typeof window.navigator.clipboard.writeText === 'function') {
+      try {
+        await window.navigator.clipboard.writeText(text);
+        setSaveBadge(successMessage, 'neutral');
+        return;
+      } catch (error) {
+        console.warn('Clipboard write failed', error);
+      }
+    }
+
+    try {
+      const fallback = document.createElement('textarea');
+      fallback.value = text;
+      fallback.setAttribute('readonly', 'readonly');
+      fallback.style.position = 'absolute';
+      fallback.style.left = '-9999px';
+      document.body.appendChild(fallback);
+      fallback.select();
+      document.execCommand('copy');
+      fallback.remove();
+      setSaveBadge(successMessage, 'neutral');
+    } catch (error) {
+      console.warn('Fallback copy failed', error);
+      setSaveBadge('Copy failed on this device.', 'warn');
+    }
+  }
+
+  function setSaveBadge(message, tone) {
+    refs.saveBadge.textContent = message;
+    refs.saveBadge.className = 'logic-status-badge';
+    if (tone === 'warn') {
+      refs.saveBadge.className += ' logic-status-badge--warn';
+      return;
+    }
+    refs.saveBadge.className += ' logic-status-badge--neutral';
+  }
+
+  function formatTimestamp(value) {
+    const timestamp = Date.parse(value);
+    if (!Number.isFinite(timestamp)) {
+      return 'Saved recently';
+    }
+    return new Date(timestamp).toLocaleString([], {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  function getLensLabel(key) {
+    return Object.prototype.hasOwnProperty.call(LENSES, key) ? LENSES[key].title : 'Logic';
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+})(typeof window !== 'undefined' ? window : globalThis, typeof document !== 'undefined' ? document : null);

--- a/logic-lab/index.html
+++ b/logic-lab/index.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Philosophy &amp; Logic Lab | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="Train bots to reason with logic, epistemology, ethics, and agency drills inside the portal."
+  >
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+    rel="stylesheet"
+  >
+  <link rel="stylesheet" href="./styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script src="../auth-identity.js"></script>
+  <script src="../score.js"></script>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script defer src="./app.js"></script>
+</head>
+<body class="logic-body">
+  <a class="logic-skip" href="#main">Skip to philosophy and logic lab</a>
+  <nav class="logic-nav" aria-label="Portal navigation">
+    <a href="../index.html">Portal</a>
+    <a href="../openai-app/index.html">OpenAI Workbench</a>
+    <a href="../sales/index.html">Sales</a>
+    <a href="../life/index.html">Life</a>
+    <a href="../start/index.html">Start</a>
+  </nav>
+
+  <main id="main" class="logic-shell">
+    <header class="logic-hero">
+      <div class="logic-hero__copy">
+        <p class="logic-hero__eyebrow">Agent training workspace</p>
+        <h1 class="logic-hero__title">Philosophy &amp; Logic Lab</h1>
+        <p class="logic-hero__lead">
+          Teach bots to define terms, separate facts from values, expose hidden premises, and lower confidence when the
+          case is weak.
+        </p>
+        <div class="logic-hero__actions">
+          <a class="logic-button logic-button--primary" href="#reasoning-form">Build a reasoning deck</a>
+          <a class="logic-button logic-button--ghost" href="../openai-app/index.html">Open Workbench</a>
+        </div>
+        <div class="logic-status-row" aria-live="polite">
+          <span id="connection-badge" class="logic-status-badge">Connecting to Gun</span>
+          <span id="identity-badge" class="logic-status-badge logic-status-badge--neutral">Resolving author</span>
+          <span id="save-badge" class="logic-status-badge logic-status-badge--neutral">Draft mode</span>
+        </div>
+      </div>
+
+      <aside class="logic-principles" aria-labelledby="logic-principles-title">
+        <p class="logic-principles__eyebrow">Reasoning loop</p>
+        <h2 id="logic-principles-title">Discipline before output.</h2>
+        <ol class="logic-principles__list">
+          <li>Define the claim.</li>
+          <li>List premises and evidence.</li>
+          <li>Check validity and soundness.</li>
+          <li>Stress test with objections.</li>
+          <li>Revise and state confidence.</li>
+        </ol>
+        <p class="logic-principles__note">
+          Stored under <code>3dvr-portal/philosophyLogic/sessions</code> in Gun so the deck can travel across devices.
+        </p>
+      </aside>
+    </header>
+
+    <section class="logic-metrics" aria-label="Lab metrics">
+      <article class="logic-metric-card">
+        <p class="logic-metric-card__eyebrow">Disciplines</p>
+        <h2 id="metric-discipline-count">4</h2>
+        <p class="logic-metric-card__detail">Logic, epistemology, ethics, and agency.</p>
+      </article>
+      <article class="logic-metric-card logic-metric-card--accent">
+        <p class="logic-metric-card__eyebrow">Practice drills</p>
+        <h2 id="metric-drill-count">0</h2>
+        <p class="logic-metric-card__detail">Use these to pressure-test a model before trusting it.</p>
+      </article>
+      <article class="logic-metric-card">
+        <p class="logic-metric-card__eyebrow">Saved sessions</p>
+        <h2 id="metric-session-count">0</h2>
+        <p class="logic-metric-card__detail">Recent decks saved locally first, then synced to Gun.</p>
+      </article>
+      <article class="logic-metric-card">
+        <p class="logic-metric-card__eyebrow">Checklist load</p>
+        <h2 id="metric-checklist-count">0</h2>
+        <p id="metric-checklist-label" class="logic-metric-card__detail">Pick a lens to see the active checklist.</p>
+      </article>
+    </section>
+
+    <section class="logic-layout" aria-labelledby="logic-layout-title">
+      <h2 id="logic-layout-title" class="logic-section-title">Reasoning desk</h2>
+
+      <aside class="logic-panel logic-panel--curriculum" aria-labelledby="discipline-title">
+        <div class="logic-panel__header">
+          <div>
+            <p class="logic-panel__eyebrow">Curriculum</p>
+            <h3 id="discipline-title">Choose the lens</h3>
+          </div>
+        </div>
+        <div id="discipline-grid" class="discipline-grid" role="list"></div>
+        <article class="logic-summary-card" aria-labelledby="lens-summary-title">
+          <p class="logic-summary-card__eyebrow">Focus</p>
+          <h3 id="lens-summary-title">Logic</h3>
+          <p id="lens-summary-body" class="logic-summary-card__body">
+            Define the terms, isolate the premises, and check whether the conclusion follows.
+          </p>
+          <ul id="checklist-list" class="checklist-list"></ul>
+        </article>
+      </aside>
+
+      <section class="logic-panel logic-panel--workspace" aria-labelledby="workspace-title">
+        <div class="logic-panel__header">
+          <div>
+            <p class="logic-panel__eyebrow">Builder</p>
+            <h3 id="workspace-title">Turn a claim into a training artifact</h3>
+          </div>
+        </div>
+
+        <form id="reasoning-form" class="reasoning-form">
+          <label class="logic-field">
+            <span class="logic-field__label">Question or claim</span>
+            <input
+              id="claim-input"
+              name="claim"
+              type="text"
+              placeholder="Example: A useful AI tutor should explain why an argument fails."
+              autocomplete="off"
+            >
+          </label>
+
+          <div class="logic-field-grid">
+            <label class="logic-field">
+              <span class="logic-field__label">Primary lens</span>
+              <select id="lens-select" name="lens">
+                <option value="logic">Logic</option>
+                <option value="epistemology">Epistemology</option>
+                <option value="ethics">Ethics</option>
+                <option value="agency">Agency</option>
+              </select>
+            </label>
+
+            <label class="logic-field">
+              <span class="logic-field__label">Depth</span>
+              <select id="depth-select" name="depth">
+                <option value="quick">Quick pass</option>
+                <option value="balanced">Balanced</option>
+                <option value="deep">Deep review</option>
+              </select>
+            </label>
+          </div>
+
+          <label class="logic-field">
+            <span class="logic-field__label">What should the bot get better at?</span>
+            <textarea
+              id="goal-input"
+              name="goal"
+              rows="3"
+              placeholder="Example: Distinguish validity from truth and say when evidence is missing."
+            ></textarea>
+          </label>
+
+          <label class="logic-field">
+            <span class="logic-field__label">Context or constraints</span>
+            <textarea
+              id="notes-input"
+              name="notes"
+              rows="5"
+              placeholder="Add edge cases, domain constraints, or business rules the model should respect."
+            ></textarea>
+          </label>
+
+          <div class="logic-action-row">
+            <button id="build-scaffold" class="logic-button logic-button--primary" type="submit">Build scaffold</button>
+            <button id="save-session" class="logic-button logic-button--secondary" type="button">Save session</button>
+            <button id="copy-scaffold" class="logic-button logic-button--ghost" type="button">Copy scaffold</button>
+            <button id="copy-prompt" class="logic-button logic-button--ghost" type="button">Copy prompt</button>
+          </div>
+        </form>
+
+        <div class="output-grid">
+          <article class="output-card">
+            <div class="output-card__header">
+              <div>
+                <p class="logic-panel__eyebrow">Reasoning deck</p>
+                <h3>Scaffold</h3>
+              </div>
+            </div>
+            <label class="logic-field logic-field--stacked" for="scaffold-output">Reasoning scaffold</label>
+            <textarea id="scaffold-output" class="logic-output" rows="18" readonly></textarea>
+          </article>
+
+          <article class="output-card">
+            <div class="output-card__header">
+              <div>
+                <p class="logic-panel__eyebrow">Prompt deck</p>
+                <h3>Training prompt</h3>
+              </div>
+            </div>
+            <label class="logic-field logic-field--stacked" for="prompt-output">Prompt output</label>
+            <textarea id="prompt-output" class="logic-output logic-output--prompt" rows="18" readonly></textarea>
+          </article>
+        </div>
+      </section>
+
+      <aside class="logic-panel logic-panel--support" aria-labelledby="drills-title">
+        <section class="support-card">
+          <div class="logic-panel__header">
+            <div>
+              <p class="logic-panel__eyebrow">Practice</p>
+              <h3 id="drills-title">Drill queue</h3>
+            </div>
+          </div>
+          <div id="drill-list" class="drill-list" role="list"></div>
+        </section>
+
+        <section class="support-card" aria-labelledby="sessions-title">
+          <div class="logic-panel__header">
+            <div>
+              <p class="logic-panel__eyebrow">History</p>
+              <h3 id="sessions-title">Recent sessions</h3>
+            </div>
+          </div>
+          <div id="session-list" class="session-list" role="list"></div>
+        </section>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/logic-lab/styles.css
+++ b/logic-lab/styles.css
@@ -1,0 +1,534 @@
+:root {
+  --logic-bg: #081117;
+  --logic-bg-soft: #12202b;
+  --logic-panel: rgba(10, 21, 31, 0.88);
+  --logic-panel-strong: rgba(14, 28, 40, 0.94);
+  --logic-panel-alt: rgba(19, 38, 54, 0.92);
+  --logic-line: rgba(143, 188, 217, 0.18);
+  --logic-line-strong: rgba(213, 175, 84, 0.28);
+  --logic-text: #eff6fb;
+  --logic-muted: #aac0d1;
+  --logic-accent: #f0c36b;
+  --logic-accent-soft: #f8dd9e;
+  --logic-mint: #8fd1c7;
+  --logic-danger: #ff9173;
+  --logic-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+  --logic-radius: 24px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: 'IBM Plex Sans', sans-serif;
+  color: var(--logic-text);
+  background:
+    radial-gradient(circle at top left, rgba(240, 195, 107, 0.16), transparent 26%),
+    radial-gradient(circle at 82% 16%, rgba(143, 209, 199, 0.14), transparent 28%),
+    linear-gradient(180deg, #04090d 0%, #09131a 42%, #0b171f 100%);
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.logic-skip {
+  position: absolute;
+  left: 16px;
+  top: 12px;
+  transform: translateY(-180%);
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #081117;
+  text-decoration: none;
+  z-index: 20;
+}
+
+.logic-skip:focus {
+  transform: translateY(0);
+}
+
+.logic-nav {
+  width: min(1260px, calc(100% - 32px));
+  margin: 18px auto 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.logic-nav a {
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  text-decoration: none;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.logic-nav a:hover,
+.logic-nav a:focus-visible,
+.logic-button:hover,
+.logic-button:focus-visible,
+.discipline-card:hover,
+.discipline-card:focus-visible,
+.drill-card:hover,
+.drill-card:focus-visible,
+.session-card:hover,
+.session-card:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(240, 195, 107, 0.28);
+}
+
+.logic-shell {
+  width: min(1260px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 20px 0 44px;
+}
+
+.logic-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.95fr);
+  gap: 20px;
+  padding: 28px;
+  border-radius: 32px;
+  background: linear-gradient(145deg, rgba(10, 20, 30, 0.96), rgba(18, 34, 46, 0.98));
+  border: 1px solid var(--logic-line);
+  box-shadow: var(--logic-shadow);
+  overflow: hidden;
+  position: relative;
+}
+
+.logic-hero::after {
+  content: "";
+  position: absolute;
+  right: -70px;
+  bottom: -100px;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(240, 195, 107, 0.22), transparent 68%);
+  pointer-events: none;
+}
+
+.logic-hero__copy,
+.logic-principles {
+  position: relative;
+  z-index: 1;
+}
+
+.logic-hero__eyebrow,
+.logic-principles__eyebrow,
+.logic-panel__eyebrow,
+.logic-metric-card__eyebrow,
+.logic-summary-card__eyebrow {
+  margin: 0 0 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.78rem;
+  color: var(--logic-accent-soft);
+}
+
+.logic-hero__title,
+.logic-principles h2,
+.logic-panel h3,
+.output-card h3,
+.support-card h3,
+.logic-metric-card h2,
+.logic-section-title {
+  font-family: 'Sora', sans-serif;
+}
+
+.logic-hero__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 4.4rem);
+  line-height: 0.98;
+  max-width: 10ch;
+}
+
+.logic-hero__lead {
+  max-width: 60ch;
+  margin: 18px 0 0;
+  color: var(--logic-muted);
+  line-height: 1.72;
+  font-size: 1.02rem;
+}
+
+.logic-hero__actions,
+.logic-action-row,
+.logic-status-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.logic-hero__actions {
+  margin-top: 24px;
+}
+
+.logic-status-row {
+  margin-top: 20px;
+}
+
+.logic-button {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--logic-text);
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+.logic-button--primary {
+  background: linear-gradient(135deg, var(--logic-accent), #f8dc93);
+  color: #0b1218;
+  font-weight: 700;
+}
+
+.logic-button--secondary {
+  border-color: var(--logic-line);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.logic-button--ghost {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.logic-status-badge {
+  padding: 9px 12px;
+  border-radius: 999px;
+  background: rgba(143, 209, 199, 0.1);
+  border: 1px solid rgba(143, 209, 199, 0.18);
+  color: #d9f2ed;
+  font-size: 0.9rem;
+}
+
+.logic-status-badge--neutral {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: var(--logic-muted);
+}
+
+.logic-status-badge--warn {
+  background: rgba(255, 145, 115, 0.08);
+  border-color: rgba(255, 145, 115, 0.18);
+  color: #ffd4c9;
+}
+
+.logic-principles {
+  padding: 22px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  backdrop-filter: blur(18px);
+}
+
+.logic-principles h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.logic-principles__list {
+  margin: 18px 0 0;
+  padding-left: 20px;
+  color: var(--logic-muted);
+  line-height: 1.7;
+}
+
+.logic-principles__note {
+  margin: 20px 0 0;
+  color: var(--logic-muted);
+  line-height: 1.6;
+}
+
+.logic-principles code {
+  font-family: 'IBM Plex Sans', sans-serif;
+  color: var(--logic-accent-soft);
+}
+
+.logic-metrics {
+  margin-top: 22px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.logic-metric-card {
+  padding: 18px;
+  border-radius: 22px;
+  background: var(--logic-panel);
+  border: 1px solid var(--logic-line);
+  box-shadow: var(--logic-shadow);
+}
+
+.logic-metric-card--accent {
+  border-color: var(--logic-line-strong);
+  background: linear-gradient(165deg, rgba(32, 27, 18, 0.95), rgba(18, 28, 34, 0.96));
+}
+
+.logic-metric-card h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.logic-metric-card__detail {
+  margin: 10px 0 0;
+  color: var(--logic-muted);
+  line-height: 1.6;
+}
+
+.logic-layout {
+  margin-top: 22px;
+  display: grid;
+  grid-template-columns: minmax(240px, 0.86fr) minmax(0, 1.3fr) minmax(260px, 0.92fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.logic-section-title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.logic-panel,
+.support-card {
+  border-radius: 24px;
+  background: var(--logic-panel-strong);
+  border: 1px solid var(--logic-line);
+  box-shadow: var(--logic-shadow);
+}
+
+.logic-panel {
+  padding: 22px;
+}
+
+.logic-panel__header,
+.output-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.discipline-grid,
+.drill-list,
+.session-list {
+  display: grid;
+  gap: 12px;
+}
+
+.discipline-card,
+.drill-card,
+.session-card {
+  width: 100%;
+  text-align: left;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--logic-panel-alt);
+  color: var(--logic-text);
+  padding: 16px;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.discipline-card.is-active,
+.drill-card.is-active,
+.session-card.is-active {
+  border-color: rgba(240, 195, 107, 0.42);
+  background: linear-gradient(180deg, rgba(53, 43, 23, 0.96), rgba(20, 33, 41, 0.98));
+}
+
+.discipline-card__title,
+.drill-card__title,
+.session-card__title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.discipline-card__meta,
+.drill-card__meta,
+.session-card__meta,
+.session-card__timestamp {
+  display: block;
+  color: var(--logic-muted);
+  line-height: 1.55;
+}
+
+.logic-summary-card {
+  margin-top: 16px;
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.logic-summary-card h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.logic-summary-card__body {
+  margin: 12px 0 0;
+  color: var(--logic-muted);
+  line-height: 1.65;
+}
+
+.checklist-list {
+  margin: 14px 0 0;
+  padding-left: 18px;
+  color: var(--logic-text);
+  line-height: 1.7;
+}
+
+.reasoning-form {
+  display: grid;
+  gap: 14px;
+}
+
+.logic-field {
+  display: grid;
+  gap: 8px;
+}
+
+.logic-field__label {
+  font-weight: 600;
+}
+
+.logic-field input,
+.logic-field select,
+.logic-field textarea,
+.logic-output {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  background: rgba(5, 10, 14, 0.72);
+  color: var(--logic-text);
+  padding: 14px 15px;
+  resize: vertical;
+}
+
+.logic-field input::placeholder,
+.logic-field textarea::placeholder {
+  color: rgba(170, 192, 209, 0.72);
+}
+
+.logic-field-grid,
+.output-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.logic-field-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.output-grid {
+  margin-top: 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.output-card {
+  padding: 20px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.logic-output {
+  min-height: 360px;
+  line-height: 1.55;
+}
+
+.logic-output--prompt {
+  background: rgba(9, 15, 20, 0.86);
+}
+
+.support-card {
+  padding: 20px;
+}
+
+.session-card__timestamp {
+  margin-top: 8px;
+  font-size: 0.88rem;
+}
+
+.support-card + .support-card {
+  margin-top: 16px;
+}
+
+.logic-empty {
+  margin: 0;
+  color: var(--logic-muted);
+  line-height: 1.6;
+}
+
+@media (max-width: 1120px) {
+  .logic-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .logic-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .logic-hero {
+    grid-template-columns: 1fr;
+    padding: 22px;
+  }
+
+  .logic-shell,
+  .logic-nav {
+    width: min(100% - 20px, 1260px);
+  }
+
+  .logic-field-grid,
+  .output-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .logic-nav,
+  .logic-hero__actions,
+  .logic-status-row,
+  .logic-action-row {
+    gap: 10px;
+  }
+
+  .logic-button,
+  .logic-nav a {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .logic-metrics {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/logic-lab.test.js
+++ b/tests/logic-lab.test.js
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const baseDir = new URL('../logic-lab/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+describe('logic lab app', () => {
+  it('ships the philosophy and logic workspace with the expected structure and scripts', async () => {
+    const indexUrl = new URL('index.html', baseDir);
+    assert.equal(await fileExists(indexUrl), true, 'index.html should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    assert.match(html, /Philosophy &amp; Logic Lab \| 3DVR Portal/);
+    assert.match(html, /Teach bots to define terms, separate facts from values/);
+    assert.match(html, /id="reasoning-form"/);
+    assert.match(html, /id="claim-input"/);
+    assert.match(html, /id="goal-input"/);
+    assert.match(html, /id="notes-input"/);
+    assert.match(html, /id="scaffold-output"/);
+    assert.match(html, /id="prompt-output"/);
+    assert.match(html, /id="drill-list"/);
+    assert.match(html, /id="session-list"/);
+    assert.match(html, /Stored under <code>3dvr-portal\/philosophyLogic\/sessions<\/code> in Gun/);
+    assert.match(html, /<script[^>]+src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"/);
+    assert.match(html, /<script[^>]+src="\.\.\/auth-identity\.js"/);
+    assert.match(html, /<script[^>]+src="\.\.\/score\.js"/);
+    assert.match(html, /<script[^>]+src="\.\/app\.js"/);
+  });
+
+  it('ships a stylesheet tailored to the logic lab layout', async () => {
+    const stylesUrl = new URL('styles.css', baseDir);
+    assert.equal(await fileExists(stylesUrl), true, 'styles.css should exist');
+
+    const css = await readFile(stylesUrl, 'utf8');
+    assert.match(css, /\.logic-shell/);
+    assert.match(css, /\.logic-layout/);
+    assert.match(css, /\.discipline-grid/);
+    assert.match(css, /\.drill-list/);
+    assert.match(css, /\.session-list/);
+    assert.match(css, /\.output-card/);
+  });
+
+  it('includes client logic for scaffolds, prompts, and Gun-backed session sync', async () => {
+    const appUrl = new URL('app.js', baseDir);
+    assert.equal(await fileExists(appUrl), true, 'app.js should exist');
+
+    const js = await readFile(appUrl, 'utf8');
+    assert.match(js, /window\.ScoreSystem && typeof window\.ScoreSystem\.ensureGun === 'function'/);
+    assert.match(js, /ensureGuestIdentity/);
+    assert.match(js, /seedDrills/);
+    assert.match(js, /buildReasoningScaffold/);
+    assert.match(js, /buildTrainingPrompt/);
+    assert.match(js, /copyText/);
+    assert.match(js, /portalRoot\.get\('philosophyLogic'\)\.get\('sessions'\)/);
+    assert.match(js, /sessionsNode\.get\(sessionId\)\.put\(session/);
+    assert.match(js, /Saved locally and synced to Gun\./);
+  });
+
+  it('registers Logic Lab in the portal dock near Learn and Meditation', async () => {
+    const portalIndex = new URL('../index.html', baseDir);
+    assert.equal(await fileExists(portalIndex), true, 'root index.html should exist');
+
+    const html = await readFile(portalIndex, 'utf8');
+    const learnIndex = html.indexOf('>Learn<');
+    const logicIndex = html.indexOf('>Logic Lab<');
+    const meditationIndex = html.indexOf('>Meditation<');
+    assert.ok(logicIndex !== -1, 'Logic Lab app card should be listed on the portal');
+    assert.ok(learnIndex !== -1, 'Learn app card should still be present');
+    assert.ok(meditationIndex !== -1, 'Meditation app card should still be present');
+    assert.ok(learnIndex < logicIndex, 'Logic Lab should render after Learn');
+    assert.ok(logicIndex < meditationIndex, 'Logic Lab should render before Meditation');
+    assert.match(html, /href="logic-lab\/(?:index\.html)?"/);
+  });
+
+  it('adds Logic Lab to the installable app list in the README', async () => {
+    const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+    assert.match(readme, /\[Logic Lab\]\(https:\/\/3dvr-portal\.vercel\.app\/logic-lab\/\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new `logic-lab` portal app for philosophy and logic training
- register the app in the portal dock and install list
- add focused coverage for the new app and existing portal homepage expectations

## Verification
- `node --test tests/logic-lab.test.js`
- `node --test tests/customer-journey-pages.test.js`
- verified the preview route in Chromium under Debian `proot`

## Notes
- no Stripe or billing behavior changed
- preview deployed and browser-verified before production release