### PR TITLE
Normalize contacts to CRM handoff records

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -473,6 +473,7 @@ import {
 import {
   CONTACT_IMPORT_ACCEPT,
   buildImportMatchKeys,
+  buildContactCrmRecord,
   mergeCommaSeparatedValues,
   parseContactFileText,
   pickDeviceContacts,
@@ -2848,25 +2849,26 @@ function addContactToCrm(id){
 
   const now = nowISO();
   const crmId = contact.crmId || contact.id || createId();
-  const payload = {
-    id: crmId,
+  const payload = buildContactCrmRecord(contact, {
+    now,
+    recordId: crmId,
     contactId: contact.id || crmId,
-    name: contact.name || '',
-    email: contact.email || '',
-    phone: contact.phone || '',
-    company: contact.company || '',
-    role: contact.role || '',
-    tags: contact.tags || '',
+    source: contact.source || 'Contacts workspace',
     status: contact.status || '',
+    tags: mergeCommaSeparatedValues(contact.tags, 'source/contacts-workspace'),
     nextFollowUp: contact.nextFollowUp || '',
     notes: contact.notes || '',
     lastContacted: contact.lastContacted || '',
     activityCount: typeof contact.activityCount === 'number' ? contact.activityCount : 0,
-    source: contact.source || 'Contacts workspace',
     created: contact.created || now,
-    updated: now,
-    syncedFromContactsAt: now
-  };
+  });
+  if(!payload){
+    setButtonState('Add to CRM', false);
+    alert('This contact needs a name, email, or phone number before it can be linked to CRM.');
+    return;
+  }
+  payload.updated = now;
+  payload.syncedFromContactsAt = now;
 
   let settled = false;
   const timer = setTimeout(() => {

--- a/src/contacts/import.js
+++ b/src/contacts/import.js
@@ -165,6 +165,62 @@ export function buildImportedCrmRecord(raw = {}, options = {}) {
   };
 }
 
+const CRM_CONTACT_LINK_TAG = 'source/contacts-workspace';
+const SUPPORTED_CRM_STATUSES = new Set([
+  'Warm - Awareness',
+  'Warm - Discovery',
+  'Warm - Invited',
+  'Warm - Follow-up',
+  'Lead',
+  'Prospect',
+  'Active',
+  'Negotiating',
+  'Won',
+  'Lost',
+]);
+
+function normalizeLinkedCrmStatus(value = '') {
+  const normalized = normalizeText(value);
+  return SUPPORTED_CRM_STATUSES.has(normalized) ? normalized : 'Warm - Awareness';
+}
+
+function deriveWarmthFromStatus(status = '') {
+  const normalized = normalizeText(status).toLowerCase();
+  if (normalized === 'active' || normalized === 'negotiating' || normalized === 'won') {
+    return 'hot';
+  }
+  if (normalized === 'lead' || normalized === 'prospect' || normalized === 'lost') {
+    return 'cold';
+  }
+  return 'warm';
+}
+
+export function buildContactCrmRecord(raw = {}, options = {}) {
+  const imported = normalizeImportedContact(raw, options);
+  if (!imported) return null;
+
+  const status = normalizeLinkedCrmStatus(options.status || imported.status);
+  const tags = mergeCommaSeparatedValues(imported.tags, options.tags || CRM_CONTACT_LINK_TAG);
+
+  return buildImportedCrmRecord(imported, {
+    ...options,
+    status,
+    warmth: normalizeText(options.warmth) || deriveWarmthFromStatus(status),
+    tags,
+    nextFollowUp: normalizeText(options.nextFollowUp) || imported.nextFollowUp,
+    notes: normalizeText(options.notes) || imported.notes,
+    created: normalizeText(options.created) || imported.created,
+    lastContacted: normalizeText(options.lastContacted) || imported.lastContacted,
+    activityCount: Number.isFinite(Number(options.activityCount))
+      ? Number(options.activityCount)
+      : imported.activityCount,
+    nextBestAction: normalizeText(options.nextBestAction) || 'Review the contact and draft the next outreach.',
+    lastSignal: normalizeText(options.lastSignal) || 'Linked from contacts workspace',
+    source: normalizeText(options.source) || imported.source || 'Contacts workspace',
+    contactId: normalizeText(options.contactId) || imported.id,
+  });
+}
+
 function decodeQuotedPrintable(value = '') {
   const source = String(value || '').replace(/=\r?\n/g, '');
   const bytes = [];

--- a/tests/contact-import.test.js
+++ b/tests/contact-import.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildContactCrmRecord,
   buildImportMatchKeys,
   buildImportedCrmRecord,
   normalizePickedContacts,
@@ -101,4 +102,37 @@ test('builds CRM import records and matching keys for dedupe', () => {
   assert.ok(keys.includes('phone:5551002000'));
   assert.ok(keys.includes('name:taylor prospect'));
   assert.ok(keys.includes('name-company:taylor prospect::prospect studio'));
+});
+
+test('builds canonical CRM records when linking a contact into the CRM workspace', () => {
+  const record = buildContactCrmRecord({
+    id: 'contact-42',
+    name: 'Jordan Friend',
+    email: 'jordan@example.com',
+    phone: '(555) 999-1000',
+    company: 'Builder Coop',
+    tags: 'friend, outreach',
+    status: 'Friend',
+    notes: 'Met after a local meetup.',
+    created: '2026-04-04T03:30:00.000Z',
+    lastContacted: '2026-04-03',
+    activityCount: 3,
+    source: 'Contacts workspace',
+  }, {
+    now: '2026-04-05T01:00:00.000Z',
+    recordId: 'crm-42',
+    contactId: 'contact-42',
+  });
+
+  assert.equal(record.id, 'crm-42');
+  assert.equal(record.recordType, 'person');
+  assert.equal(record.contactId, 'contact-42');
+  assert.equal(record.status, 'Warm - Awareness');
+  assert.equal(record.warmth, 'warm');
+  assert.equal(record.lastSignal, 'Linked from contacts workspace');
+  assert.equal(record.nextBestAction, 'Review the contact and draft the next outreach.');
+  assert.match(record.tags, /source\/contacts-workspace/);
+  assert.match(record.tags, /friend/);
+  assert.equal(record.activityCount, 3);
+  assert.equal(record.lastContacted, '2026-04-03');
 });

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -97,10 +97,12 @@ test('CRM and Contacts preserve space-aware link context', async () => {
 test('Contacts app wires shared import helpers and status messaging', async () => {
   const html = await read('contacts/index.html');
   assert.match(html, /CONTACT_IMPORT_ACCEPT/);
+  assert.match(html, /buildContactCrmRecord/);
   assert.match(html, /bulkImport\.accept = CONTACT_IMPORT_ACCEPT/);
   assert.match(html, /supportsDeviceContactPicker\(window\.navigator\)/);
   assert.match(html, /pickDeviceContacts\(/);
   assert.match(html, /parseContactFileText\(/);
+  assert.match(html, /source\/contacts-workspace/);
   assert.match(html, /function setContactsImportStatus\(message = '', tone = 'info'\)/);
   assert.match(html, /function importContactsIntoWorkspace\(records, \{ sourceLabel = 'Phone import' \} = \{\}\)/);
   assert.match(html, /function importProviderContacts\(provider\)/);


### PR DESCRIPTION
## Summary
- replace the inline Contacts -> CRM payload with a shared helper that builds canonical CRM person records
- normalize unsupported contact statuses into valid CRM statuses and add CRM-specific defaults/tags for linked contacts
- cover the handoff helper and Contacts wiring with focused regression tests

## Testing
- node --test tests/contact-import.test.js tests/crm-contacts-workflow.test.js