### PR TITLE
[codex] Add GitHub issue launcher across portal pages

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -34,5 +34,6 @@
   <script>
     window.location.replace('admin/');
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -2027,5 +2027,6 @@
 
   window.addEventListener('load', init);
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/auth/index.html
+++ b/auth/index.html
@@ -85,5 +85,6 @@
       <a href="/password-reset.html">Account Recovery</a>
     </div>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/auth/recovery.html
+++ b/auth/recovery.html
@@ -13,5 +13,6 @@
   <script>
     window.location.replace('/password-reset.html');
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/auth/sign-in.html
+++ b/auth/sign-in.html
@@ -13,5 +13,6 @@
   <script>
     window.location.replace('/sign-in.html');
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/billing/index.html
+++ b/billing/index.html
@@ -284,5 +284,6 @@
   </main>
 
   <script type="module" src="./app.js?v=20260408-customer-journey"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -445,5 +445,6 @@
   <script src="./gun-init.js"></script>
   <script src="./oauth.js"></script>
   <script src="./calendar.js" type="module"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/cell/index.html
+++ b/cell/index.html
@@ -853,5 +853,6 @@
 
     updatePreview();
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/chat.html
+++ b/chat.html
@@ -13,5 +13,6 @@
 </head>
 <body>
   <p>Redirecting to <a href="/chat/">3DVR Chat</a>…</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/chat/index.html
+++ b/chat/index.html
@@ -1258,5 +1258,6 @@ function maybeNotifyNewMessage(message, id) {
 initNotifications();
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/chatbot.html
+++ b/chatbot.html
@@ -51,5 +51,6 @@
     <p>The Codex &amp; GPT workbench now lives in its own app directory.</p>
     <p><a href="openai-app/">Continue to the OpenAI Workbench</a></p>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/cloud/index.html
+++ b/cloud/index.html
@@ -354,5 +354,6 @@
   <div>3DVR.tech · Decentralized Cloud · local-first by default</div>
 </footer>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/compat.html
+++ b/compat.html
@@ -105,5 +105,6 @@
 
   run().catch(err => out('UNCAUGHT', err?.message || err));
 </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/contacts/index.html
+++ b/contacts/index.html
@@ -3820,5 +3820,6 @@ consumePendingOauthImportResult();
 let firstRenderTimer = setTimeout(updateList, 200);
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/crm/index.html
+++ b/crm/index.html
@@ -482,5 +482,6 @@
       </div>
     </div>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/debian-browser/index.html
+++ b/debian-browser/index.html
@@ -331,5 +331,6 @@
         frame.appendChild(iframe);
       });
     </script>
-  </body>
+    <script defer src="/issue-launcher.js"></script>
+</body>
 </html>

--- a/deployment-guides/create-repo.html
+++ b/deployment-guides/create-repo.html
@@ -253,5 +253,6 @@
 
     form.addEventListener('submit', createRepository);
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/deployment-guides/dev-alias.html
+++ b/deployment-guides/dev-alias.html
@@ -51,5 +51,6 @@
       <a href="/openai-app/index.html" target="_blank" rel="noopener">OpenAI Workbench</a>
     </div>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/deployment-guides/github-token.html
+++ b/deployment-guides/github-token.html
@@ -79,5 +79,6 @@
       <a href="/openai-app/index.html" target="_blank" rel="noopener">OpenAI Workbench</a>
     </div>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/deployment-guides/index.html
+++ b/deployment-guides/index.html
@@ -59,5 +59,6 @@
       <a href="/openai-app/index.html" target="_blank" rel="noopener">OpenAI Workbench</a>
     </div>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/deployment-guides/secrets-and-workflow.html
+++ b/deployment-guides/secrets-and-workflow.html
@@ -54,5 +54,6 @@
       <a href="/openai-app/index.html" target="_blank" rel="noopener">OpenAI Workbench</a>
     </div>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/deployment-guides/self-hosted/index.html
+++ b/deployment-guides/self-hosted/index.html
@@ -76,5 +76,6 @@
       <a href="/index.html">Return to Portal</a>
     </div>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/deployment-guides/vercel-token.html
+++ b/deployment-guides/vercel-token.html
@@ -61,5 +61,6 @@
       <a href="/openai-app/index.html" target="_blank" rel="noopener">OpenAI Workbench</a>
     </div>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/education.html
+++ b/education.html
@@ -171,5 +171,6 @@ function addLesson() {
 }
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/email-operator/index.html
+++ b/email-operator/index.html
@@ -259,5 +259,6 @@
   </main>
 
   <script src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/field-simulation/index.html
+++ b/field-simulation/index.html
@@ -94,5 +94,6 @@
     }
     loop();
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/finance/ethereum.html
+++ b/finance/ethereum.html
@@ -84,5 +84,6 @@
   </main>
 
   <script type="module" src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/finance/incoming.html
+++ b/finance/incoming.html
@@ -91,5 +91,6 @@
   </main>
 
   <script type="module" src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/finance/index.html
+++ b/finance/index.html
@@ -198,5 +198,6 @@
   </main>
 
   <script type="module" src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/finance/outgoing.html
+++ b/finance/outgoing.html
@@ -139,5 +139,6 @@
   </main>
 
   <script type="module" src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/finance/stripe.html
+++ b/finance/stripe.html
@@ -135,5 +135,6 @@
   </main>
 
   <script type="module" src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/free-trial.html
