### PR TITLE
[codex] Remove billing start flow copy

### DIFF
--- a/billing/index.html
+++ b/billing/index.html
@@ -53,12 +53,8 @@
           New here? Start with one portal account, then choose a lane. Returning subscribers can switch tiers, cancel
           renewal, or open Stripe management from this same portal-linked flow.
         </p>
-        <p class="meta">
-          Portal plans upgrade your 3DVR account tier and shared usage limits. They do not include OpenAI API billing or create an OpenAI API key.
-        </p>
       </div>
       <div class="hero__actions">
-        <a class="button button--ghost" href="../start/">Open start flow</a>
         <a class="button button--ghost" href="../index.html">Back to Portal</a>
         <a class="button button--ghost" href="https://3dvr.tech/subscribe/" target="_blank" rel="noreferrer">
           Public pricing
@@ -77,12 +73,7 @@
           </div>
         </div>
         <p id="account-summary" class="status status--info">Checking your portal session...</p>
-        <p class="meta">
-          Free starts with email. Paid starts with one portal account. Use the start flow if you want the clearest
-          first step, then return here for Stripe-backed billing.
-        </p>
         <div class="button-row">
-          <a class="button button--ghost" href="../start/">Open start flow</a>
           <a id="sign-in-link" class="button button--primary" href="../sign-in.html">Sign in or create account</a>
           <button id="refresh-auth" class="button button--ghost" type="button">Refresh account</button>
         </div>
@@ -114,8 +105,7 @@
         <p id="billing-summary" class="status status--info">We will look up your Stripe customer after sign-in.</p>
         <p id="billing-detail" class="meta">
           If you already subscribe, the plan buttons below will route you to a Stripe-confirmed switch that keeps the
-          new plan and cancels older paid plans automatically. New customers can use the start flow first, then return
-          here with a selected lane.
+          new plan and cancels older paid plans automatically.
         </p>
         <p id="duplicate-warning" class="status status--warning" hidden></p>
 

--- a/tests/billing-page.test.js
+++ b/tests/billing-page.test.js
@@ -21,10 +21,11 @@ describe('billing center', () => {
 
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /Billing Center/);
-    assert.match(html, /Open start flow/);
+    assert.doesNotMatch(html, /Open start flow/);
+    assert.doesNotMatch(html, /OpenAI API billing/);
     assert.match(html, /New Customer Fast Path/);
-    assert.match(html, /Use the start flow if you want the clearest\s+first step/);
-    assert.match(html, /New customers can use the start flow first,\s+then return/);
+    assert.doesNotMatch(html, /Use the start flow if you want the clearest\s+first step/);
+    assert.doesNotMatch(html, /New customers can use the start flow first,\s+then return/);
     assert.match(html, /id="billing-email"/);
     assert.match(html, /id="manage-billing"[^>]+disabled[^>]+aria-disabled="true"/);
     assert.match(html, /Manage in Stripe/);


### PR DESCRIPTION
## Summary
- Remove the OpenAI/API billing note from the billing center hero
- Remove start-flow buttons and start-flow guidance from the billing page
- Update billing page tests to keep that copy out

## Tests
- node --test tests/billing-page.test.js