### PR TITLE
Add Gun-backed outreach CRM

### DIFF
--- a/crm/index.html
+++ b/crm/index.html
@@ -26,6 +26,7 @@
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../sales/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Sales home</a>
+        <a href="../sales/outreach.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Outreach CRM</a>
         <a href="../sales/training/" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Training playbook</a>
         <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Contacts workspace</a>
         <a href="../cell/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Cell</a>

--- a/sales/index.html
+++ b/sales/index.html
@@ -21,6 +21,7 @@
         <a href="../lead-generation.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Lead Capture</a>
         <a href="../contacts/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Contacts Workspace</a>
         <a href="../crm/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">CRM</a>
+        <a href="outreach.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Outreach CRM</a>
         <a href="../billing/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Billing</a>
         <a href="training/" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Sales Training</a>
         <a href="analytics.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Growth Lab</a>
@@ -124,7 +125,7 @@
         <h2 class="text-xl font-semibold">Today&apos;s action loop</h2>
         <ol class="list-decimal list-inside space-y-3 text-sm text-slate-300">
           <li>Pick one warm lead and open CRM.</li>
-          <li>Send the Builder or Embedded ask.</li>
+          <li>Open Outreach CRM and send the Builder or Embedded ask.</li>
           <li>Log the touch in contacts.</li>
           <li>Set the next follow-up before you stop.</li>
         </ol>
@@ -132,7 +133,10 @@
           <p class="font-semibold text-slate-100">Keep it simple</p>
           <p class="mt-2">One conversation that moves toward billing is better than ten notes that never turn into a sale.</p>
         </div>
-        <a href="analytics.html" class="inline-flex items-center justify-center rounded-lg border border-cyan-300/20 bg-cyan-500/10 px-4 py-2 text-sm font-semibold text-cyan-100 hover:bg-cyan-500/20">Open growth lab</a>
+        <div class="flex flex-wrap gap-2">
+          <a href="outreach.html" class="inline-flex items-center justify-center rounded-lg border border-amber-300/20 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-100 hover:bg-amber-500/20">Open outreach CRM</a>
+          <a href="analytics.html" class="inline-flex items-center justify-center rounded-lg border border-cyan-300/20 bg-cyan-500/10 px-4 py-2 text-sm font-semibold text-cyan-100 hover:bg-cyan-500/20">Open growth lab</a>
+        </div>
       </aside>
     </section>
 

