### PR TITLE
Move 3dvr-agent to top of v0.0.41 summary

### DIFF
--- a/releases/v0.0.41.html
+++ b/releases/v0.0.41.html
@@ -107,11 +107,11 @@
   <div class="release-summary">
     <p class="release-summary-intro">This weekly release centers on five concrete shifts:</p>
     <ul class="release-summary-list">
+      <li><strong><a href="https://github.com/tmsteph/3dvr-agent"><code>3dvr-agent</code></a>:</strong> the new local agent starts taking shape as a real outreach and operator tool.</li>
       <li><strong><a href="../pocket-workstation/index.html">Pocket Workstation</a>:</strong> a new lightweight workspace lands in the portal.</li>
       <li><strong><a href="../life/index.html">Life OS</a>:</strong> the Life app moves into a clearer daily operating shape.</li>
       <li><strong><a href="../crm/index.html">CRM</a> + <a href="../billing/index.html">billing</a> handoff:</strong> follow-through gets tighter across customer flows.</li>
       <li><strong><a href="../index.html">Portal home</a>:</strong> the front door moves closer to a real command center.</li>
-      <li><strong><a href="https://github.com/tmsteph/3dvr-agent"><code>3dvr-agent</code></a>:</strong> the new local agent starts taking shape as a real outreach and operator tool.</li>
     </ul>
   </div>
 


### PR DESCRIPTION
## Summary
- move the 3dvr-agent highlight to the top of the v0.0.41 summary list

## Testing
- not run (single-line ordering change in release notes page)