### PR TITLE
Send emails for subscription updates

### DIFF
--- a/api/webhooks/stripe.js
+++ b/api/webhooks/stripe.js
@@ -130,6 +130,135 @@ async function notifyTeam(newUserEmail, { transporter, config } = {}) {
   }
 }
 
+function resolveInvoiceLinePlan(line, config = process.env) {
+  const priceId = String(line?.price?.id || '').trim();
+  const priceMap = {
+    [String(config?.STRIPE_PRICE_STARTER_ID || config?.STRIPE_PRICE_SUPPORTER_ID || '').trim()]: 'starter',
+    [String(config?.STRIPE_PRICE_PRO_ID || config?.STRIPE_PRICE_FOUNDER_ID || '').trim()]: 'pro',
+    [String(config?.STRIPE_PRICE_BUILDER_ID || config?.STRIPE_PRICE_STUDIO_ID || '').trim()]: 'builder',
+    [String(config?.STRIPE_PRICE_EMBEDDED_ID || config?.STRIPE_PRICE_EXECUTION_ID || config?.STRIPE_PRICE_200_ID || '').trim()]: 'embedded'
+  };
+
+  if (priceId && priceMap[priceId]) {
+    return normalizeBillingPlan(priceMap[priceId]);
+  }
+
+  const nickname = String(line?.price?.nickname || line?.description || '').trim().toLowerCase();
+  if (nickname.includes('embedded') || nickname.includes('execution')) {
+    return 'embedded';
+  }
+  if (nickname.includes('builder') || nickname.includes('studio') || nickname.includes('partner')) {
+    return 'builder';
+  }
+  if (nickname.includes('founder') || nickname.includes('pro')) {
+    return 'pro';
+  }
+  if (nickname.includes('starter') || nickname.includes('supporter') || nickname.includes('family')) {
+    return 'starter';
+  }
+
+  return '';
+}
+
+function readSubscriptionUpdateDetails(invoice = {}, config = process.env) {
+  const lines = Array.isArray(invoice?.lines?.data) ? invoice.lines.data : [];
+  const chargeToday = formatCurrencyAmount(invoice?.amount_paid, invoice?.currency);
+  const positiveLine = lines
+    .filter(line => Number(line?.amount) > 0)
+    .sort((left, right) => Number(right?.amount || 0) - Number(left?.amount || 0))[0] || null;
+  const targetPlan = resolveInvoiceLinePlan(positiveLine, config);
+  const targetLabel = getBillingPlan(targetPlan)?.label || 'Updated subscription';
+  const lineSummary = lines
+    .map(line => {
+      const amount = formatCurrencyAmount(line?.amount, invoice?.currency);
+      const description = String(line?.description || '').trim();
+      return amount && description ? `${amount}: ${description}` : '';
+    })
+    .filter(Boolean);
+
+  return {
+    targetPlan,
+    targetLabel,
+    chargeToday,
+    lineSummary
+  };
+}
+
+async function sendSubscriptionUpdateEmail(email, details = {}, { transporter, config } = {}) {
+  const gmailUser = String(config?.GMAIL_USER || '').trim();
+  if (!email || !gmailUser) {
+    return;
+  }
+
+  const targetLabel = String(details.targetLabel || 'your subscription').trim();
+  const chargeToday = String(details.chargeToday || '').trim() || 'the prorated amount shown in Stripe';
+  const lineSummary = Array.isArray(details.lineSummary) ? details.lineSummary.filter(Boolean) : [];
+  const textLines = lineSummary.length
+    ? `\n\nStripe invoice details:\n- ${lineSummary.join('\n- ')}`
+    : '';
+  const htmlLines = lineSummary.length
+    ? `<ul>${lineSummary.map(line => `<li>${escapeHtml(line)}</li>`).join('')}</ul>`
+    : '';
+
+  try {
+    await sendMailSafely(transporter, {
+      from: `"Thomas @ 3DVR.Tech" <${gmailUser}>`,
+      to: email,
+      subject: `Plan updated: ${targetLabel}`,
+      text: `Hey there — Stripe confirmed your plan change to ${targetLabel}.\nAmount charged today: ${chargeToday}.${textLines}\n\nThanks,\nThomas`,
+      html: `
+        <div style="font-family: sans-serif; font-size: 16px; line-height: 1.5;">
+          <h2 style="color: #333;">Plan updated</h2>
+          <p>Stripe confirmed your plan change to <strong>${escapeHtml(targetLabel)}</strong>.</p>
+          <p><strong>Amount charged today:</strong> ${escapeHtml(chargeToday)}</p>
+          ${htmlLines}
+          <p style="margin-top: 30px;">Thanks,<br>Thomas<br>Founder, 3DVR.Tech</p>
+        </div>
+      `
+    });
+  } catch (error) {
+    console.error(`Failed to send subscription update email to ${email}:`, error?.message || error);
+  }
+}
+
+async function notifyTeamOfSubscriptionUpdate(email, details = {}, { transporter, config } = {}) {
+  const gmailUser = String(config?.GMAIL_USER || '').trim();
+  if (!email || !gmailUser) {
+    return;
+  }
+
+  const team = [
+    'tmsteph1290@gmail.com',
+    'abrandon055@gmail.com',
+    'gamboaesai@gmail.com',
+    'mark.wells3050@gmail.com',
+    'davidmartinezr@hotmail.com'
+  ];
+  const targetLabel = String(details.targetLabel || 'Updated subscription').trim();
+  const chargeToday = String(details.chargeToday || '').trim() || 'unknown amount';
+  const lineSummary = Array.isArray(details.lineSummary) ? details.lineSummary.filter(Boolean) : [];
+  const htmlLines = lineSummary.length
+    ? `<ul>${lineSummary.map(line => `<li>${escapeHtml(line)}</li>`).join('')}</ul>`
+    : '';
+
+  try {
+    await sendMailSafely(transporter, {
+      from: `"3DVR.Tech Subscription Notifier" <${gmailUser}>`,
+      to: gmailUser,
+      bcc: team,
+      subject: `Subscription update: ${email} -> ${targetLabel} (${chargeToday})`,
+      html: `
+        <p><strong>${escapeHtml(email)}</strong> changed plans.</p>
+        <p><strong>New plan:</strong> ${escapeHtml(targetLabel)}</p>
+        <p><strong>Amount charged today:</strong> ${escapeHtml(chargeToday)}</p>
+        ${htmlLines}
+      `
+    });
+  } catch (error) {
+    console.error('Failed to notify team of subscription update:', error?.message || error);
+  }
+}
+
 function formatCurrencyAmount(amountCents, currency = 'usd') {
   const normalizedCurrency = String(currency || 'usd').trim().toUpperCase() || 'USD';
   const normalizedAmountCents = Number(amountCents);
@@ -253,6 +382,41 @@ function readCheckoutPlan(session = {}) {
   return '';
 }
 
+async function syncSubscriptionPlanMetadata(subscription, { stripeClient, config } = {}) {
+  const subscriptionId = String(subscription?.id || '').trim();
+  if (!subscriptionId || !stripeClient?.subscriptions?.update) {
+    return;
+  }
+
+  const resolvedPlan = resolveManagedBillingPlanFromSubscription(subscription, config);
+  if (!resolvedPlan) {
+    return;
+  }
+
+  const existingMetadata = subscription?.metadata && typeof subscription.metadata === 'object'
+    ? subscription.metadata
+    : {};
+  const existingPlan = normalizeBillingPlan(existingMetadata.plan || '');
+  if (existingPlan === resolvedPlan) {
+    return;
+  }
+
+  try {
+    await stripeClient.subscriptions.update(subscriptionId, {
+      metadata: {
+        ...existingMetadata,
+        plan: resolvedPlan
+      }
+    });
+  } catch (error) {
+    console.warn('Failed to sync Stripe subscription plan metadata', {
+      subscriptionId,
+      resolvedPlan,
+      error: error?.message || error
+    });
+  }
+}
+
 async function autoReplaceLegacySubscriptions(event, { stripeClient, config } = {}) {
   if (!stripeClient) {
     return { cleaned: false, canceledCount: 0, cancelledSubscriptionIds: [] };
@@ -371,6 +535,13 @@ export function createStripeWebhookHandler(options = {}) {
       config: runtimeConfig
     });
 
+    if (['customer.subscription.created', 'customer.subscription.updated'].includes(event.type)) {
+      await syncSubscriptionPlanMetadata(event.data?.object || {}, {
+        stripeClient,
+        config: runtimeConfig
+      });
+    }
+
     await logStripeEvent(event, {
       receivedAt: new Date().toISOString(),
       canceledCount: cleanupResult.canceledCount || 0,
@@ -403,6 +574,18 @@ export function createStripeWebhookHandler(options = {}) {
         }
       } else {
         console.warn('No email found in session.customer_details');
+      }
+    }
+
+    if (event.type === 'invoice.payment_succeeded') {
+      const invoice = event.data?.object || {};
+      const email = String(invoice.customer_email || '').trim();
+      const billingReason = String(invoice.billing_reason || '').trim().toLowerCase();
+
+      if (email && billingReason === 'subscription_update') {
+        const updateDetails = readSubscriptionUpdateDetails(invoice, runtimeConfig);
+        await sendSubscriptionUpdateEmail(email, updateDetails, { transporter, config: runtimeConfig });
+        await notifyTeamOfSubscriptionUpdate(email, updateDetails, { transporter, config: runtimeConfig });
       }
     }
 

--- a/tests/stripe-webhook-cleanup.test.js
+++ b/tests/stripe-webhook-cleanup.test.js
@@ -9,6 +9,7 @@ const baseConfig = {
   STRIPE_PRICE_STARTER_ID: 'price_starter',
   STRIPE_PRICE_PRO_ID: 'price_pro',
   STRIPE_PRICE_BUILDER_ID: 'price_builder',
+  STRIPE_PRICE_EMBEDDED_ID: 'price_embedded',
   PORTAL_ORIGIN: 'https://portal.3dvr.tech'
 };
 
@@ -189,6 +190,30 @@ function createStripeState({
       list: mock.fn(async ({ customer } = {}) => ({
         data: (subscriptionsStore.get(customer) || []).map(cloneSubscription)
       })),
+      update: mock.fn(async (subscriptionId, patch = {}) => {
+        for (const [customerId, subscriptions] of subscriptionsStore.entries()) {
+          const index = subscriptions.findIndex(subscription => subscription.id === subscriptionId);
+          if (index === -1) {
+            continue;
+          }
+
+          const existing = subscriptions[index];
+          const updated = {
+            ...existing,
+            ...patch,
+            metadata: {
+              ...(existing.metadata || {}),
+              ...(patch.metadata || {})
+            }
+          };
+          subscriptionsStore.set(customerId, subscriptions.map((subscription, subscriptionIndex) => {
+            return subscriptionIndex === index ? updated : subscription;
+          }));
+          return cloneSubscription(updated);
+        }
+
+        throw new Error('not found');
+      }),
       cancel: mock.fn(async subscriptionId => {
         for (const [customerId, subscriptions] of subscriptionsStore.entries()) {
           const nextSubscriptions = subscriptions.map(subscription => {
@@ -370,6 +395,86 @@ test('stripe webhook cleanup keeps the updated subscription and cancels older ma
   assert.equal(state.stripe.subscriptions.cancel.mock.calls[0].arguments[0], 'sub_old_builder');
 });
 
+test('stripe webhook syncs subscription metadata to the managed plan on updates', async () => {
+  const state = createStripeState({
+    customers: [
+      createCustomer({
+        id: 'cus_new',
+        email: 'member@example.com'
+      })
+    ],
+    subscriptionsByCustomer: {
+      cus_new: [
+        createSubscription({
+          id: 'sub_embedded',
+          customer: 'cus_new',
+          plan: 'embedded',
+          priceId: 'price_embedded',
+          created: 2,
+          metadata: {
+            plan: 'pro',
+            billing_email: 'member@example.com',
+            portal_alias: 'member@3dvr',
+            portal_pub: 'pub_member'
+          }
+        })
+      ]
+    }
+  });
+
+  const handler = createStripeWebhookHandler({
+    stripeClient: state.stripe,
+    config: {
+      ...baseConfig,
+      STRIPE_LOG_EMAIL: ''
+    },
+    transporter: null,
+    readRawBody: async () => Buffer.from('{}'),
+    constructEvent: () => ({
+      id: 'evt_subscription_updated_embedded',
+      type: 'customer.subscription.updated',
+      created: 1700000000,
+      data: {
+        object: createSubscription({
+          id: 'sub_embedded',
+          customer: 'cus_new',
+          plan: 'embedded',
+          priceId: 'price_embedded',
+          created: 2,
+          metadata: {
+            plan: 'pro',
+            billing_email: 'member@example.com',
+            portal_alias: 'member@3dvr',
+            portal_pub: 'pub_member'
+          }
+        })
+      }
+    })
+  });
+
+  const req = {
+    method: 'POST',
+    headers: {
+      'stripe-signature': 'sig_test'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(state.stripe.subscriptions.update.mock.calls.length, 1);
+  assert.equal(state.stripe.subscriptions.update.mock.calls[0].arguments[0], 'sub_embedded');
+  assert.deepEqual(state.stripe.subscriptions.update.mock.calls[0].arguments[1], {
+    metadata: {
+      plan: 'embedded',
+      billing_email: 'member@example.com',
+      portal_alias: 'member@3dvr',
+      portal_pub: 'pub_member'
+    }
+  });
+});
+
 test('stripe webhook sends one-time payment emails for payment-mode checkout sessions', async () => {
   const transporter = {
     sendMail: mock.fn(async payload => payload)
@@ -439,4 +544,82 @@ test('stripe webhook sends one-time payment emails for payment-mode checkout ses
   assert.match(transporter.sendMail.mock.calls[1].arguments[0].html, /Reason:<\/strong> Custom project deposit/);
   assert.doesNotMatch(transporter.sendMail.mock.calls[0].arguments[0].subject, /Welcome to 3DVR\.Tech/);
   assert.doesNotMatch(transporter.sendMail.mock.calls[1].arguments[0].subject, /New Subscriber:/);
+});
+
+test('stripe webhook sends subscription update emails for prorated plan changes', async () => {
+  const transporter = {
+    sendMail: mock.fn(async payload => payload)
+  };
+  const handler = createStripeWebhookHandler({
+    stripeClient: createStripeState().stripe,
+    config: {
+      ...baseConfig,
+      GMAIL_USER: 'billing@3dvr.tech',
+      STRIPE_LOG_EMAIL: ''
+    },
+    transporter,
+    readRawBody: async () => Buffer.from('{}'),
+    constructEvent: () => ({
+      id: 'evt_invoice_subscription_update',
+      type: 'invoice.payment_succeeded',
+      created: 1700000000,
+      data: {
+        object: {
+          id: 'in_subscription_update',
+          billing_reason: 'subscription_update',
+          amount_paid: 6855,
+          currency: 'usd',
+          customer_email: 'client@example.com',
+          lines: {
+            data: [
+              {
+                amount: -2285,
+                description: 'Unused time on 3DVR Builder Plan after 09 Apr 2026',
+                price: {
+                  id: 'price_builder'
+                }
+              },
+              {
+                amount: 9140,
+                description: 'Remaining time on 3DVR Embedded Plan after 09 Apr 2026',
+                price: {
+                  id: 'price_embedded'
+                }
+              }
+            ]
+          }
+        }
+      }
+    })
+  });
+
+  const req = {
+    method: 'POST',
+    headers: {
+      'stripe-signature': 'sig_test'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    received: true,
+    cleanup: {
+      canceledCount: 0,
+      cancelledSubscriptionIds: []
+    }
+  });
+  assert.equal(transporter.sendMail.mock.calls.length, 2);
+  assert.deepEqual(transporter.sendMail.mock.calls.map(call => call.arguments[0].subject), [
+    'Plan updated: Embedded Plan',
+    'Subscription update: client@example.com -> Embedded Plan ($68.55)'
+  ]);
+  assert.match(transporter.sendMail.mock.calls[0].arguments[0].text, /\$68\.55/);
+  assert.match(transporter.sendMail.mock.calls[0].arguments[0].text, /Embedded Plan/);
+  assert.match(transporter.sendMail.mock.calls[0].arguments[0].text, /Unused time on 3DVR Builder Plan/);
+  assert.match(transporter.sendMail.mock.calls[1].arguments[0].html, /New plan:<\/strong> Embedded Plan/);
+  assert.match(transporter.sendMail.mock.calls[1].arguments[0].html, /Amount charged today:<\/strong> \$68\.55/);
+  assert.doesNotMatch(transporter.sendMail.mock.calls[0].arguments[0].subject, /Welcome to 3DVR\.Tech/);
 });


### PR DESCRIPTION
## Summary
- send a confirmation email and team notification when Stripe confirms a prorated subscription plan change
- sync stale subscription `metadata.plan` to the actual managed plan on subscription create/update events
- add webhook regression coverage for both the metadata sync and subscription-update email flow

## Why
- a live April 9, 2026 billing investigation showed a successful Builder -> Embedded Stripe plan change with no portal-side confirmation email because the webhook only emailed on `checkout.session.completed`
- the same live subscription was on the Embedded price but still carried stale `plan: pro` metadata

## Testing
- `node --test tests/stripe-webhook-cleanup.test.js`

## Production note
- this does not change Stripe receipt behavior
- it adds a portal-side confirmation path for successful subscription updates