### PR TITLE
Add Pocket Workstation portal app

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 
 - [Tasks](https://3dvr-portal.vercel.app/tasks.html)
 - [Notes](https://3dvr-portal.vercel.app/notes/)
+- [Pocket Workstation](https://3dvr-portal.vercel.app/pocket-workstation/)
 - [Chat](https://3dvr-portal.vercel.app/chat/)
 - [Calendar Hub](https://3dvr-portal.vercel.app/calendar/)
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)

--- a/index.html
+++ b/index.html
@@ -289,6 +289,11 @@
             <span class="app-card__title">Notes</span>
             <span class="app-card__meta">Collaborate in real time with the community.</span>
           </a>
+          <a href="pocket-workstation/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">📱</span>
+            <span class="app-card__title">Pocket Workstation</span>
+            <span class="app-card__meta">Turn your phone into a builder console with synced notes, commands, and projects.</span>
+          </a>
           <a href="newsroom/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">📰</span>
             <span class="app-card__title">News Lounge</span>

--- a/pocket-workstation/app.js
+++ b/pocket-workstation/app.js
@@ -1,0 +1,440 @@
+(function initPocketWorkstation(window, document) {
+  if (!window || !document) {
+    return;
+  }
+
+  const STORAGE_KEY = '3dvr-pocket-workstation.identity';
+  const APP_ROOT_PATH = ['3dvr-portal', 'pocketWorkstation', 'users'];
+
+  const refs = {
+    identityLabel: document.getElementById('identity-label'),
+    syncStatus: document.getElementById('sync-status'),
+    notesCount: document.getElementById('notes-count'),
+    commandsCount: document.getElementById('commands-count'),
+    projectsCount: document.getElementById('projects-count'),
+    noteForm: document.getElementById('note-form'),
+    noteStatus: document.getElementById('note-status'),
+    noteList: document.getElementById('note-list'),
+    commandForm: document.getElementById('command-form'),
+    commandStatus: document.getElementById('command-status'),
+    commandList: document.getElementById('command-list'),
+    projectForm: document.getElementById('project-form'),
+    projectStatus: document.getElementById('project-status-text'),
+    projectList: document.getElementById('project-list'),
+    helperForm: document.getElementById('helper-form'),
+    helperInput: document.getElementById('helper-input'),
+    helperOutput: document.getElementById('helper-output'),
+  };
+
+  const state = {
+    identity: null,
+    notes: [],
+    commands: [],
+    projects: [],
+  };
+
+  function normalizeText(value) {
+    return typeof value === 'string' ? value.trim() : '';
+  }
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function createId(prefix) {
+    const base = `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+    return prefix ? `${prefix}-${base}` : base;
+  }
+
+  function createLocalGunSubscriptionStub() {
+    return {
+      off() {},
+    };
+  }
+
+  function createLocalGunNodeStub() {
+    return {
+      __isGunStub: true,
+      get() {
+        return createLocalGunNodeStub();
+      },
+      put(_value, callback) {
+        if (typeof callback === 'function') {
+          setTimeout(() => callback({ err: 'gun-unavailable' }), 0);
+        }
+        return this;
+      },
+      once(callback) {
+        if (typeof callback === 'function') {
+          setTimeout(() => callback(undefined), 0);
+        }
+        return this;
+      },
+      map() {
+        return {
+          on() {
+            return createLocalGunSubscriptionStub();
+          },
+        };
+      },
+    };
+  }
+
+  function createLocalGunUserStub() {
+    return {
+      is: null,
+      _: {},
+      recall() {},
+      leave() {},
+    };
+  }
+
+  function ensureGunContext(factory, label) {
+    const ensureGun = window.ScoreSystem && typeof window.ScoreSystem.ensureGun === 'function'
+      ? window.ScoreSystem.ensureGun.bind(window.ScoreSystem)
+      : null;
+    if (ensureGun) {
+      return ensureGun(factory, { label });
+    }
+    try {
+      const gun = typeof factory === 'function' ? factory() : null;
+      if (gun) {
+        return {
+          gun,
+          user: typeof gun.user === 'function' ? gun.user() : createLocalGunUserStub(),
+          isStub: !!gun.__isGunStub,
+        };
+      }
+    } catch (error) {
+      console.warn(`Pocket Workstation Gun init failed for ${label}`, error);
+    }
+    return {
+      gun: {
+        __isGunStub: true,
+        get() {
+          return createLocalGunNodeStub();
+        },
+        user() {
+          return createLocalGunUserStub();
+        },
+      },
+      user: createLocalGunUserStub(),
+      isStub: true,
+    };
+  }
+
+  function getNodeFromPath(root, path) {
+    return path.reduce((node, key) => (node && typeof node.get === 'function' ? node.get(key) : createLocalGunNodeStub()), root);
+  }
+
+  function safeStorageGet(key) {
+    try {
+      return window.localStorage.getItem(key) || '';
+    } catch (_error) {
+      return '';
+    }
+  }
+
+  function safeStorageSet(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Ignore storage write failures.
+    }
+  }
+
+  function resolveIdentity() {
+    if (window.AuthIdentity && typeof window.AuthIdentity.syncStorageFromSharedIdentity === 'function') {
+      window.AuthIdentity.syncStorageFromSharedIdentity(window.localStorage);
+    }
+
+    const alias = normalizeText(safeStorageGet('alias'));
+    const username = normalizeText(safeStorageGet('username'));
+    if (alias) {
+      return {
+        key: `alias-${alias.toLowerCase()}`,
+        label: username || alias,
+        mode: 'signed-in',
+      };
+    }
+
+    const storedGuest = normalizeText(safeStorageGet(STORAGE_KEY));
+    const guestId = storedGuest || createId('guest');
+    if (!storedGuest) {
+      safeStorageSet(STORAGE_KEY, guestId);
+    }
+    return {
+      key: guestId,
+      label: `Guest ${guestId.slice(-6)}`,
+      mode: 'guest',
+    };
+  }
+
+  function recordToCard(record, type) {
+    if (type === 'commands') {
+      return `
+        <article class="record-card">
+          <h3>${escapeHtml(record.name || 'Untitled command')}</h3>
+          <p class="record-card__meta">${escapeHtml(record.context || 'Reusable command')}</p>
+          <code>${escapeHtml(record.command || '')}</code>
+        </article>
+      `;
+    }
+
+    if (type === 'projects') {
+      return `
+        <article class="record-card">
+          <h3>${escapeHtml(record.name || 'Untitled project')}</h3>
+          <p class="record-card__meta">${escapeHtml(record.status || 'active')}</p>
+          <p>${escapeHtml(record.nextStep || '')}</p>
+        </article>
+      `;
+    }
+
+    return `
+      <article class="record-card">
+        <h3>${escapeHtml(record.title || 'Untitled note')}</h3>
+        <p>${escapeHtml(record.body || '')}</p>
+      </article>
+    `;
+  }
+
+  function renderRecords(type) {
+    const list = type === 'notes' ? refs.noteList : type === 'commands' ? refs.commandList : refs.projectList;
+    const records = state[type];
+    const count = records.length;
+
+    if (type === 'notes') refs.notesCount.textContent = String(count);
+    if (type === 'commands') refs.commandsCount.textContent = String(count);
+    if (type === 'projects') refs.projectsCount.textContent = String(count);
+
+    if (!list) {
+      return;
+    }
+
+    if (!count) {
+      list.innerHTML = `<p class="helper-output__placeholder">No ${type} yet.</p>`;
+      return;
+    }
+
+    list.innerHTML = records
+      .slice()
+      .sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0))
+      .map(record => recordToCard(record, type))
+      .join('');
+  }
+
+  function upsertRecord(type, record) {
+    const key = String(record.id || '');
+    if (!key) {
+      return;
+    }
+    const existingIndex = state[type].findIndex(entry => entry.id === key);
+    if (existingIndex >= 0) {
+      state[type][existingIndex] = record;
+    } else {
+      state[type].push(record);
+    }
+    renderRecords(type);
+  }
+
+  function buildHelperResult(intent) {
+    const normalized = normalizeText(intent).toLowerCase();
+    let title = 'General builder flow';
+    let steps = [
+      'Clarify the target project, environment, and desired outcome.',
+      'Save the important command or note so you can reuse it later.',
+      'Run the smallest safe step first and verify the result.',
+    ];
+    let commands = [
+      'git status',
+      'git add .',
+      'git commit -m "update"',
+    ];
+    let explanation = 'Pocket Workstation v0.1 starts with practical next steps and reusable commands.';
+
+    if (normalized.includes('deploy')) {
+      title = 'Deploy workflow';
+      steps = [
+        'Check the branch and working tree before you ship.',
+        'Push the latest code and trigger the platform deploy.',
+        'Verify the live route after deployment, not just the build log.',
+      ];
+      commands = [
+        'git status',
+        'git add . && git commit -m "update" && git push',
+        'vercel deploy --prod',
+      ];
+      explanation = 'Deployment work should always end with a real runtime check.';
+    } else if (normalized.includes('ssh') || normalized.includes('server') || normalized.includes('connect')) {
+      title = 'Server connection flow';
+      steps = [
+        'Confirm the host, user, and auth method.',
+        'Connect with SSH and verify the current directory and service status.',
+        'Save the exact connection command for next time.',
+      ];
+      commands = [
+        'ssh user@example-server',
+        'pwd',
+        'systemctl status your-service',
+      ];
+      explanation = 'Server access gets safer when the exact command and destination are stored.';
+    } else if (normalized.includes('laravel')) {
+      title = 'Laravel app deploy';
+      steps = [
+        'Pull the newest code on the target environment.',
+        'Install dependencies and run production-safe build steps.',
+        'Migrate carefully and verify the app route after deploy.',
+      ];
+      commands = [
+        'composer install --no-dev --optimize-autoloader',
+        'php artisan migrate --force',
+        'php artisan optimize',
+      ];
+      explanation = 'Laravel deploys usually need dependency install, migration, and cache optimization in the right order.';
+    } else if (normalized.includes('note')) {
+      title = 'Capture and organize notes';
+      steps = [
+        'Write the note title around the decision or artifact.',
+        'Keep the body short enough to scan later on mobile.',
+        'Link the note to a project or command if it affects delivery.',
+      ];
+      commands = [
+        '3dvr notes',
+        'Open /notes in the portal',
+      ];
+      explanation = 'Notes become useful when they connect to the next action.';
+    }
+
+    return { title, steps, commands, explanation };
+  }
+
+  function renderHelper(intent) {
+    const result = buildHelperResult(intent);
+    refs.helperOutput.innerHTML = `
+      <h3>${escapeHtml(result.title)}</h3>
+      <ol>${result.steps.map(step => `<li>${escapeHtml(step)}</li>`).join('')}</ol>
+      <code>${escapeHtml(result.commands.join('\n'))}</code>
+      <p>${escapeHtml(result.explanation)}</p>
+    `;
+  }
+
+  function bindForm(form, type, statusNode, buildRecord) {
+    if (!form) {
+      return;
+    }
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      const record = buildRecord(new FormData(form));
+      upsertRecord(type, record);
+      saveRecord(type, record, statusNode);
+      form.reset();
+    });
+  }
+
+  const gunContext = ensureGunContext(
+    () => (typeof window.Gun === 'function'
+      ? window.Gun({
+          peers: window.__GUN_PEERS__ || [
+            'wss://relay.3dvr.tech/gun',
+            'wss://gun-relay-3dvr.fly.dev/gun',
+          ],
+          axe: true,
+        })
+      : null),
+    'pocket-workstation'
+  );
+
+  const portalRoot = getNodeFromPath(gunContext.gun, ['3dvr-portal']);
+  state.identity = resolveIdentity();
+
+  function getUserNode(type) {
+    return getNodeFromPath(portalRoot, ['pocketWorkstation', 'users', state.identity.key, type]);
+  }
+
+  function saveRecord(type, record, statusNode) {
+    const node = getUserNode(type);
+    if (statusNode) {
+      statusNode.textContent = 'Saved locally. Syncing to Gun…';
+    }
+    node.get(record.id).put(record, ack => {
+      if (!statusNode) {
+        return;
+      }
+      if (ack && ack.err) {
+        statusNode.textContent = 'Saved locally. Gun sync will retry when available.';
+        return;
+      }
+      statusNode.textContent = 'Saved locally and synced to Gun.';
+    });
+  }
+
+  function hydrateType(type) {
+    const node = getUserNode(type);
+    node.map().on((data, key) => {
+      if (!data || key === '_' || typeof data !== 'object') {
+        return;
+      }
+      const record = {
+        ...data,
+        id: String(data.id || key),
+      };
+      upsertRecord(type, record);
+    });
+  }
+
+  function init() {
+    refs.identityLabel.textContent = state.identity.mode === 'signed-in'
+      ? `Signed in as ${state.identity.label}`
+      : `Guest workspace for ${state.identity.label}`;
+    refs.syncStatus.textContent = gunContext.isStub ? 'Offline mode' : 'Connected to Gun';
+
+    renderRecords('notes');
+    renderRecords('commands');
+    renderRecords('projects');
+
+    hydrateType('notes');
+    hydrateType('commands');
+    hydrateType('projects');
+
+    bindForm(refs.noteForm, 'notes', refs.noteStatus, formData => ({
+      id: createId('note'),
+      title: normalizeText(formData.get('title')) || 'Untitled note',
+      body: normalizeText(formData.get('body')),
+      updatedAt: Date.now(),
+      author: state.identity.label,
+    }));
+
+    bindForm(refs.commandForm, 'commands', refs.commandStatus, formData => ({
+      id: createId('command'),
+      name: normalizeText(formData.get('name')) || 'Untitled command',
+      command: normalizeText(formData.get('command')),
+      context: normalizeText(formData.get('context')) || 'Reusable command',
+      updatedAt: Date.now(),
+      author: state.identity.label,
+    }));
+
+    bindForm(refs.projectForm, 'projects', refs.projectStatus, formData => ({
+      id: createId('project'),
+      name: normalizeText(formData.get('name')) || 'Untitled project',
+      status: normalizeText(formData.get('status')) || 'active',
+      nextStep: normalizeText(formData.get('nextStep')),
+      updatedAt: Date.now(),
+      author: state.identity.label,
+    }));
+
+    if (refs.helperForm) {
+      refs.helperForm.addEventListener('submit', event => {
+        event.preventDefault();
+        renderHelper(refs.helperInput.value);
+      });
+    }
+  }
+
+  init();
+})(window, document);

--- a/pocket-workstation/index.html
+++ b/pocket-workstation/index.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Pocket Workstation | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="Turn your phone into a builder console with synced notes, commands, projects, and a lightweight AI helper."
+  />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+  <script src="../score.js"></script>
+  <script src="../auth-identity.js"></script>
+  <link rel="stylesheet" href="../styles/global.css" />
+  <link rel="stylesheet" href="./styles.css" />
+  <meta name="theme-color" content="#07111b" />
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="theme-dark pocket-workstation-page">
+  <a class="skip-link" href="#workstationMain">Skip to Pocket Workstation</a>
+  <div class="workstation-shell">
+    <header class="workstation-hero">
+      <div class="workstation-hero__copy">
+        <p class="workstation-eyebrow">3dvr Pocket Workstation v0.1</p>
+        <h1>Turn your phone into a builder console.</h1>
+        <p class="workstation-lede">
+          One portable workspace for notes, commands, projects, and guided next steps. Built for Android,
+          usable on iPhone, and ready on desktop right now.
+        </p>
+        <div class="workstation-actions">
+          <a class="cta primary" href="#dashboard-title">Open dashboard</a>
+          <a class="cta ghost" href="../sign-in.html?redirect=%2Fpocket-workstation%2F">Sign in for sync</a>
+        </div>
+        <div class="workstation-links" aria-label="Pocket Workstation sections">
+          <a href="#notes-title">Notes</a>
+          <a href="#commands-title">Commands</a>
+          <a href="#projects-title">Projects</a>
+          <a href="#helper-title">AI helper</a>
+        </div>
+      </div>
+      <aside class="workstation-meta">
+        <div class="meta-card">
+          <p class="meta-label">Universal layer</p>
+          <ul>
+            <li>Android: Termux and local power.</li>
+            <li>iPhone: PWA and guided control.</li>
+            <li>Desktop: full dashboard view.</li>
+          </ul>
+        </div>
+        <div class="meta-card">
+          <p class="meta-label">Shared Gun paths</p>
+          <ul>
+            <li><code>3dvr-portal/pocketWorkstation/users/&lt;identity&gt;/notes</code></li>
+            <li><code>3dvr-portal/pocketWorkstation/users/&lt;identity&gt;/commands</code></li>
+            <li><code>3dvr-portal/pocketWorkstation/users/&lt;identity&gt;/projects</code></li>
+          </ul>
+        </div>
+      </aside>
+    </header>
+
+    <main id="workstationMain" class="workstation-main">
+      <section class="summary-grid" aria-labelledby="dashboard-title">
+        <article class="summary-card summary-card--wide">
+          <p class="section-label">Dashboard</p>
+          <h2 id="dashboard-title">Keep the builder brain in one place.</h2>
+          <p>
+            This first version keeps the MVP tight: account identity, synced notes, reusable commands,
+            project tracking, and a lightweight helper that turns intent into concrete next steps.
+          </p>
+          <div class="identity-row">
+            <div>
+              <span class="identity-row__label">Current identity</span>
+              <strong id="identity-label">Resolving identity…</strong>
+            </div>
+            <div>
+              <span class="identity-row__label">Sync status</span>
+              <strong id="sync-status">Connecting…</strong>
+            </div>
+          </div>
+        </article>
+        <article class="summary-card">
+          <span class="summary-card__count" id="notes-count">0</span>
+          <span class="summary-card__label">Notes</span>
+          <p>Capture ideas, deployment details, and live context fast.</p>
+        </article>
+        <article class="summary-card">
+          <span class="summary-card__count" id="commands-count">0</span>
+          <span class="summary-card__label">Commands</span>
+          <p>Keep your reusable workflows nearby on every device.</p>
+        </article>
+        <article class="summary-card">
+          <span class="summary-card__count" id="projects-count">0</span>
+          <span class="summary-card__label">Projects</span>
+          <p>Track what is active, blocked, or ready to ship.</p>
+        </article>
+      </section>
+
+      <section class="workstation-grid">
+        <article class="panel-card" aria-labelledby="notes-title">
+          <div class="panel-card__header">
+            <div>
+              <p class="section-label">/notes</p>
+              <h2 id="notes-title">Notes</h2>
+            </div>
+            <p class="panel-meta">Quick capture for ideas, server details, launch notes, and reminders.</p>
+          </div>
+          <form id="note-form" class="stack-form">
+            <label for="note-title-input">Title</label>
+            <input id="note-title-input" name="title" type="text" placeholder="Launch checklist" required />
+            <label for="note-body-input">Note</label>
+            <textarea id="note-body-input" name="body" rows="5" placeholder="What matters right now?" required></textarea>
+            <button class="cta primary" type="submit">Save note</button>
+          </form>
+          <p id="note-status" class="status-text" role="status" aria-live="polite"></p>
+          <div id="note-list" class="record-list" aria-live="polite"></div>
+        </article>
+
+        <article class="panel-card" aria-labelledby="commands-title">
+          <div class="panel-card__header">
+            <div>
+              <p class="section-label">/commands</p>
+              <h2 id="commands-title">Commands</h2>
+            </div>
+            <p class="panel-meta">Save the things you should not have to retype from memory.</p>
+          </div>
+          <form id="command-form" class="stack-form">
+            <label for="command-name-input">Name</label>
+            <input id="command-name-input" name="name" type="text" placeholder="Deploy website" required />
+            <label for="command-text-input">Command</label>
+            <textarea
+              id="command-text-input"
+              name="command"
+              rows="4"
+              placeholder="git add . && git commit -m &quot;update&quot; && git push"
+              required
+            ></textarea>
+            <label for="command-context-input">Context</label>
+            <input id="command-context-input" name="context" type="text" placeholder="Vercel deploy, Laravel, SSH, backups..." />
+            <button class="cta primary" type="submit">Save command</button>
+          </form>
+          <p id="command-status" class="status-text" role="status" aria-live="polite"></p>
+          <div id="command-list" class="record-list" aria-live="polite"></div>
+        </article>
+
+        <article class="panel-card" aria-labelledby="projects-title">
+          <div class="panel-card__header">
+            <div>
+              <p class="section-label">/projects</p>
+              <h2 id="projects-title">Projects</h2>
+            </div>
+            <p class="panel-meta">Track what you are building and what the next move is.</p>
+          </div>
+          <form id="project-form" class="stack-form">
+            <label for="project-name-input">Project</label>
+            <input id="project-name-input" name="name" type="text" placeholder="Pocket Workstation landing page" required />
+            <label for="project-status-input">Status</label>
+            <select id="project-status-input" name="status">
+              <option value="active">Active</option>
+              <option value="blocked">Blocked</option>
+              <option value="ready">Ready to ship</option>
+            </select>
+            <label for="project-next-step-input">Next step</label>
+            <textarea id="project-next-step-input" name="nextStep" rows="4" placeholder="Deploy preview and verify the CTA flow." required></textarea>
+            <button class="cta primary" type="submit">Save project</button>
+          </form>
+          <p id="project-status-text" class="status-text" role="status" aria-live="polite"></p>
+          <div id="project-list" class="record-list" aria-live="polite"></div>
+        </article>
+
+        <article class="panel-card" aria-labelledby="helper-title">
+          <div class="panel-card__header">
+            <div>
+              <p class="section-label">AI helper</p>
+              <h2 id="helper-title">What do you want to do?</h2>
+            </div>
+            <p class="panel-meta">Lightweight guidance first: steps, commands, and explanations without blocking the flow.</p>
+          </div>
+          <form id="helper-form" class="stack-form">
+            <label for="helper-input">Intent</label>
+            <textarea id="helper-input" rows="4" placeholder="Deploy my Laravel app" required></textarea>
+            <button class="cta primary" type="submit">Generate next steps</button>
+          </form>
+          <div id="helper-output" class="helper-output" aria-live="polite">
+            <p class="helper-output__placeholder">Ask for a deploy, SSH, project setup, or note workflow.</p>
+          </div>
+        </article>
+      </section>
+
+      <section class="roadmap-strip" aria-labelledby="modes-title">
+        <div>
+          <p class="section-label">Modes</p>
+          <h2 id="modes-title">Ship the universal layer first.</h2>
+        </div>
+        <div class="roadmap-grid">
+          <article>
+            <h3>Android</h3>
+            <p>Termux install flow and synced command pulls come next.</p>
+            <code>curl -s https://3dvr.tech/install | bash</code>
+          </article>
+          <article>
+            <h3>iPhone</h3>
+            <p>PWA control panel first. Shortcuts and remote helpers later.</p>
+          </article>
+          <article>
+            <h3>Desktop</h3>
+            <p>Same dashboard, bigger screen, deeper project control.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/pocket-workstation/styles.css
+++ b/pocket-workstation/styles.css
@@ -1,0 +1,252 @@
+.pocket-workstation-page {
+  background:
+    radial-gradient(circle at top left, rgba(94, 234, 212, 0.18), transparent 24%),
+    linear-gradient(180deg, #07111b 0%, #081521 46%, #04070d 100%);
+  color: #f2f7fb;
+}
+
+.workstation-shell {
+  width: min(1220px, calc(100% - 1.5rem));
+  margin: 0 auto;
+  padding: 1.25rem 0 4rem;
+}
+
+.workstation-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.workstation-hero__copy,
+.meta-card,
+.summary-card,
+.panel-card,
+.roadmap-strip {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(7, 15, 24, 0.78);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.22);
+}
+
+.workstation-hero__copy,
+.roadmap-strip {
+  border-radius: 28px;
+  padding: 1.6rem;
+}
+
+.workstation-eyebrow,
+.section-label,
+.meta-label,
+.identity-row__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  color: #8de8dd;
+}
+
+.workstation-hero h1 {
+  margin: 0.35rem 0 0.85rem;
+  font-size: clamp(2.4rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.workstation-lede,
+.panel-meta,
+.summary-card p,
+.record-card p,
+.roadmap-grid p {
+  color: rgba(242, 247, 251, 0.78);
+}
+
+.workstation-actions,
+.workstation-links,
+.identity-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.workstation-links {
+  margin-top: 1rem;
+}
+
+.workstation-links a {
+  color: #8de8dd;
+  font-weight: 600;
+}
+
+.workstation-meta {
+  display: grid;
+  gap: 1rem;
+}
+
+.meta-card {
+  border-radius: 24px;
+  padding: 1.2rem;
+}
+
+.meta-card ul,
+.roadmap-grid code {
+  margin-top: 0.85rem;
+}
+
+.meta-card ul {
+  padding-left: 1.1rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.summary-card {
+  border-radius: 22px;
+  padding: 1.2rem;
+}
+
+.summary-card--wide {
+  grid-column: span 2;
+}
+
+.summary-card__count {
+  display: block;
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: #8de8dd;
+}
+
+.summary-card__label {
+  display: block;
+  margin-top: 0.25rem;
+  font-weight: 700;
+}
+
+.identity-row {
+  margin-top: 1rem;
+}
+
+.identity-row strong {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 1.05rem;
+}
+
+.workstation-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.panel-card {
+  border-radius: 24px;
+  padding: 1.25rem;
+}
+
+.panel-card__header {
+  margin-bottom: 1rem;
+}
+
+.panel-card__header h2,
+.roadmap-strip h2 {
+  margin: 0.25rem 0 0.45rem;
+  font-size: 1.7rem;
+}
+
+.stack-form {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.stack-form input,
+.stack-form textarea,
+.stack-form select {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #f2f7fb;
+  padding: 0.85rem 0.95rem;
+  font: inherit;
+}
+
+.status-text {
+  min-height: 1.2rem;
+  margin: 0.8rem 0 0;
+  color: #8de8dd;
+}
+
+.record-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.9rem;
+}
+
+.record-card,
+.helper-output {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.95rem 1rem;
+}
+
+.record-card h3,
+.helper-output h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1.02rem;
+}
+
+.record-card__meta {
+  color: #8de8dd;
+  font-size: 0.86rem;
+}
+
+.record-card code,
+.helper-output code,
+.roadmap-grid code {
+  display: block;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.28);
+  color: #b8fbf5;
+}
+
+.helper-output__placeholder {
+  margin: 0;
+  color: rgba(242, 247, 251, 0.62);
+}
+
+.helper-output ol {
+  margin: 0.55rem 0 0.9rem;
+  padding-left: 1.15rem;
+}
+
+.roadmap-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.roadmap-grid article {
+  border-radius: 18px;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+@media (max-width: 980px) {
+  .workstation-hero,
+  .summary-grid,
+  .workstation-grid,
+  .roadmap-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-card--wide {
+    grid-column: span 1;
+  }
+}

--- a/tests/pocket-workstation.test.js
+++ b/tests/pocket-workstation.test.js
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const baseDir = new URL('../pocket-workstation/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+describe('pocket workstation app', () => {
+  it('ships the workstation workspace with dashboard, notes, commands, projects, and helper sections', async () => {
+    const indexUrl = new URL('index.html', baseDir);
+    assert.equal(await fileExists(indexUrl), true, 'index.html should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    assert.match(html, /3dvr Pocket Workstation \| 3DVR Portal/);
+    assert.match(html, /Turn your phone into a builder console\./);
+    assert.match(html, /id="dashboard-title"/);
+    assert.match(html, /id="notes-title"/);
+    assert.match(html, /id="commands-title"/);
+    assert.match(html, /id="projects-title"/);
+    assert.match(html, /id="helper-title"/);
+    assert.match(html, /id="note-form"/);
+    assert.match(html, /id="command-form"/);
+    assert.match(html, /id="project-form"/);
+    assert.match(html, /id="helper-form"/);
+    assert.match(html, /Current identity/);
+    assert.match(html, /Shared Gun paths/);
+    assert.match(html, /3dvr-portal\/pocketWorkstation\/users\/&lt;identity&gt;\/notes/);
+    assert.match(html, /curl -s https:\/\/3dvr\.tech\/install \| bash/);
+    assert.match(html, /<script[^>]+src="\.\.\/auth-identity\.js"/);
+    assert.match(html, /<script[^>]+src="\.\.\/score\.js"/);
+    assert.match(html, /<script[^>]+src="\.\/app\.js"/);
+  });
+
+  it('ships dedicated styling for the workstation dashboard', async () => {
+    const cssUrl = new URL('styles.css', baseDir);
+    assert.equal(await fileExists(cssUrl), true, 'styles.css should exist');
+
+    const css = await readFile(cssUrl, 'utf8');
+    assert.match(css, /\.workstation-hero/);
+    assert.match(css, /\.summary-grid/);
+    assert.match(css, /\.workstation-grid/);
+    assert.match(css, /\.record-list/);
+    assert.match(css, /\.roadmap-grid/);
+  });
+
+  it('includes client logic for Gun-backed sync and helper generation', async () => {
+    const appUrl = new URL('app.js', baseDir);
+    assert.equal(await fileExists(appUrl), true, 'app.js should exist');
+
+    const js = await readFile(appUrl, 'utf8');
+    assert.match(js, /APP_ROOT_PATH = \['3dvr-portal', 'pocketWorkstation', 'users'\]/);
+    assert.match(js, /window\.ScoreSystem && typeof window\.ScoreSystem\.ensureGun === 'function'/);
+    assert.match(js, /resolveIdentity/);
+    assert.match(js, /buildHelperResult/);
+    assert.match(js, /renderHelper/);
+    assert.match(js, /getUserNode\(type\)/);
+    assert.match(js, /node\.get\(record\.id\)\.put\(record, ack =>/);
+    assert.match(js, /node\.map\(\)\.on\(\(data, key\) =>/);
+    assert.match(js, /Saved locally and synced to Gun\./);
+  });
+
+  it('registers Pocket Workstation in the portal dock near Notes and Projects', async () => {
+    const portalIndex = new URL('../index.html', baseDir);
+    const html = await readFile(portalIndex, 'utf8');
+    const notesIndex = html.indexOf('>Notes<');
+    const workstationIndex = html.indexOf('>Pocket Workstation<');
+    const projectsIndex = html.indexOf('>Projects<');
+    assert.ok(workstationIndex !== -1, 'Pocket Workstation app card should be listed on the portal');
+    assert.ok(notesIndex !== -1, 'Notes app card should still be present');
+    assert.ok(projectsIndex !== -1, 'Projects app card should still be present');
+    assert.ok(notesIndex < workstationIndex, 'Pocket Workstation should render after Notes');
+    assert.ok(workstationIndex < projectsIndex, 'Pocket Workstation should render before Projects');
+    assert.match(html, /href="pocket-workstation\/(?:index\.html)?"/);
+  });
+
+  it('adds Pocket Workstation to the installable app list in the README', async () => {
+    const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+    assert.match(readme, /\[Pocket Workstation\]\(https:\/\/3dvr-portal\.vercel\.app\/pocket-workstation\/\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new Pocket Workstation portal app for the v0.1 universal dashboard layer
- ship synced notes, commands, projects, and a lightweight helper backed by clear Gun node paths
- register the app in the portal dock and README install list with focused regression coverage

## Verification
- `node --test tests/pocket-workstation.test.js tests/logic-lab.test.js`

## User-facing impact
This turns the 3dvr Pocket Workstation idea into a real portal app users can open now while the Termux installer and deeper device integrations come later.