### PR TITLE
Add branded portal startup logo

### DIFF
--- a/brand/portal-logo.svg
+++ b/brand/portal-logo.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">3DVR Portal logo</title>
+  <desc id="desc">A layered portal mark with the letters 3DVR.</desc>
+  <defs>
+    <linearGradient id="portal-bg" x1="80" x2="432" y1="70" y2="442" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="0.52" stop-color="#1d4ed8"/>
+      <stop offset="1" stop-color="#14b8a6"/>
+    </linearGradient>
+    <linearGradient id="portal-line" x1="112" x2="400" y1="120" y2="392" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="0.45" stop-color="#93c5fd"/>
+      <stop offset="1" stop-color="#67e8f9"/>
+    </linearGradient>
+    <filter id="soft-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#020617" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="#020617"/>
+  <path d="M96 256c0-88.37 71.63-160 160-160s160 71.63 160 160-71.63 160-160 160S96 344.37 96 256Z" fill="url(#portal-bg)" filter="url(#soft-shadow)"/>
+  <path d="M154 256c0-56.33 45.67-102 102-102s102 45.67 102 102-45.67 102-102 102-102-45.67-102-102Z" fill="none" stroke="url(#portal-line)" stroke-width="18"/>
+  <path d="M128 255.5h256M256 128v256" stroke="#e0f2fe" stroke-width="16" stroke-linecap="round" opacity="0.62"/>
+  <path d="M184 298c20.83 21.33 44.83 32 72 32s51.17-10.67 72-32" fill="none" stroke="#f8fafc" stroke-width="18" stroke-linecap="round"/>
+  <text x="256" y="267" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="86" font-weight="900" fill="#f8fafc" letter-spacing="-6">3D</text>
+  <text x="256" y="322" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="800" fill="#bae6fd" letter-spacing="4">VR</text>
+</svg>

--- a/index-style.css
+++ b/index-style.css
@@ -4,6 +4,92 @@ body.landing {
   align-items: stretch;
 }
 
+.app-boot {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: grid;
+  place-items: center;
+  gap: 1rem;
+  align-content: center;
+  padding: 2rem;
+  background:
+    radial-gradient(circle at 50% 38%, rgba(37, 99, 235, 0.24), transparent 30rem),
+    #07111f;
+  color: #f8fafc;
+  transition: opacity 280ms ease, visibility 280ms ease;
+}
+
+.app-ready .app-boot {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.app-boot__mark {
+  width: 112px;
+  aspect-ratio: 1;
+  border-radius: 28px;
+  box-shadow: 0 28px 80px rgba(2, 6, 23, 0.42);
+  animation: portal-boot-float 1600ms ease-in-out infinite;
+}
+
+.app-boot__mark img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.app-boot__text {
+  display: grid;
+  gap: 0.25rem;
+  text-align: center;
+}
+
+.app-boot__text strong {
+  font-size: 1.2rem;
+  letter-spacing: 0.02em;
+}
+
+.app-boot__text span {
+  color: #bae6fd;
+  font-size: 0.95rem;
+}
+
+.app-boot__bar {
+  width: min(220px, 60vw);
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.24);
+}
+
+.app-boot__bar span {
+  display: block;
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #38bdf8, #14b8a6);
+  animation: portal-boot-load 1400ms ease-in-out infinite;
+}
+
+@keyframes portal-boot-float {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-8px) scale(1.02); }
+}
+
+@keyframes portal-boot-load {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(240%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-boot__mark,
+  .app-boot__bar span {
+    animation: none;
+  }
+}
+
 .landing-shell {
   position: relative;
   z-index: 1;

--- a/index.html
+++ b/index.html
@@ -12,12 +12,18 @@
   <link rel="stylesheet" href="styles/global.css">
   <link rel="stylesheet" href="index-style.css">
   <link rel="manifest" href="/manifest.webmanifest">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
   <meta name="theme-color" content="#0e1116">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="apple-touch-icon" href="/icons/icon-192.png">
   <link rel="apple-touch-icon" sizes="512x512" href="/icons/icon-512.png">
+  <script>
+    const hidePortalBoot = () => document.documentElement.classList.add('app-ready');
+    window.addEventListener('load', hidePortalBoot, { once: true });
+    window.setTimeout(hidePortalBoot, 3600);
+  </script>
   <script>
     const prNumber = '{{PR_NUMBER}}';
     const relayUrl = '{{WSS_RELAY_URL}}';
@@ -36,6 +42,16 @@
 </head>
 <body class="landing theme-dark">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
+  <div class="app-boot" aria-hidden="true">
+    <div class="app-boot__mark">
+      <img src="/brand/portal-logo.svg" alt="">
+    </div>
+    <div class="app-boot__text">
+      <strong>3DVR Portal</strong>
+      <span>Opening your workspace</span>
+    </div>
+    <div class="app-boot__bar"><span></span></div>
+  </div>
   <div class="landing-shell">
     <div class="top-nav top-nav--collapsed">
       <div class="top-nav__primary">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -9,6 +9,7 @@
   "background_color": "#0e1116",
   "theme_color": "#0e1116",
   "icons": [
+    { "src": "/brand/portal-logo.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" },
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
     { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,7 +3,7 @@
 importScripts('/chat/notification-routing.js');
 
 // Increment this to bust old caches when you deploy
-const CACHE_VERSION = 'v13';
+const CACHE_VERSION = 'v14';
 const STATIC_CACHE = `3dvr-static-${CACHE_VERSION}`;
 const HTML_CACHE = `3dvr-html-${CACHE_VERSION}`;
 const chatNotificationRouting = self.ChatNotificationRouting || null;
@@ -22,6 +22,7 @@ const STATIC_ASSETS = [
   '/chat/notification-routing.js',
   '/styles/install-banner.css',
   '/manifest.webmanifest',
+  '/brand/portal-logo.svg',
   '/app-manifests/chat.webmanifest',
   '/app-manifests/tasks.webmanifest',
   '/app-manifests/notes.webmanifest',

--- a/tests/contacts-pwa-config.test.js
+++ b/tests/contacts-pwa-config.test.js
@@ -25,6 +25,7 @@ describe('contacts PWA configuration', () => {
     assert.equal(rootManifest.id, '/');
     assert.equal(contactsManifest.id, '/contacts/');
     assert.notEqual(rootManifest.id, contactsManifest.id);
+    assert.ok(rootManifest.icons.some((icon) => icon.src === '/brand/portal-logo.svg'));
   });
 
   it('uses a contacts-scoped webmanifest identity', async () => {


### PR DESCRIPTION
## Summary\n- add a lightweight SVG portal app logo\n- show a branded startup screen while the portal shell loads\n- include the SVG in the manifest and service worker cache\n\n## Tests\n- node --test tests/contacts-pwa-config.test.js\n- git diff --check\n- local static asset check for /brand/portal-logo.svg