### PR TITLE
[codex] Improve notes page UX

### DIFF
--- a/notes/index.html
+++ b/notes/index.html
@@ -8,6 +8,7 @@
   <script src="/gun-init.js"></script>
   <script src="/pwa-install.js" defer></script>
   <link rel="stylesheet" href="../style.css?v=notes-refresh-20240204">
+  <link rel="stylesheet" href="./styles.css?v=notes-ux-20260514">
   <link rel="stylesheet" href="/styles/install-banner.css">
   <link rel="manifest" href="/app-manifests/notes.webmanifest">
   <meta name="theme-color" content="#0e1116">
@@ -56,7 +57,7 @@
       <div class="sidebar-section">
         <div class="section-heading">
           <span>Pages</span>
-          <button class="primary-button" id="new-note-button" disabled>+ New Page</button>
+          <button class="primary-button" id="new-note-button">+ New Page</button>
         </div>
         <input type="search" id="note-search" class="sidebar-input" placeholder="Search pages..." aria-label="Search notes">
         <ul id="notes" class="notes-list" aria-label="Notes"></ul>
@@ -67,9 +68,25 @@
 
     <main class="notes-editor" aria-live="polite">
       <button id="sidebar-toggle" class="sidebar-toggle icon-button" type="button" aria-label="Show workspace" aria-controls="notes-sidebar" aria-expanded="false">☰</button>
+      <div class="notes-actionbar" aria-label="Notes workspace status">
+        <div class="notes-context">
+          <span id="active-space-label" class="notes-context__space">Quick Notes</span>
+          <strong id="active-note-label" class="notes-context__note">No page selected</strong>
+        </div>
+        <div class="notes-actionbar__actions">
+          <span id="notes-sync-status" class="notes-sync-status" aria-live="polite">Sync ready</span>
+          <span id="notes-save-status" class="notes-save-status" aria-live="polite">Ready</span>
+          <button id="actionbar-open-sidebar" class="secondary-button" type="button">Spaces</button>
+          <button id="actionbar-new-note" class="primary-button" type="button">New page</button>
+        </div>
+      </div>
       <div id="empty-state" class="empty-state">
-        <h2>Select a note to get started</h2>
-        <p>Create or choose a page from the sidebar.</p>
+        <h2>Capture the next useful thought</h2>
+        <p>Open an existing page from the sidebar or start a fresh page in Quick Notes.</p>
+        <div class="empty-state__actions">
+          <button id="empty-new-note" class="primary-button" type="button">New page</button>
+          <button id="empty-open-sidebar" class="secondary-button" type="button">Browse spaces</button>
+        </div>
       </div>
 
       <div id="editor-wrapper" class="editor-wrapper hidden" aria-label="Note editor">
@@ -321,6 +338,12 @@
     const noteMetaEl = document.getElementById('note-meta');
     const emptyStateEl = document.getElementById('empty-state');
     const editorWrapperEl = document.getElementById('editor-wrapper');
+    const activeSpaceLabelEl = document.getElementById('active-space-label');
+    const activeNoteLabelEl = document.getElementById('active-note-label');
+    const notesSyncStatusEl = document.getElementById('notes-sync-status');
+    const notesSaveStatusEl = document.getElementById('notes-save-status');
+    const actionbarOpenSidebarButton = document.getElementById('actionbar-open-sidebar');
+    const actionbarNewNoteButton = document.getElementById('actionbar-new-note');
     const slashMenuEl = document.getElementById('slash-menu');
     const slashOptionsEl = document.getElementById('slash-options');
     const insertImageButton = document.getElementById('insert-image-button');
@@ -351,6 +374,27 @@
     const folderCache = new Map();
     const noteElements = new Map();
     const noteCache = new Map();
