### PR TITLE
Format v0.0.41 overview

### DIFF
--- a/releases/v0.0.41.html
+++ b/releases/v0.0.41.html
@@ -29,6 +29,16 @@
       border-radius: 10px;
       border: 1px solid #30363d;
     }
+    .overview-lead {
+      margin: 0 0 18px;
+    }
+    .overview-highlights {
+      margin: 0;
+      padding-left: 20px;
+    }
+    .overview-highlights li + li {
+      margin-top: 10px;
+    }
     .tag {
       background: #1f6feb;
       padding: 4px 10px;
@@ -90,13 +100,14 @@
 
   <div class="section">
     <h2>Overview</h2>
-    <p>
-      This week is about turning 3DVR into a more practical operating system. The portal gets a new portable workspace,
-      stronger follow-up between contacts, CRM, billing, and support flows, a more direct command-center front door,
-      and a lightweight issue launcher across pages. In parallel, the committed
-      <code>3dvr-agent</code> work starts shaping a local outreach pipeline for crawl, enrich, tracking, and message
-      iteration.
+    <p class="overview-lead">
+      This week pushes 3DVR further toward a practical operating system for real daily use.
     </p>
+    <ul class="overview-highlights">
+      <li>The portal adds a new portable workspace, stronger CRM and billing follow-through, and a more direct command-center front door.</li>
+      <li>The live surface gets a lightweight issue launcher so bugs and follow-up can be captured without leaving the product context.</li>
+      <li>Committed <code>3dvr-agent</code> work starts shaping a local outreach pipeline for crawl, enrich, tracking, and message iteration.</li>
+    </ul>
   </div>
 
   <div class="section">


### PR DESCRIPTION
## Summary
- add lightweight formatting to the v0.0.41 overview section
- make the overview easier to scan with a lead line and highlights list

## Testing
- not run (copy/layout-only change in release notes page)