### PR TITLE
[codex] Hide homepage system layers

### DIFF
--- a/navbar.js
+++ b/navbar.js
@@ -20,7 +20,19 @@ function clearSharedIdentityCookie() {
   }
 }
 
+function hideUnreadyHomepageSections() {
+  const systemLayers = document.getElementById('systemLayers');
+  if (systemLayers) {
+    systemLayers.remove();
+  }
+  document.querySelectorAll('a[href="#systemLayers"]').forEach(link => {
+    link.remove();
+  });
+}
+
 function createNavbar() {
+  hideUnreadyHomepageSections();
+
   if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function') {
     window.ScoreSystem.recallUserSession(user);
   } else {


### PR DESCRIPTION
## Summary
- Hide the not-ready homepage `System layers` section at runtime.
- Remove the matching top-nav `System` anchor when the homepage navbar initializes.

## Validation
- `node --check navbar.js`

Note: local work also contains a fuller HTML/CSS cleanup, but this PR keeps the live change intentionally small and scoped to the loaded homepage script.