+
+    function setSaveStatus(message) {
+      if (notesSaveStatusEl) {
+        notesSaveStatusEl.textContent = message;
+      }
+    }
+
+    function updateWorkspaceSummary() {
+      const activeFolder = currentFolder ? folderCache.get(currentFolder) : null;
+      const activeNote = currentNoteId ? noteCache.get(currentNoteId) : null;
+      if (activeSpaceLabelEl) {
+        activeSpaceLabelEl.textContent = activeFolder?.name || DEFAULT_FOLDER_NAME;
+      }
+      if (activeNoteLabelEl) {
+        activeNoteLabelEl.textContent = activeNote?.title?.trim() || (currentNoteId ? 'Untitled' : 'No page selected');
+      }
+      if (notesSyncStatusEl) {
+        notesSyncStatusEl.textContent = gunContext.isStub ? 'Offline mode' : 'Sync ready';
+        notesSyncStatusEl.dataset.state = gunContext.isStub ? 'offline' : 'ready';
+      }
+    }
 
     const slashOptionData = [
       { id: 'text', label: 'Text', description: 'Start with plain paragraphs', action: () => applyBlock('paragraph') },
@@ -411,6 +455,14 @@
         setSidebarExpanded(false);
       });
     }
+
+    [actionbarOpenSidebarButton].forEach((button) => {
+      if (button) {
+        button.addEventListener('click', () => {
+          setSidebarExpanded(true);
+        });
+      }
+    });
 
     window.addEventListener('resize', () => {
       updateNavbarHeight();
@@ -541,7 +593,7 @@
       }
       li.querySelector('.folder-name').textContent = name;
       li.classList.toggle('active', currentFolder === id);
-      if (!currentFolder) {
+      if (!currentFolder && normalizedName === normalizeFolderName(DEFAULT_FOLDER_NAME)) {
         selectFolder(id);
       }
     }
@@ -634,6 +686,10 @@
         onPrimaryAck: (ack) => {
           if (ack && ack.err) {
             console.error('Failed to create space', ack.err);
+            if (gunContext.isStub || currentNoteId) {
+              setSaveStatus(gunContext.isStub ? 'Offline draft' : 'Sync unavailable');
+              return;
+            }
             flashEmptyState('Unable to create a space right now. Try again.');
           }
         }
@@ -722,17 +778,17 @@
       if (currentNoteId && noteCache.get(currentNoteId)?.folder !== id) {
         closeEditor();
       }
+      updateWorkspaceSummary();
     }
 
     function ensureFolderSelected() {
       if (currentFolder) {
         return currentFolder;
       }
-      const iterator = folderElements.keys();
-      const first = iterator.next();
-      if (!first.done) {
-        selectFolder(first.value);
-        return first.value;
+      const defaultFolderId = findFolderByNormalizedName(normalizeFolderName(DEFAULT_FOLDER_NAME));
+      if (defaultFolderId) {
+        selectFolder(defaultFolderId);
+        return defaultFolderId;
       }
       const id = createFolder(DEFAULT_FOLDER_NAME, DEFAULT_FOLDER_ID);
       selectFolder(id);
@@ -754,11 +810,12 @@
       });
     }
 