+++ b/free-trial.html
@@ -378,5 +378,6 @@
       }
     });
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/games.html
+++ b/games.html
@@ -72,5 +72,6 @@ h1 {
   <a class="game-card" href="jetpack/">Jetpack Corridor (Arrows/WASD + Jetpack)</a>
 </div>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/gun-demo.html
+++ b/gun-demo.html
@@ -200,5 +200,6 @@
   </main>
 
   <script type="module" src="/src/gun/example-usage.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/gun-explorer.html
+++ b/gun-explorer.html
@@ -12,5 +12,6 @@
 <body>
   <p>Redirecting to the <a href="/gun-explorer/">GunJS Explorer app</a>…</p>
   <script>window.location.replace('/gun-explorer/');</script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/gun-explorer/index.html
+++ b/gun-explorer/index.html
@@ -83,5 +83,6 @@
   </main>
 
   <script type="module" src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/home/index.html
+++ b/home/index.html
@@ -98,5 +98,6 @@
       </div>
     </div>
     <script src="/home/script.js"></script>
-  </body>
+    <script defer src="/issue-launcher.js"></script>
+</body>
 </html>

--- a/ideas/ai-leverage.html
+++ b/ideas/ai-leverage.html
@@ -83,5 +83,6 @@
       Submissions sync to the 3DVR Gun relay so we can share experiments with the right audience.
     </footer>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/ideas/freedom-from-work.html
+++ b/ideas/freedom-from-work.html
@@ -82,5 +82,6 @@
       Submissions sync to the 3DVR Gun relay so the team can listen and respond with care.
     </footer>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/ideas/index.html
+++ b/ideas/index.html
@@ -120,5 +120,6 @@
   </main>
   <footer class="footer">3DVR.Tech – Ideas Lab (experimental)</footer>
   <script src="ideas.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/ideas/support.html
+++ b/ideas/support.html
@@ -37,5 +37,6 @@
   </main>
   <footer class="footer">3DVR.Tech – Ideas Lab (experimental)</footer>
   <script src="ideas.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/ideas/systems.html
+++ b/ideas/systems.html
@@ -37,5 +37,6 @@
   </main>
   <footer class="footer">3DVR.Tech – Ideas Lab (experimental)</footer>
   <script src="ideas.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/ideas/websites.html
+++ b/ideas/websites.html
@@ -37,5 +37,6 @@
   </main>
   <footer class="footer">3DVR.Tech – Ideas Lab (experimental)</footer>
   <script src="ideas.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/index-style.css
+++ b/index-style.css
@@ -398,6 +398,7 @@ body.landing {
   margin-top: 0.2rem;
 }
 
+.system-strip,
 .plan-strip {
   display: grid;
   gap: 0.6rem;
@@ -410,6 +411,7 @@ body.landing {
   margin-top: 0.15rem;
 }
 
+.system-strip__label,
 .workspace-strip__label {
   font-size: 0.76rem;
   font-weight: 700;
@@ -418,12 +420,14 @@ body.landing {
   color: rgba(226, 232, 240, 0.72);
 }
 
+.system-ribbon,
 .workspace-ribbon {
   display: grid;
   gap: 0.65rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.system-pill,
 .workspace-pill {
   display: grid;
   gap: 0.28rem;
@@ -443,6 +447,7 @@ body.landing {
     box-shadow var(--transition-base);
 }
 
+.system-pill:hover,
 .workspace-pill:hover {
   transform: translateY(-2px);
   border-color: rgba(56, 189, 248, 0.52);
@@ -452,11 +457,13 @@ body.landing {
   box-shadow: 0 24px 52px rgba(4, 9, 20, 0.3);
 }
 
+.system-pill strong,
 .workspace-pill strong {
   font-size: 0.98rem;
   color: rgba(226, 232, 240, 0.98);
 }
 
+.system-pill span,
 .workspace-pill span {
   font-size: 0.82rem;
   line-height: 1.45;
@@ -616,6 +623,64 @@ body.landing {
 .app-search__empty {
   margin: 0.75rem 0 0;
   font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.launcher-lanes {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 1.4rem;
+}
+
+.launcher-lane {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem 1.05rem;
+  border-radius: 1.15rem;
+  text-decoration: none;
+  color: var(--color-text);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  background:
+    linear-gradient(155deg, rgba(10, 17, 34, 0.68), rgba(15, 23, 42, 0.58)),
+    rgba(15, 23, 42, 0.42);
+  box-shadow: 0 18px 44px rgba(4, 9, 20, 0.28);
+  transition: transform var(--transition-base),
+    border-color var(--transition-base),
+    background var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.launcher-lane:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.42);
+  background:
+    linear-gradient(155deg, rgba(8, 15, 31, 0.82), rgba(15, 23, 42, 0.72)),
+    rgba(15, 23, 42, 0.56);
+  box-shadow: 0 24px 52px rgba(4, 9, 20, 0.34);
+}
+
+.launcher-lane__eyebrow {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.launcher-lane strong {
+  font-size: 1rem;
+}
+
+.launcher-lane span:last-child {
+  font-size: 0.88rem;
+  line-height: 1.5;
   color: var(--color-text-muted);
 }
 

--- a/index.html
+++ b/index.html
@@ -51,6 +51,8 @@
         <a href="https://3dvr.tech">Home</a>
         <a href="start/">Start</a>
         <a href="start/#paid-lanes">Plans</a>
+        <a href="#systemLayers">System</a>
+        <a href="#app-hub-title">Apps</a>
         <a href="share.html">Share</a>
         <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">GitHub</a>
       </nav>
@@ -65,13 +67,33 @@
         </div>
         <div class="hero-panel">
           <div class="hero-main">
-            <span class="hero-eyebrow">Portal workspace</span>
-            <h1 id="landing-title">Get in, get moving.</h1>
-            <p class="hero-tagline">Pick one lane and keep the rest out of the way.</p>
+            <span class="hero-eyebrow">Portal. Browser. OS.</span>
+            <h1 id="landing-title">One system. Any device.</h1>
+            <p class="hero-tagline">
+              Start in your browser. Grow into your own operating system. Keep the same identity,
+              apps, subscriptions, and support lane as the control gets deeper.
+            </p>
             <div class="hero-actions">
               <a href="crm/index.html" class="cta primary">Open CRM</a>
               <a href="sales/index.html" class="cta ghost">Open Sales</a>
               <a href="web-builder-app/index.html" class="cta ghost">Open Web Builder</a>
+            </div>
+            <div class="system-strip" id="systemLayers" aria-label="3dvr system layers">
+              <span class="system-strip__label">System layers</span>
+              <div class="system-ribbon">
+                <a class="system-pill" href="notes/">
+                  <strong>Portal</strong>
+                  <span>Cloud workspace for identity, notes, CRM, billing, messaging, and AI.</span>
+                </a>
+                <a class="system-pill" href="home/">
+                  <strong>Browser</strong>
+                  <span>Launcher, multi-panel workspace, media tools, and in-browser runtime experiments.</span>
+                </a>
+                <a class="system-pill" href="pocket-workstation/index.html">
+                  <strong>OS</strong>
+                  <span>Pocket Workstation, Debian tools, and TommyOS direction for deeper device control.</span>
+                </a>
+              </div>
             </div>
             <div class="workspace-strip" aria-label="Core workspaces">
               <span class="workspace-strip__label">Core workspaces</span>
@@ -149,9 +171,9 @@
       <section class="app-hub" aria-labelledby="app-hub-title">
         <div class="app-hub__header">
           <div class="app-hub__intro">
-            <span class="eyebrow">Launchpad</span>
+            <span class="eyebrow">Command center</span>
             <h2 id="app-hub-title">App dock</h2>
-            <p>Need something else? Search or scroll the full toolset.</p>
+            <p>Same account, same apps, deeper levels of control. Search the dock or jump into the lane you need.</p>
           </div>
           <div class="app-toolbar" aria-label="App list controls">
             <div
@@ -188,6 +210,24 @@
           </div>
         </div>
         <p id="appSearchEmpty" class="app-search__empty" role="status" aria-live="polite" hidden>No apps match your search yet.</p>
+        <div class="launcher-lanes" aria-label="Suggested launcher lanes">
+          <!-- Keep this map close to the dock so future app layers can expand without changing the overall launcher structure. -->
+          <a href="crm/index.html" class="launcher-lane">
+            <span class="launcher-lane__eyebrow">Portal lane</span>
+            <strong>Run the business workspace</strong>
+            <span>CRM, Contacts, Billing, Calendar, Finance, and Notes on one account.</span>
+          </a>
+          <a href="home/" class="launcher-lane">
+            <span class="launcher-lane__eyebrow">Browser lane</span>
+            <strong>Open the workspace runtime</strong>
+            <span>Home, OpenAI Workbench, Debian Browser Lab, and media experiments live here.</span>
+          </a>
+          <a href="pocket-workstation/index.html" class="launcher-lane">
+            <span class="launcher-lane__eyebrow">OS lane</span>
+            <strong>Move toward device control</strong>
+            <span>Pocket Workstation, Personal Debian Server, Local Models, and Mini DaedalOS point deeper.</span>
+          </a>
+        </div>
         <div class="app-grid" data-app-list>
           <a href="start/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🧭</span>

--- a/index.html
+++ b/index.html
@@ -1266,5 +1266,6 @@
     const initialSearchValue = searchInput?.value ?? '';
     updateAppFilter(initialSearchValue);
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/issue-launcher.js
+++ b/issue-launcher.js
@@ -1,0 +1,369 @@
+(() => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (document.querySelector('[data-issue-launcher-root]')) return;
+
+  const REPO_OWNER = 'tmsteph';
+  const REPO_NAME = '3dvr-portal';
+  const ISSUE_BASE_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}/issues/new`;
+  const ISSUE_TYPES = [
+    { value: 'bug', label: 'Bug report' },
+    { value: 'idea', label: 'Feature idea' },
+    { value: 'copy', label: 'Copy or UX note' }
+  ];
+
+  const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+  const currentUrl = window.location.href;
+  const currentPath = window.location.pathname + window.location.search + window.location.hash;
+  const currentTitle = document.title || currentPath || 'Portal page';
+
+  const encode = (value) => encodeURIComponent(value).replace(/%20/g, '+');
+
+  const buildIssueUrl = ({ issueType, title, summary, expected }) => {
+    const bodyLines = [
+      `Issue type: ${issueType}`,
+      '',
+      'Page context',
+      `- Title: ${currentTitle}`,
+      `- Path: ${currentPath}`,
+      `- URL: ${currentUrl}`,
+      '',
+      'What happened',
+      summary || 'Please describe the issue or request.',
+      '',
+      'Expected result',
+      expected || 'Please describe what should happen instead.',
+      '',
+      'Portal note',
+      'Created from the in-portal GitHub issue launcher.'
+    ];
+
+    return `${ISSUE_BASE_URL}?title=${encode(title)}&body=${encode(bodyLines.join('\n'))}`;
+  };
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .portal-issue-launcher {
+      position: fixed;
+      right: max(1rem, env(safe-area-inset-right));
+      bottom: max(1rem, env(safe-area-inset-bottom));
+      z-index: 1200;
+      display: grid;
+      gap: 0.75rem;
+      justify-items: end;
+      pointer-events: none;
+    }
+
+    .portal-issue-launcher__button,
+    .portal-issue-launcher__panel {
+      pointer-events: auto;
+    }
+
+    .portal-issue-launcher__button {
+      border: 1px solid rgba(56, 189, 248, 0.35);
+      border-radius: 999px;
+      padding: 0.8rem 1.1rem;
+      background: rgba(15, 23, 42, 0.92);
+      color: #e2e8f0;
+      box-shadow: 0 18px 48px rgba(2, 6, 23, 0.45);
+      font: inherit;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+      backdrop-filter: blur(14px);
+    }
+
+    .portal-issue-launcher__button:hover,
+    .portal-issue-launcher__button:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(56, 189, 248, 0.58);
+      box-shadow: 0 24px 56px rgba(2, 6, 23, 0.56);
+      outline: none;
+    }
+
+    .portal-issue-launcher__button-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.55rem;
+    }
+
+    .portal-issue-launcher__panel {
+      width: min(92vw, 380px);
+      padding: 1rem;
+      border-radius: 1rem;
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      background: rgba(15, 23, 42, 0.97);
+      color: #e2e8f0;
+      box-shadow: 0 30px 70px rgba(2, 6, 23, 0.62);
+      backdrop-filter: blur(18px);
+    }
+
+    .portal-issue-launcher__panel[hidden] {
+      display: none;
+    }
+
+    .portal-issue-launcher__header {
+      display: grid;
+      gap: 0.35rem;
+      margin-bottom: 0.9rem;
+    }
+
+    .portal-issue-launcher__eyebrow {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: #67e8f9;
+    }
+
+    .portal-issue-launcher__title {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .portal-issue-launcher__copy {
+      margin: 0;
+      font-size: 0.88rem;
+      line-height: 1.5;
+      color: #94a3b8;
+    }
+
+    .portal-issue-launcher__form {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .portal-issue-launcher__field {
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .portal-issue-launcher__field label {
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: #cbd5e1;
+    }
+
+    .portal-issue-launcher__field input,
+    .portal-issue-launcher__field select,
+    .portal-issue-launcher__field textarea {
+      width: 100%;
+      border-radius: 0.8rem;
+      border: 1px solid rgba(148, 163, 184, 0.24);
+      background: rgba(30, 41, 59, 0.92);
+      color: #f8fafc;
+      padding: 0.75rem 0.85rem;
+      font: inherit;
+      resize: vertical;
+      min-height: 2.8rem;
+    }
+
+    .portal-issue-launcher__field textarea {
+      min-height: 5.4rem;
+    }
+
+    .portal-issue-launcher__field input:focus,
+    .portal-issue-launcher__field select:focus,
+    .portal-issue-launcher__field textarea:focus {
+      outline: 2px solid rgba(56, 189, 248, 0.42);
+      outline-offset: 1px;
+      border-color: rgba(56, 189, 248, 0.5);
+    }
+
+    .portal-issue-launcher__hint {
+      margin: 0;
+      font-size: 0.74rem;
+      color: #94a3b8;
+      line-height: 1.45;
+    }
+
+    .portal-issue-launcher__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.65rem;
+      justify-content: flex-end;
+    }
+
+    .portal-issue-launcher__action {
+      border-radius: 999px;
+      padding: 0.72rem 1rem;
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+      border: 1px solid rgba(148, 163, 184, 0.24);
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+    }
+
+    .portal-issue-launcher__action:hover,
+    .portal-issue-launcher__action:focus-visible {
+      transform: translateY(-1px);
+      outline: none;
+    }
+
+    .portal-issue-launcher__action--ghost {
+      background: rgba(30, 41, 59, 0.92);
+      color: #e2e8f0;
+    }
+
+    .portal-issue-launcher__action--primary {
+      background: linear-gradient(135deg, #22d3ee, #38bdf8);
+      color: #04111d;
+      border-color: rgba(56, 189, 248, 0.5);
+    }
+
+    .portal-issue-launcher__status {
+      margin: 0;
+      min-height: 1.1rem;
+      font-size: 0.8rem;
+      color: #94a3b8;
+    }
+
+    @media (max-width: 640px) {
+      .portal-issue-launcher {
+        left: 1rem;
+        right: 1rem;
+        justify-items: stretch;
+      }
+
+      .portal-issue-launcher__button {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .portal-issue-launcher__panel {
+        width: 100%;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .portal-issue-launcher__button,
+      .portal-issue-launcher__action {
+        transition: none;
+      }
+    }
+  `;
+  document.head.appendChild(style);
+
+  const root = document.createElement('section');
+  root.className = 'portal-issue-launcher';
+  root.dataset.issueLauncherRoot = 'true';
+  root.setAttribute('aria-label', 'Portal GitHub issue launcher');
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'portal-issue-launcher__button';
+  button.setAttribute('aria-expanded', 'false');
+  button.setAttribute('aria-controls', 'portalIssueLauncherPanel');
+  button.innerHTML = '<span class="portal-issue-launcher__button-label">Report portal issue</span>';
+
+  const panel = document.createElement('div');
+  panel.id = 'portalIssueLauncherPanel';
+  panel.className = 'portal-issue-launcher__panel';
+  panel.hidden = true;
+  panel.innerHTML = `
+    <div class="portal-issue-launcher__header">
+      <span class="portal-issue-launcher__eyebrow">GitHub issue</span>
+      <h2 class="portal-issue-launcher__title">Create an issue from this page</h2>
+      <p class="portal-issue-launcher__copy">
+        This opens a prefilled GitHub issue for <strong>${REPO_OWNER}/${REPO_NAME}</strong> with the current page context attached.
+      </p>
+    </div>
+    <form class="portal-issue-launcher__form">
+      <div class="portal-issue-launcher__field">
+        <label for="portalIssueType">Issue type</label>
+        <select id="portalIssueType" name="issueType"></select>
+      </div>
+      <div class="portal-issue-launcher__field">
+        <label for="portalIssueTitle">Title</label>
+        <input id="portalIssueTitle" name="title" type="text" maxlength="120" />
+      </div>
+      <div class="portal-issue-launcher__field">
+        <label for="portalIssueSummary">What happened?</label>
+        <textarea id="portalIssueSummary" name="summary" placeholder="What is broken, confusing, or missing?"></textarea>
+      </div>
+      <div class="portal-issue-launcher__field">
+        <label for="portalIssueExpected">What should happen?</label>
+        <textarea id="portalIssueExpected" name="expected" placeholder="What would the better behavior or outcome be?"></textarea>
+        <p class="portal-issue-launcher__hint">The current page title and URL are added automatically.</p>
+      </div>
+      <p class="portal-issue-launcher__status" role="status" aria-live="polite"></p>
+      <div class="portal-issue-launcher__actions">
+        <button type="button" class="portal-issue-launcher__action portal-issue-launcher__action--ghost" data-issue-close>
+          Cancel
+        </button>
+        <button type="submit" class="portal-issue-launcher__action portal-issue-launcher__action--primary">
+          Open GitHub issue
+        </button>
+      </div>
+    </form>
+  `;
+
+  root.append(button, panel);
+  document.body.appendChild(root);
+
+  const form = panel.querySelector('form');
+  const typeInput = form.querySelector('#portalIssueType');
+  const titleInput = form.querySelector('#portalIssueTitle');
+  const summaryInput = form.querySelector('#portalIssueSummary');
+  const expectedInput = form.querySelector('#portalIssueExpected');
+  const closeButton = panel.querySelector('[data-issue-close]');
+  const status = panel.querySelector('.portal-issue-launcher__status');
+
+  ISSUE_TYPES.forEach((issueType) => {
+    const option = document.createElement('option');
+    option.value = issueType.value;
+    option.textContent = issueType.label;
+    typeInput.appendChild(option);
+  });
+
+  const defaultTitle = `[portal] ${currentTitle}`;
+  titleInput.value = defaultTitle;
+
+  const openPanel = () => {
+    panel.hidden = false;
+    button.setAttribute('aria-expanded', 'true');
+    status.textContent = `Current page: ${currentPath}`;
+    if (!prefersReducedMotion) {
+      requestAnimationFrame(() => titleInput.focus());
+    } else {
+      titleInput.focus();
+    }
+  };
+
+  const closePanel = () => {
+    panel.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+    status.textContent = '';
+    button.focus();
+  };
+
+  button.addEventListener('click', () => {
+    if (panel.hidden) {
+      openPanel();
+      return;
+    }
+    closePanel();
+  });
+
+  closeButton.addEventListener('click', closePanel);
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !panel.hidden) {
+      closePanel();
+    }
+  });
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const issueType = typeInput.options[typeInput.selectedIndex]?.textContent || ISSUE_TYPES[0].label;
+    const title = titleInput.value.trim() || defaultTitle;
+    const summary = summaryInput.value.trim();
+    const expected = expectedInput.value.trim();
+    const issueUrl = buildIssueUrl({ issueType, title, summary, expected });
+    status.textContent = 'Opening GitHub issue…';
+    const opened = window.open(issueUrl, '_blank', 'noopener');
+    if (!opened) {
+      window.location.href = issueUrl;
+    }
+  });
+})();

--- a/jetpack.html
+++ b/jetpack.html
@@ -14,5 +14,6 @@
 </head>
 <body>
   <p>Redirecting to <a href="jetpack/">Jetpack Corridor</a>...</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/jetpack/index.html
+++ b/jetpack/index.html
@@ -97,5 +97,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
   <script type="module" src="main.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/job-tracker/index.html
+++ b/job-tracker/index.html
@@ -764,5 +764,6 @@
 
     renderBoard();
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/lead-generation.html
+++ b/lead-generation.html
@@ -354,5 +354,6 @@
         .join('');
     }
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/life/index.html
+++ b/life/index.html
@@ -731,5 +731,6 @@
   </main>
 
   <script src="./app.js?v=20260329-life-mvp"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/local-models-on-phones/index.html
+++ b/local-models-on-phones/index.html
@@ -149,5 +149,6 @@
       </section>
     </main>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/logic-lab/index.html
+++ b/logic-lab/index.html
@@ -237,5 +237,6 @@
       </aside>
     </section>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/magic-link.html
+++ b/magic-link.html
@@ -103,5 +103,6 @@
       }
     }
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/meditation/affirmations.html
+++ b/meditation/affirmations.html
@@ -649,5 +649,6 @@
     updateAffirmation(currentDeck, { preserveText: true });
     startAutoplay();
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/meditation/guided-stretching.html
+++ b/meditation/guided-stretching.html
@@ -1359,5 +1359,6 @@
   <footer>
     Listen inward, honor your edge, and revisit this loop whenever screen time tightens your posture.
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/meditation/index.html
+++ b/meditation/index.html
@@ -1892,5 +1892,6 @@
     }
   </script>
   <script src="../navbar.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/meeting-notes/index.html
