### PR TITLE
Brand portal logo as 3dvr portal

### DIFF
--- a/brand/portal-logo.svg
+++ b/brand/portal-logo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
-  <title id="title">3DVR Portal logo</title>
-  <desc id="desc">A layered portal mark with the letters 3DVR.</desc>
+  <title id="title">3dvr portal logo</title>
+  <desc id="desc">A layered portal mark with the words 3dvr portal.</desc>
   <defs>
     <linearGradient id="portal-bg" x1="80" x2="432" y1="70" y2="442" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#0f172a"/>
@@ -21,6 +21,6 @@
   <path d="M154 256c0-56.33 45.67-102 102-102s102 45.67 102 102-45.67 102-102 102-102-45.67-102-102Z" fill="none" stroke="url(#portal-line)" stroke-width="18"/>
   <path d="M128 255.5h256M256 128v256" stroke="#e0f2fe" stroke-width="16" stroke-linecap="round" opacity="0.62"/>
   <path d="M184 298c20.83 21.33 44.83 32 72 32s51.17-10.67 72-32" fill="none" stroke="#f8fafc" stroke-width="18" stroke-linecap="round"/>
-  <text x="256" y="267" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="86" font-weight="900" fill="#f8fafc" letter-spacing="-6">3D</text>
-  <text x="256" y="322" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="800" fill="#bae6fd" letter-spacing="4">VR</text>
+  <text x="256" y="274" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="76" font-weight="900" fill="#f8fafc" letter-spacing="-3">3dvr</text>
+  <text x="256" y="324" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="40" font-weight="800" fill="#bae6fd" letter-spacing="1">portal</text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       if (!relayUrl.includes('{{')) {
         window.__GUN_RELAY__ = relayUrl;
       }
-      window.__APP_NAME__ = window.__APP_NAME__ || '3dvr-tech';
+      window.__APP_NAME__ = window.__APP_NAME__ || '3dvr-portal';
     }
   </script>
 
@@ -47,7 +47,7 @@
       <img src="/brand/portal-logo.svg" alt="">
     </div>
     <div class="app-boot__text">
-      <strong>3DVR Portal</strong>
+      <strong>3dvr portal</strong>
       <span>Opening your workspace</span>
     </div>
     <div class="app-boot__bar"><span></span></div>

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -1,0 +1,16 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('portal logo branding', () => {
+  it('brands the SVG app logo and boot text as 3dvr portal', async () => {
+    const logo = await readFile(new URL('../brand/portal-logo.svg', import.meta.url), 'utf8');
+    const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+    assert.match(logo, /3dvr portal logo/);
+    assert.match(logo, />3dvr</);
+    assert.match(logo, />portal</);
+    assert.match(html, /window\.__APP_NAME__ = window\.__APP_NAME__ \|\| '3dvr-portal'/);
+    assert.match(html, /<strong>3dvr portal<\/strong>/);
+  });
+});


### PR DESCRIPTION
## Summary
- updates the portal SVG app logo to read `3dvr portal`
- aligns the portal boot label and app name with the portal-specific brand
- adds a focused branding regression test

## Tests
- `node --test tests/portal-logo-branding.test.js`
- `git diff --check`
- parsed `brand/portal-logo.svg` as XML