### PR TITLE
[codex] Add community system page

### DIFF
--- a/alive-system/index.html
+++ b/alive-system/index.html
@@ -9,6 +9,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="../score.js"></script>
   <link rel="stylesheet" href="./styles.css" />
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
   <div class="wrap">

--- a/community/app.js
+++ b/community/app.js
@@ -1,0 +1,228 @@
+const COMMUNITY_ROOT = 'communitySystem';
+
+const state = {
+  circles: new Map(),
+  checkins: new Map(),
+  threads: new Map(),
+  profile: {},
+};
+
+const selectors = {
+  profileForm: document.getElementById('profileForm'),
+  profileName: document.getElementById('profileName'),
+  profileGoal: document.getElementById('profileGoal'),
+  profileRole: document.getElementById('profileRole'),
+  circleForm: document.getElementById('circleForm'),
+  circleName: document.getElementById('circleName'),
+  circleFocus: document.getElementById('circleFocus'),
+  circleList: document.getElementById('circleList'),
+  checkinForm: document.getElementById('checkinForm'),
+  checkinBuild: document.getElementById('checkinBuild'),
+  checkinStuck: document.getElementById('checkinStuck'),
+  checkinNeed: document.getElementById('checkinNeed'),
+  threadForm: document.getElementById('threadForm'),
+  threadTopic: document.getElementById('threadTopic'),
+  threadMessage: document.getElementById('threadMessage'),
+  communityFeed: document.getElementById('communityFeed'),
+  syncStatus: document.getElementById('syncStatus'),
+};
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function safeText(value) {
+  return clean(value) || 'Not set yet';
+}
+
+function getGunRoot() {
+  if (typeof window.Gun !== 'function') {
+    selectors.syncStatus.textContent = 'Gun is not available in this browser session.';
+    return null;
+  }
+
+  const gun = window.gun || window.Gun(window.__GUN_PEERS__ || ['https://gun-relay-3dvr.fly.dev/gun']);
+  window.gun = gun;
+  selectors.syncStatus.textContent = 'Connected to Gun community graph.';
+
+  // Node shape:
+  // gun.get('3dvr-portal').get('communitySystem').get('profiles').get('local-builder')
+  // gun.get('3dvr-portal').get('communitySystem').get('circles').set(circle)
+  // gun.get('3dvr-portal').get('communitySystem').get('checkins').set(checkin)
+  // gun.get('3dvr-portal').get('communitySystem').get('threads').set(thread)
+  return gun.get('3dvr-portal').get(COMMUNITY_ROOT);
+}
+
+const root = getGunRoot();
+
+function renderCircles() {
+  const circles = Array.from(state.circles.values())
+    .filter(circle => circle && circle.name)
+    .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0))
+    .slice(0, 6);
+
+  selectors.circleList.innerHTML = '';
+  if (!circles.length) {
+    selectors.circleList.innerHTML = '<div class="mini-item">No circles yet. Create the first one.</div>';
+    return;
+  }
+
+  for (const circle of circles) {
+    const item = document.createElement('div');
+    item.className = 'mini-item';
+    item.innerHTML = `
+      <strong></strong>
+      <span></span>
+    `;
+    item.querySelector('strong').textContent = circle.name;
+    item.querySelector('span').textContent = circle.focus || 'Open builder support circle';
+    selectors.circleList.append(item);
+  }
+}
+
+function feedItems() {
+  const checkins = Array.from(state.checkins.values())
+    .filter(checkin => checkin && checkin.build)
+    .map(checkin => ({
+      type: 'Weekly check-in',
+      title: checkin.build,
+      body: `Stuck: ${safeText(checkin.stuck)} Need: ${safeText(checkin.need)}`,
+      createdAt: checkin.createdAt,
+    }));
+
+  const threads = Array.from(state.threads.values())
+    .filter(thread => thread && thread.topic)
+    .map(thread => ({
+      type: 'Thread',
+      title: thread.topic,
+      body: thread.message,
+      createdAt: thread.createdAt,
+    }));
+
+  return [...checkins, ...threads]
+    .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0))
+    .slice(0, 18);
+}
+
+function renderFeed() {
+  const items = feedItems();
+  selectors.communityFeed.innerHTML = '';
+
+  if (!items.length) {
+    selectors.communityFeed.innerHTML = '<div class="feed-item">No community posts yet. Add a check-in or thread.</div>';
+    return;
+  }
+
+  for (const item of items) {
+    const entry = document.createElement('article');
+    entry.className = 'feed-item';
+    entry.innerHTML = `
+      <span class="feed-item__meta"></span>
+      <strong></strong>
+      <p></p>
+    `;
+    entry.querySelector('.feed-item__meta').textContent = item.type;
+    entry.querySelector('strong').textContent = item.title;
+    entry.querySelector('p').textContent = item.body;
+    selectors.communityFeed.append(entry);
+  }
+}
+
+function saveProfile(event) {
+  event.preventDefault();
+  const profile = {
+    name: clean(selectors.profileName.value),
+    goal: clean(selectors.profileGoal.value),
+    role: clean(selectors.profileRole.value) || 'Builder',
+    updatedAt: Date.now(),
+  };
+  state.profile = profile;
+  root?.get('profiles').get('local-builder').put(profile);
+  selectors.syncStatus.textContent = 'Profile saved to community graph.';
+}
+
+function createCircle(event) {
+  event.preventDefault();
+  const circle = {
+    name: clean(selectors.circleName.value),
+    focus: clean(selectors.circleFocus.value),
+    createdAt: Date.now(),
+    sizeTarget: '3-6',
+  };
+  if (!circle.name) return;
+  root?.get('circles').set(circle);
+  selectors.circleForm.reset();
+  selectors.syncStatus.textContent = 'Circle created.';
+}
+
+function submitCheckin(event) {
+  event.preventDefault();
+  const checkin = {
+    build: clean(selectors.checkinBuild.value),
+    stuck: clean(selectors.checkinStuck.value),
+    need: clean(selectors.checkinNeed.value),
+    author: state.profile.name || 'Builder',
+    createdAt: Date.now(),
+  };
+  if (!checkin.build) return;
+  root?.get('checkins').set(checkin);
+  selectors.checkinForm.reset();
+  selectors.syncStatus.textContent = 'Weekly check-in posted.';
+}
+
+function postThread(event) {
+  event.preventDefault();
+  const thread = {
+    topic: clean(selectors.threadTopic.value),
+    message: clean(selectors.threadMessage.value),
+    author: state.profile.name || 'Builder',
+    createdAt: Date.now(),
+  };
+  if (!thread.topic || !thread.message) return;
+  root?.get('threads').set(thread);
+  selectors.threadForm.reset();
+  selectors.syncStatus.textContent = 'Builder thread posted.';
+}
+
+function bindGun() {
+  if (!root) {
+    renderCircles();
+    renderFeed();
+    return;
+  }
+
+  root.get('profiles').get('local-builder').on(profile => {
+    if (!profile) return;
+    state.profile = profile;
+    selectors.profileName.value = profile.name || '';
+    selectors.profileGoal.value = profile.goal || '';
+    selectors.profileRole.value = profile.role || 'Builder';
+  });
+
+  root.get('circles').map().on((circle, id) => {
+    if (!circle || !circle.name) return;
+    state.circles.set(id, circle);
+    renderCircles();
+  });
+
+  root.get('checkins').map().on((checkin, id) => {
+    if (!checkin || !checkin.build) return;
+    state.checkins.set(id, checkin);
+    renderFeed();
+  });
+
+  root.get('threads').map().on((thread, id) => {
+    if (!thread || !thread.topic) return;
+    state.threads.set(id, thread);
+    renderFeed();
+  });
+}
+
+selectors.profileForm.addEventListener('submit', saveProfile);
+selectors.circleForm.addEventListener('submit', createCircle);
+selectors.checkinForm.addEventListener('submit', submitCheckin);
+selectors.threadForm.addEventListener('submit', postThread);
+
+renderCircles();
+renderFeed();
+bindGun();

