### PR TITLE
Use curl -Ls in Pocket Workstation docs

### DIFF
--- a/pocket-workstation/index.html
+++ b/pocket-workstation/index.html
@@ -224,7 +224,7 @@
           <article>
             <h3>Android</h3>
             <p>Termux install flow and synced command pulls come next.</p>
-            <code>curl -s https://3dvr.tech/install | bash</code>
+            <code>curl -Ls https://3dvr.tech/install | bash</code>
           </article>
           <article>
             <h3>iPhone</h3>

--- a/tests/pocket-workstation.test.js
+++ b/tests/pocket-workstation.test.js
@@ -38,7 +38,7 @@ describe('pocket workstation app', () => {
     assert.match(html, /Current identity/);
     assert.match(html, /Shared Gun paths/);
     assert.match(html, /3dvr-portal\/pocketWorkstation\/users\/&lt;identity&gt;\/notes/);
-    assert.match(html, /curl -s https:\/\/3dvr\.tech\/install \| bash/);
+    assert.match(html, /curl -Ls https:\/\/3dvr\.tech\/install \| bash/);
     assert.match(html, /<script[^>]+src="\.\.\/auth-identity\.js"/);
     assert.match(html, /<script[^>]+src="\.\.\/score\.js"/);
     assert.match(html, /<script[^>]+src="\.\/app\.js"/);


### PR DESCRIPTION
## Summary
- update the Pocket Workstation portal page to show the redirect-safe install command
- align the workstation test with the `curl -Ls` example

## Verification
- `node --test tests/pocket-workstation.test.js`

## User-facing impact
The portal docs now show an install command that follows the apex-to-www redirect correctly.