+++ b/meeting-notes/index.html
@@ -500,5 +500,6 @@
 
     updateEmptyStates();
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/meeting-notes/meeting.html
+++ b/meeting-notes/meeting.html
@@ -399,5 +399,6 @@
       attendeeForm.reset();
     });
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/memory.html
+++ b/memory.html
@@ -206,5 +206,6 @@ function resetGame() {
 startGame();
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/mindfulness-session.html
+++ b/mindfulness-session.html
@@ -32,5 +32,6 @@
   <main>
     <p>We moved the Mindfulness Breathing Room to a new home. If you are not redirected automatically, head over to the <a href="./meditation/">guided meditation experience</a>.</p>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/mini-daedalos/index.html
+++ b/mini-daedalos/index.html
@@ -825,5 +825,6 @@
     // Optionally auto-open About on load
     openWindow('about');
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/money-ai/index.html
+++ b/money-ai/index.html
@@ -483,5 +483,6 @@
   <script src="/gun-init.js"></script>
   <script src="/score.js"></script>
   <script type="module" src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -77,5 +77,6 @@
   </div>
 
   <script src="./newsroom.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/notes.html
+++ b/notes.html
@@ -14,5 +14,6 @@
 </head>
 <body>
   <p>Redirecting to <a href="notes/">3DVR Notes</a>...</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/notes/index.html
+++ b/notes/index.html
@@ -1561,5 +1561,6 @@
       }, 2500);
     }
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/old-tasks.html
+++ b/old-tasks.html
@@ -806,5 +806,6 @@ function renderTasks() {
 }
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/openai-app/index.html
+++ b/openai-app/index.html
@@ -420,5 +420,6 @@
   </main>
 
   <script src="app.js?v=20260323-live-billing-sync"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/openai-app/logs/index.html
