### PR TITLE
Move CRM and contacts primary actions to the top

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -166,26 +166,32 @@
 
     <!-- Right column -->
     <section class="grid gap-6">
-      <!-- Add Contact -->
-      <div class="bg-gray-800/60 rounded-xl p-4 border border-white/10">
-        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <!-- Primary actions -->
+      <div id="contactsPrimaryActions" class="bg-gray-800/60 rounded-xl p-4 border border-white/10 space-y-4">
+        <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <h2 class="text-lg font-semibold">Add Contact</h2>
-            <p class="text-sm text-gray-300">Capture new relationships without leaving your list.</p>
+            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-300">Contacts workspace</p>
+            <h2 class="text-lg font-semibold">Add and find contacts fast.</h2>
+            <p class="text-sm text-gray-300">Start with the main move, then use the deeper filters only when you need them.</p>
           </div>
           <button id="openCreateContact" type="button" class="bg-teal-600 hover:bg-teal-700 px-4 py-2 rounded text-sm font-medium">
-            New contact
+            Add contact
           </button>
+        </div>
+        <div class="grid gap-3 md:grid-cols-[1fr,220px] md:items-end">
+          <div>
+            <label class="text-sm text-gray-300" for="search">Search contacts</label>
+            <input id="search" placeholder="Name, email, company, tags…" class="w-full p-2 rounded text-black" />
+          </div>
+          <a href="https://portal.3dvr.tech/crm/index.html" class="bg-white/10 hover:bg-white/20 px-4 py-2 rounded text-sm font-medium text-center border border-white/10">
+            Search CRM
+          </a>
         </div>
       </div>
 
       <!-- Filters -->
       <div class="bg-gray-800/60 rounded-xl p-4 border border-white/10">
-        <div class="grid grid-cols-2 gap-2 md:grid-cols-[1fr,180px,180px,180px,180px] items-end">
-          <div class="col-span-2 md:col-span-1">
-            <label class="text-sm text-gray-300">Search</label>
-            <input id="search" placeholder="Name, email, company, tags…" class="w-full p-2 rounded text-black" />
-          </div>
+        <div class="grid grid-cols-2 gap-2 md:grid-cols-[180px,180px,180px,180px] items-end">
           <div>
             <label class="text-sm text-gray-300">Status</label>
             <select id="filterStatus" class="w-full p-2 rounded text-black">
@@ -212,7 +218,7 @@
               <option value="unlinked">Not linked</option>
             </select>
           </div>
-          <div>
+          <div class="col-span-2 md:col-span-1">
             <label class="text-sm text-gray-300">Sort</label>
             <select id="sortOrder" class="w-full p-2 rounded text-black">
               <option value="name-first">Name (first → last)</option>

--- a/crm/index.html
+++ b/crm/index.html
@@ -128,6 +128,43 @@
       </div>
     </section>
 
+    <section id="crmPrimaryActions" class="bg-gray-800/60 border border-white/10 rounded-2xl p-5 space-y-4">
+      <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">CRM workspace</p>
+          <h2 class="text-xl font-semibold">Add the next lead or find the right record fast.</h2>
+          <p class="text-sm text-gray-300">Keep the main moves at the top. The workflow lanes can stay underneath.</p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button id="openCrmCreate" type="button" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded text-sm font-medium">Add CRM contact</button>
+          <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-4 py-2 rounded text-sm text-center border border-white/10">Search contacts</a>
+        </div>
+      </div>
+      <div class="grid gap-3 md:grid-cols-[1fr,240px] md:items-end">
+        <div>
+          <label for="filter" class="block text-sm text-gray-300">Search CRM</label>
+          <input id="filter" type="search" placeholder="Filter by name, group, problem, tags, or notes" class="w-full p-2 rounded text-black" />
+        </div>
+        <div>
+          <label for="personWorkflowFilter" class="block text-sm text-gray-300">Person workflow</label>
+          <select id="personWorkflowFilter" class="w-full p-2 rounded text-black">
+            <option value="">All people</option>
+            <option value="linked">Linked to contacts</option>
+            <option value="unlinked">Not linked to contacts</option>
+            <option value="overdue">Follow-up overdue</option>
+            <option value="none">No follow-up date</option>
+            <option value="week">Follow-up due this week</option>
+            <option value="stale-14">Stale (14+ days)</option>
+          </select>
+        </div>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button id="filterAllRecords" type="button" class="px-3 py-1.5 rounded text-sm bg-sky-600 text-white">All records</button>
+        <button id="filterWarmLeads" type="button" class="px-3 py-1.5 rounded text-sm bg-white/10 text-gray-200">Warm leads</button>
+        <p class="text-xs text-gray-400 self-center">Tip: press <kbd class="rounded border border-white/20 px-1 py-0.5">/</kbd> to jump to search.</p>
+      </div>
+    </section>
+
     <section class="bg-gray-800/60 border border-white/10 rounded-2xl p-5 space-y-4">
       <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
         <div>
