### PR TITLE
[codex] Auto-select billing plan links

### DIFF
--- a/billing/app.js
+++ b/billing/app.js
@@ -50,6 +50,31 @@ const PLAN_LABELS = {
   custom: 'Custom project'
 }
 
+const PLAN_ALIASES = {
+  starter: 'starter',
+  supporter: 'starter',
+  family: 'starter',
+  familyfriends: 'starter',
+  'family-friends': 'starter',
+  family_and_friends: 'starter',
+  '5': 'starter',
+  pro: 'pro',
+  founder: 'pro',
+  '20': 'pro',
+  builder: 'builder',
+  studio: 'builder',
+  partner: 'builder',
+  '50': 'builder',
+  embedded: 'embedded',
+  execution: 'embedded',
+  '200': 'embedded',
+  custom: 'custom',
+  one_time: 'custom',
+  'one-time': 'custom',
+  quoted: 'custom',
+  free: 'free'
+}
+
 const CANCEL_LABELS = {
   starter: 'Stop $5 billing',
   pro: 'Stop $20 billing',
@@ -448,7 +473,16 @@ function refreshSignInLink(plan = '') {
 
 function selectedPlanFromUrl() {
   const params = new URLSearchParams(window.location.search)
-  return String(params.get('plan') || '').trim().toLowerCase()
+  return normalizePlanKey(params.get('plan'))
+}
+
+function normalizePlanKey(value = '') {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+
+  return PLAN_ALIASES[normalized] || ''
 }
 
 function labelForPlan(plan = '') {
@@ -473,7 +507,13 @@ function highlightPlan(plan = '', options = {}) {
   state.selectedPlan = plan
   planCards.forEach(card => {
     const targetPlan = card.dataset.planCard || ''
-    card.classList.toggle('is-selected', Boolean(plan) && targetPlan === plan)
+    const selected = Boolean(plan) && targetPlan === plan
+    card.classList.toggle('is-selected', selected)
+    if (selected) {
+      card.setAttribute('aria-current', 'true')
+    } else {
+      card.removeAttribute('aria-current')
+    }
   })
 
   if (updateUrl) {

--- a/tests/billing-flow.e2e.test.js
+++ b/tests/billing-flow.e2e.test.js
@@ -312,6 +312,36 @@ describe('billing center subscriber flows', () => {
     }
   }, { timeout: 45000 })
 
+  it('auto-selects incoming plan links on the billing page', async t => {
+    const browser = await launchBrowser(t)
+    if (!browser) {
+      return
+    }
+
+    try {
+      const context = await createContext(browser)
+      await installGunRoutes(context)
+      await installExternalRoutes(context)
+      await installBillingRoutes(context, {
+        statusResponse: createFreeStatus()
+      })
+      const page = await context.newPage()
+
+      await page.goto(`${baseUrl}/billing/?plan=family-friends`, { waitUntil: 'domcontentloaded' })
+      await page.waitForSelector('[data-plan-card="starter"].is-selected')
+
+      const selectedLabel = (await page.textContent('#selected-plan-label')).trim()
+      const selectedCard = await page.getAttribute('[data-plan-card="starter"]', 'aria-current')
+      const signInHref = await page.getAttribute('#sign-in-link', 'href')
+
+      assert.equal(selectedLabel, 'Selected: Family & Friends')
+      assert.equal(selectedCard, 'true')
+      assert.match(signInHref, /redirect=%2Fbilling%2F%3Fplan%3Dstarter/)
+    } finally {
+      await browser.close()
+    }
+  }, { timeout: 45000 })
+
   it('disables unavailable paid plans and keeps manage billing out of the dead-end state', async t => {
     const browser = await launchBrowser(t)
     if (!browser) {


### PR DESCRIPTION
## Summary
- Normalize incoming billing ?plan= values on the browser billing page
- Auto-select and mark the matching plan card, including public aliases like family-friends
- Preserve the normalized selected plan through the sign-in redirect
- Add E2E coverage for landing on /billing/?plan=family-friends

## Tests
- npm ci
- node --test tests/billing-page.test.js tests/billing-flow.e2e.test.js