### PR TITLE
Add new-account guest migration fast path

### DIFF
--- a/docs/guest-account-migration-plan.md
+++ b/docs/guest-account-migration-plan.md
@@ -36,8 +36,28 @@ The first guest upgrade pass migrates:
 - Guest display name.
 - Guest score.
 - Guest Notes folders/pages.
+- Guest Contacts and Pocket Workstation records when the guest creates a brand-new SEA account.
 
 That is useful, but it is not a general account migration layer.
+
+## New Account Fast Path
+
+Alias-keyed copy is reasonable when the guest is creating a brand-new account because there should be no
+existing user data to reconcile. The sign-in page now distinguishes account creation from existing-account
+login and runs a narrow fast path only for new accounts.
+
+Current new-account fast path:
+
+- Copies guest contacts from `3dvr-guests/<guestId>/contacts` into `gun.user().get('contacts')`.
+- Copies legacy guest contacts from `3dvr-guests/<guestId>/contacts/contacts` into the same user contacts root.
+- Copies Pocket Workstation guest records from
+  `3dvr-portal/pocketWorkstation/users/<guestId>/{notes,commands,projects}` into
+  `3dvr-portal/pocketWorkstation/users/alias-<alias>/{notes,commands,projects}`.
+- Records a migration marker under `3dvr-portal/guestAccountMigrations/<alias>/<guestId>`.
+- Records a guest identity link under `3dvr-portal/guestIdentityLinks/<guestId>`.
+
+This path does not run for existing-account sign-ins. Existing accounts still need namespace-specific merge
+rules so guest data does not overwrite real account data.
 
 ## Desired Architecture
 
@@ -140,7 +160,7 @@ This table needs a code audit before implementation. Some apps may still write t
 - Audit all apps for Gun write paths.
 - Document each namespace, source path, target path, and merge policy.
 - Add `guest-migration.js`.
-- Move current score/name/Notes migration out of `sign-in.html` into the shared helper.
+- Move current score/name/Notes/new-account fast-path migration out of `sign-in.html` into the shared helper.
 - Add unit tests with stub Gun nodes.
 
 ### Phase 2: App Storage Scoping

--- a/sign-in.html
+++ b/sign-in.html
@@ -1233,7 +1233,7 @@
 
       if (gunIsStub) {
         console.warn('Gun.js unavailable; storing credentials locally.');
-        finishLogin(username, alias, password, verifiedRecoveryEmail);
+        finishLogin(username, alias, password, verifiedRecoveryEmail, { isNewAccount: true });
         return;
       }
 
@@ -1269,7 +1269,7 @@
                   alert("⚠️ Auth failed after creating account. Please try again.");
                 } else {
                   console.log("✅ Authenticated after account creation.");
-                  finishLogin(username, alias, password, verifiedRecoveryEmail);
+                  finishLogin(username, alias, password, verifiedRecoveryEmail, { isNewAccount: true });
                 }
               });
             }, 500);
@@ -1277,12 +1277,12 @@
 
         } else {
           console.log("✅ Logged in existing user.");
-          finishLogin(username, alias, password, verifiedRecoveryEmail);
+          finishLogin(username, alias, password, verifiedRecoveryEmail, { isNewAccount: false });
         }
       });
     }
 
-    function finishLogin(username, alias, password, recoveryEmail = '') {
+    function finishLogin(username, alias, password, recoveryEmail = '', { isNewAccount = false } = {}) {
       localStorage.setItem('signedIn', 'true');
       localStorage.setItem('username', username);
       localStorage.setItem('alias', alias);
@@ -1307,7 +1307,7 @@
         user.get('username').put(username);
       }
       localStorage.removeItem('guest');
-      migrateGuestProgress()
+      migrateGuestProgress({ isNewAccount, alias, userPubKey: userPub })
         .catch(err => {
           console.error('Guest migration failed', err);
         })
@@ -1386,7 +1386,7 @@
       return cleaned;
     }
 
