### PR TITLE
Link v0.0.41 release mentions

### DIFF
--- a/releases/v0.0.41.html
+++ b/releases/v0.0.41.html
@@ -107,11 +107,11 @@
   <div class="release-summary">
     <p class="release-summary-intro">This weekly release centers on five concrete shifts:</p>
     <ul class="release-summary-list">
-      <li><strong>Pocket Workstation:</strong> a new lightweight workspace lands in the portal.</li>
-      <li><strong>Life OS:</strong> the Life app moves into a clearer daily operating shape.</li>
-      <li><strong>CRM + billing handoff:</strong> follow-through gets tighter across customer flows.</li>
-      <li><strong>Portal home:</strong> the front door moves closer to a real command center.</li>
-      <li><strong><code>3dvr-agent</code>:</strong> the new local agent starts taking shape as a real outreach and operator tool.</li>
+      <li><strong><a href="../pocket-workstation/index.html">Pocket Workstation</a>:</strong> a new lightweight workspace lands in the portal.</li>
+      <li><strong><a href="../life/index.html">Life OS</a>:</strong> the Life app moves into a clearer daily operating shape.</li>
+      <li><strong><a href="../crm/index.html">CRM</a> + <a href="../billing/index.html">billing</a> handoff:</strong> follow-through gets tighter across customer flows.</li>
+      <li><strong><a href="../index.html">Portal home</a>:</strong> the front door moves closer to a real command center.</li>
+      <li><strong><a href="https://github.com/tmsteph/3dvr-agent"><code>3dvr-agent</code></a>:</strong> the new local agent starts taking shape as a real outreach and operator tool.</li>
     </ul>
   </div>
 
@@ -121,9 +121,9 @@
       This week pushes 3DVR further toward a practical operating system for real daily use.
     </p>
     <ul class="overview-highlights">
-      <li>The portal adds a new portable workspace, stronger CRM and billing follow-through, and a more direct command-center front door.</li>
+      <li>The portal adds a new portable workspace, stronger <a href="../crm/index.html">CRM</a> and <a href="../billing/index.html">billing</a> follow-through, and a more direct <a href="../index.html">command-center front door</a>.</li>
       <li>The live surface gets a lightweight issue launcher so bugs and follow-up can be captured without leaving the product context.</li>
-      <li>The new local <code>3dvr-agent</code> starts taking shape as a concrete outreach system with crawl, enrich, tracking, and message-iteration loops.</li>
+      <li>The new local <a href="https://github.com/tmsteph/3dvr-agent"><code>3dvr-agent</code></a> starts taking shape as a concrete outreach system with crawl, enrich, tracking, and message-iteration loops.</li>
     </ul>
   </div>
 
@@ -131,18 +131,18 @@
     <h2>Portable workspaces and operator surfaces</h2>
     <ul>
       <li>Add the new <a href="../pocket-workstation/index.html">Pocket Workstation</a> app and pairing flow so the portal has a clearer lightweight mobile desk.</li>
-      <li>Make the portal launcher feel more like a command center with stronger layout, hierarchy, and app-entry cues.</li>
+      <li>Make the <a href="../index.html">portal launcher</a> feel more like a command center with stronger layout, hierarchy, and app-entry cues.</li>
       <li>Add a GitHub issue launcher across portal pages so bugs and follow-up are easier to capture from the live surface.</li>
-      <li>Bring the calendar month view forward on mobile and make the Logic Lab drill card easier to activate.</li>
+      <li>Bring the <a href="../calendar/index.html">calendar</a> month view forward on mobile and make the <a href="../logic-lab/index.html">Logic Lab</a> drill card easier to activate.</li>
     </ul>
   </div>
 
   <div class="section">
     <h2>Customer journey, CRM, and billing</h2>
     <ul>
-      <li>Move the free-trial email field higher and tighten homepage billing handoff so the entry path is more explicit.</li>
+      <li>Move the <a href="../free-trial.html">free-trial</a> email field higher and tighten <a href="../index.html">homepage</a> <a href="../billing/index.html">billing</a> handoff so the entry path is more explicit.</li>
       <li>Simplify the portal customer journey and keep Stripe plan-switch handling aligned with portal origin rules.</li>
-      <li>Normalize contacts into CRM handoff records and move primary CRM and contacts actions to the top of those pages.</li>
+      <li>Normalize <a href="../contacts/index.html">contacts</a> into <a href="../crm/index.html">CRM</a> handoff records and move primary CRM and contacts actions to the top of those pages.</li>
       <li>Send email notifications for Stripe subscription updates so billing changes create a clearer operator trail.</li>
     </ul>
   </div>
@@ -150,9 +150,9 @@
   <div class="section">
     <h2>Life OS and the new local agent</h2>
     <ul>
-      <li>Refocus the Life app into Life OS with a clearer daily operating shape and updated tests around that flow.</li>
+      <li>Refocus the <a href="../life/index.html">Life app</a> into <a href="../life/index.html">Life OS</a> with a clearer daily operating shape and updated tests around that flow.</li>
       <li>Keep finance visibility, billing, and outreach work tied to revenue-first operations instead of generic productivity.</li>
-      <li>On committed <code>3dvr-agent</code> history this week, add the new local sales agent system plus crawl, enrich, tracking, and A/B outreach message scripts.</li>
+      <li>On committed <a href="https://github.com/tmsteph/3dvr-agent"><code>3dvr-agent</code></a> history this week, add the new local sales agent system plus crawl, enrich, tracking, and A/B outreach message scripts.</li>
       <li>Highlight the local agent as a real part of the stack: it sharpens outreach execution while the portal keeps becoming the shared front door and workflow desk.</li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- add links for the named portal surfaces and the local 3dvr-agent repo where they are mentioned in v0.0.41
- make the release page easier to navigate directly from the release copy

## Testing
- not run (link-only release note change)