+++ b/openai-app/logs/index.html
@@ -64,5 +64,6 @@
       Need a quick sanity check? Loop in the team on <a href="/chat/">chat</a>.
     </footer>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/openai-app/preview/index.html
+++ b/openai-app/preview/index.html
@@ -64,5 +64,6 @@
       Need a second set of eyes? Share the preview in <a href="/chat/">community chat</a>.
     </footer>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/openai-app/setup/index.html
+++ b/openai-app/setup/index.html
@@ -64,5 +64,6 @@
       Need a hand? Drop a note in <a href="/notes.html">portal notes</a> or ping <a href="/chat/">community chat</a>.
     </footer>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/password-reset.html
+++ b/password-reset.html
@@ -495,5 +495,6 @@
 
     loadRecoveryEmailDiagnostics();
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/personal-debian-server/index.html
+++ b/personal-debian-server/index.html
@@ -272,5 +272,6 @@
     </p>
   </footer>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/pocket-workstation/index.html
+++ b/pocket-workstation/index.html
@@ -240,5 +240,6 @@
   </div>
 
   <script src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/points-ratio/index.html
+++ b/points-ratio/index.html
@@ -145,5 +145,6 @@
     </footer>
 
     <script src="./pool-ratio.js" defer></script>
-  </body>
+    <script defer src="/issue-launcher.js"></script>
+</body>
 </html>

