### PR TITLE
[codex] Hide homepage launcher lanes

### DIFF
--- a/navbar.js
+++ b/navbar.js
@@ -28,6 +28,9 @@ function hideUnreadyHomepageSections() {
   document.querySelectorAll('a[href="#systemLayers"]').forEach(link => {
     link.remove();
   });
+  document.querySelectorAll('.launcher-lanes').forEach(section => {
+    section.remove();
+  });
 }
 
 function createNavbar() {


### PR DESCRIPTION
## Summary
- Hide the not-ready homepage launcher lane row at runtime.
- This removes Portal lane, Browser lane, and OS lane from the user-facing homepage so app search moves up.

## Validation
- `node --check navbar.js`