### PR TITLE
Simplify guest account entrypoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -751,8 +751,7 @@
 
     function startAccountFromHere() {
       const currentPath = `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`;
-      const upgradeParam = localStorage.getItem('guest') === 'true' ? '&upgrade=guest' : '';
-      window.location.href = `/sign-in.html?redirect=${encodeURIComponent(currentPath || '/index.html')}${upgradeParam}`;
+      window.location.href = `/sign-in.html?redirect=${encodeURIComponent(currentPath || '/index.html')}`;
     }
   </script>
 

--- a/navbar.js
+++ b/navbar.js
@@ -20,15 +20,6 @@ function clearSharedIdentityCookie() {
   }
 }
 
-function currentUpgradeRedirect() {
-  const path = `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`;
-  return path || '/index.html';
-}
-
-function guestUpgradeHref() {
-  return `/sign-in.html?upgrade=guest&redirect=${encodeURIComponent(currentUpgradeRedirect())}`;
-}
-
 function hideUnreadyHomepageSections() {
   const systemLayers = document.getElementById('systemLayers');
   if (systemLayers) {
@@ -104,15 +95,12 @@ function createNavbar() {
   button.innerText = 'Sign Out';
 
   button.addEventListener('click', () => {
-    if (isGuest) {
-      window.location.href = guestUpgradeHref();
-      return;
-    }
-
-    try {
-      user.leave();
-    } catch (err) {
-      console.warn('Error signing out', err);
+    if (!isGuest) {
+      try {
+        user.leave();
+      } catch (err) {
+        console.warn('Error signing out', err);
+      }
     }
     if (window.ScoreSystem) {
       window.ScoreSystem.resetManager();
@@ -153,11 +141,11 @@ function createNavbar() {
   let aliasDisplay = aliasToDisplay(localStorage.getItem('alias'));
 
   if (isGuest) {
-    stats.href = guestUpgradeHref();
-    stats.setAttribute('aria-label', 'Create an account and keep your guest progress');
-    stats.title = 'Create an account and keep your guest progress';
-    button.innerText = 'Create account';
-    button.setAttribute('aria-label', 'Create an account and keep guest progress');
+    stats.href = 'profile.html#profile';
+    stats.setAttribute('aria-label', 'View your guest profile details');
+    stats.title = 'View your guest profile';
+    button.innerText = 'Sign Out';
+    button.setAttribute('aria-label', 'Sign out of guest mode');
   }
 
   function updateNameDisplay() {

--- a/sign-in.html
+++ b/sign-in.html
@@ -810,7 +810,7 @@
 
     function isGuestUpgradeContext() {
       const params = new URLSearchParams(window.location.search);
-      return params.get('upgrade') === 'guest' || localStorage.getItem('guest') === 'true';
+      return params.get('upgrade') === 'guest';
     }
 
     function applyRedirectContext() {

--- a/tests/guest-upgrade-entrypoints.test.js
+++ b/tests/guest-upgrade-entrypoints.test.js
@@ -5,21 +5,22 @@ import { readFile } from 'node:fs/promises';
 const navbarUrl = new URL('../navbar.js', import.meta.url);
 const indexUrl = new URL('../index.html', import.meta.url);
 
-describe('guest upgrade entrypoints', () => {
-  it('turns the floating guest identity action into account creation', async () => {
+describe('guest account entrypoints', () => {
+  it('keeps the floating guest identity action as sign out instead of account creation', async () => {
     const source = await readFile(navbarUrl, 'utf8');
-    assert.match(source, /function guestUpgradeHref\(\)/);
-    assert.match(source, /upgrade=guest/);
-    assert.match(source, /Create account/);
-    assert.match(source, /Create an account and keep guest progress/);
-    assert.match(source, /if \(isGuest\) \{\s*window\.location\.href = guestUpgradeHref\(\);/);
+    assert.doesNotMatch(source, /function guestUpgradeHref\(\)/);
+    assert.doesNotMatch(source, /upgrade=guest/);
+    assert.doesNotMatch(source, /Create an account and keep guest progress/);
+    assert.match(source, /button\.innerText = 'Sign Out'/);
+    assert.match(source, /button\.setAttribute\('aria-label', 'Sign out of guest mode'\)/);
   });
 
-  it('sends the homepage auth modal through the upgrade-aware sign-in link', async () => {
+  it('sends the homepage auth modal to normal sign-in without the guest upgrade flag', async () => {
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /onclick="startAccountFromHere\(\)"/);
     assert.match(html, /function startAccountFromHere\(\)/);
-    assert.match(html, /upgradeParam = localStorage\.getItem\('guest'\) === 'true' \? '&upgrade=guest' : ''/);
+    assert.doesNotMatch(html, /upgradeParam/);
+    assert.doesNotMatch(html, /&upgrade=guest/);
     assert.match(html, /\/sign-in\.html\?redirect=/);
   });
 });

--- a/tests/sign-in-page.test.js
+++ b/tests/sign-in-page.test.js
@@ -78,6 +78,7 @@ describe('sign-in page', () => {
     const html = await readFile(signInUrl, 'utf8');
     assert.match(html, /function isGuestUpgradeContext\(\)/);
     assert.match(html, /params\.get\('upgrade'\) === 'guest'/);
+    assert.doesNotMatch(html, /localStorage\.getItem\('guest'\) === 'true';/);
     assert.match(html, /Save your guest progress/);
     assert.match(html, /Create account and keep progress/);
     assert.match(html, /migrateGuestProgress\(\{ isNewAccount, alias, userPubKey: userPub \}\)/);


### PR DESCRIPTION
## Summary
- restore the floating guest identity button to a plain Sign Out action
- stop generating guest upgrade URLs from the home auth modal
- require an explicit upgrade=guest URL before the sign-in page shows guest-upgrade copy
- keep the migration code available for normal new-account creation, but remove the prominent guest UI push

## Tests
- node --test tests/guest-upgrade-entrypoints.test.js tests/sign-in-page.test.js tests/auth-identity.test.js
- git diff --check