### PR TITLE
[codex] Add Victor dropship sample storefront

### DIFF
--- a/api/storefront/checkout.js
+++ b/api/storefront/checkout.js
@@ -1,0 +1,159 @@
+import Stripe from 'stripe';
+
+const SAMPLE_PRODUCTS = Object.freeze({
+  'compact-desk-dock': Object.freeze({
+    name: 'Compact Desk Dock',
+    description: 'A sample dropship product page for testing single-product demand.',
+    unitAmount: 7900,
+    currency: 'usd',
+    image: 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1200&q=80',
+  }),
+});
+
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function getOrigin(req, config = process.env) {
+  const host = String(req?.headers?.['x-forwarded-host'] || req?.headers?.host || '').split(',')[0].trim();
+  if (host) {
+    const proto = String(req?.headers?.['x-forwarded-proto'] || '').split(',')[0].trim()
+      || (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https');
+    return `${proto}://${host}`;
+  }
+  return String(config.PORTAL_ORIGIN || 'https://portal.3dvr.tech').replace(/\/+$/, '');
+}
+
+function getStripeClient(config = process.env) {
+  const secretKey = String(config.STRIPE_SECRET_KEY || '').trim();
+  if (!secretKey) return null;
+  return new Stripe(secretKey, { apiVersion: '2023-10-16' });
+}
+
+async function readJsonBody(req) {
+  if (req?.body && typeof req.body === 'object') return req.body;
+  if (typeof req?.body === 'string') {
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      return {};
+    }
+  }
+
+  return new Promise(resolve => {
+    let raw = '';
+    req.on?.('data', chunk => {
+      raw += chunk;
+    });
+    req.on?.('end', () => {
+      try {
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch {
+        resolve({});
+      }
+    });
+    req.on?.('error', () => resolve({}));
+  });
+}
+
+function normalizeQuantity(value) {
+  const quantity = Number.parseInt(value, 10);
+  if (!Number.isFinite(quantity)) return 1;
+  return Math.min(Math.max(quantity, 1), 5);
+}
+
+export function createStorefrontCheckoutHandler(options = {}) {
+  const config = options.config || process.env;
+  const stripe = options.stripeClient || getStripeClient(config);
+
+  return async function handler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method === 'GET') {
+      return res.status(200).json({
+        stripeConfigured: Boolean(config.STRIPE_SECRET_KEY),
+        products: Object.keys(SAMPLE_PRODUCTS),
+      });
+    }
+
+    if (req.method !== 'POST') {
+      res.setHeader('Allow', 'GET, POST, OPTIONS');
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    if (!stripe) {
+      return res.status(500).json({ error: 'Stripe is not configured on the server.' });
+    }
+
+    const body = await readJsonBody(req);
+    const productId = String(body.productId || '').trim();
+    const product = SAMPLE_PRODUCTS[productId];
+    const quantity = normalizeQuantity(body.quantity);
+    const orderId = String(body.orderId || '').trim().slice(0, 80);
+    const customerEmail = String(body.customerEmail || '').trim().toLowerCase();
+    const customerName = String(body.customerName || '').trim().slice(0, 120);
+    const origin = getOrigin(req, config);
+
+    if (!product) {
+      return res.status(400).json({ error: 'Unknown product.' });
+    }
+
+    if (!orderId) {
+      return res.status(400).json({ error: 'Missing order id.' });
+    }
+
+    try {
+      const session = await stripe.checkout.sessions.create({
+        mode: 'payment',
+        success_url: `${origin}/victor-dropship/?checkout=success&order=${encodeURIComponent(orderId)}&session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${origin}/victor-dropship/?checkout=cancel&order=${encodeURIComponent(orderId)}`,
+        customer_email: customerEmail || undefined,
+        billing_address_collection: 'auto',
+        shipping_address_collection: {
+          allowed_countries: ['US'],
+        },
+        metadata: {
+          storefront: 'victor-dropship-sample',
+          order_id: orderId,
+          product_id: productId,
+          customer_name: customerName,
+        },
+        line_items: [
+          {
+            quantity,
+            price_data: {
+              currency: product.currency,
+              unit_amount: product.unitAmount,
+              product_data: {
+                name: product.name,
+                description: product.description,
+                images: [product.image],
+                metadata: {
+                  product_id: productId,
+                  fulfillment: 'manual-vendor-order',
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      return res.status(200).json({
+        id: session.id,
+        url: session.url,
+      });
+    } catch (error) {
+      console.error('Unable to create sample storefront checkout', error);
+      return res.status(500).json({ error: error?.message || 'Unable to open checkout.' });
+    }
+  };
+}
+
+const handler = createStorefrontCheckoutHandler();
+export default handler;

--- a/tests/storefront-checkout-api.test.js
+++ b/tests/storefront-checkout-api.test.js
@@ -1,0 +1,104 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { createStorefrontCheckoutHandler } from '../api/storefront/checkout.js';
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end(payload) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(key, value) {
+      this.headers[key] = value;
+    },
+  };
+}
+
+describe('storefront checkout API', () => {
+  it('reports checkout configuration on GET', async () => {
+    const handler = createStorefrontCheckoutHandler({
+      config: { STRIPE_SECRET_KEY: 'sk_test_sample' },
+      stripeClient: { checkout: { sessions: { create: mock.fn() } } },
+    });
+    const res = createMockRes();
+
+    await handler({ method: 'GET', headers: {} }, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.stripeConfigured, true);
+    assert.deepEqual(res.body.products, ['compact-desk-dock']);
+  });
+
+  it('creates a one-time Stripe Checkout session for the sample product', async () => {
+    const create = mock.fn(async () => ({
+      id: 'cs_test_storefront',
+      url: 'https://checkout.stripe.com/c/pay/cs_test_storefront',
+    }));
+    const handler = createStorefrontCheckoutHandler({
+      config: { STRIPE_SECRET_KEY: 'sk_test_sample' },
+      stripeClient: { checkout: { sessions: { create } } },
+    });
+    const res = createMockRes();
+
+    await handler({
+      method: 'POST',
+      headers: {
+        host: 'portal.3dvr.tech',
+        'x-forwarded-proto': 'https',
+      },
+      body: {
+        orderId: 'order_123',
+        productId: 'compact-desk-dock',
+        quantity: 2,
+        customerEmail: 'buyer@example.com',
+        customerName: 'Buyer Example',
+      },
+    }, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.id, 'cs_test_storefront');
+    assert.equal(res.body.url, 'https://checkout.stripe.com/c/pay/cs_test_storefront');
+    assert.equal(create.mock.calls.length, 1);
+
+    const payload = create.mock.calls[0].arguments[0];
+    assert.equal(payload.mode, 'payment');
+    assert.equal(payload.customer_email, 'buyer@example.com');
+    assert.equal(payload.metadata.order_id, 'order_123');
+    assert.equal(payload.line_items[0].quantity, 2);
+    assert.equal(payload.line_items[0].price_data.unit_amount, 7900);
+    assert.match(payload.success_url, /\/victor-dropship\/\?checkout=success/);
+  });
+
+  it('rejects unknown products before creating checkout', async () => {
+    const create = mock.fn();
+    const handler = createStorefrontCheckoutHandler({
+      config: { STRIPE_SECRET_KEY: 'sk_test_sample' },
+      stripeClient: { checkout: { sessions: { create } } },
+    });
+    const res = createMockRes();
+
+    await handler({
+      method: 'POST',
+      headers: {},
+      body: {
+        orderId: 'order_123',
+        productId: 'missing',
+      },
+    }, res);
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.error, 'Unknown product.');
+    assert.equal(create.mock.calls.length, 0);
+  });
+});

--- a/victor-dropship/app.js
+++ b/victor-dropship/app.js
@@ -1,0 +1,132 @@
+const PRODUCT_ID = 'compact-desk-dock';
+const ORDER_NODE = 'victor-dropship-orders';
+const GUN_PEERS = window.__GUN_PEERS__ || ['wss://gun-relay-3dvr.fly.dev/gun'];
+
+const form = document.getElementById('orderForm');
+const statusEl = document.getElementById('status');
+const checkoutButton = document.getElementById('checkoutButton');
+
+let ordersNode = null;
+
+function setStatus(message, tone = '') {
+  statusEl.textContent = message;
+  statusEl.className = `status ${tone}`.trim();
+}
+
+function createOrderId() {
+  if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+    return window.crypto.randomUUID();
+  }
+  return `order-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function getOrdersNode() {
+  if (ordersNode) return ordersNode;
+  if (typeof window.Gun !== 'function') return null;
+  const gun = window.Gun(GUN_PEERS);
+  ordersNode = gun.get('3dvr-portal').get(ORDER_NODE);
+  return ordersNode;
+}
+
+function writeOrder(orderId, payload) {
+  const node = getOrdersNode();
+  if (!node) return Promise.resolve(false);
+
+  return new Promise(resolve => {
+    node.get(orderId).put(payload, ack => {
+      resolve(Boolean(!ack || !ack.err));
+    });
+  });
+}
+
+function readFormPayload() {
+  const formData = new FormData(form);
+  return {
+    customerName: String(formData.get('customerName') || '').trim(),
+    customerEmail: String(formData.get('customerEmail') || '').trim(),
+    quantity: Number.parseInt(formData.get('quantity') || '1', 10) || 1,
+  };
+}
+
+async function createCheckout(orderId, payload) {
+  const response = await fetch('/api/storefront/checkout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      orderId,
+      productId: PRODUCT_ID,
+      ...payload,
+    }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(body.error || 'Unable to open checkout.');
+  }
+  return body;
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  const payload = readFormPayload();
+  const orderId = createOrderId();
+  const now = new Date().toISOString();
+
+  checkoutButton.disabled = true;
+  setStatus('Saving order and opening checkout...');
+
+  await writeOrder(orderId, {
+    id: orderId,
+    productId: PRODUCT_ID,
+    productName: 'Compact Desk Dock',
+    customerName: payload.customerName,
+    customerEmail: payload.customerEmail,
+    quantity: payload.quantity,
+    status: 'checkout_started',
+    source: 'victor-dropship-sample',
+    created: now,
+    updated: now,
+  });
+
+  try {
+    const checkout = await createCheckout(orderId, payload);
+    await writeOrder(orderId, {
+      stripeCheckoutSessionId: checkout.id || '',
+      status: 'checkout_redirected',
+      updated: new Date().toISOString(),
+    });
+    window.location.href = checkout.url;
+  } catch (error) {
+    checkoutButton.disabled = false;
+    await writeOrder(orderId, {
+      status: 'checkout_error',
+      error: error.message || 'Checkout failed',
+      updated: new Date().toISOString(),
+    });
+    setStatus(error.message || 'Checkout is unavailable right now.', 'warning');
+  }
+}
+
+function handleReturnState() {
+  const params = new URLSearchParams(window.location.search);
+  const checkout = params.get('checkout');
+  const orderId = params.get('order');
+  const sessionId = params.get('session_id');
+
+  if (!checkout || !orderId) return;
+
+  const status = checkout === 'success' ? 'payment_returned_success' : 'checkout_cancelled';
+  writeOrder(orderId, {
+    status,
+    stripeCheckoutSessionId: sessionId || '',
+    updated: new Date().toISOString(),
+  });
+
+  if (checkout === 'success') {
+    setStatus('Payment returned from Stripe. Victor can now review the order for vendor fulfillment.');
+  } else {
+    setStatus('Checkout was cancelled before payment.', 'warning');
+  }
+}
+
+form.addEventListener('submit', handleSubmit);
+handleReturnState();

--- a/victor-dropship/index.html
+++ b/victor-dropship/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Compact Desk Dock</title>
+  <link rel="stylesheet" href="./styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+</head>
+<body>
+  <main class="storefront">
+    <section class="product-hero" aria-labelledby="productTitle">
+      <div class="product-media">
+        <img src="https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1400&q=80" alt="Compact desk setup with laptop and accessories" />
+      </div>
+      <div class="product-copy">
+        <p class="eyebrow">Dropship sample storefront</p>
+        <h1 id="productTitle">Compact Desk Dock</h1>
+        <p class="lede">A focused single-product page built to capture paid orders, hand them to Stripe, and leave Victor with a clear manual vendor fulfillment queue.</p>
+        <div class="price-row">
+          <strong>$79</strong>
+          <span>Ships from vendor after order review</span>
+        </div>
+        <form id="orderForm" class="order-form">
+          <label>
+            Name
+            <input id="customerName" name="customerName" autocomplete="name" required />
+          </label>
+          <label>
+            Email
+            <input id="customerEmail" name="customerEmail" type="email" autocomplete="email" required />
+          </label>
+          <label>
+            Quantity
+            <select id="quantity" name="quantity">
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+            </select>
+          </label>
+          <button id="checkoutButton" type="submit">Checkout with Stripe</button>
+          <p id="status" class="status" role="status" aria-live="polite"></p>
+        </form>
+      </div>
+    </section>
+
+    <section class="details" aria-label="Product details">
+      <article>
+        <h2>Simple Order Capture</h2>
+        <p>Each checkout attempt creates a Gun order intent with the product, quantity, customer contact, and current status.</p>
+      </article>
+      <article>
+        <h2>Hosted Payment</h2>
+        <p>Stripe Checkout collects payment and shipping information so the storefront does not handle card data.</p>
+      </article>
+      <article>
+        <h2>Manual Fulfillment</h2>
+        <p>Victor can review successful orders, place the vendor order, and update the order status as the workflow matures.</p>
+      </article>
+    </section>
+  </main>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/victor-dropship/styles.css
+++ b/victor-dropship/styles.css
@@ -1,0 +1,201 @@
+:root {
+  color-scheme: light;
+  --ink: #17201b;
+  --muted: #5c675f;
+  --line: #d9e2dc;
+  --paper: #fbfcf8;
+  --panel: #ffffff;
+  --accent: #1f7a5f;
+  --accent-strong: #15513f;
+  --warn: #8a4f12;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.storefront {
+  min-height: 100vh;
+}
+
+.product-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(340px, 0.95fr);
+  min-height: 76vh;
+  border-bottom: 1px solid var(--line);
+}
+
+.product-media {
+  min-height: 520px;
+  background: #dce5dd;
+}
+
+.product-media img {
+  width: 100%;
+  height: 100%;
+  min-height: 520px;
+  object-fit: cover;
+  display: block;
+}
+
+.product-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 56px;
+  gap: 22px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: clamp(3rem, 4.8rem, 4.8rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.lede {
+  max-width: 620px;
+  color: var(--muted);
+  font-size: 1.08rem;
+  line-height: 1.65;
+}
+
+.price-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.price-row strong {
+  font-size: 2.1rem;
+}
+
+.price-row span {
+  color: var(--muted);
+}
+
+.order-form {
+  display: grid;
+  gap: 14px;
+  max-width: 520px;
+  padding-top: 8px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: #34423a;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 46px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: var(--panel);
+  color: var(--ink);
+  font: inherit;
+}
+
+button {
+  min-height: 50px;
+  border: 0;
+  border-radius: 8px;
+  background: var(--accent);
+  color: white;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--accent-strong);
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.status {
+  min-height: 22px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.status.warning {
+  color: var(--warn);
+}
+
+.details {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+}
+
+.details article {
+  min-height: 190px;
+  padding: 34px;
+  background: var(--panel);
+}
+
+.details h2 {
+  font-size: 1.05rem;
+}
+
+.details p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+@media (max-width: 820px) {
+  .product-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .product-media,
+  .product-media img {
+    min-height: 42vh;
+  }
+
+  .product-copy {
+    padding: 34px 22px 42px;
+  }
+
+  h1 {
+    font-size: 3rem;
+  }
+
+  .details {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a sample single-product dropship storefront at `/victor-dropship/`.
- Capture order intents in Gun before redirecting customers to Stripe Checkout.
- Add a standalone one-time Stripe Checkout API route for the sample product.
- Cover the checkout route with unit tests.

## Validation
- `node --check api/storefront/checkout.js`
- `node --check victor-dropship/app.js`
- `node --check tests/storefront-checkout-api.test.js`
- `node --test tests/storefront-checkout-api.test.js`
- `curl -I http://127.0.0.1:3000/victor-dropship/`
- `curl -I http://127.0.0.1:3000/victor-dropship/styles.css`
- `curl -I http://127.0.0.1:3000/victor-dropship/app.js`