### PR TITLE
Scope Notes to guest and user identities

### DIFF
--- a/notes/index.html
+++ b/notes/index.html
@@ -6,6 +6,7 @@
   <title>📝 3DVR Notes</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/gun-init.js"></script>
+  <script src="/auth-identity.js"></script>
   <script src="/pwa-install.js" defer></script>
   <link rel="stylesheet" href="../style.css?v=notes-refresh-20240204">
   <link rel="stylesheet" href="./styles.css?v=notes-ux-20260514">
@@ -236,15 +237,84 @@
 
     const gun = gunContext.gun;
 
+    if (window.AuthIdentity && typeof window.AuthIdentity.syncStorageFromSharedIdentity === 'function') {
+      try {
+        window.AuthIdentity.syncStorageFromSharedIdentity();
+      } catch (err) {
+        console.warn('Failed to sync shared identity before loading notes', err);
+      }
+    }
+
     const portalRoot = gun && typeof gun.get === 'function'
       ? gun.get('3dvr-portal')
       : createLocalGunNodeStub();
 
-    // Notes now live under 3dvr-portal/notes with folders in 3dvr-portal/noteFolders to align with
-    // the unified portal workspace graph. Legacy simple-notes/simple-folders nodes are still observed
-    // so older clients remain compatible while the data migrates forward.
-    const foldersPrimary = portalRoot.get('noteFolders');
-    const notesPrimary = portalRoot.get('notes');
+    function normalizeIdentityKey(value = '') {
+      return String(value || '').trim().toLowerCase();
+    }
+
+    function ensureGuestIdentity() {
+      const legacyId = localStorage.getItem('userId');
+      if (legacyId && !localStorage.getItem('guestId')) {
+        localStorage.setItem('guestId', legacyId);
+      }
+      let guestId = localStorage.getItem('guestId');
+      if (!guestId) {
+        guestId = `guest_${Math.random().toString(36).slice(2, 11)}`;
+        localStorage.setItem('guestId', guestId);
+      }
+      localStorage.setItem('guest', 'true');
+      if (!localStorage.getItem('guestDisplayName')) {
+        localStorage.setItem('guestDisplayName', 'Guest');
+      }
+      return guestId;
+    }
+
+    function resolveNotesWorkspace() {
+      const signedIn = localStorage.getItem('signedIn') === 'true';
+      const alias = normalizeIdentityKey(localStorage.getItem('alias'));
+      const userPub = normalizeIdentityKey(localStorage.getItem('userPubKey'));
+      const activeUser = gunContext.user;
+      const userHasSession = Boolean(activeUser && activeUser.is && typeof activeUser.get === 'function');
+
+      if (signedIn && userHasSession) {
+        return {
+          mode: 'user',
+          key: userPub || alias || 'gun-user',
+          folders: activeUser.get('noteFolders'),
+          notes: activeUser.get('notes')
+        };
+      }
+
+      if (signedIn && (userPub || alias)) {
+        const userKey = userPub || alias;
+        const userRoot = portalRoot.get('notesUsers').get(userKey);
+        return {
+          mode: 'user',
+          key: userKey,
+          folders: userRoot.get('noteFolders'),
+          notes: userRoot.get('notes')
+        };
+      }
+
+      const guestId = ensureGuestIdentity();
+      const guestRoot = gun.get('3dvr-guests').get(guestId);
+      return {
+        mode: 'guest',
+        key: guestId,
+        folders: guestRoot.get('noteFolders'),
+        notes: guestRoot.get('notes')
+      };
+    }
+
+    const notesWorkspace = resolveNotesWorkspace();
+    const foldersPrimary = notesWorkspace.folders;
+    const notesPrimary = notesWorkspace.notes;
+
+    // Keep the old shared note paths as read-only legacy sources so existing data can mirror forward
+    // without continuing to write new personal notes into a shared bucket.
+    const foldersSharedLegacy = portalRoot.get('noteFolders');
+    const notesSharedLegacy = portalRoot.get('notes');
 
     const foldersLegacy = gun && typeof gun.get === 'function'
       ? gun.get('simple-folders')
@@ -258,8 +328,10 @@
       return sources.filter((source, index) => source && sources.indexOf(source) === index);
     }
 