--- a/points.html
+++ b/points.html
@@ -294,5 +294,6 @@
     <footer class="points-footer">
       <p>Questions or ideas? Email <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a> and we will get back to you.</p>
     </footer>
-  </body>
+    <script defer src="/issue-launcher.js"></script>
+</body>
 </html>

--- a/pong.html
+++ b/pong.html
@@ -204,5 +204,6 @@ function winGame() {
 loop();
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/portal.3dvr.tech/video/index.html
+++ b/portal.3dvr.tech/video/index.html
@@ -95,5 +95,6 @@
       Built by <a href="https://3dvr.tech" target="_blank" rel="noopener">3dvr.tech</a> • Powered by <a href="https://vdo.ninja" target="_blank" rel="noopener">VDO.Ninja</a>
     </footer>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -1959,5 +1959,6 @@ refreshOauthProfile();
 consumePendingProfileOauthResult();
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -152,5 +152,6 @@
       </section>
     </main>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/index.html
+++ b/releases/index.html
@@ -342,5 +342,6 @@
     </ul>
   </div>
   <p class="footer-note">Looking for something older? Browse the git history for snapshots before v0.0.1.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.1.html
+++ b/releases/v0.0.1.html
@@ -159,5 +159,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.10.html
+++ b/releases/v0.0.10.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.11.html
+++ b/releases/v0.0.11.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.12.html
+++ b/releases/v0.0.12.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.13.html
+++ b/releases/v0.0.13.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.14.html
+++ b/releases/v0.0.14.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.15.html
+++ b/releases/v0.0.15.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.16.html
+++ b/releases/v0.0.16.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.17.html
+++ b/releases/v0.0.17.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.18.html
+++ b/releases/v0.0.18.html
@@ -121,5 +121,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.19.html
+++ b/releases/v0.0.19.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.2.html
+++ b/releases/v0.0.2.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.20.html
+++ b/releases/v0.0.20.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.21.html
+++ b/releases/v0.0.21.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.22.html
+++ b/releases/v0.0.22.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.23.html
+++ b/releases/v0.0.23.html
@@ -200,5 +200,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.24.html
+++ b/releases/v0.0.24.html
@@ -161,5 +161,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.25.html
+++ b/releases/v0.0.25.html
@@ -130,5 +130,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.26.html
+++ b/releases/v0.0.26.html
@@ -133,5 +133,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.27.html
+++ b/releases/v0.0.27.html
@@ -140,5 +140,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.28.html
+++ b/releases/v0.0.28.html
@@ -166,5 +166,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.29.html
+++ b/releases/v0.0.29.html
@@ -174,5 +174,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.3.html
+++ b/releases/v0.0.3.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.30.html
+++ b/releases/v0.0.30.html
@@ -142,5 +142,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.31.html
+++ b/releases/v0.0.31.html
@@ -145,5 +145,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.32.html
+++ b/releases/v0.0.32.html
@@ -150,5 +150,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.33.html
+++ b/releases/v0.0.33.html
@@ -136,5 +136,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.34.html
+++ b/releases/v0.0.34.html
@@ -146,5 +146,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.35.html
+++ b/releases/v0.0.35.html
@@ -122,5 +122,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.36.html
+++ b/releases/v0.0.36.html
@@ -121,5 +121,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.37.html
+++ b/releases/v0.0.37.html
@@ -121,5 +121,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.38.html
+++ b/releases/v0.0.38.html
@@ -121,5 +121,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.39.html
+++ b/releases/v0.0.39.html
@@ -121,5 +121,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.4.html
+++ b/releases/v0.0.4.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.40.html
+++ b/releases/v0.0.40.html
@@ -125,5 +125,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.5.html
+++ b/releases/v0.0.5.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.6.html
+++ b/releases/v0.0.6.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.7.html
+++ b/releases/v0.0.7.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.8.html
+++ b/releases/v0.0.8.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/releases/v0.0.9.html
+++ b/releases/v0.0.9.html
@@ -120,5 +120,6 @@
   </div>
 
   <p style="margin-top: 40px; opacity: 0.6;">© 2025 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/rewards.html
+++ b/rewards.html
@@ -106,5 +106,6 @@
       logDiv.innerHTML = 'Please sign in first.';
     }
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/roadmap/index.html
+++ b/roadmap/index.html
@@ -132,5 +132,6 @@
       </footer>
     </main>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/roadmap/march-april/index.html
