### PR TITLE
[codex] Keep footer feedback inside page footer

### DIFF
--- a/issue-launcher.js
+++ b/issue-launcher.js
@@ -352,7 +352,10 @@
   `;
 
   root.append(button, panel);
-  document.body.appendChild(root);
+  const mountTarget = shouldFloatLauncher
+    ? document.body
+    : document.querySelector('footer') || document.body;
+  mountTarget.appendChild(root);
 
   const form = panel.querySelector('form');
   const typeInput = form.querySelector('#portalIssueType');

--- a/tests/issue-launcher.test.js
+++ b/tests/issue-launcher.test.js
@@ -37,6 +37,7 @@ test('issue launcher ships a GitHub issue helper for the portal repo', async () 
   assert.match(source, /portal-issue-launcher--footer/);
   assert.match(source, /shouldFloatLauncher = launcherPreference === 'floating'/);
   assert.match(source, /portal-issue-launcher portal-issue-launcher--footer/);
+  assert.match(source, /document\.querySelector\('footer'\) \|\| document\.body/);
   assert.match(source, /remaining <= root\.offsetHeight \+ 24/);
   assert.match(source, /window\.addEventListener\('scroll', syncDockModeSoon/);
 });


### PR DESCRIPTION
## Summary
- Mount footer-mode page feedback inside the nearest existing `<footer>` instead of appending it as a direct body child.
- Preserve body mounting for explicit floating feedback mode.
- Add a focused assertion for the footer mount behavior.

## Why
On the portal home page, `body.landing` uses flex layout around `.landing-shell`. Appending the footer-mode launcher directly to `body` made it render as a separate side item.

## Validation
- `node --test --test-name-pattern "issue launcher ships" tests/issue-launcher.test.js`