### PR TITLE
Add weekly release notes through v0.0.46

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -82,16 +82,37 @@
   <div class="section">
     <h2>Latest Release</h2>
     <article class="release-card">
-      <a class="release-link" href="v0.0.43.html">v0.0.43</a>
-      <span class="release-meta">Week of May 4, 2026</span>
+      <a class="release-link" href="v0.0.46.html">v0.0.46</a>
+      <span class="release-meta">Week of May 18, 2026</span>
       <p class="release-summary">
-        3dvr-agent beta 1.0.1-beta.2, inbox delivery failure monitoring, and the next staged weekly release entry.
+        Guest identity cleanup, Gun video labs, mobile game passes, Open Source guidance, and the Nomad Clip prototype push.
       </p>
     </article>
   </div>
   <div class="section">
     <h2>Release History</h2>
     <ul class="release-grid">
+      <li class="release-card">
+        <a class="release-link" href="v0.0.46.html">v0.0.46</a>
+        <span class="release-meta">Week of May 18, 2026</span>
+        <p class="release-summary">
+          Guest identity cleanup, Gun video labs, mobile game passes, Open Source guidance, and the Nomad Clip prototype push.
+        </p>
+      </li>
+      <li class="release-card">
+        <a class="release-link" href="v0.0.45.html">v0.0.45</a>
+        <span class="release-meta">Week of May 11, 2026</span>
+        <p class="release-summary">
+          Portal launcher cleanup, Victor storefront work, education pages, billing plan selection, recovery email, and OAuth layout polish.
+        </p>
+      </li>
+      <li class="release-card">
+        <a class="release-link" href="v0.0.44.html">v0.0.44</a>
+        <span class="release-meta">Week of May 4, 2026</span>
+        <p class="release-summary">
+          Video meeting operations, agent control surfaces, health checks, test stabilization, private clipboard, and Garden Planet experiments.
+        </p>
+      </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.43.html">v0.0.43</a>
         <span class="release-meta">Week of May 4, 2026</span>

--- a/releases/v0.0.43.html
+++ b/releases/v0.0.43.html
@@ -84,7 +84,7 @@
   <p><a class="back-link" href="index.html">← Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
     <a class="release-nav-link" href="v0.0.42.html">← Previous release</a>
-    <span class="release-nav-link is-disabled" aria-disabled="true">Next release →</span>
+    <a class="release-nav-link" href="v0.0.44.html">Next release →</a>
   </nav>
   <h1>Release v0.0.43</h1>
   <div class="tag">Week of May 4, 2026</div>

