### PR TITLE
Buffer Gun chunk stream playback in order

### DIFF
--- a/gun-chunk-stream/README.md
+++ b/gun-chunk-stream/README.md
@@ -8,5 +8,7 @@ This app records locally and uploads while recording:
 - Each chunk is converted to a data URL.
 - Gun stores chunks at `3dvr-gun-chunk-stream/<room>/chunks/<participantId_sequence>`.
 - Receivers append chunks into a `MediaSource` video player when supported.
+- Receivers buffer chunks by sequence before playback because Gun map data can arrive out of order.
+- The chunk log shows direct links to received chunks so you can confirm data is arriving even when playback is blocked.
 
 This should be smoother than the pure frame/audio live room because the browser encodes synchronized audio and video locally first. It is still experimental: WebM chunk playback support varies by mobile browser, and Gun is still carrying large base64 payloads through the graph.

--- a/gun-chunk-stream/app.js
+++ b/gun-chunk-stream/app.js
@@ -20,6 +20,7 @@
     chunksReceived: document.getElementById('chunks-received'),
     lastSize: document.getElementById('last-size'),
     playbackMode: document.getElementById('playback-mode'),
+    chunkList: document.getElementById('chunk-list'),
     eventLog: document.getElementById('event-log')
   };
 
@@ -79,6 +80,18 @@
     item.textContent = `${new Date().toLocaleTimeString()} ${message}`;
     refs.eventLog.prepend(item);
     while (refs.eventLog.children.length > 50) refs.eventLog.lastElementChild.remove();
+  }
+
+  function logChunk(chunk) {
+    const item = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = chunk.dataUrl;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = `${chunk.name || 'Guest'} chunk ${chunk.sequence || '?'} (${Math.round(chunk.dataUrl.length / 1024)} KB)`;
+    item.append(link);
+    refs.chunkList.prepend(item);
+    while (refs.chunkList.children.length > 24) refs.chunkList.lastElementChild.remove();
   }
 
   function setStatus(message) {
@@ -305,13 +318,27 @@
     label.append(title, state);
     tile.append(video, label);
     refs.chunkGrid.appendChild(tile);
-    const player = { video, title, state, queue: [], appending: false, sourceBuffer: null, mediaSource: null, fallback: false };
+    const player = {
+      video,
+      title,
+      state,
+      pending: new Map(),
+      nextSequence: 1,
+      sourceBuffer: null,
+      mediaSource: null,
+      fallback: false
+    };
 
     if (window.MediaSource && MediaSource.isTypeSupported(mimeType)) {
       player.mediaSource = new MediaSource();
       video.src = URL.createObjectURL(player.mediaSource);
       player.mediaSource.addEventListener('sourceopen', () => {
         player.sourceBuffer = player.mediaSource.addSourceBuffer(mimeType);
+        try {
+          player.sourceBuffer.mode = 'sequence';
+        } catch (_error) {
+          // Some browsers expose a readonly mode for this codec.
+        }
         player.sourceBuffer.addEventListener('updateend', () => appendNext(player));
         appendNext(player);
       }, { once: true });
@@ -325,17 +352,18 @@
   }
 
   function appendNext(player) {
-    if (player.fallback || player.appending || !player.sourceBuffer || player.sourceBuffer.updating) return;
-    const next = player.queue.shift();
+    if (player.fallback || !player.sourceBuffer || player.sourceBuffer.updating) return;
+    const next = player.pending.get(player.nextSequence);
     if (!next) return;
-    player.appending = true;
+    player.pending.delete(player.nextSequence);
+    player.nextSequence += 1;
     try {
       player.sourceBuffer.appendBuffer(next);
     } catch (error) {
       console.warn('Append failed', error);
       player.state.textContent = 'Append failed';
-    } finally {
-      player.appending = false;
+      player.pending.set(player.nextSequence - 1, next);
+      player.nextSequence -= 1;
     }
   }
 
@@ -348,6 +376,7 @@
     chunksReceived += 1;
     refs.chunksReceived.textContent = String(chunksReceived);
     refs.lastSize.textContent = `${Math.round(chunk.dataUrl.length / 1024)} KB`;
+    logChunk(chunk);
 
     if (player.fallback) {
       player.video.src = chunk.dataUrl;
@@ -355,7 +384,7 @@
     }
 
     const buffer = await fetch(chunk.dataUrl).then(response => response.arrayBuffer());
-    player.queue.push(buffer);
+    player.pending.set(Number(chunk.sequence || 1), buffer);
     appendNext(player);
     player.video.play().catch(() => {
       player.state.textContent = 'Tap to play';

--- a/gun-chunk-stream/index.html
+++ b/gun-chunk-stream/index.html
@@ -107,6 +107,7 @@
         <p class="eyebrow">Events</p>
         <h2 id="debug-title">Chunk log</h2>
       </div>
+      <ol id="chunk-list" class="chunk-list" aria-label="Received chunks"></ol>
       <ol id="event-log" aria-live="polite"></ol>
     </section>
   </main>

--- a/gun-chunk-stream/styles.css
+++ b/gun-chunk-stream/styles.css
@@ -279,6 +279,20 @@ dd {
   color: var(--chunk-muted);
 }
 
+.chunk-list {
+  display: grid;
+  gap: 0.45rem;
+  max-height: 180px;
+  margin: 1rem 0 0;
+  padding-left: 1.4rem;
+  overflow: auto;
+}
+
+.chunk-list a {
+  color: var(--chunk-accent);
+  font-weight: 800;
+}
+
 .chunk-footer {
   padding: 1.5rem 0 2rem;
   border-top: 1px solid var(--chunk-line);

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -241,6 +241,7 @@ describe('Gun Chunk Stream app', () => {
     assert.match(html, /id="chunk-size"/);
     assert.match(html, /id="start-stream"/);
     assert.match(html, /id="chunk-grid"/);
+    assert.match(html, /id="chunk-list"/);
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
     assert.match(js, /ROOM_ROOT = '3dvr-gun-chunk-stream'/);
     assert.match(js, /recorder\.start\(sliceMs\)/);
@@ -248,6 +249,9 @@ describe('Gun Chunk Stream app', () => {
     assert.match(js, /reader\.readAsDataURL\(blob\)/);
     assert.match(js, /chunksNode\.get\(`\$\{localId\}_\$\{sequence\}`\)\.put/);
     assert.match(js, /new MediaSource\(\)/);
+    assert.match(js, /pending: new Map\(\)/);
+    assert.match(js, /nextSequence: 1/);
+    assert.match(js, /player\.pending\.set\(Number\(chunk\.sequence \|\| 1\), buffer\)/);
     assert.match(js, /appendBuffer/);
     assert.doesNotMatch(js, /RTCPeerConnection/);
     assert.match(readme, /MediaRecorder\.start\(timeslice\)/);


### PR DESCRIPTION
## Summary
- buffer received Gun chunk stream data by sequence before appending to MediaSource
- set SourceBuffer sequence mode when supported
- add a visible received chunk ledger with direct chunk links for debugging

## Tests
- node --test tests/webrtc-lab.test.js tests/video-smart-join.test.js tests/video-ops.test.js tests/video-meshcast.test.js
- git diff --check
- node --check gun-chunk-stream/app.js