### PR TITLE
[codex] Make storefront customer-facing with three products

### DIFF
--- a/api/stripe/[route].js
+++ b/api/stripe/[route].js
@@ -6,10 +6,24 @@ import { createStripeStatusHandler } from '../../src/billing/api-status.js';
 const SAMPLE_STOREFRONT_PRODUCTS = Object.freeze({
   'compact-desk-dock': Object.freeze({
     name: 'Compact Desk Dock',
-    description: 'A sample dropship product page for testing single-product demand.',
+    description: 'A low-profile docking stand for a cleaner laptop workspace.',
     unitAmount: 7900,
     currency: 'usd',
     image: 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1200&q=80',
+  }),
+  'magnetic-cable-kit': Object.freeze({
+    name: 'Magnetic Cable Kit',
+    description: 'Reusable magnetic clips and cable ties for a cleaner desk, nightstand, or travel bag.',
+    unitAmount: 2900,
+    currency: 'usd',
+    image: 'https://images.unsplash.com/photo-1558618666-fcd25c85cd64?auto=format&fit=crop&w=1200&q=80',
+  }),
+  'travel-tech-pouch': Object.freeze({
+    name: 'Travel Tech Pouch',
+    description: 'A compact organizer for chargers, adapters, earbuds, and everyday carry tech.',
+    unitAmount: 4900,
+    currency: 'usd',
+    image: 'https://images.unsplash.com/photo-1553062407-98eeb64c6a62?auto=format&fit=crop&w=1200&q=80',
   }),
 });
 