+++ b/roadmap/march-april/index.html
@@ -197,5 +197,6 @@
       </footer>
     </main>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/roadmap/march-april/week-1/index.html
+++ b/roadmap/march-april/week-1/index.html
@@ -477,5 +477,6 @@ Keep each version direct, concrete, and skimmable.</textarea>
       </footer>
     </main>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/analytics.html
+++ b/sales/analytics.html
@@ -208,5 +208,6 @@
   </main>
 
   <script type="module" src="./analytics.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/buyer-journey.html
+++ b/sales/buyer-journey.html
@@ -196,5 +196,6 @@
       &copy; 2026 3dvr.tech — Internal sales map
     </div>
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/index.html
+++ b/sales/index.html
@@ -369,5 +369,6 @@
       &copy; 2025 3dvr.tech — Built for Builders
     </div>
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/leads.html
+++ b/sales/leads.html
@@ -105,5 +105,6 @@
       &copy; 2025 3dvr.tech
     </div>
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/marketing.html
+++ b/sales/marketing.html
@@ -119,5 +119,6 @@
       &copy; 2025 3dvr.tech
     </div>
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/pitch.html
+++ b/sales/pitch.html
@@ -132,5 +132,6 @@
       &copy; 2025 3dvr.tech — Built for Builders
     </div>
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/research.html
+++ b/sales/research.html
@@ -725,5 +725,6 @@
     </div>
   </footer>
   <script defer src="/sales/research.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/scoreboard.html
