### PR TITLE
Organize v0.0.41 summary

### DIFF
--- a/releases/v0.0.41.html
+++ b/releases/v0.0.41.html
@@ -52,6 +52,17 @@
       font-size: 16px;
       color: #9ba3b4;
     }
+    .release-summary-intro {
+      margin: 0 0 14px;
+    }
+    .release-summary-list {
+      margin: 0;
+      padding-left: 20px;
+      color: #c9d1d9;
+    }
+    .release-summary-list li + li {
+      margin-top: 8px;
+    }
     .back-link {
       color: #58a6ff;
       text-decoration: none;
@@ -93,10 +104,16 @@
   </nav>
   <h1>Release v0.0.41</h1>
   <div class="tag">Week of April 13, 2026</div>
-  <p class="release-summary">
-    Pocket Workstation lands, Life becomes Life OS, CRM and billing handoff get tighter, the portal home becomes a
-    command center, and the companion 3dvr-agent outreach stack starts taking shape.
-  </p>
+  <div class="release-summary">
+    <p class="release-summary-intro">This weekly release centers on five concrete shifts:</p>
+    <ul class="release-summary-list">
+      <li><strong>Pocket Workstation:</strong> a new lightweight workspace lands in the portal.</li>
+      <li><strong>Life OS:</strong> the Life app moves into a clearer daily operating shape.</li>
+      <li><strong>CRM + billing handoff:</strong> follow-through gets tighter across customer flows.</li>
+      <li><strong>Portal home:</strong> the front door moves closer to a real command center.</li>
+      <li><strong><code>3dvr-agent</code>:</strong> companion outreach tooling starts taking shape.</li>
+    </ul>
+  </div>
 
   <div class="section">
     <h2>Overview</h2>


### PR DESCRIPTION
## Summary
- reorganize the v0.0.41 top summary into labeled highlights
- keep the same release content while making the first screen easier to scan

## Testing
- not run (copy/layout-only change in release notes page)