### PR TITLE
Add pure Gun chunk stream experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Gun Video Lab](https://3dvr-portal.vercel.app/gun-video-lab/)
 - [Gun Clip Lab](https://3dvr-portal.vercel.app/gun-clip-lab/)
 - [Gun Live Room](https://3dvr-portal.vercel.app/gun-live-room/)
+- [Gun Chunk Stream](https://3dvr-portal.vercel.app/gun-chunk-stream/)
 - [Chat](https://3dvr-portal.vercel.app/chat/)
 - [Calendar Hub](https://3dvr-portal.vercel.app/calendar/)
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)

--- a/gun-chunk-stream/README.md
+++ b/gun-chunk-stream/README.md
@@ -1,0 +1,12 @@
+# 3DVR Gun Chunk Stream
+
+Pure Gun audio/video chunk stream experiment.
+
+This app records locally and uploads while recording:
+
+- `MediaRecorder.start(timeslice)` emits short audio/video WebM chunks.
+- Each chunk is converted to a data URL.
+- Gun stores chunks at `3dvr-gun-chunk-stream/<room>/chunks/<participantId_sequence>`.
+- Receivers append chunks into a `MediaSource` video player when supported.
+
+This should be smoother than the pure frame/audio live room because the browser encodes synchronized audio and video locally first. It is still experimental: WebM chunk playback support varies by mobile browser, and Gun is still carrying large base64 payloads through the graph.

--- a/gun-chunk-stream/app.js
+++ b/gun-chunk-stream/app.js
@@ -1,0 +1,442 @@
+(function initGunChunkStream() {
+  const refs = {
+    roomForm: document.getElementById('room-form'),
+    displayName: document.getElementById('display-name'),
+    roomId: document.getElementById('room-id'),
+    randomRoom: document.getElementById('random-room'),
+    cameraSelect: document.getElementById('camera-select'),
+    micSelect: document.getElementById('mic-select'),
+    chunkSize: document.getElementById('chunk-size'),
+    copyLink: document.getElementById('copy-link'),
+    startPreview: document.getElementById('start-preview'),
+    startStream: document.getElementById('start-stream'),
+    stopStream: document.getElementById('stop-stream'),
+    statusLine: document.getElementById('status-line'),
+    localVideo: document.getElementById('local-video'),
+    localLabel: document.getElementById('local-label'),
+    localState: document.getElementById('local-state'),
+    chunkGrid: document.getElementById('chunk-grid'),
+    chunksSent: document.getElementById('chunks-sent'),
+    chunksReceived: document.getElementById('chunks-received'),
+    lastSize: document.getElementById('last-size'),
+    playbackMode: document.getElementById('playback-mode'),
+    eventLog: document.getElementById('event-log')
+  };
+
+  const ROOM_ROOT = '3dvr-gun-chunk-stream';
+  const CAMERA_PREF_KEY = 'gunChunkStreamCameraId';
+  const MIC_PREF_KEY = 'gunChunkStreamMicId';
+  const MIME_CANDIDATES = [
+    'video/webm;codecs=vp8,opus',
+    'video/webm;codecs=vp9,opus',
+    'video/webm'
+  ];
+
+  let gun = null;
+  let roomNode = null;
+  let chunksNode = null;
+  let presenceNode = null;
+  let localStream = null;
+  let recorder = null;
+  let joined = false;
+  let roomId = '';
+  let localName = '';
+  let localId = getOrCreateLocalId();
+  let sequence = 0;
+  let chunksSent = 0;
+  let chunksReceived = 0;
+  let heartbeatTimer = null;
+  const seenChunks = new Set();
+  const remotePlayers = new Map();
+
+  function normalizeRoom(value = '') {
+    return String(value || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80);
+  }
+
+  function createId(prefix = 'gunchunk') {
+    return `${prefix}_${Math.random().toString(36).slice(2, 10)}_${Date.now().toString(36)}`;
+  }
+
+  function getOrCreateLocalId() {
+    try {
+      const stored = localStorage.getItem('gunChunkStreamParticipantId');
+      if (stored) return stored;
+      const next = createId('peer');
+      localStorage.setItem('gunChunkStreamParticipantId', next);
+      return next;
+    } catch (_error) {
+      return createId('peer');
+    }
+  }
+
+  function logEvent(message) {
+    const item = document.createElement('li');
+    item.textContent = `${new Date().toLocaleTimeString()} ${message}`;
+    refs.eventLog.prepend(item);
+    while (refs.eventLog.children.length > 50) refs.eventLog.lastElementChild.remove();
+  }
+
+  function setStatus(message) {
+    refs.statusLine.textContent = message;
+    logEvent(message);
+  }
+
+  function readTabPreference(key) {
+    try {
+      return sessionStorage.getItem(key) || '';
+    } catch (_error) {
+      return '';
+    }
+  }
+
+  function writeTabPreference(key, value) {
+    try {
+      if (value) sessionStorage.setItem(key, value);
+      else sessionStorage.removeItem(key);
+    } catch (_error) {
+      // Ignore storage failures.
+    }
+  }
+
+  function resolveInitialRoom() {
+    const params = new URLSearchParams(window.location.search);
+    return normalizeRoom(params.get('room') || '') || `gun-chunk-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}`;
+  }
+
+  function roomLink() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('room', normalizeRoom(refs.roomId.value) || roomId || resolveInitialRoom());
+    return url.toString();
+  }
+
+  function updateRoomUrl() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('room', roomId);
+    window.history.replaceState({}, '', url.toString());
+  }
+
+  function ensureGun() {
+    if (gun) return gun;
+    if (typeof Gun !== 'function') throw new Error('Gun is not available.');
+    gun = Gun({
+      peers: window.__GUN_PEERS__ || [
+        'wss://gun-relay-3dvr.fly.dev/gun'
+      ],
+      axe: true
+    });
+    return gun;
+  }
+
+  function pickMimeType() {
+    if (!window.MediaRecorder || typeof MediaRecorder.isTypeSupported !== 'function') {
+      return '';
+    }
+    return MIME_CANDIDATES.find(type => MediaRecorder.isTypeSupported(type)) || '';
+  }
+
+  function setSelectOptions(select, devices, fallbackLabel) {
+    const key = select === refs.cameraSelect ? CAMERA_PREF_KEY : MIC_PREF_KEY;
+    const selected = select.value || readTabPreference(key);
+    select.textContent = '';
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = fallbackLabel;
+    select.append(defaultOption);
+    devices.forEach((device, index) => {
+      const option = document.createElement('option');
+      option.value = device.deviceId;
+      option.textContent = device.label || `${fallbackLabel.replace('Default ', '')} ${index + 1}`;
+      select.append(option);
+    });
+    select.value = Array.from(select.options).some(option => option.value === selected) ? selected : '';
+  }
+
+  async function refreshDevices() {
+    if (!navigator.mediaDevices || typeof navigator.mediaDevices.enumerateDevices !== 'function') return;
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      setSelectOptions(refs.cameraSelect, devices.filter(device => device.kind === 'videoinput'), 'Default camera');
+      setSelectOptions(refs.micSelect, devices.filter(device => device.kind === 'audioinput'), 'Default microphone');
+    } catch (error) {
+      console.warn('Device enumeration failed', error);
+    }
+  }
+
+  function selectedVideoConstraint() {
+    const deviceId = refs.cameraSelect.value;
+    return {
+      width: { ideal: 480 },
+      height: { ideal: 270 },
+      frameRate: { ideal: 12, max: 15 },
+      ...(deviceId ? { deviceId: { exact: deviceId } } : {})
+    };
+  }
+
+  function selectedAudioConstraint() {
+    const deviceId = refs.micSelect.value;
+    return {
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+      ...(deviceId ? { deviceId: { exact: deviceId } } : {})
+    };
+  }
+
+  function stopLocalStream() {
+    if (!localStream) return;
+    localStream.getTracks().forEach(track => track.stop());
+    localStream = null;
+    refs.localVideo.srcObject = null;
+  }
+
+  async function startPreview() {
+    if (!navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+      throw new Error('This browser does not expose camera/mic access.');
+    }
+    stopRecorder();
+    stopLocalStream();
+    localStream = await navigator.mediaDevices.getUserMedia({
+      video: selectedVideoConstraint(),
+      audio: selectedAudioConstraint()
+    });
+    refs.localVideo.srcObject = localStream;
+    refs.localState.textContent = 'Ready';
+    refs.startPreview.disabled = true;
+    refs.startStream.disabled = !joined;
+    setStatus('Camera and mic ready for local recording.');
+    await refreshDevices();
+  }
+
+  function blobToDataUrl(blob) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error || new Error('Unable to read chunk.'));
+      reader.onloadend = () => resolve(String(reader.result || ''));
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  async function publishChunk(blob) {
+    if (!chunksNode || !blob.size) return;
+    const dataUrl = await blobToDataUrl(blob);
+    sequence += 1;
+    chunksSent += 1;
+    refs.chunksSent.textContent = String(chunksSent);
+    refs.lastSize.textContent = `${Math.round(dataUrl.length / 1024)} KB`;
+    chunksNode.get(`${localId}_${sequence}`).put({
+      id: `${localId}_${sequence}`,
+      participantId: localId,
+      name: localName,
+      sequence,
+      mimeType: blob.type || pickMimeType() || 'video/webm',
+      dataUrl,
+      createdAt: Date.now()
+    });
+  }
+
+  function startStreaming() {
+    if (!joined || !localStream) {
+      setStatus('Join a room and start camera/mic first.');
+      return;
+    }
+    if (!window.MediaRecorder) {
+      setStatus('This browser does not support MediaRecorder.');
+      return;
+    }
+    if (recorder && recorder.state !== 'inactive') return;
+    const mimeType = pickMimeType();
+    recorder = new MediaRecorder(localStream, mimeType ? { mimeType } : undefined);
+    recorder.ondataavailable = event => {
+      if (!event.data || !event.data.size) return;
+      publishChunk(event.data).catch(error => {
+        console.warn('Chunk upload failed', error);
+        setStatus(error.message || 'Chunk upload failed.');
+      });
+    };
+    recorder.onstop = () => {
+      refs.startStream.disabled = !joined || !localStream;
+      refs.stopStream.disabled = true;
+      refs.localState.textContent = localStream ? 'Ready' : 'Offline';
+      setStatus('Stopped chunk recording.');
+    };
+    const sliceMs = Math.max(1000, Math.min(4000, Number(refs.chunkSize.value || 2000)));
+    recorder.start(sliceMs);
+    refs.startStream.disabled = true;
+    refs.stopStream.disabled = false;
+    refs.localState.textContent = `Uploading every ${Math.round(sliceMs / 1000)}s`;
+    setStatus(`Recording locally and uploading ${Math.round(sliceMs / 1000)}s chunks to Gun.`);
+  }
+
+  function stopRecorder() {
+    if (recorder && recorder.state !== 'inactive') recorder.stop();
+    recorder = null;
+  }
+
+  function publishPresence() {
+    if (!presenceNode) return;
+    presenceNode.get(localId).put({
+      id: localId,
+      name: localName,
+      joinedAt: Date.now(),
+      lastSeen: Date.now()
+    });
+  }
+
+  function createRemotePlayer(participantId, name = 'Guest', mimeType = 'video/webm') {
+    if (remotePlayers.has(participantId)) return remotePlayers.get(participantId);
+    const tile = document.createElement('article');
+    tile.className = 'chunk-tile';
+    tile.dataset.peerId = participantId;
+    const video = document.createElement('video');
+    video.controls = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    const label = document.createElement('div');
+    label.className = 'tile-label';
+    const title = document.createElement('strong');
+    title.textContent = name;
+    const state = document.createElement('span');
+    state.textContent = 'Waiting';
+    label.append(title, state);
+    tile.append(video, label);
+    refs.chunkGrid.appendChild(tile);
+    const player = { video, title, state, queue: [], appending: false, sourceBuffer: null, mediaSource: null, fallback: false };
+
+    if (window.MediaSource && MediaSource.isTypeSupported(mimeType)) {
+      player.mediaSource = new MediaSource();
+      video.src = URL.createObjectURL(player.mediaSource);
+      player.mediaSource.addEventListener('sourceopen', () => {
+        player.sourceBuffer = player.mediaSource.addSourceBuffer(mimeType);
+        player.sourceBuffer.addEventListener('updateend', () => appendNext(player));
+        appendNext(player);
+      }, { once: true });
+    } else {
+      player.fallback = true;
+      refs.playbackMode.textContent = 'Latest chunk';
+    }
+
+    remotePlayers.set(participantId, player);
+    return player;
+  }
+
+  function appendNext(player) {
+    if (player.fallback || player.appending || !player.sourceBuffer || player.sourceBuffer.updating) return;
+    const next = player.queue.shift();
+    if (!next) return;
+    player.appending = true;
+    try {
+      player.sourceBuffer.appendBuffer(next);
+    } catch (error) {
+      console.warn('Append failed', error);
+      player.state.textContent = 'Append failed';
+    } finally {
+      player.appending = false;
+    }
+  }
+
+  async function receiveChunk(chunk) {
+    if (!chunk || chunk.participantId === localId || !chunk.dataUrl || seenChunks.has(chunk.id)) return;
+    seenChunks.add(chunk.id);
+    const player = createRemotePlayer(chunk.participantId, chunk.name || 'Guest', chunk.mimeType || 'video/webm');
+    player.title.textContent = chunk.name || 'Guest';
+    player.state.textContent = `Chunk ${chunk.sequence || '?'}`;
+    chunksReceived += 1;
+    refs.chunksReceived.textContent = String(chunksReceived);
+    refs.lastSize.textContent = `${Math.round(chunk.dataUrl.length / 1024)} KB`;
+
+    if (player.fallback) {
+      player.video.src = chunk.dataUrl;
+      return;
+    }
+
+    const buffer = await fetch(chunk.dataUrl).then(response => response.arrayBuffer());
+    player.queue.push(buffer);
+    appendNext(player);
+    player.video.play().catch(() => {
+      player.state.textContent = 'Tap to play';
+    });
+  }
+
+  function watchChunks() {
+    chunksNode.map().on(chunk => {
+      receiveChunk(chunk).catch(error => {
+        console.warn('Chunk receive failed', error);
+      });
+    });
+  }
+
+  function joinRoom(event) {
+    if (event) event.preventDefault();
+    roomId = normalizeRoom(refs.roomId.value) || resolveInitialRoom();
+    localName = String(refs.displayName.value || '').trim() || `Guest ${localId.slice(-4)}`;
+    refs.roomId.value = roomId;
+    refs.localLabel.textContent = `${localName} (you)`;
+    ensureGun();
+    roomNode = gun.get(ROOM_ROOT).get(roomId);
+    chunksNode = roomNode.get('chunks');
+    presenceNode = roomNode.get('participants');
+    joined = true;
+    updateRoomUrl();
+    publishPresence();
+    heartbeatTimer = setInterval(publishPresence, 10000);
+    watchChunks();
+    refs.startStream.disabled = !localStream;
+    setStatus(`Joined Gun chunk room ${roomId}.`);
+  }
+
+  async function copyLink() {
+    const link = roomLink();
+    try {
+      await navigator.clipboard.writeText(link);
+      setStatus('Room link copied.');
+    } catch (_error) {
+      window.prompt('Copy room link', link);
+    }
+  }
+
+  function leave() {
+    stopRecorder();
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    if (presenceNode) presenceNode.get(localId).put(null);
+    stopLocalStream();
+  }
+
+  refs.roomId.value = resolveInitialRoom();
+  refs.cameraSelect.value = readTabPreference(CAMERA_PREF_KEY);
+  refs.micSelect.value = readTabPreference(MIC_PREF_KEY);
+  try {
+    refs.displayName.value = localStorage.getItem('username')
+      || localStorage.getItem('guestDisplayName')
+      || '';
+  } catch (_error) {
+    refs.displayName.value = '';
+  }
+  refs.cameraSelect.addEventListener('change', () => {
+    writeTabPreference(CAMERA_PREF_KEY, refs.cameraSelect.value);
+    refs.startPreview.disabled = false;
+    setStatus('Camera selection changed. Start camera and mic again to apply it.');
+  });
+  refs.micSelect.addEventListener('change', () => {
+    writeTabPreference(MIC_PREF_KEY, refs.micSelect.value);
+    refs.startPreview.disabled = false;
+    setStatus('Microphone selection changed. Start camera and mic again to apply it.');
+  });
+  refs.randomRoom.addEventListener('click', () => {
+    refs.roomId.value = createId('room').replace(/^room_/, 'gun-chunk-');
+  });
+  refs.roomForm.addEventListener('submit', joinRoom);
+  refs.copyLink.addEventListener('click', copyLink);
+  refs.startPreview.addEventListener('click', () => startPreview().catch(error => setStatus(error.message || 'Unable to start media.')));
+  refs.startStream.addEventListener('click', startStreaming);
+  refs.stopStream.addEventListener('click', stopRecorder);
+  refreshDevices();
+  if (navigator.mediaDevices && typeof navigator.mediaDevices.addEventListener === 'function') {
+    navigator.mediaDevices.addEventListener('devicechange', refreshDevices);
+  }
+  window.addEventListener('beforeunload', leave);
+}());

--- a/gun-chunk-stream/index.html
+++ b/gun-chunk-stream/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3DVR Gun Chunk Stream | Portal</title>
+  <meta
+    name="description"
+    content="A pure Gun test that records local WebM chunks and uploads them while recording."
+  >
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <link rel="stylesheet" href="../style.css?v=gun-chunk-stream">
+  <link rel="stylesheet" href="./styles.css?v=20260519">
+</head>
+<body class="chunk-page">
+  <header class="chunk-header">
+    <nav class="chunk-nav" aria-label="Gun Chunk Stream navigation">
+      <a href="../index.html">Portal</a>
+      <a href="/gun-live-room/">Gun Live Room</a>
+      <a href="/gun-clip-lab/">Gun AV Clip Lab</a>
+      <a href="/portal.3dvr.tech/video/">Video Home</a>
+    </nav>
+    <section class="hero-grid">
+      <div>
+        <p class="eyebrow">Pure Gun Chunk Stream</p>
+        <h1>Record locally, upload while recording.</h1>
+        <p>
+          This test records audio and video in the browser, emits short WebM chunks, and syncs those chunks
+          through Gun while recording continues.
+        </p>
+      </div>
+      <aside class="lab-note">
+        <strong>Different from live frames</strong>
+        <span>MediaRecorder does the local encoding first. Gun only carries finished WebM chunks.</span>
+      </aside>
+    </section>
+  </header>
+
+  <main class="chunk-shell">
+    <section class="setup-panel" aria-labelledby="setup-title">
+      <div>
+        <p class="eyebrow">Room</p>
+        <h2 id="setup-title">Chunk room</h2>
+      </div>
+      <form id="room-form" class="room-form">
+        <label for="display-name">Name</label>
+        <input id="display-name" name="displayName" type="text" maxlength="40" autocomplete="name">
+        <label for="room-id">Room</label>
+        <div class="room-row">
+          <input id="room-id" name="roomId" type="text" maxlength="80" required>
+          <button type="button" id="random-room">Random</button>
+        </div>
+        <label for="camera-select">Camera</label>
+        <select id="camera-select" name="cameraSelect">
+          <option value="">Default camera</option>
+        </select>
+        <label for="mic-select">Microphone</label>
+        <select id="mic-select" name="micSelect">
+          <option value="">Default microphone</option>
+        </select>
+        <label for="chunk-size">Chunk length</label>
+        <select id="chunk-size" name="chunkSize">
+          <option value="1000">1 second</option>
+          <option value="2000" selected>2 seconds</option>
+          <option value="4000">4 seconds</option>
+        </select>
+        <div class="button-row">
+          <button type="submit" class="primary">Join room</button>
+          <button type="button" id="copy-link">Copy link</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="controls-panel" aria-label="Chunk controls">
+      <button type="button" id="start-preview" class="primary">Start camera and mic</button>
+      <button type="button" id="start-stream" disabled>Record and upload chunks</button>
+      <button type="button" id="stop-stream" disabled>Stop recording</button>
+      <p id="status-line" class="status-line" role="status">Join a room, then start camera and mic.</p>
+    </section>
+
+    <section class="chunk-grid" id="chunk-grid" aria-label="Gun chunk streams">
+      <article class="chunk-tile local-tile">
+        <video id="local-video" autoplay muted playsinline></video>
+        <div class="tile-label">
+          <strong id="local-label">You</strong>
+          <span id="local-state">Offline</span>
+        </div>
+      </article>
+    </section>
+
+    <section class="metrics-panel" aria-labelledby="metrics-title">
+      <div>
+        <p class="eyebrow">Chunks</p>
+        <h2 id="metrics-title">Upload stats</h2>
+      </div>
+      <dl>
+        <div><dt>Chunks sent</dt><dd id="chunks-sent">0</dd></div>
+        <div><dt>Chunks received</dt><dd id="chunks-received">0</dd></div>
+        <div><dt>Last chunk</dt><dd id="last-size">0 KB</dd></div>
+        <div><dt>Mode</dt><dd id="playback-mode">MediaSource</dd></div>
+      </dl>
+    </section>
+
+    <section class="debug-panel" aria-labelledby="debug-title">
+      <div>
+        <p class="eyebrow">Events</p>
+        <h2 id="debug-title">Chunk log</h2>
+      </div>
+      <ol id="event-log" aria-live="polite"></ol>
+    </section>
+  </main>
+
+  <footer class="chunk-footer">
+    <p>Gun Chunk Stream is still experimental, but should be smoother than sending individual image frames because the browser encodes local audio/video before each upload.</p>
+  </footer>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/gun-chunk-stream/styles.css
+++ b/gun-chunk-stream/styles.css
@@ -1,0 +1,321 @@
+:root {
+  --chunk-bg: #f4f1ea;
+  --chunk-panel: #fffdf7;
+  --chunk-ink: #1d2526;
+  --chunk-muted: #69736f;
+  --chunk-line: #d7d0c0;
+  --chunk-accent: #2f6358;
+  --chunk-rust: #8b5634;
+  --chunk-dark: #12221f;
+  --chunk-shadow: 0 18px 42px rgba(29, 37, 38, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.chunk-page {
+  margin: 0;
+  background: var(--chunk-bg);
+  color: var(--chunk-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.55;
+}
+
+.chunk-header,
+.chunk-shell,
+.chunk-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.chunk-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0.75rem 0;
+}
+
+.chunk-nav a,
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.62rem 0.85rem;
+  border: 1px solid var(--chunk-line);
+  border-radius: 8px;
+  background: var(--chunk-panel);
+  color: var(--chunk-ink);
+  font: inherit;
+  font-weight: 850;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+button.primary {
+  background: var(--chunk-dark);
+  border-color: var(--chunk-dark);
+  color: #fffaf0;
+}
+
+button:disabled {
+  opacity: 0.52;
+  cursor: not-allowed;
+}
+
+.hero-grid {
+  min-height: 42vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.4fr);
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: end;
+  padding: clamp(2rem, 5vw, 4rem) 0;
+}
+
+.eyebrow {
+  margin: 0 0 0.65rem;
+  color: var(--chunk-rust);
+  font-size: 0.76rem;
+  font-weight: 950;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p,
+span,
+strong,
+dd {
+  overflow-wrap: anywhere;
+}
+
+h1 {
+  max-width: 12ch;
+  margin: 0;
+  font-size: clamp(3rem, 8vw, 6.2rem);
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3.5vw, 2.8rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.hero-grid p {
+  max-width: 64ch;
+  margin: 1rem 0 0;
+  color: var(--chunk-muted);
+  font-size: 1.08rem;
+}
+
+.lab-note,
+.setup-panel,
+.controls-panel,
+.metrics-panel,
+.debug-panel {
+  border: 1px solid var(--chunk-line);
+  border-radius: 8px;
+  background: var(--chunk-panel);
+  box-shadow: var(--chunk-shadow);
+}
+
+.lab-note {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem;
+}
+
+.lab-note strong {
+  color: var(--chunk-accent);
+}
+
+.lab-note span,
+.status-line {
+  color: var(--chunk-muted);
+}
+
+.chunk-shell {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.4fr) minmax(0, 1fr);
+  gap: 1rem;
+  padding-bottom: 4rem;
+}
+
+.setup-panel,
+.controls-panel,
+.metrics-panel,
+.debug-panel {
+  padding: 1rem;
+}
+
+.room-form,
+.controls-panel {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.room-form {
+  margin-top: 1rem;
+}
+
+label {
+  color: var(--chunk-muted);
+  font-size: 0.85rem;
+  font-weight: 850;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 42px;
+  padding: 0.66rem 0.75rem;
+  border: 1px solid var(--chunk-line);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--chunk-ink);
+  font: inherit;
+}
+
+.room-row,
+.button-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+}
+
+.status-line {
+  margin: 0.4rem 0 0;
+  font-size: 0.92rem;
+}
+
+.chunk-grid {
+  grid-row: span 2;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.chunk-tile {
+  min-height: 290px;
+  position: relative;
+  border: 1px solid var(--chunk-line);
+  border-radius: 8px;
+  background: #111a18;
+  overflow: hidden;
+  box-shadow: var(--chunk-shadow);
+}
+
+.chunk-tile video {
+  width: 100%;
+  height: 100%;
+  min-height: 290px;
+  display: block;
+  object-fit: cover;
+  background: #111a18;
+}
+
+.tile-label {
+  position: absolute;
+  left: 0.75rem;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 8px;
+  background: rgba(18, 34, 31, 0.78);
+  color: #fffaf0;
+  backdrop-filter: blur(10px);
+}
+
+.tile-label span {
+  color: rgba(255, 250, 240, 0.72);
+}
+
+.metrics-panel dl {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin: 1rem 0 0;
+}
+
+.metrics-panel div {
+  padding: 0.75rem;
+  border: 1px solid var(--chunk-line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.48);
+}
+
+dt {
+  color: var(--chunk-muted);
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+dd {
+  margin: 0.2rem 0 0;
+  font-weight: 900;
+}
+
+.debug-panel {
+  grid-column: 1 / -1;
+}
+
+#event-log {
+  display: grid;
+  gap: 0.45rem;
+  max-height: 240px;
+  margin: 1rem 0 0;
+  padding-left: 1.4rem;
+  overflow: auto;
+  color: var(--chunk-muted);
+}
+
+.chunk-footer {
+  padding: 1.5rem 0 2rem;
+  border-top: 1px solid var(--chunk-line);
+  color: var(--chunk-muted);
+}
+
+@media (max-width: 900px) {
+  .hero-grid,
+  .chunk-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-grid {
+    min-height: auto;
+  }
+
+  .chunk-grid {
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .chunk-header,
+  .chunk-shell,
+  .chunk-footer {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  h1 {
+    max-width: 10ch;
+    font-size: clamp(2.6rem, 16vw, 4.4rem);
+  }
+
+  .room-row,
+  .button-row,
+  .metrics-panel dl,
+  .chunk-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -469,6 +469,12 @@
             <span class="app-card__title">Gun Live Room</span>
             <span class="app-card__meta">Try a Zoom-style room with tiny frames and mic chunks through Gun.</span>
           </a>
+          <a href="gun-chunk-stream/" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">CHNK</span>
+            <span class="app-card__title">Gun Chunk Stream</span>
+            <span class="app-card__meta">Record local WebM chunks and upload them through Gun while recording.</span>
+          </a>
           <a href="wellness.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌿</span>
             <span class="app-card__title">Wellness</span>

--- a/portal.3dvr.tech/video/index.html
+++ b/portal.3dvr.tech/video/index.html
@@ -97,6 +97,9 @@
       <a class="button secondary" href="/gun-live-room/">
         Gun Live Room
       </a>
+      <a class="button secondary" href="/gun-chunk-stream/">
+        Gun Chunk Stream
+      </a>
       <!-- Crunched room preset -->
       <a class="button secondary" target="_blank" rel="noopener"
         href="https://vdo.ninja/?room=3dvrtech&label&showlabels&codec=h264&vb=120&ab=24&fps=4&scale=96p&stereo=0&buffer=30">

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -7,6 +7,7 @@ const appDir = new URL('../webrtc-lab/', import.meta.url);
 const gunVideoDir = new URL('../gun-video-lab/', import.meta.url);
 const gunClipDir = new URL('../gun-clip-lab/', import.meta.url);
 const gunLiveDir = new URL('../gun-live-room/', import.meta.url);
+const gunChunkDir = new URL('../gun-chunk-stream/', import.meta.url);
 
 async function fileExists(path) {
   try {
@@ -216,5 +217,58 @@ describe('Gun Live Room app', () => {
     assert.ok(gunLiveIndex < wellnessIndex, 'Gun Live Room should render before Wellness');
     assert.match(readme, /\[Gun Live Room\]\(https:\/\/3dvr-portal\.vercel\.app\/gun-live-room\/\)/);
     assert.match(videoHome, /href="\/gun-live-room\/"/);
+  });
+});
+
+describe('Gun Chunk Stream app', () => {
+  it('ships a pure Gun simultaneous local-recording chunk stream', async () => {
+    const indexUrl = new URL('index.html', gunChunkDir);
+    const stylesUrl = new URL('styles.css', gunChunkDir);
+    const appUrl = new URL('app.js', gunChunkDir);
+    const readmeUrl = new URL('README.md', gunChunkDir);
+
+    assert.equal(await fileExists(indexUrl), true, 'Gun Chunk Stream index should exist');
+    assert.equal(await fileExists(stylesUrl), true, 'Gun Chunk Stream styles should exist');
+    assert.equal(await fileExists(appUrl), true, 'Gun Chunk Stream app script should exist');
+    assert.equal(await fileExists(readmeUrl), true, 'Gun Chunk Stream README should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    const js = await readFile(appUrl, 'utf8');
+    const readme = await readFile(readmeUrl, 'utf8');
+
+    assert.match(html, /3DVR Gun Chunk Stream \| Portal/);
+    assert.match(html, /Record locally, upload while recording/);
+    assert.match(html, /id="chunk-size"/);
+    assert.match(html, /id="start-stream"/);
+    assert.match(html, /id="chunk-grid"/);
+    assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
+    assert.match(js, /ROOM_ROOT = '3dvr-gun-chunk-stream'/);
+    assert.match(js, /recorder\.start\(sliceMs\)/);
+    assert.match(js, /new MediaRecorder\(localStream/);
+    assert.match(js, /reader\.readAsDataURL\(blob\)/);
+    assert.match(js, /chunksNode\.get\(`\$\{localId\}_\$\{sequence\}`\)\.put/);
+    assert.match(js, /new MediaSource\(\)/);
+    assert.match(js, /appendBuffer/);
+    assert.doesNotMatch(js, /RTCPeerConnection/);
+    assert.match(readme, /MediaRecorder\.start\(timeslice\)/);
+    assert.match(readme, /3dvr-gun-chunk-stream\/<room>\/chunks\/<participantId_sequence>/);
+  });
+
+  it('registers the Gun Chunk Stream beside the other pure Gun experiments', async () => {
+    const portalHtml = await readFile(new URL('../index.html', appDir), 'utf8');
+    const readme = await readFile(new URL('../README.md', appDir), 'utf8');
+    const videoHome = await readFile(new URL('../portal.3dvr.tech/video/index.html', appDir), 'utf8');
+
+    const gunLiveIndex = portalHtml.indexOf('>Gun Live Room<');
+    const gunChunkIndex = portalHtml.indexOf('>Gun Chunk Stream<');
+    const wellnessIndex = portalHtml.indexOf('>Wellness<');
+
+    assert.ok(gunChunkIndex !== -1, 'Gun Chunk Stream app card should be listed on the portal');
+    assert.ok(gunLiveIndex !== -1, 'Gun Live Room app card should still be listed');
+    assert.ok(wellnessIndex !== -1, 'Wellness app card should still be listed');
+    assert.ok(gunLiveIndex < gunChunkIndex, 'Gun Chunk Stream should render after Gun Live Room');
+    assert.ok(gunChunkIndex < wellnessIndex, 'Gun Chunk Stream should render before Wellness');
+    assert.match(readme, /\[Gun Chunk Stream\]\(https:\/\/3dvr-portal\.vercel\.app\/gun-chunk-stream\/\)/);
+    assert.match(videoHome, /href="\/gun-chunk-stream\/"/);
   });
 });


### PR DESCRIPTION
## Summary
- add Gun Chunk Stream as a separate pure-Gun audio/video experiment
- record local WebM chunks and upload them through Gun while recording continues
- add MediaSource playback, device selectors, and portal/video hub links

## Tests
- node --test tests/webrtc-lab.test.js tests/video-smart-join.test.js tests/video-ops.test.js tests/video-meshcast.test.js
- git diff --check