### PR TITLE
[codex] Add homepage app search shortcut

### DIFF
--- a/navbar.js
+++ b/navbar.js
@@ -33,7 +33,31 @@ function hideUnreadyHomepageSections() {
   });
 }
 
+function ensureHomepageSearchShortcuts() {
+  const topButtons = document.querySelector('.top-buttons');
+  if (topButtons && !topButtons.querySelector('[data-home-search-shortcut]')) {
+    const searchLink = document.createElement('a');
+    searchLink.href = '#appSearch';
+    searchLink.dataset.appSearchTrigger = 'true';
+    searchLink.dataset.homeSearchShortcut = 'true';
+    searchLink.textContent = 'Search apps';
+    topButtons.insertAdjacentElement('afterbegin', searchLink);
+  }
+
+  const heroActions = document.querySelector('.hero-actions');
+  if (heroActions && !heroActions.querySelector('[data-home-search-shortcut]')) {
+    const searchAction = document.createElement('a');
+    searchAction.href = '#appSearch';
+    searchAction.className = 'cta primary';
+    searchAction.dataset.appSearchTrigger = 'true';
+    searchAction.dataset.homeSearchShortcut = 'true';
+    searchAction.textContent = 'Search apps';
+    heroActions.insertAdjacentElement('afterbegin', searchAction);
+  }
+}
+
 function createNavbar() {
+  ensureHomepageSearchShortcuts();
   hideUnreadyHomepageSections();
 
   if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function') {
@@ -211,4 +235,5 @@ function createNavbar() {
   }
 }
 
+ensureHomepageSearchShortcuts();
 window.addEventListener('load', createNavbar);


### PR DESCRIPTION
## Summary
- Add a `Search apps` link at the start of the homepage top nav.
- Add a primary `Search apps` hero action so app search is available immediately when the page loads.
- Reuse the existing `data-app-search-trigger` behavior so clicking the shortcut scrolls to and focuses the app search.

## Validation
- `node --check navbar.js`