### PR TITLE
Include agent work in release notes

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -120,14 +120,14 @@
         <a class="release-link" href="v0.0.45.html">v0.0.45</a>
         <span class="release-meta">Week of May 11, 2026</span>
         <p class="release-summary">
-          Portal launcher cleanup, Victor storefront work, education pages, billing plan selection, recovery email, and OAuth layout polish.
+          Portal launcher cleanup, billing plan selection, recovery email, OAuth layout polish, and agent worker scaling notes.
         </p>
       </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.44.html">v0.0.44</a>
         <span class="release-meta">Week of May 4, 2026</span>
         <p class="release-summary">
-          Video meeting operations, agent control surfaces, health checks, test stabilization, private clipboard, and Garden Planet experiments.
+          Video meeting operations, 3dvr-agent outreach phases, task workers, health checks, private clipboard, and Garden Planet experiments.
         </p>
       </li>
       <li class="release-card">

--- a/releases/v0.0.44.html
+++ b/releases/v0.0.44.html
@@ -31,7 +31,7 @@
     <p>This backfilled weekly release covers the operational work that landed after v0.0.43.</p>
     <ul class="release-summary-list">
       <li><strong>Video operations:</strong> smart join flows, meeting ops, meshcast presets, and video packs moved closer to a usable portal meeting surface.</li>
-      <li><strong>Agent operations:</strong> admin control surfaces, heartbeat checks, Gun host configuration, and DigitalOcean notes made the agent runtime easier to operate.</li>
+      <li><strong>Agent operations:</strong> 3dvr-agent outreach phases, yolo patch workflows, inbox triage, heartbeat checks, and task workers moved the agent from local helper toward a real operating loop.</li>
       <li><strong>Reliability:</strong> portal health checks, Playwright stabilization, Gun relay selection, and private clipboard work improved the day-to-day build loop.</li>
       <li><strong>Experiments:</strong> <a href="../garden-planet/">Garden Planet</a>, expansion path work, and Space Jetpack tests kept the prototype layer moving.</li>
     </ul>
@@ -56,6 +56,15 @@
       <li><a href="https://github.com/tmsteph/3dvr-portal/commit/6655e28">6655e28</a> configured the portal Gun host.</li>
       <li><a href="https://github.com/tmsteph/3dvr-portal/commit/4d47508">4d47508</a> documented the DigitalOcean operations path.</li>
       <li><a href="https://github.com/tmsteph/3dvr-portal/commit/186a5dc">186a5dc</a> added the private device clipboard.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Companion Agent Work</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-agent/pull/28">3dvr-agent #28</a> through <a href="https://github.com/tmsteph/3dvr-agent/pull/33">#33</a> built the lead-route, email-discovery, form-outreach, adapter, and autopilot routing phases.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-agent/pull/34">3dvr-agent #34</a> through <a href="https://github.com/tmsteph/3dvr-agent/pull/37">#37</a> ported yolo workflows and moved them onto patch-based edits.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-agent/pull/39">3dvr-agent #39</a> through <a href="https://github.com/tmsteph/3dvr-agent/pull/49">#49</a> added guidance, concurrency-safe tracking, public inbox gates, shared ops coordination, revenue experiments, and remote task workers.</li>
     </ul>
   </div>
 

--- a/releases/v0.0.45.html
+++ b/releases/v0.0.45.html
@@ -34,6 +34,7 @@
       <li><strong>Storefronts:</strong> Victor sample storefront work moved from internal sample toward customer-facing products.</li>
       <li><strong>Learning and positioning:</strong> human-scale technology, attention visualization, and education suite pages expanded the public learning layer.</li>
       <li><strong>Billing and auth:</strong> plan autoselect, recovery email, recovery tests, and OAuth placement all made account setup less awkward.</li>
+      <li><strong>Agent runtime:</strong> 3dvr-agent planning continued with community naming, worker scaling, tenant-aware scheduling, heartbeat metadata, and the Termux GitHub workflow.</li>
     </ul>
   </div>
 
@@ -62,6 +63,18 @@
       <li><a href="https://github.com/tmsteph/3dvr-portal/pull/581">#581 Add recovery sign-in end-to-end coverage</a></li>
       <li><a href="https://github.com/tmsteph/3dvr-portal/pull/582">#582 Make recovery email optional</a></li>
       <li><a href="https://github.com/tmsteph/3dvr-portal/pull/583">#583 Move OAuth below submit</a></li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Companion Agent Work</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-agent/commit/b6eba81">b6eba81</a> added the community naming service roadmap.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-agent/commit/a753dad">a753dad</a> added the portal agent worker scaling plan.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-agent/commit/ec7c967">ec7c967</a> added tenant-aware task scheduling.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-agent/commit/82b56c5">82b56c5</a> serialized worker heartbeat metadata.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-agent/commit/409544d">409544d</a> stabilized inbox state and published sales loop state.</li>
+      <li><a href="https://github.com/tmsteph/3dvr-agent/commit/a436372">a436372</a> documented the Termux GitHub push workflow.</li>
     </ul>
   </div>
 

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -28,6 +28,7 @@ describe('release hub backfill', () => {
     assert.match(html, /href="v0\.0\.45\.html">v0\.0\.45</);
     assert.match(html, /Week of May 11, 2026/);
     assert.match(html, /billing plan selection/);
+    assert.match(html, /agent worker scaling/);
     assert.match(html, /href="v0\.0\.44\.html">v0\.0\.44</);
     assert.match(html, /Week of May 4, 2026/);
     assert.match(html, /Video meeting operations/);
@@ -56,8 +57,8 @@ describe('release hub backfill', () => {
   it('ships the new milestone pages with coherent navigation, summaries, and source links', async () => {
     const releases = [
       ['v0.0.46.html', /Week of May 18, 2026/, /Pure Gun media/i, /3dvr-web\/pull\/185/],
-      ['v0.0.45.html', /Week of May 11, 2026/, /plan autoselect/i, /pull\/579/],
-      ['v0.0.44.html', /Week of May 4, 2026/, /Video operations/i, /commit\/67c1e8f/],
+      ['v0.0.45.html', /Week of May 11, 2026/, /tenant-aware task scheduling/i, /3dvr-agent\/commit\/ec7c967/],
+      ['v0.0.44.html', /Week of May 4, 2026/, /3dvr-agent outreach phases/i, /3dvr-agent\/pull\/49/],
       ['v0.0.43.html', /Week of May 4, 2026/, /1\.0\.1-beta\.2/, /href="v0\.0\.44\.html"/],
       ['v0.0.42.html', /Week of April 20, 2026/, /pre-release notes/i, /aria-disabled="true"/],
       ['v0.0.36.html', /Late January 2026/, /social planning/i, /href="v0\.0\.37\.html"/],


### PR DESCRIPTION
## Summary\n- add companion 3dvr-agent notes to v0.0.44 and v0.0.45\n- update the release hub summaries to surface agent work\n- extend release hub tests to cover the agent links\n\n## Tests\n- node --test tests/releases-hub.test.js\n- git diff --check