-    function copyGunCollection(source, target, { fields = [], nestedFields = [] } = {}) {
+    function copyGunCollection(source, target, { fields = [], nestedFields = [], copyAllFields = false, metadata = null } = {}) {
       return new Promise(resolve => {
         if (!source || typeof source.once !== 'function' || !target || typeof target.get !== 'function') {
           resolve(0);
@@ -1411,12 +1411,16 @@
               if (!cleaned) return;
 
               const targetRecord = target.get(id);
-              const payload = {};
+              const payload = copyAllFields ? { ...cleaned } : {};
+              delete payload._;
               fields.forEach(field => {
                 if (Object.prototype.hasOwnProperty.call(cleaned, field)) {
                   payload[field] = cleaned[field];
                 }
               });
+              if (metadata && Object.keys(payload).length > 0) {
+                Object.assign(payload, metadata);
+              }
               if (Object.keys(payload).length > 0) {
                 targetRecord.put(payload);
               }
@@ -1438,6 +1442,14 @@
       });
     }
 
+    function migrationMetadata(namespace, guestId) {
+      return {
+        migratedFromGuestId: guestId,
+        migratedAt: Date.now(),
+        migrationNamespace: namespace
+      };
+    }
+
     function migrateGuestNotes(guestProfile) {
       if (!guestProfile || typeof guestProfile.get !== 'function' || !user || typeof user.get !== 'function') {
         return Promise.resolve();
@@ -1454,7 +1466,53 @@
       ]);
     }
 
-    function migrateGuestProgress() {
+    function migrateNewGuestAccountData(guestProfile, { guestId, alias }) {
+      if (!guestProfile || typeof guestProfile.get !== 'function' || !user || typeof user.get !== 'function') {
+        return Promise.resolve();
+      }
+
+      const tasks = [];
+      const contactsMetadata = migrationMetadata('contacts', guestId);
+      const guestContacts = guestProfile.get('contacts');
+      tasks.push(copyGunCollection(guestContacts, user.get('contacts'), {
+        copyAllFields: true,
+        metadata: contactsMetadata
+      }));
+      tasks.push(copyGunCollection(guestContacts.get('contacts'), user.get('contacts'), {
+        copyAllFields: true,
+        metadata: contactsMetadata
+      }));
+
+      const normalizedAlias = String(alias || '').trim().toLowerCase();
+      if (normalizedAlias && portalRoot && typeof portalRoot.get === 'function') {
+        const pocketRoot = portalRoot.get('pocketWorkstation').get('users');
+        const pocketSource = pocketRoot.get(guestId);
+        const pocketTarget = pocketRoot.get(`alias-${normalizedAlias}`);
+        ['notes', 'commands', 'projects'].forEach(type => {
+          tasks.push(copyGunCollection(pocketSource.get(type), pocketTarget.get(type), {
+            copyAllFields: true,
+            metadata: migrationMetadata(`pocketWorkstation.${type}`, guestId)
+          }));
+        });
+
+        portalRoot.get('guestAccountMigrations').get(normalizedAlias).get(guestId).put({
+          guestId,
+          alias: normalizedAlias,
+          mode: 'new-account-fast-path',
+          migratedAt: Date.now()
+        });
+        portalRoot.get('guestIdentityLinks').get(guestId).put({
+          guestId,
+          alias: normalizedAlias,
+          linkedAt: Date.now(),
+          reason: 'new-account-fast-path'
+        });
+      }
+
+      return Promise.all(tasks);
+    }
+
+    function migrateGuestProgress({ isNewAccount = false, alias = '' } = {}) {
       return new Promise(resolve => {
         const guestId = localStorage.getItem('guestId');
         if (!guestId) {
@@ -1488,6 +1546,13 @@
             await migrateGuestNotes(guestProfile);
           } catch (err) {
             console.warn('Unable to migrate guest notes', err);
+          }
+          if (isNewAccount) {
+            try {
+              await migrateNewGuestAccountData(guestProfile, { guestId, alias });
+            } catch (err) {
+              console.warn('Unable to run new-account guest migration', err);
+            }
           }
           clearGuestSession();
           resolve();

--- a/tests/sign-in-page.test.js
+++ b/tests/sign-in-page.test.js
@@ -80,10 +80,22 @@ describe('sign-in page', () => {
     assert.match(html, /params\.get\('upgrade'\) === 'guest'/);
     assert.match(html, /Save your guest progress/);
     assert.match(html, /Create account and keep progress/);
-    assert.match(html, /migrateGuestProgress\(\)/);
+    assert.match(html, /migrateGuestProgress\(\{ isNewAccount, alias, userPubKey: userPub \}\)/);
     assert.match(html, /function migrateGuestNotes\(guestProfile\)/);
     assert.match(html, /guestProfile\.get\('notes'\)/);
     assert.match(html, /user\.get\('notes'\)/);
     assert.match(html, /Stay in guest mode/);
+  });
+
+  it('runs the guest data fast path only for newly created accounts', async () => {
+    const html = await readFile(signInUrl, 'utf8');
+    assert.match(html, /finishLogin\(username, alias, password, verifiedRecoveryEmail, \{ isNewAccount: true \}\)/);
+    assert.match(html, /finishLogin\(username, alias, password, verifiedRecoveryEmail, \{ isNewAccount: false \}\)/);
+    assert.match(html, /function migrateNewGuestAccountData\(guestProfile, \{ guestId, alias \}\)/);
+    assert.match(html, /guestProfile\.get\('contacts'\)/);
+    assert.match(html, /user\.get\('contacts'\)/);
+    assert.match(html, /pocketWorkstation'\)\.get\('users'\)/);
+    assert.match(html, /guestAccountMigrations/);
+    assert.match(html, /guestIdentityLinks/);
   });
 });


### PR DESCRIPTION
## Summary
- distinguish newly created accounts from existing account sign-ins during portal sign-in
- run a new-account-only guest data fast path for contacts and Pocket Workstation records
- keep existing score/name/Notes guest migration and record migration markers for recovery/debug
- document the new-account fast path in the guest migration plan

## Tests
- node --test tests/sign-in-page.test.js tests/guest-upgrade-entrypoints.test.js tests/contacts-core.test.js tests/pocket-workstation.test.js
- git diff --check