### PR TITLE
[codex] Add guest account upgrade flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,7 +624,7 @@
       <h2 id="auth-modal-title">Sign in to save your progress</h2>
       <p>Create an account to sync your points across all your devices.</p>
       <div class="auth-modal__actions">
-        <button type="button" class="cta primary" onclick="window.location.href='/sign-in.html'">Sign in / Create account</button>
+        <button type="button" class="cta primary" onclick="startAccountFromHere()">Create account</button>
         <button type="button" class="cta ghost" onclick="continueAsGuest()">Continue as guest</button>
       </div>
     </div>
@@ -737,6 +737,12 @@
       authModal.style.display = 'none';
       authModal.setAttribute('aria-hidden', 'true');
       window.dispatchEvent(new Event('auth-modal:closed'));
+    }
+
+    function startAccountFromHere() {
+      const currentPath = `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`;
+      const upgradeParam = localStorage.getItem('guest') === 'true' ? '&upgrade=guest' : '';
+      window.location.href = `/sign-in.html?redirect=${encodeURIComponent(currentPath || '/index.html')}${upgradeParam}`;
     }
   </script>
 

--- a/navbar.js
+++ b/navbar.js
@@ -20,6 +20,15 @@ function clearSharedIdentityCookie() {
   }
 }
 
+function currentUpgradeRedirect() {
+  const path = `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`;
+  return path || '/index.html';
+}
+
+function guestUpgradeHref() {
+  return `/sign-in.html?upgrade=guest&redirect=${encodeURIComponent(currentUpgradeRedirect())}`;
+}
+
 function hideUnreadyHomepageSections() {
   const systemLayers = document.getElementById('systemLayers');
   if (systemLayers) {
@@ -95,6 +104,11 @@ function createNavbar() {
   button.innerText = 'Sign Out';
 
   button.addEventListener('click', () => {
+    if (isGuest) {
+      window.location.href = guestUpgradeHref();
+      return;
+    }
+
     try {
       user.leave();
     } catch (err) {
@@ -137,6 +151,14 @@ function createNavbar() {
   const isGuest = !isSignedIn && localStorage.getItem('guest') === 'true';
   let latestDisplayName = '';
   let aliasDisplay = aliasToDisplay(localStorage.getItem('alias'));
+
+  if (isGuest) {
+    stats.href = guestUpgradeHref();
+    stats.setAttribute('aria-label', 'Create an account and keep your guest progress');
+    stats.title = 'Create an account and keep your guest progress';
+    button.innerText = 'Create account';
+    button.setAttribute('aria-label', 'Create an account and keep guest progress');
+  }
 
   function updateNameDisplay() {
     if (latestDisplayName) {

--- a/sign-in.html
+++ b/sign-in.html
@@ -808,6 +808,11 @@
 
     watchGunRelay();
 
+    function isGuestUpgradeContext() {
+      const params = new URLSearchParams(window.location.search);
+      return params.get('upgrade') === 'guest' || localStorage.getItem('guest') === 'true';
+    }
+
     function applyRedirectContext() {
       const authTitle = document.getElementById('auth-title');
       const authDescription = document.getElementById('auth-description');
@@ -823,7 +828,9 @@
         return;
       }
 
-      if (!redirectContext.isBilling && redirectContext.destination === DEFAULT_POST_SIGN_IN_DESTINATION) {
+      const shouldUpgradeGuest = isGuestUpgradeContext();
+
+      if (!shouldUpgradeGuest && !redirectContext.isBilling && redirectContext.destination === DEFAULT_POST_SIGN_IN_DESTINATION) {
         redirectPanel.hidden = true;
         return;
       }
@@ -850,6 +857,28 @@
         }
         if (guestNote && guestButton) {
           guestNote.innerHTML = 'Billing needs an account so Stripe stays linked to one portal identity. <button id="guest-button" type="button" onclick="continueAsGuest()">Back to portal home</button>';
+        }
+        return;
+      }
+
+      if (shouldUpgradeGuest) {
+        const guestName = (localStorage.getItem('guestDisplayName') || '').trim();
+        if (authTitle) {
+          authTitle.textContent = 'Save your guest progress';
+        }
+        if (authDescription) {
+          authDescription.textContent = 'Create a portal account and we will move this guest session into it after sign-in.';
+        }
+        redirectEyebrow.textContent = 'Guest session';
+        redirectTitle.textContent = guestName
+          ? `Keep ${guestName}'s points and progress.`
+          : 'Keep your guest points and progress.';
+        redirectBody.textContent = 'Use a username and password below. Your current guest score moves into the account, then this browser returns to where you were.';
+        if (authSubmit) {
+          authSubmit.textContent = 'Create account and keep progress';
+        }
+        if (guestNote) {
+          guestNote.innerHTML = 'Need more time? <button id="guest-button" type="button" onclick="continueAsGuest()">Stay in guest mode</button>';
         }
         return;
       }

--- a/tests/guest-upgrade-entrypoints.test.js
+++ b/tests/guest-upgrade-entrypoints.test.js
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const navbarUrl = new URL('../navbar.js', import.meta.url);
+const indexUrl = new URL('../index.html', import.meta.url);
+
+describe('guest upgrade entrypoints', () => {
+  it('turns the floating guest identity action into account creation', async () => {
+    const source = await readFile(navbarUrl, 'utf8');
+    assert.match(source, /function guestUpgradeHref\(\)/);
+    assert.match(source, /upgrade=guest/);
+    assert.match(source, /Create account/);
+    assert.match(source, /Create an account and keep guest progress/);
+    assert.match(source, /if \(isGuest\) \{\s*window\.location\.href = guestUpgradeHref\(\);/);
+  });
+
+  it('sends the homepage auth modal through the upgrade-aware sign-in link', async () => {
+    const html = await readFile(indexUrl, 'utf8');
+    assert.match(html, /onclick="startAccountFromHere\(\)"/);
+    assert.match(html, /function startAccountFromHere\(\)/);
+    assert.match(html, /upgradeParam = localStorage\.getItem\('guest'\) === 'true' \? '&upgrade=guest' : ''/);
+    assert.match(html, /\/sign-in\.html\?redirect=/);
+  });
+});

--- a/tests/sign-in-page.test.js
+++ b/tests/sign-in-page.test.js
@@ -73,4 +73,14 @@ describe('sign-in page', () => {
     assert.match(html, /Continuing without account recovery/);
     assert.match(html, /recoveryEmailVerifiedAt/);
   });
+
+  it('explains guest account upgrades and keeps guest progress', async () => {
+    const html = await readFile(signInUrl, 'utf8');
+    assert.match(html, /function isGuestUpgradeContext\(\)/);
+    assert.match(html, /params\.get\('upgrade'\) === 'guest'/);
+    assert.match(html, /Save your guest progress/);
+    assert.match(html, /Create account and keep progress/);
+    assert.match(html, /migrateGuestProgress\(\)/);
+    assert.match(html, /Stay in guest mode/);
+  });
 });


### PR DESCRIPTION
## Summary
- Turn the floating guest identity action into a clear `Create account` path.
- Send guest users to `sign-in.html?upgrade=guest` with the current page preserved as the redirect target.
- Add sign-in copy that explains guest progress will move into the new account.
- Keep the existing guest progress migration path intact and add static coverage for the upgrade entrypoints.

## Validation
- `node --test tests/sign-in-page.test.js tests/guest-upgrade-entrypoints.test.js tests/auth-identity.test.js tests/contacts-identity.e2e.test.js`