### PR TITLE
[codex] Require verified recovery email

### DIFF
--- a/api/calendar/reminder-email.js
+++ b/api/calendar/reminder-email.js
@@ -1,3 +1,4 @@
+import { createHmac, randomBytes, randomInt, timingSafeEqual } from 'node:crypto';
 import nodemailer from 'nodemailer';
 
 function setCorsHeaders(res) {
@@ -111,6 +112,15 @@ function resolveOperatorAlertToken(config = process.env) {
   return normalizeText(
     config.AGENT_OPERATOR_EMAIL_TOKEN
     || config.THREEDVR_AUTOPILOT_EMAIL_TOKEN
+  );
+}
+
+function resolveRecoveryVerificationSecret(config = process.env) {
+  return normalizeText(
+    config.ACCOUNT_RECOVERY_VERIFICATION_SECRET
+    || config.AGENT_OPERATOR_EMAIL_TOKEN
+    || config.THREEDVR_AUTOPILOT_EMAIL_TOKEN
+    || config.GMAIL_APP_PASSWORD
   );
 }
 
@@ -259,6 +269,90 @@ function buildAdminResetRequestAckHtml({ resetUrl }) {
       <p>You can also follow up from the recovery page: <a href="${resetUrl}">${resetUrl}</a></p>
     </div>
   `;
+}
+
+function buildRecoveryVerificationHtml({ code, expiresMinutes }) {
+  return `
+    <div style="font-family: Arial, sans-serif; line-height: 1.6;">
+      <h2 style="margin-bottom: 12px;">Verify your 3DVR recovery email</h2>
+      <p>Enter this code on the 3DVR sign-in page before creating or updating a password account.</p>
+      <p style="font-size: 28px; letter-spacing: 0.18em; font-weight: 700; margin: 18px 0;">${escapeHtml(code)}</p>
+      <p>This code expires in ${escapeHtml(String(expiresMinutes))} minutes.</p>
+      <p style="margin: 0; color: #555;">If you did not request this, you can ignore this email.</p>
+    </div>
+  `;
+}
+
+function signRecoveryVerificationPayload(payload, secret) {
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = createHmac('sha256', secret).update(body).digest('base64url');
+  return `${body}.${signature}`;
+}
+
+function safeEqualText(left = '', right = '') {
+  const leftBuffer = Buffer.from(String(left));
+  const rightBuffer = Buffer.from(String(right));
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function parseRecoveryVerificationToken(verificationId = '', secret = '') {
+  const [body = '', signature = ''] = String(verificationId || '').split('.');
+  if (!body || !signature || !secret) {
+    return null;
+  }
+  const expectedSignature = createHmac('sha256', secret).update(body).digest('base64url');
+  if (!safeEqualText(signature, expectedSignature)) {
+    return null;
+  }
+  try {
+    return JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+  } catch (_error) {
+    return null;
+  }
+}
+
+function createRecoveryVerification({ email, config = process.env } = {}) {
+  const normalizedEmail = normalizeEmail(email);
+  const secret = resolveRecoveryVerificationSecret(config);
+  if (!normalizedEmail || !secret) {
+    return null;
+  }
+
+  const code = String(randomInt(0, 1000000)).padStart(6, '0');
+  const expiresAt = Date.now() + 10 * 60 * 1000;
+  const nonce = randomBytes(12).toString('base64url');
+  const codeHash = createHmac('sha256', secret)
+    .update(`${normalizedEmail}:${code}:${expiresAt}:${nonce}`)
+    .digest('base64url');
+
+  return {
+    code,
+    expiresAt,
+    expiresMinutes: 10,
+    verificationId: signRecoveryVerificationPayload({
+      email: normalizedEmail,
+      codeHash,
+      expiresAt,
+      nonce
+    }, secret)
+  };
+}
+
+function confirmRecoveryVerification({ email, code, verificationId, config = process.env } = {}) {
+  const normalizedEmail = normalizeEmail(email);
+  const normalizedCode = normalizeText(code).replace(/\D/g, '');
+  const secret = resolveRecoveryVerificationSecret(config);
+  const payload = parseRecoveryVerificationToken(verificationId, secret);
+  if (!normalizedEmail || normalizedCode.length !== 6 || !payload) {
+    return false;
+  }
+  if (payload.email !== normalizedEmail || Number(payload.expiresAt || 0) < Date.now()) {
+    return false;
+  }
+  const expectedHash = createHmac('sha256', secret)
+    .update(`${normalizedEmail}:${normalizedCode}:${payload.expiresAt}:${payload.nonce}`)
+    .digest('base64url');
+  return safeEqualText(payload.codeHash, expectedHash);
 }
 
 function buildLeadOutreachHtml({ headline, message, senderName, senderEmail }) {
@@ -421,14 +515,18 @@ export function createAccountRecoveryEmailHandler(options = {}) {
     const username = normalizeText(req.body?.username);
     const temporaryPassword = normalizeText(req.body?.temporaryPassword);
     const issuedBy = normalizeText(req.body?.issuedBy);
+    const code = normalizeText(req.body?.code);
+    const verificationId = normalizeText(req.body?.verificationId);
 
     if (
       mode !== 'lookup'
       && mode !== 'admin-reset-request'
       && mode !== 'admin-reset-issued'
+      && mode !== 'recovery-verification'
+      && mode !== 'confirm-recovery-email'
     ) {
       return res.status(400).json({
-        error: 'Unsupported recovery mode. Use lookup, admin-reset-request, or admin-reset-issued.'
+        error: 'Unsupported recovery mode. Use lookup, recovery-verification, confirm-recovery-email, admin-reset-request, or admin-reset-issued.'
       });
     }
 
@@ -443,6 +541,25 @@ export function createAccountRecoveryEmailHandler(options = {}) {
     if (mode === 'admin-reset-issued' && (!alias || !username || temporaryPassword.length < 6)) {
       return res.status(400).json({
         error: 'Alias, username, and a temporary password (6+ chars) are required.'
+      });
+    }
+
+    if (mode === 'confirm-recovery-email') {
+      const verified = confirmRecoveryVerification({
+        email,
+        code,
+        verificationId,
+        config
+      });
+      if (!verified) {
+        return res.status(400).json({
+          error: 'Recovery email verification failed or expired.'
+        });
+      }
+      return res.status(200).json({
+        success: true,
+        mode,
+        email
       });
     }
 
@@ -471,6 +588,31 @@ export function createAccountRecoveryEmailHandler(options = {}) {
     const from = `"3DVR Portal Accounts" <${sender}>`;
 
     try {
+      if (mode === 'recovery-verification') {
+        const verification = createRecoveryVerification({ email, config });
+        if (!verification) {
+          return res.status(503).json(createRecoveryUnavailableBody(config));
+        }
+
+        await transport.sendMail({
+          from,
+          to: email,
+          subject: 'Verify your 3DVR recovery email',
+          html: buildRecoveryVerificationHtml({
+            code: verification.code,
+            expiresMinutes: verification.expiresMinutes
+          })
+        });
+
+        return res.status(200).json({
+          success: true,
+          mode,
+          email,
+          verificationId: verification.verificationId,
+          expiresAt: verification.expiresAt
+        });
+      }
+
       if (mode === 'lookup') {
         await transport.sendMail({
           from,
@@ -753,7 +895,13 @@ export function createUnifiedEmailHandler(options = {}) {
     }
 
     const mode = normalizeText(req.body?.mode).toLowerCase();
-    if (mode === 'lookup' || mode === 'admin-reset-request' || mode === 'admin-reset-issued') {
+    if (
+      mode === 'lookup'
+      || mode === 'recovery-verification'
+      || mode === 'confirm-recovery-email'
+      || mode === 'admin-reset-request'
+      || mode === 'admin-reset-issued'
+    ) {
       return accountRecoveryHandler(req, res);
     }
     if (mode === 'operator-alert') {

--- a/sign-in.html
+++ b/sign-in.html
@@ -269,6 +269,49 @@
       line-height: 1.5;
     }
 
+    .recovery-panel {
+      display: grid;
+      gap: 10px;
+    }
+
+    .recovery-actions {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .secondary-button {
+      padding: 12px 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(9, 20, 38, 0.9);
+      color: var(--text-primary);
+      font-weight: 650;
+      cursor: pointer;
+      transition: border 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+      white-space: nowrap;
+    }
+
+    .secondary-button:hover {
+      transform: translateY(-1px);
+      border-color: rgba(240, 199, 94, 0.36);
+    }
+
+    .secondary-button[disabled] {
+      opacity: 0.55;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    .recovery-status {
+      min-height: 1.1rem;
+      margin: 0;
+      font-size: 0.82rem;
+      color: rgba(248, 251, 255, 0.72);
+      line-height: 1.5;
+    }
+
     .primary-button {
       width: 100%;
       padding: 15px 18px;
@@ -449,15 +492,32 @@
             <label for="password">Password</label>
             <input type="password" id="password" name="password" placeholder="Enter your password" autocomplete="current-password" required>
           </div>
-          <div>
-            <label for="recovery-email">Recovery email (optional)</label>
+          <div class="recovery-panel">
+            <label for="recovery-email">Recovery email</label>
             <input
               type="email"
               id="recovery-email"
               name="recovery-email"
               placeholder="you@example.com"
               autocomplete="email"
+              required
             >
+            <button id="send-recovery-code" type="button" class="secondary-button">Send verification code</button>
+            <div class="recovery-actions">
+              <input
+                type="text"
+                id="recovery-code"
+                name="recovery-code"
+                placeholder="6-digit code"
+                inputmode="numeric"
+                autocomplete="one-time-code"
+                maxlength="6"
+              >
+              <button id="verify-recovery-code" type="button" class="secondary-button">Verify</button>
+            </div>
+            <p id="recovery-status" class="recovery-status" role="status" aria-live="polite">
+              Verify this email so you can recover the account later.
+            </p>
           </div>
           <div class="oauth-panel" aria-labelledby="oauth-options-title">
             <div class="oauth-divider" id="oauth-options-title">Or continue with OAuth</div>
@@ -632,6 +692,12 @@
     const user = gunContext.user;
     const portalRoot = gun && typeof gun.get === 'function' ? gun.get('3dvr-portal') : createLocalGunNodeStub();
     const gunIsStub = !!gunContext.isStub;
+    const recoveryVerificationState = {
+      email: '',
+      verificationId: '',
+      verifiedEmail: '',
+      expiresAt: 0
+    };
     const DEFAULT_POST_SIGN_IN_DESTINATION = 'index.html';
     const BILLING_PLAN_LABELS = {
       starter: '$5 Family & Friends',
@@ -813,6 +879,118 @@
         : tone === 'success'
         ? '#b8f1c5'
         : 'rgba(248, 251, 255, 0.72)';
+    }
+
+    function normalizeRecoveryEmailInput(value = '') {
+      if (
+        window.AccountRecovery
+        && typeof window.AccountRecovery.normalizeEmail === 'function'
+      ) {
+        return window.AccountRecovery.normalizeEmail(value);
+      }
+      const normalized = String(value || '').trim().toLowerCase();
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized) ? normalized : '';
+    }
+
+    function currentRecoveryEmail() {
+      const input = document.getElementById('recovery-email');
+      return normalizeRecoveryEmailInput(input ? input.value : '');
+    }
+
+    function setRecoveryStatus(message = '', tone = 'info') {
+      const statusEl = document.getElementById('recovery-status');
+      if (!statusEl) return;
+      statusEl.textContent = message || 'Verify this email so you can recover the account later.';
+      statusEl.style.color = tone === 'error'
+        ? '#ffb4b4'
+        : tone === 'success'
+        ? '#b8f1c5'
+        : 'rgba(248, 251, 255, 0.72)';
+    }
+
+    function resetRecoveryVerification() {
+      recoveryVerificationState.email = '';
+      recoveryVerificationState.verificationId = '';
+      recoveryVerificationState.verifiedEmail = '';
+      recoveryVerificationState.expiresAt = 0;
+      setRecoveryStatus();
+    }
+
+    function isRecoveryEmailVerified(email = currentRecoveryEmail()) {
+      return Boolean(email && recoveryVerificationState.verifiedEmail === email);
+    }
+
+    async function postRecoveryEmail(payload = {}) {
+      const response = await fetch('/api/calendar/reminder-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(body.error || 'Unable to verify recovery email.');
+      }
+      return body;
+    }
+
+    async function sendRecoveryVerificationCode() {
+      const email = currentRecoveryEmail();
+      const button = document.getElementById('send-recovery-code');
+      if (!email) {
+        setRecoveryStatus('Enter a valid recovery email first.', 'error');
+        return;
+      }
+      if (button) button.disabled = true;
+      setRecoveryStatus('Sending verification code...', 'info');
+      try {
+        const body = await postRecoveryEmail({
+          mode: 'recovery-verification',
+          email
+        });
+        recoveryVerificationState.email = email;
+        recoveryVerificationState.verificationId = body.verificationId || '';
+        recoveryVerificationState.verifiedEmail = '';
+        recoveryVerificationState.expiresAt = Number(body.expiresAt || 0);
+        setRecoveryStatus('Check your email for the 6-digit verification code.', 'success');
+        document.getElementById('recovery-code')?.focus();
+      } catch (error) {
+        resetRecoveryVerification();
+        setRecoveryStatus(error.message || 'Unable to send verification code.', 'error');
+      } finally {
+        if (button) button.disabled = false;
+      }
+    }
+
+    async function verifyRecoveryCode() {
+      const email = currentRecoveryEmail();
+      const codeInput = document.getElementById('recovery-code');
+      const code = String(codeInput ? codeInput.value : '').trim();
+      const button = document.getElementById('verify-recovery-code');
+      if (!email || !recoveryVerificationState.verificationId || recoveryVerificationState.email !== email) {
+        setRecoveryStatus('Send a verification code to this email first.', 'error');
+        return;
+      }
+      if (!/^\d{6}$/.test(code)) {
+        setRecoveryStatus('Enter the 6-digit verification code.', 'error');
+        return;
+      }
+      if (button) button.disabled = true;
+      setRecoveryStatus('Verifying recovery email...', 'info');
+      try {
+        await postRecoveryEmail({
+          mode: 'confirm-recovery-email',
+          email,
+          code,
+          verificationId: recoveryVerificationState.verificationId
+        });
+        recoveryVerificationState.verifiedEmail = email;
+        setRecoveryStatus('Recovery email verified.', 'success');
+      } catch (error) {
+        recoveryVerificationState.verifiedEmail = '';
+        setRecoveryStatus(error.message || 'Recovery email verification failed.', 'error');
+      } finally {
+        if (button) button.disabled = false;
+      }
     }
 
     function onceGun(node) {
@@ -1010,8 +1188,14 @@
         alert("Please enter both username and password.");
         return;
       }
-      if (rawRecoveryEmail && !recoveryEmail) {
-        alert('Enter a valid recovery email or leave the field empty.');
+      if (!rawRecoveryEmail || !recoveryEmail) {
+        alert('Enter a valid recovery email.');
+        setRecoveryStatus('A valid recovery email is required for password accounts.', 'error');
+        return;
+      }
+      if (!isRecoveryEmailVerified(recoveryEmail)) {
+        alert('Verify your recovery email before continuing.');
+        setRecoveryStatus('Verify this recovery email before signing in or signing up.', 'error');
         return;
       }
 
@@ -1221,6 +1405,9 @@
 
           if (normalizedRecoveryEmail) {
             nextRecord.recoveryEmail = normalizedRecoveryEmail;
+            nextRecord.recoveryEmailVerifiedAt = data && data.recoveryEmail === normalizedRecoveryEmail && data.recoveryEmailVerifiedAt
+              ? data.recoveryEmailVerifiedAt
+              : Date.now();
           }
 
           node.put(nextRecord);
@@ -1271,6 +1458,18 @@
         button.addEventListener('click', () => startOauth(button.dataset.provider || ''));
       });
       const usernameInput = document.getElementById('username');
+      const recoveryEmailInput = document.getElementById('recovery-email');
+      const sendRecoveryButton = document.getElementById('send-recovery-code');
+      const verifyRecoveryButton = document.getElementById('verify-recovery-code');
+      if (recoveryEmailInput) {
+        recoveryEmailInput.addEventListener('input', resetRecoveryVerification);
+      }
+      if (sendRecoveryButton) {
+        sendRecoveryButton.addEventListener('click', sendRecoveryVerificationCode);
+      }
+      if (verifyRecoveryButton) {
+        verifyRecoveryButton.addEventListener('click', verifyRecoveryCode);
+      }
       if (usernameInput) {
         try {
           usernameInput.focus({ preventScroll: true });

--- a/tests/account-recovery-email.test.js
+++ b/tests/account-recovery-email.test.js
@@ -130,6 +130,92 @@ describe('account recovery email api', () => {
     assert.equal(res.body.alias, 'Pilot@3dvr');
   });
 
+  it('sends and confirms recovery email verification codes', async () => {
+    const mail = createMailTransport();
+    const handler = createAccountRecoveryEmailHandler({
+      config: {
+        ...baseConfig,
+        ACCOUNT_RECOVERY_VERIFICATION_SECRET: 'verification-secret'
+      },
+      mailTransport: mail
+    });
+
+    const sendReq = {
+      method: 'POST',
+      body: {
+        mode: 'recovery-verification',
+        email: 'User@example.com'
+      }
+    };
+    const sendRes = createMockRes();
+
+    await handler(sendReq, sendRes);
+
+    assert.equal(sendRes.statusCode, 200);
+    assert.equal(sendRes.body.mode, 'recovery-verification');
+    assert.equal(sendRes.body.email, 'user@example.com');
+    assert.match(sendRes.body.verificationId, /\./);
+    assert.equal(mail.sendMail.mock.calls.length, 1);
+
+    const sentHtml = mail.sendMail.mock.calls[0].arguments[0].html;
+    const code = sentHtml.match(/([0-9]{6})/)?.[1];
+    assert.match(code, /^[0-9]{6}$/);
+
+    const confirmReq = {
+      method: 'POST',
+      body: {
+        mode: 'confirm-recovery-email',
+        email: 'user@example.com',
+        code,
+        verificationId: sendRes.body.verificationId
+      }
+    };
+    const confirmRes = createMockRes();
+
+    await handler(confirmReq, confirmRes);
+
+    assert.equal(confirmRes.statusCode, 200);
+    assert.deepEqual(confirmRes.body, {
+      success: true,
+      mode: 'confirm-recovery-email',
+      email: 'user@example.com'
+    });
+  });
+
+  it('rejects invalid recovery email verification codes', async () => {
+    const mail = createMailTransport();
+    const handler = createAccountRecoveryEmailHandler({
+      config: {
+        ...baseConfig,
+        ACCOUNT_RECOVERY_VERIFICATION_SECRET: 'verification-secret'
+      },
+      mailTransport: mail
+    });
+
+    const sendRes = createMockRes();
+    await handler({
+      method: 'POST',
+      body: {
+        mode: 'recovery-verification',
+        email: 'user@example.com'
+      }
+    }, sendRes);
+
+    const confirmRes = createMockRes();
+    await handler({
+      method: 'POST',
+      body: {
+        mode: 'confirm-recovery-email',
+        email: 'user@example.com',
+        code: '000000',
+        verificationId: sendRes.body.verificationId
+      }
+    }, confirmRes);
+
+    assert.equal(confirmRes.statusCode, 400);
+    assert.equal(confirmRes.body.error, 'Recovery email verification failed or expired.');
+  });
+
   it('sends admin-reset-request notifications to team and requester', async () => {
     const mail = createMailTransport();
     const handler = createAccountRecoveryEmailHandler({

--- a/tests/sign-in-page.test.js
+++ b/tests/sign-in-page.test.js
@@ -55,4 +55,18 @@ describe('sign-in page', () => {
     assert.match(html, /PortalOAuth\.storeConnectionFromResult/);
     assert.match(html, /PortalOAuth\.begin\(provider,/);
   });
+
+  it('requires verified recovery email before password sign-in or sign-up', async () => {
+    const html = await readFile(signInUrl, 'utf8');
+    assert.match(html, /<label for="recovery-email">Recovery email<\/label>/);
+    assert.match(html, /id="recovery-email"[\s\S]*required/);
+    assert.match(html, /id="send-recovery-code"/);
+    assert.match(html, /id="recovery-code"/);
+    assert.match(html, /id="verify-recovery-code"/);
+    assert.match(html, /mode:\s*'recovery-verification'/);
+    assert.match(html, /mode:\s*'confirm-recovery-email'/);
+    assert.match(html, /isRecoveryEmailVerified\(recoveryEmail\)/);
+    assert.match(html, /recoveryEmailVerifiedAt/);
+    assert.doesNotMatch(html, /Recovery email \(optional\)/);
+  });
 });


### PR DESCRIPTION
## Summary
- Require recovery email on the password sign-in/sign-up form
- Add send-code and confirm-code recovery email verification using server-signed tokens
- Store recoveryEmailVerifiedAt when a verified recovery email is recorded
- Keep OAuth accounts using the provider email as the verified recovery email path
- Add recovery email verification tests

## Tests
- npm ci
- node --test tests/sign-in-page.test.js tests/account-recovery.test.js tests/account-recovery-email.test.js tests/auth-identity.test.js