--- a/community/index.html
+++ b/community/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>3DVR Community System</title>
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <link rel="stylesheet" href="../styles/global.css" />
+  <link rel="stylesheet" href="./styles.css" />
+  <script defer src="./app.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="community-page theme-dark">
+  <a class="skip-link" href="#communityMain">Skip to community workspace</a>
+  <div class="community-shell">
+    <header class="community-hero" aria-labelledby="communityTitle">
+      <nav class="community-nav" aria-label="Community navigation">
+        <a href="../index.html">Portal</a>
+        <a href="../cell/index.html">Cell</a>
+        <a href="../contacts/index.html">Contacts</a>
+        <a href="../projects/index.html">Projects</a>
+      </nav>
+      <div class="hero-grid">
+        <section class="hero-panel">
+          <p class="eyebrow">3DVR Community System v0.1</p>
+          <h1 id="communityTitle">A support layer for builders.</h1>
+          <p class="hero-copy">
+            Not social media. A calm builder network where people can clarify their vision, find a small circle,
+            run weekly check-ins, and keep momentum without getting pulled back into conformity.
+          </p>
+          <div class="hero-actions">
+            <a class="button primary" href="#circleForm">Create a circle</a>
+            <a class="button secondary" href="#checkinForm">Do weekly check-in</a>
+          </div>
+        </section>
+        <aside class="system-card" aria-labelledby="systemLayersTitle">
+          <h2 id="systemLayersTitle">Three layers</h2>
+          <ol>
+            <li><strong>Personal Space</strong><span>Goals, notes, and projects stay grounded.</span></li>
+            <li><strong>Small Circles</strong><span>3-6 people, honest check-ins, direct help.</span></li>
+            <li><strong>Public Builder Layer</strong><span>Progress, collaboration, and open invitations.</span></li>
+          </ol>
+        </aside>
+      </div>
+    </header>
+
+    <main id="communityMain" class="community-main">
+      <section class="card profile-card" aria-labelledby="profileTitle">
+        <div>
+          <p class="eyebrow">Personal space</p>
+          <h2 id="profileTitle">Builder profile</h2>
+          <p>
+            Save the simple version of who you are, what you are building, and how people can help.
+          </p>
+        </div>
+        <form id="profileForm" class="stacked-form">
+          <label>
+            Name
+            <input id="profileName" name="name" autocomplete="name" placeholder="Thomas" />
+          </label>
+          <label>
+            Current goal
+            <textarea id="profileGoal" name="goal" rows="3" placeholder="What are you trying to build or become?"></textarea>
+          </label>
+          <label>
+            Role
+            <select id="profileRole" name="role">
+              <option>Builder</option>
+              <option>Guide</option>
+              <option>Connector</option>
+            </select>
+          </label>
+          <button class="button primary" type="submit">Save profile</button>
+        </form>
+      </section>
+
+      <section class="grid-two">
+        <article class="card" aria-labelledby="circleTitle">
+          <p class="eyebrow">Small circles</p>
+          <h2 id="circleTitle">Create or join a circle</h2>
+          <p>
+            Keep circles intentionally small. The goal is honest support, not another noisy group chat.
+          </p>
+          <form id="circleForm" class="stacked-form">
+            <label>
+              Circle name
+              <input id="circleName" name="circleName" required placeholder="Saturday Builders" />
+            </label>
+            <label>
+              Focus
+              <input id="circleFocus" name="circleFocus" placeholder="Websites, health, outreach, creative work..." />
+            </label>
+            <button class="button primary" type="submit">Create circle</button>
+          </form>
+          <div class="mini-list" id="circleList" aria-live="polite"></div>
+        </article>
+
+        <article class="card" aria-labelledby="checkinTitle">
+          <p class="eyebrow">Weekly flow</p>
+          <h2 id="checkinTitle">Weekly check-in</h2>
+          <p>Answer the three questions. Keep it specific enough that someone can actually help.</p>
+          <form id="checkinForm" class="stacked-form">
+            <label>
+              What did I build this week?
+              <textarea id="checkinBuild" required rows="3"></textarea>
+            </label>
+            <label>
+              Where did I get stuck?
+              <textarea id="checkinStuck" rows="3"></textarea>
+            </label>
+            <label>
+              What do I need?
+              <textarea id="checkinNeed" rows="3"></textarea>
+            </label>
+            <button class="button primary" type="submit">Submit check-in</button>
+          </form>
+        </article>
+      </section>
+
+      <section class="grid-two">
+        <article class="card" aria-labelledby="threadTitle">
+          <p class="eyebrow">Focused threads</p>
+          <h2 id="threadTitle">Post a builder thread</h2>
+          <p>
+            Threads are for one focused topic: a blocker, offer, project update, or collaboration request.
+          </p>
+          <form id="threadForm" class="stacked-form">
+            <label>
+              Topic
+              <input id="threadTopic" required placeholder="Need feedback on my homepage offer" />
+            </label>
+            <label>
+              Message
+              <textarea id="threadMessage" required rows="4"></textarea>
+            </label>
+            <button class="button primary" type="submit">Post thread</button>
+          </form>
+        </article>
+
+        <aside class="card blueprint-card" aria-labelledby="blueprintTitle">
+          <p class="eyebrow">Operating rule</p>
+          <h2 id="blueprintTitle">What makes this different</h2>
+          <ul>
+            <li>People are supported in building their vision, not dragged back to default settings.</li>
+            <li>Small circles replace random unsupportive environments.</li>
+            <li>Public sharing is progress-first, not dopamine-first.</li>
+            <li>Every check-in should produce one next move, one ask, or one useful connection.</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section class="card feed-card" aria-labelledby="feedTitle">
+        <div class="feed-header">
+          <div>
+            <p class="eyebrow">Live builder layer</p>
+            <h2 id="feedTitle">Community feed</h2>
+          </div>
+          <p id="syncStatus" role="status" aria-live="polite">Connecting to Gun...</p>
+        </div>
+        <div id="communityFeed" class="feed-list" aria-live="polite"></div>
+      </section>
+    </main>
+  </div>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/community/styles.css
+++ b/community/styles.css
@@ -1,0 +1,292 @@
+:root {
+  --community-bg: #07131d;
+  --community-panel: rgba(13, 28, 43, 0.82);
+  --community-panel-strong: rgba(16, 40, 57, 0.94);
+  --community-text: #f5f8fb;
+  --community-muted: #a9bfce;
+  --community-line: rgba(151, 201, 224, 0.2);
+  --community-aqua: #90e8d4;
+  --community-gold: #f3c969;
+  --community-coral: #ff9f8f;
+  --community-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.community-page {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--community-text);
+  font-family: "Avenir Next", "Trebuchet MS", Verdana, sans-serif;
+  background:
+    radial-gradient(circle at 14% 10%, rgba(144, 232, 212, 0.18), transparent 26rem),
+    radial-gradient(circle at 86% 4%, rgba(243, 201, 105, 0.14), transparent 24rem),
+    linear-gradient(145deg, #05101a 0%, #07131d 48%, #0c1f2b 100%);
+}
+
+body.community-page::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 42px 42px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.75), transparent 75%);
+}
+
+a {
+  color: inherit;
+}
+
+.community-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 22px 0 56px;
+}
+
+.community-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.community-nav a,
+.button {
+  border: 1px solid var(--community-line);
+  border-radius: 999px;
+  padding: 10px 14px;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.hero-grid,
+.grid-two {
+  display: grid;
+  grid-template-columns: minmax(0, 1.28fr) minmax(280px, 0.72fr);
+  gap: 18px;
+}
+
+.hero-panel,
+.card,
+.system-card {
+  border: 1px solid var(--community-line);
+  border-radius: 28px;
+  background: var(--community-panel);
+  box-shadow: var(--community-shadow);
+  backdrop-filter: blur(18px);
+}
+
+.hero-panel {
+  min-height: 430px;
+  padding: clamp(24px, 5vw, 56px);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-panel::after {
+  content: "";
+  position: absolute;
+  right: -80px;
+  bottom: -120px;
+  width: 320px;
+  height: 320px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 159, 143, 0.2), transparent 68%);
+}
+
+.eyebrow {
+  color: var(--community-aqua);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  margin: 0 0 12px;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 10ch;
+  margin-bottom: 20px;
+  font-size: clamp(2.8rem, 8vw, 6.6rem);
+  line-height: 0.9;
+  letter-spacing: -0.07em;
+}
+
+h2 {
+  margin-bottom: 10px;
+  font-size: clamp(1.45rem, 3vw, 2.3rem);
+  letter-spacing: -0.04em;
+}
+
+.hero-copy,
+.card p,
+.system-card span,
+.blueprint-card li,
+.feed-item p {
+  color: var(--community-muted);
+  line-height: 1.65;
+}
+
+.hero-copy {
+  max-width: 62ch;
+  font-size: 1.08rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 26px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--community-text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+}
+
+.button.primary {
+  border-color: transparent;
+  color: #07131d;
+  background: linear-gradient(135deg, var(--community-aqua), var(--community-gold));
+}
+
+.button.secondary {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.system-card,
+.card {
+  padding: 24px;
+}
+
+.system-card {
+  background: var(--community-panel-strong);
+}
+
+.system-card ol,
+.blueprint-card ul {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.system-card li strong,
+.system-card li span {
+  display: block;
+}
+
+.community-main {
+  display: grid;
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.profile-card {
+  display: grid;
+  grid-template-columns: minmax(0, 0.7fr) minmax(280px, 1fr);
+  gap: 20px;
+}
+
+.stacked-form {
+  display: grid;
+  gap: 14px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: var(--community-muted);
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 12px 14px;
+  color: var(--community-text);
+  background: rgba(2, 10, 17, 0.7);
+  font: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.mini-list,
+.feed-list {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.mini-item,
+.feed-item {
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 18px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.mini-item strong,
+.feed-item strong {
+  display: block;
+  margin-bottom: 5px;
+}
+
+.feed-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+#syncStatus {
+  margin: 0;
+  color: var(--community-gold);
+  font-size: 0.9rem;
+}
+
+.feed-item__meta {
+  color: var(--community-aqua);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 820px) {
+  .hero-grid,
+  .grid-two,
+  .profile-card {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-panel {
+    min-height: auto;
+  }
+
+  .feed-header {
+    display: block;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -163,6 +163,11 @@
                 <span class="shortcut-card__title">Support Group</span>
                 <span class="shortcut-card__meta">Cell: small-group accountability and weekly momentum.</span>
               </a>
+              <a href="community/index.html" class="shortcut-card">
+                <span class="shortcut-card__icon" aria-hidden="true">🌐</span>
+                <span class="shortcut-card__title">Community System</span>
+                <span class="shortcut-card__meta">Circles, weekly check-ins, and builder threads.</span>
+              </a>
               <a href="start/index.html" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">🧭</span>
                 <span class="shortcut-card__title">Start Your Thing</span>
@@ -249,6 +254,11 @@
             <span class="app-card__title">Cell</span>
             <span class="app-card__meta">Build a portable organizing unit for people, projects, and mutual support.</span>
           </a>
+          <a href="community/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🌐</span>
+            <span class="app-card__title">Community</span>
+            <span class="app-card__meta">Create builder circles, weekly check-ins, and focused project support threads.</span>
+          </a>
           <a href="life/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌿</span>
             <span class="app-card__title">Life</span>
@@ -261,7 +271,7 @@
           </a>
           <a href="/chat/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">💬</span>
-            <span class="app-card__title">Messenger</span>
+            <span class="app-card__title">Chat</span>
             <span class="app-card__meta">Stay in the loop, route notifications, and ship ideas faster.</span>
           </a>
           <a href="contacts/index.html" class="app-card">

--- a/tests/community-page.test.js
+++ b/tests/community-page.test.js
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const baseDir = new URL('../community/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+describe('community system page', () => {
+  it('ships the community workspace route with the MVP surfaces', async () => {
+    const html = await readFile(new URL('index.html', baseDir), 'utf8');
+
+    assert.equal(await fileExists(new URL('index.html', baseDir)), true);
+    assert.match(html, /3DVR Community System/);
+    assert.match(html, /id="profileForm"/);
+    assert.match(html, /id="circleForm"/);
+    assert.match(html, /id="checkinForm"/);
+    assert.match(html, /id="threadForm"/);
+    assert.match(html, /id="communityFeed"/);
+    assert.match(html, /Small Circles/);
+    assert.match(html, /Public Builder Layer/);
+    assert.match(html, /<script[^>]+src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"/);
+    assert.match(html, /<script[^>]+src="\.{2}\/gun-init\.js"/);
+    assert.match(html, /<script[^>]+src="\.\/app\.js"/);
+  });
+
+  it('uses explicit Gun nodes for profiles, circles, check-ins, and threads', async () => {
+    const js = await readFile(new URL('app.js', baseDir), 'utf8');
+
+    assert.match(js, /COMMUNITY_ROOT = 'communitySystem'/);
+    assert.match(js, /gun\.get\('3dvr-portal'\)\.get\(COMMUNITY_ROOT\)/);
+    assert.match(js, /get\('profiles'\)/);
+    assert.match(js, /get\('circles'\)/);
+    assert.match(js, /get\('checkins'\)/);
+    assert.match(js, /get\('threads'\)/);
+    assert.match(js, /sizeTarget: '3-6'/);
+  });
+
+  it('registers Community in the portal launcher near Cell', async () => {
+    const html = await readFile(new URL('../index.html', baseDir), 'utf8');
+    const cellIndex = html.indexOf('>Cell<');
+    const communityIndex = html.indexOf('>Community<');
+    const lifeIndex = html.indexOf('>Life<');
+
+    assert.ok(cellIndex !== -1, 'Cell app card should still be present');
+    assert.ok(communityIndex !== -1, 'Community app card should be listed on the portal');
+    assert.ok(lifeIndex !== -1, 'Life app card should still be present');
+    assert.ok(cellIndex < communityIndex, 'Community should appear after Cell');
+    assert.ok(communityIndex < lifeIndex, 'Community should appear before Life');
+    assert.match(html, /href="community\/(?:index\.html)?"/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-pass `3DVR Community System` portal page at `/community/`.

Changes:
- Adds a mobile-friendly community workspace with builder profile, create/join circle, weekly check-in, focused thread, and live feed sections.
- Stores community data through explicit Gun nodes under `gun.get('3dvr-portal').get('communitySystem')` for profiles, circles, check-ins, and threads.
- Registers Community in the portal support shortcuts and app dock near Cell.
- Restores the expected Chat app card label used by the existing Cell launcher test.
- Adds the missing Vercel Insights script to `alive-system/index.html` so the HTML guard stays green.
- Adds `tests/community-page.test.js` coverage for route presence, Gun node usage, and launcher registration.

## Validation

- `node --check community/app.js`
- `node --test tests/community-page.test.js tests/vercel-insights-tag.test.js`
- `node --test tests/cell.test.js tests/community-page.test.js tests/vercel-insights-tag.test.js`
- `npm test` was run after `npm install`; it passed the new/community, cell, and insights coverage but still reports two existing Android/proot Playwright installer expectation failures in `tests/playwright-install-runtime.test.js` where this environment maps Chrome to Chromium fallback.

## Billing / deployment impact

No billing, Stripe, OAuth, or server API changes.