### PR TITLE
[codex] add education suite web design lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)
 - [Life](https://3dvr-portal.vercel.app/life/)
 - [Alive System](https://3dvr-portal.vercel.app/alive-system/)
+- [Education Suite](https://3dvr-portal.vercel.app/education-suite/)
 - [Attention Visualized](https://3dvr-portal.vercel.app/attention-visualized/)
 - [Logic Lab](https://3dvr-portal.vercel.app/logic-lab/)
 

--- a/app-manifests/education-suite.webmanifest
+++ b/app-manifests/education-suite.webmanifest
@@ -1,0 +1,16 @@
+{
+  "id": "/education-suite/",
+  "name": "3DVR Education Suite",
+  "short_name": "Education Suite",
+  "description": "Browser-first lessons for web design, Python, programming languages, databases, and cloud systems.",
+  "start_url": "/education-suite/?source=pwa",
+  "scope": "/education-suite/",
+  "display": "standalone",
+  "background_color": "#f6f8fb",
+  "theme_color": "#f6f8fb",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/education-suite/app.js
+++ b/education-suite/app.js
@@ -1,0 +1,189 @@
+const preview = document.getElementById('sitePreview');
+const cssOutput = document.getElementById('cssOutput');
+const contrastBadge = document.getElementById('contrastBadge');
+const spacingRange = document.getElementById('spacingRange');
+const radiusRange = document.getElementById('radiusRange');
+const typeRange = document.getElementById('typeRange');
+const spacingValue = document.getElementById('spacingValue');
+const radiusValue = document.getElementById('radiusValue');
+const typeValue = document.getElementById('typeValue');
+const headlineInput = document.getElementById('headlineInput');
+const bodyInput = document.getElementById('bodyInput');
+const previewHeadline = document.getElementById('previewHeadline');
+const previewBody = document.getElementById('previewBody');
+const copyCss = document.getElementById('copyCss');
+
+const themes = {
+  harbor: {
+    bg: '#f3fbfa',
+    text: '#16202f',
+    muted: '#5b6977',
+    accent: '#136f6f',
+    accent2: '#2f6fed',
+    warm: '#c78914',
+  },
+  orchard: {
+    bg: '#fff8f5',
+    text: '#211d19',
+    muted: '#75645a',
+    accent: '#557a46',
+    accent2: '#e45d4f',
+    warm: '#b7791f',
+  },
+  signal: {
+    bg: '#f8f7ff',
+    text: '#181924',
+    muted: '#5e6073',
+    accent: '#6d4de0',
+    accent2: '#0f8f7e',
+    warm: '#d97706',
+  },
+};
+
+const state = {
+  layout: 'landing',
+  theme: 'harbor',
+  spacing: 24,
+  radius: 8,
+  typeScale: 1,
+};
+
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '');
+  const value = Number.parseInt(normalized, 16);
+  return {
+    r: (value >> 16) & 255,
+    g: (value >> 8) & 255,
+    b: value & 255,
+  };
+}
+
+function channelToLinear(value) {
+  const channel = value / 255;
+  return channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance(hex) {
+  const { r, g, b } = hexToRgb(hex);
+  return 0.2126 * channelToLinear(r) + 0.7152 * channelToLinear(g) + 0.0722 * channelToLinear(b);
+}
+
+function contrastRatio(foreground, background) {
+  const lighter = Math.max(luminance(foreground), luminance(background));
+  const darker = Math.min(luminance(foreground), luminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function setPressed(selector, activeValue, dataName) {
+  document.querySelectorAll(selector).forEach((button) => {
+    button.setAttribute('aria-pressed', String(button.dataset[dataName] === activeValue));
+  });
+}
+
+function buildCss() {
+  const theme = themes[state.theme];
+  const layoutRule = state.layout === 'gallery'
+    ? 'grid-template-columns: 1fr;'
+    : state.layout === 'dashboard'
+      ? 'grid-template-columns: 0.65fr 1fr;'
+      : 'grid-template-columns: minmax(0, 1.1fr) minmax(220px, 0.75fr);';
+
+  return `.page {
+  color: ${theme.text};
+  background: ${theme.bg};
+  --space: ${state.spacing}px;
+  --radius: ${state.radius}px;
+  --type-scale: ${state.typeScale.toFixed(2)};
+}
+
+.hero {
+  display: grid;
+  ${layoutRule}
+  gap: var(--space);
+}
+
+.button {
+  border-radius: var(--radius);
+  background: ${theme.accent};
+  color: white;
+}
+
+.card {
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in srgb, ${theme.accent} 22%, transparent);
+}`;
+}
+
+function updateContrast(theme) {
+  const ratio = contrastRatio('#ffffff', theme.accent);
+  const rounded = ratio.toFixed(1);
+  const passes = ratio >= 4.5;
+  contrastBadge.textContent = `${passes ? 'AA' : 'Check'} contrast ${rounded}:1`;
+  contrastBadge.style.background = passes ? '#e8f7ef' : '#fff1d6';
+  contrastBadge.style.color = passes ? '#0d6b3c' : '#815400';
+}
+
+function render() {
+  const theme = themes[state.theme];
+  preview.className = `site-preview site-preview--${state.layout} theme-${state.theme}`;
+  preview.style.setProperty('--preview-space', `${state.spacing}px`);
+  preview.style.setProperty('--preview-radius', `${state.radius}px`);
+  preview.style.setProperty('--preview-type', state.typeScale.toFixed(2));
+
+  spacingValue.textContent = `${state.spacing}px`;
+  radiusValue.textContent = `${state.radius}px`;
+  typeValue.textContent = state.typeScale.toFixed(2);
+  previewHeadline.textContent = headlineInput.value.trim() || 'Build clearer pages faster';
+  previewBody.textContent = bodyInput.value.trim() || 'A strong page gives people orientation, one useful action, and enough structure to understand what comes next.';
+  cssOutput.textContent = buildCss();
+
+  updateContrast(theme);
+  setPressed('[data-layout]', state.layout, 'layout');
+  setPressed('[data-theme]', state.theme, 'theme');
+}
+
+document.querySelectorAll('[data-layout]').forEach((button) => {
+  button.addEventListener('click', () => {
+    state.layout = button.dataset.layout;
+    render();
+  });
+});
+
+document.querySelectorAll('[data-theme]').forEach((button) => {
+  button.addEventListener('click', () => {
+    state.theme = button.dataset.theme;
+    render();
+  });
+});
+
+spacingRange.addEventListener('input', () => {
+  state.spacing = Number(spacingRange.value);
+  render();
+});
+
+radiusRange.addEventListener('input', () => {
+  state.radius = Number(radiusRange.value);
+  render();
+});
+
+typeRange.addEventListener('input', () => {
+  state.typeScale = Number(typeRange.value);
+  render();
+});
+
+headlineInput.addEventListener('input', render);
+bodyInput.addEventListener('input', render);
+
+copyCss.addEventListener('click', async () => {
+  try {
+    await navigator.clipboard.writeText(cssOutput.textContent);
+    copyCss.textContent = 'Copied';
+    setTimeout(() => {
+      copyCss.textContent = 'Copy CSS';
+    }, 1400);
+  } catch {
+    copyCss.textContent = 'Select CSS';
+  }
+});
+
+render();

--- a/education-suite/index.html
+++ b/education-suite/index.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Education Suite: Web Design Lab | 3DVR Portal</title>
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="./styles.css">
+  <link rel="manifest" href="/app-manifests/education-suite.webmanifest">
+  <meta name="theme-color" content="#f6f8fb">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="suite-page">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+  <main id="mainContent" class="suite-shell">
+    <nav class="suite-topbar" aria-label="Education suite navigation">
+      <a href="/index.html">Portal</a>
+      <a href="#web-design-lab">Web design</a>
+      <a href="#suite-roadmap">Roadmap</a>
+    </nav>
+
+    <section id="web-design-lab" class="lab-workspace" aria-labelledby="suite-title">
+      <div class="lab-intro">
+        <span class="suite-kicker">3DVR Education Suite</span>
+        <h1 id="suite-title">Interactive web design lab</h1>
+        <p>
+          Change the layout, spacing, type scale, radius, and palette. The preview updates live,
+          and the CSS panel shows the system choices behind the design.
+        </p>
+      </div>
+
+      <div class="builder-grid">
+        <aside class="control-panel" aria-label="Web design controls">
+          <div class="control-group">
+            <h2>Layout</h2>
+            <div class="segmented-control" role="group" aria-label="Preview layout">
+              <button type="button" data-layout="landing" aria-pressed="true">Landing</button>
+              <button type="button" data-layout="dashboard" aria-pressed="false">Dashboard</button>
+              <button type="button" data-layout="gallery" aria-pressed="false">Gallery</button>
+            </div>
+          </div>
+
+          <div class="control-group">
+            <h2>Palette</h2>
+            <div class="swatch-row" role="group" aria-label="Preview palette">
+              <button type="button" class="swatch swatch--harbor" data-theme="harbor" aria-pressed="true"><span>Harbor</span></button>
+              <button type="button" class="swatch swatch--orchard" data-theme="orchard" aria-pressed="false"><span>Orchard</span></button>
+              <button type="button" class="swatch swatch--signal" data-theme="signal" aria-pressed="false"><span>Signal</span></button>
+            </div>
+          </div>
+
+          <label class="slider-field" for="spacingRange">
+            <span>Spacing <output id="spacingValue" for="spacingRange">24px</output></span>
+            <input id="spacingRange" type="range" min="12" max="44" value="24" step="2">
+          </label>
+
+          <label class="slider-field" for="radiusRange">
+            <span>Radius <output id="radiusValue" for="radiusRange">8px</output></span>
+            <input id="radiusRange" type="range" min="0" max="8" value="8" step="1">
+          </label>
+
+          <label class="slider-field" for="typeRange">
+            <span>Type scale <output id="typeValue" for="typeRange">1.00</output></span>
+            <input id="typeRange" type="range" min="0.9" max="1.2" value="1" step="0.05">
+          </label>
+
+          <label class="copy-field" for="headlineInput">
+            <span>Headline</span>
+            <input id="headlineInput" type="text" value="Build clearer pages faster" autocomplete="off">
+          </label>
+
+          <label class="copy-field" for="bodyInput">
+            <span>Supporting copy</span>
+            <textarea id="bodyInput" rows="4">A strong page gives people orientation, one useful action, and enough structure to understand what comes next.</textarea>
+          </label>
+        </aside>
+
+        <section class="preview-panel" aria-labelledby="preview-title">
+          <div class="panel-heading">
+            <div>
+              <span class="suite-kicker">Live preview</span>
+              <h2 id="preview-title">Browser-rendered site surface</h2>
+            </div>
+            <span id="contrastBadge" class="contrast-badge">AA contrast</span>
+          </div>
+
+          <div id="sitePreview" class="site-preview site-preview--landing theme-harbor" aria-label="Generated web design preview">
+            <header class="mock-nav">
+              <strong>Northstar Studio</strong>
+              <nav aria-label="Preview navigation">
+                <a href="#preview-title">Work</a>
+                <a href="#preview-title">Process</a>
+                <a href="#preview-title">Contact</a>
+              </nav>
+            </header>
+            <section class="mock-hero">
+              <div class="mock-copy">
+                <span class="mock-eyebrow">Design system practice</span>
+                <h3 id="previewHeadline">Build clearer pages faster</h3>
+                <p id="previewBody">A strong page gives people orientation, one useful action, and enough structure to understand what comes next.</p>
+                <button type="button">Start the audit</button>
+              </div>
+              <div class="mock-visual" aria-hidden="true">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+            </section>
+            <section class="mock-cards" aria-label="Preview content cards">
+              <article>
+                <strong>Hierarchy</strong>
+                <span>Put the most important decision first.</span>
+              </article>
+              <article>
+                <strong>Rhythm</strong>
+                <span>Use spacing to group related ideas.</span>
+              </article>
+              <article>
+                <strong>Feedback</strong>
+                <span>Make actions and states visible.</span>
+              </article>
+            </section>
+          </div>
+        </section>
+
+        <section class="inspector-panel" aria-labelledby="inspector-title">
+          <div class="panel-heading">
+            <div>
+              <span class="suite-kicker">Inspector</span>
+              <h2 id="inspector-title">CSS output</h2>
+            </div>
+            <button id="copyCss" class="plain-button" type="button">Copy CSS</button>
+          </div>
+          <pre><code id="cssOutput"></code></pre>
+          <div class="lesson-stack" aria-label="Web design lesson checkpoints">
+            <article>
+              <strong>1. Structure</strong>
+              <span>Use semantic regions before styling the page.</span>
+            </article>
+            <article>
+              <strong>2. Layout</strong>
+              <span>Choose grid, flex, and spacing from the content shape.</span>
+            </article>
+            <article>
+              <strong>3. Responsive rules</strong>
+              <span>Collapse columns when reading becomes cramped.</span>
+            </article>
+            <article>
+              <strong>4. Accessibility</strong>
+              <span>Check contrast, focus states, labels, and tap targets.</span>
+            </article>
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <section id="suite-roadmap" class="roadmap-section" aria-labelledby="roadmap-title">
+      <div class="section-heading">
+        <span class="suite-kicker">Plan for the full suite</span>
+        <h2 id="roadmap-title">Browser-first computer science path</h2>
+        <p>
+          The suite should run locally in the browser whenever possible, then call cloud servers for
+          heavier execution, shared grading, AI review, persistent projects, or safe sandboxing.
+        </p>
+      </div>
+      <div class="roadmap-grid">
+        <article>
+          <span>Phase 1</span>
+          <h3>Interactive web design</h3>
+          <p>HTML structure, CSS layout, responsive design, accessibility, page audits, and live previews.</p>
+          <strong>Runtime: browser DOM, CSS, local storage.</strong>
+        </article>
+        <article>
+          <span>Phase 2</span>
+          <h3>Python in the browser</h3>
+          <p>Variables, functions, files, data cleaning, notebooks, and small automations.</p>
+          <strong>Runtime: Pyodide locally, cloud workers for packages and long jobs.</strong>
+        </article>
+        <article>
+          <span>Phase 3</span>
+          <h3>Programming languages</h3>
+          <p>JavaScript, Python, shell, C basics, TypeScript, and language tradeoffs through tiny projects.</p>
+          <strong>Runtime: WebAssembly compilers where practical, container runners when needed.</strong>
+        </article>
+        <article>
+          <span>Phase 4</span>
+          <h3>Databases</h3>
+          <p>Tables, indexes, SQL, document stores, sync, migrations, privacy, and backups.</p>
+          <strong>Runtime: SQLite in WASM, IndexedDB, optional hosted Postgres labs.</strong>
+        </article>
+        <article>
+          <span>Phase 5</span>
+          <h3>Cloud systems</h3>
+          <p>APIs, queues, auth, deployments, logs, observability, serverless limits, and cost controls.</p>
+          <strong>Runtime: portal API routes, ephemeral sandboxes, GitHub-backed project history.</strong>
+        </article>
+        <article>
+          <span>Phase 6</span>
+          <h3>Capstone builder track</h3>
+          <p>Ship a complete browser app with design, code, data, deployment, docs, and a demo video.</p>
+          <strong>Runtime: local-first app shell with cloud sync and review hooks.</strong>
+        </article>
+      </div>
+    </section>
+  </main>
+  <script src="./app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/education-suite/styles.css
+++ b/education-suite/styles.css
@@ -1,0 +1,578 @@
+:root {
+  --suite-bg: #f6f8fb;
+  --suite-ink: #16202f;
+  --suite-muted: #5c687a;
+  --suite-panel: #ffffff;
+  --suite-line: #d9e1ec;
+  --suite-coral: #e45d4f;
+  --suite-teal: #158f8f;
+  --suite-gold: #c78914;
+  --suite-blue: #2f6fed;
+  --suite-radius: 8px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body.suite-page {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--suite-ink);
+  background:
+    linear-gradient(120deg, rgba(47, 111, 237, 0.1), transparent 30%),
+    linear-gradient(240deg, rgba(228, 93, 79, 0.1), transparent 28%),
+    var(--suite-bg);
+  font-family: Inter, "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.skip-link {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  z-index: 20;
+  padding: 0.7rem 1rem;
+  border-radius: var(--suite-radius);
+  background: var(--suite-ink);
+  color: white;
+  font-weight: 800;
+  transform: translateY(-160%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.suite-shell {
+  width: min(1220px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1.25rem 0 4rem;
+}
+
+.suite-topbar {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.suite-topbar a,
+.plain-button,
+.mock-copy button,
+.segmented-control button {
+  border: 1px solid var(--suite-line);
+  border-radius: var(--suite-radius);
+  background: var(--suite-panel);
+  color: var(--suite-ink);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.suite-topbar a {
+  padding: 0.55rem 0.8rem;
+}
+
+.lab-workspace,
+.roadmap-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.lab-intro,
+.section-heading {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 760px;
+}
+
+.suite-kicker {
+  width: fit-content;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(21, 143, 143, 0.1);
+  color: #0f7777;
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  max-width: 12ch;
+  font-size: clamp(2.6rem, 6vw, 5.6rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+h2 {
+  font-size: clamp(1.25rem, 2vw, 1.65rem);
+  line-height: 1.15;
+}
+
+h3 {
+  font-size: 1.08rem;
+  line-height: 1.2;
+}
+
+p {
+  color: var(--suite-muted);
+  line-height: 1.65;
+}
+
+.builder-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  grid-template-areas:
+    "controls preview"
+    "controls inspector";
+  gap: 1rem;
+  align-items: start;
+}
+
+.control-panel,
+.preview-panel,
+.inspector-panel,
+.roadmap-grid article {
+  border: 1px solid var(--suite-line);
+  border-radius: var(--suite-radius);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 20px 48px rgba(21, 32, 47, 0.08);
+}
+
+.control-panel {
+  grid-area: controls;
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  position: sticky;
+  top: 1rem;
+}
+
+.preview-panel {
+  grid-area: preview;
+  overflow: hidden;
+}
+
+.inspector-panel {
+  grid-area: inspector;
+  overflow: hidden;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--suite-line);
+}
+
+.control-group {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.segmented-control {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.35rem;
+}
+
+.segmented-control button,
+.plain-button {
+  min-height: 2.6rem;
+  padding: 0.55rem 0.7rem;
+}
+
+.segmented-control button[aria-pressed="true"],
+.plain-button:hover {
+  border-color: transparent;
+  background: var(--suite-ink);
+  color: white;
+}
+
+.swatch-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.45rem;
+}
+
+.swatch {
+  min-height: 4.5rem;
+  border: 2px solid transparent;
+  border-radius: var(--suite-radius);
+  cursor: pointer;
+  display: flex;
+  align-items: flex-end;
+  padding: 0.5rem;
+}
+
+.swatch span {
+  padding: 0.2rem 0.35rem;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.86);
+  color: #111827;
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.swatch[aria-pressed="true"] {
+  border-color: var(--suite-ink);
+}
+
+.swatch--harbor {
+  background: linear-gradient(135deg, #134e4a, #2f6fed 55%, #f6c85f);
+}
+
+.swatch--orchard {
+  background: linear-gradient(135deg, #557a46, #e45d4f 55%, #f1d37a);
+}
+
+.swatch--signal {
+  background: linear-gradient(135deg, #24292f, #8b5cf6 48%, #20c997);
+}
+
+.slider-field,
+.copy-field {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--suite-muted);
+  font-weight: 800;
+}
+
+.slider-field span,
+.copy-field span {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.slider-field input,
+.copy-field input,
+.copy-field textarea {
+  width: 100%;
+  border: 1px solid var(--suite-line);
+  border-radius: var(--suite-radius);
+  background: #fff;
+  color: var(--suite-ink);
+  font: inherit;
+}
+
+.copy-field input,
+.copy-field textarea {
+  padding: 0.65rem 0.75rem;
+}
+
+.contrast-badge {
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  background: #e8f7ef;
+  color: #0d6b3c;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.site-preview {
+  --preview-bg: #f8fbff;
+  --preview-surface: #ffffff;
+  --preview-text: #172033;
+  --preview-muted: #667085;
+  --preview-accent: #136f6f;
+  --preview-accent-2: #2f6fed;
+  --preview-warm: #c78914;
+  --preview-space: 24px;
+  --preview-radius: 8px;
+  --preview-type: 1;
+  margin: 1rem;
+  padding: var(--preview-space);
+  border: 1px solid color-mix(in srgb, var(--preview-accent) 28%, transparent);
+  border-radius: var(--preview-radius);
+  background: var(--preview-bg);
+  color: var(--preview-text);
+  transition: border-radius 0.2s ease, padding 0.2s ease, background 0.2s ease;
+}
+
+.theme-harbor {
+  --preview-bg: #f3fbfa;
+  --preview-text: #16202f;
+  --preview-muted: #5b6977;
+  --preview-accent: #136f6f;
+  --preview-accent-2: #2f6fed;
+  --preview-warm: #c78914;
+}
+
+.theme-orchard {
+  --preview-bg: #fff8f5;
+  --preview-text: #211d19;
+  --preview-muted: #75645a;
+  --preview-accent: #557a46;
+  --preview-accent-2: #e45d4f;
+  --preview-warm: #b7791f;
+}
+
+.theme-signal {
+  --preview-bg: #f8f7ff;
+  --preview-text: #181924;
+  --preview-muted: #5e6073;
+  --preview-accent: #6d4de0;
+  --preview-accent-2: #0f8f7e;
+  --preview-warm: #d97706;
+}
+
+.mock-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: var(--preview-space);
+}
+
+.mock-nav nav {
+  display: flex;
+  gap: 0.75rem;
+  color: var(--preview-muted);
+  font-size: calc(0.9rem * var(--preview-type));
+  font-weight: 800;
+}
+
+.mock-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(220px, 0.75fr);
+  gap: var(--preview-space);
+  align-items: stretch;
+}
+
+.mock-copy {
+  display: grid;
+  gap: calc(var(--preview-space) * 0.55);
+  align-content: center;
+}
+
+.mock-eyebrow {
+  width: fit-content;
+  color: var(--preview-accent);
+  font-size: calc(0.78rem * var(--preview-type));
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mock-copy h3 {
+  max-width: 11ch;
+  color: var(--preview-text);
+  font-size: calc(3.5rem * var(--preview-type));
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.mock-copy p {
+  max-width: 36rem;
+  color: var(--preview-muted);
+  font-size: calc(1rem * var(--preview-type));
+}
+
+.mock-copy button {
+  width: fit-content;
+  border-color: transparent;
+  background: var(--preview-accent);
+  color: white;
+  padding: 0.75rem 0.95rem;
+}
+
+.mock-visual {
+  min-height: 270px;
+  display: grid;
+  gap: calc(var(--preview-space) * 0.45);
+  padding: calc(var(--preview-space) * 0.7);
+  border-radius: var(--preview-radius);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--preview-accent) 18%, transparent), transparent),
+    var(--preview-surface);
+  border: 1px solid color-mix(in srgb, var(--preview-accent) 22%, transparent);
+}
+
+.mock-visual span {
+  border-radius: calc(var(--preview-radius) * 0.75);
+  background: linear-gradient(90deg, var(--preview-accent), var(--preview-accent-2), var(--preview-warm));
+}
+
+.mock-visual span:nth-child(2) {
+  width: 76%;
+  background: color-mix(in srgb, var(--preview-accent-2) 62%, white);
+}
+
+.mock-visual span:nth-child(3) {
+  width: 58%;
+  background: color-mix(in srgb, var(--preview-warm) 70%, white);
+}
+
+.mock-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: calc(var(--preview-space) * 0.65);
+  margin-top: var(--preview-space);
+}
+
+.mock-cards article,
+.lesson-stack article {
+  display: grid;
+  gap: 0.3rem;
+  border: 1px solid var(--suite-line);
+  border-radius: var(--suite-radius);
+  background: var(--preview-surface, #fff);
+}
+
+.mock-cards article {
+  padding: calc(var(--preview-space) * 0.65);
+}
+
+.mock-cards span,
+.lesson-stack span {
+  color: var(--preview-muted, var(--suite-muted));
+}
+
+.site-preview--dashboard .mock-hero {
+  grid-template-columns: 0.65fr 1fr;
+}
+
+.site-preview--dashboard .mock-copy {
+  padding: calc(var(--preview-space) * 0.7);
+  border-left: 5px solid var(--preview-accent);
+  background: var(--preview-surface);
+  border-radius: var(--preview-radius);
+}
+
+.site-preview--dashboard .mock-copy h3 {
+  font-size: calc(2.7rem * var(--preview-type));
+}
+
+.site-preview--gallery .mock-hero {
+  grid-template-columns: 1fr;
+}
+
+.site-preview--gallery .mock-visual {
+  min-height: 190px;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.site-preview--gallery .mock-cards {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.inspector-panel pre {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  background: #151f2e;
+  color: #eaf1fb;
+}
+
+.inspector-panel code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+.lesson-stack {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.lesson-stack article {
+  padding: 0.8rem;
+}
+
+.roadmap-section {
+  margin-top: 1.25rem;
+}
+
+.roadmap-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.roadmap-grid article {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem;
+}
+
+.roadmap-grid article > span {
+  width: fit-content;
+  padding: 0.25rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(47, 111, 237, 0.1);
+  color: #245bc7;
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.roadmap-grid strong {
+  color: var(--suite-ink);
+}
+
+@media (max-width: 980px) {
+  .builder-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "controls"
+      "preview"
+      "inspector";
+  }
+
+  .control-panel {
+    position: static;
+  }
+
+  .lesson-stack,
+  .roadmap-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 680px) {
+  .suite-shell {
+    width: min(100% - 1rem, 1220px);
+  }
+
+  .suite-topbar {
+    justify-content: stretch;
+  }
+
+  .suite-topbar a {
+    flex: 1;
+    text-align: center;
+  }
+
+  .panel-heading,
+  .mock-nav {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .mock-hero,
+  .mock-cards,
+  .lesson-stack,
+  .roadmap-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mock-copy h3 {
+    max-width: 100%;
+    font-size: calc(2.45rem * var(--preview-type));
+  }
+}

--- a/index.html
+++ b/index.html
@@ -321,6 +321,11 @@
             <span class="app-card__title">Learn</span>
             <span class="app-card__meta">Unlock new lessons and level up your skills.</span>
           </a>
+          <a href="education-suite/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">WEB</span>
+            <span class="app-card__title">Education Suite</span>
+            <span class="app-card__meta">Practice web design now, then follow the roadmap into Python, languages, databases, and cloud labs.</span>
+          </a>
           <a href="attention-visualized/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">AI</span>
             <span class="app-card__title">Attention Visualized</span>

--- a/tests/education-suite.test.js
+++ b/tests/education-suite.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const suiteDir = new URL('../education-suite/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test('education suite ships the browser-first web design lab', async () => {
+  const indexUrl = new URL('index.html', suiteDir);
+  assert.equal(await fileExists(indexUrl), true);
+
+  const html = await readFile(indexUrl, 'utf8');
+  assert.match(html, /Education Suite: Web Design Lab \| 3DVR Portal/);
+  assert.match(html, /Interactive web design lab/);
+  assert.match(html, /id="sitePreview"/);
+  assert.match(html, /id="spacingRange"/);
+  assert.match(html, /id="radiusRange"/);
+  assert.match(html, /id="typeRange"/);
+  assert.match(html, /id="headlineInput"/);
+  assert.match(html, /id="cssOutput"/);
+  assert.match(html, /Copy CSS/);
+  assert.match(html, /HTML structure, CSS layout, responsive design, accessibility/);
+  assert.match(html, /href="\/app-manifests\/education-suite\.webmanifest"/);
+  assert.match(html, /<script src="\.\/app\.js"><\/script>/);
+  assert.match(html, /<script defer src="\/issue-launcher\.js"><\/script>/);
+});
+
+test('education suite documents the plan for the full curriculum', async () => {
+  const html = await readFile(new URL('index.html', suiteDir), 'utf8');
+
+  assert.match(html, /Python in the browser/);
+  assert.match(html, /Programming languages/);
+  assert.match(html, /Databases/);
+  assert.match(html, /Cloud systems/);
+  assert.match(html, /Capstone builder track/);
+  assert.match(html, /Pyodide locally, cloud workers for packages and long jobs/);
+  assert.match(html, /SQLite in WASM, IndexedDB, optional hosted Postgres labs/);
+  assert.match(html, /ephemeral sandboxes, GitHub-backed project history/);
+});
+
+test('education suite includes focused styling, browser logic, and manifest metadata', async () => {
+  const css = await readFile(new URL('styles.css', suiteDir), 'utf8');
+  const js = await readFile(new URL('app.js', suiteDir), 'utf8');
+  const manifest = await readFile(new URL('../app-manifests/education-suite.webmanifest', import.meta.url), 'utf8');
+
+  assert.match(css, /\.builder-grid/);
+  assert.match(css, /\.site-preview/);
+  assert.match(css, /\.segmented-control/);
+  assert.match(css, /\.roadmap-grid/);
+  assert.match(css, /@media \(max-width: 680px\)/);
+
+  assert.match(js, /const themes =/);
+  assert.match(js, /function contrastRatio/);
+  assert.match(js, /function buildCss/);
+  assert.match(js, /function render/);
+  assert.match(js, /navigator\.clipboard\.writeText/);
+
+  assert.match(manifest, /3DVR Education Suite/);
+  assert.match(manifest, /"start_url": "\/education-suite\/\?source=pwa"/);
+  assert.match(manifest, /"scope": "\/education-suite\/"/);
+});
+
+test('portal homepage and README link to the education suite', async () => {
+  const homepage = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+  const learnIndex = homepage.indexOf('>Learn<');
+  const suiteIndex = homepage.indexOf('>Education Suite<');
+  const attentionIndex = homepage.indexOf('>Attention Visualized<');
+
+  assert.ok(learnIndex !== -1, 'Learn app card should still be listed');
+  assert.ok(suiteIndex !== -1, 'Education Suite app card should be listed');
+  assert.ok(attentionIndex !== -1, 'Attention Visualized app card should still be listed');
+  assert.ok(learnIndex < suiteIndex, 'Education Suite should render after Learn');
+  assert.ok(suiteIndex < attentionIndex, 'Education Suite should render before Attention Visualized');
+  assert.match(homepage, /href="education-suite\/"/);
+  assert.match(homepage, /Practice web design now, then follow the roadmap into Python, languages, databases, and cloud labs\./);
+  assert.match(readme, /\[Education Suite\]\(https:\/\/3dvr-portal\.vercel\.app\/education-suite\/\)/);
+});


### PR DESCRIPTION
## What changed

- Added a new `education-suite/` app that starts the broader browser-first education suite with an interactive web design lab.
- Built live controls for layout, palette, spacing, radius, type scale, headline, supporting copy, generated CSS, and contrast feedback.
- Added a written roadmap for the rest of the suite: Python in the browser, programming languages, databases, cloud systems, and capstone projects.
- Linked the new app from the portal homepage and README, and added a PWA manifest.

## Validation

- `node --test tests/education-suite.test.js`
- `node --test tests/education-suite.test.js tests/issue-launcher.test.js`
- `git diff --check`
- Local Playwright smoke against `http://127.0.0.1:3000/education-suite/` confirmed layout controls, generated CSS, roadmap cards, contrast badge, and manifest wiring.