### PR TITLE
[codex] Tighten billing hero copy

### DIFF
--- a/billing/index.html
+++ b/billing/index.html
@@ -49,10 +49,10 @@
       <div>
         <p class="hero__eyebrow">Stripe Billing</p>
         <h1 class="hero__title">Billing Center</h1>
-        <p class="hero__lead">
-          New here? Start with one portal account, then choose a lane. Returning subscribers can switch tiers, cancel
-          renewal, or open Stripe management from this same portal-linked flow.
-        </p>
+        <div class="hero__lead">
+          <p>One portal account. One billing center.</p>
+          <p>Choose a lane, switch tiers, cancel renewal, or manage Stripe.</p>
+        </div>
       </div>
       <div class="hero__actions">
         <a class="button button--ghost" href="../index.html">Back to Portal</a>

--- a/tests/billing-page.test.js
+++ b/tests/billing-page.test.js
@@ -21,6 +21,9 @@ describe('billing center', () => {
 
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /Billing Center/);
+    assert.match(html, /One portal account\. One billing center\./);
+    assert.match(html, /Choose a lane, switch tiers, cancel renewal, or manage Stripe\./);
+    assert.doesNotMatch(html, /New here\? Start with one portal account, then choose a lane/);
     assert.doesNotMatch(html, /Open start flow/);
     assert.doesNotMatch(html, /OpenAI API billing/);
     assert.match(html, /New Customer Fast Path/);


### PR DESCRIPTION
## Summary
- Replace the dense billing hero paragraph with two shorter lines
- Keep the same account, plan, tier switching, cancel, and Stripe management meaning
- Update billing page tests for the cleaner copy

## Tests
- node --test tests/billing-page.test.js