### PR TITLE
Highlight local agent in v0.0.41

### DIFF
--- a/releases/v0.0.41.html
+++ b/releases/v0.0.41.html
@@ -111,7 +111,7 @@
       <li><strong>Life OS:</strong> the Life app moves into a clearer daily operating shape.</li>
       <li><strong>CRM + billing handoff:</strong> follow-through gets tighter across customer flows.</li>
       <li><strong>Portal home:</strong> the front door moves closer to a real command center.</li>
-      <li><strong><code>3dvr-agent</code>:</strong> companion outreach tooling starts taking shape.</li>
+      <li><strong><code>3dvr-agent</code>:</strong> the new local agent starts taking shape as a real outreach and operator tool.</li>
     </ul>
   </div>
 
@@ -123,7 +123,7 @@
     <ul class="overview-highlights">
       <li>The portal adds a new portable workspace, stronger CRM and billing follow-through, and a more direct command-center front door.</li>
       <li>The live surface gets a lightweight issue launcher so bugs and follow-up can be captured without leaving the product context.</li>
-      <li>Committed <code>3dvr-agent</code> work starts shaping a local outreach pipeline for crawl, enrich, tracking, and message iteration.</li>
+      <li>The new local <code>3dvr-agent</code> starts taking shape as a concrete outreach system with crawl, enrich, tracking, and message-iteration loops.</li>
     </ul>
   </div>
 
@@ -148,12 +148,12 @@
   </div>
 
   <div class="section">
-    <h2>Life OS and companion agent work</h2>
+    <h2>Life OS and the new local agent</h2>
     <ul>
       <li>Refocus the Life app into Life OS with a clearer daily operating shape and updated tests around that flow.</li>
       <li>Keep finance visibility, billing, and outreach work tied to revenue-first operations instead of generic productivity.</li>
-      <li>On committed <code>3dvr-agent</code> history this week, add a local sales agent system plus crawl, enrich, tracking, and A/B outreach message scripts.</li>
-      <li>Treat the agent repo as companion operator tooling: it sharpens outreach execution while the portal keeps becoming the shared front door and workflow desk.</li>
+      <li>On committed <code>3dvr-agent</code> history this week, add the new local sales agent system plus crawl, enrich, tracking, and A/B outreach message scripts.</li>
+      <li>Highlight the local agent as a real part of the stack: it sharpens outreach execution while the portal keeps becoming the shared front door and workflow desk.</li>
     </ul>
   </div>
 


### PR DESCRIPTION
## Summary
- strengthen the v0.0.41 release copy around the new local 3dvr-agent
- treat the local agent as a real part of the stack instead of a side note

## Testing
- not run (copy-only release note change)