### PR TITLE
[codex] Make portal launcher feel like a command center

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -398,6 +398,7 @@ body.landing {
   margin-top: 0.2rem;
 }
 
+.system-strip,
 .plan-strip {
   display: grid;
   gap: 0.6rem;
@@ -410,6 +411,7 @@ body.landing {
   margin-top: 0.15rem;
 }
 
+.system-strip__label,
 .workspace-strip__label {
   font-size: 0.76rem;
   font-weight: 700;
@@ -418,12 +420,14 @@ body.landing {
   color: rgba(226, 232, 240, 0.72);
 }
 
+.system-ribbon,
 .workspace-ribbon {
   display: grid;
   gap: 0.65rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.system-pill,
 .workspace-pill {
   display: grid;
   gap: 0.28rem;
@@ -443,6 +447,7 @@ body.landing {
     box-shadow var(--transition-base);
 }
 
+.system-pill:hover,
 .workspace-pill:hover {
   transform: translateY(-2px);
   border-color: rgba(56, 189, 248, 0.52);
@@ -452,11 +457,13 @@ body.landing {
   box-shadow: 0 24px 52px rgba(4, 9, 20, 0.3);
 }
 
+.system-pill strong,
 .workspace-pill strong {
   font-size: 0.98rem;
   color: rgba(226, 232, 240, 0.98);
 }
 
+.system-pill span,
 .workspace-pill span {
   font-size: 0.82rem;
   line-height: 1.45;
@@ -616,6 +623,64 @@ body.landing {
 .app-search__empty {
   margin: 0.75rem 0 0;
   font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.launcher-lanes {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 1.4rem;
+}
+
+.launcher-lane {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem 1.05rem;
+  border-radius: 1.15rem;
+  text-decoration: none;
+  color: var(--color-text);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  background:
+    linear-gradient(155deg, rgba(10, 17, 34, 0.68), rgba(15, 23, 42, 0.58)),
+    rgba(15, 23, 42, 0.42);
+  box-shadow: 0 18px 44px rgba(4, 9, 20, 0.28);
+  transition: transform var(--transition-base),
+    border-color var(--transition-base),
+    background var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.launcher-lane:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.42);
+  background:
+    linear-gradient(155deg, rgba(8, 15, 31, 0.82), rgba(15, 23, 42, 0.72)),
+    rgba(15, 23, 42, 0.56);
+  box-shadow: 0 24px 52px rgba(4, 9, 20, 0.34);
+}
+
+.launcher-lane__eyebrow {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.launcher-lane strong {
+  font-size: 1rem;
+}
+
+.launcher-lane span:last-child {
+  font-size: 0.88rem;
+  line-height: 1.5;
   color: var(--color-text-muted);
 }
 

--- a/index.html
+++ b/index.html
@@ -51,6 +51,8 @@
         <a href="https://3dvr.tech">Home</a>
         <a href="start/">Start</a>
         <a href="start/#paid-lanes">Plans</a>
+        <a href="#systemLayers">System</a>
+        <a href="#app-hub-title">Apps</a>
         <a href="share.html">Share</a>
         <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">GitHub</a>
       </nav>
@@ -65,13 +67,33 @@
         </div>
         <div class="hero-panel">
           <div class="hero-main">
-            <span class="hero-eyebrow">Portal workspace</span>
-            <h1 id="landing-title">Get in, get moving.</h1>
-            <p class="hero-tagline">Pick one lane and keep the rest out of the way.</p>
+            <span class="hero-eyebrow">Portal. Browser. OS.</span>
+            <h1 id="landing-title">One system. Any device.</h1>
+            <p class="hero-tagline">
+              Start in your browser. Grow into your own operating system. Keep the same identity,
+              apps, subscriptions, and support lane as the control gets deeper.
+            </p>
             <div class="hero-actions">
               <a href="crm/index.html" class="cta primary">Open CRM</a>
               <a href="sales/index.html" class="cta ghost">Open Sales</a>
               <a href="web-builder-app/index.html" class="cta ghost">Open Web Builder</a>
+            </div>
+            <div class="system-strip" id="systemLayers" aria-label="3dvr system layers">
+              <span class="system-strip__label">System layers</span>
+              <div class="system-ribbon">
+                <a class="system-pill" href="notes/">
+                  <strong>Portal</strong>
+                  <span>Cloud workspace for identity, notes, CRM, billing, messaging, and AI.</span>
+                </a>
+                <a class="system-pill" href="home/">
+                  <strong>Browser</strong>
+                  <span>Launcher, multi-panel workspace, media tools, and in-browser runtime experiments.</span>
+                </a>
+                <a class="system-pill" href="pocket-workstation/index.html">
+                  <strong>OS</strong>
+                  <span>Pocket Workstation, Debian tools, and TommyOS direction for deeper device control.</span>
+                </a>
+              </div>
             </div>
             <div class="workspace-strip" aria-label="Core workspaces">
               <span class="workspace-strip__label">Core workspaces</span>
@@ -149,9 +171,9 @@
       <section class="app-hub" aria-labelledby="app-hub-title">
         <div class="app-hub__header">
           <div class="app-hub__intro">
-            <span class="eyebrow">Launchpad</span>
+            <span class="eyebrow">Command center</span>
             <h2 id="app-hub-title">App dock</h2>
-            <p>Need something else? Search or scroll the full toolset.</p>
+            <p>Same account, same apps, deeper levels of control. Search the dock or jump into the lane you need.</p>
           </div>
           <div class="app-toolbar" aria-label="App list controls">
             <div
@@ -188,6 +210,24 @@
           </div>
         </div>
         <p id="appSearchEmpty" class="app-search__empty" role="status" aria-live="polite" hidden>No apps match your search yet.</p>
+        <div class="launcher-lanes" aria-label="Suggested launcher lanes">
+          <!-- Keep this map close to the dock so future app layers can expand without changing the overall launcher structure. -->
+          <a href="crm/index.html" class="launcher-lane">
+            <span class="launcher-lane__eyebrow">Portal lane</span>
+            <strong>Run the business workspace</strong>
+            <span>CRM, Contacts, Billing, Calendar, Finance, and Notes on one account.</span>
+          </a>
+          <a href="home/" class="launcher-lane">
+            <span class="launcher-lane__eyebrow">Browser lane</span>
+            <strong>Open the workspace runtime</strong>
+            <span>Home, OpenAI Workbench, Debian Browser Lab, and media experiments live here.</span>
+          </a>
+          <a href="pocket-workstation/index.html" class="launcher-lane">
+            <span class="launcher-lane__eyebrow">OS lane</span>
+            <strong>Move toward device control</strong>
+            <span>Pocket Workstation, Personal Debian Server, Local Models, and Mini DaedalOS point deeper.</span>
+          </a>
+        </div>
         <div class="app-grid" data-app-list>
           <a href="start/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🧭</span>

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -5,11 +5,19 @@ import { readFile } from 'node:fs/promises';
 describe('portal customer journey pages', () => {
   it('gives the portal home a clear concrete entry path', async () => {
     const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
-    assert.match(html, /Get in, get moving\./);
-    assert.match(html, /Pick one lane and keep the rest out of the way\./);
+    assert.match(html, /One system\. Any device\./);
+    assert.match(html, /Start in your browser\. Grow into your own operating system\./);
+    assert.match(html, /same identity,/i);
     assert.match(html, /Open CRM/);
     assert.match(html, /Open Sales/);
     assert.match(html, /Open Web Builder/);
+    assert.match(html, /System layers/);
+    assert.match(html, /Portal/);
+    assert.match(html, /Browser/);
+    assert.match(html, /OS/);
+    assert.match(html, /Cloud workspace for identity, notes, CRM, billing, messaging, and AI\./);
+    assert.match(html, /Launcher, multi-panel workspace, media tools, and in-browser runtime experiments\./);
+    assert.match(html, /TommyOS direction for deeper device control\./);
     assert.match(html, /Core workspaces/);
     assert.match(html, /Contacts/);
     assert.match(html, /Messenger/);
@@ -34,6 +42,12 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Start Here: tools and paid help for a project, offer, or business\./);
     assert.match(html, /Search the dock/);
     assert.match(html, /App dock/);
+    assert.match(html, /Command center/);
+    assert.match(html, /Same account, same apps, deeper levels of control\./);
+    assert.match(html, /Suggested launcher lanes/);
+    assert.match(html, /Run the business workspace/);
+    assert.match(html, /Open the workspace runtime/);
+    assert.match(html, /Move toward device control/);
     assert.match(html, /data-app-list/);
     assert.match(html, /shortcut-grid/);
     assert.doesNotMatch(html, /https:\/\/3dvr\.tech\/subscribe\/free-plan\.html/);


### PR DESCRIPTION
## What changed
- rewrote the portal hero to position the product as `Portal. Browser. OS.` and `One system. Any device.`
- added a `System layers` rail tied to real destinations already in the portal
- added launcher-lane cards ahead of the dock so the portal reads as a command center instead of a flat app list
- preserved the current launcher, dark style, and app-grid architecture

## Why
The portal already behaves like the center of the product, but the UI was not saying that clearly enough. This change makes the launcher support the Portal -> Browser -> OS vision without rebuilding the shell.

## Impact
- portal users see how the current apps map to cloud workspace, browser runtime, and deeper device-control directions
- the launcher feels more OS-like while staying within the current maintainable structure
- the shared story now matches the main 3dvr homepage

## Validation
- `node --test tests/customer-journey-pages.test.js`

## Paired web change
- tmsteph/3dvr-web branch: `feature/homepage-direct-portal-billing`
