### PR TITLE
[codex] add portal lead outreach email mode

### DIFF
--- a/api/calendar/reminder-email.js
+++ b/api/calendar/reminder-email.js
@@ -261,6 +261,19 @@ function buildAdminResetRequestAckHtml({ resetUrl }) {
   `;
 }
 
+function buildLeadOutreachHtml({ headline, message, senderName, senderEmail }) {
+  const fromLabel = normalizeText(senderName) || 'Thomas @ 3DVR';
+  const replyLabel = normalizeEmail(senderEmail);
+
+  return `
+    <div style="font-family: Arial, sans-serif; line-height: 1.6;">
+      <p>${formatMessage(headline || 'Quick note from 3DVR')}</p>
+      <p>${formatMessage(message)}</p>
+      <p style="margin-top: 20px;">${escapeHtml(fromLabel)}${replyLabel ? `<br><a href="mailto:${replyLabel}">${escapeHtml(replyLabel)}</a>` : ''}</p>
+    </div>
+  `;
+}
+
 function getRequestHeader(req, key) {
   const headers = req?.headers || {};
   const target = String(key || '').toLowerCase();
@@ -630,6 +643,89 @@ export function createOperatorAlertEmailHandler(options = {}) {
   };
 }
 
+export function createLeadOutreachEmailHandler(options = {}) {
+  const {
+    config = process.env,
+    mailTransport
+  } = options;
+
+  function getTransport() {
+    return mailTransport || createTransport(config);
+  }
+
+  return async function leadOutreachEmailHandler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method !== 'POST') {
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    const expectedToken = resolveOperatorAlertToken(config);
+    const providedToken = parseOperatorAlertToken(req);
+    if (!expectedToken || providedToken !== expectedToken) {
+      return res.status(401).json({ error: 'Unauthorized lead outreach trigger.' });
+    }
+
+    const to = normalizeRecipientList(req.body?.to);
+    const subject = normalizeText(req.body?.subject);
+    const text = normalizeText(req.body?.text);
+    const headline = normalizeText(req.body?.headline);
+    const senderName = normalizeText(req.body?.senderName || 'Thomas @ 3DVR');
+    const senderEmail = normalizeEmail(req.body?.senderEmail || resolveMailCredentials(config).user);
+
+    if (!to.length) {
+      return res.status(400).json({ error: 'At least one outreach recipient is required.' });
+    }
+
+    if (!subject) {
+      return res.status(400).json({ error: 'An outreach subject is required.' });
+    }
+
+    if (!text) {
+      return res.status(400).json({ error: 'An outreach text body is required.' });
+    }
+
+    let transport;
+    try {
+      transport = getTransport();
+    } catch (error) {
+      return res.status(503).json({
+        error: error.message || 'Lead outreach email is not configured on this deployment.'
+      });
+    }
+
+    const sender = resolveMailCredentials(config).user || 'no-reply@3dvr.tech';
+    const from = `"${senderName || 'Thomas @ 3DVR'}" <${sender}>`;
+    const replyTo = senderEmail || undefined;
+
+    try {
+      await transport.sendMail({
+        from,
+        to,
+        replyTo,
+        subject,
+        text,
+        html: buildLeadOutreachHtml({
+          headline,
+          message: text,
+          senderName,
+          senderEmail
+        })
+      });
+
+      return res.status(200).json({ success: true, mode: 'lead-outreach' });
+    } catch (error) {
+      return res.status(500).json({
+        error: error.message || 'Unable to send lead outreach email.'
+      });
+    }
+  };
+}
+
 export function createUnifiedEmailHandler(options = {}) {
   const {
     config = process.env,
@@ -639,6 +735,7 @@ export function createUnifiedEmailHandler(options = {}) {
   const calendarHandler = createCalendarReminderEmailHandler({ config, mailTransport });
   const accountRecoveryHandler = createAccountRecoveryEmailHandler({ config, mailTransport });
   const operatorAlertHandler = createOperatorAlertEmailHandler({ config, mailTransport });
+  const leadOutreachHandler = createLeadOutreachEmailHandler({ config, mailTransport });
 
   return async function unifiedEmailHandler(req, res) {
     setCorsHeaders(res);
@@ -657,6 +754,9 @@ export function createUnifiedEmailHandler(options = {}) {
     }
     if (mode === 'operator-alert') {
       return operatorAlertHandler(req, res);
+    }
+    if (mode === 'lead-outreach') {
+      return leadOutreachHandler(req, res);
     }
 
     return calendarHandler(req, res);

--- a/tests/account-recovery-email.test.js
+++ b/tests/account-recovery-email.test.js
@@ -304,4 +304,66 @@ describe('account recovery email api', () => {
     assert.match(sent.html, /3DVR operator alert/i);
     assert.match(sent.text, /New leads are ready for review/i);
   });
+
+  it('rejects lead outreach without the shared token', async () => {
+    const mail = createMailTransport();
+    const handler = createUnifiedEmailHandler({
+      config: baseConfig,
+      mailTransport: mail
+    });
+
+    const req = {
+      method: 'POST',
+      headers: {},
+      body: {
+        mode: 'lead-outreach',
+        to: 'tmsteph1290@gmail.com',
+        subject: 'Quick idea for your site',
+        text: 'I noticed one small customer-flow issue worth tightening.'
+      }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 401);
+    assert.equal(mail.sendMail.mock.calls.length, 0);
+  });
+
+  it('sends lead outreach through the unified mail route', async () => {
+    const mail = createMailTransport();
+    const handler = createUnifiedEmailHandler({
+      config: baseConfig,
+      mailTransport: mail
+    });
+
+    const req = {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer operator-secret'
+      },
+      body: {
+        mode: 'lead-outreach',
+        to: ['tmsteph1290@gmail.com'],
+        subject: 'Quick idea for your site',
+        headline: 'Quick note from 3DVR',
+        text: 'I noticed one small customer-flow issue worth tightening.',
+        senderName: 'Thomas @ 3DVR',
+        senderEmail: '3dvr.tech@gmail.com'
+      }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.mode, 'lead-outreach');
+    assert.equal(mail.sendMail.mock.calls.length, 1);
+    const sent = mail.sendMail.mock.calls[0].arguments[0];
+    assert.deepEqual(sent.to, ['tmsteph1290@gmail.com']);
+    assert.equal(sent.subject, 'Quick idea for your site');
+    assert.equal(sent.replyTo, '3dvr.tech@gmail.com');
+    assert.match(sent.html, /Quick note from 3DVR/i);
+    assert.match(sent.text, /customer-flow issue/i);
+  });
 });


### PR DESCRIPTION
## What changed
- added a protected `lead-outreach` mode to the unified portal mail endpoint
- reused the existing shared operator token for authorization
- added regression coverage for unauthorized and authorized lead-outreach requests

## Why
The agent needed to send first-touch prospect emails through the portal mail relay instead of sending directly through local Gmail. The portal endpoint previously supported account recovery and operator alerts, but not outbound lead outreach.

## Impact
- `3dvr-agent` can now route outreach through `https://portal.3dvr.tech/api/calendar/reminder-email`
- outbound lead mail uses the portal transport and can set `replyTo` for Thomas
- the route stays protected behind the shared operator token

## Validation
- `node --test tests/account-recovery-email.test.js`
- local end-to-end relay test using the portal handler plus real Gmail credentials/token sent a test message to `tmsteph1290@gmail.com`
