### PR TITLE
Backfill release notes through v0.0.40

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -82,16 +82,57 @@
   <div class="section">
     <h2>Latest Release</h2>
     <article class="release-card">
-      <a class="release-link" href="v0.0.35.html">v0.0.35</a>
-      <span class="release-meta">Week of January 12, 2026</span>
+      <a class="release-link" href="v0.0.40.html">v0.0.40</a>
+      <span class="release-meta">Week of April 6, 2026</span>
       <p class="release-summary">
-        Cross-site review of portal, 3dvr.tech, and tmsteph.com updates alongside release hub upkeep.
+        OAuth identity, calendar standalone prep, live Stripe finance visibility, customer journey simplification,
+        and the new Logic Lab.
       </p>
     </article>
   </div>
   <div class="section">
     <h2>Release History</h2>
     <ul class="release-grid">
+      <li class="release-card">
+        <a class="release-link" href="v0.0.40.html">v0.0.40</a>
+        <span class="release-meta">Week of April 6, 2026</span>
+        <p class="release-summary">
+          OAuth identity, calendar standalone prep, live Stripe finance visibility, customer journey simplification,
+          and the new Logic Lab.
+        </p>
+      </li>
+      <li class="release-card">
+        <a class="release-link" href="v0.0.39.html">v0.0.39</a>
+        <span class="release-meta">Week of March 30, 2026</span>
+        <p class="release-summary">
+          Sales training turns into a daily outreach desk while research, profitability, growth, and onboarding all
+          tighten across the portal.
+        </p>
+      </li>
+      <li class="release-card">
+        <a class="release-link" href="v0.0.38.html">v0.0.38</a>
+        <span class="release-meta">Late March 2026</span>
+        <p class="release-summary">
+          Billing recovery work, roadmap and CRM alignment, live sync, Email Operator, Cell, and Life OS push the
+          portal toward a more operational workspace.
+        </p>
+      </li>
+      <li class="release-card">
+        <a class="release-link" href="v0.0.37.html">v0.0.37</a>
+        <span class="release-meta">Mid February 2026</span>
+        <p class="release-summary">
+          Jetpack Corridor gets a major gameplay pass while Playwright smoke coverage and Money Autopilot land in the
+          portal stack.
+        </p>
+      </li>
+      <li class="release-card">
+        <a class="release-link" href="v0.0.36.html">v0.0.36</a>
+        <span class="release-meta">Late January 2026</span>
+        <p class="release-summary">
+          The portal home gains experimental routing, local dev gets lighter, social planning becomes editable, and
+          sales pitch work gets its own page.
+        </p>
+      </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.35.html">v0.0.35</a>
         <span class="release-meta">Week of January 12, 2026</span>

--- a/releases/v0.0.36.html
+++ b/releases/v0.0.36.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>3dvr Portal – Release v0.0.35 (Week of January 12, 2026)</title>
+  <title>3dvr Portal – Release v0.0.36 (Late January 2026)</title>
   <style>
     body {
       margin: 0 auto;
@@ -66,11 +66,6 @@
       align-items: center;
       gap: 8px;
     }
-    .release-nav-link.is-disabled {
-      opacity: 0.4;
-      pointer-events: none;
-      cursor: default;
-    }
   </style>
 
   <script defer src="/_vercel/insights/script.js"></script>
@@ -78,46 +73,50 @@
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
-    <a class="release-nav-link" href="v0.0.34.html">← Previous release</a>
-    <a class="release-nav-link" href="v0.0.36.html">Next release →</a>
+    <a class="release-nav-link" href="v0.0.35.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.37.html">Next release →</a>
   </nav>
-  <h1>Release v0.0.35</h1>
-  <div class="tag">Week of January 12, 2026</div>
+  <h1>Release v0.0.36</h1>
+  <div class="tag">Late January 2026</div>
   <p class="release-summary">
-    Weekly release checkpoint with a cross-site review of portal, 3dvr.tech, and tmsteph.com changes alongside
-    release hub upkeep.
+    Experimental app routing, a lighter local dev workflow, editable social planning, and a dedicated sales pitch page
+    tighten the portal’s day-to-day operating surface.
   </p>
 
   <div class="section">
     <h2>Overview</h2>
     <p>
