### PR TITLE
Expand Market Lab with Gun-backed landing tests

### DIFF
--- a/market-lab/app.js
+++ b/market-lab/app.js
@@ -1,6 +1,14 @@
 const STORAGE_KEY = '3dvr.marketLab.experiments.v1';
 const SOURCE_STORAGE_KEY = '3dvr.marketLab.currentSource.v1';
 const DEFAULT_SOURCE = 'direct';
+const GUN_ROOT_KEY = '3dvr-portal';
+const GUN_SECTION_KEY = 'market-lab';
+const GUN_STATE_KEY = 'state';
+const CLIENT_ID_KEY = '3dvr.marketLab.clientId.v1';
+const DEFAULT_GUN_PEERS = [
+  'https://gun-manhattan.herokuapp.com/gun',
+  'https://gun-us.herokuapp.com/gun'
+];
 
 const DEFAULT_EXPERIMENTS = [
   {
@@ -11,6 +19,11 @@ const DEFAULT_EXPERIMENTS = [
     cta: 'Book a free brainstorming call.',
     headline: 'Finally launch the idea you keep carrying around.',
     explanation: 'Turn a rough idea into a first page, offer, or working next step with direct 3DVR help.',
+    landingPath: 'launch-your-idea/',
+    segment: 'Entrepreneurs, creators, and side hustlers',
+    pain: 'Idea is stuck in notes instead of shipping',
+    offer: 'Free brainstorming call',
+    nextBestAction: 'Ask what idea they keep circling, what would count as launched, and what small page or offer could go live first.',
     status: 'Testing',
     clicks: 0,
     replies: 0,
@@ -27,6 +40,11 @@ const DEFAULT_EXPERIMENTS = [
     cta: 'Get tech support.',
     headline: 'A calm personal tech department for everyday problems.',
     explanation: 'Get practical help with sites, accounts, devices, software, and small systems without hiring a full team.',
+    landingPath: 'personal-tech-department/',
+    segment: 'Small businesses, older adults, and busy professionals',
+    pain: 'Tech tasks keep interrupting the real work',
+    offer: '$20/month personal tech department',
+    nextBestAction: 'Ask what tech task keeps costing them time and whether a calm monthly support lane would help.',
     status: 'Testing',
     clicks: 0,
     replies: 0,
@@ -43,6 +61,11 @@ const DEFAULT_EXPERIMENTS = [
     cta: 'Join the builder community.',
     headline: 'Open-source computing should feel human.',
     explanation: 'Build toward local-first tools, humane interfaces, Linux-friendly workflows, and portable digital independence.',
+    landingPath: 'open-future-computing/',
+    segment: 'Linux, open-source, makers, and digital nomads',
+    pain: 'Modern computing feels closed, extractive, or too hard to own',
+    offer: 'Builder community invitation',
+    nextBestAction: 'Ask which open computing problem they care about most and whether they want to follow or help build the 3DVR stack.',
     status: 'Testing',
     clicks: 0,
     replies: 0,
@@ -61,32 +84,33 @@ const METRICS = [
 ];
 
 const storage = {
-  load() {
+  loadPayload() {
     try {
       const raw = window.localStorage.getItem(STORAGE_KEY);
-      if (!raw) return cloneDefaults();
-      return mergeStoredData(JSON.parse(raw));
+      if (!raw) return { experiments: cloneDefaults(), updatedAt: 0 };
+      const parsed = JSON.parse(raw);
+      return normalizePayload(parsed);
     } catch (error) {
       console.warn('Market Lab could not load local data; using defaults.', error);
-      return cloneDefaults();
+      return { experiments: cloneDefaults(), updatedAt: 0 };
     }
   },
-  save(experiments) {
+  save(payload) {
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(experiments));
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
     } catch (error) {
       console.warn('Market Lab could not save local data.', error);
     }
-
-    // Later: write the same normalized payload to Gun.js, Supabase, or a portal API here.
-    // Suggested path: 3dvr-portal/market-lab/experiments/{experimentId}
   },
   reset() {
     window.localStorage.removeItem(STORAGE_KEY);
   }
 };
 
-let experiments = storage.load();
+const localPayload = storage.loadPayload();
+let experiments = localPayload.experiments;
+let lastSavedAt = localPayload.updatedAt;
+let applyingRemote = false;
 
 const mockupGrid = document.getElementById('mockupGrid');
 const dashboard = document.getElementById('experimentDashboard');
@@ -95,6 +119,8 @@ const leadingExperimentDetail = document.getElementById('leadingExperimentDetail
 const resetButton = document.getElementById('resetExperiments');
 const sourceInput = document.getElementById('sourceInput');
 const applySourceButton = document.getElementById('applySource');
+const syncStatus = document.getElementById('syncStatus');
+const marketLabGun = createGunBackup();
 
 let currentSource = loadCurrentSource();
 sourceInput.value = currentSource;
@@ -116,6 +142,11 @@ function mergeStoredData(stored) {
     return {
       ...base,
       status: normalizeText(match.status) || base.status,
+      landingPath: normalizeText(match.landingPath) || base.landingPath,
+      segment: normalizeText(match.segment) || base.segment,
+      pain: normalizeText(match.pain) || base.pain,
+      offer: normalizeText(match.offer) || base.offer,
+      nextBestAction: normalizeText(match.nextBestAction) || base.nextBestAction,
       clicks: normalizeCount(match.clicks),
       replies: normalizeCount(match.replies),
       callsBooked: normalizeCount(match.callsBooked),
@@ -126,11 +157,50 @@ function mergeStoredData(stored) {
   });
 }
 
+function normalizePayload(value) {
+  if (Array.isArray(value)) {
+    return { experiments: mergeStoredData(value), updatedAt: 0 };
+  }
+
+  if (!value || typeof value !== 'object') {
+    return { experiments: cloneDefaults(), updatedAt: 0 };
+  }
+
+  const rawExperiments = Array.isArray(value.experiments) ? value.experiments : [];
+  return {
+    experiments: mergeStoredData(rawExperiments),
+    updatedAt: normalizeTimestamp(value.updatedAt)
+  };
+}
+
+function normalizeRemotePayload(value) {
+  if (!value || typeof value !== 'object') return null;
+
+  try {
+    const experimentsValue = typeof value.experiments === 'string'
+      ? JSON.parse(value.experiments)
+      : value.experiments;
+
+    return normalizePayload({
+      experiments: experimentsValue,
+      updatedAt: value.updatedAt
+    });
+  } catch (error) {
+    console.warn('Market Lab could not parse Gun backup payload.', error);
+    return null;
+  }
+}
+
 function normalizeText(value) {
   return typeof value === 'string' ? value : '';
 }
 
 function normalizeCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+}
+
+function normalizeTimestamp(value) {
   const number = Number(value);
   return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
 }
@@ -168,6 +238,133 @@ function saveCurrentSource(value) {
   window.localStorage.setItem(SOURCE_STORAGE_KEY, currentSource);
 }
 
+function createClientId() {
+  const existing = window.localStorage.getItem(CLIENT_ID_KEY);
+  if (existing) return existing;
+
+  const id = `market-lab-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  window.localStorage.setItem(CLIENT_ID_KEY, id);
+  return id;
+}
+
+function createGunBackup() {
+  if (typeof Gun !== 'function') {
+    return { enabled: false, clientId: createClientId(), stateNode: null, eventsNode: null };
+  }
+
+  try {
+    const gun = Gun(window.__GUN_PEERS__ || DEFAULT_GUN_PEERS);
+    const root = gun.get(GUN_ROOT_KEY).get(GUN_SECTION_KEY);
+    return {
+      enabled: true,
+      clientId: createClientId(),
+      stateNode: root.get(GUN_STATE_KEY),
+      eventsNode: root.get('events')
+    };
+  } catch (error) {
+    console.warn('Market Lab could not start Gun backup.', error);
+    return { enabled: false, clientId: createClientId(), stateNode: null, eventsNode: null };
+  }
+}
+
+function setSyncStatus(message) {
+  if (syncStatus) {
+    syncStatus.textContent = message;
+  }
+}
+
+function buildPayload(updatedAt = Date.now()) {
+  return {
+    schemaVersion: 1,
+    updatedAt,
+    updatedBy: marketLabGun.clientId,
+    experiments
+  };
+}
+
+function persistExperiments({ sync = true } = {}) {
+  const updatedAt = Date.now();
+  lastSavedAt = updatedAt;
+  const payload = buildPayload(updatedAt);
+  storage.save(payload);
+
+  if (sync && !applyingRemote) {
+    backupToGun(payload);
+  }
+}
+
+function backupToGun(payload) {
+  if (!marketLabGun.enabled || !marketLabGun.stateNode) {
+    setSyncStatus('Gun backup: local only');
+    return;
+  }
+
+  try {
+    marketLabGun.stateNode.put({
+      schemaVersion: payload.schemaVersion,
+      updatedAt: payload.updatedAt,
+      updatedBy: payload.updatedBy,
+      experiments: JSON.stringify(payload.experiments)
+    }, (ack) => {
+      if (ack && ack.err) {
+        console.warn('Market Lab Gun backup failed.', ack.err);
+        setSyncStatus('Gun backup: retrying locally');
+        return;
+      }
+      setSyncStatus('Gun backup: synced');
+    });
+  } catch (error) {
+    console.warn('Market Lab could not write Gun backup.', error);
+    setSyncStatus('Gun backup: local only');
+  }
+}
+
+function backupEventToGun(id, eventName) {
+  if (!marketLabGun.enabled || !marketLabGun.eventsNode) return;
+
+  const createdAt = Date.now();
+  const eventId = `${createdAt}-${marketLabGun.clientId}-${id}-${eventName}`;
+
+  try {
+    marketLabGun.eventsNode.get(eventId).put({
+      id: eventId,
+      experimentId: id,
+      event: eventName,
+      source: currentSource,
+      createdAt
+    });
+  } catch (error) {
+    console.warn('Market Lab could not write Gun event.', error);
+  }
+}
+
+function startGunBackup() {
+  if (!marketLabGun.enabled || !marketLabGun.stateNode) {
+    setSyncStatus('Gun backup: local only');
+    return;
+  }
+
+  setSyncStatus('Gun backup: connecting...');
+
+  marketLabGun.stateNode.on((data) => {
+    const remote = normalizeRemotePayload(data);
+    if (!remote || remote.updatedAt <= lastSavedAt) return;
+
+    applyingRemote = true;
+    experiments = remote.experiments;
+    lastSavedAt = remote.updatedAt;
+    storage.save({
+      schemaVersion: 1,
+      updatedAt: remote.updatedAt,
+      updatedBy: data.updatedBy || 'gun',
+      experiments
+    });
+    render();
+    setSyncStatus('Gun backup: synced from peer');
+    applyingRemote = false;
+  });
+}
+
 function scoreExperiment(experiment) {
   return experiment.clicks
     + experiment.replies * 3
@@ -176,7 +373,7 @@ function scoreExperiment(experiment) {
 }
 
 function saveAndRender() {
-  storage.save(experiments);
+  persistExperiments();
   render();
 }
 
@@ -200,8 +397,9 @@ function incrementMetric(id, key) {
       : experiment.clicksBySource
   }));
 
-  // Later: send real analytics and CRM events here.
-  // Example payload: { experimentId: id, event: key, source: currentSource, createdAt: Date.now() }
+  backupEventToGun(id, key);
+
+  // Later: forward this same payload to analytics, booked-call forms, and CRM activity history.
 }
 
 function updateNotes(id, value) {
@@ -234,9 +432,17 @@ function renderMockups() {
         <h3>${escapeHtml(experiment.headline)}</h3>
       </div>
       <p>${escapeHtml(experiment.explanation)}</p>
-      <button class="cta-button" type="button" data-cta-click="${escapeHtml(experiment.id)}">
-        ${escapeHtml(experiment.cta)} <span class="source-button-label">(${escapeHtml(currentSource)})</span>
-      </button>
+      <div class="link-grid">
+        <a class="lab-link primary" href="${escapeHtml(getLandingHref(experiment))}">
+          Test page
+        </a>
+        <a class="lab-link" href="${escapeHtml(getCrmHref(experiment))}">
+          CRM draft
+        </a>
+        <a class="lab-link" href="${escapeHtml(getContactsHref(experiment))}">
+          Contacts
+        </a>
+      </div>
     </article>
   `).join('');
 }
@@ -272,6 +478,11 @@ function renderDashboard() {
           <b>CTA clicks by source</b>
           <div class="source-pills">${sourcePills}</div>
         </div>
+        <div class="link-grid">
+          <a class="lab-link primary" href="${escapeHtml(getLandingHref(experiment))}">Open landing page</a>
+          <a class="lab-link" href="${escapeHtml(getCrmHref(experiment))}">Open CRM draft</a>
+          <a class="lab-link" href="${escapeHtml(getContactsHref(experiment))}">Open contacts</a>
+        </div>
         <div class="notes-wrap">
           <label for="notes-${escapeHtml(experiment.id)}">Notes</label>
           <textarea id="notes-${escapeHtml(experiment.id)}" data-notes-id="${escapeHtml(experiment.id)}" placeholder="What happened when this angle met reality?">${escapeHtml(experiment.notes)}</textarea>
@@ -279,6 +490,41 @@ function renderDashboard() {
       </article>
     `;
   }).join('');
+}
+
+function getLandingHref(experiment) {
+  const path = normalizeText(experiment.landingPath) || `${experiment.id}/`;
+  const params = new URLSearchParams({ source: currentSource });
+  return `${path}?${params.toString()}`;
+}
+
+function getCrmHref(experiment) {
+  const params = new URLSearchParams({
+    draft: '1',
+    type: 'person',
+    status: 'Warm - Awareness',
+    segment: experiment.segment || experiment.audience,
+    pain: experiment.pain || experiment.message,
+    pilot: 'Conversation',
+    offer: experiment.offer || experiment.cta,
+    signal: experiment.message,
+    experiment: experiment.name,
+    nextBestAction: experiment.nextBestAction || experiment.cta,
+    source: `market-lab/${currentSource}`,
+    tags: `source/market-lab,experiment/${experiment.id},angle/${normalizeSourceLabel(experiment.name)}`
+  });
+
+  return `../crm/index.html?${params.toString()}`;
+}
+
+function getContactsHref(experiment) {
+  const params = new URLSearchParams({
+    source: `market-lab/${currentSource}`,
+    tags: `source/market-lab,experiment/${experiment.id}`,
+    notes: `${experiment.name}: ${experiment.message} ${experiment.nextBestAction || ''}`.trim()
+  });
+
+  return `../contacts/index.html?${params.toString()}`;
 }
 
 function render() {
@@ -314,9 +560,6 @@ document.addEventListener('click', (event) => {
   const ctaButton = event.target.closest('[data-cta-click]');
   if (ctaButton) {
     incrementMetric(ctaButton.dataset.ctaClick, 'clicks');
-
-    // Later: replace this with a real form, booking flow, or CRM handoff.
-    return;
   }
 
   const metricButton = event.target.closest('[data-metric-id][data-metric-key]');
@@ -340,7 +583,7 @@ document.addEventListener('input', (event) => {
     experiments = experiments.map((experiment) => (
       experiment.id === id ? { ...experiment, notes: draft } : experiment
     ));
-    storage.save(experiments);
+    persistExperiments();
     renderLeader();
   }
 });
@@ -348,6 +591,7 @@ document.addEventListener('input', (event) => {
 resetButton.addEventListener('click', () => {
   storage.reset();
   experiments = cloneDefaults();
+  persistExperiments();
   render();
 });
 
@@ -365,3 +609,4 @@ sourceInput.addEventListener('keydown', (event) => {
 });
 
 render();
+startGunBackup();

--- a/market-lab/index.html
+++ b/market-lab/index.html
@@ -49,6 +49,7 @@
     a { color: inherit; }
 
     button,
+    input,
     textarea {
       font: inherit;
     }
@@ -183,6 +184,19 @@
       font-weight: 500;
       letter-spacing: 0;
       text-transform: none;
+    }
+
+    .sync-status {
+      display: inline-flex;
+      width: fit-content;
+      margin-top: 0.85rem;
+      padding: 0.28rem 0.55rem;
+      border: 1px solid rgba(94, 234, 212, 0.24);
+      border-radius: 999px;
+      color: #b7fff2;
+      background: rgba(94, 234, 212, 0.08);
+      font-size: 0.82rem;
+      font-weight: 800;
     }
 
     section {
@@ -399,6 +413,33 @@
       font-weight: 800;
     }
 
+    .link-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.65rem;
+    }
+
+    .lab-link {
+      display: inline-flex;
+      min-height: 40px;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.045);
+      font-size: 0.9rem;
+      font-weight: 800;
+      text-align: center;
+      text-decoration: none;
+    }
+
+    .lab-link.primary {
+      border-color: rgba(94, 234, 212, 0.32);
+      color: #b7fff2;
+      background: rgba(94, 234, 212, 0.08);
+    }
+
     .tool-row {
       display: flex;
       justify-content: flex-end;
@@ -443,6 +484,7 @@
       .source-panel,
       .mockup-grid,
       .dashboard-grid,
+      .link-grid,
       .architecture {
         grid-template-columns: 1fr;
       }
@@ -497,13 +539,14 @@
             Add source labels to test posts and outreach links. Example:
             <code>/market-lab/?source=instagram</code>
           </p>
+          <p class="sync-status" id="syncStatus">Gun backup: connecting...</p>
         </div>
         <button class="ghost-button" type="button" id="applySource">Apply source</button>
       </section>
 
       <section aria-labelledby="mockups-title">
-        <h2 id="mockups-title">Landing-page mockups</h2>
-        <p class="section-lead">Use these cards as lightweight offers. Each CTA click increments that experiment.</p>
+        <h2 id="mockups-title">Landing pages to test</h2>
+        <p class="section-lead">Use these as real links in CRM, contacts, posts, texts, and calls. CTA clicks increment the experiment and can open a CRM conversation draft.</p>
         <div class="mockup-grid" id="mockupGrid"></div>
       </section>
 
@@ -512,7 +555,7 @@
         <p class="section-lead">Track the small signals that matter before building a heavier funnel.</p>
         <div class="dashboard-grid" id="experimentDashboard"></div>
         <div class="tool-row">
-          <button class="ghost-button" type="button" id="resetExperiments">Reset local data</button>
+          <button class="ghost-button" type="button" id="resetExperiments">Reset lab data</button>
         </div>
       </section>
 
@@ -521,21 +564,23 @@
         <div class="architecture">
           <article class="architecture-card">
             <h3>Local first</h3>
-            <p>Browser localStorage is the source of truth for this MVP, so the lab works without accounts or backend setup.</p>
+            <p>Browser localStorage keeps the lab usable even when the network or Gun peers are unavailable.</p>
           </article>
           <article class="architecture-card">
-            <h3>Sync later</h3>
-            <p>The storage adapter in <code>app.js</code> is where Gun.js, Supabase, or a portal API can be added.</p>
+            <h3>Gun backed</h3>
+            <p>The same normalized experiment payload is backed up to Gun at <code>3dvr-portal/market-lab/state</code>.</p>
           </article>
           <article class="architecture-card">
-            <h3>CRM later</h3>
-            <p>CTA handlers are the handoff point for real analytics events, CRM records, form submits, and booked-call data.</p>
+            <h3>Conversation ready</h3>
+            <p>Each angle has CRM and contacts links so a real person can move straight into follow-up.</p>
           </article>
         </div>
       </section>
     </main>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
   <script src="app.js" defer></script>
   <script defer src="/issue-launcher.js"></script>
 </body>

--- a/market-lab/landing.css
+++ b/market-lab/landing.css
@@ -1,0 +1,199 @@
+:root {
+  --bg: #0d1117;
+  --surface: #151b25;
+  --surface-soft: #1b2431;
+  --line: rgba(226, 232, 240, 0.15);
+  --line-strong: rgba(226, 232, 240, 0.25);
+  --text: #f8fafc;
+  --muted: #b8c1cc;
+  --quiet: #8d99a8;
+  --teal: #5eead4;
+  --blue: #93c5fd;
+  --gold: #f6d365;
+  --shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+}
+
+* { box-sizing: border-box; }
+
+html {
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(94, 234, 212, 0.12), transparent 24rem),
+    radial-gradient(circle at 88% 8%, rgba(246, 211, 101, 0.1), transparent 28rem),
+    var(--bg);
+}
+
+a { color: inherit; }
+
+.shell {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1.25rem 0 4rem;
+}
+
+.top-link {
+  display: inline-flex;
+  margin-bottom: 2rem;
+  color: var(--quiet);
+  font-size: 0.92rem;
+  text-decoration: none;
+}
+
+.top-link:hover { color: var(--text); }
+
+.hero {
+  display: grid;
+  min-height: 68vh;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  gap: clamp(1.5rem, 5vw, 4rem);
+  align-items: center;
+  padding: 2rem 0 3rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  width: fit-content;
+  margin: 0 0 1rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid rgba(94, 234, 212, 0.32);
+  border-radius: 999px;
+  background: rgba(94, 234, 212, 0.1);
+  color: #b7fff2;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  max-width: 780px;
+  font-size: clamp(3rem, 8vw, 6.3rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.lead {
+  max-width: 690px;
+  margin: 1.2rem 0 0;
+  color: var(--muted);
+  font-size: clamp(1.05rem, 2vw, 1.24rem);
+}
+
+.panel {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(21, 27, 37, 0.92));
+  box-shadow: var(--shadow);
+  padding: 1.2rem;
+}
+
+.panel h2,
+.section h2 {
+  margin: 0;
+  font-size: clamp(1.7rem, 4vw, 2.6rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.panel p,
+.section p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.4rem;
+}
+
+.button {
+  display: inline-flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-weight: 850;
+  text-align: center;
+  text-decoration: none;
+}
+
+.button.primary {
+  border-color: transparent;
+  background: linear-gradient(135deg, rgba(94, 234, 212, 0.94), rgba(147, 197, 253, 0.94));
+  color: #07111f;
+}
+
+.signal {
+  display: inline-flex;
+  width: fit-content;
+  padding: 0.28rem 0.55rem;
+  border: 1px solid rgba(246, 211, 101, 0.26);
+  border-radius: 999px;
+  background: rgba(246, 211, 101, 0.08);
+  color: #fde68a;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.section {
+  display: grid;
+  gap: 1rem;
+  margin: 3rem 0;
+}
+
+.proof-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.proof-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 1rem;
+}
+
+.proof-card strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.sync-note {
+  color: var(--quiet);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 860px) {
+  .hero,
+  .proof-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .button {
+    width: 100%;
+  }
+}

--- a/market-lab/landing.js
+++ b/market-lab/landing.js
@@ -1,0 +1,321 @@
+const STORAGE_KEY = '3dvr.marketLab.experiments.v1';
+const SOURCE_STORAGE_KEY = '3dvr.marketLab.currentSource.v1';
+const CLIENT_ID_KEY = '3dvr.marketLab.clientId.v1';
+const GUN_ROOT_KEY = '3dvr-portal';
+const GUN_SECTION_KEY = 'market-lab';
+const GUN_STATE_KEY = 'state';
+const DEFAULT_SOURCE = 'direct';
+const DEFAULT_GUN_PEERS = [
+  'https://gun-manhattan.herokuapp.com/gun',
+  'https://gun-us.herokuapp.com/gun'
+];
+
+const DEFAULT_EXPERIMENTS = [
+  {
+    id: 'launch-your-idea',
+    name: 'Launch Your Idea',
+    message: 'We help people finally launch their ideas.',
+    audience: 'entrepreneurs, creators, side hustlers',
+    cta: 'Book a free brainstorming call.',
+    headline: 'Finally launch the idea you keep carrying around.',
+    explanation: 'Turn a rough idea into a first page, offer, or working next step with direct 3DVR help.',
+    landingPath: 'launch-your-idea/',
+    segment: 'Entrepreneurs, creators, and side hustlers',
+    pain: 'Idea is stuck in notes instead of shipping',
+    offer: 'Free brainstorming call',
+    nextBestAction: 'Ask what idea they keep circling, what would count as launched, and what small page or offer could go live first.',
+    status: 'Testing',
+    clicks: 0,
+    replies: 0,
+    callsBooked: 0,
+    signups: 0,
+    clicksBySource: {},
+    notes: ''
+  },
+  {
+    id: 'personal-tech-department',
+    name: 'Personal Tech Department',
+    message: 'Your personal tech department for $20/month.',
+    audience: 'small businesses, older adults, busy professionals',
+    cta: 'Get tech support.',
+    headline: 'A calm personal tech department for everyday problems.',
+    explanation: 'Get practical help with sites, accounts, devices, software, and small systems without hiring a full team.',
+    landingPath: 'personal-tech-department/',
+    segment: 'Small businesses, older adults, and busy professionals',
+    pain: 'Tech tasks keep interrupting the real work',
+    offer: '$20/month personal tech department',
+    nextBestAction: 'Ask what tech task keeps costing them time and whether a calm monthly support lane would help.',
+    status: 'Testing',
+    clicks: 0,
+    replies: 0,
+    callsBooked: 0,
+    signups: 0,
+    clicksBySource: {},
+    notes: ''
+  },
+  {
+    id: 'open-future-computing',
+    name: 'Open Future Computing',
+    message: 'Open-source computing for real humans.',
+    audience: 'Linux/open-source people, makers, digital nomads',
+    cta: 'Join the builder community.',
+    headline: 'Open-source computing should feel human.',
+    explanation: 'Build toward local-first tools, humane interfaces, Linux-friendly workflows, and portable digital independence.',
+    landingPath: 'open-future-computing/',
+    segment: 'Linux, open-source, makers, and digital nomads',
+    pain: 'Modern computing feels closed, extractive, or too hard to own',
+    offer: 'Builder community invitation',
+    nextBestAction: 'Ask which open computing problem they care about most and whether they want to follow or help build the 3DVR stack.',
+    status: 'Testing',
+    clicks: 0,
+    replies: 0,
+    callsBooked: 0,
+    signups: 0,
+    clicksBySource: {},
+    notes: ''
+  }
+];
+
+const page = document.body;
+const experimentId = page?.dataset?.experimentId || '';
+const source = loadSource();
+const gunBackup = createGunBackup();
+
+document.querySelectorAll('[data-source-label]').forEach((element) => {
+  element.textContent = source;
+});
+
+document.querySelectorAll('[data-market-cta]').forEach((link) => {
+  link.addEventListener('click', () => {
+    incrementClick(experimentId);
+  });
+});
+
+document.querySelectorAll('[data-crm-link]').forEach((link) => {
+  const experiment = getExperiment(experimentId);
+  if (experiment) link.href = getCrmHref(experiment);
+});
+
+document.querySelectorAll('[data-contacts-link]').forEach((link) => {
+  const experiment = getExperiment(experimentId);
+  if (experiment) link.href = getContactsHref(experiment);
+});
+
+function loadSource() {
+  const params = new URLSearchParams(window.location.search);
+  const querySource = params.get('source') || params.get('utm_source') || params.get('ref');
+  const current = normalizeSourceLabel(querySource || window.localStorage.getItem(SOURCE_STORAGE_KEY) || DEFAULT_SOURCE);
+  window.localStorage.setItem(SOURCE_STORAGE_KEY, current);
+  return current;
+}
+
+function incrementClick(id) {
+  const payload = loadPayload();
+  const experiments = payload.experiments.map((experiment) => {
+    if (experiment.id !== id) return experiment;
+    return {
+      ...experiment,
+      clicks: normalizeCount(experiment.clicks) + 1,
+      clicksBySource: {
+        ...experiment.clicksBySource,
+        [source]: normalizeCount(experiment.clicksBySource?.[source]) + 1
+      }
+    };
+  });
+  const nextPayload = {
+    schemaVersion: 1,
+    updatedAt: Date.now(),
+    updatedBy: gunBackup.clientId,
+    experiments
+  };
+
+  savePayload(nextPayload);
+  backupToGun(nextPayload);
+  backupEventToGun(id, 'clicks');
+}
+
+function loadPayload() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { experiments: cloneDefaults(), updatedAt: 0 };
+    return normalizePayload(JSON.parse(raw));
+  } catch (error) {
+    console.warn('Market Lab landing could not load local data.', error);
+    return { experiments: cloneDefaults(), updatedAt: 0 };
+  }
+}
+
+function savePayload(payload) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Market Lab landing could not save local data.', error);
+  }
+}
+
+function backupToGun(payload) {
+  if (!gunBackup.enabled || !gunBackup.stateNode) return;
+
+  // This mirrors the dashboard backup path so landing pages can update shared counts.
+  try {
+    gunBackup.stateNode.put({
+      schemaVersion: payload.schemaVersion,
+      updatedAt: payload.updatedAt,
+      updatedBy: payload.updatedBy,
+      experiments: JSON.stringify(payload.experiments)
+    });
+  } catch (error) {
+    console.warn('Market Lab landing could not write Gun backup.', error);
+  }
+}
+
+function backupEventToGun(id, eventName) {
+  if (!gunBackup.enabled || !gunBackup.eventsNode) return;
+
+  const createdAt = Date.now();
+  const eventId = `${createdAt}-${gunBackup.clientId}-${id}-${eventName}`;
+
+  // Later: this same event can feed real analytics, CRM activity, or form attribution.
+  try {
+    gunBackup.eventsNode.get(eventId).put({
+      id: eventId,
+      experimentId: id,
+      event: eventName,
+      source,
+      createdAt
+    });
+  } catch (error) {
+    console.warn('Market Lab landing could not write Gun event.', error);
+  }
+}
+
+function createGunBackup() {
+  if (typeof Gun !== 'function') {
+    return { enabled: false, clientId: createClientId(), stateNode: null, eventsNode: null };
+  }
+
+  try {
+    const gun = Gun(window.__GUN_PEERS__ || DEFAULT_GUN_PEERS);
+    const root = gun.get(GUN_ROOT_KEY).get(GUN_SECTION_KEY);
+    return {
+      enabled: true,
+      clientId: createClientId(),
+      stateNode: root.get(GUN_STATE_KEY),
+      eventsNode: root.get('events')
+    };
+  } catch (error) {
+    console.warn('Market Lab landing could not start Gun backup.', error);
+    return { enabled: false, clientId: createClientId(), stateNode: null, eventsNode: null };
+  }
+}
+
+function createClientId() {
+  const existing = window.localStorage.getItem(CLIENT_ID_KEY);
+  if (existing) return existing;
+
+  const id = `market-lab-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  window.localStorage.setItem(CLIENT_ID_KEY, id);
+  return id;
+}
+
+function cloneDefaults() {
+  return DEFAULT_EXPERIMENTS.map((experiment) => ({
+    ...experiment,
+    clicksBySource: { ...experiment.clicksBySource }
+  }));
+}
+
+function normalizePayload(value) {
+  if (Array.isArray(value)) {
+    return { experiments: mergeStoredData(value), updatedAt: 0 };
+  }
+
+  if (!value || typeof value !== 'object') {
+    return { experiments: cloneDefaults(), updatedAt: 0 };
+  }
+
+  return {
+    experiments: mergeStoredData(Array.isArray(value.experiments) ? value.experiments : []),
+    updatedAt: normalizeCount(value.updatedAt)
+  };
+}
+
+function mergeStoredData(stored) {
+  return DEFAULT_EXPERIMENTS.map((base) => {
+    const match = Array.isArray(stored) ? stored.find((item) => item && item.id === base.id) : null;
+    if (!match) return { ...base, clicksBySource: { ...base.clicksBySource } };
+
+    return {
+      ...base,
+      status: normalizeText(match.status) || base.status,
+      clicks: normalizeCount(match.clicks),
+      replies: normalizeCount(match.replies),
+      callsBooked: normalizeCount(match.callsBooked),
+      signups: normalizeCount(match.signups),
+      clicksBySource: normalizeSourceMap(match.clicksBySource),
+      notes: normalizeText(match.notes)
+    };
+  });
+}
+
+function getExperiment(id) {
+  return DEFAULT_EXPERIMENTS.find((experiment) => experiment.id === id);
+}
+
+function getCrmHref(experiment) {
+  const params = new URLSearchParams({
+    draft: '1',
+    type: 'person',
+    status: 'Warm - Awareness',
+    segment: experiment.segment,
+    pain: experiment.pain,
+    pilot: 'Conversation',
+    offer: experiment.offer,
+    signal: experiment.message,
+    experiment: experiment.name,
+    nextBestAction: experiment.nextBestAction,
+    source: `market-lab/${source}`,
+    tags: `source/market-lab,experiment/${experiment.id},angle/${normalizeSourceLabel(experiment.name)}`
+  });
+
+  return `../../crm/index.html?${params.toString()}`;
+}
+
+function getContactsHref(experiment) {
+  const params = new URLSearchParams({
+    source: `market-lab/${source}`,
+    tags: `source/market-lab,experiment/${experiment.id}`,
+    notes: `${experiment.name}: ${experiment.message} ${experiment.nextBestAction}`.trim()
+  });
+
+  return `../../contacts/index.html?${params.toString()}`;
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value : '';
+}
+
+function normalizeCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+}
+
+function normalizeSourceLabel(value) {
+  const normalized = normalizeText(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return normalized || DEFAULT_SOURCE;
+}
+
+function normalizeSourceMap(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+  return Object.entries(value).reduce((map, [label, count]) => {
+    const key = normalizeSourceLabel(label);
+    map[key] = (map[key] || 0) + normalizeCount(count);
+    return map;
+  }, {});
+}

--- a/market-lab/launch-your-idea/index.html
+++ b/market-lab/launch-your-idea/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Launch Your Idea | 3DVR Market Lab</title>
+  <meta
+    name="description"
+    content="A test landing page for people who want to turn a rough idea into a live page, offer, or first concrete launch step."
+  />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#111827" />
+  <link rel="stylesheet" href="../landing.css" />
+</head>
+<body data-experiment-id="launch-your-idea">
+  <div class="shell">
+    <a class="top-link" href="../">Back to Market Lab</a>
+
+    <main class="hero">
+      <section>
+        <p class="eyebrow">Launch Your Idea</p>
+        <h1>Finally launch the idea you keep carrying around.</h1>
+        <p class="lead">
+          3DVR helps turn a rough idea into a first page, clear offer, or working next step so the idea can meet real people.
+        </p>
+        <div class="cta-row">
+          <a class="button primary" href="../?source=landing-launch-your-idea" data-market-cta>Book a free brainstorming call</a>
+          <a class="button" href="#" data-crm-link>Open CRM conversation draft</a>
+        </div>
+      </section>
+
+      <aside class="panel">
+        <span class="signal">Source: <span data-source-label>direct</span></span>
+        <h2>What this tests</h2>
+        <p>
+          This angle is for entrepreneurs, creators, and side hustlers who need momentum more than a complicated platform pitch.
+        </p>
+        <p class="sync-note">CTA clicks are saved locally and backed up to Gun for the Market Lab dashboard.</p>
+      </aside>
+    </main>
+
+    <section class="section">
+      <h2>Small enough to start.</h2>
+      <div class="proof-grid">
+        <article class="proof-card">
+          <strong>Name the offer</strong>
+          <p>Clarify who it is for, what it solves, and what the first response should be.</p>
+        </article>
+        <article class="proof-card">
+          <strong>Make the first page</strong>
+          <p>Build a simple public page that makes the idea explainable and shareable.</p>
+        </article>
+        <article class="proof-card">
+          <strong>Start the conversation</strong>
+          <p>Use the page as a practical reason to message people and learn what lands.</p>
+        </article>
+      </div>
+      <div class="cta-row">
+        <a class="button primary" href="#" data-crm-link data-market-cta>Start a launch conversation</a>
+        <a class="button" href="#" data-contacts-link>Open contacts with this context</a>
+      </div>
+    </section>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../../gun-init.js"></script>
+  <script src="../landing.js" defer></script>
+</body>
+</html>

--- a/market-lab/open-future-computing/index.html
+++ b/market-lab/open-future-computing/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Open Future Computing | 3DVR Market Lab</title>
+  <meta
+    name="description"
+    content="A test landing page for open-source, Linux, maker, and digital independence conversations around 3DVR."
+  />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#111827" />
+  <link rel="stylesheet" href="../landing.css" />
+</head>
+<body data-experiment-id="open-future-computing">
+  <div class="shell">
+    <a class="top-link" href="../">Back to Market Lab</a>
+
+    <main class="hero">
+      <section>
+        <p class="eyebrow">Open Future Computing</p>
+        <h1>Open-source computing for real humans.</h1>
+        <p class="lead">
+          3DVR is exploring humane, local-first, Linux-friendly tools for people who want more ownership over how computing fits into life.
+        </p>
+        <div class="cta-row">
+          <a class="button primary" href="../?source=landing-open-future-computing" data-market-cta>Join the builder community</a>
+          <a class="button" href="#" data-crm-link>Open CRM conversation draft</a>
+        </div>
+      </section>
+
+      <aside class="panel">
+        <span class="signal">Source: <span data-source-label>direct</span></span>
+        <h2>What this tests</h2>
+        <p>
+          This angle is for Linux people, open-source builders, makers, and digital nomads who want computing to be portable, repairable, and user-owned.
+        </p>
+        <p class="sync-note">CTA clicks are saved locally and backed up to Gun for the Market Lab dashboard.</p>
+      </aside>
+    </main>
+
+    <section class="section">
+      <h2>Own more of the stack.</h2>
+      <div class="proof-grid">
+        <article class="proof-card">
+          <strong>Local-first tools</strong>
+          <p>Prefer software that works on your device, backs up clearly, and does not trap your data.</p>
+        </article>
+        <article class="proof-card">
+          <strong>Open hardware direction</strong>
+          <p>Explore practical devices, laptop setups, pocket workstations, and repairable computing experiments.</p>
+        </article>
+        <article class="proof-card">
+          <strong>Human interfaces</strong>
+          <p>Build calmer tools that protect attention instead of turning every screen into a slot machine.</p>
+        </article>
+      </div>
+      <div class="cta-row">
+        <a class="button primary" href="#" data-crm-link data-market-cta>Start an open computing conversation</a>
+        <a class="button" href="#" data-contacts-link>Open contacts with this context</a>
+      </div>
+    </section>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../../gun-init.js"></script>
+  <script src="../landing.js" defer></script>
+</body>
+</html>

--- a/market-lab/personal-tech-department/index.html
+++ b/market-lab/personal-tech-department/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Personal Tech Department | 3DVR Market Lab</title>
+  <meta
+    name="description"
+    content="A test landing page for small businesses and busy people who need calm ongoing help with tech, accounts, sites, and systems."
+  />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#111827" />
+  <link rel="stylesheet" href="../landing.css" />
+</head>
+<body data-experiment-id="personal-tech-department">
+  <div class="shell">
+    <a class="top-link" href="../">Back to Market Lab</a>
+
+    <main class="hero">
+      <section>
+        <p class="eyebrow">Personal Tech Department</p>
+        <h1>Your personal tech department for $20/month.</h1>
+        <p class="lead">
+          Get steady help with websites, accounts, devices, software, automation, and the small tech problems that keep stealing attention.
+        </p>
+        <div class="cta-row">
+          <a class="button primary" href="../?source=landing-personal-tech-department" data-market-cta>Get tech support</a>
+          <a class="button" href="#" data-crm-link>Open CRM conversation draft</a>
+        </div>
+      </section>
+
+      <aside class="panel">
+        <span class="signal">Source: <span data-source-label>direct</span></span>
+        <h2>What this tests</h2>
+        <p>
+          This angle is for small businesses, older adults, and busy professionals who want a practical person to call before tech spirals.
+        </p>
+        <p class="sync-note">CTA clicks are saved locally and backed up to Gun for the Market Lab dashboard.</p>
+      </aside>
+    </main>
+
+    <section class="section">
+      <h2>Less chaos around everyday tech.</h2>
+      <div class="proof-grid">
+        <article class="proof-card">
+          <strong>Fix small blockers</strong>
+          <p>Accounts, websites, files, phones, forms, billing, email, and confusing software tasks.</p>
+        </article>
+        <article class="proof-card">
+          <strong>Keep systems moving</strong>
+          <p>Create simple repeatable workflows instead of solving the same problem every week.</p>
+        </article>
+        <article class="proof-card">
+          <strong>Stay calm</strong>
+          <p>Use plain language, slower decisions, and useful follow-up instead of panic support.</p>
+        </article>
+      </div>
+      <div class="cta-row">
+        <a class="button primary" href="#" data-crm-link data-market-cta>Start a support conversation</a>
+        <a class="button" href="#" data-contacts-link>Open contacts with this context</a>
+      </div>
+    </section>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../../gun-init.js"></script>
+  <script src="../landing.js" defer></script>
+</body>
+</html>

--- a/tests/market-lab.test.js
+++ b/tests/market-lab.test.js
@@ -4,7 +4,13 @@ import { readFile } from 'node:fs/promises';
 
 const pageUrl = new URL('../market-lab/index.html', import.meta.url);
 const appUrl = new URL('../market-lab/app.js', import.meta.url);
+const landingScriptUrl = new URL('../market-lab/landing.js', import.meta.url);
 const indexUrl = new URL('../index.html', import.meta.url);
+const landingPages = [
+  ['Launch Your Idea', '../market-lab/launch-your-idea/index.html'],
+  ['Personal Tech Department', '../market-lab/personal-tech-department/index.html'],
+  ['Open Future Computing', '../market-lab/open-future-computing/index.html'],
+];
 
 describe('Market Lab', () => {
   it('ships the dashboard page with the required experiments and explanation', async () => {
@@ -12,15 +18,18 @@ describe('Market Lab', () => {
 
     assert.match(html, /3DVR Market Lab/);
     assert.match(html, /This page helps 3dvr\.tech test which market message gets the most energy back from reality\./);
-    assert.match(html, /Landing-page mockups/);
+    assert.match(html, /Landing pages to test/);
     assert.match(html, /Experiment dashboard/);
     assert.match(html, /Current leader/);
     assert.match(html, /Current source label/);
     assert.match(html, /\?source=instagram/);
+    assert.match(html, /Gun backup: connecting/);
+    assert.match(html, /3dvr-portal\/market-lab\/state/);
+    assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
     assert.match(html, /app\.js/);
   });
 
-  it('defines the initial experiments, local storage adapter, source labels, metrics, and winner formula', async () => {
+  it('defines the initial experiments, Gun backup, source labels, metrics, and winner formula', async () => {
     const js = await readFile(appUrl, 'utf8');
 
     assert.match(js, /Launch Your Idea/);
@@ -30,13 +39,45 @@ describe('Market Lab', () => {
     assert.match(js, /Open Future Computing/);
     assert.match(js, /Open-source computing for real humans\./);
     assert.match(js, /window\.localStorage/);
+    assert.match(js, /createGunBackup/);
+    assert.match(js, /GUN_ROOT_KEY = '3dvr-portal'/);
+    assert.match(js, /GUN_STATE_KEY = 'state'/);
+    assert.match(js, /JSON\.stringify\(payload\.experiments\)/);
+    assert.match(js, /backupEventToGun/);
     assert.match(js, /utm_source/);
     assert.match(js, /SOURCE_STORAGE_KEY/);
     assert.match(js, /clicksBySource/);
-    assert.match(js, /Gun\.js, Supabase, or a portal API/);
+    assert.match(js, /getCrmHref/);
+    assert.match(js, /getContactsHref/);
     assert.match(js, /experiment\.replies \* 3/);
     assert.match(js, /experiment\.callsBooked \* 5/);
     assert.match(js, /experiment\.signups \* 10/);
+  });
+
+  it('ships testable landing pages for each market angle', async () => {
+    for (const [name, path] of landingPages) {
+      const html = await readFile(new URL(path, import.meta.url), 'utf8');
+
+      assert.match(html, new RegExp(name.replaceAll('$', '\\$')));
+      assert.match(html, /data-market-cta/);
+      assert.match(html, /data-crm-link/);
+      assert.match(html, /data-contacts-link/);
+      assert.match(html, /landing\.css/);
+      assert.match(html, /landing\.js/);
+      assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+    }
+  });
+
+  it('lets landing pages increment counts locally and back them up through Gun', async () => {
+    const js = await readFile(landingScriptUrl, 'utf8');
+
+    assert.match(js, /incrementClick/);
+    assert.match(js, /window\.localStorage/);
+    assert.match(js, /createGunBackup/);
+    assert.match(js, /backupToGun/);
+    assert.match(js, /backupEventToGun/);
+    assert.match(js, /getCrmHref/);
+    assert.match(js, /getContactsHref/);
   });
 
   it('links Market Lab from the portal app dock', async () => {


### PR DESCRIPTION
## Summary
- turns Market Lab into a Gun-backed experiment tracker with sync status and CRM/contact handoff links
- adds three testable landing pages for Launch Your Idea, Personal Tech Department, and Open Future Computing
- adds shared landing CSS/JS so CTA clicks update localStorage and back up to Gun

## Tests
- `node --check market-lab/app.js`
- `node --check market-lab/landing.js`
- `node --test tests/market-lab.test.js`
- `git diff --check`
- smoke checked `/market-lab/` and all three landing routes with a local static server