+++ b/sales/scoreboard.html
@@ -334,5 +334,6 @@
       </article>
     </section>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/scripts.html
+++ b/sales/scripts.html
@@ -100,5 +100,6 @@
       &copy; 2025 3dvr.tech
     </div>
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/team.html
+++ b/sales/team.html
@@ -110,5 +110,6 @@
       &copy; 2025 3dvr.tech
     </div>
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sales/training/index.html
+++ b/sales/training/index.html
@@ -975,5 +975,6 @@
     renderOverview(null);
   }
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/science/index.html
+++ b/science/index.html
@@ -160,5 +160,6 @@
         Keep experiments synced in Gun, keep exports VR-ready, and keep the portal evolving together.
       </footer>
     </main>
-  </body>
+    <script defer src="/issue-launcher.js"></script>
+</body>
 </html>

--- a/score-rewards/index.html
+++ b/score-rewards/index.html
@@ -264,5 +264,6 @@
       </ol>
     </section>
   </div>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/seo/index.html
+++ b/seo/index.html
@@ -210,5 +210,6 @@
 
   <footer class="footer">3DVR.Tech – SEO / Visibility Plan</footer>
   <script src="/seo/seo.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/share.html
+++ b/share.html
@@ -70,5 +70,6 @@
     });
   </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/sign-in.html
+++ b/sign-in.html
@@ -1232,5 +1232,6 @@
       }
     });
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/social/command-center.html
+++ b/social/command-center.html
@@ -168,5 +168,6 @@
 
   <script src="./gun-helpers.js"></script>
   <script src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/social/goals.html
+++ b/social/goals.html
@@ -104,5 +104,6 @@
 
   <script src="./gun-helpers.js"></script>
   <script type="module" src="./goals.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/social/ideation.html
+++ b/social/ideation.html
@@ -126,5 +126,6 @@
 
   <script src="./gun-helpers.js"></script>
   <script type="module" src="./ideation.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/social/index.html
+++ b/social/index.html
@@ -105,5 +105,6 @@
       </div>
     </section>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/social/results.html
+++ b/social/results.html
@@ -117,5 +117,6 @@
 
   <script src="./gun-helpers.js"></script>
   <script type="module" src="./results.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/social/scheduler.html
+++ b/social/scheduler.html
@@ -201,5 +201,6 @@
 
   <script src="./gun-helpers.js"></script>
   <script type="module" src="./scheduler.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/start/index.html
+++ b/start/index.html
@@ -388,5 +388,6 @@
     </footer>
 
     <script type="module" src="/start/router.js"></script>
-  </body>
+    <script defer src="/issue-launcher.js"></script>
+</body>
 </html>

