### PR TITLE
Add open source field guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Notes](https://3dvr-portal.vercel.app/notes/)
 - [Pocket Workstation](https://3dvr-portal.vercel.app/pocket-workstation/)
 - [Phone Holder System](https://3dvr-portal.vercel.app/phone-holder-system/)
+- [Open Source](https://3dvr-portal.vercel.app/open-source/)
 - [Chat](https://3dvr-portal.vercel.app/chat/)
 - [Calendar Hub](https://3dvr-portal.vercel.app/calendar/)
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)

--- a/index.html
+++ b/index.html
@@ -306,6 +306,11 @@
             <span class="app-card__title">Human-Scale Tech</span>
             <span class="app-card__meta">Plan the trusted, open, healthy technology ecosystem behind 3DVR.</span>
           </a>
+          <a href="open-source/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">{ }</span>
+            <span class="app-card__title">Open Source</span>
+            <span class="app-card__meta">Map Linux, browsers, creative tools, hardware, phones, and Open Source Ecology.</span>
+          </a>
           <a href="job-tracker/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🧭</span>
             <span class="app-card__title">Job Tracker</span>

--- a/open-source/README.md
+++ b/open-source/README.md
@@ -1,0 +1,5 @@
+# Open Source Field Guide
+
+Portal page explaining open source as shared infrastructure: Linux, Debian, browsers, creative tools, audio/CAD gaps, open hardware, phones, and Open Source Ecology.
+
+The page is intentionally educational rather than exhaustive. It should help a customer or collaborator understand why 3DVR cares about open systems and where the practical opportunities are.

--- a/open-source/index.html
+++ b/open-source/index.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Source Field Guide | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="A 3DVR field guide to open source software, Linux, browsers, creative tools, hardware, and Open Source Ecology."
+  >
+  <link rel="stylesheet" href="../style.css?v=open-source-field-guide">
+  <link rel="stylesheet" href="./styles.css?v=20260519">
+</head>
+<body class="open-source-page">
+  <nav class="opensource-nav" aria-label="Open source navigation">
+    <a href="../index.html">Portal</a>
+    <a href="#software">Software</a>
+    <a href="#creative">Creative</a>
+    <a href="#hardware">Hardware</a>
+    <a href="#ecology">Ecology</a>
+  </nav>
+
+  <header class="open-hero">
+    <section class="hero-copy" aria-labelledby="open-source-title">
+      <p class="eyebrow">3DVR Field Guide</p>
+      <h1 id="open-source-title">Open source is shared infrastructure.</h1>
+      <p>
+        It is not just free apps. It is a way to publish the recipe, inspect the tool, repair the system,
+        teach the next person, and keep civilization from depending on black boxes.
+      </p>
+      <div class="hero-actions">
+        <a class="action primary" href="#map">Explore the map</a>
+        <a class="action" href="#gaps">See gaps</a>
+      </div>
+    </section>
+
+    <section class="system-board" aria-label="Open source system map">
+      <div class="node node-os">Linux</div>
+      <div class="node node-browser">Browsers</div>
+      <div class="node node-art">Art</div>
+      <div class="node node-hardware">Hardware</div>
+      <div class="node node-ecology">Ecology</div>
+      <div class="node node-cad">CAD</div>
+      <div class="center-node">Commons</div>
+    </section>
+  </header>
+
+  <main>
+    <section class="principles" id="map" aria-labelledby="map-title">
+      <div class="section-intro">
+        <p class="eyebrow">Mental Model</p>
+        <h2 id="map-title">The source is the recipe.</h2>
+        <p>
+          When the source is open, people can study it, fix it, fork it, translate it, package it,
+          audit it, and adapt it to places the original team never imagined.
+        </p>
+      </div>
+      <div class="cards three-up">
+        <article class="guide-card">
+          <span class="kicker">Freedom</span>
+          <h3>Use and study</h3>
+          <p>People can run the tool and inspect how it works instead of trusting marketing claims.</p>
+        </article>
+        <article class="guide-card">
+          <span class="kicker">Repair</span>
+          <h3>Fix and share</h3>
+          <p>A bug can be patched by the community, not only by a vendor with a business reason to care.</p>
+        </article>
+        <article class="guide-card">
+          <span class="kicker">Resilience</span>
+          <h3>Fork and preserve</h3>
+          <p>If a project changes direction, the knowledge can keep living in another branch or community.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="stack-section" id="software" aria-labelledby="software-title">
+      <div class="section-intro">
+        <p class="eyebrow">Software Stack</p>
+        <h2 id="software-title">Debian, Linux, and browsers are the everyday layer.</h2>
+        <p>
+          Debian shows how a long-running volunteer operating system can become a foundation for servers,
+          desktops, embedded systems, and derivative distributions. Linux is the kernel layer underneath
+          much of modern infrastructure. Open browsers keep the web inspectable and portable.
+        </p>
+      </div>
+      <div class="resource-grid">
+        <a class="resource-card" href="https://www.debian.org/" target="_blank" rel="noopener">
+          <strong>Debian</strong>
+          <span>Universal operating system; a stable base for learning Linux and servers.</span>
+        </a>
+        <a class="resource-card" href="https://kernel.org/" target="_blank" rel="noopener">
+          <strong>Linux kernel</strong>
+          <span>The open kernel layer powering desktops, servers, phones, appliances, and clouds.</span>
+        </a>
+        <a class="resource-card" href="https://www.mozilla.org/firefox/" target="_blank" rel="noopener">
+          <strong>Firefox</strong>
+          <span>A browser path that keeps the web from becoming a single-engine monoculture.</span>
+        </a>
+        <a class="resource-card" href="https://www.chromium.org/chromium-projects/" target="_blank" rel="noopener">
+          <strong>Chromium</strong>
+          <span>The open browser project behind many Chromium-family browsers.</span>
+        </a>
+      </div>
+    </section>
+
+    <section class="stack-section" id="creative" aria-labelledby="creative-title">
+      <div class="section-intro">
+        <p class="eyebrow">Creation Tools</p>
+        <h2 id="creative-title">Artists need serious open tools too.</h2>
+        <p>
+          The creative stack is already strong in places: Krita for painting, Blender for 3D, FreeCAD for
+          parametric design, and Ardour for audio production. The mission is not just “free alternatives.”
+          It is professional tools that respect ownership, learning, and long-term access.
+        </p>
+      </div>
+      <div class="cards tool-grid">
+        <a class="guide-card tool-card" href="https://krita.org/en/" target="_blank" rel="noopener">
+          <span class="kicker">Painting</span>
+          <h3>Krita</h3>
+          <p>Digital painting and 2D art without locking artists into a rented toolchain.</p>
+        </a>
+        <a class="guide-card tool-card" href="https://www.blender.org/" target="_blank" rel="noopener">
+          <span class="kicker">3D</span>
+          <h3>Blender</h3>
+          <p>Modeling, animation, rendering, compositing, video, scripting, and a deep add-on ecosystem.</p>
+        </a>
+        <a class="guide-card tool-card" href="https://www.freecad.org/" target="_blank" rel="noopener">
+          <span class="kicker">CAD</span>
+          <h3>FreeCAD</h3>
+          <p>Parametric CAD for repair parts, product prototypes, fixtures, and open hardware drawings.</p>
+        </a>
+        <a class="guide-card tool-card" href="https://ardour.org/" target="_blank" rel="noopener">
+          <span class="kicker">Audio</span>
+          <h3>Ardour</h3>
+          <p>A real open-source DAW path for recording, editing, mixing, and mastering audio and MIDI.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="gap-panel" id="gaps" aria-labelledby="gaps-title">
+      <div>
+        <p class="eyebrow">Where 3DVR Can Care</p>
+        <h2 id="gaps-title">Some categories still need a better open default.</h2>
+      </div>
+      <div class="gap-list">
+        <article>
+          <strong>DAW</strong>
+          <span>Open audio exists, but musicians still need smoother onboarding, plugin trust, templates, and hardware bundles.</span>
+        </article>
+        <article>
+          <strong>CAD</strong>
+          <span>Open CAD needs better product-design workflows, manufacturing handoff, and beginner-to-builder education.</span>
+        </article>
+        <article>
+          <strong>Phones</strong>
+          <span>Open mobile needs better daily-driver reliability, repairability, radio transparency, app compatibility, and UX polish.</span>
+        </article>
+        <article>
+          <strong>Creative computers</strong>
+          <span>Artists need machines shipped with Linux, pen/tablet support, color workflow, audio, 3D, and export paths already tuned.</span>
+        </article>
+      </div>
+    </section>
+
+    <section class="stack-section" id="hardware" aria-labelledby="hardware-title">
+      <div class="section-intro">
+        <p class="eyebrow">Hardware</p>
+        <h2 id="hardware-title">Open hardware is harder, but it matters.</h2>
+        <p>
+          Software can be copied nearly for free. Hardware has supply chains, chips, tooling, certification,
+          firmware, repairs, and inventory. That is why openness in hardware often arrives in layers:
+          repair docs, schematics, open firmware, replaceable modules, Linux support, and community ports.
+        </p>
+      </div>
+      <div class="resource-grid">
+        <a class="resource-card" href="https://frame.work/" target="_blank" rel="noopener">
+          <strong>Framework</strong>
+          <span>Repairable laptops and modular thinking; useful model for user-serviceable computers.</span>
+        </a>
+        <a class="resource-card" href="https://support.system76.com/articles/open-firmware-systems/" target="_blank" rel="noopener">
+          <strong>System76 Open Firmware</strong>
+          <span>Coreboot and open embedded controller work on supported systems.</span>
+        </a>
+        <a class="resource-card" href="https://pine64.org/devices/pinephone/" target="_blank" rel="noopener">
+          <strong>PINE64 PinePhone</strong>
+          <span>A community Linux phone platform for open mobile operating systems.</span>
+        </a>
+        <a class="resource-card" href="https://www.fairphone.com/" target="_blank" rel="noopener">
+          <strong>Fairphone</strong>
+          <span>Repairability and ethical supply-chain pressure, even when the full stack is not open.</span>
+        </a>
+      </div>
+    </section>
+
+    <section class="ecology-section" id="ecology" aria-labelledby="ecology-title">
+      <div class="section-intro">
+        <p class="eyebrow">Beyond Computers</p>
+        <h2 id="ecology-title">Open source ecology turns tools into civilization patterns.</h2>
+        <p>
+          Open Source Ecology asks what happens when farming, housing, machines, energy, and fabrication
+          are documented as shared designs instead of closed products. The idea is bigger than software:
+          people should be able to learn how their world is made.
+        </p>
+      </div>
+      <div class="ecology-grid">
+        <a class="ecology-card" href="https://www.opensourceecology.org/" target="_blank" rel="noopener">
+          <strong>Open Source Ecology</strong>
+          <span>Open blueprints for machines, housing, fabrication, and a more collaborative productive economy.</span>
+        </a>
+        <a class="ecology-card" href="https://wiki.opensourceecology.org/" target="_blank" rel="noopener">
+          <strong>OSE Wiki</strong>
+          <span>Documentation, prototypes, and development notes for the Global Village Construction Set idea.</span>
+        </a>
+      </div>
+    </section>
+
+    <section class="practice-section" aria-labelledby="practice-title">
+      <div class="section-intro">
+        <p class="eyebrow">3DVR Practice</p>
+        <h2 id="practice-title">Use open source like a craft path.</h2>
+      </div>
+      <ol class="practice-list">
+        <li><strong>Install one open tool.</strong><span>Debian, Krita, Blender, FreeCAD, or Ardour.</span></li>
+        <li><strong>Make one thing.</strong><span>A note, sketch, model, repair part, sample pack, or local server.</span></li>
+        <li><strong>Document the recipe.</strong><span>Write the steps so another person can repeat the work.</span></li>
+        <li><strong>Share upstream when ready.</strong><span>File a bug, improve docs, publish a template, or fund maintainers.</span></li>
+      </ol>
+    </section>
+  </main>
+
+  <footer class="opensource-footer">
+    <p>Open source is how 3DVR connects learning, repair, software, hardware, and ecological resilience.</p>
+  </footer>
+</body>
+</html>

--- a/open-source/styles.css
+++ b/open-source/styles.css
@@ -1,0 +1,441 @@
+:root {
+  --os-bg: #f7f4ec;
+  --os-ink: #202528;
+  --os-muted: #677177;
+  --os-panel: #fffdf7;
+  --os-line: #d8d0c0;
+  --os-green: #52715a;
+  --os-blue: #355f7c;
+  --os-rust: #985c35;
+  --os-gold: #a98635;
+  --os-charcoal: #172026;
+  --os-shadow: 0 18px 42px rgba(32, 37, 40, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.open-source-page {
+  margin: 0;
+  background: var(--os-bg);
+  color: var(--os-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.55;
+}
+
+.opensource-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.6rem;
+  border-bottom: 1px solid var(--os-line);
+  background: rgba(247, 244, 236, 0.9);
+  backdrop-filter: blur(14px);
+}
+
+.opensource-nav a,
+.action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.62rem 0.9rem;
+  border: 1px solid var(--os-line);
+  border-radius: 8px;
+  color: var(--os-ink);
+  text-decoration: none;
+  font-weight: 850;
+}
+
+.opensource-nav a:hover,
+.action:hover,
+.resource-card:hover,
+.tool-card:hover,
+.ecology-card:hover {
+  border-color: var(--os-rust);
+}
+
+.open-hero,
+main,
+.opensource-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.open-hero {
+  min-height: calc(100vh - 56px);
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(360px, 1.05fr);
+  gap: clamp(1.25rem, 4vw, 4rem);
+  align-items: center;
+  padding: clamp(2rem, 6vw, 5rem) 0;
+}
+
+.hero-copy {
+  max-width: 660px;
+}
+
+.eyebrow {
+  margin: 0 0 0.7rem;
+  color: var(--os-rust);
+  font-size: 0.76rem;
+  font-weight: 950;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p,
+span,
+strong {
+  overflow-wrap: anywhere;
+}
+
+h1 {
+  margin: 0;
+  max-width: 12ch;
+  font-size: clamp(3rem, 8.5vw, 6.6rem);
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(2rem, 4.5vw, 4rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1.15rem;
+  line-height: 1.18;
+}
+
+.hero-copy p,
+.section-intro p,
+.guide-card p,
+.resource-card span,
+.ecology-card span,
+.gap-list span,
+.practice-list span {
+  color: var(--os-muted);
+}
+
+.hero-copy p {
+  max-width: 58ch;
+  margin: 1.25rem 0 0;
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.action {
+  background: var(--os-panel);
+  box-shadow: 0 10px 24px rgba(32, 37, 40, 0.08);
+}
+
+.action.primary {
+  background: var(--os-charcoal);
+  color: #fffaf0;
+  border-color: var(--os-charcoal);
+}
+
+.system-board {
+  min-height: 600px;
+  position: relative;
+  border: 1px solid var(--os-line);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(82, 113, 90, 0.16), transparent 36%),
+    linear-gradient(315deg, rgba(53, 95, 124, 0.13), transparent 38%),
+    #ebe5d8;
+  box-shadow: var(--os-shadow);
+  overflow: hidden;
+}
+
+.system-board::before,
+.system-board::after {
+  content: "";
+  position: absolute;
+  inset: 12%;
+  border: 1px solid rgba(32, 37, 40, 0.15);
+  border-radius: 50%;
+}
+
+.system-board::after {
+  inset: 26%;
+}
+
+.center-node,
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  min-width: 112px;
+  min-height: 58px;
+  padding: 0.7rem;
+  border: 1px solid rgba(32, 37, 40, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 253, 247, 0.88);
+  color: var(--os-charcoal);
+  font-weight: 950;
+  box-shadow: 0 12px 28px rgba(32, 37, 40, 0.11);
+  text-align: center;
+}
+
+.center-node {
+  left: 50%;
+  top: 50%;
+  min-width: 150px;
+  min-height: 86px;
+  background: var(--os-charcoal);
+  color: #fffaf0;
+  transform: translate(-50%, -50%);
+}
+
+.node-os {
+  left: 12%;
+  top: 15%;
+}
+
+.node-browser {
+  right: 11%;
+  top: 19%;
+}
+
+.node-art {
+  left: 10%;
+  bottom: 22%;
+}
+
+.node-hardware {
+  right: 10%;
+  bottom: 23%;
+}
+
+.node-ecology {
+  left: 39%;
+  bottom: 8%;
+}
+
+.node-cad {
+  left: 43%;
+  top: 7%;
+}
+
+main {
+  display: grid;
+  gap: clamp(2.2rem, 5vw, 4rem);
+  padding-bottom: 4rem;
+}
+
+.principles,
+.stack-section,
+.gap-panel,
+.ecology-section,
+.practice-section {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.section-intro {
+  max-width: 820px;
+}
+
+.section-intro p {
+  max-width: 70ch;
+}
+
+.cards,
+.resource-grid,
+.ecology-grid {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.three-up,
+.tool-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.resource-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ecology-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.guide-card,
+.resource-card,
+.gap-panel,
+.gap-list article,
+.ecology-card,
+.practice-list li {
+  border: 1px solid var(--os-line);
+  border-radius: 8px;
+  background: var(--os-panel);
+  box-shadow: 0 10px 28px rgba(32, 37, 40, 0.07);
+}
+
+.guide-card,
+.resource-card,
+.ecology-card {
+  display: grid;
+  align-content: start;
+  min-height: 178px;
+  padding: 1rem;
+  color: var(--os-ink);
+  text-decoration: none;
+}
+
+.kicker {
+  display: inline-flex;
+  width: fit-content;
+  margin-bottom: 1.15rem;
+  color: var(--os-rust);
+  font-size: 0.75rem;
+  font-weight: 950;
+  text-transform: uppercase;
+}
+
+.resource-card strong,
+.ecology-card strong {
+  margin-bottom: 0.45rem;
+  color: var(--os-blue);
+  font-size: 1.05rem;
+}
+
+.gap-panel {
+  grid-template-columns: minmax(0, 0.78fr) minmax(330px, 1.22fr);
+  align-items: start;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.gap-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.gap-list article {
+  display: grid;
+  grid-template-columns: minmax(86px, 0.25fr) 1fr;
+  gap: 0.75rem;
+  padding: 0.85rem;
+}
+
+.gap-list strong {
+  color: var(--os-green);
+}
+
+.ecology-section {
+  padding: clamp(1rem, 3vw, 2rem);
+  border: 1px solid var(--os-line);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(82, 113, 90, 0.12), transparent 42%),
+    var(--os-panel);
+}
+
+.practice-list {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.practice-list li {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.35fr) 1fr;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.practice-list strong {
+  color: var(--os-rust);
+}
+
+.opensource-footer {
+  padding: 1.25rem 0 2rem;
+  border-top: 1px solid var(--os-line);
+  color: var(--os-muted);
+}
+
+@media (max-width: 960px) {
+  .opensource-nav {
+    overflow-x: auto;
+    justify-content: flex-start;
+  }
+
+  .open-hero,
+  .gap-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .open-hero {
+    min-height: auto;
+    padding-top: 2rem;
+  }
+
+  .system-board {
+    min-height: 500px;
+  }
+
+  .three-up,
+  .tool-grid,
+  .resource-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .open-hero,
+  main,
+  .opensource-footer {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  h1 {
+    max-width: 11ch;
+  }
+
+  .system-board {
+    min-height: 470px;
+  }
+
+  .center-node,
+  .node {
+    min-width: 92px;
+    min-height: 50px;
+    font-size: 0.82rem;
+  }
+
+  .three-up,
+  .tool-grid,
+  .resource-grid,
+  .ecology-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gap-list article,
+  .practice-list li {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-actions {
+    display: grid;
+  }
+}

--- a/tests/open-source-page.test.js
+++ b/tests/open-source-page.test.js
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const appDir = new URL('../open-source/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+describe('open source field guide', () => {
+  it('ships the field guide page and styles', async () => {
+    const indexUrl = new URL('index.html', appDir);
+    const stylesUrl = new URL('styles.css', appDir);
+    const readmeUrl = new URL('README.md', appDir);
+
+    assert.equal(await fileExists(indexUrl), true, 'open source index should exist');
+    assert.equal(await fileExists(stylesUrl), true, 'open source styles should exist');
+    assert.equal(await fileExists(readmeUrl), true, 'open source README should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    assert.match(html, /Open Source Field Guide \| 3DVR Portal/);
+    assert.match(html, /Open source is shared infrastructure/);
+    assert.match(html, /Debian, Linux, and browsers/);
+    assert.match(html, /Krita/);
+    assert.match(html, /Blender/);
+    assert.match(html, /FreeCAD/);
+    assert.match(html, /Ardour/);
+    assert.match(html, /Open Source Ecology/);
+    assert.match(html, /https:\/\/www\.opensourceecology\.org\//);
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css/);
+  });
+
+  it('registers the app in the portal dock and installable app list', async () => {
+    const portalHtml = await readFile(new URL('../index.html', appDir), 'utf8');
+    const readme = await readFile(new URL('../README.md', appDir), 'utf8');
+
+    const techIndex = portalHtml.indexOf('>Human-Scale Tech<');
+    const openSourceIndex = portalHtml.indexOf('>Open Source<');
+    const jobTrackerIndex = portalHtml.indexOf('>Job Tracker<');
+
+    assert.ok(openSourceIndex !== -1, 'Open Source app card should be listed on the portal');
+    assert.ok(techIndex !== -1, 'Human-Scale Tech app card should still be listed');
+    assert.ok(jobTrackerIndex !== -1, 'Job Tracker app card should still be listed');
+    assert.ok(techIndex < openSourceIndex, 'Open Source should render after Human-Scale Tech');
+    assert.ok(openSourceIndex < jobTrackerIndex, 'Open Source should render before Job Tracker');
+    assert.match(portalHtml, /href="open-source\/"/);
+    assert.match(readme, /\[Open Source\]\(https:\/\/3dvr-portal\.vercel\.app\/open-source\/\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- add an Open Source field guide page covering Linux, Debian, browsers, creative tools, hardware, phones, and Open Source Ecology
- register the page in the portal dock and README app list
- add tests for the page content and dock placement

## Sources referenced
- Debian: https://www.debian.org/
- Krita: https://krita.org/en/
- Blender: https://www.blender.org/
- Ardour: https://ardour.org/
- PINE64 PinePhone: https://pine64.org/devices/pinephone/
- System76 Open Firmware: https://support.system76.com/articles/open-firmware-systems/
- Open Source Ecology: https://www.opensourceecology.org/

## Tests
- node --test tests/open-source-page.test.js tests/customer-journey-pages.test.js
- git diff --check