### PR TITLE
Tighten homepage billing handoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <nav class="top-buttons" id="landingQuickLinks" aria-label="3DVR quick links">
         <a href="https://3dvr.tech">Home</a>
         <a href="start/">Start</a>
-        <a href="https://3dvr.tech/subscribe/" target="_blank" rel="noopener">Plans</a>
+        <a href="start/#paid-lanes">Plans</a>
         <a href="share.html">Share</a>
         <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">GitHub</a>
       </nav>
@@ -101,19 +101,19 @@
             <div class="plan-strip" aria-label="Quick plan links">
               <span class="plan-strip__label">Plans</span>
               <div class="plan-ribbon plan-ribbon--compact">
-                <a class="plan-pill" href="https://3dvr.tech/subscribe/free-plan.html" target="_blank" rel="noopener">
+                <a class="plan-pill" href="free-trial.html">
                   <strong>Free</strong>
                   <span>Get started</span>
                 </a>
-                <a class="plan-pill" href="https://3dvr.tech/subscribe/family-friends.html" target="_blank" rel="noopener">
+                <a class="plan-pill" href="sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
                   <strong>$5</strong>
                   <span>Family &amp; Friends</span>
                 </a>
-                <a class="plan-pill" href="https://3dvr.tech/subscribe/founder-plan.html" target="_blank" rel="noopener">
+                <a class="plan-pill" href="sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dpro">
                   <strong>$20</strong>
                   <span>Founder</span>
                 </a>
-                <a class="plan-pill" href="https://3dvr.tech/subscribe/builder-plan.html" target="_blank" rel="noopener">
+                <a class="plan-pill" href="sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dbuilder">
                   <strong>$50</strong>
                   <span>Builder</span>
                 </a>

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -17,6 +17,11 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Meetings, follow-ups, and synced schedules\./);
     assert.match(html, /Finance/);
     assert.match(html, /Billing/);
+    assert.match(html, /href="start\/#paid-lanes"/);
+    assert.match(html, /href="free-trial\.html"/);
+    assert.match(html, /href="sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dstarter"/);
+    assert.match(html, /href="sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dpro"/);
+    assert.match(html, /href="sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dbuilder"/);
     assert.match(html, /Get started/);
     assert.match(html, /Family &amp; Friends/);
     assert.match(html, /Builder/);
@@ -31,6 +36,10 @@ describe('portal customer journey pages', () => {
     assert.match(html, /App dock/);
     assert.match(html, /data-app-list/);
     assert.match(html, /shortcut-grid/);
+    assert.doesNotMatch(html, /https:\/\/3dvr\.tech\/subscribe\/free-plan\.html/);
+    assert.doesNotMatch(html, /https:\/\/3dvr\.tech\/subscribe\/family-friends\.html/);
+    assert.doesNotMatch(html, /https:\/\/3dvr\.tech\/subscribe\/founder-plan\.html/);
+    assert.doesNotMatch(html, /https:\/\/3dvr\.tech\/subscribe\/builder-plan\.html/);
   });
 
   it('keeps the portal homepage calm on very narrow mobile screens', async () => {


### PR DESCRIPTION
## Summary
- keep homepage plan links inside the portal flow instead of sending users to public pricing pages
- send the generic `Plans` nav link to the start page paid-lanes section
- preserve the selected paid plan through `sign-in -> billing?plan=...` from the homepage
- add regression coverage for the homepage billing handoff

## Testing
- `node --test tests/customer-journey-pages.test.js`

## Impact
- homepage users can click the paid plan they want and arrive in billing with that plan already selected
- homepage free plan users stay in the portal account journey via `free-trial.html`