### PR TITLE
Add operator alert email relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ STRIPE_PRICE_EMBEDDED_ID=price_replace_me
 GMAIL_USER=replace_me@example.com
 GMAIL_APP_PASSWORD=replace_me
 STRIPE_LOG_EMAIL=replace_me@example.com
+AGENT_OPERATOR_EMAIL_TOKEN=replace_me
 
 # Optional integration settings
 STRIPE_CUSTOMER_PORTAL_LOGIN_URL=

--- a/api/calendar/reminder-email.js
+++ b/api/calendar/reminder-email.js
@@ -3,7 +3,7 @@ import nodemailer from 'nodemailer';
 function setCorsHeaders(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Operator-Token');
 }
 
 function normalizeText(value) {
@@ -102,9 +102,16 @@ function resolveTeamRecipients(config = process.env) {
 }
 
 function resolvePortalOrigin(config = process.env) {
-  const origin = normalizeText(config.PORTAL_PUBLIC_ORIGIN);
+  const origin = normalizeText(config.PORTAL_PUBLIC_ORIGIN || config.PORTAL_ORIGIN);
   if (!origin) return 'https://3dvr-portal.vercel.app';
   return origin.endsWith('/') ? origin.slice(0, -1) : origin;
+}
+
+function resolveOperatorAlertToken(config = process.env) {
+  return normalizeText(
+    config.AGENT_OPERATOR_EMAIL_TOKEN
+    || config.THREEDVR_AUTOPILOT_EMAIL_TOKEN
+  );
 }
 
 function resolveMailCredentials(config = process.env) {
@@ -250,6 +257,67 @@ function buildAdminResetRequestAckHtml({ resetUrl }) {
       <p>We sent your request to the admin team.</p>
       <p>When temporary credentials are ready, you will get another email.</p>
       <p>You can also follow up from the recovery page: <a href="${resetUrl}">${resetUrl}</a></p>
+    </div>
+  `;
+}
+
+function getRequestHeader(req, key) {
+  const headers = req?.headers || {};
+  const target = String(key || '').toLowerCase();
+  for (const [headerKey, value] of Object.entries(headers)) {
+    if (String(headerKey).toLowerCase() === target) {
+      return typeof value === 'string' ? value : Array.isArray(value) ? value[0] : '';
+    }
+  }
+  return '';
+}
+
+function parseOperatorAlertToken(req) {
+  const authorization = normalizeText(getRequestHeader(req, 'authorization'));
+  if (authorization) {
+    const match = authorization.match(/^Bearer\s+(.+)$/i);
+    if (match) return normalizeText(match[1]);
+  }
+  return normalizeText(
+    getRequestHeader(req, 'x-operator-token')
+    || req.body?.token
+  );
+}
+
+function normalizeStringList(value) {
+  const list = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(/\r?\n|,/)
+      : [];
+
+  return list
+    .map(item => normalizeText(item))
+    .filter(Boolean);
+}
+
+function buildOperatorAlertHtml({ summary, actionItems, commands, metadata }) {
+  const summaryText = formatMessage(summary || 'No summary provided.');
+  const actions = actionItems.length
+    ? `<ul>${actionItems.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`
+    : '<p style="margin: 0 0 12px;">No action items.</p>';
+  const commandList = commands.length
+    ? `<ul>${commands.map(item => `<li><code>${escapeHtml(item)}</code></li>`).join('')}</ul>`
+    : '';
+  const metadataEntries = Object.entries(metadata || {})
+    .filter(([, value]) => normalizeText(value))
+    .map(([key, value]) => `<li><strong>${escapeHtml(key)}:</strong> ${escapeHtml(value)}</li>`)
+    .join('');
+
+  return `
+    <div style="font-family: Arial, sans-serif; line-height: 1.6;">
+      <h2 style="margin-bottom: 12px;">3DVR operator alert</h2>
+      <p style="margin: 0 0 12px;">${summaryText}</p>
+      <h3 style="margin: 20px 0 8px;">Action items</h3>
+      ${actions}
+      ${commandList ? `<h3 style="margin: 20px 0 8px;">Useful commands</h3>${commandList}` : ''}
+      ${metadataEntries ? `<h3 style="margin: 20px 0 8px;">Run metadata</h3><ul>${metadataEntries}</ul>` : ''}
+      <p style="margin: 20px 0 0; color: #555;">Triggered by 3dvr-agent through the portal mail relay.</p>
     </div>
   `;
 }
@@ -472,6 +540,96 @@ export function createAccountRecoveryEmailHandler(options = {}) {
   };
 }
 
+export function createOperatorAlertEmailHandler(options = {}) {
+  const {
+    config = process.env,
+    mailTransport
+  } = options;
+
+  function getTransport() {
+    return mailTransport || createTransport(config);
+  }
+
+  return async function operatorAlertEmailHandler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method !== 'POST') {
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    const expectedToken = resolveOperatorAlertToken(config);
+    const providedToken = parseOperatorAlertToken(req);
+    if (!expectedToken || providedToken !== expectedToken) {
+      return res.status(401).json({ error: 'Unauthorized operator alert trigger.' });
+    }
+
+    const to = normalizeRecipientList(req.body?.to);
+    const subject = normalizeText(req.body?.subject);
+    const summary = normalizeText(req.body?.summary);
+    const text = normalizeText(req.body?.text);
+    const actionItems = normalizeStringList(req.body?.actionItems);
+    const commands = normalizeStringList(req.body?.commands);
+    const metadata = req.body?.metadata && typeof req.body.metadata === 'object'
+      ? req.body.metadata
+      : {};
+
+    if (!to.length) {
+      return res.status(400).json({ error: 'At least one operator alert recipient is required.' });
+    }
+
+    if (!subject) {
+      return res.status(400).json({ error: 'An operator alert subject is required.' });
+    }
+
+    if (!summary && !text) {
+      return res.status(400).json({ error: 'A summary or text body is required.' });
+    }
+
+    let transport;
+    try {
+      transport = getTransport();
+    } catch (error) {
+      return res.status(503).json({
+        error: error.message || 'Operator alert email is not configured on this deployment.'
+      });
+    }
+
+    const sender = resolveMailCredentials(config).user || 'no-reply@3dvr.tech';
+    const from = `"3DVR Operator" <${sender}>`;
+    const plainText = text || [
+      summary,
+      '',
+      actionItems.length ? `Action items:\n- ${actionItems.join('\n- ')}` : '',
+      commands.length ? `Useful commands:\n- ${commands.join('\n- ')}` : '',
+    ].filter(Boolean).join('\n');
+
+    try {
+      await transport.sendMail({
+        from,
+        to,
+        subject,
+        text: plainText,
+        html: buildOperatorAlertHtml({
+          summary: summary || text,
+          actionItems,
+          commands,
+          metadata
+        })
+      });
+
+      return res.status(200).json({ success: true, mode: 'operator-alert' });
+    } catch (error) {
+      return res.status(500).json({
+        error: error.message || 'Unable to send operator alert email.'
+      });
+    }
+  };
+}
+
 export function createUnifiedEmailHandler(options = {}) {
   const {
     config = process.env,
@@ -480,6 +638,7 @@ export function createUnifiedEmailHandler(options = {}) {
 
   const calendarHandler = createCalendarReminderEmailHandler({ config, mailTransport });
   const accountRecoveryHandler = createAccountRecoveryEmailHandler({ config, mailTransport });
+  const operatorAlertHandler = createOperatorAlertEmailHandler({ config, mailTransport });
 
   return async function unifiedEmailHandler(req, res) {
     setCorsHeaders(res);
@@ -495,6 +654,9 @@ export function createUnifiedEmailHandler(options = {}) {
     const mode = normalizeText(req.body?.mode).toLowerCase();
     if (mode === 'lookup' || mode === 'admin-reset-request' || mode === 'admin-reset-issued') {
       return accountRecoveryHandler(req, res);
+    }
+    if (mode === 'operator-alert') {
+      return operatorAlertHandler(req, res);
     }
 
     return calendarHandler(req, res);

--- a/tests/account-recovery-email.test.js
+++ b/tests/account-recovery-email.test.js
@@ -1,12 +1,13 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { createAccountRecoveryEmailHandler } from '../api/calendar/reminder-email.js';
+import { createAccountRecoveryEmailHandler, createUnifiedEmailHandler } from '../api/calendar/reminder-email.js';
 
 const baseConfig = {
   GMAIL_USER: 'bot@example.com',
   GMAIL_APP_PASSWORD: 'app_password',
   ACCOUNT_RECOVERY_TEAM_EMAILS: 'admin1@example.com,admin2@example.com',
-  PORTAL_PUBLIC_ORIGIN: 'https://portal.3dvr.tech'
+  PORTAL_PUBLIC_ORIGIN: 'https://portal.3dvr.tech',
+  AGENT_OPERATOR_EMAIL_TOKEN: 'operator-secret'
 };
 
 function createMailTransport() {
@@ -238,5 +239,69 @@ describe('account recovery email api', () => {
     assert.equal(res.body.mailConfigured, false);
     assert.equal(res.body.teamRecipientsConfigured, true);
     assert.match(res.body.error, /not configured on this deployment/i);
+  });
+
+  it('rejects operator alerts without the shared token', async () => {
+    const mail = createMailTransport();
+    const handler = createUnifiedEmailHandler({
+      config: baseConfig,
+      mailTransport: mail
+    });
+
+    const req = {
+      method: 'POST',
+      headers: {},
+      body: {
+        mode: 'operator-alert',
+        to: 'thomas@example.com',
+        subject: 'Need input',
+        summary: 'Review the new leads.'
+      }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 401);
+    assert.equal(mail.sendMail.mock.calls.length, 0);
+  });
+
+  it('sends operator alerts through the unified mail route', async () => {
+    const mail = createMailTransport();
+    const handler = createUnifiedEmailHandler({
+      config: baseConfig,
+      mailTransport: mail
+    });
+
+    const req = {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer operator-secret'
+      },
+      body: {
+        mode: 'operator-alert',
+        to: ['thomas@example.com'],
+        subject: '[3dvr-agent] action needed',
+        summary: 'New leads are ready for review.',
+        actionItems: ['Review/send new outreach', 'Check contacted lead follow-ups'],
+        commands: ['ask-next', 'ask-send --enrich --mark "Lead Name"'],
+        metadata: {
+          runId: '2026-04-23T01-02-03Z',
+          counts: 'new=5, contacted=2'
+        }
+      }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.mode, 'operator-alert');
+    assert.equal(mail.sendMail.mock.calls.length, 1);
+    const sent = mail.sendMail.mock.calls[0].arguments[0];
+    assert.deepEqual(sent.to, ['thomas@example.com']);
+    assert.equal(sent.subject, '[3dvr-agent] action needed');
+    assert.match(sent.html, /3DVR operator alert/i);
+    assert.match(sent.text, /New leads are ready for review/i);
   });
 });


### PR DESCRIPTION
## Summary
- add a protected operator alert mode to the existing Gmail mail route
- let 3dvr-agent relay autopilot alerts through the portal transport
- document the shared token env var and cover the new mode with tests

## Verification
- node --test tests/account-recovery-email.test.js
- npm run dev
