### PR TITLE
Add Pocket Workstation pairing flow

### DIFF
--- a/pocket-workstation/app.js
+++ b/pocket-workstation/app.js
@@ -5,6 +5,7 @@
 
   const STORAGE_KEY = '3dvr-pocket-workstation.identity';
   const APP_ROOT_PATH = ['3dvr-portal', 'pocketWorkstation', 'users'];
+  const PAIRING_PATH = ['3dvr-portal', 'pocketWorkstation', 'pairing'];
 
   const refs = {
     identityLabel: document.getElementById('identity-label'),
@@ -12,6 +13,9 @@
     notesCount: document.getElementById('notes-count'),
     commandsCount: document.getElementById('commands-count'),
     projectsCount: document.getElementById('projects-count'),
+    pairingForm: document.getElementById('pairing-form'),
+    pairingCodeInput: document.getElementById('pairing-code-input'),
+    pairingStatus: document.getElementById('pairing-status'),
     noteForm: document.getElementById('note-form'),
     noteStatus: document.getElementById('note-status'),
     noteList: document.getElementById('note-list'),
@@ -49,6 +53,10 @@
   function createId(prefix) {
     const base = `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
     return prefix ? `${prefix}-${base}` : base;
+  }
+
+  function normalizeCode(value) {
+    return normalizeText(value).toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
   }
 
   function createLocalGunSubscriptionStub() {
@@ -173,6 +181,15 @@
       label: `Guest ${guestId.slice(-6)}`,
       mode: 'guest',
     };
+  }
+
+  function getPairingCodeFromUrl() {
+    try {
+      const url = new URL(window.location.href);
+      return normalizeCode(url.searchParams.get('pairCode') || '');
+    } catch (_error) {
+      return '';
+    }
   }
 
   function recordToCard(record, type) {
@@ -351,6 +368,7 @@
   );
 
   const portalRoot = getNodeFromPath(gunContext.gun, ['3dvr-portal']);
+  const pairingNode = getNodeFromPath(gunContext.gun, PAIRING_PATH);
   state.identity = resolveIdentity();
 
   function getUserNode(type) {
@@ -388,11 +406,51 @@
     });
   }
 
+  function buildSignInRedirect(code) {
+    return `../sign-in.html?redirect=${encodeURIComponent(`/pocket-workstation/?pairCode=${encodeURIComponent(code)}#connect-title`)}`;
+  }
+
+  function linkPairingCode(code) {
+    const normalizedCode = normalizeCode(code);
+    if (!normalizedCode) {
+      refs.pairingStatus.textContent = 'Enter the 6-character code shown in Termux.';
+      return;
+    }
+
+    if (state.identity.mode !== 'signed-in') {
+      refs.pairingStatus.innerHTML = `Sign in first, then come back to link this code. <a href="${escapeHtml(buildSignInRedirect(normalizedCode))}">Sign in</a>`;
+      return;
+    }
+
+    refs.pairingStatus.textContent = 'Linking this browser to the Termux session…';
+    pairingNode.get(normalizedCode).put({
+      code: normalizedCode,
+      alias: state.identity.label,
+      identityKey: state.identity.key,
+      pairedAt: Date.now(),
+      source: 'portal-pocket-workstation',
+    }, ack => {
+      if (ack && ack.err) {
+        refs.pairingStatus.textContent = 'Could not link the code yet. Retry when Gun is reachable.';
+        return;
+      }
+      refs.pairingStatus.textContent = `Linked code ${normalizedCode}. Return to Termux and the CLI should finish automatically.`;
+    });
+  }
+
   function init() {
     refs.identityLabel.textContent = state.identity.mode === 'signed-in'
       ? `Signed in as ${state.identity.label}`
       : `Guest workspace for ${state.identity.label}`;
     refs.syncStatus.textContent = gunContext.isStub ? 'Offline mode' : 'Connected to Gun';
+
+    const pairingCode = getPairingCodeFromUrl();
+    if (pairingCode && refs.pairingCodeInput) {
+      refs.pairingCodeInput.value = pairingCode;
+      refs.pairingStatus.textContent = state.identity.mode === 'signed-in'
+        ? `Ready to link code ${pairingCode}.`
+        : 'Sign in on this device first, then link the code.';
+    }
 
     renderRecords('notes');
     renderRecords('commands');
@@ -432,6 +490,13 @@
       refs.helperForm.addEventListener('submit', event => {
         event.preventDefault();
         renderHelper(refs.helperInput.value);
+      });
+    }
+
+    if (refs.pairingForm) {
+      refs.pairingForm.addEventListener('submit', event => {
+        event.preventDefault();
+        linkPairingCode(refs.pairingCodeInput.value);
       });
     }
   }

--- a/pocket-workstation/index.html
+++ b/pocket-workstation/index.html
@@ -97,6 +97,33 @@
         </article>
       </section>
 
+      <section class="pairing-card" aria-labelledby="connect-title">
+        <div class="pairing-copy">
+          <p class="section-label">Termux connect</p>
+          <h2 id="connect-title">Link this browser to your `3dvr connect` code.</h2>
+          <p>
+            Run <code>3dvr connect</code> in Termux, then enter the code here. If you are already signed in on this device,
+            this links the CLI without typing your alias into the terminal.
+          </p>
+        </div>
+        <form id="pairing-form" class="pairing-form">
+          <label for="pairing-code-input">Connection code</label>
+          <input
+            id="pairing-code-input"
+            name="pairCode"
+            type="text"
+            inputmode="text"
+            autocomplete="off"
+            spellcheck="false"
+            maxlength="6"
+            placeholder="AB12CD"
+            required
+          />
+          <button class="cta primary" type="submit">Link this device</button>
+        </form>
+        <p id="pairing-status" class="status-text" role="status" aria-live="polite"></p>
+      </section>
+
       <section class="workstation-grid">
         <article class="panel-card" aria-labelledby="notes-title">
           <div class="panel-card__header">

--- a/pocket-workstation/styles.css
+++ b/pocket-workstation/styles.css
@@ -101,6 +101,40 @@
   margin-bottom: 1rem;
 }
 
+.pairing-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  gap: 1rem;
+  border-radius: 24px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(7, 15, 24, 0.78);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.22);
+}
+
+.pairing-copy p:last-child {
+  color: rgba(242, 247, 251, 0.78);
+}
+
+.pairing-form {
+  display: grid;
+  gap: 0.65rem;
+  align-content: start;
+}
+
+.pairing-form input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #f2f7fb;
+  padding: 0.85rem 0.95rem;
+  font: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
 .summary-card {
   border-radius: 22px;
   padding: 1.2rem;
@@ -241,6 +275,7 @@
 @media (max-width: 980px) {
   .workstation-hero,
   .summary-grid,
+  .pairing-card,
   .workstation-grid,
   .roadmap-grid {
     grid-template-columns: 1fr;

--- a/tests/pocket-workstation.test.js
+++ b/tests/pocket-workstation.test.js
@@ -27,6 +27,10 @@ describe('pocket workstation app', () => {
     assert.match(html, /id="commands-title"/);
     assert.match(html, /id="projects-title"/);
     assert.match(html, /id="helper-title"/);
+    assert.match(html, /id="connect-title"/);
+    assert.match(html, /id="pairing-form"/);
+    assert.match(html, /id="pairing-code-input"/);
+    assert.match(html, /Link this browser to your `3dvr connect` code\./);
     assert.match(html, /id="note-form"/);
     assert.match(html, /id="command-form"/);
     assert.match(html, /id="project-form"/);
@@ -47,6 +51,8 @@ describe('pocket workstation app', () => {
     const css = await readFile(cssUrl, 'utf8');
     assert.match(css, /\.workstation-hero/);
     assert.match(css, /\.summary-grid/);
+    assert.match(css, /\.pairing-card/);
+    assert.match(css, /\.pairing-form/);
     assert.match(css, /\.workstation-grid/);
     assert.match(css, /\.record-list/);
     assert.match(css, /\.roadmap-grid/);
@@ -58,7 +64,11 @@ describe('pocket workstation app', () => {
 
     const js = await readFile(appUrl, 'utf8');
     assert.match(js, /APP_ROOT_PATH = \['3dvr-portal', 'pocketWorkstation', 'users'\]/);
+    assert.match(js, /PAIRING_PATH = \['3dvr-portal', 'pocketWorkstation', 'pairing'\]/);
     assert.match(js, /window\.ScoreSystem && typeof window\.ScoreSystem\.ensureGun === 'function'/);
+    assert.match(js, /getPairingCodeFromUrl/);
+    assert.match(js, /linkPairingCode/);
+    assert.match(js, /pairingNode\.get\(normalizedCode\)\.put/);
     assert.match(js, /resolveIdentity/);
     assert.match(js, /buildHelperResult/);
     assert.match(js, /renderHelper/);


### PR DESCRIPTION
## Summary
- add a short-code pairing flow to Pocket Workstation so Termux can connect without typing an alias
- prefill the browser pairing screen from the CLI query param and write approved codes into Gun
- expand the workstation tests to cover the pairing UI and Gun path

## Verification
- `node --test tests/pocket-workstation.test.js`

## User-facing impact
This makes `3dvr connect` smoother by letting a signed-in portal session approve the connection code directly.