@@ -229,7 +266,7 @@
           <p id="crmImportStatus" class="hidden rounded-lg border px-3 py-2 text-xs" role="status" aria-live="polite"></p>
         </div>
         <div class="grid gap-2 sm:grid-cols-2">
-          <button id="openCrmCreate" type="button" class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm">Full lead form</button>
+          <span class="bg-white/10 text-white px-3 py-2 rounded text-sm text-center border border-white/10">Use top button for full lead form</span>
           <button id="openGroupCreate" type="button" class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm">New group</button>
           <button id="openProblemCreate" type="button" class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm">Log problem</button>
           <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm text-center">Open contacts</a>
@@ -261,32 +298,6 @@
       </div>
 
       <div class="space-y-6">
-        <div class="bg-gray-800/60 border border-white/10 rounded-2xl p-5 space-y-3">
-          <div class="flex flex-wrap gap-2">
-            <button id="filterAllRecords" type="button" class="px-3 py-1.5 rounded text-sm bg-sky-600 text-white">All records</button>
-            <button id="filterWarmLeads" type="button" class="px-3 py-1.5 rounded text-sm bg-white/10 text-gray-200">Warm leads</button>
-          </div>
-          <div class="grid gap-3 md:grid-cols-[1fr,240px] md:items-end">
-            <div>
-              <label for="filter" class="block text-sm text-gray-300">Search workspace</label>
-              <input id="filter" type="search" placeholder="Filter by name, group, problem, tags, or notes" class="w-full p-2 rounded text-black" />
-            </div>
-            <div>
-              <label for="personWorkflowFilter" class="block text-sm text-gray-300">Person workflow</label>
-              <select id="personWorkflowFilter" class="w-full p-2 rounded text-black">
-                <option value="">All people</option>
-                <option value="linked">Linked to contacts</option>
-                <option value="unlinked">Not linked to contacts</option>
-                <option value="overdue">Follow-up overdue</option>
-                <option value="none">No follow-up date</option>
-                <option value="week">Follow-up due this week</option>
-                <option value="stale-14">Stale (14+ days)</option>
-              </select>
-            </div>
-          </div>
-          <p class="text-xs text-gray-400">Tip: press <kbd class="rounded border border-white/20 px-1 py-0.5">/</kbd> to jump to search.</p>
-        </div>
-
         <div class="bg-gray-800/60 border border-white/10 rounded-2xl p-5">
           <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-4">
             <h2 class="text-xl font-semibold">Pipeline</h2>

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -11,6 +11,10 @@ async function read(relativePath) {
 
 test('CRM page exposes workflow filters and import controls for fast lead retrieval', async () => {
   const html = await read('crm/index.html');
+  assert.match(html, /id="crmPrimaryActions"/);
+  assert.match(html, /Add CRM contact/);
+  assert.match(html, /Search contacts/);
+  assert.match(html, /Search CRM/);
   assert.match(html, /id="filterAllRecords"/);
   assert.match(html, /id="filterWarmLeads"/);
   assert.match(html, /id="personWorkflowFilter"/);
@@ -48,6 +52,10 @@ test('CRM page exposes workflow filters and import controls for fast lead retrie
   assert.match(html, /value="unlinked"/);
   assert.match(html, /value="overdue"/);
   assert.match(html, /value="stale-14"/);
+  assert.ok(
+    html.indexOf('id="crmPrimaryActions"') < html.indexOf("Today's Sales Moves"),
+    'expected CRM primary actions to appear before sales moves'
+  );
 });
 
 test('CRM app includes keyboard search shortcut, workflow filters, and import wiring', async () => {
@@ -96,6 +104,10 @@ test('CRM and Contacts preserve space-aware link context', async () => {
 
 test('Contacts app wires shared import helpers and status messaging', async () => {
   const html = await read('contacts/index.html');
+  assert.match(html, /id="contactsPrimaryActions"/);
+  assert.match(html, /Add contact/);
+  assert.match(html, /Search contacts/);
+  assert.match(html, /Search CRM/);
   assert.match(html, /CONTACT_IMPORT_ACCEPT/);
   assert.match(html, /buildContactCrmRecord/);
   assert.match(html, /bulkImport\.accept = CONTACT_IMPORT_ACCEPT/);
@@ -107,4 +119,8 @@ test('Contacts app wires shared import helpers and status messaging', async () =
   assert.match(html, /function importContactsIntoWorkspace\(records, \{ sourceLabel = 'Phone import' \} = \{\}\)/);
   assert.match(html, /function importProviderContacts\(provider\)/);
   assert.match(html, /runtime\.listContacts/);
+  assert.ok(
+    html.indexOf('id="contactsPrimaryActions"') < html.indexOf('id="filterStatus"'),
+    'expected contacts primary actions to appear before secondary filters'
+  );
 });


### PR DESCRIPTION
## Summary
- move the main add/search actions to the top of CRM and Contacts so the core path is visible immediately
- keep the heavier workflow, import, and filter controls underneath the primary actions
- extend the CRM/Contacts page-structure tests to lock in the new order

## Testing
- node --test tests/crm-contacts-workflow.test.js tests/contact-import.test.js