### PR TITLE
Add phone holder prototype roadmap

### DIFF
--- a/phone-holder-system/README.md
+++ b/phone-holder-system/README.md
@@ -1,5 +1,7 @@
 # 3DVR Phone Holder System
 
-Concept app for the 3DVR Nomad Clip: a modular ergonomic phone-holder system for travel workstations, AR glasses, desk docks, backpack straps, and healthier mobile computing.
+Concept app for the 3DVR Nomad Clip: a grip, stand, tripod, extender, travel dock, and pocket workstation handle for healthier mobile computing.
+
+The prototype roadmap starts with off-the-shelf base platforms, then layers on 3DVR modifications, target geometry, ergonomic grip experiments, counterweight balance, natural materials, future workstation features, joystick-style phone controls, and the longer-term "phone becomes the brain" direction.
 
 The current page uses a CSS-built product render because the referenced ChatGPT share image was not directly downloadable from the coding environment. Replace the render with a real exported product image when one is available.

--- a/phone-holder-system/index.html
+++ b/phone-holder-system/index.html
@@ -6,7 +6,7 @@
   <title>3DVR Phone Holder System | 3DVR Portal</title>
   <meta
     name="description"
-    content="A 3DVR concept app for a modular ergonomic phone holder, travel dock, and AR-friendly mobile workstation."
+    content="A 3DVR Nomad Clip concept for an extendable handheld tripod, ergonomic phone grip, travel dock, and AR-friendly mobile workstation."
   >
   <link rel="stylesheet" href="../style.css?v=phone-holder-system">
   <link rel="stylesheet" href="./styles.css?v=20260519">
@@ -16,17 +16,18 @@
     <a href="../index.html">Portal</a>
     <a href="#modes">Modes</a>
     <a href="#prototype">Prototype</a>
+    <a href="#roadmap">Roadmap</a>
     <a href="#path">Path</a>
   </nav>
 
   <header class="hero-shell">
     <section class="hero-copy" aria-labelledby="phone-holder-title">
-      <p class="eyebrow">3DVR Concept Lab</p>
-      <h1 id="phone-holder-title">Stop holding the phone. Start docking it.</h1>
-      <p>
-        A modular ergonomic phone-holder system for travel, work, AR glasses, desk setups, backpacks,
-        and everyday movement. The phone becomes the compute brick; the human gets their body back.
-      </p>
+        <p class="eyebrow">3DVR Nomad Clip</p>
+        <h1 id="phone-holder-title">Stop holding the phone. Start docking it.</h1>
+        <p>
+        A grip, stand, tripod, and extender for the phone-as-brain workstation era. The phone becomes
+        the compute brick; the human gets their body back.
+        </p>
       <div class="hero-actions" aria-label="Primary actions">
         <a class="action primary" href="#prototype">Explore concept</a>
         <a class="action" href="#path">Build path</a>
@@ -100,6 +101,91 @@
         <div><strong>Shield plate</strong><span>Distance, orientation, and heat separation from the body.</span></div>
         <div><strong>Touch layer</strong><span>Cork, linen, hemp composite, rubber, wood, copper, or aluminum.</span></div>
         <div><strong>USB-C pass-through</strong><span>Charging, display, keyboard, headphones, and data.</span></div>
