### PR TITLE
Refocus Life app into Life OS

### DIFF
--- a/life/app.js
+++ b/life/app.js
@@ -3,7 +3,7 @@ const categoryDefs = [
   { key: 'body', label: 'Body' },
   { key: 'money', label: 'Money' },
   { key: 'relationships', label: 'Relationships' },
-  { key: 'projects', label: 'Projects' }
+  { key: 'mission', label: 'Mission' }
 ];
 
 const STORAGE_KEY = 'portal-life-checkins';
@@ -162,7 +162,11 @@ function normalizeEntry(entry, fallbackId = makeId()) {
   const categories = {};
 
   for (const category of categoryDefs) {
-    categories[category.key] = clampScore(source.categories && source.categories[category.key]);
+    const rawValue = source.categories && (
+      source.categories[category.key]
+      ?? (category.key === 'mission' ? source.categories.projects : undefined)
+    );
+    categories[category.key] = clampScore(rawValue);
   }
 
   return {
@@ -170,8 +174,12 @@ function normalizeEntry(entry, fallbackId = makeId()) {
     createdAt: source.createdAt || new Date().toISOString(),
     date: source.date || toDateInputValue(),
     mood: clampScore(source.mood),
+    alignment: clampScore(source.alignment),
     today: String(source.today || '').trim(),
+    avoidance: String(source.avoidance || '').trim(),
+    trueTask: String(source.trueTask || '').trim(),
     tomorrow: String(source.tomorrow || '').trim(),
+    vision: String(source.vision || '').trim(),
     weeklyReflection: String(source.weeklyReflection || source.reflection || '').trim(),
     categories,
     author: String(source.author || '').trim()
@@ -179,7 +187,7 @@ function normalizeEntry(entry, fallbackId = makeId()) {
 }
 
 function summarizeEntry(entry) {
-  return entry.today || entry.tomorrow || entry.weeklyReflection || 'No written note yet.';
+  return entry.trueTask || entry.today || entry.tomorrow || entry.weeklyReflection || 'No written note yet.';
 }
 
 function average(values) {
@@ -242,15 +250,19 @@ function getFormDraft() {
   return {
     date: readValue('lifeDate'),
     mood: clampScore(readValue('moodScore')),
+    alignment: clampScore(readValue('alignmentScore')),
     today: readValue('todayText').trim(),
+    avoidance: readValue('avoidanceText').trim(),
+    trueTask: readValue('trueTaskText').trim(),
     tomorrow: readValue('tomorrowText').trim(),
+    vision: readValue('visionText').trim(),
     weeklyReflection: readValue('weeklyText').trim(),
     categories: {
       mind: clampScore(readValue('mindScore')),
       body: clampScore(readValue('bodyScore')),
       money: clampScore(readValue('moneyScore')),
       relationships: clampScore(readValue('relationshipsScore')),
-      projects: clampScore(readValue('projectsScore'))
+      mission: clampScore(readValue('missionScore'))
     }
   };
 }
@@ -259,12 +271,19 @@ function applyDraft(draft) {
   const source = draft && typeof draft === 'object' ? draft : {};
   setValue('lifeDate', source.date || toDateInputValue());
   setValue('moodScore', clampScore(source.mood || 7));
+  setValue('alignmentScore', clampScore(source.alignment || 7));
   setValue('todayText', source.today || '');
+  setValue('avoidanceText', source.avoidance || '');
+  setValue('trueTaskText', source.trueTask || '');
   setValue('tomorrowText', source.tomorrow || '');
+  setValue('visionText', source.vision || '');
   setValue('weeklyText', source.weeklyReflection || '');
 
   for (const category of categoryDefs) {
-    const nextValue = source.categories && source.categories[category.key] ? source.categories[category.key] : 7;
+    const nextValue = source.categories && (
+      source.categories[category.key]
+      ?? (category.key === 'mission' ? source.categories.projects : undefined)
+    );
     setValue(`${category.key}Score`, clampScore(nextValue));
   }
 }
@@ -364,21 +383,40 @@ function renderEntryList(entries) {
 
   list.innerHTML = entries.map((entry) => `
     <li class="entry-item">
-      <strong>${toReadableDate(entry.date)} · Mood ${entry.mood}/10</strong>
+      <strong>${toReadableDate(entry.date)} · Mood ${entry.mood}/10 · Alignment ${entry.alignment}/10</strong>
       <div class="entry-meta">${categoryDefs.map((category) => `${category.label} ${entry.categories[category.key]}/10`).join(' · ')}</div>
+      <div class="entry-facts">
+        <span class="entry-fact">Mission ${entry.categories.mission}/10</span>
+        ${entry.trueTask ? `<span class="entry-fact">True task named</span>` : ''}
+        ${entry.avoidance ? `<span class="entry-fact">Avoidance logged</span>` : ''}
+      </div>
       <p class="entry-copy">${escapeHtml(summarizeEntry(entry))}</p>
+      ${(entry.avoidance || entry.trueTask) ? `
+        <div class="entry-stack">
+          ${entry.trueTask ? `<div class="entry-block"><strong>One true task</strong><p class="entry-copy">${escapeHtml(entry.trueTask)}</p></div>` : ''}
+          ${entry.avoidance ? `<div class="entry-block"><strong>Avoidance</strong><p class="entry-copy">${escapeHtml(entry.avoidance)}</p></div>` : ''}
+        </div>
+      ` : ''}
     </li>
   `).join('');
 }
 
 function renderSummary(entries) {
   const averageMood = document.getElementById('averageMood');
+  const averageAlignment = document.getElementById('averageAlignment');
   const trendLabel = document.getElementById('trendLabel');
   const streakValue = document.getElementById('streakValue');
   const latestReflection = document.getElementById('latestReflection');
+  const currentVision = document.getElementById('currentVision');
 
   if (averageMood) {
     averageMood.textContent = entries.length ? `${average(entries.map((entry) => entry.mood)).toFixed(1)} / 10` : '--';
+  }
+
+  if (averageAlignment) {
+    averageAlignment.textContent = entries.length
+      ? `${average(entries.map((entry) => entry.alignment)).toFixed(1)} / 10`
+      : '--';
   }
 
   if (trendLabel) {
@@ -393,6 +431,13 @@ function renderSummary(entries) {
   if (latestReflection) {
     const weekly = entries.find((entry) => entry.weeklyReflection);
     latestReflection.textContent = weekly ? weekly.weeklyReflection : 'No reflections yet. Save one when you want to review the week.';
+  }
+
+  if (currentVision) {
+    const visionEntry = entries.find((entry) => entry.vision);
+    currentVision.textContent = visionEntry
+      ? visionEntry.vision
+      : 'No vision saved yet. Use the check-in form when you want to name what you are building.';
   }
 }
 
@@ -506,6 +551,8 @@ function initializeForm() {
       persistDraftFromForm();
     });
   }
+
+  updateSliderValue('alignmentScore', 'alignmentValue');
 
   for (const input of document.querySelectorAll('#lifeForm input, #lifeForm textarea')) {
     input.addEventListener('input', persistDraftFromForm);

--- a/life/index.html
+++ b/life/index.html
@@ -347,7 +347,7 @@
 
     .metric-grid {
       display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 12px;
     }
 
@@ -427,6 +427,44 @@
       margin-bottom: 8px;
     }
 
+    .entry-facts {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 10px;
+    }
+
+    .entry-fact {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 8px;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid rgba(255,255,255,0.06);
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+
+    .entry-stack {
+      display: grid;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .entry-block {
+      padding: 10px 12px;
+      border-radius: 14px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.05);
+    }
+
+    .entry-block strong {
+      margin-bottom: 4px;
+      font-size: 0.82rem;
+      letter-spacing: 0.02em;
+      color: var(--blue);
+    }
+
     .entry-copy {
       color: var(--text);
       line-height: 1.55;
@@ -485,7 +523,7 @@
     <header class="topbar">
       <div class="topbar__brand">
         <strong>Life</strong>
-        <span>Find your passions and organize your life with a free starter flow.</span>
+        <span>Clarity, alignment, and one real next move inside the portal.</span>
       </div>
       <nav class="topbar__links" aria-label="Life navigation">
         <a href="../index.html">Home</a>
@@ -498,10 +536,10 @@
 
     <section class="hero">
       <span class="eyebrow">Life OS</span>
-      <h1>See your life clearly, then move it forward.</h1>
+      <h1>Clarity first. Then action.</h1>
       <p class="lead">
-        Life is the simple check-in loop for 3dvr. Track how you feel, what happened today, what matters tomorrow, and how the big parts of life are moving.
-        The data stays inside the portal on Gun so it can sync across browsers and pair with your other apps.
+        Life OS is the builder-facing check-in loop for 3dvr. Track mood, alignment, avoidance, mission, and the one task that would actually move life forward.
+        The data stays inside the portal on Gun so it can sync across browsers and still fit the rest of your operating system.
       </p>
       <div class="hero-actions">
         <a class="button button--primary" href="#checkin">Start a check-in</a>
@@ -510,16 +548,16 @@
       </div>
       <div class="hero-stats" aria-label="Life overview">
         <div class="stat">
-          <span>Daily focus</span>
-          <strong>1 check-in</strong>
+          <span>Daily reset</span>
+          <strong>Clarity + action</strong>
         </div>
         <div class="stat">
-          <span>Weekly rhythm</span>
-          <strong>1 reflection</strong>
+          <span>Inner signal</span>
+          <strong>Mood + alignment</strong>
         </div>
         <div class="stat">
-          <span>Life areas</span>
-          <strong>5 simple categories</strong>
+          <span>Builder scope</span>
+          <strong>Mission in the loop</strong>
         </div>
       </div>
     </section>
@@ -528,9 +566,9 @@
       <article class="card" id="checkin">
         <div class="card__body">
           <span class="eyebrow">Daily check-in</span>
-          <h2 class="section-title" id="lifeTitle">What changed today?</h2>
+          <h2 class="section-title" id="lifeTitle">What is true today?</h2>
           <p class="section-copy">
-            Keep this lightweight. You can add one note a day, or come back later for a fuller weekly reflection.
+            Keep this lightweight and honest. Name the signal, name the avoidance, and pick the one task that actually matters.
           </p>
 
           <form id="lifeForm" class="form-grid">
@@ -546,14 +584,35 @@
               </label>
             </div>
 
+            <label for="alignmentScore">
+              Alignment
+              <output id="alignmentValue" for="alignmentScore">7</output>
+              <input id="alignmentScore" name="alignmentScore" type="range" min="1" max="10" step="1" value="7" />
+            </label>
+
             <label for="todayText">
               What happened today?
               <textarea id="todayText" name="todayText" placeholder="A short summary of the day."></textarea>
             </label>
 
+            <label for="avoidanceText">
+              What am I avoiding?
+              <textarea id="avoidanceText" name="avoidanceText" placeholder="The thing I keep circling around instead of facing."></textarea>
+            </label>
+
+            <label for="trueTaskText">
+              One true task
+              <input id="trueTaskText" name="trueTaskText" type="text" placeholder="The one thing that would actually move life forward." />
+            </label>
+
             <label for="tomorrowText">
               What matters tomorrow?
               <textarea id="tomorrowText" name="tomorrowText" placeholder="The one thing to protect next."></textarea>
+            </label>
+
+            <label for="visionText">
+              Who am I becoming / what am I building?
+              <textarea id="visionText" name="visionText" placeholder="The direction, life, or system I am trying to build on purpose."></textarea>
             </label>
 
             <div class="category-grid" aria-label="Life categories">
@@ -574,8 +633,8 @@
                 <input id="relationshipsScore" name="relationshipsScore" type="range" min="1" max="10" step="1" value="7" />
               </div>
               <div class="category-card">
-                <div class="category-head"><span>Projects</span><output id="projectsValue" for="projectsScore">7</output></div>
-                <input id="projectsScore" name="projectsScore" type="range" min="1" max="10" step="1" value="7" />
+                <div class="category-head"><span>Mission</span><output id="missionValue" for="missionScore">7</output></div>
+                <input id="missionScore" name="missionScore" type="range" min="1" max="10" step="1" value="7" />
               </div>
             </div>
 
@@ -603,6 +662,10 @@
                 <strong id="averageMood">--</strong>
               </div>
               <div class="metric">
+                <span>Average alignment</span>
+                <strong id="averageAlignment">--</strong>
+              </div>
+              <div class="metric">
                 <span>7-day trend</span>
                 <strong id="trendLabel">--</strong>
               </div>
@@ -619,6 +682,14 @@
             <span class="eyebrow">Category balance</span>
             <h3 class="section-title">How the big areas are moving</h3>
             <div class="bars" id="categoryBars" aria-live="polite"></div>
+          </div>
+        </section>
+
+        <section class="card">
+          <div class="card__body">
+            <span class="eyebrow">Vision</span>
+            <h3 class="section-title">Current vision</h3>
+            <p class="section-copy" id="currentVision">No vision saved yet. Use the check-in form when you want to name what you are building.</p>
           </div>
         </section>
 

--- a/tests/life.test.js
+++ b/tests/life.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 describe('life app', () => {
-  it('ships the Life portal app with Gun-backed check-ins and the new free-plan framing', async () => {
+  it('ships the Life portal app with Gun-backed Life OS check-ins and the new free-plan framing', async () => {
     const lifeHtml = await readFile(new URL('../life/index.html', import.meta.url), 'utf8');
     const lifeJs = await readFile(new URL('../life/app.js', import.meta.url), 'utf8');
     const portalIndex = await readFile(new URL('../index.html', import.meta.url), 'utf8');
@@ -11,9 +11,17 @@ describe('life app', () => {
     const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
 
     assert.match(lifeHtml, /Life \| 3dvr Portal/);
-    assert.match(lifeHtml, /Find your passions and organize your life/);
+    assert.match(lifeHtml, /Clarity first\. Then action\./);
+    assert.match(lifeHtml, /Track mood, alignment, avoidance, mission, and the one task/);
     assert.match(lifeHtml, /id="lifeForm"/);
+    assert.match(lifeHtml, /id="alignmentScore"/);
+    assert.match(lifeHtml, /id="avoidanceText"/);
+    assert.match(lifeHtml, /id="trueTaskText"/);
+    assert.match(lifeHtml, /id="visionText"/);
     assert.match(lifeHtml, /id="weeklyText"/);
+    assert.match(lifeHtml, /Current vision/);
+    assert.match(lifeHtml, /Average alignment/);
+    assert.match(lifeHtml, /Mission/);
     assert.match(lifeHtml, /Open Cell/);
     assert.match(lifeHtml, /Open CRM/);
     assert.match(lifeHtml, /Stored under <code>3dvr-portal\/life<\/code> in Gun/);
@@ -21,6 +29,12 @@ describe('life app', () => {
     assert.match(lifeJs, /3dvr-portal\/life\/entries/);
     assert.match(lifeJs, /ensureGuestIdentity/);
     assert.match(lifeJs, /portal-life-checkins/);
+    assert.match(lifeJs, /alignment/);
+    assert.match(lifeJs, /avoidance/);
+    assert.match(lifeJs, /trueTask/);
+    assert.match(lifeJs, /vision/);
+    assert.match(lifeJs, /mission/);
+    assert.match(lifeJs, /source\.categories\.projects/);
     assert.match(lifeJs, /Saved to Life and queued for Gun sync/);
 
     assert.match(portalIndex, /<span class="app-card__title">Life<\/span>/);


### PR DESCRIPTION
## Summary
- tighten the Life page copy around clarity, alignment, mission, and action while preserving the current portal layout
- add new daily fields for alignment, avoidance, one true task, and current vision
- rename Projects to Mission, extend dashboard summaries, and keep older entries compatible

## Testing
- node --test tests/life.test.js