### PR TITLE
Add Nomad Clip field test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Notes](https://3dvr-portal.vercel.app/notes/)
 - [Pocket Workstation](https://3dvr-portal.vercel.app/pocket-workstation/)
 - [Phone Holder System](https://3dvr-portal.vercel.app/phone-holder-system/)
+- [Nomad Clip Field Test](https://3dvr-portal.vercel.app/nomad-clip-field-test/)
 - [Open Source](https://3dvr-portal.vercel.app/open-source/)
 - [WebRTC Lab](https://3dvr-portal.vercel.app/webrtc-lab/)
 - [Gun Video Lab](https://3dvr-portal.vercel.app/gun-video-lab/)

--- a/index.html
+++ b/index.html
@@ -366,6 +366,12 @@
             <span class="app-card__title">Phone Holder System</span>
             <span class="app-card__meta">Prototype the Nomad Clip for ergonomic phone docking, travel, and AR workflows.</span>
           </a>
+          <a href="nomad-clip-field-test/index.html" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">KIT</span>
+            <span class="app-card__title">Nomad Clip Field Test</span>
+            <span class="app-card__meta">Turn subscriber hardware into a focused grip, stand, tripod, and extender beta.</span>
+          </a>
           <a href="newsroom/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">📰</span>
             <span class="app-card__title">News Lounge</span>

--- a/nomad-clip-field-test/README.md
+++ b/nomad-clip-field-test/README.md
@@ -1,0 +1,10 @@
+# 3DVR Nomad Clip Field Test
+
+Subscriber hardware beta page for the Nomad Clip V0.
+
+The page frames the $300-700 hardware budget as a small field lab, not a generic giveaway:
+
+- Build two serious kits or a few lighter kits.
+- Use off-the-shelf tripod spines, magic arms, grip materials, USB-C hubs, optional MagSafe adapters, optional split keyboards, and optional lap-base experiments.
+- Give kits to subscribers who will return photos, comfort notes, posture notes, failure points, and short test videos.
+- Use the feedback to discover geometry, posture, transitions, and what feels good physically.

--- a/nomad-clip-field-test/index.html
+++ b/nomad-clip-field-test/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3DVR Nomad Clip Field Test | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="A subscriber hardware field test for the 3DVR Nomad Clip: grip, stand, tripod, extender, lap workstation, and phone-as-brain prototype."
+  >
+  <link rel="stylesheet" href="../style.css?v=nomad-clip-field-test">
+  <link rel="stylesheet" href="./styles.css?v=20260519">
+</head>
+<body class="field-test-page">
+  <nav class="field-nav" aria-label="Nomad Clip field test navigation">
+    <a href="../index.html">Portal</a>
+    <a href="/phone-holder-system/">Nomad Clip</a>
+    <a href="#v0-stack">V0 stack</a>
+    <a href="#testers">Testers</a>
+    <a href="#budget">Budget</a>
+  </nav>
+
+  <header class="field-hero">
+    <section class="hero-copy" aria-labelledby="field-title">
+      <p class="eyebrow">Subscriber Hardware Beta</p>
+      <h1 id="field-title">3DVR Nomad Clip Field Test</h1>
+      <p>
+        A small hardware beta for subscribers who want to help shape a healthier phone workstation:
+        grip, stand, tripod, extender, lap mode, table mode, and future control handle.
+      </p>
+      <div class="hero-actions">
+        <a class="action primary" href="#testers">Field test terms</a>
+        <a class="action" href="#v0-stack">Build the V0 kit</a>
+      </div>
+    </section>
+
+    <section class="kit-board" aria-label="Nomad Clip field test kit map">
+      <div class="kit-node spine">Tripod spine</div>
+      <div class="kit-node grip">Grip wrap</div>
+      <div class="kit-node arm">Magic arm</div>
+      <div class="kit-node hub">USB-C hub</div>
+      <div class="kit-node keyboard">Split keyboard</div>
+      <div class="kit-node lap">Lap base</div>
+      <div class="kit-center">Nomad Clip V0</div>
+    </section>
+  </header>
+
+  <main>
+    <section class="principles" aria-labelledby="principles-title">
+      <div class="section-intro">
+        <p class="eyebrow">Prototype Goal</p>
+        <h2 id="principles-title">Do not optimize for perfection. Optimize for discovery.</h2>
+        <p>
+          The first real prototype should discover geometry, posture, transitions, and what feels good
+          physically. Subscribers get early hardware; 3DVR gets real field notes.
+        </p>
+      </div>
+      <div class="cards four-up">
+        <article class="field-card">
+          <span class="kicker">Modularity</span>
+          <h3>Swap the parts</h3>
+          <p>Use off-the-shelf arms, clamps, adapters, and hubs so the kit can evolve fast.</p>
+        </article>
+        <article class="field-card">
+          <span class="kicker">Comfort</span>
+          <h3>Hold it for real</h3>
+          <p>Grip thickness, wrist angle, and texture matter more than a perfect CAD render.</p>
+        </article>
+        <article class="field-card">
+          <span class="kicker">Lap / Table</span>
+          <h3>Test daily positions</h3>
+          <p>Couch, train, bed, desk, and cafe table use should all inform the final geometry.</p>
+        </article>
+        <article class="field-card">
+          <span class="kicker">Keyboard</span>
+          <h3>Leave room to type</h3>
+          <p>The handle should grow toward split keyboard wings and a tiny cyberdeck workflow.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="stack-panel" id="v0-stack" aria-labelledby="stack-title">
+      <div class="section-intro">
+        <p class="eyebrow">Recommended V0 Stack</p>
+        <h2 id="stack-title">Easy to order. Easy to modify.</h2>
+        <p>
+          This stack uses existing parts to test the real invention: geometry, posture, transitions,
+          and physical feel.
+        </p>
+      </div>
+      <div class="comparison-wrap" aria-label="Recommended V0 hardware stack">
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>Attribute</th>
+              <th><a href="https://www.ulanzi.com/products/mt85-automatic-pop-up-phone-tripod">Ulanzi MT85 Convertible Tripod</a></th>
+              <th><a href="https://www.bhphotovideo.com/c/product/1934370-REG/r_go_tools_rgosbuswlwh_ergonomic_wireless_split_break.html">R-Go Split Break Keyboard</a></th>
+              <th><a href="https://www.smallrig.com/Desktop-Shooting-Magic-Arm-with-Crab-Clamp-Kit-4766.html">SmallRig Magic Arm</a></th>
+              <th><a href="https://www.belkin.com/p/usb-c-to-4-port-usb-c-hub/AVC018btBK.html">Belkin USB-C Hub</a></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><th>Purpose</th><td>Main spine / tripod</td><td>Ergonomic typing</td><td>Adjustable mounting</td><td>Device expansion</td></tr>
+            <tr><th>Pocketable</th><td>Yes</td><td>Moderate</td><td>Moderate</td><td>Yes</td></tr>
+            <tr><th>Ergonomic impact</th><td>Very high</td><td>Very high</td><td>Very high</td><td>Medium</td></tr>
+            <tr><th>Joystick mode</th><td>Excellent</td><td>Not applicable</td><td>Good</td><td>Not applicable</td></tr>
+            <tr><th>Lap mode</th><td>Good</td><td>Excellent</td><td>Excellent</td><td>Good</td></tr>
+            <tr><th>Table mode</th><td>Excellent</td><td>Excellent</td><td>Excellent</td><td>Excellent</td></tr>
+            <tr><th>Expandability</th><td>High</td><td>High</td><td>Very high</td><td>Very high</td></tr>
+            <tr><th>Beginner friendly</th><td>Excellent</td><td>Good</td><td>Good</td><td>Excellent</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="build-grid" aria-labelledby="kit-title">
+      <div class="section-intro">
+        <p class="eyebrow">Kit Layers</p>
+        <h2 id="kit-title">What each part proves.</h2>
+      </div>
+      <div class="cards three-up">
+        <article class="field-card">
+          <span class="kicker">Spine</span>
+          <h3>Tripod / extender core</h3>
+          <p>Tests joystick mode, table mode, extendable viewing, and pocketable base assumptions.</p>
+        </article>
+        <article class="field-card">
+          <span class="kicker">Keyboard</span>
+          <h3>Split typing layer</h3>
+          <p>Tests lap mode, posture, and whether Nomad Clip can become a tiny cyberdeck.</p>
+        </article>
+        <article class="field-card">
+          <span class="kicker">Arm</span>
+          <h3>Adjustable screen geometry</h3>
+          <p>Tests neck angle, screen distance, lap balance, and ergonomic positioning.</p>
+        </article>
+        <article class="field-card">
+          <span class="kicker">Mounts</span>
+          <h3>Extra modular arms</h3>
+          <p>Become keyboard wings, accessory mounts, cable anchors, and future AR support points.</p>
+        </article>
+        <article class="field-card">
+          <span class="kicker">Grip</span>
+          <h3>Material feel</h3>
+          <p>Cork, tennis grip, silicone, leather, or linen wrap determine fatigue, comfort, and perceived quality.</p>
+        </article>
+        <article class="field-card">
+          <span class="kicker">Expansion</span>
+          <h3>USB-C workstation hub</h3>
+          <p>Turns the phone into an editing station, streaming setup, wired audio path, and mini desktop.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="tester-panel" id="testers" aria-labelledby="tester-title">
+      <div>
+        <p class="eyebrow">Subscriber Field Test</p>
+        <h2 id="tester-title">Give hardware to testers, not random people.</h2>
+        <p>
+          Frame this as a limited subscriber field test. The kit is not a free prize; it is a prototype
+          exchange. Testers get early hardware and 3DVR gets honest notes.
+        </p>
+      </div>
+      <ol class="tester-list">
+        <li><strong>Who gets it:</strong> subscribers who will test lap, table, travel, and handheld modes.</li>
+        <li><strong>What they return:</strong> photos, comfort notes, posture notes, failure points, and one-minute videos.</li>
+        <li><strong>What they earn:</strong> early access, field tester credit, and possible discount on final hardware.</li>
+        <li><strong>What 3DVR learns:</strong> geometry, transitions, what feels good, and whether this should become real hardware.</li>
+      </ol>
+    </section>
+
+    <section class="budget-panel" id="budget" aria-labelledby="budget-title">
+      <div class="section-intro">
+        <p class="eyebrow">Budget</p>
+        <h2 id="budget-title">Use the $300-700 as a small lab.</h2>
+        <p>Two serious kits or a few lighter kits are better than spreading the money across weak parts.</p>
+      </div>
+      <div class="budget-grid">
+        <article class="budget-card">
+          <strong>$300 floor</strong>
+          <span>Build two lightweight kits with spine, grip material, adapter, and basic hub.</span>
+        </article>
+        <article class="budget-card">
+          <strong>$500 middle</strong>
+          <span>Build two serious kits with tripod spine, magic arm, MagSafe mount, grip materials, and USB-C expansion.</span>
+        </article>
+        <article class="budget-card">
+          <strong>$700 ceiling</strong>
+          <span>Build two premium kits or three mixed kits, adding split keyboard and lap-base experiments.</span>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="field-footer">
+    <p>3DVR Nomad Clip Field Test: discover the physical interface for healthier phone-based computing.</p>
+  </footer>
+</body>
+</html>

--- a/nomad-clip-field-test/styles.css
+++ b/nomad-clip-field-test/styles.css
@@ -1,0 +1,390 @@
+:root {
+  --field-bg: #f4f1ea;
+  --field-panel: #fffdf7;
+  --field-ink: #1f2528;
+  --field-muted: #697177;
+  --field-line: #d8d0c0;
+  --field-blue: #315f7e;
+  --field-rust: #8b5634;
+  --field-sage: #5f715c;
+  --field-dark: #162027;
+  --field-shadow: 0 18px 42px rgba(31, 37, 40, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.field-test-page {
+  margin: 0;
+  background: var(--field-bg);
+  color: var(--field-ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.55;
+}
+
+.field-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.6rem;
+  border-bottom: 1px solid var(--field-line);
+  background: rgba(244, 241, 234, 0.9);
+  backdrop-filter: blur(14px);
+}
+
+.field-nav a,
+.action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.62rem 0.9rem;
+  border: 1px solid var(--field-line);
+  border-radius: 8px;
+  color: var(--field-ink);
+  text-decoration: none;
+  font-weight: 850;
+}
+
+.field-nav a:hover,
+.action:hover {
+  border-color: var(--field-rust);
+}
+
+.field-hero,
+main,
+.field-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.field-hero {
+  min-height: calc(100vh - 56px);
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(360px, 1.05fr);
+  gap: clamp(1.25rem, 4vw, 4rem);
+  align-items: center;
+  padding: clamp(2rem, 6vw, 5rem) 0;
+}
+
+.hero-copy {
+  max-width: 660px;
+}
+
+.eyebrow {
+  margin: 0 0 0.7rem;
+  color: var(--field-rust);
+  font-size: 0.76rem;
+  font-weight: 950;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p,
+span,
+strong,
+td,
+th {
+  overflow-wrap: anywhere;
+}
+
+h1 {
+  margin: 0;
+  max-width: 12ch;
+  font-size: clamp(3rem, 8.5vw, 6.6rem);
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(2rem, 4.5vw, 4rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1.15rem;
+  line-height: 1.18;
+}
+
+.hero-copy p,
+.section-intro p,
+.field-card p,
+.tester-panel p,
+.tester-list,
+.budget-card span {
+  color: var(--field-muted);
+}
+
+.hero-copy p {
+  max-width: 58ch;
+  margin: 1.25rem 0 0;
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.action {
+  background: var(--field-panel);
+  box-shadow: 0 10px 24px rgba(31, 37, 40, 0.08);
+}
+
+.action.primary {
+  background: var(--field-dark);
+  color: #fffaf0;
+  border-color: var(--field-dark);
+}
+
+.kit-board {
+  min-height: 600px;
+  position: relative;
+  border: 1px solid var(--field-line);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(49, 95, 126, 0.14), transparent 36%),
+    linear-gradient(315deg, rgba(139, 86, 52, 0.16), transparent 38%),
+    #ebe5d8;
+  box-shadow: var(--field-shadow);
+  overflow: hidden;
+}
+
+.kit-board::before,
+.kit-board::after {
+  content: "";
+  position: absolute;
+  inset: 13%;
+  border: 1px solid rgba(31, 37, 40, 0.16);
+  border-radius: 50%;
+}
+
+.kit-board::after {
+  inset: 28%;
+}
+
+.kit-node,
+.kit-center {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  min-width: 118px;
+  min-height: 54px;
+  padding: 0.7rem;
+  border: 1px solid rgba(31, 37, 40, 0.15);
+  border-radius: 8px;
+  background: rgba(255, 253, 247, 0.86);
+  box-shadow: 0 12px 28px rgba(31, 37, 40, 0.1);
+  color: var(--field-dark);
+  font-weight: 900;
+  text-align: center;
+}
+
+.kit-center {
+  left: 50%;
+  top: 50%;
+  min-width: 150px;
+  min-height: 86px;
+  color: #fffaf0;
+  background: var(--field-dark);
+  transform: translate(-50%, -50%);
+}
+
+.spine { left: 11%; top: 16%; }
+.grip { right: 12%; top: 18%; }
+.arm { left: 8%; top: 47%; }
+.hub { right: 10%; top: 50%; }
+.keyboard { left: 18%; bottom: 14%; }
+.lap { right: 18%; bottom: 13%; }
+
+main {
+  display: grid;
+  gap: clamp(2.2rem, 5vw, 4rem);
+  padding-bottom: 4rem;
+}
+
+.principles,
+.stack-panel,
+.build-grid,
+.tester-panel,
+.budget-panel {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.section-intro {
+  max-width: 820px;
+}
+
+.cards {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.four-up {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.three-up,
+.budget-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.field-card,
+.stack-panel,
+.tester-panel,
+.budget-card {
+  border: 1px solid var(--field-line);
+  border-radius: 8px;
+  background: var(--field-panel);
+  box-shadow: 0 10px 28px rgba(31, 37, 40, 0.07);
+}
+
+.field-card,
+.budget-card {
+  min-height: 185px;
+  padding: 1rem;
+}
+
+.kicker {
+  display: inline-flex;
+  margin-bottom: 1.25rem;
+  color: var(--field-rust);
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.stack-panel,
+.tester-panel,
+.budget-panel {
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.comparison-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--field-line);
+  border-radius: 8px;
+}
+
+.comparison-table {
+  width: 100%;
+  min-width: 960px;
+  border-collapse: collapse;
+  background: #fbfaf7;
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 0.8rem;
+  border-bottom: 1px solid var(--field-line);
+  border-right: 1px solid var(--field-line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.comparison-table th {
+  color: var(--field-dark);
+  font-size: 0.84rem;
+}
+
+.comparison-table td {
+  color: var(--field-muted);
+}
+
+.comparison-table a {
+  color: var(--field-blue);
+}
+
+.tester-panel {
+  grid-template-columns: minmax(0, 0.85fr) minmax(320px, 1.15fr);
+  align-items: start;
+}
+
+.tester-list {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.budget-card {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.budget-card strong {
+  color: var(--field-blue);
+  font-size: 1.1rem;
+}
+
+.field-footer {
+  padding: 1.25rem 0 2rem;
+  border-top: 1px solid var(--field-line);
+  color: var(--field-muted);
+}
+
+@media (max-width: 980px) {
+  .field-nav {
+    justify-content: flex-start;
+    overflow-x: auto;
+  }
+
+  .field-hero,
+  .tester-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .field-hero {
+    min-height: auto;
+    padding-top: 2rem;
+  }
+
+  .four-up,
+  .three-up,
+  .budget-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .field-hero,
+  main,
+  .field-footer {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  h1 {
+    max-width: 10ch;
+  }
+
+  .kit-board {
+    min-height: 460px;
+  }
+
+  .kit-node {
+    min-width: 92px;
+    font-size: 0.82rem;
+  }
+
+  .kit-center {
+    min-width: 120px;
+  }
+
+  .hero-actions {
+    display: grid;
+  }
+}

--- a/tests/nomad-clip-field-test.test.js
+++ b/tests/nomad-clip-field-test.test.js
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const appDir = new URL('../nomad-clip-field-test/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+describe('Nomad Clip field test app', () => {
+  it('ships a subscriber hardware beta page', async () => {
+    const indexUrl = new URL('index.html', appDir);
+    const stylesUrl = new URL('styles.css', appDir);
+    const readmeUrl = new URL('README.md', appDir);
+
+    assert.equal(await fileExists(indexUrl), true, 'field test index should exist');
+    assert.equal(await fileExists(stylesUrl), true, 'field test styles should exist');
+    assert.equal(await fileExists(readmeUrl), true, 'field test README should exist');
+
+    const html = await readFile(indexUrl, 'utf8');
+    const readme = await readFile(readmeUrl, 'utf8');
+
+    assert.match(html, /3DVR Nomad Clip Field Test \| 3DVR Portal/);
+    assert.match(html, /Subscriber Hardware Beta/);
+    assert.match(html, /grip, stand, tripod, extender/);
+    assert.match(html, /Ulanzi MT85 Convertible Tripod/);
+    assert.match(html, /R-Go Split Break Keyboard/);
+    assert.match(html, /SmallRig Magic Arm/);
+    assert.match(html, /Belkin USB-C Hub/);
+    assert.match(html, /\$300-700/);
+    assert.match(html, /discover geometry, posture, transitions/);
+    assert.match(readme, /small field lab/);
+  });
+
+  it('registers the field test in the portal and README', async () => {
+    const portalHtml = await readFile(new URL('../index.html', appDir), 'utf8');
+    const readme = await readFile(new URL('../README.md', appDir), 'utf8');
+
+    const holderIndex = portalHtml.indexOf('>Phone Holder System<');
+    const fieldIndex = portalHtml.indexOf('>Nomad Clip Field Test<');
+    const newsroomIndex = portalHtml.indexOf('>News Lounge<');
+
+    assert.ok(fieldIndex !== -1, 'Nomad Clip Field Test app card should be listed on the portal');
+    assert.ok(holderIndex !== -1, 'Phone Holder System app card should still be listed');
+    assert.ok(newsroomIndex !== -1, 'News Lounge app card should still be listed');
+    assert.ok(holderIndex < fieldIndex, 'Field Test should render after Phone Holder System');
+    assert.ok(fieldIndex < newsroomIndex, 'Field Test should render before News Lounge');
+    assert.match(readme, /\[Nomad Clip Field Test\]\(https:\/\/3dvr-portal\.vercel\.app\/nomad-clip-field-test\/\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a subscriber-facing Nomad Clip Field Test page
- frame the 00-700 hardware budget as a small prototype lab, not a generic giveaway
- list V0 kit parts, tester expectations, and budget tiers
- link the page from the portal dock and README

## Tests
- node --test tests/nomad-clip-field-test.test.js tests/phone-holder-system.test.js
- git diff --check