### PR TITLE
Make Logic Lab drill card clickable

### DIFF
--- a/logic-lab/app.js
+++ b/logic-lab/app.js
@@ -78,6 +78,7 @@
     checklistList: document.getElementById('checklist-list'),
     drillList: document.getElementById('drill-list'),
     sessionList: document.getElementById('session-list'),
+    jumpLinks: Array.from(document.querySelectorAll('[data-jump-target]')),
     metricDrillCount: document.getElementById('metric-drill-count'),
     metricSessionCount: document.getElementById('metric-session-count'),
     metricChecklistCount: document.getElementById('metric-checklist-count'),
@@ -451,6 +452,24 @@
     });
     refs.copyPrompt.addEventListener('click', () => {
       copyText(refs.promptOutput.value, 'Prompt copied to the clipboard.');
+    });
+
+    refs.jumpLinks.forEach(link => {
+      link.addEventListener('click', event => {
+        const targetId = normalizeText(link.getAttribute('data-jump-target'));
+        const target = targetId ? document.getElementById(targetId) : null;
+        if (!target) {
+          return;
+        }
+
+        event.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        window.setTimeout(() => {
+          if (typeof target.focus === 'function') {
+            target.focus({ preventScroll: true });
+          }
+        }, 220);
+      });
     });
   }
 

--- a/logic-lab/index.html
+++ b/logic-lab/index.html
@@ -76,11 +76,17 @@
         <h2 id="metric-discipline-count">4</h2>
         <p class="logic-metric-card__detail">Logic, epistemology, ethics, and agency.</p>
       </article>
-      <article class="logic-metric-card logic-metric-card--accent">
+      <a
+        class="logic-metric-card logic-metric-card--accent logic-metric-card--link"
+        href="#drills-title"
+        data-jump-target="drills-title"
+        aria-label="Open the drill queue"
+      >
         <p class="logic-metric-card__eyebrow">Practice drills</p>
         <h2 id="metric-drill-count">0</h2>
         <p class="logic-metric-card__detail">Use these to pressure-test a model before trusting it.</p>
-      </article>
+        <p class="logic-metric-card__detail logic-metric-card__hint">Open drill queue</p>
+      </a>
       <article class="logic-metric-card">
         <p class="logic-metric-card__eyebrow">Saved sessions</p>
         <h2 id="metric-session-count">0</h2>
@@ -213,7 +219,7 @@
           <div class="logic-panel__header">
             <div>
               <p class="logic-panel__eyebrow">Practice</p>
-              <h3 id="drills-title">Drill queue</h3>
+              <h3 id="drills-title" tabindex="-1">Drill queue</h3>
             </div>
           </div>
           <div id="drill-list" class="drill-list" role="list"></div>

--- a/logic-lab/styles.css
+++ b/logic-lab/styles.css
@@ -278,6 +278,20 @@ textarea {
   box-shadow: var(--logic-shadow);
 }
 
+.logic-metric-card--link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.logic-metric-card--link:hover,
+.logic-metric-card--link:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(240, 195, 107, 0.42);
+}
+
 .logic-metric-card--accent {
   border-color: var(--logic-line-strong);
   background: linear-gradient(165deg, rgba(32, 27, 18, 0.95), rgba(18, 28, 34, 0.96));
@@ -292,6 +306,12 @@ textarea {
   margin: 10px 0 0;
   color: var(--logic-muted);
   line-height: 1.6;
+}
+
+.logic-metric-card__hint {
+  margin-top: 12px;
+  color: var(--logic-accent-soft);
+  font-weight: 600;
 }
 
 .logic-layout {
@@ -470,6 +490,11 @@ textarea {
 
 .support-card {
   padding: 20px;
+}
+
+#drills-title:focus-visible {
+  outline: 2px solid var(--logic-accent);
+  outline-offset: 6px;
 }
 
 .session-card__timestamp {

--- a/tests/logic-lab.test.js
+++ b/tests/logic-lab.test.js
@@ -30,6 +30,9 @@ describe('logic lab app', () => {
     assert.match(html, /id="prompt-output"/);
     assert.match(html, /id="drill-list"/);
     assert.match(html, /id="session-list"/);
+    assert.match(html, /href="#drills-title"/);
+    assert.match(html, /data-jump-target="drills-title"/);
+    assert.match(html, /Open drill queue/);
     assert.match(html, /Stored under <code>3dvr-portal\/philosophyLogic\/sessions<\/code> in Gun/);
     assert.match(html, /<script[^>]+src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"/);
     assert.match(html, /<script[^>]+src="\.\.\/auth-identity\.js"/);
@@ -48,6 +51,7 @@ describe('logic lab app', () => {
     assert.match(css, /\.drill-list/);
     assert.match(css, /\.session-list/);
     assert.match(css, /\.output-card/);
+    assert.match(css, /\.logic-metric-card--link/);
   });
 
   it('includes client logic for scaffolds, prompts, and Gun-backed session sync', async () => {
@@ -61,6 +65,8 @@ describe('logic lab app', () => {
     assert.match(js, /buildReasoningScaffold/);
     assert.match(js, /buildTrainingPrompt/);
     assert.match(js, /copyText/);
+    assert.match(js, /data-jump-target/);
+    assert.match(js, /scrollIntoView/);
     assert.match(js, /portalRoot\.get\('philosophyLogic'\)\.get\('sessions'\)/);
     assert.match(js, /sessionsNode\.get\(sessionId\)\.put\(session/);
     assert.match(js, /Saved locally and synced to Gun\./);


### PR DESCRIPTION
## Summary
- turn the Logic Lab `Practice drills` metric card into a real link to the drill queue
- add smooth scroll and focus handling so the jump feels intentional
- extend Logic Lab coverage for the new link behavior

## Verification
- `node --test tests/logic-lab.test.js`

## Notes
- no billing, auth, or API behavior changed
- intended as a small UX polish for the live Logic Lab app