### PR TITLE
Load outreach handoff artifacts

### DIFF
--- a/sales/outreach.js
+++ b/sales/outreach.js
@@ -7,6 +7,8 @@ const state = {
   artifacts: new Map(),
   sent: new Map(),
   activeProfileId: '',
+  pendingArtifactId: new URLSearchParams(window.location.search).get('artifact') || '',
+  pendingArtifactLoaded: false,
 };
 
 const elements = {
@@ -344,6 +346,7 @@ function renderAll() {
   renderProfiles();
   renderArtifacts();
   renderSent();
+  loadPendingArtifact();
 }
 
 function saveProfile(event) {
@@ -483,6 +486,21 @@ function loadMessageFromArtifact(artifactId) {
   elements.sentLeadName.value = artifact.leadName || '';
   elements.sentMessage.value = artifact.draftText || '';
   elements.sentMessage.focus();
+}
+
+function loadPendingArtifact() {
+  if (state.pendingArtifactLoaded || !state.pendingArtifactId) {
+    return;
+  }
+
+  const artifact = state.artifacts.get(state.pendingArtifactId);
+  if (!artifact) {
+    return;
+  }
+
+  state.pendingArtifactLoaded = true;
+  loadMessageFromArtifact(state.pendingArtifactId);
+  elements.artifactSaveStatus.textContent = `Loaded handoff for ${artifact.leadName}.`;
 }
 
 function saveSentMessage(event) {

--- a/tests/sales-outreach-crm.test.js
+++ b/tests/sales-outreach-crm.test.js
@@ -27,6 +27,8 @@ test('outreach CRM connects profiles, potential messages, and sent touches throu
   assert.match(outreachJs, /const OUTREACH_ARTIFACT_NODE_PATH = \['3dvr', 'crm', 'outreach-artifacts'\]/);
   assert.match(outreachJs, /touchType: 'outreach-sent'/);
   assert.match(outreachJs, /artifactId/);
+  assert.match(outreachJs, /pendingArtifactId/);
+  assert.match(outreachJs, /new URLSearchParams\(window\.location\.search\)\.get\('artifact'\)/);
   assert.match(outreachJs, /attachmentsJson/);
   assert.match(outreachJs, /readAsDataURL/);
   assert.match(outreachJs, /data:\$\{mime\};base64/);


### PR DESCRIPTION
## Summary
- Add `?artifact=<slug>` support to Outreach CRM
- Auto-load handoff artifacts into the sent-message form after the local agent writes them to Gun
- Cover handoff query behavior in the outreach CRM structure test

## Verification
- `node -c sales/outreach.js`
- `node --test tests/sales-outreach-crm.test.js`