### PR TITLE
[codex] support threaded lead replies

### DIFF
--- a/api/calendar/reminder-email.js
+++ b/api/calendar/reminder-email.js
@@ -676,6 +676,8 @@ export function createLeadOutreachEmailHandler(options = {}) {
     const headline = normalizeText(req.body?.headline);
     const senderName = normalizeText(req.body?.senderName || 'Thomas @ 3DVR');
     const senderEmail = normalizeEmail(req.body?.senderEmail || resolveMailCredentials(config).user);
+    const inReplyTo = normalizeText(req.body?.inReplyTo);
+    const references = normalizeText(req.body?.references);
 
     if (!to.length) {
       return res.status(400).json({ error: 'At least one outreach recipient is required.' });
@@ -707,6 +709,8 @@ export function createLeadOutreachEmailHandler(options = {}) {
         from,
         to,
         replyTo,
+        inReplyTo: inReplyTo || undefined,
+        references: references || undefined,
         subject,
         text,
         html: buildLeadOutreachHtml({

--- a/tests/account-recovery-email.test.js
+++ b/tests/account-recovery-email.test.js
@@ -345,11 +345,13 @@ describe('account recovery email api', () => {
       body: {
         mode: 'lead-outreach',
         to: ['tmsteph1290@gmail.com'],
-        subject: 'Quick idea for your site',
+        subject: 'Re: Quick idea for your site',
         headline: 'Quick note from 3DVR',
         text: 'I noticed one small customer-flow issue worth tightening.',
         senderName: 'Thomas @ 3DVR',
-        senderEmail: '3dvr.tech@gmail.com'
+        senderEmail: '3dvr.tech@gmail.com',
+        inReplyTo: '<reply-message@example.com>',
+        references: '<thread-root@example.com> <reply-message@example.com>'
       }
     };
     const res = createMockRes();
@@ -361,8 +363,10 @@ describe('account recovery email api', () => {
     assert.equal(mail.sendMail.mock.calls.length, 1);
     const sent = mail.sendMail.mock.calls[0].arguments[0];
     assert.deepEqual(sent.to, ['tmsteph1290@gmail.com']);
-    assert.equal(sent.subject, 'Quick idea for your site');
+    assert.equal(sent.subject, 'Re: Quick idea for your site');
     assert.equal(sent.replyTo, '3dvr.tech@gmail.com');
+    assert.equal(sent.inReplyTo, '<reply-message@example.com>');
+    assert.equal(sent.references, '<thread-root@example.com> <reply-message@example.com>');
     assert.match(sent.html, /Quick note from 3DVR/i);
     assert.match(sent.text, /customer-flow issue/i);
   });


### PR DESCRIPTION
## What changed
- extended the portal `lead-outreach` mail mode to accept `inReplyTo` and `references`
- passed those values through to the underlying mail transport
- updated the mail-route test coverage for threaded reply sends

## Why
The inbox auto-reply flow in `3dvr-agent` needs to send real follow-up replies that stay on the existing email thread instead of starting a fresh cold email every time.

## Impact
- portal-backed lead outreach can now be used for threaded follow-up replies
- the agent can preserve Gmail-style conversation threading while still using the protected portal relay

## Validation
- `node --test tests/account-recovery-email.test.js`
