### PR TITLE
Bring calendar month view forward on mobile

### DIFF
--- a/calendar/calendar.css
+++ b/calendar/calendar.css
@@ -56,6 +56,34 @@ body {
   max-width: 720px;
 }
 
+.calendar-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.calendar-header__action {
+  align-items: center;
+  background: rgba(67, 109, 147, 0.16);
+  border: 1px solid rgba(132, 156, 188, 0.22);
+  border-radius: 999px;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.16);
+  color: var(--calendar-text-soft);
+  display: inline-flex;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 10px 16px;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.calendar-header__action:hover {
+  background: rgba(67, 109, 147, 0.28);
+  border-color: rgba(156, 192, 224, 0.32);
+  transform: translateY(-1px);
+}
+
 .calendar-header__highlights {
   display: grid;
   gap: 14px;
@@ -456,6 +484,7 @@ button:focus-visible {
   gap: 16px;
   min-height: 100%;
   padding: 26px;
+  scroll-margin-top: 20px;
 }
 
 .calendar-view__header {
@@ -932,7 +961,21 @@ button:focus-visible {
   }
 
   .calendar-header__highlights {
-    grid-template-columns: 1fr;
+    display: flex;
+    gap: 12px;
+    grid-template-columns: none;
+    margin-right: -2px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  .calendar-highlight {
+    flex: 0 0 min(240px, 82vw);
+    min-width: min(240px, 82vw);
+    scroll-snap-align: start;
   }
 
   .calendar-shell {
@@ -944,7 +987,21 @@ button:focus-visible {
   }
 
   .calendar-quickstats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    display: flex;
+    gap: 12px;
+    grid-template-columns: none;
+    margin-right: -2px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  .calendar-stat {
+    flex: 0 0 min(220px, 72vw);
+    min-height: auto;
+    scroll-snap-align: start;
   }
 
   .calendar-workspace {
@@ -1028,11 +1085,21 @@ button:focus-visible {
     font-size: 0.95rem;
   }
 
+  .calendar-header__actions {
+    width: 100%;
+  }
+
+  .calendar-header__action {
+    justify-content: center;
+    width: 100%;
+  }
+
   .calendar-quickstats {
-    grid-template-columns: 1fr;
+    margin-right: -4px;
   }
 
   .calendar-stat {
+    flex-basis: min(208px, 78vw);
     min-height: 0;
   }
 

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -32,6 +32,9 @@
       Manage your schedule directly in the portal. Events live in your local calendar first, with optional
       syncs to Google or Outlook when you need them.
     </p>
+    <div class="calendar-header__actions" aria-label="Calendar shortcuts">
+      <a class="calendar-header__action" href="#calendar-view-title">Jump to month view</a>
+    </div>
     <div class="calendar-header__highlights" aria-label="Calendar highlights">
       <article class="calendar-highlight">
         <span>Local first</span>

--- a/tests/calendar-ui.test.js
+++ b/tests/calendar-ui.test.js
@@ -6,6 +6,8 @@ test('calendar hub presents a clear hero, month-first workspace, and side rail',
   const html = await readFile(new URL('../calendar/index.html', import.meta.url), 'utf8');
 
   assert.match(html, /<header class="calendar-header">/);
+  assert.match(html, /<div class="calendar-header__actions" aria-label="Calendar shortcuts">/);
+  assert.match(html, /Jump to month view/);
   assert.match(html, /<div class="calendar-header__highlights" aria-label="Calendar highlights">/);
   assert.match(html, /Local first/);
   assert.match(html, /Fast capture/);
@@ -47,4 +49,14 @@ test('calendar runtime updates the quick summary strip from event and connection
   assert.match(js, /function updateCalendarQuickStats\(events = state\.localEvents\)/);
   assert.match(js, /state\.connections\.has\(provider\)/);
   assert.match(js, /getEventsForSelectedDate\(events\)/);
+});
+
+test('calendar stylesheet keeps the month view reachable on smaller screens', async () => {
+  const css = await readFile(new URL('../calendar/calendar.css', import.meta.url), 'utf8');
+
+  assert.match(css, /\.calendar-header__action \{/);
+  assert.match(css, /\.calendar-view \{[\s\S]*scroll-margin-top: 20px;/);
+  assert.match(css, /@media \(max-width: 720px\) \{[\s\S]*?\.calendar-header__highlights \{[\s\S]*?overflow-x: auto;/);
+  assert.match(css, /@media \(max-width: 720px\) \{[\s\S]*?\.calendar-quickstats \{[\s\S]*?overflow-x: auto;/);
+  assert.match(css, /@media \(max-width: 540px\) \{[\s\S]*?\.calendar-header__action \{[\s\S]*?width: 100%;/);
 });


### PR DESCRIPTION
## Summary
- add a direct jump-to-month shortcut in the calendar header
- compact the calendar highlight and summary strips on small screens so the month view appears much sooner
- extend the calendar UI regression to cover the new mobile-first layout behavior

## Testing
- node --test tests/calendar-ui.test.js tests/calendar-pwa-config.test.js tests/calendar-prefill.test.js