-      This week focuses on the cadence and clarity of the release process while confirming the latest updates across
-      the portal, 3dvr.tech, and tmsteph.com. The release hub now highlights the newest milestone, and each release
-      page is linked forward and backward to make browsing the weekly history seamless.
+      This release picks up after the January release-hub checkpoint and backfills a cluster of practical portal work:
+      the home page gets clearer boundaries for experimental apps, local development stops depending on a heavier
+      Vercel dev loop, and the social planning workspace becomes something you can actually edit instead of just read.
     </p>
   </div>
 
   <div class="section">
-    <h2>Portal updates</h2>
+    <h2>Portal home and developer workflow</h2>
     <ul>
-      <li>Published the v0.0.35 milestone so the portal release hub stays current.</li>
-      <li>Linked v0.0.34 to the newest weekly notes for easier navigation through recent history.</li>
+      <li>Group experimental apps more deliberately and add a homepage toggle so the dock is easier to scan.</li>
+      <li>Replace the Vercel-first dev loop with a local static server and add a cleaner <code>npm start</code> flow.</li>
+      <li>Persist usernames more reliably so signed-in people do not fall back to stray guest placeholders.</li>
     </ul>
   </div>
 
   <div class="section">
-    <h2>3dvr.tech review</h2>
+    <h2>Social planning becomes editable</h2>
     <ul>
-      <li>Reviewed recent 3dvr.tech commits and PRs for portal-impacting changes.</li>
-      <li>No portal-facing updates were ready to merge into the release notes this week.</li>
+      <li>Add editing controls to the social command center and respect hidden-state panels during edit flows.</li>
+      <li>Make social media goals editable instead of fixed copy.</li>
+      <li>Bring in image upload and thumbnail preview support to make planning assets easier to review.</li>
+      <li>Soften the visual palette so the workspace feels more usable over longer sessions.</li>
     </ul>
   </div>
 
   <div class="section">
-    <h2>tmsteph.com review</h2>
+    <h2>Sales pitch packaging</h2>
     <ul>
-      <li>Checked the latest tmsteph.com updates and PR activity for cross-site highlights.</li>
-      <li>No new changes required release note coverage this week.</li>
+      <li>Move the sales pitch into its own dedicated page instead of burying it inside broader sales copy.</li>
+      <li>Add a shareable anchor and script so the pitch can be linked directly.</li>
+      <li>Expand the pitch vision section to make the sales story more explicit and reusable.</li>
     </ul>
   </div>
 

--- a/releases/v0.0.37.html
+++ b/releases/v0.0.37.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal – Release v0.0.37 (Mid February 2026)</title>
+  <style>
+    body {
+      margin: 0 auto;
+      font-family: Arial, Helvetica, sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      line-height: 1.65;
+      padding: 20px;
+      max-width: 900px;
+    }
+    h1,
+    h2,
+    h3 {
+      color: #58a6ff;
+    }
+    a {
+      color: #58a6ff;
+    }
+    .section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #161b22;
+      border-radius: 10px;
+      border: 1px solid #30363d;
+    }
+    .tag {
+      background: #1f6feb;
+      padding: 4px 10px;
+      border-radius: 6px;
+      display: inline-block;
+      font-size: 14px;
+      margin-bottom: 20px;
+    }
+    .release-summary {
+      margin: 0 0 24px;
+      font-size: 16px;
+      color: #9ba3b4;
+    }
+    .back-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .back-link:hover {
+      text-decoration: underline;
+    }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+  </style>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.36.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.38.html">Next release →</a>
+  </nav>
+  <h1>Release v0.0.37</h1>
+  <div class="tag">Mid February 2026</div>
+  <p class="release-summary">
+    Jetpack Corridor gets a serious gameplay pass while Playwright smoke checks and Money Autopilot push the portal
+    toward something that can test, automate, and publish with more confidence.
+  </p>
+
+  <div class="section">
+    <h2>Overview</h2>
+    <p>
+      Mid-February folds together three different threads of work: the arcade gets a stronger mobile-first Jetpack
+      experience, the portal finally gains automated browser smoke checks, and Money AI evolves from a single page into
+      an automation loop with secure tokens, publishing routes, and cron support.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>Jetpack and game polish</h2>
+    <ul>
+      <li>Integrate Jetpack Corridor into the games hub and keep mobile navigation workable with a collapsible top nav.</li>
+      <li>Refactor the game into modules, harden boot and fallback loading, and tune obstacles and start flow.</li>
+      <li>Improve the mobile HUD, joystick strafe, vertical climb, and touch-driven turn behavior.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Testing and runtime stability</h2>
+    <ul>
+      <li>Add automated Playwright smoke checks for local and CI verification.</li>
+      <li>Fix cross-platform scheduler and test stability issues so browser coverage is more reliable.</li>
+      <li>Keep the sales homepage links aligned with the new dedicated pitch page.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Money automation stack</h2>
+    <ul>
+      <li>Add the Money Autopilot loop with Gun sync, secure trigger support, publishing paths, and market discovery.</li>
+      <li>Introduce per-user autopilot tokens, plan rate limits, and stronger token-secret fallback handling.</li>
+      <li>Wire checkout CTAs and cron scheduling while fitting within Hobby-plan runtime limits.</li>
+      <li>Tighten signal relevance and keyword sanitization so the automation loop stays closer to real demand.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+</body>
+</html>

