### PR TITLE
Clarify Gun clip lab captures audio and video

### DIFF
--- a/gun-clip-lab/README.md
+++ b/gun-clip-lab/README.md
@@ -1,13 +1,13 @@
 # 3DVR Gun Clip Lab
 
-Proof of concept for recording short WebM clips and storing the latest clip in Gun.
+Proof of concept for recording short WebM audio/video clips and storing the latest clip in Gun.
 
 This intentionally stays separate from the frame-streaming `/gun-video-lab/` app. It is based on the Gun repo examples at `examples/basic/video.html` and `examples/vanilla/video.html`:
 
-- Capture camera or screen media with `MediaRecorder`.
+- Capture camera or screen media plus audio with `MediaRecorder`.
 - Convert the recorded Blob to a `data:video/webm` URL with `FileReader`.
 - Optionally encrypt that data URL with SEA and a passphrase.
 - Write the latest clip to `3dvr-gun-clip-lab/<room>/latestClip`.
 - Subscribe to that clip and replay it in a normal `<video>` element.
 
-This is not live conferencing. It is useful for testing Gun as a small clip handoff, async video note, or fallback recording transport.
+This is not live conferencing. It is useful for testing Gun as a small audio/video clip handoff, async video note, or fallback recording transport.

--- a/gun-clip-lab/index.html
+++ b/gun-clip-lab/index.html
@@ -6,7 +6,7 @@
   <title>3DVR Gun Clip Lab | Portal</title>
   <meta
     name="description"
-    content="A Gun video proof of concept based on the Gun repo MediaRecorder example."
+    content="A Gun audio and video proof of concept based on the Gun repo MediaRecorder example."
   >
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
@@ -24,16 +24,16 @@
     </nav>
     <section class="hero-grid">
       <div>
-        <p class="eyebrow">Gun Clip Store</p>
-        <h1>Record a tiny clip into Gun.</h1>
+        <p class="eyebrow">Gun AV Clip Store</p>
+        <h1>Record audio and video into Gun.</h1>
         <p>
           This keeps the frame-stream lab intact and adds the other Gun video style: a short MediaRecorder
-          WebM clip stored as a data URL, optionally encrypted with SEA.
+          WebM clip with audio and video stored as a data URL, optionally encrypted with SEA.
         </p>
       </div>
       <aside class="lab-note">
         <strong>Based on Gun examples</strong>
-        <span>Mirrors the Gun repo video demo shape: MediaRecorder, FileReader data URL, then `gun.get(...).put(...)`.</span>
+        <span>Mirrors the Gun repo video demo shape: MediaRecorder captures audio/video, FileReader makes a data URL, then `gun.get(...).put(...)` stores it.</span>
       </aside>
     </section>
   </header>
@@ -66,14 +66,14 @@
       <button type="button" id="screen-record">Record screen</button>
       <button type="button" id="stop-record" disabled>Stop recording</button>
       <button type="button" id="clear-clip">Clear room clip</button>
-      <p id="status-line" class="status-line" role="status">Join a room, then record a short clip.</p>
+      <p id="status-line" class="status-line" role="status">Join a room, then record a short audio/video clip.</p>
     </section>
 
     <section class="player-panel" aria-labelledby="player-title">
       <div class="panel-heading">
         <div>
           <p class="eyebrow">Playback</p>
-          <h2 id="player-title">Latest Gun clip</h2>
+          <h2 id="player-title">Latest Gun audio/video clip</h2>
         </div>
         <span id="clip-meta">No clip yet</span>
       </div>
@@ -96,7 +96,7 @@
   </main>
 
   <footer class="clip-footer">
-    <p>This is a store-and-replay experiment, not a live meeting stack. Keep clips short.</p>
+    <p>This is a store-and-replay audio/video experiment, not a live meeting stack. Keep clips short.</p>
   </footer>
 
   <script src="./app.js"></script>

--- a/index.html
+++ b/index.html
@@ -461,7 +461,7 @@
             <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">REC</span>
             <span class="app-card__title">Gun Clip Lab</span>
-            <span class="app-card__meta">Record short WebM clips and store the latest one through Gun.</span>
+            <span class="app-card__meta">Record short audio/video WebM clips and store the latest one through Gun.</span>
           </a>
           <a href="wellness.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌿</span>

--- a/portal.3dvr.tech/video/index.html
+++ b/portal.3dvr.tech/video/index.html
@@ -92,7 +92,7 @@
         Gun Video Lab
       </a>
       <a class="button secondary" href="/gun-clip-lab/">
-        Gun Clip Lab
+        Gun AV Clip Lab
       </a>
       <!-- Crunched room preset -->
       <a class="button secondary" target="_blank" rel="noopener"

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -122,7 +122,8 @@ describe('Gun Clip Lab app', () => {
     const readme = await readFile(readmeUrl, 'utf8');
 
     assert.match(html, /3DVR Gun Clip Lab \| Portal/);
-    assert.match(html, /Gun Clip Store/);
+    assert.match(html, /Gun AV Clip Store/);
+    assert.match(html, /Record audio and video into Gun/);
     assert.match(html, /id="camera-record"/);
     assert.match(html, /id="screen-record"/);
     assert.match(html, /id="clip-player"/);
@@ -130,10 +131,13 @@ describe('Gun Clip Lab app', () => {
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/sea\.js"><\/script>/);
     assert.match(js, /ROOM_ROOT = '3dvr-gun-clip-lab'/);
     assert.match(js, /new MediaRecorder\(media\)/);
+    assert.match(js, /getUserMedia\(\{ video: true, audio: true \}\)/);
+    assert.match(js, /getDisplayMedia\(\{ video: true, audio: true \}\)/);
     assert.match(js, /reader\.readAsDataURL\(blob\)/);
     assert.match(js, /data:video\/webm/);
     assert.match(js, /clipNode\.put/);
     assert.match(readme, /examples\/basic\/video\.html/);
+    assert.match(readme, /audio\/video clips/);
     assert.match(readme, /3dvr-gun-clip-lab\/<room>\/latestClip/);
   });
 


### PR DESCRIPTION
## Summary
- clarify that Gun Clip Lab records audio and video together
- update portal/video hub labels and README wording
- add test assertions for audio-enabled MediaRecorder requests

## Tests
- node --test tests/webrtc-lab.test.js tests/video-smart-join.test.js tests/video-ops.test.js tests/video-meshcast.test.js
- git diff --check