### PR TITLE
Add native WebRTC lab proof of concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Pocket Workstation](https://3dvr-portal.vercel.app/pocket-workstation/)
 - [Phone Holder System](https://3dvr-portal.vercel.app/phone-holder-system/)
 - [Open Source](https://3dvr-portal.vercel.app/open-source/)
+- [WebRTC Lab](https://3dvr-portal.vercel.app/webrtc-lab/)
 - [Chat](https://3dvr-portal.vercel.app/chat/)
 - [Calendar Hub](https://3dvr-portal.vercel.app/calendar/)
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)

--- a/index.html
+++ b/index.html
@@ -445,6 +445,12 @@
             <span class="app-card__title">Video Chat</span>
             <span class="app-card__meta">Jump into 3dvr.tech Ninja meetings in one click.</span>
           </a>
+          <a href="webrtc-lab/" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">RTC</span>
+            <span class="app-card__title">WebRTC Lab</span>
+            <span class="app-card__meta">Test native browser video rooms with Gun-backed signaling.</span>
+          </a>
           <a href="wellness.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌿</span>
             <span class="app-card__title">Wellness</span>

--- a/portal.3dvr.tech/video/index.html
+++ b/portal.3dvr.tech/video/index.html
@@ -85,6 +85,9 @@
       <a class="button secondary" href="/portal.3dvr.tech/video/ops.html">
         🛠️ Meeting Ops
       </a>
+      <a class="button secondary" href="/webrtc-lab/">
+        Native WebRTC Lab
+      </a>
       <!-- Crunched room preset -->
       <a class="button secondary" target="_blank" rel="noopener"
         href="https://vdo.ninja/?room=3dvrtech&label&showlabels&codec=h264&vb=120&ab=24&fps=4&scale=96p&stereo=0&buffer=30">

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const appDir = new URL('../webrtc-lab/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+describe('WebRTC Lab app', () => {
+  it('ships a native WebRTC proof of concept with Gun signaling', async () => {
+    const indexUrl = new URL('index.html', appDir);
+    const stylesUrl = new URL('styles.css', appDir);
+    const appUrl = new URL('app.js', appDir);
+    const readmeUrl = new URL('README.md', appDir);
+
+    assert.equal(await fileExists(indexUrl), true, 'WebRTC Lab index should exist');
+    assert.equal(await fileExists(stylesUrl), true, 'WebRTC Lab styles should exist');
+    assert.equal(await fileExists(appUrl), true, 'WebRTC Lab app script should exist');
+    assert.equal(await fileExists(readmeUrl), true, 'WebRTC Lab README should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    const js = await readFile(appUrl, 'utf8');
+    const readme = await readFile(readmeUrl, 'utf8');
+
+    assert.match(html, /3DVR WebRTC Lab \| Portal/);
+    assert.match(html, /Native WebRTC POC/);
+    assert.match(html, /id="local-video"/);
+    assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
+    assert.match(html, /<script src="\.\/app\.js"><\/script>/);
+    assert.match(js, /new RTCPeerConnection\(\{ iceServers: ICE_SERVERS \}\)/);
+    assert.match(js, /navigator\.mediaDevices\.getUserMedia/);
+    assert.match(js, /ROOM_ROOT = '3dvr-webrtc-lab'/);
+    assert.match(js, /signalsNode\.map\(\)\.on\(handleSignal\)/);
+    assert.match(js, /participantsNode\.map\(\)\.on/);
+    assert.match(readme, /Mesh WebRTC/);
+  });
+
+  it('registers the lab in the portal and existing video hub', async () => {
+    const portalHtml = await readFile(new URL('../index.html', appDir), 'utf8');
+    const readme = await readFile(new URL('../README.md', appDir), 'utf8');
+    const videoHome = await readFile(new URL('../portal.3dvr.tech/video/index.html', appDir), 'utf8');
+
+    assert.match(portalHtml, /href="webrtc-lab\/"/);
+    assert.match(portalHtml, />WebRTC Lab</);
+    assert.match(readme, /\[WebRTC Lab\]\(https:\/\/3dvr-portal\.vercel\.app\/webrtc-lab\/\)/);
+    assert.match(videoHome, /href="\/webrtc-lab\/"/);
+    assert.match(videoHome, /Native WebRTC Lab/);
+  });
+});

--- a/webrtc-lab/README.md
+++ b/webrtc-lab/README.md
@@ -1,0 +1,12 @@
+# 3DVR WebRTC Lab
+
+Native WebRTC proof of concept for small 3DVR video rooms.
+
+This app uses:
+
+- WebRTC peer connections for media.
+- Browser `getUserMedia()` for camera and microphone access.
+- Gun at `3dvr-webrtc-lab/<room>` for lightweight signaling and room presence.
+- Public STUN servers for NAT discovery.
+
+It is intentionally not a production replacement for a Selective Forwarding Unit. Mesh WebRTC is useful for two or three people while testing connection behavior, but larger meetings need an SFU or other managed media layer.

--- a/webrtc-lab/app.js
+++ b/webrtc-lab/app.js
@@ -1,0 +1,396 @@
+(function initWebRtcLab() {
+  const refs = {
+    roomForm: document.getElementById('room-form'),
+    displayName: document.getElementById('display-name'),
+    roomId: document.getElementById('room-id'),
+    randomRoom: document.getElementById('random-room'),
+    copyLink: document.getElementById('copy-link'),
+    startCamera: document.getElementById('start-camera'),
+    toggleMic: document.getElementById('toggle-mic'),
+    toggleCamera: document.getElementById('toggle-camera'),
+    leaveRoom: document.getElementById('leave-room'),
+    statusLine: document.getElementById('status-line'),
+    localVideo: document.getElementById('local-video'),
+    localLabel: document.getElementById('local-label'),
+    localState: document.getElementById('local-state'),
+    videoGrid: document.getElementById('video-grid'),
+    eventLog: document.getElementById('event-log')
+  };
+
+  const ICE_SERVERS = [
+    { urls: 'stun:stun.l.google.com:19302' },
+    { urls: 'stun:stun1.l.google.com:19302' }
+  ];
+  const ROOM_ROOT = '3dvr-webrtc-lab';
+  const SIGNAL_TTL_MS = 1000 * 60 * 20;
+
+  let gun = null;
+  let roomNode = null;
+  let participantsNode = null;
+  let signalsNode = null;
+  let roomId = '';
+  let localId = getOrCreateLocalId();
+  let localName = '';
+  let localStream = null;
+  let joined = false;
+  let heartbeatTimer = null;
+  const peers = new Map();
+  const seenSignals = new Set();
+
+  function normalizeRoom(value = '') {
+    return String(value || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80);
+  }
+
+  function createId(prefix = 'rtc') {
+    return `${prefix}_${Math.random().toString(36).slice(2, 10)}_${Date.now().toString(36)}`;
+  }
+
+  function getOrCreateLocalId() {
+    try {
+      const stored = localStorage.getItem('webrtcLabParticipantId');
+      if (stored) return stored;
+      const next = createId('peer');
+      localStorage.setItem('webrtcLabParticipantId', next);
+      return next;
+    } catch (_error) {
+      return createId('peer');
+    }
+  }
+
+  function logEvent(message) {
+    const item = document.createElement('li');
+    item.textContent = `${new Date().toLocaleTimeString()} ${message}`;
+    refs.eventLog.prepend(item);
+    while (refs.eventLog.children.length > 40) {
+      refs.eventLog.lastElementChild.remove();
+    }
+  }
+
+  function setStatus(message) {
+    refs.statusLine.textContent = message;
+    logEvent(message);
+  }
+
+  function resolveInitialRoom() {
+    const params = new URLSearchParams(window.location.search);
+    const fromUrl = normalizeRoom(params.get('room') || '');
+    if (fromUrl) return fromUrl;
+    return `3dvr-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}`;
+  }
+
+  function updateRoomUrl() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('room', roomId);
+    window.history.replaceState({}, '', url.toString());
+  }
+
+  function roomLink() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('room', normalizeRoom(refs.roomId.value) || roomId || resolveInitialRoom());
+    return url.toString();
+  }
+
+  function ensureGun() {
+    if (gun) return gun;
+    if (typeof Gun !== 'function') {
+      throw new Error('Gun is not available for signaling.');
+    }
+    gun = Gun({
+      peers: window.__GUN_PEERS__ || [
+        'wss://relay.3dvr.tech/gun',
+        'wss://gun-relay-3dvr.fly.dev/gun'
+      ],
+      axe: true
+    });
+    return gun;
+  }
+
+  async function startCamera() {
+    if (localStream) return localStream;
+    if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+      throw new Error('This browser does not expose camera/mic access.');
+    }
+    localStream = await navigator.mediaDevices.getUserMedia({
+      video: {
+        width: { ideal: 640 },
+        height: { ideal: 360 },
+        frameRate: { ideal: 15, max: 24 }
+      },
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true
+      }
+    });
+    refs.localVideo.srcObject = localStream;
+    refs.startCamera.disabled = true;
+    refs.toggleMic.disabled = false;
+    refs.toggleCamera.disabled = false;
+    refs.localState.textContent = 'Camera on';
+    setStatus('Camera ready.');
+    peers.forEach(peer => {
+      localStream.getTracks().forEach(track => peer.connection.addTrack(track, localStream));
+    });
+    return localStream;
+  }
+
+  function stopLocalStream() {
+    if (!localStream) return;
+    localStream.getTracks().forEach(track => track.stop());
+    localStream = null;
+    refs.localVideo.srcObject = null;
+    refs.startCamera.disabled = false;
+    refs.toggleMic.disabled = true;
+    refs.toggleCamera.disabled = true;
+    refs.localState.textContent = 'Camera off';
+  }
+
+  function createPeer(remoteId, remoteName = 'Guest') {
+    if (peers.has(remoteId)) return peers.get(remoteId);
+    const connection = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+    const peer = {
+      id: remoteId,
+      name: remoteName || 'Guest',
+      connection,
+      stream: new MediaStream(),
+      tile: createRemoteTile(remoteId, remoteName)
+    };
+    peers.set(remoteId, peer);
+
+    if (localStream) {
+      localStream.getTracks().forEach(track => connection.addTrack(track, localStream));
+    }
+
+    connection.ontrack = event => {
+      event.streams[0].getTracks().forEach(track => peer.stream.addTrack(track));
+      peer.tile.video.srcObject = peer.stream;
+      peer.tile.state.textContent = 'Connected';
+    };
+
+    connection.onicecandidate = event => {
+      if (event.candidate) {
+        sendSignal(remoteId, 'candidate', event.candidate);
+      }
+    };
+
+    connection.onconnectionstatechange = () => {
+      peer.tile.state.textContent = connection.connectionState;
+      if (['failed', 'closed', 'disconnected'].includes(connection.connectionState)) {
+        logEvent(`${peer.name} ${connection.connectionState}.`);
+      }
+    };
+
+    logEvent(`Peer ready: ${peer.name}.`);
+    return peer;
+  }
+
+  function createRemoteTile(remoteId, name) {
+    const tile = document.createElement('article');
+    tile.className = 'video-tile';
+    tile.dataset.peerId = remoteId;
+    const video = document.createElement('video');
+    video.autoplay = true;
+    video.playsInline = true;
+    const label = document.createElement('div');
+    label.className = 'tile-label';
+    const title = document.createElement('strong');
+    title.textContent = name || 'Guest';
+    const state = document.createElement('span');
+    state.textContent = 'Connecting';
+    label.append(title, state);
+    tile.append(video, label);
+    refs.videoGrid.appendChild(tile);
+    return { tile, video, state, title };
+  }
+
+  async function makeOffer(remoteId, remoteName) {
+    const peer = createPeer(remoteId, remoteName);
+    const offer = await peer.connection.createOffer();
+    await peer.connection.setLocalDescription(offer);
+    sendSignal(remoteId, 'offer', peer.connection.localDescription);
+    logEvent(`Offer sent to ${remoteName || remoteId}.`);
+  }
+
+  async function handleOffer(signal) {
+    const peer = createPeer(signal.from, signal.fromName);
+    await peer.connection.setRemoteDescription(new RTCSessionDescription(signal.payload));
+    const answer = await peer.connection.createAnswer();
+    await peer.connection.setLocalDescription(answer);
+    sendSignal(signal.from, 'answer', peer.connection.localDescription);
+    logEvent(`Answer sent to ${signal.fromName || signal.from}.`);
+  }
+
+  async function handleAnswer(signal) {
+    const peer = peers.get(signal.from);
+    if (!peer) return;
+    await peer.connection.setRemoteDescription(new RTCSessionDescription(signal.payload));
+    logEvent(`Answer received from ${signal.fromName || signal.from}.`);
+  }
+
+  async function handleCandidate(signal) {
+    const peer = peers.get(signal.from) || createPeer(signal.from, signal.fromName);
+    try {
+      await peer.connection.addIceCandidate(new RTCIceCandidate(signal.payload));
+    } catch (error) {
+      console.warn('ICE candidate failed', error);
+    }
+  }
+
+  function sendSignal(to, type, payload) {
+    if (!signalsNode) return;
+    const id = createId('signal');
+    signalsNode.get(id).put({
+      id,
+      roomId,
+      from: localId,
+      fromName: localName,
+      to,
+      type,
+      payload,
+      createdAt: Date.now()
+    });
+  }
+
+  function handleSignal(signal, id) {
+    if (!signal || id === '_' || seenSignals.has(id)) return;
+    if (signal.to !== localId || signal.from === localId) return;
+    if (Date.now() - Number(signal.createdAt || 0) > SIGNAL_TTL_MS) return;
+    seenSignals.add(id);
+    Promise.resolve()
+      .then(() => {
+        if (signal.type === 'offer') return handleOffer(signal);
+        if (signal.type === 'answer') return handleAnswer(signal);
+        if (signal.type === 'candidate') return handleCandidate(signal);
+        return null;
+      })
+      .catch(error => {
+        console.error('Signal handling failed', error);
+        setStatus(`Signal failed: ${error.message || error}`);
+      });
+  }
+
+  function publishPresence() {
+    if (!participantsNode) return;
+    participantsNode.get(localId).put({
+      id: localId,
+      name: localName,
+      joinedAt: Date.now(),
+      lastSeen: Date.now()
+    });
+  }
+
+  function watchParticipants() {
+    participantsNode.map().on((participant, id) => {
+      if (!joined || !participant || id === '_' || id === localId) return;
+      const lastSeen = Number(participant.lastSeen || 0);
+      if (Date.now() - lastSeen > 45000) return;
+      if (!peers.has(id) && localId < id) {
+        makeOffer(id, participant.name).catch(error => {
+          console.error('Offer failed', error);
+          setStatus(`Offer failed: ${error.message || error}`);
+        });
+      }
+    });
+  }
+
+  async function joinRoom(event) {
+    if (event) event.preventDefault();
+    roomId = normalizeRoom(refs.roomId.value) || resolveInitialRoom();
+    refs.roomId.value = roomId;
+    localName = String(refs.displayName.value || '').trim() || `Guest ${localId.slice(-4)}`;
+    refs.localLabel.textContent = `${localName} (you)`;
+    ensureGun();
+    roomNode = gun.get(ROOM_ROOT).get(roomId);
+    participantsNode = roomNode.get('participants');
+    signalsNode = roomNode.get('signals');
+    updateRoomUrl();
+    joined = true;
+    refs.leaveRoom.disabled = false;
+    publishPresence();
+    heartbeatTimer = setInterval(publishPresence, 10000);
+    signalsNode.map().on(handleSignal);
+    watchParticipants();
+    setStatus(`Joined room ${roomId}. Start camera if it is not already on.`);
+  }
+
+  function leaveRoom() {
+    joined = false;
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    if (participantsNode) {
+      participantsNode.get(localId).put(null);
+    }
+    peers.forEach(peer => {
+      peer.connection.close();
+      peer.tile.tile.remove();
+    });
+    peers.clear();
+    refs.leaveRoom.disabled = true;
+    setStatus('Left room.');
+  }
+
+  function toggleMic() {
+    if (!localStream) return;
+    const enabled = !localStream.getAudioTracks().every(track => track.enabled);
+    localStream.getAudioTracks().forEach(track => {
+      track.enabled = enabled;
+    });
+    refs.toggleMic.textContent = enabled ? 'Mute mic' : 'Unmute mic';
+    refs.localState.textContent = enabled ? 'Mic on' : 'Mic muted';
+  }
+
+  function toggleCamera() {
+    if (!localStream) return;
+    const enabled = !localStream.getVideoTracks().every(track => track.enabled);
+    localStream.getVideoTracks().forEach(track => {
+      track.enabled = enabled;
+    });
+    refs.toggleCamera.textContent = enabled ? 'Hide camera' : 'Show camera';
+    refs.localState.textContent = enabled ? 'Camera on' : 'Camera hidden';
+  }
+
+  async function copyLink() {
+    const link = roomLink();
+    try {
+      await navigator.clipboard.writeText(link);
+      setStatus('Room link copied.');
+    } catch (_error) {
+      window.prompt('Copy room link', link);
+    }
+  }
+
+  function init() {
+    refs.roomId.value = resolveInitialRoom();
+    try {
+      refs.displayName.value = localStorage.getItem('username')
+        || localStorage.getItem('guestDisplayName')
+        || '';
+    } catch (_error) {
+      refs.displayName.value = '';
+    }
+    refs.randomRoom.addEventListener('click', () => {
+      refs.roomId.value = createId('room').replace(/^room_/, '3dvr-');
+    });
+    refs.copyLink.addEventListener('click', copyLink);
+    refs.startCamera.addEventListener('click', () => {
+      startCamera().catch(error => setStatus(error.message || 'Unable to start camera.'));
+    });
+    refs.roomForm.addEventListener('submit', joinRoom);
+    refs.toggleMic.addEventListener('click', toggleMic);
+    refs.toggleCamera.addEventListener('click', toggleCamera);
+    refs.leaveRoom.addEventListener('click', leaveRoom);
+    window.addEventListener('beforeunload', () => {
+      leaveRoom();
+      stopLocalStream();
+    });
+  }
+
+  init();
+})();

--- a/webrtc-lab/index.html
+++ b/webrtc-lab/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3DVR WebRTC Lab | Portal</title>
+  <meta
+    name="description"
+    content="A native WebRTC proof-of-concept for 3DVR video rooms with Gun-backed signaling."
+  >
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <link rel="stylesheet" href="../style.css?v=webrtc-lab">
+  <link rel="stylesheet" href="./styles.css?v=20260519">
+</head>
+<body class="webrtc-page">
+  <header class="lab-header">
+    <nav class="lab-nav" aria-label="WebRTC Lab navigation">
+      <a href="../index.html">Portal</a>
+      <a href="/portal.3dvr.tech/video/">Video Home</a>
+      <a href="/meeting-notes/">Meeting Notes</a>
+    </nav>
+    <section class="hero-grid">
+      <div>
+        <p class="eyebrow">Native WebRTC POC</p>
+        <h1>Simple video rooms without vdo.ninja.</h1>
+        <p>
+          A small browser-to-browser conferencing experiment. Gun relays the room signals; WebRTC carries
+          the audio and video directly between participants.
+        </p>
+      </div>
+      <aside class="lab-note">
+        <strong>Proof of concept</strong>
+        <span>This is mesh WebRTC, not a production SFU. It is best for two or three people while we test reliability.</span>
+      </aside>
+    </section>
+  </header>
+
+  <main class="lab-shell">
+    <section class="room-panel" aria-labelledby="room-title">
+      <div>
+        <p class="eyebrow">Room</p>
+        <h2 id="room-title">Start or join a room</h2>
+      </div>
+      <form id="room-form" class="room-form">
+        <label for="display-name">Name</label>
+        <input id="display-name" name="displayName" type="text" maxlength="40" autocomplete="name">
+        <label for="room-id">Room</label>
+        <div class="room-row">
+          <input id="room-id" name="roomId" type="text" maxlength="80" required>
+          <button type="button" id="random-room">Random</button>
+        </div>
+        <div class="button-row">
+          <button type="submit" class="primary">Join room</button>
+          <button type="button" id="copy-link">Copy link</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="controls-panel" aria-label="Media controls">
+      <button type="button" id="start-camera" class="primary">Start camera</button>
+      <button type="button" id="toggle-mic" disabled>Mute mic</button>
+      <button type="button" id="toggle-camera" disabled>Hide camera</button>
+      <button type="button" id="leave-room" disabled>Leave</button>
+      <p id="status-line" class="status-line" role="status">Choose a room and start your camera.</p>
+    </section>
+
+    <section class="video-grid" id="video-grid" aria-label="Video tiles">
+      <article class="video-tile local-tile">
+        <video id="local-video" autoplay muted playsinline></video>
+        <div class="tile-label">
+          <strong id="local-label">You</strong>
+          <span id="local-state">Camera off</span>
+        </div>
+      </article>
+    </section>
+
+    <section class="debug-panel" aria-labelledby="debug-title">
+      <div>
+        <p class="eyebrow">Signals</p>
+        <h2 id="debug-title">Connection log</h2>
+      </div>
+      <ol id="event-log" aria-live="polite"></ol>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <p>Built as a 3DVR WebRTC proof of concept. Use HTTPS or localhost so browser camera permissions work.</p>
+  </footer>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/webrtc-lab/styles.css
+++ b/webrtc-lab/styles.css
@@ -1,0 +1,297 @@
+:root {
+  --rtc-bg: #f5f2ea;
+  --rtc-ink: #1d2428;
+  --rtc-muted: #677178;
+  --rtc-panel: #fffdf7;
+  --rtc-line: #d7cfbf;
+  --rtc-blue: #315f7e;
+  --rtc-green: #50735b;
+  --rtc-rust: #985c35;
+  --rtc-dark: #142027;
+  --rtc-shadow: 0 18px 42px rgba(29, 36, 40, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.webrtc-page {
+  margin: 0;
+  background: var(--rtc-bg);
+  color: var(--rtc-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.55;
+}
+
+.lab-header,
+.lab-shell,
+.lab-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.lab-nav {
+  display: flex;
+  gap: 0.45rem;
+  padding: 0.75rem 0;
+}
+
+.lab-nav a,
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.62rem 0.85rem;
+  border: 1px solid var(--rtc-line);
+  border-radius: 8px;
+  background: var(--rtc-panel);
+  color: var(--rtc-ink);
+  font: inherit;
+  font-weight: 850;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+button.primary {
+  background: var(--rtc-dark);
+  border-color: var(--rtc-dark);
+  color: #fffaf0;
+}
+
+button:disabled {
+  opacity: 0.52;
+  cursor: not-allowed;
+}
+
+.hero-grid {
+  min-height: 44vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.42fr);
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: end;
+  padding: clamp(2rem, 5vw, 4rem) 0;
+}
+
+.eyebrow {
+  margin: 0 0 0.65rem;
+  color: var(--rtc-rust);
+  font-size: 0.76rem;
+  font-weight: 950;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p,
+span,
+strong {
+  overflow-wrap: anywhere;
+}
+
+h1 {
+  max-width: 12ch;
+  margin: 0;
+  font-size: clamp(3rem, 8vw, 6.2rem);
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3.5vw, 2.8rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.hero-grid p {
+  max-width: 60ch;
+  margin: 1rem 0 0;
+  color: var(--rtc-muted);
+  font-size: 1.08rem;
+}
+
+.lab-note,
+.room-panel,
+.controls-panel,
+.debug-panel {
+  border: 1px solid var(--rtc-line);
+  border-radius: 8px;
+  background: var(--rtc-panel);
+  box-shadow: var(--rtc-shadow);
+}
+
+.lab-note {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem;
+}
+
+.lab-note strong {
+  color: var(--rtc-blue);
+}
+
+.lab-note span {
+  color: var(--rtc-muted);
+}
+
+.lab-shell {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.42fr) minmax(0, 1fr);
+  gap: 1rem;
+  padding-bottom: 4rem;
+}
+
+.room-panel,
+.controls-panel,
+.debug-panel {
+  padding: 1rem;
+}
+
+.room-panel,
+.controls-panel {
+  align-self: start;
+}
+
+.room-form {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
+label {
+  color: var(--rtc-muted);
+  font-size: 0.85rem;
+  font-weight: 850;
+}
+
+input {
+  width: 100%;
+  min-height: 42px;
+  padding: 0.66rem 0.75rem;
+  border: 1px solid var(--rtc-line);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--rtc-ink);
+  font: inherit;
+}
+
+.room-row,
+.button-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+}
+
+.controls-panel {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.status-line {
+  margin: 0.4rem 0 0;
+  color: var(--rtc-muted);
+  font-size: 0.92rem;
+}
+
+.video-grid {
+  grid-row: span 2;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.video-tile {
+  min-height: 260px;
+  position: relative;
+  border: 1px solid var(--rtc-line);
+  border-radius: 8px;
+  background: #111a20;
+  overflow: hidden;
+  box-shadow: var(--rtc-shadow);
+}
+
+.video-tile video {
+  width: 100%;
+  height: 100%;
+  min-height: 260px;
+  display: block;
+  object-fit: cover;
+  background: #111a20;
+}
+
+.tile-label {
+  position: absolute;
+  left: 0.75rem;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 8px;
+  background: rgba(20, 32, 39, 0.78);
+  color: #fffaf0;
+  backdrop-filter: blur(10px);
+}
+
+.tile-label span {
+  color: rgba(255, 250, 240, 0.72);
+}
+
+.debug-panel {
+  grid-column: 1 / -1;
+}
+
+#event-log {
+  display: grid;
+  gap: 0.45rem;
+  max-height: 260px;
+  overflow: auto;
+  padding-left: 1.3rem;
+  color: var(--rtc-muted);
+}
+
+.lab-footer {
+  padding: 1.25rem 0 2rem;
+  border-top: 1px solid var(--rtc-line);
+  color: var(--rtc-muted);
+}
+
+@media (max-width: 900px) {
+  .hero-grid,
+  .lab-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-grid {
+    min-height: auto;
+  }
+
+  .video-grid {
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 620px) {
+  .lab-header,
+  .lab-shell,
+  .lab-footer {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  .lab-nav,
+  .button-row {
+    display: grid;
+  }
+
+  .room-row {
+    grid-template-columns: 1fr;
+  }
+
+  .video-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add /webrtc-lab as a native browser WebRTC proof of concept with Gun-backed signaling
- include room links, local media controls, remote video tiles, status logs, and mesh-room caveats
- link the lab from the portal dock, README, and existing video hub
- add static coverage for the app structure and video hub registration

## Tests
- node --test tests/webrtc-lab.test.js tests/video-smart-join.test.js tests/video-ops.test.js tests/video-meshcast.test.js
- git diff --check

## Notes
- This is a mesh WebRTC POC for two or three people, not a production SFU replacement.
- Real validation still needs HTTPS camera permissions and two browsers/devices in the same room.