--- a/releases/v0.0.38.html
+++ b/releases/v0.0.38.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal – Release v0.0.38 (Late March 2026)</title>
+  <style>
+    body {
+      margin: 0 auto;
+      font-family: Arial, Helvetica, sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      line-height: 1.65;
+      padding: 20px;
+      max-width: 900px;
+    }
+    h1,
+    h2,
+    h3 {
+      color: #58a6ff;
+    }
+    a {
+      color: #58a6ff;
+    }
+    .section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #161b22;
+      border-radius: 10px;
+      border: 1px solid #30363d;
+    }
+    .tag {
+      background: #1f6feb;
+      padding: 4px 10px;
+      border-radius: 6px;
+      display: inline-block;
+      font-size: 14px;
+      margin-bottom: 20px;
+    }
+    .release-summary {
+      margin: 0 0 24px;
+      font-size: 16px;
+      color: #9ba3b4;
+    }
+    .back-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .back-link:hover {
+      text-decoration: underline;
+    }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+  </style>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.37.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.39.html">Next release →</a>
+  </nav>
+  <h1>Release v0.0.38</h1>
+  <div class="tag">Late March 2026</div>
+  <p class="release-summary">
+    Billing recovery work, roadmap and CRM alignment, live worksheet sync, Email Operator, Cell, and Life OS turn the
+    portal into a more coherent operating workspace.
+  </p>
+
+  <div class="section">
+    <h2>Overview</h2>
+    <p>
+      Late March is about operational coherence. Billing fixes get less fragile, the roadmap shifts from abstract plan
+      to live worksheet, CRM and billing status start lining up more closely, and several new workspaces land that make
+      the portal feel more like a daily system than a loose bundle of pages.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>Billing, roadmap, and account alignment</h2>
+    <ul>
+      <li>Fix legacy subscriber handling, cancellation clarity, alias-linked subscription lookup, and multi-email account edges.</li>
+      <li>Refresh the March-April roadmap into a live worksheet with bubble and entry-list inputs plus shared sync.</li>
+      <li>Align CRM roadmap flows with live billing status so the portal’s growth path tracks real account state more closely.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>New portal workspaces</h2>
+    <ul>
+      <li>Add the <a href="../email-operator/index.html">Email Operator</a> so approval-first outreach has a dedicated shell.</li>
+      <li>Add the <a href="../cell/index.html">Cell</a> app and wire it into Gun so community support has a shared data path.</li>
+      <li>Add the <a href="../life/index.html">Life OS / Life</a> workspace and align the free path around life organization messaging.</li>
+      <li>Restore GPT-5 options in the web builder and tighten the portal’s focus rule and PR workflow docs.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>CRM and workflow reliability</h2>
+    <ul>
+      <li>Improve CRM and contacts mobile workflow with Playwright UX coverage.</li>
+      <li>Route add-to-contacts behavior more cleanly for signed-in users and preferred spaces.</li>
+      <li>Default new leads into warmer stages and tighten sales hub alignment with CRM and billing workflow.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+</body>
+</html>

