### PR TITLE
[codex] Make issue launcher footer by default

### DIFF
--- a/issue-launcher.js
+++ b/issue-launcher.js
@@ -22,6 +22,12 @@
   const currentUrl = window.location.href;
   const currentPath = window.location.pathname + window.location.search + window.location.hash;
   const currentTitle = document.title || currentPath || 'Portal page';
+  const launcherPreference =
+    document.documentElement?.dataset.issueLauncher ||
+    document.body?.dataset.issueLauncher ||
+    document.querySelector('meta[name="portal:issue-launcher"]')?.getAttribute('content') ||
+    '';
+  const shouldFloatLauncher = launcherPreference === 'floating';
 
   const encode = (value) => encodeURIComponent(value).replace(/%20/g, '+');
 
@@ -280,7 +286,9 @@
   document.head.appendChild(style);
 
   const root = document.createElement('section');
-  root.className = 'portal-issue-launcher';
+  root.className = shouldFloatLauncher
+    ? 'portal-issue-launcher'
+    : 'portal-issue-launcher portal-issue-launcher--footer';
   root.dataset.issueLauncherRoot = 'true';
   root.setAttribute('aria-label', 'Portal GitHub issue launcher');
 
@@ -356,6 +364,10 @@
   const status = panel.querySelector('.portal-issue-launcher__status');
 
   function updateBodyPadding() {
+    if (!shouldFloatLauncher) {
+      document.body.style.paddingBottom = '';
+      return;
+    }
     const shouldPad = !root.classList.contains('portal-issue-launcher--footer');
     const launcherHeight = Math.ceil(root.getBoundingClientRect().height || 0);
     document.body.style.paddingBottom = shouldPad && launcherHeight
@@ -364,6 +376,11 @@
   }
 
   function syncDockMode() {
+    if (!shouldFloatLauncher) {
+      root.classList.add('portal-issue-launcher--footer');
+      updateBodyPadding();
+      return;
+    }
     const doc = document.documentElement;
     const remaining = doc.scrollHeight - (window.scrollY + window.innerHeight);
     const shouldDockAsFooter = remaining <= root.offsetHeight + 24;

--- a/tests/issue-launcher.test.js
+++ b/tests/issue-launcher.test.js
@@ -35,6 +35,8 @@ test('issue launcher ships a GitHub issue helper for the portal repo', async () 
   assert.match(source, /- URL:/);
   assert.match(source, /Current page:/);
   assert.match(source, /portal-issue-launcher--footer/);
+  assert.match(source, /shouldFloatLauncher = launcherPreference === 'floating'/);
+  assert.match(source, /portal-issue-launcher portal-issue-launcher--footer/);
   assert.match(source, /remaining <= root\.offsetHeight \+ 24/);
   assert.match(source, /window\.addEventListener\('scroll', syncDockModeSoon/);
 });


### PR DESCRIPTION
## Summary
- Make the shared page feedback launcher render in footer placement by default.
- Keep the existing fixed/floating behavior available through `data-issue-launcher="floating"` or matching portal issue-launcher meta content.
- Update the focused launcher test to cover the new default and opt-in behavior.

## Validation
- `node --test --test-name-pattern "issue launcher ships" tests/issue-launcher.test.js`

Note: the full `tests/issue-launcher.test.js` run currently fails on an unrelated uncommitted local guide page missing `/issue-launcher.js`; that file is outside this PR scope.