### PR TITLE
[codex] Improve ski game mobile layout

### DIFF
--- a/tribes-flight.html
+++ b/tribes-flight.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="portal:issue-launcher" content="off">
   <title>3DVR - Jetpack Ski Prototype</title>
   <link rel="stylesheet" href="styles/global.css">
   <style>
@@ -23,7 +24,7 @@
   }
 
   body.touch-enabled {
-    --control-safe-zone: 18rem;
+    --control-safe-zone: 12rem;
   }
 
   canvas {
@@ -343,6 +344,8 @@
   @media (max-width: 720px) {
     .overlay {
       top: calc(5.2rem + env(safe-area-inset-top, 0px));
+      max-height: 44vh;
+      overflow: auto;
     }
 
     .status {
@@ -356,34 +359,139 @@
   }
 
   @media (max-width: 520px) {
+    body.touch-enabled {
+      --control-safe-zone: 8rem;
+    }
+
     .overlay {
       width: calc(100% - 1.4rem);
+      top: calc(4.4rem + env(safe-area-inset-top, 0px));
+      padding: 0.9rem;
+      max-height: 36vh;
+    }
+
+    .overlay h1 {
+      font-size: 1.25rem;
+    }
+
+    .overlay p,
+    .overlay .hint,
+    .control-list {
+      font-size: 0.78rem;
+      line-height: 1.45;
+    }
+
+    .overlay .hint,
+    .control-list {
+      display: none;
+    }
+
+    .overlay-links {
+      margin-top: 0.8rem;
+      gap: 0.4rem;
+    }
+
+    .overlay-links a {
+      padding: 0.34rem 0.58rem;
+      font-size: 0.66rem;
+      letter-spacing: 0.04em;
     }
 
     .overlay-toggle {
-      width: calc(100% - 1.4rem);
+      top: auto;
+      bottom: calc(var(--safe-bottom) + var(--control-safe-zone) + 0.7rem);
+      width: min(190px, calc(100% - 1.4rem));
+      padding: 0.52rem 0.95rem;
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
     }
 
     .status {
-      top: calc(var(--safe-top));
-      right: calc(var(--safe-right) - 0.75rem);
+      top: calc(env(safe-area-inset-top, 0px) + 0.65rem);
+      right: calc(env(safe-area-inset-right, 0px) + 0.65rem);
+      padding: 0.48rem 0.62rem;
+      border-radius: 12px;
+      gap: 0.1rem;
+      font-size: 0.58rem;
+      letter-spacing: 0.1em;
+      box-shadow: 0 10px 24px rgba(8, 145, 178, 0.25);
+    }
+
+    .status span:last-child {
+      font-size: 0.78rem;
     }
 
     .score-panel {
-      top: calc(var(--safe-top) + 3.6rem);
-      right: calc(var(--safe-right) - 0.75rem);
-      min-width: 188px;
+      top: calc(env(safe-area-inset-top, 0px) + 0.65rem);
+      left: calc(env(safe-area-inset-left, 0px) + 0.65rem);
+      right: auto;
+      min-width: auto;
+      width: min(170px, calc(58vw - 0.75rem));
+      padding: 0.55rem 0.65rem;
+      gap: 0.3rem;
+      border-radius: 12px;
+      box-shadow: 0 10px 24px rgba(8, 145, 178, 0.25);
+    }
+
+    .score-panel-title,
+    .score-row-label {
+      font-size: 0.56rem;
+      letter-spacing: 0.1em;
+    }
+
+    .score-row-value {
+      font-size: 0.74rem;
+    }
+
+    .bar {
+      height: 6px;
+    }
+
+    .score-panel-target-row {
+      display: none;
     }
   }
 
   @media (max-width: 420px) {
     .touch-controls {
-      padding: 0.6rem 0.75rem;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      width: calc(100% - 4.9rem);
+      left: calc(env(safe-area-inset-left, 0px) + 0.75rem);
+      right: auto;
+      bottom: calc(env(safe-area-inset-bottom, 0px) + 0.75rem);
+      transform: none;
+      padding: 0;
+      background: transparent;
+      border: 0;
+      box-shadow: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+      column-gap: 0.4rem;
+      row-gap: 0.4rem;
     }
 
     .touch-controls .control-cluster {
-      flex: 1 1 100%;
-      justify-content: center;
+      display: contents;
+    }
+
+    .touch-controls .control-cluster.primary-cluster {
+      display: contents;
+    }
+
+    .touch-controls button {
+      min-width: 0;
+      min-height: 38px;
+      padding: 0.45rem 0.32rem;
+      border-radius: 11px;
+      font-size: 0.66rem;
+      letter-spacing: 0.02em;
+      background: rgba(15, 23, 42, 0.72);
+      box-shadow: 0 10px 18px rgba(13, 148, 136, 0.22);
+    }
+
+    .touch-controls button.primary {
+      grid-column: span 2;
     }
   }
   </style>
@@ -396,9 +504,8 @@
     <button class="overlay-close" type="button" id="overlayClose">Close</button>
     <h1 id="rangeTitle">Zero-G Ski Range</h1>
     <p>
-      Chain skiing, sustained jetpack lines, and hybrid weapons converge inside a real-time 3D ski bowl inspired by
-      Tribes: Aerial Assault. Carve the holographic terrain to sync slope acceleration, vertical thrust, and the iconic
-      spinfusor + chaingun combo while chasing targets that drift through the nebula ahead.
+      Carve the holographic bowl, feather the jetpack, and chase drifting targets with the spinfusor or chaingun.
+      Build speed on the slope, then boost into the next line.
     </p>
     <div class="hint">
       Toggle loadouts with <strong>1</strong> and <strong>2</strong>, then use <strong>Shift</strong> to feather your
@@ -446,7 +553,7 @@
       <span class="score-row-label">Hits</span>
       <span class="score-row-value" id="hit-count">0</span>
     </div>
-    <div class="score-panel-row">
+    <div class="score-panel-row score-panel-target-row">
       <span class="score-row-label">Target</span>
       <span class="score-row-value"><span id="target-health">100</span>%</span>
     </div>
@@ -457,13 +564,23 @@
       <button type="button" class="control-btn" data-action="right" aria-label="Lean right">▶</button>
     </div>
     <div class="control-cluster">
-      <button type="button" class="control-btn" data-action="jetpack" aria-label="Engage jetpack">Jetpack</button>
+      <button type="button" class="control-btn" data-action="jetpack" aria-label="Engage jetpack">Jet</button>
       <button type="button" class="control-btn" data-action="brake" aria-label="Air brake">Brake</button>
     </div>
     <div class="control-cluster primary-cluster">
       <button type="button" class="control-btn primary" data-action="fire" aria-label="Fire current weapon">Fire</button>
     </div>
   </div>
+  <script>
+    if (window.matchMedia('(max-width: 520px)').matches) {
+      document.getElementById('infoOverlay')?.classList.add('overlay-hidden');
+      const compactOverlayToggle = document.getElementById('overlayToggle');
+      if (compactOverlayToggle) {
+        compactOverlayToggle.classList.add('overlay-toggle-visible');
+        compactOverlayToggle.setAttribute('aria-expanded', 'false');
+      }
+    }
+  </script>
   <script>
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
@@ -530,7 +647,12 @@
     });
   }
 