--- a/releases/v0.0.44.html
+++ b/releases/v0.0.44.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.44 (Week of May 4, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.43.html">Previous release</a>
+    <a class="release-nav-link" href="v0.0.45.html">Next release</a>
+  </nav>
+  <h1>Release v0.0.44</h1>
+  <div class="tag">Week of May 4, 2026</div>
+  <div class="release-summary">
+    <p>This backfilled weekly release covers the operational work that landed after v0.0.43.</p>
+    <ul class="release-summary-list">
+      <li><strong>Video operations:</strong> smart join flows, meeting ops, meshcast presets, and video packs moved closer to a usable portal meeting surface.</li>
+      <li><strong>Agent operations:</strong> admin control surfaces, heartbeat checks, Gun host configuration, and DigitalOcean notes made the agent runtime easier to operate.</li>
+      <li><strong>Reliability:</strong> portal health checks, Playwright stabilization, Gun relay selection, and private clipboard work improved the day-to-day build loop.</li>
+      <li><strong>Experiments:</strong> <a href="../garden-planet/">Garden Planet</a>, expansion path work, and Space Jetpack tests kept the prototype layer moving.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Merged PRs</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/558">#558 Garden Planet landing page</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/559">#559 Stabilize portal tests</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/560">#560 Add portal health route and stabilize the dev server</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/561">#561 Stabilize Playwright suites</a></li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Commit Trail</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/commit/b353458">b353458</a> added loopback video room links.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/commit/67c1e8f">67c1e8f</a> introduced the smart video launcher control flow.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/commit/a9d33d8">a9d33d8</a> added the admin agent operations control surface.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/commit/6655e28">6655e28</a> configured the portal Gun host.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/commit/4d47508">4d47508</a> documented the DigitalOcean operations path.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/commit/186a5dc">186a5dc</a> added the private device clipboard.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Issue Pulse</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/542">#542 3DVR Portal</a> stayed the umbrella issue for portal direction.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/417">#417 Gun relay down</a> remained the reliability context for relay and Gun-host decisions.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/553">#553 3DVR Community System</a> started to frame the shared portal/community surface.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/releases/v0.0.45.html
+++ b/releases/v0.0.45.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.45 (Week of May 11, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.44.html">Previous release</a>
+    <a class="release-nav-link" href="v0.0.46.html">Next release</a>
+  </nav>
+  <h1>Release v0.0.45</h1>
+  <div class="tag">Week of May 11, 2026</div>
+  <div class="release-summary">
+    <p>This backfilled weekly release is mostly product cleanup: fewer confusing entry points, clearer billing, and sharper portal apps.</p>
+    <ul class="release-summary-list">
+      <li><strong>Portal surface:</strong> issue launcher, footer, homepage lanes, and app search were simplified so the homepage had less clutter.</li>
+      <li><strong>Storefronts:</strong> Victor sample storefront work moved from internal sample toward customer-facing products.</li>
+      <li><strong>Learning and positioning:</strong> human-scale technology, attention visualization, and education suite pages expanded the public learning layer.</li>
+      <li><strong>Billing and auth:</strong> plan autoselect, recovery email, recovery tests, and OAuth placement all made account setup less awkward.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Merged PRs</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/562">#562 Make the issue launcher footer-friendly by default</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/563">#563 Move the footer feedback control inside the page footer</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/564">#564 Compact the footer issue launcher button</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/565">#565 Hide homepage system layers</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/566">#566 Hide homepage launcher lanes</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/567">#567 Add homepage app search shortcut</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/568">#568 Add Victor dropship sample storefront</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/569">#569 Fix Vercel function count</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/570">#570 Update Victor storefront for customer-facing products</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/571">#571 Add human-scale technology guide</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/572">#572 Tighten notes account UX</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/573">#573 Add agent sales command center</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/574">#574 Document Termux GitHub push workflow</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/575">#575 Add attention visualized lesson</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/576">#576 Add education suite web design lab</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/577">#577 Remove portal billing explainer copy</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/578">#578 Simplify billing hero copy</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/579">#579 Auto-select billing plans from links</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/580">#580 Add verified recovery email to signup</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/581">#581 Add recovery sign-in end-to-end coverage</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/582">#582 Make recovery email optional</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/583">#583 Move OAuth below submit</a></li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Issue Pulse</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/407">#407 Trial duration</a> and <a href="https://github.com/tmsteph/3dvr-portal/issues/406">#406 Welcome email</a> stayed relevant to signup expectations.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/524">#524 Contacts and CRM join contacts</a> remained the main CRM cleanup thread.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/361">#361 Stripe available balance</a> stayed open for finance visibility.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/releases/v0.0.46.html
+++ b/releases/v0.0.46.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.46 (Week of May 18, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+    .release-nav-link.is-disabled { opacity: 0.4; pointer-events: none; cursor: default; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.45.html">Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+  </nav>
+  <h1>Release v0.0.46</h1>
+  <div class="tag">Week of May 18, 2026</div>
+  <div class="release-summary">
+    <p>This weekly release captures the fast prototype sprint around guest identity, pure Gun media tests, mobile games, and the Nomad Clip hardware direction.</p>
+    <ul class="release-summary-list">
+      <li><strong>Guest identity:</strong> upgrade flow work, scoped notes, a migration plan, a new-account fast path, and simpler guest entry points made guest data safer.</li>
+      <li><strong>Pure Gun media:</strong> WebRTC and Gun labs explored frames, clips, live rooms, device selection, and local chunk streaming.</li>
+      <li><strong>Mobile playability:</strong> Stellar Drift, Ski, and Pong were adjusted for smaller screens and less crowded controls.</li>
+      <li><strong>3DVR direction:</strong> the open-source guide, phone-holder concept app, Nomad Clip roadmap, and field-test page pulled hardware and software into one story.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Merged PRs</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/584">#584 Improve Stellar Drift mobile layout</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/585">#585 Improve Ski game mobile layout</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/586">#586 Improve Pong mobile layout</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/587">#587 Add guest account upgrade flow</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/588">#588 Scope notes to guest and user identities</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/589">#589 Add phone holder concept app</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/590">#590 Add guest migration planning doc</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/591">#591 Add open-source field guide</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/592">#592 Add new-account guest migration fast path</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/593">#593 Simplify guest entry points</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/594">#594 Add WebRTC lab</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/595">#595 Add Gun video frame lab</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/596">#596 Add Gun clip lab</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/597">#597 Clarify audio and video clip capture</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/598">#598 Add Gun live room</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/599">#599 Add device selectors to Gun live room</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/600">#600 Add Gun chunk stream lab</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/601">#601 Add ordered buffering and visible chunk ledger</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/602">#602 Add Nomad Clip prototype roadmap</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/603">#603 Add Nomad Clip field test page</a></li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Issue Pulse</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/367">#367 Recovery feature</a> stayed connected to account durability and guest-to-user questions.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/405">#405 Web builder own app</a> remained relevant as more standalone apps landed in the portal.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/issues/513">#513 Calendar UI</a>, <a href="https://github.com/tmsteph/3dvr-portal/issues/542">#542 Portal</a>, and <a href="https://github.com/tmsteph/3dvr-portal/issues/553">#553 Community System</a> stayed open for larger system design.</li>
+    </ul>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">© 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -15,14 +15,22 @@ async function fileExists(path) {
 }
 
 describe('release hub backfill', () => {
-  it('updates the release index with the retroactive milestones through v0.0.43', async () => {
+  it('updates the release index with the weekly milestones through v0.0.46', async () => {
     const indexUrl = new URL('index.html', baseDir);
     assert.equal(await fileExists(indexUrl), true, 'releases/index.html should exist');
 
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /Latest Release/);
-    assert.match(html, /href="v0\.0\.43\.html">v0\.0\.43</);
+    assert.match(html, /href="v0\.0\.46\.html">v0\.0\.46</);
+    assert.match(html, /Week of May 18, 2026/);
+    assert.match(html, /Guest identity cleanup/);
+    assert.match(html, /href="v0\.0\.45\.html">v0\.0\.45</);
+    assert.match(html, /Week of May 11, 2026/);
+    assert.match(html, /billing plan selection/);
+    assert.match(html, /href="v0\.0\.44\.html">v0\.0\.44</);
     assert.match(html, /Week of May 4, 2026/);
+    assert.match(html, /Video meeting operations/);
+    assert.match(html, /href="v0\.0\.43\.html">v0\.0\.43</);
     assert.match(html, /1\.0\.1-beta\.2/);
     assert.match(html, /href="v0\.0\.42\.html">v0\.0\.42</);
     assert.match(html, /Week of April 20, 2026/);
@@ -44,9 +52,12 @@ describe('release hub backfill', () => {
     assert.match(html, /href="v0\.0\.36\.html"/);
   });
 
-  it('ships the new milestone pages with coherent navigation and summaries', async () => {
+  it('ships the new milestone pages with coherent navigation, summaries, and source links', async () => {
     const releases = [
-      ['v0.0.43.html', /Week of May 4, 2026/, /1\.0\.1-beta\.2/, /aria-disabled="true"/],
+      ['v0.0.46.html', /Week of May 18, 2026/, /Pure Gun media/i, /pull\/603/],
+      ['v0.0.45.html', /Week of May 11, 2026/, /plan autoselect/i, /pull\/579/],
+      ['v0.0.44.html', /Week of May 4, 2026/, /Video operations/i, /commit\/67c1e8f/],
+      ['v0.0.43.html', /Week of May 4, 2026/, /1\.0\.1-beta\.2/, /href="v0\.0\.44\.html"/],
       ['v0.0.42.html', /Week of April 20, 2026/, /pre-release notes/i, /aria-disabled="true"/],
       ['v0.0.36.html', /Late January 2026/, /social planning/i, /href="v0\.0\.37\.html"/],
       ['v0.0.37.html', /Mid February 2026/, /Money Autopilot/i, /href="v0\.0\.38\.html"/],


### PR DESCRIPTION
## Summary\n- add backfilled release pages v0.0.44 and v0.0.45\n- add current weekly release page v0.0.46\n- update release hub latest card, release history, v0.0.43 forward nav, and release tests\n\n## Tests\n- node --test tests/releases-hub.test.js\n- git diff --check