--- a/tests/storefront-checkout-api.test.js
+++ b/tests/storefront-checkout-api.test.js
@@ -37,7 +37,39 @@ describe('storefront checkout API', () => {
 
     assert.equal(res.statusCode, 200);
     assert.equal(res.body.stripeConfigured, true);
-    assert.deepEqual(res.body.products, ['compact-desk-dock']);
+    assert.deepEqual(res.body.products, ['compact-desk-dock', 'magnetic-cable-kit', 'travel-tech-pouch']);
+  });
+
+  it('creates checkout for the cable kit product', async () => {
+    const create = mock.fn(async () => ({
+      id: 'cs_test_cable',
+      url: 'https://checkout.stripe.com/c/pay/cs_test_cable',
+    }));
+    const handler = createStripeDashboardHandler({
+      config: { STRIPE_SECRET_KEY: 'sk_test_sample', PORTAL_ORIGIN: 'https://portal.3dvr.tech' },
+      stripeClient: { checkout: { sessions: { create } } },
+    });
+    const res = createMockRes();
+
+    await handler({
+      method: 'POST',
+      headers: {
+        host: 'portal.3dvr.tech',
+        'x-forwarded-proto': 'https',
+      },
+      query: { route: 'storefront-checkout' },
+      body: {
+        orderId: 'order_kit',
+        productId: 'magnetic-cable-kit',
+        quantity: 1,
+      },
+    }, res);
+
+    assert.equal(res.statusCode, 200);
+    const payload = create.mock.calls[0].arguments[0];
+    assert.equal(payload.metadata.product_id, 'magnetic-cable-kit');
+    assert.equal(payload.line_items[0].price_data.product_data.name, 'Magnetic Cable Kit');
+    assert.equal(payload.line_items[0].price_data.unit_amount, 2900);
   });
 
   it('creates a one-time Stripe Checkout session for the sample product', async () => {

--- a/victor-dropship/app.js
+++ b/victor-dropship/app.js
@@ -1,10 +1,36 @@
-const PRODUCT_ID = 'compact-desk-dock';
 const ORDER_NODE = 'victor-dropship-orders';
 const GUN_PEERS = window.__GUN_PEERS__ || ['wss://gun-relay-3dvr.fly.dev/gun'];
+
+const PRODUCTS = Object.freeze({
+  'compact-desk-dock': Object.freeze({
+    name: 'Compact Desk Dock',
+    price: '$79',
+    summary: 'Compact support for a cleaner laptop setup',
+    image: 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1400&q=80',
+    alt: 'Compact desk setup with laptop and accessories',
+  }),
+  'magnetic-cable-kit': Object.freeze({
+    name: 'Magnetic Cable Kit',
+    price: '$29',
+    summary: 'Clips and ties for clean cable routing',
+    image: 'https://images.unsplash.com/photo-1558618666-fcd25c85cd64?auto=format&fit=crop&w=1400&q=80',
+    alt: 'Organized charging cables on a desk',
+  }),
+  'travel-tech-pouch': Object.freeze({
+    name: 'Travel Tech Pouch',
+    price: '$49',
+    summary: 'Compact organizer for chargers and adapters',
+    image: 'https://images.unsplash.com/photo-1553062407-98eeb64c6a62?auto=format&fit=crop&w=1400&q=80',
+    alt: 'Travel pouch with everyday carry accessories',
+  }),
+});
 
 const form = document.getElementById('orderForm');
 const statusEl = document.getElementById('status');
 const checkoutButton = document.getElementById('checkoutButton');
+const productImage = document.getElementById('productImage');
+const productPrice = document.getElementById('productPrice');
+const productSummary = document.getElementById('productSummary');
 
 let ordersNode = null;
 
@@ -41,7 +67,9 @@ function writeOrder(orderId, payload) {
 
 function readFormPayload() {
   const formData = new FormData(form);
+  const productId = String(formData.get('productId') || 'compact-desk-dock').trim();
   return {
+    productId: PRODUCTS[productId] ? productId : 'compact-desk-dock',
     customerName: String(formData.get('customerName') || '').trim(),
     customerEmail: String(formData.get('customerEmail') || '').trim(),
     quantity: Number.parseInt(formData.get('quantity') || '1', 10) || 1,
@@ -54,7 +82,6 @@ async function createCheckout(orderId, payload) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       orderId,
-      productId: PRODUCT_ID,
       ...payload,
     }),
   });
@@ -68,16 +95,17 @@ async function createCheckout(orderId, payload) {
 async function handleSubmit(event) {
   event.preventDefault();
   const payload = readFormPayload();
+  const product = PRODUCTS[payload.productId] || PRODUCTS['compact-desk-dock'];
   const orderId = createOrderId();
   const now = new Date().toISOString();
 
   checkoutButton.disabled = true;
-  setStatus('Saving order and opening checkout...');
+  setStatus('Opening secure checkout...');
 
   await writeOrder(orderId, {
     id: orderId,
-    productId: PRODUCT_ID,
-    productName: 'Compact Desk Dock',
+    productId: payload.productId,
+    productName: product.name,
     customerName: payload.customerName,
     customerEmail: payload.customerEmail,
     quantity: payload.quantity,
@@ -122,11 +150,32 @@ function handleReturnState() {
   });
 
   if (checkout === 'success') {
-    setStatus('Payment returned from Stripe. Victor can now review the order for vendor fulfillment.');
+    setStatus('Order received. Watch your email for confirmation and shipping updates.');
   } else {
     setStatus('Checkout was cancelled before payment.', 'warning');
   }
 }
 
+function syncSelectedProduct() {
+  const payload = readFormPayload();
+  const product = PRODUCTS[payload.productId] || PRODUCTS['compact-desk-dock'];
+  if (productImage) {
+    productImage.src = product.image;
+    productImage.alt = product.alt;
+  }
+  if (productPrice) {
+    productPrice.textContent = product.price;
+  }
+  if (productSummary) {
+    productSummary.textContent = product.summary;
+  }
+}
+
 form.addEventListener('submit', handleSubmit);
+form.addEventListener('change', event => {
+  if (event.target?.name === 'productId') {
+    syncSelectedProduct();
+  }
+});
+syncSelectedProduct();
 handleReturnState();

--- a/victor-dropship/index.html
+++ b/victor-dropship/index.html
@@ -3,25 +3,49 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Compact Desk Dock</title>
+  <title>Desk Essentials Co.</title>
   <link rel="stylesheet" href="./styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
 </head>
 <body>
   <main class="storefront">
-    <section class="product-hero" aria-labelledby="productTitle">
+    <section class="product-hero" aria-labelledby="storeTitle">
       <div class="product-media">
-        <img src="https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1400&q=80" alt="Compact desk setup with laptop and accessories" />
+        <img id="productImage" src="https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1400&q=80" alt="Compact desk setup with laptop and accessories" />
       </div>
       <div class="product-copy">
-        <p class="eyebrow">Dropship sample storefront</p>
-        <h1 id="productTitle">Compact Desk Dock</h1>
-        <p class="lede">A focused single-product page built to capture paid orders, hand them to Stripe, and leave Victor with a clear manual vendor fulfillment queue.</p>
+        <p class="eyebrow">Desk Essentials Co.</p>
+        <h1 id="storeTitle">Small upgrades for a cleaner workspace.</h1>
+        <p class="lede">Choose from practical desk and travel accessories built for everyday work, charging, and carry.</p>
         <div class="price-row">
-          <strong>$79</strong>
-          <span>Ships from vendor after order review</span>
+          <strong id="productPrice">$79</strong>
+          <span id="productSummary">Compact support for a cleaner laptop setup</span>
         </div>
         <form id="orderForm" class="order-form">
+          <fieldset class="product-picker">
+            <legend>Choose a product</legend>
+            <label class="product-option">
+              <input type="radio" name="productId" value="compact-desk-dock" checked />
+              <span>
+                <strong>Compact Desk Dock</strong>
+                <small>$79 · Low-profile laptop docking stand</small>
+              </span>
+            </label>
+            <label class="product-option">
+              <input type="radio" name="productId" value="magnetic-cable-kit" />
+              <span>
+                <strong>Magnetic Cable Kit</strong>
+                <small>$29 · Clips and ties for clean cable routing</small>
+              </span>
+            </label>
+            <label class="product-option">
+              <input type="radio" name="productId" value="travel-tech-pouch" />
+              <span>
+                <strong>Travel Tech Pouch</strong>
+                <small>$49 · Compact organizer for chargers and adapters</small>
+              </span>
+            </label>
+          </fieldset>
           <label>
             Name
             <input id="customerName" name="customerName" autocomplete="name" required />
@@ -40,7 +64,7 @@
               <option value="5">5</option>
             </select>
           </label>
-          <button id="checkoutButton" type="submit">Checkout with Stripe</button>
+          <button id="checkoutButton" type="submit">Secure checkout</button>
           <p id="status" class="status" role="status" aria-live="polite"></p>
         </form>
       </div>
@@ -48,16 +72,16 @@
 
     <section class="details" aria-label="Product details">
       <article>
-        <h2>Simple Order Capture</h2>
-        <p>Each checkout attempt creates a Gun order intent with the product, quantity, customer contact, and current status.</p>
+        <h2>Work-Ready Gear</h2>
+        <p>Useful accessories for desks, laptop bags, nightstands, and small workspaces.</p>
       </article>
       <article>
-        <h2>Hosted Payment</h2>
-        <p>Stripe Checkout collects payment and shipping information so the storefront does not handle card data.</p>
+        <h2>Simple Checkout</h2>
+        <p>Choose your item, confirm quantity, and complete shipping and payment in a secure checkout.</p>
       </article>
       <article>
-        <h2>Manual Fulfillment</h2>
-        <p>Victor can review successful orders, place the vendor order, and update the order status as the workflow matures.</p>
+        <h2>Tracked Shipping</h2>
+        <p>Orders are reviewed and sent to the best available fulfillment partner.</p>
       </article>
     </section>
   </main>

--- a/victor-dropship/styles.css
+++ b/victor-dropship/styles.css
@@ -104,6 +104,52 @@ h1 {
   padding-top: 8px;
 }
 
+.product-picker {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.product-picker legend {
+  margin-bottom: 2px;
+  color: #34423a;
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+
+.product-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  cursor: pointer;
+}
+
+.product-option:has(input:checked) {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(31, 122, 95, 0.16);
+}
+
+.product-option input {
+  width: 18px;
+  min-height: 18px;
+  margin: 0;
+}
+
+.product-option small {
+  display: block;
+  margin-top: 3px;
+  color: var(--muted);
+  font-weight: 500;
+  line-height: 1.35;
+}
+
 label {
   display: grid;
   gap: 7px;


### PR DESCRIPTION
## Summary
- Remove visible internal/technical copy from the storefront page.
- Remove visible mention of Victor from the customer-facing experience.
- Add three selectable products: Compact Desk Dock, Magnetic Cable Kit, and Travel Tech Pouch.
- Update checkout payloads/tests so all products can route through the existing Stripe storefront checkout endpoint.

## Validation
- `node --check api/stripe/[route].js`
- `node --check victor-dropship/app.js`
- `node --check tests/storefront-checkout-api.test.js`
- `node --test tests/storefront-checkout-api.test.js` from `/root/3dvr-portal`
- `node --test tests/calendar-provider-api.test.js tests/oauth-provider-api.test.js` from `/tmp/3dvr-products`