### PR TITLE
[codex] add attention visualized lesson

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)
 - [Life](https://3dvr-portal.vercel.app/life/)
 - [Alive System](https://3dvr-portal.vercel.app/alive-system/)
+- [Attention Visualized](https://3dvr-portal.vercel.app/attention-visualized/)
 - [Logic Lab](https://3dvr-portal.vercel.app/logic-lab/)
 
 Open the page you want and use your browser’s **Install** or **Add to Home Screen** option to pin it like a native app.

--- a/app-manifests/attention-visualized.webmanifest
+++ b/app-manifests/attention-visualized.webmanifest
@@ -1,0 +1,16 @@
+{
+  "id": "/attention-visualized/",
+  "name": "3DVR Attention Visualized",
+  "short_name": "Attention Lab",
+  "description": "Explore self-attention, Q/K/V, softmax, and tiny JavaScript attention in the browser.",
+  "start_url": "/attention-visualized/?source=pwa",
+  "scope": "/attention-visualized/",
+  "display": "standalone",
+  "background_color": "#09111f",
+  "theme_color": "#09111f",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/attention-visualized/app.js
+++ b/attention-visualized/app.js
@@ -1,0 +1,221 @@
+const tokenInput = document.getElementById('tokenInput');
+const focusToken = document.getElementById('focusToken');
+const temperature = document.getElementById('temperature');
+const temperatureValue = document.getElementById('temperatureValue');
+const headMix = document.getElementById('headMix');
+const headMixValue = document.getElementById('headMixValue');
+const focusSummary = document.getElementById('focusSummary');
+const canvas = document.getElementById('attentionCanvas');
+const heatmap = document.getElementById('heatmap');
+const context = canvas.getContext('2d');
+
+const headLabels = ['syntax', 'semantic', 'position'];
+
+function tokenize(text) {
+  return text
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.replace(/[^\w'-]/g, '').toLowerCase())
+    .filter(Boolean)
+    .slice(0, 10);
+}
+
+function hashToken(token) {
+  let hash = 2166136261;
+  for (let index = 0; index < token.length; index += 1) {
+    hash ^= token.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function embeddingFor(token, index, total, mode) {
+  const hash = hashToken(token);
+  const vowels = (token.match(/[aeiou]/g) || []).length;
+  const consonants = Math.max(token.length - vowels, 1);
+  const position = total <= 1 ? 0 : index / (total - 1);
+  const base = [
+    ((hash & 255) / 255) * 2 - 1,
+    (((hash >>> 8) & 255) / 255) * 2 - 1,
+    (vowels / Math.max(token.length, 1)) * 2 - 1,
+    (consonants / Math.max(token.length, 1)) * 2 - 1,
+  ];
+
+  if (mode === 1) {
+    base[0] += token.length / 8;
+    base[2] += vowels > 0 ? 0.45 : -0.25;
+  }
+
+  if (mode === 2) {
+    base[1] += 1 - Math.abs(position - 0.5) * 2;
+    base[3] += position;
+  }
+
+  return base;
+}
+
+function dot(left, right) {
+  return left.reduce((sum, value, index) => sum + value * right[index], 0);
+}
+
+function softmax(values, temp) {
+  const scaled = values.map((value) => value / temp);
+  const max = Math.max(...scaled);
+  const exps = scaled.map((value) => Math.exp(value - max));
+  const total = exps.reduce((sum, value) => sum + value, 0);
+  return exps.map((value) => value / total);
+}
+
+function buildMatrix(tokens, temp, mode) {
+  const embeddings = tokens.map((token, index) => embeddingFor(token, index, tokens.length, mode));
+  return embeddings.map((query) => {
+    const scores = embeddings.map((key) => dot(query, key) / Math.sqrt(query.length));
+    return softmax(scores, temp);
+  });
+}
+
+function resizeCanvas() {
+  const rect = canvas.getBoundingClientRect();
+  const ratio = window.devicePixelRatio || 1;
+  canvas.width = Math.max(1, Math.floor(rect.width * ratio));
+  canvas.height = Math.max(300, Math.floor((rect.width * 0.46) * ratio));
+  context.setTransform(ratio, 0, 0, ratio, 0, 0);
+  return { width: rect.width, height: canvas.height / ratio };
+}
+
+function drawCanvas(tokens, matrix, selectedIndex) {
+  const { width, height } = resizeCanvas();
+  context.clearRect(0, 0, width, height);
+
+  const padding = Math.min(78, Math.max(28, width * 0.08));
+  const y = height * 0.68;
+  const spacing = tokens.length <= 1 ? 0 : (width - padding * 2) / (tokens.length - 1);
+  const points = tokens.map((token, index) => ({
+    token,
+    x: padding + spacing * index,
+    y,
+  }));
+
+  const query = points[selectedIndex];
+  const weights = matrix[selectedIndex] || [];
+
+  weights.forEach((weight, index) => {
+    if (index === selectedIndex || weight < 0.035) return;
+    const target = points[index];
+    const controlY = height * (0.12 + (1 - weight) * 0.18);
+    context.beginPath();
+    context.moveTo(query.x, query.y - 26);
+    context.quadraticCurveTo((query.x + target.x) / 2, controlY, target.x, target.y - 26);
+    context.strokeStyle = `rgba(34, 211, 238, ${Math.min(0.95, 0.18 + weight * 2.7)})`;
+    context.lineWidth = 1 + weight * 12;
+    context.stroke();
+  });
+
+  points.forEach((point, index) => {
+    const isSelected = index === selectedIndex;
+    const weight = weights[index] || 0;
+    context.beginPath();
+    context.arc(point.x, point.y, isSelected ? 26 : 22 + weight * 16, 0, Math.PI * 2);
+    context.fillStyle = isSelected ? '#22d3ee' : `rgba(134, 239, 172, ${0.28 + weight * 1.8})`;
+    context.fill();
+    context.lineWidth = 2;
+    context.strokeStyle = 'rgba(226, 232, 240, 0.38)';
+    context.stroke();
+    context.fillStyle = isSelected ? '#06101c' : '#e5eefb';
+    context.font = '700 14px Segoe UI, sans-serif';
+    context.textAlign = 'center';
+    context.fillText(point.token, point.x, point.y + 5);
+  });
+}
+
+function renderHeatmap(tokens, matrix) {
+  heatmap.innerHTML = '';
+  heatmap.style.setProperty('--token-count', tokens.length);
+
+  const header = document.createElement('div');
+  header.className = 'heatmap-row';
+  header.appendChild(labelCell('Q/K'));
+  tokens.forEach((token) => header.appendChild(labelCell(token)));
+  heatmap.appendChild(header);
+
+  matrix.forEach((row, rowIndex) => {
+    const rowNode = document.createElement('div');
+    rowNode.className = 'heatmap-row';
+    rowNode.appendChild(labelCell(tokens[rowIndex]));
+    row.forEach((weight) => {
+      const cell = document.createElement('span');
+      cell.className = 'heatmap-cell';
+      cell.textContent = weight.toFixed(2);
+      cell.style.background = `rgba(34, 211, 238, ${0.18 + weight * 0.9})`;
+      rowNode.appendChild(cell);
+    });
+    heatmap.appendChild(rowNode);
+  });
+}
+
+function labelCell(text) {
+  const cell = document.createElement('span');
+  cell.className = 'heatmap-label';
+  cell.textContent = text;
+  return cell;
+}
+
+function syncFocusOptions(tokens) {
+  const previous = focusToken.value;
+  focusToken.innerHTML = '';
+  tokens.forEach((token, index) => {
+    const option = document.createElement('option');
+    option.value = String(index);
+    option.textContent = `${index + 1}. ${token}`;
+    focusToken.appendChild(option);
+  });
+
+  if (previous && Number(previous) < tokens.length) {
+    focusToken.value = previous;
+  } else {
+    focusToken.value = String(Math.min(2, tokens.length - 1));
+  }
+}
+
+function updateSummary(tokens, matrix, selectedIndex) {
+  const row = matrix[selectedIndex] || [];
+  const strongest = row
+    .map((weight, index) => ({ weight, index }))
+    .filter((entry) => entry.index !== selectedIndex)
+    .sort((left, right) => right.weight - left.weight)[0];
+
+  if (!strongest) {
+    focusSummary.textContent = `${tokens[selectedIndex]} has no other token to attend to`;
+    return;
+  }
+
+  focusSummary.textContent = `${tokens[selectedIndex]} attends most to ${tokens[strongest.index]} (${strongest.weight.toFixed(2)})`;
+}
+
+function render() {
+  const tokens = tokenize(tokenInput.value);
+  if (tokens.length === 0) {
+    tokenInput.value = 'the cat sat';
+    return render();
+  }
+
+  syncFocusOptions(tokens);
+  const selectedIndex = Math.min(Number(focusToken.value) || 0, tokens.length - 1);
+  const temp = Number(temperature.value);
+  const mode = Number(headMix.value);
+  const matrix = buildMatrix(tokens, temp, mode);
+
+  temperatureValue.textContent = temp.toFixed(2);
+  headMixValue.textContent = headLabels[mode];
+  drawCanvas(tokens, matrix, selectedIndex);
+  renderHeatmap(tokens, matrix);
+  updateSummary(tokens, matrix, selectedIndex);
+}
+
+tokenInput.addEventListener('input', render);
+focusToken.addEventListener('change', render);
+temperature.addEventListener('input', render);
+headMix.addEventListener('input', render);
+window.addEventListener('resize', render);
+
+render();

--- a/attention-visualized/index.html
+++ b/attention-visualized/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Attention Visualized | 3DVR Portal</title>
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="./styles.css">
+  <link rel="manifest" href="/app-manifests/attention-visualized.webmanifest">
+  <meta name="theme-color" content="#09111f">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="attention-page">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+  <main id="mainContent" class="attention-shell">
+    <section class="attention-hero" aria-labelledby="attention-title">
+      <div class="attention-hero__copy">
+        <span class="attention-kicker">Open-source AI school</span>
+        <h1 id="attention-title">Attention Is All You Need, explained for builders</h1>
+        <p>
+          A browser-first lab for seeing how tokens look at each other, how softmax turns similarity
+          into weights, and why transformers changed modern AI.
+        </p>
+        <div class="attention-actions">
+          <a class="attention-button attention-button--primary" href="#lab-title">Open the lab</a>
+          <a class="attention-button" href="/index.html">Back to portal</a>
+        </div>
+      </div>
+      <div class="network-preview" aria-hidden="true">
+        <span class="network-token network-token--query">sat</span>
+        <span class="network-token network-token--strong">cat</span>
+        <span class="network-token network-token--mid">mat</span>
+        <span class="network-token network-token--weak">the</span>
+        <span class="network-line network-line--strong"></span>
+        <span class="network-line network-line--mid"></span>
+        <span class="network-line network-line--weak"></span>
+      </div>
+    </section>
+
+    <section class="lesson-band" aria-labelledby="why-title">
+      <div class="section-heading">
+        <span class="attention-kicker">Part 1</span>
+        <h2 id="why-title">Why transformers matter</h2>
+        <p>
+          Old sequence models read text mostly in order. Attention lets every token compare itself
+          with every other token, so context can move through the whole sentence at once.
+        </p>
+      </div>
+      <div class="concept-grid">
+        <article class="concept-card">
+          <strong>RNN bottleneck</strong>
+          <span>Context had to squeeze through step-by-step memory.</span>
+        </article>
+        <article class="concept-card">
+          <strong>Attention shift</strong>
+          <span>Each token gets a spotlight and chooses what matters.</span>
+        </article>
+        <article class="concept-card">
+          <strong>Parallel building</strong>
+          <span>Many token comparisons can run together on modern hardware.</span>
+        </article>
+      </div>
+    </section>
+
+    <section class="lab-panel" aria-labelledby="lab-title">
+      <div class="section-heading">
+        <span class="attention-kicker">Part 2</span>
+        <h2 id="lab-title">Self-attention visualization</h2>
+        <p>
+          Edit the sentence, pick a focus token, and change the temperature. The canvas shows which
+          tokens are being attended to, while the heatmap shows the full attention matrix.
+        </p>
+      </div>
+
+      <div class="control-grid">
+        <label class="control-field" for="tokenInput">
+          <span>Token input</span>
+          <input id="tokenInput" type="text" value="The cat sat on the mat" autocomplete="off" spellcheck="false">
+        </label>
+        <label class="control-field" for="focusToken">
+          <span>Focus token</span>
+          <select id="focusToken"></select>
+        </label>
+        <label class="control-field" for="temperature">
+          <span>Temperature <output id="temperatureValue" for="temperature">1.00</output></span>
+          <input id="temperature" type="range" min="0.35" max="2.5" value="1" step="0.05">
+        </label>
+        <label class="control-field" for="headMix">
+          <span>Head flavor <output id="headMixValue" for="headMix">syntax</output></span>
+          <input id="headMix" type="range" min="0" max="2" value="0" step="1">
+        </label>
+      </div>
+
+      <div class="lab-layout">
+        <article class="visual-card">
+          <div class="visual-card__header">
+            <h3>Attention lines</h3>
+            <span id="focusSummary">sat attends most to cat</span>
+          </div>
+          <canvas id="attentionCanvas" width="900" height="420" aria-label="Canvas showing attention links between tokens"></canvas>
+        </article>
+        <article class="visual-card">
+          <div class="visual-card__header">
+            <h3>Attention heatmap</h3>
+            <span>Rows are queries, columns are keys.</span>
+          </div>
+          <div id="heatmap" class="heatmap" role="table" aria-label="Attention weights heatmap"></div>
+        </article>
+      </div>
+    </section>
+
+    <section class="formula-panel" aria-labelledby="formula-title">
+      <div class="section-heading">
+        <span class="attention-kicker">Part 3</span>
+        <h2 id="formula-title">The formula, without the fog</h2>
+        <p>
+          Attention(Q, K, V) = softmax((QK^T) / sqrt(d_k))V. Q asks a question, K describes what a
+          token can match, and V is the information that gets blended into the result.
+        </p>
+      </div>
+      <div class="formula-flow">
+        <article><strong>Query</strong><span>What am I looking for?</span></article>
+        <article><strong>Key</strong><span>What do I offer to match?</span></article>
+        <article><strong>Value</strong><span>What information do I pass along?</span></article>
+        <article><strong>Softmax</strong><span>Turn scores into attention weights.</span></article>
+      </div>
+    </section>
+
+    <section class="code-panel" aria-labelledby="code-title">
+      <div class="section-heading">
+        <span class="attention-kicker">Part 4</span>
+        <h2 id="code-title">Tiny attention in JavaScript</h2>
+        <p>Every number in the lab is generated in the browser from small deterministic embeddings.</p>
+      </div>
+      <pre><code>const tokens = ["the", "cat", "sat"];
+const embeddings = [
+  [0.1, 0.8],
+  [0.7, 0.2],
+  [0.6, 0.9]
+];
+
+const scores = dot(query, key) / Math.sqrt(query.length);
+const weights = softmax(scores);
+const output = weightedSum(weights, values);</code></pre>
+    </section>
+
+    <section class="reflection-panel" aria-labelledby="reflection-title">
+      <div class="section-heading">
+        <span class="attention-kicker">Part 5</span>
+        <h2 id="reflection-title">Attention as human focus</h2>
+        <p>
+          The parallel is useful if we keep it grounded: people also allocate focus, ignore noise,
+          and connect memory with context. That does not make a model conscious. It does give us a
+          practical metaphor for learning how pattern systems work.
+        </p>
+      </div>
+    </section>
+  </main>
+  <script src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/attention-visualized/styles.css
+++ b/attention-visualized/styles.css
@@ -1,0 +1,397 @@
+:root {
+  --attention-bg: #09111f;
+  --attention-panel: rgba(15, 23, 42, 0.82);
+  --attention-panel-strong: rgba(20, 31, 52, 0.94);
+  --attention-border: rgba(125, 211, 252, 0.24);
+  --attention-text: #e5eefb;
+  --attention-muted: #a7b4c8;
+  --attention-cyan: #22d3ee;
+  --attention-green: #86efac;
+  --attention-amber: #fbbf24;
+  --attention-pink: #f472b6;
+  --attention-radius: 8px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body.attention-page {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  color: var(--attention-text);
+  background:
+    linear-gradient(135deg, rgba(34, 211, 238, 0.1), transparent 28%),
+    linear-gradient(225deg, rgba(244, 114, 182, 0.1), transparent 32%),
+    var(--attention-bg);
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  z-index: 20;
+  padding: 0.65rem 1rem;
+  background: var(--attention-cyan);
+  color: #07111f;
+  border-radius: var(--attention-radius);
+  font-weight: 700;
+  transform: translateY(-160%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.attention-shell {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2rem 0 4rem;
+}
+
+.attention-hero {
+  min-height: min(720px, 82vh);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.82fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  align-items: center;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.attention-hero__copy {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.attention-kicker {
+  width: fit-content;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid rgba(34, 211, 238, 0.35);
+  border-radius: 999px;
+  color: var(--attention-cyan);
+  background: rgba(34, 211, 238, 0.08);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  max-width: 11ch;
+  font-size: clamp(3rem, 7vw, 6.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+
+h2 {
+  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  line-height: 1.05;
+}
+
+h3 {
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+p {
+  color: var(--attention-muted);
+  line-height: 1.7;
+}
+
+.attention-hero p {
+  max-width: 48rem;
+  font-size: 1.08rem;
+}
+
+.attention-actions,
+.control-grid,
+.formula-flow,
+.concept-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.attention-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: var(--attention-radius);
+  color: var(--attention-text);
+  background: rgba(15, 23, 42, 0.72);
+  font-weight: 800;
+}
+
+.attention-button--primary {
+  color: #06101c;
+  border-color: transparent;
+  background: var(--attention-cyan);
+}
+
+.network-preview {
+  position: relative;
+  min-height: 460px;
+  border: 1px solid var(--attention-border);
+  border-radius: var(--attention-radius);
+  background:
+    linear-gradient(rgba(148, 163, 184, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.06) 1px, transparent 1px),
+    rgba(15, 23, 42, 0.58);
+  background-size: 32px 32px;
+  overflow: hidden;
+}
+
+.network-token {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 84px;
+  aspect-ratio: 1;
+  border-radius: 999px;
+  border: 1px solid rgba(226, 232, 240, 0.28);
+  background: var(--attention-panel-strong);
+  font-weight: 900;
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
+}
+
+.network-token--query {
+  left: 43%;
+  top: 42%;
+  color: #06101c;
+  background: var(--attention-cyan);
+}
+
+.network-token--strong {
+  left: 16%;
+  top: 20%;
+}
+
+.network-token--mid {
+  right: 15%;
+  top: 18%;
+}
+
+.network-token--weak {
+  right: 24%;
+  bottom: 14%;
+}
+
+.network-line {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  height: 4px;
+  border-radius: 999px;
+  transform-origin: left center;
+}
+
+.network-line--strong {
+  width: 210px;
+  background: var(--attention-green);
+  transform: rotate(211deg);
+}
+
+.network-line--mid {
+  width: 185px;
+  background: var(--attention-amber);
+  transform: rotate(316deg);
+  opacity: 0.78;
+}
+
+.network-line--weak {
+  width: 150px;
+  background: var(--attention-pink);
+  transform: rotate(37deg);
+  opacity: 0.42;
+}
+
+.lesson-band,
+.lab-panel,
+.formula-panel,
+.code-panel,
+.reflection-panel {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--attention-radius);
+  background: rgba(8, 13, 24, 0.5);
+}
+
+.section-heading {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.section-heading p {
+  max-width: 66rem;
+}
+
+.concept-card,
+.formula-flow article,
+.visual-card,
+.code-panel pre {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--attention-radius);
+  background: var(--attention-panel);
+}
+
+.concept-card,
+.formula-flow article {
+  flex: 1 1 220px;
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+}
+
+.concept-card span,
+.formula-flow span {
+  color: var(--attention-muted);
+}
+
+.control-grid {
+  align-items: end;
+}
+
+.control-field {
+  flex: 1 1 220px;
+  display: grid;
+  gap: 0.45rem;
+  color: var(--attention-muted);
+  font-weight: 800;
+}
+
+.control-field input,
+.control-field select {
+  width: 100%;
+  min-height: 2.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: var(--attention-radius);
+  background: rgba(2, 6, 23, 0.78);
+  color: var(--attention-text);
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+}
+
+.lab-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+  gap: 1rem;
+}
+
+.visual-card {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.visual-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.visual-card__header span {
+  color: var(--attention-muted);
+  font-size: 0.88rem;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: rgba(2, 6, 23, 0.42);
+}
+
+.heatmap {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.heatmap-row {
+  display: grid;
+  grid-template-columns: 76px repeat(var(--token-count), minmax(44px, 1fr));
+  gap: 0.35rem;
+  align-items: stretch;
+}
+
+.heatmap-cell,
+.heatmap-label {
+  min-height: 2.6rem;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.heatmap-label {
+  color: var(--attention-muted);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.heatmap-cell {
+  color: #06101c;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.code-panel pre {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  color: #dbeafe;
+}
+
+.code-panel code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.92rem;
+  line-height: 1.65;
+}
+
+@media (max-width: 860px) {
+  .attention-hero,
+  .lab-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .attention-hero {
+    min-height: auto;
+    padding: 4rem 0 1.5rem;
+  }
+
+  h1 {
+    max-width: 100%;
+    font-size: clamp(2.7rem, 18vw, 4.6rem);
+  }
+
+  .network-preview {
+    min-height: 340px;
+  }
+
+  .network-token {
+    width: 70px;
+  }
+
+  .visual-card__header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -321,6 +321,11 @@
             <span class="app-card__title">Learn</span>
             <span class="app-card__meta">Unlock new lessons and level up your skills.</span>
           </a>
+          <a href="attention-visualized/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">AI</span>
+            <span class="app-card__title">Attention Visualized</span>
+            <span class="app-card__meta">See self-attention, softmax, Q/K/V, and tiny JavaScript attention in one browser lab.</span>
+          </a>
           <a href="logic-lab/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">&#9878;</span>
             <span class="app-card__title">Logic Lab</span>

--- a/tests/attention-visualized.test.js
+++ b/tests/attention-visualized.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const appDir = new URL('../attention-visualized/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test('attention visualized app ships the interactive lesson structure', async () => {
+  const htmlUrl = new URL('index.html', appDir);
+  assert.equal(await fileExists(htmlUrl), true);
+
+  const html = await readFile(htmlUrl, 'utf8');
+  assert.match(html, /Attention Visualized \| 3DVR Portal/);
+  assert.match(html, /Attention Is All You Need, explained for builders/);
+  assert.match(html, /id="tokenInput"/);
+  assert.match(html, /id="focusToken"/);
+  assert.match(html, /id="temperature"/);
+  assert.match(html, /id="headMix"/);
+  assert.match(html, /id="attentionCanvas"/);
+  assert.match(html, /id="heatmap"/);
+  assert.match(html, /Attention\(Q, K, V\) = softmax/);
+  assert.match(html, /Tiny attention in JavaScript/);
+  assert.match(html, /Attention as human focus/);
+  assert.match(html, /href="\/app-manifests\/attention-visualized\.webmanifest"/);
+  assert.match(html, /<script src="\.\/app\.js"><\/script>/);
+  assert.match(html, /<script defer src="\/issue-launcher\.js"><\/script>/);
+});
+
+test('attention visualized app includes focused styling, browser logic, and app manifest', async () => {
+  const css = await readFile(new URL('styles.css', appDir), 'utf8');
+  const js = await readFile(new URL('app.js', appDir), 'utf8');
+  const manifest = await readFile(new URL('../app-manifests/attention-visualized.webmanifest', import.meta.url), 'utf8');
+
+  assert.match(css, /\.attention-hero/);
+  assert.match(css, /\.network-preview/);
+  assert.match(css, /\.lab-layout/);
+  assert.match(css, /\.heatmap-row/);
+  assert.match(css, /@media \(max-width: 860px\)/);
+
+  assert.match(js, /function tokenize/);
+  assert.match(js, /function softmax/);
+  assert.match(js, /function buildMatrix/);
+  assert.match(js, /function drawCanvas/);
+  assert.match(js, /function renderHeatmap/);
+  assert.match(js, /temperature\.addEventListener\('input', render\)/);
+
+  assert.match(manifest, /3DVR Attention Visualized/);
+  assert.match(manifest, /"start_url": "\/attention-visualized\/\?source=pwa"/);
+  assert.match(manifest, /"scope": "\/attention-visualized\/"/);
+});
+
+test('portal homepage links to attention visualized near Learn', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const learnIndex = html.indexOf('>Learn<');
+  const attentionIndex = html.indexOf('>Attention Visualized<');
+  const logicIndex = html.indexOf('>Logic Lab<');
+
+  assert.ok(learnIndex !== -1, 'Learn app card should still be listed');
+  assert.ok(attentionIndex !== -1, 'Attention Visualized app card should be listed');
+  assert.ok(logicIndex !== -1, 'Logic Lab app card should still be listed');
+  assert.ok(learnIndex < attentionIndex, 'Attention Visualized should render after Learn');
+  assert.ok(attentionIndex < logicIndex, 'Attention Visualized should render before Logic Lab');
+  assert.match(html, /href="attention-visualized\/"/);
+  assert.match(html, /See self-attention, softmax, Q\/K\/V, and tiny JavaScript attention in one browser lab\./);
+});
+
+test('README lists attention visualized as an installable learning app', async () => {
+  const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+  assert.match(readme, /\[Attention Visualized\]\(https:\/\/3dvr-portal\.vercel\.app\/attention-visualized\/\)/);
+});


### PR DESCRIPTION
## What changed

- Added a new `attention-visualized/` browser lesson app for the "Attention Is All You Need" education concept.
- Added interactive token input, focus selection, temperature/head controls, canvas attention lines, a heatmap, Q/K/V explanation, and tiny JavaScript attention example.
- Added a PWA manifest, README listing, homepage app dock link, and focused Node tests.

## Validation

- `node --test tests/attention-visualized.test.js`
- `git diff --check`
- Playwright render smoke against `http://127.0.0.1:3000/attention-visualized/` confirmed a nonblank canvas, 36 heatmap cells, and the manifest link.

## Notes

- Full `npm test` was run and reached unrelated existing failures in `tests/playwright-install-runtime.test.js`, `tests/social-command-center.e2e.test.js`, and `tests/vercel-insights-tag.test.js`. The new focused test passed.