--- a/sales/outreach.html
+++ b/sales/outreach.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Outreach CRM | 3dvr Sales</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <script defer type="module" src="/sales/outreach.js"></script>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-100 font-sans">
+  <header class="bg-gradient-to-br from-slate-950 via-emerald-950 to-amber-900 text-white">
+    <div class="max-w-7xl mx-auto px-6 py-8 space-y-4">
+      <nav class="text-xs uppercase tracking-[0.3em] text-amber-200 flex items-center gap-2">
+        <a href="index.html" class="text-amber-100 hover:text-white">Sales Directory</a>
+        <span aria-hidden="true">/</span>
+        <span>Outreach CRM</span>
+      </nav>
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div class="space-y-3">
+          <p class="text-xs uppercase tracking-[0.3em] text-amber-200">Customer memory • Gun-backed</p>
+          <h1 class="text-3xl font-bold">Outreach CRM</h1>
+          <p class="max-w-3xl text-sm text-slate-200">
+            Keep customer profiles, potential messages, screenshots, and sent touches in one shared Gun workspace.
+            This is the bridge between the local agent and the portal.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <a
+            href="../crm/index.html"
+            class="inline-flex items-center justify-center rounded-lg bg-white px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-amber-50"
+          >Full CRM</a>
+          <a
+            href="scoreboard.html"
+            class="inline-flex items-center justify-center rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20"
+          >Profitability Desk</a>
+          <a
+            href="training/"
+            class="inline-flex items-center justify-center rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20"
+          >Reach-Out Desk</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-7xl mx-auto px-6 py-10 space-y-8">
+    <section class="grid gap-4 md:grid-cols-3">
+      <article class="rounded-2xl border border-white/5 bg-slate-900/80 p-5 shadow-lg">
+        <p class="text-xs uppercase tracking-[0.25em] text-slate-400">Profiles</p>
+        <p class="mt-3 text-3xl font-semibold text-emerald-200" data-count="profiles">0</p>
+        <p class="mt-2 text-sm text-slate-300">Customer records from the shared CRM node.</p>
+      </article>
+      <article class="rounded-2xl border border-white/5 bg-slate-900/80 p-5 shadow-lg">
+        <p class="text-xs uppercase tracking-[0.25em] text-slate-400">Potential messages</p>
+        <p class="mt-3 text-3xl font-semibold text-amber-200" data-count="artifacts">0</p>
+        <p class="mt-2 text-sm text-slate-300">Agent drafts and screenshots from the outreach artifact node.</p>
+      </article>
+      <article class="rounded-2xl border border-white/5 bg-slate-900/80 p-5 shadow-lg">
+        <p class="text-xs uppercase tracking-[0.25em] text-slate-400">Sent messages</p>
+        <p class="mt-3 text-3xl font-semibold text-blue-200" data-count="sent">0</p>
+        <p class="mt-2 text-sm text-slate-300">Logged touches from the shared CRM touch log.</p>
+      </article>
+    </section>
+
+    <section class="grid gap-6 xl:grid-cols-[0.95fr,1.15fr,0.9fr]">
+      <article class="rounded-2xl border border-white/5 bg-slate-900/70 p-6 shadow-lg space-y-5">
+        <div>
+          <p class="text-xs uppercase tracking-[0.3em] text-emerald-300">Customer profiles</p>
+          <h2 class="mt-2 text-xl font-semibold">Who are we talking to?</h2>
+          <p id="profileStatus" class="mt-2 text-sm text-slate-300">Loading customer profiles from Gun…</p>
+        </div>
+
+        <form id="profileForm" class="rounded-xl border border-white/5 bg-slate-950/70 p-4 space-y-3">
+          <div>
+            <label for="profileName" class="block text-sm text-slate-300">Customer or business name</label>
+            <input id="profileName" type="text" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" placeholder="Dark Horse Coffee Roasters" />
+          </div>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label for="profileEmail" class="block text-sm text-slate-300">Email</label>
+              <input id="profileEmail" type="email" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" placeholder="owner@example.com" />
+            </div>
+            <div>
+              <label for="profileWebsite" class="block text-sm text-slate-300">Website</label>
+              <input id="profileWebsite" type="url" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" placeholder="https://example.com" />
+            </div>
+          </div>
+          <div>
+            <label for="profileNotes" class="block text-sm text-slate-300">Profile notes</label>
+            <textarea id="profileNotes" rows="4" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" placeholder="What they sell, what you noticed, why they might care."></textarea>
+          </div>
+          <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-emerald-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-300">
+            Save profile
+          </button>
+          <p id="profileSaveStatus" class="text-xs text-slate-400"></p>
+        </form>
+
+        <div id="profileList" class="space-y-3"></div>
+      </article>
+
+      <article class="rounded-2xl border border-white/5 bg-slate-900/70 p-6 shadow-lg space-y-5">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-[0.3em] text-amber-300">Potential messages</p>
+            <h2 class="mt-2 text-xl font-semibold">Drafts and screenshots from the agent</h2>
+            <p id="artifactStatus" class="mt-2 text-sm text-slate-300">Loading saved outreach artifacts…</p>
+          </div>
+          <a
+            href="../email-operator/index.html"
+            class="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm font-semibold text-white hover:bg-white/20"
+          >Email Operator</a>
+        </div>
+        <form id="artifactForm" class="rounded-xl border border-white/5 bg-slate-950/70 p-4 space-y-3">
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label for="artifactLeadName" class="block text-sm text-slate-300">Lead name</label>
+              <input id="artifactLeadName" type="text" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" placeholder="Dark Horse Coffee Roasters" />
+            </div>
+            <div>
+              <label for="artifactFiles" class="block text-sm text-slate-300">Screenshots</label>
+              <input id="artifactFiles" type="file" multiple accept="image/png,image/jpeg,image/webp" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-200" />
+            </div>
+          </div>
+          <div>
+            <label for="artifactDraft" class="block text-sm text-slate-300">Potential message</label>
+            <textarea id="artifactDraft" rows="6" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" placeholder="Store the draft before it gets sent."></textarea>
+          </div>
+          <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-amber-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-amber-200">
+            Save potential message
+          </button>
+          <p id="artifactSaveStatus" class="text-xs text-slate-400"></p>
+        </form>
+        <div id="artifactList" class="space-y-4"></div>
+      </article>
+
+      <article class="rounded-2xl border border-white/5 bg-slate-900/70 p-6 shadow-lg space-y-5">
+        <div>
+          <p class="text-xs uppercase tracking-[0.3em] text-blue-300">Messages sent</p>
+          <h2 class="mt-2 text-xl font-semibold">Log the actual touch</h2>
+          <p id="sentStatus" class="mt-2 text-sm text-slate-300">Loading sent-message history…</p>
+        </div>
+
+        <form id="sentForm" class="rounded-xl border border-white/5 bg-slate-950/70 p-4 space-y-3">
+          <input id="sentArtifactId" type="hidden" />
+          <div>
+            <label for="sentLeadName" class="block text-sm text-slate-300">Lead name</label>
+            <input id="sentLeadName" type="text" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" placeholder="Dark Horse Coffee Roasters" />
+          </div>
+          <div>
+            <label for="sentChannel" class="block text-sm text-slate-300">Channel</label>
+            <select id="sentChannel" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white">
+              <option value="email">Email</option>
+              <option value="contact-form">Contact form</option>
+              <option value="instagram">Instagram</option>
+              <option value="phone">Phone</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <div>
+            <label for="sentMessage" class="block text-sm text-slate-300">Message sent</label>
+            <textarea id="sentMessage" rows="7" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" placeholder="Paste or load the exact message here."></textarea>
+          </div>
+          <div>
+            <label for="sentFollowUp" class="block text-sm text-slate-300">Next follow-up</label>
+            <input id="sentFollowUp" type="date" class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" />
+          </div>
+          <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-blue-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-blue-300">
+            Log sent message
+          </button>
+          <p id="sentSaveStatus" class="text-xs text-slate-400"></p>
+        </form>
+
+        <div id="sentList" class="space-y-3"></div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/sales/outreach.js
+++ b/sales/outreach.js
@@ -1,0 +1,583 @@
+const CRM_NODE_KEY = '3dvr-crm';
+const TOUCH_LOG_NODE_PATH = ['3dvr-portal', 'crm-touch-log'];
+const OUTREACH_ARTIFACT_NODE_PATH = ['3dvr', 'crm', 'outreach-artifacts'];
+
+const state = {
+  profiles: new Map(),
+  artifacts: new Map(),
+  sent: new Map(),
+  activeProfileId: '',
+};
+
+const elements = {
+  profileStatus: document.getElementById('profileStatus'),
+  artifactStatus: document.getElementById('artifactStatus'),
+  sentStatus: document.getElementById('sentStatus'),
+  profileList: document.getElementById('profileList'),
+  artifactList: document.getElementById('artifactList'),
+  sentList: document.getElementById('sentList'),
+  profileForm: document.getElementById('profileForm'),
+  profileName: document.getElementById('profileName'),
+  profileEmail: document.getElementById('profileEmail'),
+  profileWebsite: document.getElementById('profileWebsite'),
+  profileNotes: document.getElementById('profileNotes'),
+  profileSaveStatus: document.getElementById('profileSaveStatus'),
+  artifactForm: document.getElementById('artifactForm'),
+  artifactLeadName: document.getElementById('artifactLeadName'),
+  artifactDraft: document.getElementById('artifactDraft'),
+  artifactFiles: document.getElementById('artifactFiles'),
+  artifactSaveStatus: document.getElementById('artifactSaveStatus'),
+  sentForm: document.getElementById('sentForm'),
+  sentArtifactId: document.getElementById('sentArtifactId'),
+  sentLeadName: document.getElementById('sentLeadName'),
+  sentChannel: document.getElementById('sentChannel'),
+  sentMessage: document.getElementById('sentMessage'),
+  sentFollowUp: document.getElementById('sentFollowUp'),
+  sentSaveStatus: document.getElementById('sentSaveStatus'),
+  countProfiles: document.querySelector('[data-count="profiles"]'),
+  countArtifacts: document.querySelector('[data-count="artifacts"]'),
+  countSent: document.querySelector('[data-count="sent"]'),
+};
+
+function createGun() {
+  if (typeof window.Gun !== 'function') {
+    return null;
+  }
+
+  const peers = window.__GUN_PEERS__ || [
+    'wss://relay.3dvr.tech/gun',
+    'wss://gun-relay-3dvr.fly.dev/gun',
+    'https://gun-relay-3dvr.fly.dev/gun',
+  ];
+
+  try {
+    return window.Gun({ peers });
+  } catch (error) {
+    console.warn('Outreach CRM Gun init failed', error);
+    try {
+      return window.Gun({ peers, radisk: false, localStorage: false });
+    } catch (fallbackError) {
+      console.warn('Outreach CRM Gun fallback failed', fallbackError);
+      return null;
+    }
+  }
+}
+
+function getNodeFromPath(gun, path) {
+  return path.reduce((node, part) => node.get(part), gun);
+}
+
+function slugify(value) {
+  return String(value || '')
+    .toLowerCase()
+    .trim()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function safe(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function safeAttr(value) {
+  return safe(value).replace(/"/g, '&quot;');
+}
+
+function formatTimestamp(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown time';
+  }
+
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function getParticipantLabel() {
+  return String(
+    localStorage.getItem('username')
+      || localStorage.getItem('alias')
+      || localStorage.getItem('guestDisplayName')
+      || 'Guest'
+  ).trim();
+}
+
+function getParticipantId() {
+  return String(
+    localStorage.getItem('username')
+      || localStorage.getItem('alias')
+      || localStorage.getItem('guestId')
+      || 'guest'
+  ).trim();
+}
+
+function normalizeProfile(data = {}, id = '') {
+  const profileId = String(data.id || data.contactId || id || '').trim();
+  const name = String(data.name || data.leadName || data.company || data.email || '').trim();
+
+  return {
+    ...data,
+    id: profileId,
+    recordType: String(data.recordType || 'person').trim(),
+    name,
+    email: String(data.email || '').trim(),
+    website: String(data.website || data.link || '').trim(),
+    notes: String(data.notes || data.profileNotes || '').trim(),
+    status: String(data.status || 'Lead').trim(),
+    nextFollowUp: String(data.nextFollowUp || '').trim(),
+    updatedAt: String(data.updatedAt || data.updated || '').trim(),
+  };
+}
+
+function normalizeArtifact(data = {}, id = '') {
+  let attachments = [];
+  try {
+    attachments = JSON.parse(data.attachmentsJson || '[]');
+  } catch (error) {
+    attachments = [];
+  }
+
+  return {
+    ...data,
+    id: String(data.id || id || '').trim(),
+    leadName: String(data.leadName || data.name || id || '').trim(),
+    draftText: String(data.draftText || '').trim(),
+    attachmentCount: Number(data.attachmentCount || attachments.length || 0),
+    attachments,
+    updatedAt: String(data.updatedAt || data.updated || '').trim(),
+  };
+}
+
+function readFileAsBase64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => {
+      const result = String(reader.result || '');
+      const [, data = ''] = result.split(',');
+      resolve({
+        name: file.name,
+        mime: file.type || 'application/octet-stream',
+        size: file.size,
+        encoding: 'base64',
+        data,
+      });
+    });
+    reader.addEventListener('error', () => reject(reader.error || new Error('File read failed')));
+    reader.readAsDataURL(file);
+  });
+}
+
+function normalizeSent(data = {}, id = '') {
+  return {
+    ...data,
+    id: String(data.id || id || '').trim(),
+    contactName: String(data.contactName || data.leadName || data.name || '').trim(),
+    timestamp: String(data.timestamp || data.time || data.updatedAt || '').trim(),
+    note: String(data.note || data.message || '').trim(),
+    touchType: String(data.touchType || '').trim(),
+    touchTypeLabel: String(data.touchTypeLabel || data.touchType || 'Touch').trim(),
+    source: String(data.source || '').trim(),
+    channel: String(data.channel || '').trim(),
+    artifactId: String(data.artifactId || '').trim(),
+    followUp: String(data.followUp || '').trim(),
+    loggedBy: String(data.loggedBy || '').trim(),
+  };
+}
+
+function updateCounts() {
+  elements.countProfiles.textContent = String(state.profiles.size);
+  elements.countArtifacts.textContent = String(state.artifacts.size);
+  elements.countSent.textContent = String(
+    Array.from(state.sent.values()).filter((entry) => entry.touchType === 'outreach-sent').length
+  );
+}
+
+function getRecentSentEntries(limit = 12) {
+  return Array.from(state.sent.values())
+    .filter((entry) => entry.touchType === 'outreach-sent')
+    .sort((a, b) => String(b.timestamp).localeCompare(String(a.timestamp)))
+    .slice(0, limit);
+}
+
+function getMatchingProfile(leadName) {
+  const leadSlug = slugify(leadName);
+  return Array.from(state.profiles.values()).find((profile) => {
+    return slugify(profile.name) === leadSlug || slugify(profile.company) === leadSlug || profile.id === leadSlug;
+  });
+}
+
+function renderProfiles() {
+  const profiles = Array.from(state.profiles.values())
+    .filter((profile) => profile.name)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .slice(0, 30);
+
+  elements.profileStatus.textContent = profiles.length
+    ? `${profiles.length} customer profiles loaded from Gun.`
+    : 'No customer profiles yet. Save the first one here or create it from a message artifact.';
+
+  elements.profileList.innerHTML = profiles.length
+    ? profiles.map((profile) => `
+      <article class="rounded-xl border border-white/5 bg-slate-950/70 p-4 space-y-3">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 class="font-semibold text-white">${safe(profile.name)}</h3>
+            <p class="text-xs text-slate-400">${safe(profile.status || 'Lead')}${profile.nextFollowUp ? ` · Follow-up ${safe(profile.nextFollowUp)}` : ''}</p>
+          </div>
+          <button
+            type="button"
+            data-action="use-profile"
+            data-profile-id="${safeAttr(profile.id)}"
+            class="rounded-lg border border-white/10 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white hover:bg-white/20"
+          >Use</button>
+        </div>
+        ${profile.website ? `<a href="${safeAttr(profile.website)}" class="text-sm text-emerald-200 underline underline-offset-2">${safe(profile.website)}</a>` : ''}
+        ${profile.email ? `<p class="text-sm text-slate-300">${safe(profile.email)}</p>` : ''}
+        ${profile.notes ? `<p class="text-sm text-slate-300 whitespace-pre-wrap">${safe(profile.notes)}</p>` : ''}
+      </article>
+    `).join('')
+    : '<p class="rounded-xl border border-dashed border-white/10 bg-slate-950/50 p-4 text-sm text-slate-400">Customer profile records will appear here.</p>';
+}
+
+function renderArtifacts() {
+  const artifacts = Array.from(state.artifacts.values())
+    .filter((artifact) => artifact.leadName || artifact.draftText)
+    .sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)));
+
+  elements.artifactStatus.textContent = artifacts.length
+    ? `${artifacts.length} potential message artifacts loaded from the local agent Gun path.`
+    : 'No agent message artifacts found yet. Use ask-artifact save from the local agent.';
+
+  elements.artifactList.innerHTML = artifacts.length
+    ? artifacts.map((artifact) => {
+      const profile = getMatchingProfile(artifact.leadName);
+      return `
+        <article class="rounded-2xl border border-white/5 bg-slate-950/70 p-4 space-y-4">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 class="text-lg font-semibold text-white">${safe(artifact.leadName || artifact.id)}</h3>
+              <p class="text-xs text-slate-400">
+                ${artifact.updatedAt ? `Saved ${safe(formatTimestamp(artifact.updatedAt))}` : 'Saved by local agent'}
+                ${profile ? ` · Profile linked` : ' · No profile match yet'}
+              </p>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <button
+                type="button"
+                data-action="load-message"
+                data-artifact-id="${safeAttr(artifact.id)}"
+                class="rounded-lg bg-amber-300 px-3 py-1.5 text-xs font-semibold text-slate-950 hover:bg-amber-200"
+              >Load message</button>
+              <button
+                type="button"
+                data-action="create-profile"
+                data-artifact-id="${safeAttr(artifact.id)}"
+                class="rounded-lg border border-white/10 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white hover:bg-white/20"
+              >Profile</button>
+            </div>
+          </div>
+          <pre class="max-h-72 overflow-auto whitespace-pre-wrap rounded-xl border border-white/5 bg-slate-900/80 p-3 text-sm text-slate-200">${safe(artifact.draftText || 'No draft text stored.')}</pre>
+          <div class="grid gap-3 sm:grid-cols-2">
+            ${artifact.attachments.length ? artifact.attachments.map((attachment) => renderAttachment(attachment)).join('') : '<p class="text-sm text-slate-400">No screenshots attached.</p>'}
+          </div>
+        </article>
+      `;
+    }).join('')
+    : '<p class="rounded-xl border border-dashed border-white/10 bg-slate-950/50 p-4 text-sm text-slate-400">Potential messages and screenshots will appear here after `ask-artifact save`.</p>';
+}
+
+function renderAttachment(attachment) {
+  if (!attachment || !attachment.data) {
+    return '';
+  }
+
+  const mime = String(attachment.mime || 'application/octet-stream');
+  const name = String(attachment.name || 'attachment');
+  const src = `data:${mime};base64,${attachment.data}`;
+
+  if (mime.startsWith('image/')) {
+    return `
+      <figure class="rounded-xl border border-white/5 bg-slate-900/80 p-2">
+        <img src="${safeAttr(src)}" alt="${safeAttr(name)}" class="max-h-72 w-full rounded-lg object-contain" loading="lazy" />
+        <figcaption class="mt-2 text-xs text-slate-400">${safe(name)} · ${safe(String(attachment.size || 0))} bytes</figcaption>
+      </figure>
+    `;
+  }
+
+  return `<p class="text-sm text-slate-400">${safe(name)} · ${safe(mime)}</p>`;
+}
+
+function renderSent() {
+  const entries = getRecentSentEntries();
+
+  elements.sentStatus.textContent = entries.length
+    ? `${entries.length} recent sent outreach messages loaded from the shared touch log.`
+    : 'No sent outreach logged yet. Load a draft, send it, then log the touch.';
+
+  elements.sentList.innerHTML = entries.length
+    ? entries.map((entry) => `
+      <article class="rounded-xl border border-white/5 bg-slate-950/70 p-4">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 class="font-semibold text-white">${safe(entry.contactName || 'Unnamed lead')}</h3>
+            <p class="text-xs text-slate-400">${safe(formatTimestamp(entry.timestamp))}${entry.channel ? ` · ${safe(entry.channel)}` : ''}</p>
+          </div>
+          <span class="rounded-full bg-blue-400/10 px-3 py-1 text-xs font-semibold text-blue-100">${safe(entry.source || 'Outreach CRM')}</span>
+        </div>
+        ${entry.note ? `<p class="mt-3 text-sm text-slate-300 whitespace-pre-wrap">${safe(entry.note)}</p>` : ''}
+        <p class="mt-3 text-xs text-slate-500">Logged by ${safe(entry.loggedBy || 'Unknown')}${entry.followUp ? ` · Follow-up ${safe(entry.followUp)}` : ''}</p>
+      </article>
+    `).join('')
+    : '<p class="rounded-xl border border-dashed border-white/10 bg-slate-950/50 p-4 text-sm text-slate-400">Sent messages will appear here after you log them.</p>';
+}
+
+function renderAll() {
+  updateCounts();
+  renderProfiles();
+  renderArtifacts();
+  renderSent();
+}
+
+function saveProfile(event) {
+  event.preventDefault();
+  if (!crmRecordsNode) return;
+
+  const name = elements.profileName.value.trim();
+  if (!name) {
+    elements.profileSaveStatus.textContent = 'Name is required.';
+    return;
+  }
+
+  const id = state.activeProfileId || slugify(name);
+  const existing = state.profiles.get(id) || {};
+  const now = new Date().toISOString();
+  const payload = normalizeProfile({
+    ...existing,
+    id,
+    recordType: existing.recordType || 'person',
+    name,
+    email: elements.profileEmail.value.trim(),
+    website: elements.profileWebsite.value.trim(),
+    notes: elements.profileNotes.value.trim(),
+    status: existing.status || 'Lead',
+    updatedAt: now,
+  }, id);
+
+  crmRecordsNode.get(id).put(payload, (ack = {}) => {
+    if (ack.err) {
+      elements.profileSaveStatus.textContent = `Profile save failed: ${ack.err}`;
+      return;
+    }
+    state.profiles.set(id, payload);
+    state.activeProfileId = id;
+    elements.profileSaveStatus.textContent = `Saved ${name}.`;
+    renderAll();
+  });
+}
+
+function loadProfile(profileId) {
+  const profile = state.profiles.get(profileId);
+  if (!profile) return;
+
+  state.activeProfileId = profile.id;
+  elements.profileName.value = profile.name || '';
+  elements.profileEmail.value = profile.email || '';
+  elements.profileWebsite.value = profile.website || '';
+  elements.profileNotes.value = profile.notes || '';
+  elements.sentLeadName.value = profile.name || '';
+}
+
+function createProfileFromArtifact(artifactId) {
+  const artifact = state.artifacts.get(artifactId);
+  if (!artifact || !artifact.leadName) return;
+
+  const id = slugify(artifact.leadName);
+  const existing = state.profiles.get(id) || {};
+  const now = new Date().toISOString();
+  const payload = normalizeProfile({
+    ...existing,
+    id,
+    recordType: existing.recordType || 'person',
+    name: existing.name || artifact.leadName,
+    notes: existing.notes || `Outreach artifact saved from local agent.\n\n${artifact.draftText.slice(0, 500)}`,
+    status: existing.status || 'Lead',
+    updatedAt: now,
+  }, id);
+
+  crmRecordsNode.get(id).put(payload, (ack = {}) => {
+    if (ack.err) {
+      elements.profileSaveStatus.textContent = `Profile sync failed: ${ack.err}`;
+      return;
+    }
+    state.profiles.set(id, payload);
+    loadProfile(id);
+    renderAll();
+  });
+}
+
+async function saveArtifact(event) {
+  event.preventDefault();
+  if (!artifactNode) return;
+
+  const leadName = elements.artifactLeadName.value.trim();
+  const draftText = elements.artifactDraft.value.trim();
+  if (!leadName || !draftText) {
+    elements.artifactSaveStatus.textContent = 'Lead name and message are required.';
+    return;
+  }
+
+  elements.artifactSaveStatus.textContent = 'Reading screenshots…';
+  const id = slugify(leadName);
+  const files = Array.from(elements.artifactFiles.files || []);
+  let attachments = [];
+
+  try {
+    attachments = await Promise.all(files.map(readFileAsBase64));
+  } catch (error) {
+    elements.artifactSaveStatus.textContent = `Screenshot read failed: ${error.message}`;
+    return;
+  }
+
+  const existing = state.artifacts.get(id) || {};
+  const now = new Date().toISOString();
+  const payload = normalizeArtifact({
+    ...existing,
+    id,
+    leadName,
+    draftText,
+    attachmentsJson: JSON.stringify(attachments),
+    attachmentCount: attachments.length,
+    updatedAt: now,
+    createdAt: existing.createdAt || now,
+  }, id);
+
+  artifactNode.get(id).put({
+    ...payload,
+    attachmentsJson: JSON.stringify(attachments),
+  }, (ack = {}) => {
+    if (ack.err) {
+      elements.artifactSaveStatus.textContent = `Artifact save failed: ${ack.err}`;
+      return;
+    }
+
+    state.artifacts.set(id, payload);
+    elements.artifactSaveStatus.textContent = `Saved potential message for ${leadName}.`;
+    elements.artifactFiles.value = '';
+    renderAll();
+  });
+}
+
+function loadMessageFromArtifact(artifactId) {
+  const artifact = state.artifacts.get(artifactId);
+  if (!artifact) return;
+
+  elements.sentArtifactId.value = artifact.id || '';
+  elements.sentLeadName.value = artifact.leadName || '';
+  elements.sentMessage.value = artifact.draftText || '';
+  elements.sentMessage.focus();
+}
+
+function saveSentMessage(event) {
+  event.preventDefault();
+  if (!touchLogNode) return;
+
+  const leadName = elements.sentLeadName.value.trim();
+  const message = elements.sentMessage.value.trim();
+  if (!leadName || !message) {
+    elements.sentSaveStatus.textContent = 'Lead name and message are required.';
+    return;
+  }
+
+  const artifactId = elements.sentArtifactId.value.trim();
+  const profile = getMatchingProfile(leadName);
+  const logId = `${slugify(leadName) || 'outreach'}-${Date.now()}`;
+  const timestamp = new Date().toISOString();
+  const entry = normalizeSent({
+    id: logId,
+    recordId: profile ? profile.id : slugify(leadName),
+    crmRecordId: profile ? profile.id : '',
+    contactName: leadName,
+    timestamp,
+    followUp: elements.sentFollowUp.value,
+    note: message,
+    touchType: 'outreach-sent',
+    touchTypeLabel: 'Outreach sent',
+    source: 'Outreach CRM',
+    channel: elements.sentChannel.value,
+    artifactId,
+    participantId: getParticipantId(),
+    loggedBy: getParticipantLabel(),
+  }, logId);
+
+  touchLogNode.get(logId).put(entry, (ack = {}) => {
+    if (ack.err) {
+      elements.sentSaveStatus.textContent = `Sent log failed: ${ack.err}`;
+      return;
+    }
+
+    state.sent.set(logId, entry);
+    elements.sentSaveStatus.textContent = `Logged sent message for ${leadName}.`;
+    elements.sentArtifactId.value = '';
+    elements.sentMessage.value = '';
+    renderAll();
+  });
+}
+
+function handlePageClick(event) {
+  const target = event.target.closest('[data-action]');
+  if (!target) return;
+
+  const action = target.dataset.action;
+  if (action === 'load-message') {
+    loadMessageFromArtifact(target.dataset.artifactId);
+  } else if (action === 'create-profile') {
+    createProfileFromArtifact(target.dataset.artifactId);
+  } else if (action === 'use-profile') {
+    loadProfile(target.dataset.profileId);
+  }
+}
+
+function subscribeMap(node, map, normalizer, onRender) {
+  if (!node || typeof node.map !== 'function') {
+    return;
+  }
+
+  node.map().on((data, id) => {
+    if (!id) return;
+    if (!data) {
+      map.delete(id);
+    } else {
+      map.set(id, normalizer(data, id));
+    }
+    onRender();
+  });
+}
+
+const outreachGun = createGun();
+const crmRecordsNode = outreachGun ? outreachGun.get(CRM_NODE_KEY) : null;
+const artifactNode = outreachGun ? getNodeFromPath(outreachGun, OUTREACH_ARTIFACT_NODE_PATH) : null;
+const touchLogNode = outreachGun ? getNodeFromPath(outreachGun, TOUCH_LOG_NODE_PATH) : null;
+
+if (!outreachGun) {
+  elements.profileStatus.textContent = 'Gun is unavailable. Customer profiles cannot sync.';
+  elements.artifactStatus.textContent = 'Gun is unavailable. Potential messages cannot sync.';
+  elements.sentStatus.textContent = 'Gun is unavailable. Sent messages cannot sync.';
+} else {
+  subscribeMap(crmRecordsNode, state.profiles, normalizeProfile, renderAll);
+  subscribeMap(artifactNode, state.artifacts, normalizeArtifact, renderAll);
+  subscribeMap(touchLogNode, state.sent, normalizeSent, renderAll);
+}
+
+elements.profileForm.addEventListener('submit', saveProfile);
+elements.artifactForm.addEventListener('submit', saveArtifact);
+elements.sentForm.addEventListener('submit', saveSentMessage);
+document.addEventListener('click', handlePageClick);
+renderAll();