-    const folderSources = uniqueSources([foldersPrimary, foldersLegacy]);
-    const noteSources = uniqueSources([notesPrimary, notesLegacy]);
+    const folderSources = uniqueSources([foldersPrimary]);
+    const noteSources = uniqueSources([notesPrimary]);
+    const folderReadSources = uniqueSources([foldersPrimary, foldersSharedLegacy, foldersLegacy]);
+    const noteReadSources = uniqueSources([notesPrimary, notesSharedLegacy, notesLegacy]);
 
     const primaryFolderSource = folderSources[0];
     const primaryNoteSource = noteSources[0];
@@ -325,6 +397,10 @@
           ref.put(null);
         }
       });
+    }
+
+    function sourcesForExistingRecord(refs, writeSources, id) {
+      return uniqueSources([refs.get(id), ...writeSources]);
     }
 
     const folderList = document.getElementById('folders');
@@ -598,7 +674,7 @@
       }
     }
 
-    folderSources.forEach((source) => {
+    folderReadSources.forEach((source) => {
       if (!source || typeof source.map !== 'function') {
         return;
       }
@@ -652,7 +728,7 @@
       }, 750);
     }
 
-    folderSources.forEach(registerFolderSnapshot);
+    folderReadSources.forEach(registerFolderSnapshot);
     if (pendingFolderSnapshots === 0) {
       maybeSeedDefaultFolder();
     }
@@ -741,7 +817,7 @@
       deleteBtn.addEventListener('click', (event) => {
         event.stopPropagation();
         if (confirm('Delete this space and its notes?')) {
-          removeFromSources(folderSources, id, {
+          removeFromSources(sourcesForExistingRecord(folderSourceRefs, folderSources, id), id, {
             onPrimaryAck: (ack) => {
               if (ack && ack.err) {
                 console.error('Failed to delete space', ack.err);
@@ -798,7 +874,7 @@
     function removeNotesInFolder(folderId) {
       noteCache.forEach((note, id) => {
         if (note.folder === folderId) {
-          removeFromSources(noteSources, id, {
+          removeFromSources(sourcesForExistingRecord(noteSourceRefs, noteSources, id), id, {
             onPrimaryAck: (ack) => {
               if (ack && ack.err) {
                 console.error('Failed to delete note', ack.err);
@@ -928,7 +1004,7 @@
       updateWorkspaceSummary();
     }
 
-    noteSources.forEach((source) => {
+    noteReadSources.forEach((source) => {
       if (!source || typeof source.map !== 'function') {
         return;
       }
@@ -976,7 +1052,7 @@
         deleteBtn.addEventListener('click', (event) => {
           event.stopPropagation();
           if (confirm('Delete this note?')) {
-            removeFromSources(noteSources, id, {
+            removeFromSources(sourcesForExistingRecord(noteSourceRefs, noteSources, id), id, {
               onPrimaryAck: (ack) => {
                 if (ack && ack.err) {
                   console.error('Failed to delete note', ack.err);

--- a/sign-in.html
+++ b/sign-in.html
@@ -1377,6 +1377,83 @@
       });
     }
 
+    function sanitizeGunRecord(record) {
+      if (!record || typeof record !== 'object') {
+        return null;
+      }
+      const cleaned = { ...record };
+      delete cleaned._;
+      return cleaned;
+    }
+
+    function copyGunCollection(source, target, { fields = [], nestedFields = [] } = {}) {
+      return new Promise(resolve => {
+        if (!source || typeof source.once !== 'function' || !target || typeof target.get !== 'function') {
+          resolve(0);
+          return;
+        }
+
+        let copied = 0;
+        let resolved = false;
+
+        function finish() {
+          if (resolved) return;
+          resolved = true;
+          resolve(copied);
+        }
+
+        try {
+          source.once(snapshot => {
+            const records = snapshot && typeof snapshot === 'object' ? Object.entries(snapshot) : [];
+            records.forEach(([id, record]) => {
+              if (!id || id === '_') return;
+              const cleaned = sanitizeGunRecord(record);
+              if (!cleaned) return;
+
+              const targetRecord = target.get(id);
+              const payload = {};
+              fields.forEach(field => {
+                if (Object.prototype.hasOwnProperty.call(cleaned, field)) {
+                  payload[field] = cleaned[field];
+                }
+              });
+              if (Object.keys(payload).length > 0) {
+                targetRecord.put(payload);
+              }
+              nestedFields.forEach(field => {
+                if (Object.prototype.hasOwnProperty.call(cleaned, field)) {
+                  targetRecord.get(field).put(cleaned[field]);
+                }
+              });
+              copied += 1;
+            });
+            finish();
+          });
+        } catch (err) {
+          console.warn('Unable to copy guest collection', err);
+          finish();
+        }
+
+        setTimeout(finish, 1500);
+      });
+    }
+
+    function migrateGuestNotes(guestProfile) {
+      if (!guestProfile || typeof guestProfile.get !== 'function' || !user || typeof user.get !== 'function') {
+        return Promise.resolve();
+      }
+
+      const folderFields = ['name', 'createdAt', 'updatedAt'];
+      const noteFields = ['title', 'folder', 'createdAt', 'updatedAt'];
+      return Promise.all([
+        copyGunCollection(guestProfile.get('noteFolders'), user.get('noteFolders'), { fields: folderFields }),
+        copyGunCollection(guestProfile.get('notes'), user.get('notes'), {
+          fields: noteFields,
+          nestedFields: ['content']
+        })
+      ]);
+    }
+
     function migrateGuestProgress() {
       return new Promise(resolve => {
         const guestId = localStorage.getItem('guestId');
@@ -1387,7 +1464,7 @@
         }
 
         const guestProfile = gun.get('3dvr-guests').get(guestId);
-        guestProfile.once(snapshot => {
+        guestProfile.once(async snapshot => {
           const guestName = snapshot && typeof snapshot.username === 'string'
             ? snapshot.username.trim()
             : '';
@@ -1407,6 +1484,11 @@
             });
           }
 
+          try {
+            await migrateGuestNotes(guestProfile);
+          } catch (err) {
+            console.warn('Unable to migrate guest notes', err);
+          }
           clearGuestSession();
           resolve();
         });

--- a/tests/notes-identity.test.js
+++ b/tests/notes-identity.test.js
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const notesUrl = new URL('../notes/index.html', import.meta.url);
+
+describe('notes identity storage', () => {
+  it('scopes notes to signed-in users or guest ids instead of writing new notes to shared roots', async () => {
+    const html = await readFile(notesUrl, 'utf8');
+
+    assert.match(html, /<script src="\/auth-identity\.js"><\/script>/);
+    assert.match(html, /function resolveNotesWorkspace\(\)/);
+    assert.match(html, /activeUser\.get\('noteFolders'\)/);
+    assert.match(html, /activeUser\.get\('notes'\)/);
+    assert.match(html, /portalRoot\.get\('notesUsers'\)\.get\(userKey\)/);
+    assert.match(html, /gun\.get\('3dvr-guests'\)\.get\(guestId\)/);
+    assert.match(html, /const folderSources = uniqueSources\(\[foldersPrimary\]\)/);
+    assert.match(html, /const noteSources = uniqueSources\(\[notesPrimary\]\)/);
+    assert.match(html, /const folderReadSources = uniqueSources\(\[foldersPrimary, foldersSharedLegacy, foldersLegacy\]\)/);
+    assert.match(html, /const noteReadSources = uniqueSources\(\[notesPrimary, notesSharedLegacy, notesLegacy\]\)/);
+    assert.match(html, /folderReadSources\.forEach\(registerFolderSnapshot\)/);
+    assert.match(html, /noteReadSources\.forEach\(\(source\) =>/);
+  });
+});

--- a/tests/sign-in-page.test.js
+++ b/tests/sign-in-page.test.js
@@ -81,6 +81,9 @@ describe('sign-in page', () => {
     assert.match(html, /Save your guest progress/);
     assert.match(html, /Create account and keep progress/);
     assert.match(html, /migrateGuestProgress\(\)/);
+    assert.match(html, /function migrateGuestNotes\(guestProfile\)/);
+    assert.match(html, /guestProfile\.get\('notes'\)/);
+    assert.match(html, /user\.get\('notes'\)/);
     assert.match(html, /Stay in guest mode/);
   });
 });


### PR DESCRIPTION
## Summary
- store new Notes data under the active signed-in user or guest id instead of the shared top-level Notes bucket
- read old shared Notes paths as legacy sources and mirror them into the scoped workspace
- copy guest note folders and pages into the signed-in user during guest account upgrade

## Tests
- node --test tests/auth-identity.test.js tests/contacts-core.test.js tests/sign-in-page.test.js tests/notes-identity.test.js tests/guest-upgrade-entrypoints.test.js