+      </div>
+    </section>
+
+    <section class="roadmap-panel" id="roadmap" aria-labelledby="roadmap-title">
+      <div class="section-intro">
+        <p class="eyebrow">Prototype Roadmap</p>
+        <h2 id="roadmap-title">Start with a handle, not a selfie stick.</h2>
+        <p>
+          The first 3DVR Nomad Clip prototype should prove one object that works as a grip, stand,
+          tripod, and extender, built from an off-the-shelf base platform with 3DVR modifications.
+        </p>
+      </div>
+
+      <div class="comparison-wrap" aria-label="Prototype base platform comparison">
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>Attribute</th>
+              <th><a href="https://www.apple.com/us/xc/product/HNKK2ZM/A">Joby TelePod Mobile</a></th>
+              <th><a href="https://www.homedepot.com/p/OBJLGEV-Selfie-Stick-Tripod-Extendable-Grip-Phone-Tripod-with-Detachable-Remote-Pocket-Size-3-in-1-Mini-Phone-Grip-5321D27ISA99102/335612872">OBJLGEV mini tripod</a></th>
+              <th><a href="https://www.bhphotovideo.com/c/product/1852999-REG/ulanzi_t027gbb1_mt70_selfie_stick_tripod.html">Ulanzi MT70</a></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><th>Role</th><td>Best base platform</td><td>Cheapest prototype base</td><td>Best modular creator base</td></tr>
+            <tr><th>Extendable</th><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+            <tr><th>Tripod legs</th><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+            <tr><th>Grip potential</th><td>High</td><td>Medium</td><td>High</td></tr>
+            <tr><th>Easy to modify</th><td>High</td><td>Medium</td><td>Very high</td></tr>
+            <tr><th>Workstation potential</th><td>Very high</td><td>Medium</td><td>Very high</td></tr>
+            <tr><th>Accessory mounting</th><td>Medium</td><td>Medium</td><td>High</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="roadmap-grid">
+        <article class="concept-card">
+          <span class="card-kicker">Phase 0.1</span>
+          <h3>Modify an existing extendable core</h3>
+          <p>Buy one tripod handle, wrap or sleeve the grip, test wrist angle, and add a phone mount that can rotate fast.</p>
+        </article>
+        <article class="concept-card">
+          <span class="card-kicker">Hand</span>
+          <h3>Make the grip thicker</h3>
+          <p>Phones force a pinch grip. Use cork, linen wrap, silicone, leather, or a rounded printed shell closer to a camera grip, bicycle handle, or trekking pole.</p>
+        </article>
+        <article class="concept-card">
+          <span class="card-kicker">Tripod</span>
+          <h3>Make the feet feel good in hand</h3>
+          <p>Most tripod legs are sharp or awkward. Test rounded fold-out legs, magnetic closure, and a palm-support shape.</p>
+        </article>
+        <article class="concept-card">
+          <span class="card-kicker">Balance</span>
+          <h3>Add counterweight below the phone</h3>
+          <p>A phone is top-heavy. A battery, copper insert, or weighted base can make the handle feel like a balanced tool.</p>
+        </article>
+        <article class="concept-card">
+          <span class="card-kicker">Geometry</span>
+          <h3>Target geometry</h3>
+          <p>Test 15-25 cm collapsed, 40-80 cm extended, center grip below phone, optional side grip, and adjustable viewing angle.</p>
+        </article>
+        <article class="concept-card">
+          <span class="card-kicker">3DVR</span>
+          <h3>The phone becomes the brain</h3>
+          <p>The real version can add battery, cooling, USB-C hub, wired audio, split keyboard dock, wearable clip, and AR glasses routing.</p>
+        </article>
+      </div>
+
+      <div class="material-strip" aria-label="Material and later feature ideas">
+        <div>
+          <strong>Product frame</strong>
+          <span>3DVR Nomad Clip: grip, stand, tripod, extender, and pocket workstation handle in one modular object.</span>
+        </div>
+        <div>
+          <strong>Materials to test</strong>
+          <span>Cork, linen, hemp composite, bamboo laminate, carbon fiber tubes, aluminum core, copper inserts, shungite body-facing plate.</span>
+        </div>
+        <div>
+          <strong>Future workstation features</strong>
+          <span>MagSafe/Qi2 docking, USB-C pass-through, detachable keyboard halves, neck strap, lap stand mode, AR glasses support, E-ink back display, red-light strip, and joystick-style phone controls.</span>
+        </div>
+        <div>
+          <strong>Control handle direction</strong>
+          <span>The grip could become an active controller with a thumbstick, trigger, scroll wheel, programmable buttons, or Bluetooth/USB-C input for camera, games, AR, scrolling, and one-hand navigation.</span>
+        </div>
       </div>
     </section>
 

--- a/phone-holder-system/styles.css
+++ b/phone-holder-system/styles.css
@@ -307,6 +307,7 @@ main {
 
 .section-grid,
 .prototype-panel,
+.roadmap-panel,
 .build-path {
   display: grid;
   gap: 1.25rem;
@@ -335,6 +336,7 @@ main {
 
 .concept-card,
 .prototype-panel,
+.roadmap-panel,
 .steps li {
   border: 1px solid var(--holder-line);
   border-radius: 8px;
@@ -383,6 +385,74 @@ main {
 }
 
 .feature-list span {
+  color: var(--holder-muted);
+}
+
+.roadmap-panel {
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.comparison-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--holder-line);
+  border-radius: 8px;
+}
+
+.comparison-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  background: #fbfaf7;
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 0.8rem;
+  border-bottom: 1px solid var(--holder-line);
+  border-right: 1px solid var(--holder-line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.comparison-table th {
+  color: var(--holder-charcoal);
+  font-size: 0.84rem;
+}
+
+.comparison-table td {
+  color: var(--holder-muted);
+}
+
+.comparison-table a {
+  color: var(--holder-blue);
+}
+
+.roadmap-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.material-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.material-strip div {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem;
+  border: 1px solid var(--holder-line);
+  border-radius: 8px;
+  background: #fbfaf7;
+}
+
+.material-strip strong {
+  color: var(--holder-blue);
+}
+
+.material-strip span {
   color: var(--holder-muted);
 }
 
@@ -453,7 +523,9 @@ main {
   }
 
   .three-up,
-  .mode-grid {
+  .mode-grid,
+  .roadmap-grid,
+  .material-strip {
     grid-template-columns: 1fr;
   }
 }

--- a/tests/phone-holder-system.test.js
+++ b/tests/phone-holder-system.test.js
@@ -28,6 +28,16 @@ describe('phone holder system app', () => {
     assert.match(html, /3DVR Phone Holder System \| 3DVR Portal/);
     assert.match(html, /Stop holding the phone\. Start docking it\./);
     assert.match(html, /The 3DVR Nomad Clip/);
+    assert.match(html, /grip, stand, tripod, and extender/);
+    assert.match(html, /id="roadmap"/);
+    assert.match(html, /off-the-shelf base platform/);
+    assert.match(html, /Joby TelePod Mobile/);
+    assert.match(html, /Ulanzi MT70/);
+    assert.match(html, /Target geometry/);
+    assert.match(html, /Future workstation features/);
+    assert.match(html, /joystick-style phone controls/);
+    assert.match(html, /Control handle direction/);
+    assert.match(html, /The phone becomes the brain/);
     assert.match(html, /id="modes"/);
     assert.match(html, /id="path"/);
     assert.match(html, /class="device-render"/);


### PR DESCRIPTION
## Summary
- add a practical prototype roadmap to the Phone Holder System app
- compare off-the-shelf tripod handle bases and immediate modifications
- capture the larger phone-as-brain workstation direction, materials, and later smart features

## Tests
- node --test tests/phone-holder-system.test.js
- git diff --check