### PR TITLE
Add Gun video frame streaming lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Phone Holder System](https://3dvr-portal.vercel.app/phone-holder-system/)
 - [Open Source](https://3dvr-portal.vercel.app/open-source/)
 - [WebRTC Lab](https://3dvr-portal.vercel.app/webrtc-lab/)
+- [Gun Video Lab](https://3dvr-portal.vercel.app/gun-video-lab/)
 - [Chat](https://3dvr-portal.vercel.app/chat/)
 - [Calendar Hub](https://3dvr-portal.vercel.app/calendar/)
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)

--- a/gun-video-lab/README.md
+++ b/gun-video-lab/README.md
@@ -1,0 +1,12 @@
+# 3DVR Gun Video Lab
+
+Proof of concept for streaming very small camera frames directly through Gun.
+
+This app intentionally does not use WebRTC media tracks. It:
+
+- Captures the webcam into a small canvas.
+- Compresses each frame as a JPEG data URL.
+- Writes the latest frame to `3dvr-gun-video-lab/<room>/frames/<participantId>`.
+- Lets viewers subscribe to the latest frame with Gun.
+
+This is not a normal conferencing architecture. It is useful for experiments, thumbnails, emergency still-frame fallback ideas, and harsh-network testing. For normal meetings, use WebRTC or an SFU.

--- a/gun-video-lab/app.js
+++ b/gun-video-lab/app.js
@@ -1,0 +1,323 @@
+(function initGunVideoLab() {
+  const refs = {
+    roomForm: document.getElementById('room-form'),
+    displayName: document.getElementById('display-name'),
+    roomId: document.getElementById('room-id'),
+    randomRoom: document.getElementById('random-room'),
+    frameRate: document.getElementById('frame-rate'),
+    quality: document.getElementById('quality'),
+    copyLink: document.getElementById('copy-link'),
+    startCamera: document.getElementById('start-camera'),
+    startStream: document.getElementById('start-stream'),
+    stopStream: document.getElementById('stop-stream'),
+    clearFrame: document.getElementById('clear-frame'),
+    statusLine: document.getElementById('status-line'),
+    localVideo: document.getElementById('local-video'),
+    captureCanvas: document.getElementById('capture-canvas'),
+    localLabel: document.getElementById('local-label'),
+    localState: document.getElementById('local-state'),
+    remoteFrame: document.getElementById('remote-frame'),
+    remoteLabel: document.getElementById('remote-label'),
+    remoteState: document.getElementById('remote-state'),
+    framesSent: document.getElementById('frames-sent'),
+    framesReceived: document.getElementById('frames-received'),
+    frameSize: document.getElementById('frame-size'),
+    frameAge: document.getElementById('frame-age'),
+    eventLog: document.getElementById('event-log')
+  };
+
+  const ROOM_ROOT = '3dvr-gun-video-lab';
+  const FRAME_WIDTH = 160;
+  const FRAME_HEIGHT = 90;
+
+  let gun = null;
+  let roomNode = null;
+  let framesNode = null;
+  let participantsNode = null;
+  let localStream = null;
+  let localId = getOrCreateLocalId();
+  let localName = '';
+  let roomId = '';
+  let joined = false;
+  let publishTimer = null;
+  let heartbeatTimer = null;
+  let framesSent = 0;
+  let framesReceived = 0;
+  let latestRemoteAt = 0;
+
+  function normalizeRoom(value = '') {
+    return String(value || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80);
+  }
+
+  function createId(prefix = 'gunvid') {
+    return `${prefix}_${Math.random().toString(36).slice(2, 10)}_${Date.now().toString(36)}`;
+  }
+
+  function getOrCreateLocalId() {
+    try {
+      const stored = localStorage.getItem('gunVideoLabParticipantId');
+      if (stored) return stored;
+      const next = createId('viewer');
+      localStorage.setItem('gunVideoLabParticipantId', next);
+      return next;
+    } catch (_error) {
+      return createId('viewer');
+    }
+  }
+
+  function logEvent(message) {
+    const item = document.createElement('li');
+    item.textContent = `${new Date().toLocaleTimeString()} ${message}`;
+    refs.eventLog.prepend(item);
+    while (refs.eventLog.children.length > 40) {
+      refs.eventLog.lastElementChild.remove();
+    }
+  }
+
+  function setStatus(message) {
+    refs.statusLine.textContent = message;
+    logEvent(message);
+  }
+
+  function resolveInitialRoom() {
+    const params = new URLSearchParams(window.location.search);
+    const fromUrl = normalizeRoom(params.get('room') || '');
+    if (fromUrl) return fromUrl;
+    return `gun-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}`;
+  }
+
+  function roomLink() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('room', normalizeRoom(refs.roomId.value) || roomId || resolveInitialRoom());
+    return url.toString();
+  }
+
+  function updateRoomUrl() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('room', roomId);
+    window.history.replaceState({}, '', url.toString());
+  }
+
+  function ensureGun() {
+    if (gun) return gun;
+    if (typeof Gun !== 'function') {
+      throw new Error('Gun is not available.');
+    }
+    gun = Gun({
+      peers: window.__GUN_PEERS__ || [
+        'wss://relay.3dvr.tech/gun',
+        'wss://gun-relay-3dvr.fly.dev/gun'
+      ],
+      axe: true
+    });
+    return gun;
+  }
+
+  async function startCamera() {
+    if (localStream) return localStream;
+    if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+      throw new Error('This browser does not expose camera access.');
+    }
+    localStream = await navigator.mediaDevices.getUserMedia({
+      video: {
+        width: { ideal: 320 },
+        height: { ideal: 180 },
+        frameRate: { ideal: 8, max: 12 }
+      },
+      audio: false
+    });
+    refs.localVideo.srcObject = localStream;
+    refs.startCamera.disabled = true;
+    refs.startStream.disabled = !joined;
+    refs.localState.textContent = 'Camera on';
+    setStatus('Camera ready.');
+    return localStream;
+  }
+
+  function stopCamera() {
+    if (!localStream) return;
+    localStream.getTracks().forEach(track => track.stop());
+    localStream = null;
+    refs.localVideo.srcObject = null;
+    refs.startCamera.disabled = false;
+    refs.startStream.disabled = true;
+    refs.localState.textContent = 'Camera off';
+  }
+
+  function publishPresence() {
+    if (!participantsNode) return;
+    participantsNode.get(localId).put({
+      id: localId,
+      name: localName,
+      joinedAt: Date.now(),
+      lastSeen: Date.now()
+    });
+  }
+
+  function watchPresence() {
+    participantsNode.map().on((participant, id) => {
+      if (!participant || id === '_' || id === localId) return;
+      const lastSeen = Number(participant.lastSeen || 0);
+      if (Date.now() - lastSeen > 45000) return;
+      refs.remoteLabel.textContent = participant.name || 'Remote stream';
+    });
+  }
+
+  function watchFrames() {
+    framesNode.map().on((frame, id) => {
+      if (!frame || id === '_' || id === localId) return;
+      if (!frame.dataUrl || typeof frame.dataUrl !== 'string') return;
+      latestRemoteAt = Number(frame.createdAt || Date.now());
+      refs.remoteFrame.src = frame.dataUrl;
+      refs.remoteLabel.textContent = frame.name || 'Remote stream';
+      refs.remoteState.textContent = `${frame.width || FRAME_WIDTH}x${frame.height || FRAME_HEIGHT}`;
+      framesReceived += 1;
+      refs.framesReceived.textContent = String(framesReceived);
+      refs.frameSize.textContent = `${Math.round(frame.dataUrl.length / 1024)} KB`;
+    });
+  }
+
+  function captureFrame() {
+    if (!localStream || !framesNode) return;
+    const canvas = refs.captureCanvas;
+    const context = canvas.getContext('2d', { alpha: false });
+    canvas.width = FRAME_WIDTH;
+    canvas.height = FRAME_HEIGHT;
+    context.drawImage(refs.localVideo, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
+    const quality = Math.max(0.15, Math.min(0.75, Number(refs.quality.value || 0.35)));
+    const dataUrl = canvas.toDataURL('image/jpeg', quality);
+    framesSent += 1;
+    refs.framesSent.textContent = String(framesSent);
+    refs.frameSize.textContent = `${Math.round(dataUrl.length / 1024)} KB`;
+    framesNode.get(localId).put({
+      id: localId,
+      name: localName,
+      width: FRAME_WIDTH,
+      height: FRAME_HEIGHT,
+      quality,
+      dataUrl,
+      frameNumber: framesSent,
+      createdAt: Date.now()
+    });
+  }
+
+  function startPublishing() {
+    if (!joined || !localStream) {
+      setStatus('Join a room and start your camera first.');
+      return;
+    }
+    if (publishTimer) return;
+    const fps = Math.max(0.2, Math.min(3, Number(refs.frameRate.value || 1)));
+    const interval = Math.round(1000 / fps);
+    captureFrame();
+    publishTimer = setInterval(captureFrame, interval);
+    refs.startStream.disabled = true;
+    refs.stopStream.disabled = false;
+    refs.localState.textContent = `Publishing ${fps} fps`;
+    setStatus(`Publishing tiny frames at ${fps} fps.`);
+  }
+
+  function stopPublishing() {
+    if (publishTimer) {
+      clearInterval(publishTimer);
+      publishTimer = null;
+    }
+    refs.startStream.disabled = !joined || !localStream;
+    refs.stopStream.disabled = true;
+    refs.localState.textContent = localStream ? 'Camera on' : 'Camera off';
+    setStatus('Stopped publishing frames.');
+  }
+
+  function clearMyFrame() {
+    if (framesNode) {
+      framesNode.get(localId).put(null);
+    }
+    setStatus('Cleared local published frame.');
+  }
+
+  function joinRoom(event) {
+    if (event) event.preventDefault();
+    roomId = normalizeRoom(refs.roomId.value) || resolveInitialRoom();
+    refs.roomId.value = roomId;
+    localName = String(refs.displayName.value || '').trim() || `Guest ${localId.slice(-4)}`;
+    refs.localLabel.textContent = `${localName} (you)`;
+    ensureGun();
+    roomNode = gun.get(ROOM_ROOT).get(roomId);
+    framesNode = roomNode.get('frames');
+    participantsNode = roomNode.get('participants');
+    joined = true;
+    updateRoomUrl();
+    publishPresence();
+    heartbeatTimer = setInterval(publishPresence, 10000);
+    watchPresence();
+    watchFrames();
+    refs.startStream.disabled = !localStream;
+    setStatus(`Joined Gun frame room ${roomId}.`);
+  }
+
+  function leaveRoom() {
+    stopPublishing();
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    if (participantsNode) {
+      participantsNode.get(localId).put(null);
+    }
+    joined = false;
+    refs.startStream.disabled = true;
+    setStatus('Left room.');
+  }
+
+  async function copyLink() {
+    const link = roomLink();
+    try {
+      await navigator.clipboard.writeText(link);
+      setStatus('Room link copied.');
+    } catch (_error) {
+      window.prompt('Copy room link', link);
+    }
+  }
+
+  function updateFrameAge() {
+    if (!latestRemoteAt) {
+      refs.frameAge.textContent = '-';
+      return;
+    }
+    refs.frameAge.textContent = `${Math.max(0, Math.round((Date.now() - latestRemoteAt) / 1000))}s`;
+  }
+
+  function init() {
+    refs.roomId.value = resolveInitialRoom();
+    try {
+      refs.displayName.value = localStorage.getItem('username')
+        || localStorage.getItem('guestDisplayName')
+        || '';
+    } catch (_error) {
+      refs.displayName.value = '';
+    }
+    refs.randomRoom.addEventListener('click', () => {
+      refs.roomId.value = createId('room').replace(/^room_/, 'gun-');
+    });
+    refs.copyLink.addEventListener('click', copyLink);
+    refs.startCamera.addEventListener('click', () => {
+      startCamera().catch(error => setStatus(error.message || 'Unable to start camera.'));
+    });
+    refs.roomForm.addEventListener('submit', joinRoom);
+    refs.startStream.addEventListener('click', startPublishing);
+    refs.stopStream.addEventListener('click', stopPublishing);
+    refs.clearFrame.addEventListener('click', clearMyFrame);
+    setInterval(updateFrameAge, 1000);
+    window.addEventListener('beforeunload', () => {
+      leaveRoom();
+      stopCamera();
+    });
+  }
+
+  init();
+})();

--- a/gun-video-lab/index.html
+++ b/gun-video-lab/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3DVR Gun Video Lab | Portal</title>
+  <meta
+    name="description"
+    content="A tiny proof of concept that streams low-rate camera frames directly through Gun."
+  >
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <link rel="stylesheet" href="../style.css?v=gun-video-lab">
+  <link rel="stylesheet" href="./styles.css?v=20260519">
+</head>
+<body class="gun-video-page">
+  <header class="lab-header">
+    <nav class="lab-nav" aria-label="Gun Video Lab navigation">
+      <a href="../index.html">Portal</a>
+      <a href="/webrtc-lab/">WebRTC Lab</a>
+      <a href="/portal.3dvr.tech/video/">Video Home</a>
+    </nav>
+    <section class="hero-grid">
+      <div>
+        <p class="eyebrow">Gun Frame Stream</p>
+        <h1>Video as tiny synced Gun frames.</h1>
+        <p>
+          This experiment does not use WebRTC media tracks. It captures small JPEG frames from your camera,
+          writes the newest frame to Gun, and lets other browsers watch that shared frame key.
+        </p>
+      </div>
+      <aside class="lab-note">
+        <strong>Deliberately tiny</strong>
+        <span>Use low resolution and low FPS. This is a resilience experiment, not normal video conferencing.</span>
+      </aside>
+    </section>
+  </header>
+
+  <main class="lab-shell">
+    <section class="room-panel" aria-labelledby="room-title">
+      <div>
+        <p class="eyebrow">Room</p>
+        <h2 id="room-title">Publish or watch</h2>
+      </div>
+      <form id="room-form" class="room-form">
+        <label for="display-name">Name</label>
+        <input id="display-name" name="displayName" type="text" maxlength="40" autocomplete="name">
+        <label for="room-id">Room</label>
+        <div class="room-row">
+          <input id="room-id" name="roomId" type="text" maxlength="80" required>
+          <button type="button" id="random-room">Random</button>
+        </div>
+        <div class="settings-grid">
+          <label for="frame-rate">FPS</label>
+          <input id="frame-rate" name="frameRate" type="number" min="0.2" max="3" step="0.2" value="1">
+          <label for="quality">Quality</label>
+          <input id="quality" name="quality" type="number" min="0.15" max="0.75" step="0.05" value="0.35">
+        </div>
+        <div class="button-row">
+          <button type="submit" class="primary">Join room</button>
+          <button type="button" id="copy-link">Copy link</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="controls-panel" aria-label="Stream controls">
+      <button type="button" id="start-camera" class="primary">Start camera</button>
+      <button type="button" id="start-stream" disabled>Publish frames</button>
+      <button type="button" id="stop-stream" disabled>Stop publishing</button>
+      <button type="button" id="clear-frame">Clear my frame</button>
+      <p id="status-line" class="status-line" role="status">Join a room, then start your camera.</p>
+    </section>
+
+    <section class="stream-grid" aria-label="Gun frame streams">
+      <article class="stream-tile">
+        <video id="local-video" autoplay muted playsinline></video>
+        <canvas id="capture-canvas" width="160" height="90" hidden></canvas>
+        <div class="tile-label">
+          <strong id="local-label">You</strong>
+          <span id="local-state">Camera off</span>
+        </div>
+      </article>
+      <article class="stream-tile">
+        <img id="remote-frame" alt="Latest remote Gun frame">
+        <div class="tile-label">
+          <strong id="remote-label">Room frame</strong>
+          <span id="remote-state">Waiting</span>
+        </div>
+      </article>
+    </section>
+
+    <section class="metrics-panel" aria-labelledby="metrics-title">
+      <div>
+        <p class="eyebrow">Metrics</p>
+        <h2 id="metrics-title">Frame sync</h2>
+      </div>
+      <dl>
+        <div><dt>Frames sent</dt><dd id="frames-sent">0</dd></div>
+        <div><dt>Frames received</dt><dd id="frames-received">0</dd></div>
+        <div><dt>Last frame size</dt><dd id="frame-size">0 KB</dd></div>
+        <div><dt>Frame age</dt><dd id="frame-age">-</dd></div>
+      </dl>
+    </section>
+
+    <section class="debug-panel" aria-labelledby="debug-title">
+      <div>
+        <p class="eyebrow">Events</p>
+        <h2 id="debug-title">Gun frame log</h2>
+      </div>
+      <ol id="event-log" aria-live="polite"></ol>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <p>Gun frame streaming is useful for experiments, thumbnails, snapshots, and harsh-network fallback ideas. Real meetings still need WebRTC or an SFU.</p>
+  </footer>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/gun-video-lab/styles.css
+++ b/gun-video-lab/styles.css
@@ -1,0 +1,331 @@
+:root {
+  --gun-bg: #f5f2ea;
+  --gun-ink: #1e2528;
+  --gun-muted: #687178;
+  --gun-panel: #fffdf7;
+  --gun-line: #d7cfbf;
+  --gun-blue: #315f7e;
+  --gun-green: #50735b;
+  --gun-rust: #985c35;
+  --gun-dark: #142027;
+  --gun-shadow: 0 18px 42px rgba(30, 37, 40, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.gun-video-page {
+  margin: 0;
+  background: var(--gun-bg);
+  color: var(--gun-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.55;
+}
+
+.lab-header,
+.lab-shell,
+.lab-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.lab-nav {
+  display: flex;
+  gap: 0.45rem;
+  padding: 0.75rem 0;
+}
+
+.lab-nav a,
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.62rem 0.85rem;
+  border: 1px solid var(--gun-line);
+  border-radius: 8px;
+  background: var(--gun-panel);
+  color: var(--gun-ink);
+  font: inherit;
+  font-weight: 850;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+button.primary {
+  background: var(--gun-dark);
+  border-color: var(--gun-dark);
+  color: #fffaf0;
+}
+
+button:disabled {
+  opacity: 0.52;
+  cursor: not-allowed;
+}
+
+.hero-grid {
+  min-height: 42vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.42fr);
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: end;
+  padding: clamp(2rem, 5vw, 4rem) 0;
+}
+
+.eyebrow {
+  margin: 0 0 0.65rem;
+  color: var(--gun-rust);
+  font-size: 0.76rem;
+  font-weight: 950;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p,
+span,
+strong {
+  overflow-wrap: anywhere;
+}
+
+h1 {
+  max-width: 12ch;
+  margin: 0;
+  font-size: clamp(3rem, 8vw, 6.2rem);
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3.5vw, 2.8rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.hero-grid p {
+  max-width: 62ch;
+  margin: 1rem 0 0;
+  color: var(--gun-muted);
+  font-size: 1.08rem;
+}
+
+.lab-note,
+.room-panel,
+.controls-panel,
+.metrics-panel,
+.debug-panel {
+  border: 1px solid var(--gun-line);
+  border-radius: 8px;
+  background: var(--gun-panel);
+  box-shadow: var(--gun-shadow);
+}
+
+.lab-note {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem;
+}
+
+.lab-note strong {
+  color: var(--gun-blue);
+}
+
+.lab-note span {
+  color: var(--gun-muted);
+}
+
+.lab-shell {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.42fr) minmax(0, 1fr);
+  gap: 1rem;
+  padding-bottom: 4rem;
+}
+
+.room-panel,
+.controls-panel,
+.metrics-panel,
+.debug-panel {
+  padding: 1rem;
+}
+
+.room-form,
+.controls-panel {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.room-form {
+  margin-top: 1rem;
+}
+
+label {
+  color: var(--gun-muted);
+  font-size: 0.85rem;
+  font-weight: 850;
+}
+
+input {
+  width: 100%;
+  min-height: 42px;
+  padding: 0.66rem 0.75rem;
+  border: 1px solid var(--gun-line);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--gun-ink);
+  font: inherit;
+}
+
+.room-row,
+.button-row,
+.settings-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.room-row,
+.button-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.settings-grid {
+  grid-template-columns: auto 1fr auto 1fr;
+  align-items: center;
+}
+
+.status-line {
+  margin: 0.4rem 0 0;
+  color: var(--gun-muted);
+  font-size: 0.92rem;
+}
+
+.stream-grid {
+  grid-row: span 2;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.stream-tile {
+  min-height: 300px;
+  position: relative;
+  border: 1px solid var(--gun-line);
+  border-radius: 8px;
+  background: #111a20;
+  overflow: hidden;
+  box-shadow: var(--gun-shadow);
+}
+
+.stream-tile video,
+.stream-tile img {
+  width: 100%;
+  height: 100%;
+  min-height: 300px;
+  display: block;
+  object-fit: cover;
+  background: #111a20;
+}
+
+.stream-tile img:not([src]) {
+  opacity: 0;
+}
+
+.tile-label {
+  position: absolute;
+  left: 0.75rem;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 8px;
+  background: rgba(20, 32, 39, 0.78);
+  color: #fffaf0;
+  backdrop-filter: blur(10px);
+}
+
+.tile-label span {
+  color: rgba(255, 250, 240, 0.72);
+}
+
+.metrics-panel dl {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin: 1rem 0 0;
+}
+
+.metrics-panel div {
+  padding: 0.7rem;
+  border: 1px solid var(--gun-line);
+  border-radius: 8px;
+  background: #fbfaf7;
+}
+
+.metrics-panel dt {
+  color: var(--gun-muted);
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.metrics-panel dd {
+  margin: 0.15rem 0 0;
+  color: var(--gun-blue);
+  font-size: 1.2rem;
+  font-weight: 950;
+}
+
+.debug-panel {
+  grid-column: 1 / -1;
+}
+
+#event-log {
+  display: grid;
+  gap: 0.45rem;
+  max-height: 260px;
+  overflow: auto;
+  padding-left: 1.3rem;
+  color: var(--gun-muted);
+}
+
+.lab-footer {
+  padding: 1.25rem 0 2rem;
+  border-top: 1px solid var(--gun-line);
+  color: var(--gun-muted);
+}
+
+@media (max-width: 900px) {
+  .hero-grid,
+  .lab-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-grid {
+    min-height: auto;
+  }
+
+  .stream-grid {
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 620px) {
+  .lab-header,
+  .lab-shell,
+  .lab-footer {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  .lab-nav,
+  .button-row,
+  .room-row,
+  .settings-grid,
+  .stream-grid,
+  .metrics-panel dl {
+    grid-template-columns: 1fr;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -451,6 +451,12 @@
             <span class="app-card__title">WebRTC Lab</span>
             <span class="app-card__meta">Test native browser video rooms with Gun-backed signaling.</span>
           </a>
+          <a href="gun-video-lab/" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">GUN</span>
+            <span class="app-card__title">Gun Video Lab</span>
+            <span class="app-card__meta">Stream tiny camera frames directly through Gun for harsh-network experiments.</span>
+          </a>
           <a href="wellness.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌿</span>
             <span class="app-card__title">Wellness</span>

--- a/portal.3dvr.tech/video/index.html
+++ b/portal.3dvr.tech/video/index.html
@@ -88,6 +88,9 @@
       <a class="button secondary" href="/webrtc-lab/">
         Native WebRTC Lab
       </a>
+      <a class="button secondary" href="/gun-video-lab/">
+        Gun Video Lab
+      </a>
       <!-- Crunched room preset -->
       <a class="button secondary" target="_blank" rel="noopener"
         href="https://vdo.ninja/?room=3dvrtech&label&showlabels&codec=h264&vb=120&ab=24&fps=4&scale=96p&stereo=0&buffer=30">

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -4,6 +4,7 @@ import { access, readFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
 
 const appDir = new URL('../webrtc-lab/', import.meta.url);
+const gunVideoDir = new URL('../gun-video-lab/', import.meta.url);
 
 async function fileExists(path) {
   try {
@@ -53,5 +54,52 @@ describe('WebRTC Lab app', () => {
     assert.match(readme, /\[WebRTC Lab\]\(https:\/\/3dvr-portal\.vercel\.app\/webrtc-lab\/\)/);
     assert.match(videoHome, /href="\/webrtc-lab\/"/);
     assert.match(videoHome, /Native WebRTC Lab/);
+  });
+});
+
+describe('Gun Video Lab app', () => {
+  it('ships a Gun-backed frame streaming proof of concept', async () => {
+    const indexUrl = new URL('index.html', gunVideoDir);
+    const stylesUrl = new URL('styles.css', gunVideoDir);
+    const appUrl = new URL('app.js', gunVideoDir);
+    const readmeUrl = new URL('README.md', gunVideoDir);
+
+    assert.equal(await fileExists(indexUrl), true, 'Gun Video Lab index should exist');
+    assert.equal(await fileExists(stylesUrl), true, 'Gun Video Lab styles should exist');
+    assert.equal(await fileExists(appUrl), true, 'Gun Video Lab app script should exist');
+    assert.equal(await fileExists(readmeUrl), true, 'Gun Video Lab README should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    const js = await readFile(appUrl, 'utf8');
+    const readme = await readFile(readmeUrl, 'utf8');
+
+    assert.match(html, /3DVR Gun Video Lab \| Portal/);
+    assert.match(html, /Gun Frame Stream/);
+    assert.match(html, /id="capture-canvas"/);
+    assert.match(html, /id="remote-frame"/);
+    assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
+    assert.match(js, /ROOM_ROOT = '3dvr-gun-video-lab'/);
+    assert.match(js, /canvas\.toDataURL\('image\/jpeg', quality\)/);
+    assert.match(js, /framesNode\.get\(localId\)\.put/);
+    assert.match(js, /framesNode\.map\(\)\.on/);
+    assert.match(readme, /Writes the latest frame to `3dvr-gun-video-lab\/<room>\/frames\/<participantId>`/);
+  });
+
+  it('registers the Gun Video Lab next to the WebRTC lab', async () => {
+    const portalHtml = await readFile(new URL('../index.html', appDir), 'utf8');
+    const readme = await readFile(new URL('../README.md', appDir), 'utf8');
+    const videoHome = await readFile(new URL('../portal.3dvr.tech/video/index.html', appDir), 'utf8');
+
+    const webrtcIndex = portalHtml.indexOf('>WebRTC Lab<');
+    const gunVideoIndex = portalHtml.indexOf('>Gun Video Lab<');
+    const wellnessIndex = portalHtml.indexOf('>Wellness<');
+
+    assert.ok(gunVideoIndex !== -1, 'Gun Video Lab app card should be listed on the portal');
+    assert.ok(webrtcIndex !== -1, 'WebRTC Lab app card should still be listed');
+    assert.ok(wellnessIndex !== -1, 'Wellness app card should still be listed');
+    assert.ok(webrtcIndex < gunVideoIndex, 'Gun Video Lab should render after WebRTC Lab');
+    assert.ok(gunVideoIndex < wellnessIndex, 'Gun Video Lab should render before Wellness');
+    assert.match(readme, /\[Gun Video Lab\]\(https:\/\/3dvr-portal\.vercel\.app\/gun-video-lab\/\)/);
+    assert.match(videoHome, /href="\/gun-video-lab\/"/);
   });
 });


### PR DESCRIPTION
## Summary
- keep the native WebRTC lab and add a second /gun-video-lab experiment
- stream tiny webcam JPEG frames directly through Gun nodes
- expose FPS/quality controls, copyable room links, frame metrics, and Gun frame logs
- link the lab from the portal dock, README, and existing video hub

## Tests
- node --test tests/webrtc-lab.test.js tests/video-smart-join.test.js tests/video-ops.test.js tests/video-meshcast.test.js
- git diff --check

## Notes
- This is intentionally not normal conferencing. It is a literal Gun frame-streaming experiment for low-rate visual sync and harsh-network fallback ideas.