### PR TITLE
[codex] Move OAuth below sign-in submit

### DIFF
--- a/sign-in.html
+++ b/sign-in.html
@@ -518,6 +518,9 @@
               Optional for now. Verify this email if you want account recovery enabled.
             </p>
           </div>
+          <div class="actions">
+            <button id="auth-submit" type="submit" class="primary-button">Sign in or sign up</button>
+          </div>
           <div class="oauth-panel" aria-labelledby="oauth-options-title">
             <div class="oauth-divider" id="oauth-options-title">Or continue with OAuth</div>
             <div class="oauth-grid">
@@ -528,9 +531,6 @@
             <p id="oauth-status" class="oauth-status" role="status" aria-live="polite">
               Google and Microsoft can later power contacts and calendar. Apple adds account verification for portal access.
             </p>
-          </div>
-          <div class="actions">
-            <button id="auth-submit" type="submit" class="primary-button">Sign in or sign up</button>
           </div>
           <p class="disclaimer">We use decentralized GUN.js storage. Your credentials are encrypted before leaving your device.</p>
           <p class="guest-note">

--- a/tests/sign-in-page.test.js
+++ b/tests/sign-in-page.test.js
@@ -54,6 +54,10 @@ describe('sign-in page', () => {
     assert.match(html, /PortalOAuth\.writeAuthSession/);
     assert.match(html, /PortalOAuth\.storeConnectionFromResult/);
     assert.match(html, /PortalOAuth\.begin\(provider,/);
+    assert.ok(
+      html.indexOf('id="auth-submit"') < html.indexOf('class="oauth-panel"'),
+      'password submit should appear before the OAuth panel'
+    );
   });
 
   it('keeps recovery email optional while offering verification', async () => {


### PR DESCRIPTION
## Summary
- Move the OAuth panel below the primary sign-in/sign-up button.
- Add a regression check so the password submit stays before OAuth in the sign-in page markup.

## Validation
- `node --test tests/sign-in-page.test.js tests/contacts-identity.e2e.test.js`