--- a/sales/scoreboard.html
+++ b/sales/scoreboard.html
@@ -42,6 +42,10 @@
             class="inline-flex items-center justify-center rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20"
           >CRM</a>
           <a
+            href="outreach.html"
+            class="inline-flex items-center justify-center rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20"
+          >Outreach CRM</a>
+          <a
             href="../billing/index.html"
             class="inline-flex items-center justify-center rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20"
           >Billing</a>
@@ -186,6 +190,13 @@
           >
             <span>Pick the next segment</span>
             <span class="text-amber-300">Open research</span>
+          </a>
+          <a
+            href="outreach.html"
+            class="flex items-center justify-between rounded-xl border border-white/5 bg-slate-950/80 px-4 py-3 text-sm text-slate-200 hover:border-amber-300/30"
+          >
+            <span>Send and log real outreach</span>
+            <span class="text-amber-300">Open outreach CRM</span>
           </a>
           <a
             href="../crm/index.html"

--- a/tests/sales-outreach-crm.test.js
+++ b/tests/sales-outreach-crm.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('outreach CRM connects profiles, potential messages, and sent touches through Gun', async () => {
+  const salesHubHtml = await readFile(new URL('../sales/index.html', import.meta.url), 'utf8');
+  const crmHtml = await readFile(new URL('../crm/index.html', import.meta.url), 'utf8');
+  const scoreboardHtml = await readFile(new URL('../sales/scoreboard.html', import.meta.url), 'utf8');
+  const outreachHtml = await readFile(new URL('../sales/outreach.html', import.meta.url), 'utf8');
+  const outreachJs = await readFile(new URL('../sales/outreach.js', import.meta.url), 'utf8');
+
+  assert.match(salesHubHtml, /Outreach CRM/);
+  assert.match(crmHtml, /Outreach CRM/);
+  assert.match(scoreboardHtml, /Outreach CRM/);
+
+  assert.match(outreachHtml, /Customer profiles/);
+  assert.match(outreachHtml, /Potential messages/);
+  assert.match(outreachHtml, /Messages sent/);
+  assert.match(outreachHtml, /id="artifactForm"/);
+  assert.match(outreachHtml, /type="file" multiple accept="image\/png,image\/jpeg,image\/webp"/);
+  assert.match(outreachHtml, /type="module" src="\/sales\/outreach\.js"/);
+  assert.match(outreachHtml, /https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+  assert.match(outreachHtml, /\/gun-init\.js/);
+
+  assert.match(outreachJs, /const CRM_NODE_KEY = '3dvr-crm'/);
+  assert.match(outreachJs, /const TOUCH_LOG_NODE_PATH = \['3dvr-portal', 'crm-touch-log'\]/);
+  assert.match(outreachJs, /const OUTREACH_ARTIFACT_NODE_PATH = \['3dvr', 'crm', 'outreach-artifacts'\]/);
+  assert.match(outreachJs, /touchType: 'outreach-sent'/);
+  assert.match(outreachJs, /artifactId/);
+  assert.match(outreachJs, /attachmentsJson/);
+  assert.match(outreachJs, /readAsDataURL/);
+  assert.match(outreachJs, /data:\$\{mime\};base64/);
+});


### PR DESCRIPTION
## Summary
- Add a Sales Outreach CRM page for customer profiles, potential messages/artifacts, and sent-message logging
- Read/write Gun nodes for `3dvr-crm`, `3dvr/crm/outreach-artifacts`, and `3dvr-portal/crm-touch-log`
- Link Outreach CRM from Sales, Profitability Desk, and CRM navigation

## Verification
- `node -c sales/outreach.js`
- `node --test tests/sales-outreach-crm.test.js tests/sales-index.test.js tests/sales-profitability-scoreboard.test.js`
- Mobile Chromium smoke screenshot against local static server