--- a/releases/v0.0.39.html
+++ b/releases/v0.0.39.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal – Release v0.0.39 (Week of March 30, 2026)</title>
+  <style>
+    body {
+      margin: 0 auto;
+      font-family: Arial, Helvetica, sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      line-height: 1.65;
+      padding: 20px;
+      max-width: 900px;
+    }
+    h1,
+    h2,
+    h3 {
+      color: #58a6ff;
+    }
+    a {
+      color: #58a6ff;
+    }
+    .section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #161b22;
+      border-radius: 10px;
+      border: 1px solid #30363d;
+    }
+    .tag {
+      background: #1f6feb;
+      padding: 4px 10px;
+      border-radius: 6px;
+      display: inline-block;
+      font-size: 14px;
+      margin-bottom: 20px;
+    }
+    .release-summary {
+      margin: 0 0 24px;
+      font-size: 16px;
+      color: #9ba3b4;
+    }
+    .back-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .back-link:hover {
+      text-decoration: underline;
+    }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+  </style>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.38.html">← Previous release</a>
+    <a class="release-nav-link" href="v0.0.40.html">Next release →</a>
+  </nav>
+  <h1>Release v0.0.39</h1>
+  <div class="tag">Week of March 30, 2026</div>
+  <p class="release-summary">
+    Sales training turns into a daily outreach desk while research, profitability, growth, and onboarding all tighten
+    across the portal.
+  </p>
+
+  <div class="section">
+    <h2>Overview</h2>
+    <p>
+      This is a dense operator-facing release. Sales training stops pretending to be generic documentation and becomes a
+      daily desk for outreach. Research gets queues, interview tracking, and scheduled handoff. Finance gains clearer
+      profitability signals. The portal home and start flow get simpler language and a more app-like shape.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>Sales and research become operational</h2>
+    <ul>
+      <li>Turn sales training into a daily outreach workspace with a today queue, Gun-backed sync, and cleaner layout.</li>
+      <li>Add a buyer journey stage view, revenue close section, CRM handoff, and a dedicated market research desk.</li>
+      <li>Bring in research playbooks, segment scoreboards, ICP guidance, first-15 interview tracking, and scheduling flow.</li>
+      <li>Log real CRM replies and queue touches so the research and outreach system has better follow-through.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Finance, growth, and operator support</h2>
+    <ul>
+      <li>Add a profitability desk to sales and align the finance hub around the same metrics and billing counts.</li>
+      <li>Introduce the Growth Lab and homepage growth cron for experiment-driven homepage work.</li>
+      <li>Wire approval-first outreach more tightly into <a href="../email-operator/index.html">Email Operator</a>.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Home and onboarding clarity</h2>
+    <ul>
+      <li>Make the portal home more app-like, simplify its intro, and describe entry paths in plain language.</li>
+      <li>Turn the start page into a more direct router for free, paid, and returning users.</li>
+      <li>Use the canonical public email consistently and tighten Debian proot guidance for browser automation work.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+</body>
+</html>