+  if (window.matchMedia('(max-width: 520px)').matches) {
+    hideOverlay();
+  }
+
   const ASPECT_RATIO = 16 / 9;
+  const compactViewportQuery = window.matchMedia('(max-width: 520px)');
 
   const input = {
     left: false,
@@ -656,12 +778,18 @@
 
   function resizeCanvas() {
     const viewportWidth = window.innerWidth || 960;
-    const desiredWidth = Math.min(1080, Math.max(320, viewportWidth - 24));
+    const viewportHeight = window.innerHeight || 540;
+    const useFullViewport = compactViewportQuery.matches;
+    const desiredWidth = useFullViewport
+      ? viewportWidth
+      : Math.min(1080, Math.max(320, viewportWidth - 24));
     const width = Math.round(desiredWidth);
-    const height = Math.round(width / ASPECT_RATIO);
+    const height = useFullViewport
+      ? Math.round(viewportHeight)
+      : Math.round(width / ASPECT_RATIO);
 
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
+    canvas.style.width = useFullViewport ? '100vw' : `${width}px`;
+    canvas.style.height = useFullViewport ? '100vh' : `${height}px`;
     canvas.width = width;
     canvas.height = height;
 
@@ -1389,6 +1517,10 @@
   }
 
   function drawUIOverlay() {
+    if (compactViewportQuery.matches) {
+      return;
+    }
+
     const altitude = Math.max(0, player.y - groundHeight(player.x, player.z) - player.radius);
     const horizontalSpeed = Math.sqrt(player.vx * player.vx + player.vz * player.vz);
     const rangeDepth = Math.max(0, target.z - player.z);


### PR DESCRIPTION
## Summary
- Compact the Zero-G Ski Range mobile HUD and touch controls.
- Hide the guide overlay by default on phone widths behind a small Guide button.
- Make the mobile canvas fill the viewport instead of rendering as a short 16:9 slice.
- Remove duplicate in-canvas stats on mobile and disable the issue launcher on the full-screen game page.

## Validation
- Ran local dev server at `http://127.0.0.1:3000`.
- Used Playwright mobile viewports at `360x740`, `390x844`, and `430x932` to confirm controls fit within the screen with no viewport overflow.
- Captured a mobile screenshot to inspect the compact layout.