--- a/stellar-flight.html
+++ b/stellar-flight.html
@@ -2923,5 +2923,6 @@
     updateCompass();
   });
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/tasks.html
+++ b/tasks.html
@@ -13,5 +13,6 @@
   <script>
     window.location.replace('/old-tasks.html');
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/tasks/index.html
+++ b/tasks/index.html
@@ -13,5 +13,6 @@
   <script>
     window.location.replace('/old-tasks.html');
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/test-gun.html
+++ b/test-gun.html
@@ -49,5 +49,6 @@
       }
     });
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -5,11 +5,19 @@ import { readFile } from 'node:fs/promises';
 describe('portal customer journey pages', () => {
   it('gives the portal home a clear concrete entry path', async () => {
     const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
-    assert.match(html, /Get in, get moving\./);
-    assert.match(html, /Pick one lane and keep the rest out of the way\./);
+    assert.match(html, /One system\. Any device\./);
+    assert.match(html, /Start in your browser\. Grow into your own operating system\./);
+    assert.match(html, /same identity,/i);
     assert.match(html, /Open CRM/);
     assert.match(html, /Open Sales/);
     assert.match(html, /Open Web Builder/);
+    assert.match(html, /System layers/);
+    assert.match(html, /Portal/);
+    assert.match(html, /Browser/);
+    assert.match(html, /OS/);
+    assert.match(html, /Cloud workspace for identity, notes, CRM, billing, messaging, and AI\./);
+    assert.match(html, /Launcher, multi-panel workspace, media tools, and in-browser runtime experiments\./);
+    assert.match(html, /TommyOS direction for deeper device control\./);
     assert.match(html, /Core workspaces/);
     assert.match(html, /Contacts/);
     assert.match(html, /Messenger/);
@@ -34,6 +42,12 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Start Here: tools and paid help for a project, offer, or business\./);
     assert.match(html, /Search the dock/);
     assert.match(html, /App dock/);
+    assert.match(html, /Command center/);
+    assert.match(html, /Same account, same apps, deeper levels of control\./);
+    assert.match(html, /Suggested launcher lanes/);
+    assert.match(html, /Run the business workspace/);
+    assert.match(html, /Open the workspace runtime/);
+    assert.match(html, /Move toward device control/);
     assert.match(html, /data-app-list/);
     assert.match(html, /shortcut-grid/);
     assert.doesNotMatch(html, /https:\/\/3dvr\.tech\/subscribe\/free-plan\.html/);

--- a/tests/issue-launcher.test.js
+++ b/tests/issue-launcher.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const repoRoot = new URL('../', import.meta.url);
+
+async function collectHtmlFiles(dirUrl, files = []) {
+  const entries = await readdir(dirUrl, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'tests' || entry.name.startsWith('.git')) continue;
+    const entryUrl = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, dirUrl);
+    if (entry.isDirectory()) {
+      await collectHtmlFiles(entryUrl, files);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(entryUrl);
+    }
+  }
+  return files;
+}
+
+test('issue launcher ships a GitHub issue helper for the portal repo', async () => {
+  const source = await readFile(new URL('../issue-launcher.js', import.meta.url), 'utf8');
+
+  assert.match(source, /tmsteph/);
+  assert.match(source, /3dvr-portal/);
+  assert.match(source, /issues\/new/);
+  assert.match(source, /Report portal issue/);
+  assert.match(source, /Create an issue from this page/);
+  assert.match(source, /Current page:/);
+});
+
+test('portal html pages include the shared issue launcher', async () => {
+  const htmlFiles = await collectHtmlFiles(repoRoot);
+  assert.ok(htmlFiles.length > 100, 'expected to inspect the portal html entry points');
+
+  for (const fileUrl of htmlFiles) {
+    const html = await readFile(fileUrl, 'utf8');
+    const relativePath = path.relative(new URL('../', import.meta.url).pathname, fileUrl.pathname);
+    assert.match(
+      html,
+      /<script[^>]+src="\/issue-launcher\.js"[^>]*><\/script>/,
+      `expected issue launcher include in ${relativePath}`
+    );
+  }
+});

--- a/tinymark/index.html
+++ b/tinymark/index.html
@@ -206,5 +206,6 @@ More stuff here.`;
 
     render();
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/tribes-flight.html
+++ b/tribes-flight.html
@@ -1467,5 +1467,6 @@
   requestAnimationFrame(loop);
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/web-builder-app/index.html
+++ b/web-builder-app/index.html
@@ -231,5 +231,6 @@
   </main>
 
   <script type="module" src="app.js?v=20260323-live-billing-sync"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/website-builder.html
+++ b/website-builder.html
@@ -408,5 +408,6 @@
   startHistorySubscription();
 </script>
 
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/wellness.html
+++ b/wellness.html
@@ -276,5 +276,6 @@
   <footer>
     Built for the 3DVR community. Share your favorite wellness resources in the #wellbeing channel.
   </footer>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/workbench-dev-lab/index.html
+++ b/workbench-dev-lab/index.html
@@ -112,5 +112,6 @@
   </main>
 
   <script src="app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/workbench-ideas/index.html
+++ b/workbench-ideas/index.html
@@ -114,5 +114,6 @@
       <div class="idea-board" data-idea-list></div>
     </section>
   </main>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/workbench-site-builder/index.html
+++ b/workbench-site-builder/index.html
@@ -138,5 +138,6 @@
   </section>
 
   <script src="app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/xr-motion-lab/index.html
+++ b/xr-motion-lab/index.html
@@ -524,5 +524,6 @@
       viewerStatus.textContent = `Viewer: ${isStereo ? 'stereo' : 'mono'}`;
     });
   </script>
+  <script defer src="/issue-launcher.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## What changed
- added a shared in-portal GitHub issue launcher script at `/issue-launcher.js`
- injected the launcher across the portal HTML entry points so users can open a prefilled GitHub issue from the current page
- added coverage to ensure the launcher stays included across portal pages

## Why
The portal needed an easy way to capture bugs and feature requests from wherever the user is working instead of making them navigate manually to GitHub and recreate page context.

## Impact
- any portal page can open a GitHub issue for `tmsteph/3dvr-portal`
- the issue includes the current page title, path, and URL automatically
- the launcher works without adding page-specific logic to each app

## Validation
- `node --test tests/issue-launcher.test.js tests/customer-journey-pages.test.js`
