### PR TITLE
Add portal release v0.0.42

### DIFF
--- a/api/calendar/reminder-email.js
+++ b/api/calendar/reminder-email.js
@@ -261,6 +261,19 @@ function buildAdminResetRequestAckHtml({ resetUrl }) {
   `;
 }
 
+function buildLeadOutreachHtml({ headline, message, senderName, senderEmail }) {
+  const fromLabel = normalizeText(senderName) || 'Thomas @ 3DVR';
+  const replyLabel = normalizeEmail(senderEmail);
+
+  return `
+    <div style="font-family: Arial, sans-serif; line-height: 1.6;">
+      <p>${formatMessage(headline || 'Quick note from 3DVR')}</p>
+      <p>${formatMessage(message)}</p>
+      <p style="margin-top: 20px;">${escapeHtml(fromLabel)}${replyLabel ? `<br><a href="mailto:${replyLabel}">${escapeHtml(replyLabel)}</a>` : ''}</p>
+    </div>
+  `;
+}
+
 function getRequestHeader(req, key) {
   const headers = req?.headers || {};
   const target = String(key || '').toLowerCase();
@@ -630,6 +643,89 @@ export function createOperatorAlertEmailHandler(options = {}) {
   };
 }
 
+export function createLeadOutreachEmailHandler(options = {}) {
+  const {
+    config = process.env,
+    mailTransport
+  } = options;
+
+  function getTransport() {
+    return mailTransport || createTransport(config);
+  }
+
+  return async function leadOutreachEmailHandler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method !== 'POST') {
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    const expectedToken = resolveOperatorAlertToken(config);
+    const providedToken = parseOperatorAlertToken(req);
+    if (!expectedToken || providedToken !== expectedToken) {
+      return res.status(401).json({ error: 'Unauthorized lead outreach trigger.' });
+    }
+
+    const to = normalizeRecipientList(req.body?.to);
+    const subject = normalizeText(req.body?.subject);
+    const text = normalizeText(req.body?.text);
+    const headline = normalizeText(req.body?.headline);
+    const senderName = normalizeText(req.body?.senderName || 'Thomas @ 3DVR');
+    const senderEmail = normalizeEmail(req.body?.senderEmail || resolveMailCredentials(config).user);
+
+    if (!to.length) {
+      return res.status(400).json({ error: 'At least one outreach recipient is required.' });
+    }
+
+    if (!subject) {
+      return res.status(400).json({ error: 'An outreach subject is required.' });
+    }
+
+    if (!text) {
+      return res.status(400).json({ error: 'An outreach text body is required.' });
+    }
+
+    let transport;
+    try {
+      transport = getTransport();
+    } catch (error) {
+      return res.status(503).json({
+        error: error.message || 'Lead outreach email is not configured on this deployment.'
+      });
+    }
+
+    const sender = resolveMailCredentials(config).user || 'no-reply@3dvr.tech';
+    const from = `"${senderName || 'Thomas @ 3DVR'}" <${sender}>`;
+    const replyTo = senderEmail || undefined;
+
+    try {
+      await transport.sendMail({
+        from,
+        to,
+        replyTo,
+        subject,
+        text,
+        html: buildLeadOutreachHtml({
+          headline,
+          message: text,
+          senderName,
+          senderEmail
+        })
+      });
+
+      return res.status(200).json({ success: true, mode: 'lead-outreach' });
+    } catch (error) {
+      return res.status(500).json({
+        error: error.message || 'Unable to send lead outreach email.'
+      });
+    }
+  };
+}
+
 export function createUnifiedEmailHandler(options = {}) {
   const {
     config = process.env,
@@ -639,6 +735,7 @@ export function createUnifiedEmailHandler(options = {}) {
   const calendarHandler = createCalendarReminderEmailHandler({ config, mailTransport });
   const accountRecoveryHandler = createAccountRecoveryEmailHandler({ config, mailTransport });
   const operatorAlertHandler = createOperatorAlertEmailHandler({ config, mailTransport });
+  const leadOutreachHandler = createLeadOutreachEmailHandler({ config, mailTransport });
 
   return async function unifiedEmailHandler(req, res) {
     setCorsHeaders(res);
@@ -657,6 +754,9 @@ export function createUnifiedEmailHandler(options = {}) {
     }
     if (mode === 'operator-alert') {
       return operatorAlertHandler(req, res);
+    }
+    if (mode === 'lead-outreach') {
+      return leadOutreachHandler(req, res);
     }
 
     return calendarHandler(req, res);

--- a/api/calendar/reminder-email.js
+++ b/api/calendar/reminder-email.js
@@ -676,6 +676,8 @@ export function createLeadOutreachEmailHandler(options = {}) {
     const headline = normalizeText(req.body?.headline);
     const senderName = normalizeText(req.body?.senderName || 'Thomas @ 3DVR');
     const senderEmail = normalizeEmail(req.body?.senderEmail || resolveMailCredentials(config).user);
+    const inReplyTo = normalizeText(req.body?.inReplyTo);
+    const references = normalizeText(req.body?.references);
 
     if (!to.length) {
       return res.status(400).json({ error: 'At least one outreach recipient is required.' });
@@ -707,6 +709,8 @@ export function createLeadOutreachEmailHandler(options = {}) {
         from,
         to,
         replyTo,
+        inReplyTo: inReplyTo || undefined,
+        references: references || undefined,
         subject,
         text,
         html: buildLeadOutreachHtml({

--- a/releases/index.html
+++ b/releases/index.html
@@ -82,17 +82,23 @@
   <div class="section">
     <h2>Latest Release</h2>
     <article class="release-card">
-      <a class="release-link" href="v0.0.41.html">v0.0.41</a>
-      <span class="release-meta">Week of April 13, 2026</span>
+      <a class="release-link" href="v0.0.42.html">v0.0.42</a>
+      <span class="release-meta">Week of April 20, 2026</span>
       <p class="release-summary">
-        Pocket Workstation, Life OS, tighter CRM and billing handoff, the command-center launcher, and companion
-        3dvr-agent outreach tooling.
+        3dvr-agent pre-release notes, portal release cadence alignment, and the next staged weekly release entry.
       </p>
     </article>
   </div>
   <div class="section">
     <h2>Release History</h2>
     <ul class="release-grid">
+      <li class="release-card">
+        <a class="release-link" href="v0.0.42.html">v0.0.42</a>
+        <span class="release-meta">Week of April 20, 2026</span>
+        <p class="release-summary">
+          3dvr-agent pre-release notes, portal release cadence alignment, and the next staged weekly release entry.
+        </p>
+      </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.41.html">v0.0.41</a>
         <span class="release-meta">Week of April 13, 2026</span>

--- a/releases/v0.0.41.html
+++ b/releases/v0.0.41.html
@@ -100,7 +100,7 @@
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
     <a class="release-nav-link" href="v0.0.40.html">← Previous release</a>
-    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
+    <a class="release-nav-link" href="v0.0.42.html">Next release →</a>
   </nav>
   <h1>Release v0.0.41</h1>
   <div class="tag">Week of April 13, 2026</div>

--- a/releases/v0.0.42.html
+++ b/releases/v0.0.42.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal – Release v0.0.42 (Week of April 20, 2026)</title>
+  <style>
+    body {
+      margin: 0 auto;
+      font-family: Arial, Helvetica, sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      line-height: 1.65;
+      padding: 20px;
+      max-width: 900px;
+    }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #161b22;
+      border-radius: 10px;
+      border: 1px solid #30363d;
+    }
+    .overview-lead { margin: 0 0 18px; }
+    .overview-highlights {
+      margin: 0;
+      padding-left: 20px;
+    }
+    .overview-highlights li + li { margin-top: 10px; }
+    .tag {
+      background: #1f6feb;
+      padding: 4px 10px;
+      border-radius: 6px;
+      display: inline-block;
+      font-size: 14px;
+      margin-bottom: 20px;
+    }
+    .release-summary {
+      margin: 0 0 24px;
+      font-size: 16px;
+      color: #9ba3b4;
+    }
+    .release-summary-intro { margin: 0 0 14px; }
+    .release-summary-list {
+      margin: 0;
+      padding-left: 20px;
+      color: #c9d1d9;
+    }
+    .release-summary-list li + li { margin-top: 8px; }
+    .back-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .back-link:hover { text-decoration: underline; }
+    .release-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 20px 0 40px;
+    }
+    .release-nav-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .release-nav-link.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+      cursor: default;
+    }
+  </style>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">← Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.41.html">← Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
+  </nav>
+  <h1>Release v0.0.42</h1>
+  <div class="tag">Week of April 20, 2026</div>
+  <div class="release-summary">
+    <p class="release-summary-intro">This staged weekly release sets up the next agent-facing cut:</p>
+    <ul class="release-summary-list">
+      <li><strong><a href="https://github.com/tmsteph/3dvr-agent"><code>3dvr-agent</code></a>:</strong> the pre-release notes are now drafted and aligned with the portal cadence.</li>
+      <li><strong>Release hub:</strong> the portal release index now carries the next weekly entry for the staged rollout.</li>
+      <li><strong>Versioning:</strong> the agent package version is aligned to the pre-release candidate <code>1.0.1-beta.1</code>.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Overview</h2>
+    <p class="overview-lead">
+      This update is intentionally small and release-focused. It records the next staged agent cut without changing the portal user experience.
+    </p>
+    <ul class="overview-highlights">
+      <li>The agent repo now has a pre-release draft that matches the weekly portal cadence.</li>
+      <li>The portal release hub now includes a new top-of-list entry for the next weekly milestone.</li>
+      <li>The agent package version is aligned to the new pre-release identifier so downstream tooling can see the staged state.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Release staging</h2>
+    <ul>
+      <li>Add the agent release draft with candidate version <code>1.0.1-beta.1</code>.</li>
+      <li>Update the portal release hub to show <code>v0.0.42</code> as the newest weekly entry.</li>
+      <li>Keep the release page navigation linked forward from <code>v0.0.41</code> to this new page.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>What changed in the agent</h2>
+    <ul>
+      <li>Outbound drafting prefers the local Qwen/llama stack.</li>
+      <li>Autonomous sending only marks leads contacted after a successful send.</li>
+      <li>Crawl can fall back from Overpass to search seeding when map queries fail.</li>
+      <li>Release notes now exist as a pre-release draft in the agent repo.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech – Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/tests/account-recovery-email.test.js
+++ b/tests/account-recovery-email.test.js
@@ -345,11 +345,13 @@ describe('account recovery email api', () => {
       body: {
         mode: 'lead-outreach',
         to: ['tmsteph1290@gmail.com'],
-        subject: 'Quick idea for your site',
+        subject: 'Re: Quick idea for your site',
         headline: 'Quick note from 3DVR',
         text: 'I noticed one small customer-flow issue worth tightening.',
         senderName: 'Thomas @ 3DVR',
-        senderEmail: '3dvr.tech@gmail.com'
+        senderEmail: '3dvr.tech@gmail.com',
+        inReplyTo: '<reply-message@example.com>',
+        references: '<thread-root@example.com> <reply-message@example.com>'
       }
     };
     const res = createMockRes();
@@ -361,8 +363,10 @@ describe('account recovery email api', () => {
     assert.equal(mail.sendMail.mock.calls.length, 1);
     const sent = mail.sendMail.mock.calls[0].arguments[0];
     assert.deepEqual(sent.to, ['tmsteph1290@gmail.com']);
-    assert.equal(sent.subject, 'Quick idea for your site');
+    assert.equal(sent.subject, 'Re: Quick idea for your site');
     assert.equal(sent.replyTo, '3dvr.tech@gmail.com');
+    assert.equal(sent.inReplyTo, '<reply-message@example.com>');
+    assert.equal(sent.references, '<thread-root@example.com> <reply-message@example.com>');
     assert.match(sent.html, /Quick note from 3DVR/i);
     assert.match(sent.text, /customer-flow issue/i);
   });

--- a/tests/account-recovery-email.test.js
+++ b/tests/account-recovery-email.test.js
@@ -304,4 +304,66 @@ describe('account recovery email api', () => {
     assert.match(sent.html, /3DVR operator alert/i);
     assert.match(sent.text, /New leads are ready for review/i);
   });
+
+  it('rejects lead outreach without the shared token', async () => {
+    const mail = createMailTransport();
+    const handler = createUnifiedEmailHandler({
+      config: baseConfig,
+      mailTransport: mail
+    });
+
+    const req = {
+      method: 'POST',
+      headers: {},
+      body: {
+        mode: 'lead-outreach',
+        to: 'tmsteph1290@gmail.com',
+        subject: 'Quick idea for your site',
+        text: 'I noticed one small customer-flow issue worth tightening.'
+      }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 401);
+    assert.equal(mail.sendMail.mock.calls.length, 0);
+  });
+
+  it('sends lead outreach through the unified mail route', async () => {
+    const mail = createMailTransport();
+    const handler = createUnifiedEmailHandler({
+      config: baseConfig,
+      mailTransport: mail
+    });
+
+    const req = {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer operator-secret'
+      },
+      body: {
+        mode: 'lead-outreach',
+        to: ['tmsteph1290@gmail.com'],
+        subject: 'Quick idea for your site',
+        headline: 'Quick note from 3DVR',
+        text: 'I noticed one small customer-flow issue worth tightening.',
+        senderName: 'Thomas @ 3DVR',
+        senderEmail: '3dvr.tech@gmail.com'
+      }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.mode, 'lead-outreach');
+    assert.equal(mail.sendMail.mock.calls.length, 1);
+    const sent = mail.sendMail.mock.calls[0].arguments[0];
+    assert.deepEqual(sent.to, ['tmsteph1290@gmail.com']);
+    assert.equal(sent.subject, 'Quick idea for your site');
+    assert.equal(sent.replyTo, '3dvr.tech@gmail.com');
+    assert.match(sent.html, /Quick note from 3DVR/i);
+    assert.match(sent.text, /customer-flow issue/i);
+  });
 });

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -15,12 +15,15 @@ async function fileExists(path) {
 }
 
 describe('release hub backfill', () => {
-  it('updates the release index with the retroactive milestones through v0.0.41', async () => {
+  it('updates the release index with the retroactive milestones through v0.0.42', async () => {
     const indexUrl = new URL('index.html', baseDir);
     assert.equal(await fileExists(indexUrl), true, 'releases/index.html should exist');
 
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /Latest Release/);
+    assert.match(html, /href="v0\.0\.42\.html">v0\.0\.42</);
+    assert.match(html, /Week of April 20, 2026/);
+    assert.match(html, /pre-release notes/i);
     assert.match(html, /href="v0\.0\.41\.html">v0\.0\.41</);
     assert.match(html, /Week of April 13, 2026/);
     assert.match(html, /Pocket Workstation/i);
@@ -40,12 +43,13 @@ describe('release hub backfill', () => {
 
   it('ships the new milestone pages with coherent navigation and summaries', async () => {
     const releases = [
+      ['v0.0.42.html', /Week of April 20, 2026/, /pre-release notes/i, /aria-disabled="true"/],
       ['v0.0.36.html', /Late January 2026/, /social planning/i, /href="v0\.0\.37\.html"/],
       ['v0.0.37.html', /Mid February 2026/, /Money Autopilot/i, /href="v0\.0\.38\.html"/],
       ['v0.0.38.html', /Late March 2026/, /Email Operator/i, /href="v0\.0\.39\.html"/],
       ['v0.0.39.html', /Week of March 30, 2026/, /profitability/i, /href="v0\.0\.40\.html"/],
       ['v0.0.40.html', /Week of April 6, 2026/, /Logic Lab/i, /href="v0\.0\.41\.html"/],
-      ['v0.0.41.html', /Week of April 13, 2026/, /Pocket Workstation/i, /aria-disabled="true"/],
+      ['v0.0.41.html', /Week of April 13, 2026/, /Pocket Workstation/i, /href="v0\.0\.42\.html"/],
     ];
 
     for (const [filename, datePattern, topicPattern, navPattern] of releases) {


### PR DESCRIPTION
Adds the next portal release page for the staged 3dvr-agent pre-release.

Includes:
- new release page for v0.0.42
- release index updated to surface v0.0.42 as latest
- v0.0.41 navigation linked forward to the new page
- release hub test coverage for the new entry

Validation:
- `node --test tests/releases-hub.test.js`