--- a/releases/v0.0.40.html
+++ b/releases/v0.0.40.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>3dvr Portal – Release v0.0.35 (Week of January 12, 2026)</title>
+  <title>3dvr Portal – Release v0.0.40 (Week of April 6, 2026)</title>
   <style>
     body {
       margin: 0 auto;
@@ -78,46 +78,49 @@
 <body>
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
-    <a class="release-nav-link" href="v0.0.34.html">← Previous release</a>
-    <a class="release-nav-link" href="v0.0.36.html">Next release →</a>
+    <a class="release-nav-link" href="v0.0.39.html">← Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
   </nav>
-  <h1>Release v0.0.35</h1>
-  <div class="tag">Week of January 12, 2026</div>
+  <h1>Release v0.0.40</h1>
+  <div class="tag">Week of April 6, 2026</div>
   <p class="release-summary">
-    Weekly release checkpoint with a cross-site review of portal, 3dvr.tech, and tmsteph.com changes alongside
-    release hub upkeep.
+    OAuth identity, calendar standalone prep, live Stripe finance visibility, customer journey simplification, and the
+    new Logic Lab define the current portal surface.
   </p>
 
   <div class="section">
     <h2>Overview</h2>
     <p>
-      This week focuses on the cadence and clarity of the release process while confirming the latest updates across
-      the portal, 3dvr.tech, and tmsteph.com. The release hub now highlights the newest milestone, and each release
-      page is linked forward and backward to make browsing the weekly history seamless.
+      This release ties together core account, finance, and portal-entry work while adding one new training workspace.
+      Identity handling is stronger, calendar is better prepared for standalone deployment, finance surfaces more real
+      Stripe visibility, and the front door becomes more explicit about where a new user should go next.
     </p>
   </div>
 
   <div class="section">
-    <h2>Portal updates</h2>
+    <h2>Identity and account linking</h2>
     <ul>
-      <li>Published the v0.0.35 milestone so the portal release hub stays current.</li>
-      <li>Linked v0.0.34 to the newest weekly notes for easier navigation through recent history.</li>
+      <li>Add portal OAuth identity and provider integrations so account state can move more cleanly across apps.</li>
+      <li>Clarify customer handoff language and keep billing plan-switch handling from drifting out of sync with the portal.</li>
+      <li>Move free-trial email capture higher in the flow so the entry path is easier to start.</li>
     </ul>
   </div>
 
   <div class="section">
-    <h2>3dvr.tech review</h2>
+    <h2>Calendar and portal home</h2>
     <ul>
-      <li>Reviewed recent 3dvr.tech commits and PRs for portal-impacting changes.</li>
-      <li>No portal-facing updates were ready to merge into the release notes this week.</li>
+      <li>Refine the calendar hub layout, reduce visual harshness, and promote it more clearly from the portal home.</li>
+      <li>Prepare calendar for standalone subdomain PWA usage and fix the related wildcard and proxy rewrites.</li>
+      <li>Promote core business workspaces on the homepage and simplify the customer journey messaging.</li>
     </ul>
   </div>
 
   <div class="section">
-    <h2>tmsteph.com review</h2>
+    <h2>Finance and reasoning tools</h2>
     <ul>
-      <li>Checked the latest tmsteph.com updates and PR activity for cross-site highlights.</li>
-      <li>No new changes required release note coverage this week.</li>
+      <li>Add live Stripe MRR and cashflow visibility to finance, then tighten the mobile layout for that workspace.</li>
+      <li>Consolidate calendar provider APIs and keep browser coverage around these flows in place.</li>
+      <li>Add the new <a href="../logic-lab/index.html">Logic Lab</a> so the portal can train bots with explicit philosophy and logic drills.</li>
     </ul>
   </div>
 

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const baseDir = new URL('../releases/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+describe('release hub backfill', () => {
+  it('updates the release index with the retroactive milestones through v0.0.40', async () => {
+    const indexUrl = new URL('index.html', baseDir);
+    assert.equal(await fileExists(indexUrl), true, 'releases/index.html should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    assert.match(html, /Latest Release/);
+    assert.match(html, /href="v0\.0\.40\.html">v0\.0\.40</);
+    assert.match(html, /Week of April 6, 2026/);
+    assert.match(html, /Logic Lab/);
+    assert.match(html, /href="v0\.0\.39\.html">v0\.0\.39</);
+    assert.match(html, /href="v0\.0\.38\.html">v0\.0\.38</);
+    assert.match(html, /href="v0\.0\.37\.html">v0\.0\.37</);
+    assert.match(html, /href="v0\.0\.36\.html">v0\.0\.36</);
+  });
+
+  it('links v0.0.35 forward into the new retroactive chain', async () => {
+    const html = await readFile(new URL('v0.0.35.html', baseDir), 'utf8');
+    assert.match(html, /href="v0\.0\.34\.html"/);
+    assert.match(html, /href="v0\.0\.36\.html"/);
+  });
+
+  it('ships the new milestone pages with coherent navigation and summaries', async () => {
+    const releases = [
+      ['v0.0.36.html', /Late January 2026/, /social planning/i, /href="v0\.0\.37\.html"/],
+      ['v0.0.37.html', /Mid February 2026/, /Money Autopilot/i, /href="v0\.0\.38\.html"/],
+      ['v0.0.38.html', /Late March 2026/, /Email Operator/i, /href="v0\.0\.39\.html"/],
+      ['v0.0.39.html', /Week of March 30, 2026/, /profitability/i, /href="v0\.0\.40\.html"/],
+      ['v0.0.40.html', /Week of April 6, 2026/, /Logic Lab/i, /aria-disabled="true"/],
+    ];
+
+    for (const [filename, datePattern, topicPattern, navPattern] of releases) {
+      const url = new URL(filename, baseDir);
+      assert.equal(await fileExists(url), true, `${filename} should exist`);
+      const html = await readFile(url, 'utf8');
+      assert.match(html, /<nav class="release-nav" aria-label="Release navigation">/);
+      assert.match(html, datePattern);
+      assert.match(html, topicPattern);
+      assert.match(html, navPattern);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- backfill the portal release hub with milestone notes from v0.0.36 through v0.0.40
- update the releases index so the latest release points at the new April milestone
- add regression coverage for release hub navigation and the retroactive entries

## Verification
- `node --test tests/releases-hub.test.js`
- `node --test tests/customer-journey-pages.test.js tests/logic-lab.test.js`

## Notes
- this keeps the release hub closer to actual portal history after the January 2026 gap
- no billing or API behavior changed