-    newNoteButton.addEventListener('click', () => {
+    function createNewNote() {
       const activeFolder = ensureFolderSelected();
       if (!activeFolder) {
         return;
       }
+      setSaveStatus('Creating page...');
       const id = generateId();
       const now = Date.now();
       const payload = {
@@ -768,18 +825,43 @@
         createdAt: now,
         updatedAt: now
       };
+      const optimisticNote = { ...payload, id };
+      noteSourceRefs.set(id, primaryNoteSource);
+      noteCache.set(id, optimisticNote);
+      ensureNoteListItem(id, optimisticNote);
+      openNote(id);
+      setSaveStatus(gunContext.isStub ? 'Offline draft' : 'Page created');
+      setTimeout(() => noteTitleEl.focus(), 120);
       putToSources(noteSources, id, payload, {
         onPrimaryAck: (ack) => {
           if (ack && ack.err) {
             console.error('Failed to create note', ack.err);
+            setSaveStatus(gunContext.isStub ? 'Offline draft' : 'Sync unavailable');
             return;
           }
-          openNote(id);
-          setTimeout(() => noteTitleEl.focus(), 120);
+          setSaveStatus('Page created');
         }
       });
-      noteSourceRefs.set(id, primaryNoteSource);
+    }
+
+    [newNoteButton, actionbarNewNoteButton].forEach((button) => {
+      if (button) {
+        button.addEventListener('click', createNewNote);
+      }
     });
+
+    function bindEmptyStateActions() {
+      const emptyNewNoteButton = document.getElementById('empty-new-note');
+      const emptyOpenSidebarButton = document.getElementById('empty-open-sidebar');
+      if (emptyNewNoteButton) {
+        emptyNewNoteButton.onclick = createNewNote;
+      }
+      if (emptyOpenSidebarButton) {
+        emptyOpenSidebarButton.onclick = () => setSidebarExpanded(true);
+      }
+    }
+
+    bindEmptyStateActions();
 
     noteSearchInput.addEventListener('input', () => {
       filterNotes();
@@ -843,6 +925,7 @@
         updateEditorMeta(merged);
       }
       filterNotes();
+      updateWorkspaceSummary();
     }
 
     noteSources.forEach((source) => {
@@ -924,6 +1007,7 @@
       li.dataset.title = titleEl.textContent.toLowerCase();
       li.dataset.contentPreview = getContentPreview(note.content || '');
       li.classList.toggle('active', currentNoteId === id);
+      updateWorkspaceSummary();
     }
 
     function filterNotes() {
@@ -978,6 +1062,8 @@
         noteContentEl.innerHTML = note.content || '';
       }
       updateEditorMeta(note);
+      updateWorkspaceSummary();
+      setSaveStatus('Ready');
     }
 
     function attachNoteListener(id) {
@@ -1025,6 +1111,8 @@
       noteMetaEl.textContent = '';
       hideSlashMenu();
       noteElements.forEach((li) => li.classList.remove('active'));
+      updateWorkspaceSummary();
+      setSaveStatus('Ready');
     }
 
     function clearNotesSelection() {
@@ -1120,6 +1208,8 @@
       putToSources(noteSources, currentNoteId, { title: value, updatedAt: now });
       ensureNoteListItem(currentNoteId, cached);
       filterNotes();
+      updateWorkspaceSummary();
+      setSaveStatus(gunContext.isStub ? 'Offline draft' : 'Saved to sync queue');
     });
 
     noteTitleEl.addEventListener('input', () => {
@@ -1131,6 +1221,8 @@
       noteCache.set(currentNoteId, cached);
       ensureNoteListItem(currentNoteId, cached);
       filterNotes();
+      updateWorkspaceSummary();
+      setSaveStatus('Editing...');
     });
 
     noteContentEl.addEventListener('keydown', (event) => {
@@ -1214,9 +1306,11 @@
       if (saveTimer) {
         clearTimeout(saveTimer);
       }
+      setSaveStatus('Editing...');
       saveTimer = setTimeout(() => {
         const html = noteContentEl.innerHTML;
         suppressContentUpdate = true;
+        setSaveStatus('Saving...');
         const now = Date.now();
         putFieldToSources(noteSources, currentNoteId, 'content', html);
         putFieldToSources(noteSources, currentNoteId, 'updatedAt', now);
@@ -1227,6 +1321,8 @@
         ensureNoteListItem(currentNoteId, cached);
         updateEditorMeta(cached);
         filterNotes();
+        updateWorkspaceSummary();
+        setSaveStatus(gunContext.isStub ? 'Offline draft' : 'Saved to sync queue');
         setTimeout(() => {
           suppressContentUpdate = false;
         }, 150);
@@ -1552,13 +1648,16 @@
 
     function flashEmptyState(message) {
       emptyStateEl.classList.remove('hidden');
-      emptyStateEl.innerHTML = `<h2>${message}</h2><p>Create a space to organize your notes like Notion.</p>`;
+      emptyStateEl.innerHTML = `<h2>${message}</h2><p>Create a space to organize your notes.</p>`;
       setTimeout(() => {
         if (!currentNoteId) {
           emptyStateEl.innerHTML = defaultEmptyMessage;
+          bindEmptyStateActions();
         }
       }, 2500);
     }
+
+    updateWorkspaceSummary();
   </script>
   <script defer src="/issue-launcher.js"></script>
 </body>

--- a/notes/styles.css
+++ b/notes/styles.css
@@ -1,0 +1,287 @@
+:root {
+  --notes-bg: #f6f4ee;
+  --notes-panel: #fffdf8;
+  --notes-panel-strong: #ffffff;
+  --notes-line: #ded9ce;
+  --notes-ink: #232a27;
+  --notes-muted: #6f756f;
+  --notes-soft: #ebe7dc;
+  --notes-accent: #2f6f58;
+  --notes-accent-strong: #1f513f;
+  --notes-warn: #8f5a17;
+}
+
+body.notes-page {
+  background: var(--notes-bg);
+  color: var(--notes-ink);
+}
+
+body.notes-page .notes-shell {
+  min-height: calc(100vh - var(--notes-navbar-height, 56px));
+}
+
+body.notes-page .notes-sidebar {
+  background: #efebe2;
+  border-right-color: var(--notes-line);
+}
+
+body.notes-page .notes-editor {
+  min-width: 0;
+  background:
+    linear-gradient(180deg, rgba(255, 253, 248, 0.94), rgba(246, 244, 238, 0.96)),
+    var(--notes-bg);
+}
+
+body.notes-page #note-title.note-title {
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border-bottom: 0;
+  color: var(--notes-ink);
+}
+
+body.notes-page #note-title.note-title:focus,
+body.notes-page .note-content:focus {
+  outline: none;
+}
+
+body.notes-page #note-title.note-title:focus-visible,
+body.notes-page .note-content:focus-visible {
+  box-shadow: 0 0 0 3px rgba(47, 111, 88, 0.14);
+  border-radius: 8px;
+}
+
+body.notes-page .notes-actionbar {
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 64px;
+  padding: 12px 24px;
+  background: rgba(255, 253, 248, 0.92);
+  border-bottom: 1px solid var(--notes-line);
+  backdrop-filter: blur(14px);
+}
+
+body.notes-page .notes-context {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+body.notes-page .notes-context__space {
+  color: var(--notes-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+body.notes-page .notes-context__note {
+  max-width: 42rem;
+  overflow: hidden;
+  color: var(--notes-ink);
+  font-size: 1rem;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+body.notes-page .notes-actionbar__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+body.notes-page .notes-sync-status,
+body.notes-page .notes-save-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--notes-line);
+  border-radius: 8px;
+  color: var(--notes-muted);
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+body.notes-page .notes-sync-status[data-state="offline"] {
+  color: var(--notes-warn);
+  border-color: rgba(143, 90, 23, 0.28);
+  background: rgba(255, 247, 229, 0.88);
+}
+
+body.notes-page .primary-button,
+body.notes-page .secondary-button {
+  min-height: 34px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 7px 12px;
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+body.notes-page .primary-button {
+  background: var(--notes-accent);
+  color: #ffffff;
+}
+
+body.notes-page .primary-button:hover {
+  background: var(--notes-accent-strong);
+}
+
+body.notes-page .secondary-button {
+  background: #ffffff;
+  color: var(--notes-ink);
+  border-color: var(--notes-line);
+  cursor: pointer;
+}
+
+body.notes-page .secondary-button:hover {
+  background: var(--notes-soft);
+}
+
+body.notes-page .folder-item,
+body.notes-page .note-item {
+  min-height: 42px;
+}
+
+body.notes-page .folder-content,
+body.notes-page .note-item-content {
+  min-width: 0;
+}
+
+body.notes-page .note-item-title,
+body.notes-page .folder-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+body.notes-page .folder-item.active,
+body.notes-page .note-item.active {
+  background: #dfece4;
+  box-shadow: inset 0 0 0 1px rgba(47, 111, 88, 0.24);
+}
+
+body.notes-page .editor-wrapper {
+  width: min(100%, 940px);
+  margin: 0 auto;
+  padding-top: 34px;
+}
+
+body.notes-page .note-header,
+body.notes-page .note-content {
+  width: min(100%, 760px);
+}
+
+body.notes-page .note-title {
+  font-size: 2.45rem;
+  line-height: 1.08;
+  letter-spacing: 0;
+}
+
+body.notes-page .note-meta {
+  flex-shrink: 0;
+}
+
+body.notes-page .note-toolbar {
+  position: static;
+  z-index: 4;
+  max-width: 100%;
+  margin: 6px 0 18px;
+  overflow-x: auto;
+  border-color: var(--notes-line);
+  border-radius: 8px;
+}
+
+body.notes-page .note-content {
+  min-height: 55vh;
+  padding-bottom: 30vh;
+}
+
+body.notes-page .empty-state {
+  width: min(100% - 32px, 520px);
+  padding: 34px;
+  border: 1px solid var(--notes-line);
+  border-radius: 8px;
+  background: rgba(255, 253, 248, 0.82);
+  box-shadow: 0 18px 60px rgba(39, 33, 23, 0.08);
+}
+
+body.notes-page .empty-state h2 {
+  margin: 0 0 10px;
+  color: var(--notes-ink);
+  font-size: 1.65rem;
+}
+
+body.notes-page .empty-state p {
+  margin: 0;
+  color: var(--notes-muted);
+}
+
+body.notes-page .empty-state__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+@media (max-width: 900px) {
+  body.notes-page .sidebar-toggle {
+    display: none;
+  }
+
+  body.notes-page .notes-actionbar {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 16px;
+  }
+
+  body.notes-page .notes-actionbar__actions {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  body.notes-page .notes-sync-status,
+  body.notes-page .notes-save-status {
+    min-height: 28px;
+  }
+
+  body.notes-page .editor-wrapper {
+    padding-top: 22px;
+  }
+
+  body.notes-page .note-header,
+  body.notes-page .note-content {
+    width: 100%;
+  }
+}
+
+@media (max-width: 560px) {
+  body.notes-page .notes-context__note {
+    max-width: calc(100vw - 34px);
+  }
+
+  body.notes-page .notes-actionbar__actions > button {
+    flex: 1 1 120px;
+  }
+
+  body.notes-page .note-title {
+    font-size: 2rem;
+  }
+
+  body.notes-page .empty-state {
+    padding: 26px 20px;
+  }
+}

--- a/scripts/playwright/smoke.mjs
+++ b/scripts/playwright/smoke.mjs
@@ -91,7 +91,7 @@ try {
   const heading = (await page.locator('#landing-title').innerText()).trim();
 
   assert.equal(pageTitle, '3DVR Portal');
-  assert.match(heading, /Welcome to the 3DVR Portal|Choose your path into the portal|Get in, get moving\.|One system\. Any device\./i);
+  assert.match(heading, /Welcome to the 3DVR Portal|Choose your path into the portal|Get in, get moving\.|One system\. Any device\.|One portal\. Fast access\./i);
 
   console.log(`Playwright smoke check passed in ${browserTarget.displayName} at ${baseUrl}`);
 } finally {

--- a/tests/notes-ux.test.js
+++ b/tests/notes-ux.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('notes page ships the focused UX layer and visible creation path', async () => {
+  const html = await readFile(new URL('../notes/index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /href="\.\/styles\.css\?v=notes-ux-20260514"/);
+  assert.match(html, /id="active-space-label"/);
+  assert.match(html, /id="active-note-label"/);
+  assert.match(html, /id="notes-sync-status"/);
+  assert.match(html, /id="notes-save-status"/);
+  assert.match(html, /id="actionbar-new-note"/);
+  assert.match(html, /id="empty-new-note"/);
+  assert.match(html, /Capture the next useful thought/);
+  assert.match(html, /findFolderByNormalizedName\(normalizeFolderName\(DEFAULT_FOLDER_NAME\)\)/);
+  assert.match(html, /optimisticNote/);
+  assert.match(html, /Offline draft/);
+  assert.match(html, /currentNoteId/);
+  assert.doesNotMatch(html, /id="new-note-button" disabled/);
+});
+
+test('notes UX CSS overrides stale global note-title rules', async () => {
+  const css = await readFile(new URL('../notes/styles.css', import.meta.url), 'utf8');
+
+  assert.match(css, /body\.notes-page #note-title\.note-title/);
+  assert.match(css, /background:\s*transparent/);
+  assert.match(css, /border-bottom:\s*0/);
+  assert.match(css, /\.notes-actionbar/);
+  assert.match(css, /position:\s*static/);
+  assert.match(css, /\.empty-state__actions/);
+  assert.match(css, /Saved to sync queue|notes-save-status/);
+});


### PR DESCRIPTION
## Summary
- Add a Notes-specific UX stylesheet to override stale global editor-title rules and calm the writing surface.
- Add a persistent action/status bar with active space/page context, sync/save state, and direct New page/Spaces actions.
- Make empty-state page creation optimistic so Notes still opens an offline draft when Gun is unavailable.
- Add focused Notes UX regression coverage.

## Validation
- `node --test tests/notes-ux.test.js tests/gun-peer-config.test.js tests/issue-launcher.test.js`
- Playwright smoke with `/root/3dvr-portal/node_modules/playwright` and `/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome`, service workers blocked, external Gun/CDN calls blocked: verified desktop editor opens from empty state, title CSS override is active, toolbar does not overlap content, and mobile shows New page/Spaces without the old hamburger overlap.