### PR TITLE
Show Market Lab in main app dock

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,8 +343,7 @@
             <span class="app-card__title">Lead Capture</span>
             <span class="app-card__meta">Collect inbound leads and sync with CRM instantly.</span>
           </a>
-          <a href="market-lab/" class="app-card" data-app-tier="experimental">
-            <span class="app-card__badge">Experimental</span>
+          <a href="market-lab/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">📣</span>
             <span class="app-card__title">Market Lab</span>
             <span class="app-card__meta">Track marketing angles, signal scores, CTA clicks, replies, calls, and signups.</span>


### PR DESCRIPTION
## Summary\n- remove the experimental flag from the Market Lab dock card\n- keep Market Lab visible in the default app dock without toggling experimental apps\n\n## Tests\n- node --test tests/market-lab.test.js\n- git diff --check