### PR TITLE
Add memory capture workflow app

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,6 +283,11 @@
             <span class="app-card__title">CRM</span>
             <span class="app-card__meta">Track deals and sync with contacts seamlessly.</span>
           </a>
+          <a href="memory-capture/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🎙️</span>
+            <span class="app-card__title">Memory Capture</span>
+            <span class="app-card__meta">Brain dump conversations into CRM leads, proposals, and 3dvr-agent cleanup tasks.</span>
+          </a>
           <a href="deployment-guides/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🛠️</span>
             <span class="app-card__title">Deploy Guides</span>

--- a/memory-capture/app.js
+++ b/memory-capture/app.js
@@ -1,0 +1,670 @@
+const CAPTURE_STORAGE_KEY = '3dvr.memoryCapture.captures.v1';
+const SOURCE_STORAGE_KEY = '3dvr.memoryCapture.source.v1';
+const ROOT_KEY = '3dvr-portal';
+const CAPTURE_NODE = 'memoryCapture';
+const PROPOSALS_NODE = 'proposals';
+const CRM_NODE = '3dvr-crm';
+const TOUCH_LOG_NODE = 'crm-touch-log';
+const MANAGED_AGENT_OWNER_ALIAS = '3dvr-managed';
+const DEFAULT_SOURCE = 'memory-capture';
+const DEFAULT_PEERS = [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+];
+
+const state = {
+  captures: loadLocalCaptures(),
+  proposals: {},
+  latestCapture: null,
+  mediaRecorder: null,
+  audioChunks: [],
+  recognition: null,
+  dictating: false,
+  recording: false
+};
+
+const gun = typeof Gun === 'function' ? Gun(window.__GUN_PEERS__ || DEFAULT_PEERS) : null;
+const portalRoot = gun ? gun.get(ROOT_KEY) : null;
+const captureRoot = portalRoot ? portalRoot.get(CAPTURE_NODE).get('captures') : null;
+const proposalRoot = portalRoot ? portalRoot.get(PROPOSALS_NODE) : null;
+const touchLogRoot = portalRoot ? portalRoot.get(TOUCH_LOG_NODE) : null;
+const crmRoot = gun ? gun.get(CRM_NODE) : null;
+const agentQueueRoot = portalRoot
+  ? portalRoot.get('agentOps').get(MANAGED_AGENT_OWNER_ALIAS).get('taskQueue')
+  : null;
+
+const els = {
+  syncStatus: document.getElementById('syncStatus'),
+  lastAction: document.getElementById('lastAction'),
+  captureText: document.getElementById('captureText'),
+  sourceInput: document.getElementById('sourceInput'),
+  captureMode: document.getElementById('captureMode'),
+  dictateButton: document.getElementById('dictateButton'),
+  recordButton: document.getElementById('recordButton'),
+  clearButton: document.getElementById('clearButton'),
+  saveCaptureButton: document.getElementById('saveCaptureButton'),
+  crmButton: document.getElementById('crmButton'),
+  proposalButton: document.getElementById('proposalButton'),
+  agentButton: document.getElementById('agentButton'),
+  refreshButton: document.getElementById('refreshButton'),
+  inferenceList: document.getElementById('inferenceList'),
+  recentList: document.getElementById('recentList'),
+  proposalList: document.getElementById('proposalList'),
+  crmDraftLink: document.getElementById('crmDraftLink'),
+  audioPreview: document.getElementById('audioPreview')
+};
+
+els.sourceInput.value = window.localStorage.getItem(SOURCE_STORAGE_KEY) || DEFAULT_SOURCE;
+
+function setStatus(status, detail = '') {
+  els.syncStatus.textContent = status;
+  if (detail) els.lastAction.textContent = detail;
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function slug(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48) || 'capture';
+}
+
+function makeId(prefix, seed = '') {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${slug(seed)}-${Date.now().toString(36)}-${random}`;
+}
+
+function safe(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function loadLocalCaptures() {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(CAPTURE_STORAGE_KEY) || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('Unable to load local memory captures.', error);
+    return [];
+  }
+}
+
+function saveLocalCaptures() {
+  try {
+    window.localStorage.setItem(CAPTURE_STORAGE_KEY, JSON.stringify(state.captures.slice(0, 40)));
+  } catch (error) {
+    console.warn('Unable to save local memory captures.', error);
+  }
+}
+
+function putGun(node, payload) {
+  return new Promise((resolve, reject) => {
+    if (!node || typeof node.put !== 'function') {
+      reject(new Error('Gun is unavailable.'));
+      return;
+    }
+    const timer = window.setTimeout(() => resolve({ timedOut: true }), 8000);
+    node.put(payload, (ack) => {
+      window.clearTimeout(timer);
+      if (ack && ack.err) {
+        reject(new Error(String(ack.err)));
+      } else {
+        resolve(ack || {});
+      }
+    });
+  });
+}
+
+function firstMatch(text, patterns) {
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) return normalizeText(match[1]);
+  }
+  return '';
+}
+
+function inferCapture(rawText) {
+  const text = normalizeText(rawText);
+  const lower = text.toLowerCase();
+  const referrer = firstMatch(text, [
+    /\bthrough\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/,
+    /\bfrom\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/,
+    /\bintroduced by\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/i
+  ]);
+  const name = firstMatch(text, [
+    /\bmet\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/,
+    /\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)\s+wants?\b/,
+    /\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)\s+needs?\b/,
+    /\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)\s+has\b/
+  ]);
+
+  let marketSegment = 'Owner-led service business';
+  let fit = 'website';
+  let offerAmount = 'Website / tech support path';
+  const tags = ['memory-capture'];
+  const pains = [];
+  const nextSteps = [];
+
+  if (referrer) tags.push(`referral/${slug(referrer)}`);
+  if (lower.includes('mark')) tags.push('mark-referral');
+  if (lower.includes('alibaba') || lower.includes('reseller') || lower.includes('ecommerce') || lower.includes('product')) {
+    marketSegment = 'Ecommerce / product reseller';
+    offerAmount = '$5/month onboarding, then product landing page or $20/month support';
+    tags.push('ecommerce', 'reseller', 'product-page');
+    pains.push('Needs product presentation, trust, order/contact workflow, and a simple first launch path.');
+    nextSteps.push('Ask for first product link/photo, business name, target customer, logo/colors, competitor examples, and best contact method.');
+  }
+  if (lower.includes('party rental') || lower.includes('bounce') || lower.includes('wedding')) {
+    marketSegment = 'Local services / event rentals';
+    tags.push('local-services', 'event-rentals');
+    pains.push('Needs a clearer local service website, quote path, and follow-up loop.');
+    nextSteps.push('Ask for business name, service area, best photos, price list, and current Facebook/Instagram page.');
+  }
+  if (lower.includes('cinema 4d') || lower.includes('render') || lower.includes('lake house') || lower.includes('spatial')) {
+    marketSegment = 'Spatial design / visualization';
+    fit = 'app';
+    offerAmount = 'Prototype tiers: still renders, flythrough, interactive walkthrough';
+    tags.push('spatial-design', 'rendering', 'proposal');
+    pains.push('Needs a repeatable proposal and portfolio workflow for visualizing spaces before people spend money.');
+    nextSteps.push('Gather before photos, measurements, inspiration images, and define the first render package.');
+  }
+  if (lower.includes('website') || lower.includes('site')) {
+    tags.push('website');
+    pains.push('Needs a clearer website or landing page.');
+  }
+  if (lower.includes('overwhelmed') || lower.includes('confused') || lower.includes('nervous')) {
+    tags.push('overwhelmed');
+    pains.push('Feels overwhelmed and needs a low-friction next step.');
+  }
+  if (lower.includes('$5') || lower.includes('5/month') || lower.includes('five dollar')) {
+    tags.push('starter-tier');
+    offerAmount = '$5/month onboarding tier';
+  }
+
+  const inferredName = name || (referrer ? `${referrer} referral lead` : 'Memory capture lead');
+  const signal = text.length > 220 ? `${text.slice(0, 217)}...` : text;
+
+  return {
+    name: inferredName,
+    company: lower.includes('parents') ? "Parents' business (unknown)" : '',
+    referrer,
+    status: 'Warm - Awareness',
+    warmth: 'warm',
+    urgency: lower.includes('asap') || lower.includes('urgent') ? 'high' : 'medium',
+    fit,
+    marketSegment,
+    primaryPain: pains[0] || 'Potential business need captured from a fast conversation.',
+    nextBestAction: nextSteps[0] || 'Capture one anchor, confirm the business need, and set the next follow-up.',
+    offerAmount,
+    lastSignal: signal,
+    tags: Array.from(new Set(tags)).join(', '),
+    confidence: text.length > 30 ? 'useful draft' : 'needs more context'
+  };
+}
+
+function buildCrmDraftUrl(inference) {
+  const params = new URLSearchParams({
+    draft: '1',
+    type: 'person',
+    lead: inference.name,
+    company: inference.company,
+    status: inference.status,
+    warmth: inference.warmth,
+    fit: inference.fit,
+    urgency: inference.urgency,
+    segment: inference.marketSegment,
+    pain: inference.primaryPain,
+    offer: inference.offerAmount,
+    signal: inference.lastSignal,
+    nextBestAction: inference.nextBestAction,
+    source: getSource(),
+    tags: inference.tags
+  });
+  return `../crm/?${params.toString()}`;
+}
+
+function renderInference() {
+  const inference = inferCapture(els.captureText.value);
+  const rows = [
+    ['Name / lead', inference.name],
+    ['Segment', inference.marketSegment],
+    ['Pain', inference.primaryPain],
+    ['Next step', inference.nextBestAction],
+    ['Offer', inference.offerAmount],
+    ['Tags', inference.tags],
+    ['Confidence', inference.confidence]
+  ];
+
+  els.inferenceList.innerHTML = rows.map(([label, value]) => `
+    <div>
+      <dt>${safe(label)}</dt>
+      <dd>${safe(value || '-')}</dd>
+    </div>
+  `).join('');
+  els.crmDraftLink.href = buildCrmDraftUrl(inference);
+}
+
+function getSource() {
+  const source = normalizeText(els.sourceInput.value) || DEFAULT_SOURCE;
+  window.localStorage.setItem(SOURCE_STORAGE_KEY, source);
+  return source;
+}
+
+function buildCaptureRecord() {
+  const rawText = normalizeText(els.captureText.value);
+  if (!rawText) {
+    throw new Error('Add a quick note or dictate a memory first.');
+  }
+
+  const inference = inferCapture(rawText);
+  const now = new Date().toISOString();
+  const id = state.latestCapture?.rawText === rawText
+    ? state.latestCapture.id
+    : makeId('capture', inference.name);
+
+  return {
+    id,
+    rawText,
+    mode: els.captureMode.value || 'conversation',
+    source: getSource(),
+    inference,
+    createdAt: state.latestCapture?.id === id ? state.latestCapture.createdAt : now,
+    updatedAt: now,
+    crmRecordId: state.latestCapture?.crmRecordId || '',
+    proposalId: state.latestCapture?.proposalId || '',
+    agentTaskId: state.latestCapture?.agentTaskId || ''
+  };
+}
+
+async function saveCapture() {
+  const record = buildCaptureRecord();
+  state.latestCapture = record;
+  state.captures = [record, ...state.captures.filter(item => item.id !== record.id)].slice(0, 40);
+  saveLocalCaptures();
+
+  try {
+    await putGun(captureRoot.get(record.id), record);
+    setStatus('Gun synced', `Saved capture ${record.id}.`);
+  } catch (error) {
+    setStatus('Local copy kept', error.message || 'Gun sync failed.');
+  }
+
+  renderRecent();
+  renderProposals();
+  return record;
+}
+
+function buildCrmRecord(capture) {
+  const now = new Date().toISOString();
+  const inference = capture.inference;
+  const id = capture.crmRecordId || makeId('lead-memory', inference.name);
+  return {
+    id,
+    recordType: 'person',
+    name: inference.name,
+    email: '',
+    phone: '',
+    company: inference.company,
+    role: '',
+    tags: inference.tags,
+    status: inference.status,
+    warmth: inference.warmth,
+    fit: inference.fit,
+    urgency: inference.urgency,
+    marketSegment: inference.marketSegment,
+    primaryPain: inference.primaryPain,
+    painSeverity: inference.urgency === 'high' ? 'high' : 'medium',
+    currentWorkaround: 'Captured from raw memory. Needs confirmation.',
+    pilotStatus: 'Watching',
+    offerAmount: inference.offerAmount,
+    lastSignal: inference.lastSignal,
+    nextExperiment: 'Low-energy memory capture follow-up',
+    nextBestAction: inference.nextBestAction,
+    objection: '',
+    lastContacted: now,
+    nextFollowUp: '',
+    groupId: '',
+    linkedGroupIds: '',
+    linkedPersonIds: '',
+    contactId: '',
+    source: capture.source,
+    activityCount: 1,
+    notes: [
+      'Created from Memory Capture.',
+      '',
+      capture.rawText
+    ].join('\n'),
+    created: now,
+    updated: now
+  };
+}
+
+function buildTouchLog(capture, crmRecord) {
+  const now = new Date().toISOString();
+  return {
+    id: makeId('touch-memory', crmRecord.name),
+    recordId: crmRecord.id,
+    contactId: '',
+    contactName: crmRecord.name,
+    type: 'note',
+    channel: capture.mode || 'conversation',
+    summary: `Memory capture: ${capture.inference.lastSignal}`,
+    outcome: capture.inference.nextBestAction,
+    source: 'memory-capture',
+    created: now,
+    updated: now
+  };
+}
+
+async function createCrmLead() {
+  const capture = await saveCapture();
+  const crmRecord = buildCrmRecord(capture);
+  const touch = buildTouchLog(capture, crmRecord);
+
+  await putGun(crmRoot.get(crmRecord.id), crmRecord);
+  await putGun(touchLogRoot.get(touch.id), touch);
+
+  capture.crmRecordId = crmRecord.id;
+  state.latestCapture = capture;
+  await putGun(captureRoot.get(capture.id), capture);
+  state.captures = [capture, ...state.captures.filter(item => item.id !== capture.id)].slice(0, 40);
+  saveLocalCaptures();
+  renderRecent();
+  setStatus('CRM lead created', crmRecord.name);
+}
+
+function buildProposal(capture) {
+  const now = new Date().toISOString();
+  const inference = capture.inference;
+  const id = capture.proposalId || makeId('proposal', inference.name);
+  return {
+    id,
+    title: `${inference.name} proposal`,
+    status: 'idea',
+    linkedCrmRecordId: capture.crmRecordId || '',
+    sourceCaptureId: capture.id,
+    offer: inference.offerAmount,
+    scope: inference.primaryPain,
+    nextBestAction: inference.nextBestAction,
+    price: '',
+    sentAt: '',
+    followUpAt: '',
+    tags: inference.tags,
+    notes: capture.rawText,
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+async function createProposal() {
+  const capture = await saveCapture();
+  const proposal = buildProposal(capture);
+  await putGun(proposalRoot.get(proposal.id), proposal);
+  state.proposals[proposal.id] = proposal;
+
+  capture.proposalId = proposal.id;
+  state.latestCapture = capture;
+  await putGun(captureRoot.get(capture.id), capture);
+  state.captures = [capture, ...state.captures.filter(item => item.id !== capture.id)].slice(0, 40);
+  saveLocalCaptures();
+  renderRecent();
+  renderProposals();
+  setStatus('Proposal tracked', proposal.title);
+}
+
+function buildAgentTask(capture) {
+  const now = Date.now();
+  const id = makeId('memory-task', capture.inference.name);
+  const task = [
+    'Process this 3dvr Memory Capture into clean CRM/proposal actions.',
+    `Capture id: ${capture.id}`,
+    `Suggested lead: ${capture.inference.name}`,
+    `Source: ${capture.source}`,
+    `Mode: ${capture.mode}`,
+    capture.crmRecordId ? `CRM record id: ${capture.crmRecordId}` : 'Create or update the CRM record if useful.',
+    capture.proposalId ? `Proposal id: ${capture.proposalId}` : 'Create or update a proposal if this is a deal/project.',
+    '',
+    'Raw capture:',
+    capture.rawText
+  ].join('\n');
+
+  return {
+    id,
+    task,
+    tenantId: 'portal:memory-capture',
+    tenantAlias: window.localStorage.getItem('alias') || window.localStorage.getItem('username') || 'memory-capture',
+    tenantPlan: 'free',
+    backend: 'codex',
+    repo: 'tmsteph/3dvr-portal',
+    model: '',
+    thinking: '',
+    unsafe: false,
+    riskClass: 'workspace_write',
+    approvalStatus: 'not_required',
+    requiredCapabilities: 'codex,crm,gun',
+    maxRuntimeMs: 0,
+    status: 'queued',
+    requestedBy: 'memory-capture',
+    createdAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+    resultSummary: '',
+    error: '',
+    workerDeviceId: '',
+    sourceCaptureId: capture.id
+  };
+}
+
+async function queueAgentTask() {
+  const capture = await saveCapture();
+  const task = buildAgentTask(capture);
+  const summary = {
+    id: task.id,
+    status: task.status,
+    task: task.task,
+    tenantId: task.tenantId,
+    tenantAlias: task.tenantAlias,
+    tenantPlan: task.tenantPlan,
+    riskClass: task.riskClass,
+    approvalStatus: task.approvalStatus,
+    requiredCapabilities: task.requiredCapabilities,
+    updatedAt: task.updatedAt
+  };
+
+  await putGun(agentQueueRoot.get('tasks').get(task.id), task);
+  await putGun(agentQueueRoot.get('latest').get(task.id), summary);
+
+  capture.agentTaskId = task.id;
+  state.latestCapture = capture;
+  await putGun(captureRoot.get(capture.id), capture);
+  state.captures = [capture, ...state.captures.filter(item => item.id !== capture.id)].slice(0, 40);
+  saveLocalCaptures();
+  renderRecent();
+  setStatus('Agent task queued', task.id);
+}
+
+function renderRecent() {
+  const captures = state.captures
+    .filter(Boolean)
+    .sort((a, b) => String(b.updatedAt || '').localeCompare(String(a.updatedAt || '')))
+    .slice(0, 8);
+
+  if (!captures.length) {
+    els.recentList.innerHTML = '<p class="empty">No captures yet.</p>';
+    return;
+  }
+
+  els.recentList.innerHTML = captures.map(capture => `
+    <article class="recent-card">
+      <strong>${safe(capture.inference?.name || 'Memory capture')}</strong>
+      <p>${safe(capture.inference?.lastSignal || capture.rawText || '')}</p>
+      <span>${safe(capture.mode || 'conversation')} | ${safe(capture.updatedAt || '')}</span>
+    </article>
+  `).join('');
+}
+
+function renderProposals() {
+  const proposals = Object.values(state.proposals || {})
+    .filter(Boolean)
+    .sort((a, b) => String(b.updatedAt || b.createdAt || '').localeCompare(String(a.updatedAt || a.createdAt || '')))
+    .slice(0, 8);
+
+  if (!els.proposalList) return;
+  if (!proposals.length) {
+    els.proposalList.innerHTML = '<p class="empty">No proposals tracked yet.</p>';
+    return;
+  }
+
+  els.proposalList.innerHTML = proposals.map(proposal => `
+    <article class="recent-card">
+      <strong>${safe(proposal.title || 'Proposal')}</strong>
+      <p>${safe(proposal.scope || proposal.nextBestAction || '')}</p>
+      <span>${safe(proposal.status || 'idea')} | ${safe(proposal.offer || 'offer TBD')}</span>
+    </article>
+  `).join('');
+}
+
+function subscribeCaptures() {
+  if (!captureRoot || typeof captureRoot.map !== 'function') {
+    setStatus('Local mode', 'Gun is unavailable; local captures still work.');
+    renderRecent();
+    return;
+  }
+
+  setStatus('Gun connected', 'Listening for memory captures.');
+  captureRoot.map().on((data, key) => {
+    if (!key || !data || typeof data !== 'object') return;
+    const capture = {
+      ...data,
+      inference: data.inference && typeof data.inference === 'object' ? data.inference : inferCapture(data.rawText || '')
+    };
+    state.captures = [capture, ...state.captures.filter(item => item.id !== capture.id)].slice(0, 40);
+    saveLocalCaptures();
+    renderRecent();
+  });
+}
+
+function subscribeProposals() {
+  if (!proposalRoot || typeof proposalRoot.map !== 'function') {
+    renderProposals();
+    return;
+  }
+
+  proposalRoot.map().on((data, key) => {
+    if (!key) return;
+    if (!data) {
+      delete state.proposals[key];
+    } else if (typeof data === 'object') {
+      state.proposals[key] = { ...state.proposals[key], ...data, id: data.id || key };
+    }
+    renderProposals();
+  });
+}
+
+function setupDictation() {
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!SpeechRecognition) {
+    els.dictateButton.textContent = 'Dictation unavailable';
+    els.dictateButton.disabled = true;
+    return;
+  }
+
+  state.recognition = new SpeechRecognition();
+  state.recognition.continuous = true;
+  state.recognition.interimResults = true;
+  state.recognition.lang = 'en-US';
+
+  let finalTranscript = '';
+  state.recognition.onresult = (event) => {
+    let interim = '';
+    for (let index = event.resultIndex; index < event.results.length; index += 1) {
+      const transcript = event.results[index][0].transcript;
+      if (event.results[index].isFinal) finalTranscript += `${transcript} `;
+      else interim += transcript;
+    }
+    const base = normalizeText(els.captureText.value.replace(/\n\nListening:.*/s, ''));
+    els.captureText.value = normalizeText(`${base}\n\n${finalTranscript}${interim ? `\n\nListening: ${interim}` : ''}`);
+    renderInference();
+  };
+  state.recognition.onend = () => {
+    state.dictating = false;
+    els.dictateButton.textContent = 'Start dictation';
+    els.captureText.value = els.captureText.value.replace(/\n\nListening:.*/s, '').trim();
+    renderInference();
+  };
+}
+
+async function toggleRecording() {
+  if (state.recording && state.mediaRecorder) {
+    state.mediaRecorder.stop();
+    return;
+  }
+
+  if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
+    setStatus('Audio unavailable', 'This browser cannot record audio here.');
+    return;
+  }
+
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  state.audioChunks = [];
+  state.mediaRecorder = new MediaRecorder(stream);
+  state.mediaRecorder.ondataavailable = (event) => {
+    if (event.data.size > 0) state.audioChunks.push(event.data);
+  };
+  state.mediaRecorder.onstop = () => {
+    const blob = new Blob(state.audioChunks, { type: 'audio/webm' });
+    const url = URL.createObjectURL(blob);
+    els.audioPreview.hidden = false;
+    els.audioPreview.innerHTML = `
+      <p class="empty">Audio note recorded locally. Add a short text summary before syncing.</p>
+      <audio controls src="${url}"></audio>
+    `;
+    stream.getTracks().forEach(track => track.stop());
+    state.recording = false;
+    els.recordButton.textContent = 'Record audio note';
+    setStatus('Audio recorded', 'Audio stays local; text summary syncs to CRM.');
+  };
+  state.mediaRecorder.start();
+  state.recording = true;
+  els.recordButton.textContent = 'Stop recording';
+  setStatus('Recording', 'Speak naturally, then add or dictate a short summary.');
+}
+
+els.captureText.addEventListener('input', renderInference);
+els.sourceInput.addEventListener('input', () => window.localStorage.setItem(SOURCE_STORAGE_KEY, getSource()));
+els.clearButton.addEventListener('click', () => {
+  els.captureText.value = '';
+  state.latestCapture = null;
+  els.audioPreview.hidden = true;
+  els.audioPreview.innerHTML = '';
+  renderInference();
+  setStatus('Ready', 'Cleared current capture.');
+});
+els.saveCaptureButton.addEventListener('click', () => saveCapture().catch(error => setStatus('Save failed', error.message)));
+els.crmButton.addEventListener('click', () => createCrmLead().catch(error => setStatus('CRM failed', error.message)));
+els.proposalButton.addEventListener('click', () => createProposal().catch(error => setStatus('Proposal failed', error.message)));
+els.agentButton.addEventListener('click', () => queueAgentTask().catch(error => setStatus('Agent queue failed', error.message)));
+els.refreshButton.addEventListener('click', renderRecent);
+els.dictateButton.addEventListener('click', () => {
+  if (!state.recognition) return;
+  if (state.dictating) {
+    state.recognition.stop();
+    return;
+  }
+  state.dictating = true;
+  els.dictateButton.textContent = 'Stop dictation';
+  state.recognition.start();
+});
+els.recordButton.addEventListener('click', () => toggleRecording().catch(error => setStatus('Recording failed', error.message)));
+
+setupDictation();
+renderInference();
+renderRecent();
+subscribeCaptures();
+subscribeProposals();

--- a/memory-capture/index.html
+++ b/memory-capture/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Memory Capture | 3dvr portal</title>
+  <meta
+    name="description"
+    content="Low-energy voice and text capture for turning fast conversations into CRM records, proposals, and 3dvr-agent tasks."
+  />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#0d1117" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+</head>
+<body>
+  <div class="shell">
+    <header class="hero">
+      <nav class="topbar" aria-label="Memory capture navigation">
+        <a href="../">Portal</a>
+        <a href="../crm/">CRM</a>
+        <a href="../admin/#agent-ops-card">Agent Ops</a>
+      </nav>
+      <div class="hero-grid">
+        <div>
+          <p class="eyebrow">Low-energy logging</p>
+          <h1>Brain dump first. Organize later.</h1>
+          <p class="lead">
+            Capture a conversation in seconds, then let the portal turn it into a CRM lead, proposal idea, touch log, or agent task.
+          </p>
+        </div>
+        <aside class="status-card" aria-live="polite">
+          <span>System</span>
+          <strong id="syncStatus">Connecting to Gun...</strong>
+          <p id="lastAction">Ready for a fast capture.</p>
+        </aside>
+      </div>
+    </header>
+
+    <main>
+      <section class="capture-layout" aria-labelledby="capture-title">
+        <article class="panel capture-panel">
+          <div class="section-head">
+            <p class="eyebrow">Capture</p>
+            <h2 id="capture-title">What just happened?</h2>
+          </div>
+
+          <div class="control-strip" aria-label="Fast capture controls">
+            <button id="dictateButton" class="action-button primary" type="button">Start dictation</button>
+            <button id="recordButton" class="action-button" type="button">Record audio note</button>
+            <button id="clearButton" class="action-button subtle" type="button">Clear</button>
+          </div>
+
+          <label class="field">
+            <span>Fast dump</span>
+            <textarea
+              id="captureText"
+              rows="11"
+              placeholder="Example: Met Victor through Mark. Wants to start Alibaba reselling. Seems overwhelmed by setup and product sourcing. Interested in low-cost help. Waiting on first product."
+            ></textarea>
+          </label>
+
+          <div id="audioPreview" class="audio-preview" hidden></div>
+
+          <div class="field-grid">
+            <label class="field">
+              <span>Source</span>
+              <input id="sourceInput" type="text" value="memory-capture" autocomplete="off" />
+            </label>
+            <label class="field">
+              <span>Mode</span>
+              <select id="captureMode">
+                <option value="conversation">Conversation</option>
+                <option value="lead">Lead</option>
+                <option value="proposal">Proposal</option>
+                <option value="project">Project</option>
+                <option value="reflection">Reflection</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="button-grid">
+            <button id="saveCaptureButton" class="action-button primary" type="button">Save capture</button>
+            <button id="crmButton" class="action-button" type="button">Create CRM lead</button>
+            <button id="proposalButton" class="action-button" type="button">Create proposal</button>
+            <button id="agentButton" class="action-button" type="button">Queue agent cleanup</button>
+          </div>
+        </article>
+
+        <aside class="panel">
+          <div class="section-head">
+            <p class="eyebrow">AI-shaped preview</p>
+            <h2>Inferred structure</h2>
+          </div>
+          <dl class="inference-list" id="inferenceList"></dl>
+          <div class="link-stack">
+            <a id="crmDraftLink" href="../crm/?draft=1&source=memory-capture">Open CRM draft</a>
+            <a href="../sales/">Open sales hub</a>
+            <a href="../admin/#agent-ops-card">Open agent queue</a>
+          </div>
+        </aside>
+      </section>
+
+      <section class="panel" aria-labelledby="pipeline-title">
+        <div class="section-head row">
+          <div>
+            <p class="eyebrow">Pipeline</p>
+            <h2 id="pipeline-title">What this app connects to</h2>
+          </div>
+          <button id="refreshButton" class="action-button subtle" type="button">Refresh</button>
+        </div>
+        <div class="pipeline-grid">
+          <article>
+            <strong>Raw memory</strong>
+            <p>Saved under <code>3dvr-portal/memoryCapture/captures</code> with a local fallback.</p>
+          </article>
+          <article>
+            <strong>CRM + touch log</strong>
+            <p>Creates leads in <code>3dvr-crm</code> and activity notes in <code>3dvr-portal/crm-touch-log</code>.</p>
+          </article>
+          <article>
+            <strong>Proposals</strong>
+            <p>Tracks scope ideas under <code>3dvr-portal/proposals</code> before they become formal deals.</p>
+          </article>
+          <article>
+            <strong>DigitalOcean agent</strong>
+            <p>Queues cleanup work in <code>agentOps/3dvr-managed/taskQueue</code> for 3dvr-agent or Codex.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="recent-title">
+        <div class="section-head">
+          <p class="eyebrow">Recent</p>
+          <h2 id="recent-title">Recent captures</h2>
+        </div>
+        <div id="recentList" class="recent-list">
+          <p class="empty">No captures yet.</p>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="proposals-title">
+        <div class="section-head">
+          <p class="eyebrow">Sales process</p>
+          <h2 id="proposals-title">Proposal tracker</h2>
+        </div>
+        <div id="proposalList" class="recent-list">
+          <p class="empty">No proposals tracked yet.</p>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script src="app.js" defer></script>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/memory-capture/style.css
+++ b/memory-capture/style.css
@@ -1,0 +1,354 @@
+:root {
+  --bg: #0d1117;
+  --surface: #151b25;
+  --surface-soft: #1b2431;
+  --surface-warm: #241f1a;
+  --line: rgba(226, 232, 240, 0.14);
+  --line-strong: rgba(226, 232, 240, 0.24);
+  --text: #f8fafc;
+  --muted: #b8c1cc;
+  --quiet: #8d99a8;
+  --teal: #5eead4;
+  --blue: #93c5fd;
+  --gold: #f6d365;
+  --rose: #fda4af;
+  --shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+}
+
+* { box-sizing: border-box; }
+
+html {
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(94, 234, 212, 0.12), transparent 24rem),
+    radial-gradient(circle at 86% 6%, rgba(246, 211, 101, 0.1), transparent 28rem),
+    var(--bg);
+}
+
+a { color: inherit; }
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button { cursor: pointer; }
+
+.shell {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1rem 0 4rem;
+}
+
+.topbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-bottom: 2rem;
+}
+
+.topbar a,
+.link-stack a {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.045);
+  padding: 0.45rem 0.75rem;
+  font-size: 0.92rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.topbar a:hover,
+.link-stack a:hover {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.hero {
+  padding: 1rem 0 3rem;
+}
+
+.hero-grid,
+.capture-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 390px);
+  gap: clamp(1rem, 4vw, 2rem);
+  align-items: start;
+}
+
+.eyebrow {
+  margin: 0 0 0.65rem;
+  color: var(--teal);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h1 {
+  max-width: 780px;
+  font-size: clamp(3rem, 8vw, 6.4rem);
+}
+
+h2 {
+  font-size: clamp(1.7rem, 4vw, 2.6rem);
+}
+
+.lead {
+  max-width: 730px;
+  margin: 1.15rem 0 0;
+  color: var(--muted);
+  font-size: clamp(1.05rem, 2vw, 1.22rem);
+}
+
+.panel,
+.status-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.status-card {
+  padding: 1rem;
+  background: linear-gradient(180deg, rgba(246, 211, 101, 0.12), rgba(21, 27, 37, 0.92));
+}
+
+.status-card span {
+  color: var(--gold);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.status-card strong {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 1.25rem;
+}
+
+.status-card p {
+  margin: 0.45rem 0 0;
+  color: var(--muted);
+}
+
+.panel {
+  padding: 1rem;
+}
+
+.capture-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.section-head {
+  margin-bottom: 1rem;
+}
+
+.section-head.row {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.field,
+.field-grid {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.field-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field span {
+  color: var(--quiet);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #0f1622;
+  color: var(--text);
+  padding: 0.72rem 0.8rem;
+}
+
+textarea {
+  min-height: 240px;
+  resize: vertical;
+}
+
+.control-strip,
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.button-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.action-button {
+  min-height: 44px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.65rem 0.75rem;
+  font-weight: 850;
+}
+
+.action-button.primary {
+  border-color: transparent;
+  background: linear-gradient(135deg, rgba(94, 234, 212, 0.94), rgba(147, 197, 253, 0.94));
+  color: #07111f;
+}
+
+.action-button.subtle {
+  color: var(--muted);
+  background: transparent;
+}
+
+.audio-preview {
+  border: 1px solid rgba(94, 234, 212, 0.22);
+  border-radius: 8px;
+  background: rgba(94, 234, 212, 0.06);
+  padding: 0.75rem;
+}
+
+.audio-preview audio {
+  width: 100%;
+}
+
+.inference-list {
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+}
+
+.inference-list div {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 0.75rem;
+}
+
+.inference-list dt {
+  color: var(--quiet);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.inference-list dd {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+}
+
+.link-stack {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.pipeline-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.pipeline-grid article,
+.recent-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 1rem;
+}
+
+.pipeline-grid strong,
+.recent-card strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.pipeline-grid p,
+.recent-card p,
+.empty {
+  margin: 0;
+  color: var(--muted);
+}
+
+.recent-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.recent-card span {
+  display: inline-flex;
+  width: fit-content;
+  margin-top: 0.65rem;
+  border: 1px solid rgba(246, 211, 101, 0.26);
+  border-radius: 999px;
+  background: rgba(246, 211, 101, 0.08);
+  color: #fde68a;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+code {
+  color: #fde68a;
+}
+
+@media (max-width: 980px) {
+  .hero-grid,
+  .capture-layout,
+  .pipeline-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .field-grid,
+  .control-strip,
+  .button-grid {
+    grid-template-columns: 1fr;
+  }
+
+  textarea {
+    min-height: 190px;
+  }
+}

--- a/sales/index.html
+++ b/sales/index.html
@@ -19,6 +19,7 @@
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../start/" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Start Here</a>
         <a href="../lead-generation.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Lead Capture</a>
+        <a href="../memory-capture/" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Memory Capture</a>
         <a href="../contacts/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Contacts Workspace</a>
         <a href="../crm/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">CRM</a>
         <a href="outreach.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Outreach CRM</a>

--- a/tests/memory-capture.test.js
+++ b/tests/memory-capture.test.js
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const pageUrl = new URL('../memory-capture/index.html', import.meta.url);
+const appUrl = new URL('../memory-capture/app.js', import.meta.url);
+const styleUrl = new URL('../memory-capture/style.css', import.meta.url);
+const portalUrl = new URL('../index.html', import.meta.url);
+const salesUrl = new URL('../sales/index.html', import.meta.url);
+
+describe('Memory Capture app', () => {
+  it('ships a low-energy capture app wired to CRM, proposals, and agent ops', async () => {
+    const html = await readFile(pageUrl, 'utf8');
+
+    assert.match(html, /Memory Capture \| 3dvr portal/);
+    assert.match(html, /Brain dump first\. Organize later\./);
+    assert.match(html, /Start dictation/);
+    assert.match(html, /Record audio note/);
+    assert.match(html, /Create CRM lead/);
+    assert.match(html, /Create proposal/);
+    assert.match(html, /Queue agent cleanup/);
+    assert.match(html, /Proposal tracker/);
+    assert.match(html, /3dvr-portal\/memoryCapture\/captures/);
+    assert.match(html, /agentOps\/3dvr-managed\/taskQueue/);
+    assert.match(html, /app\.js/);
+  });
+
+  it('writes captures into the existing Gun-backed CRM and managed agent infrastructure', async () => {
+    const js = await readFile(appUrl, 'utf8');
+
+    assert.match(js, /CAPTURE_NODE = 'memoryCapture'/);
+    assert.match(js, /PROPOSALS_NODE = 'proposals'/);
+    assert.match(js, /CRM_NODE = '3dvr-crm'/);
+    assert.match(js, /TOUCH_LOG_NODE = 'crm-touch-log'/);
+    assert.match(js, /MANAGED_AGENT_OWNER_ALIAS = '3dvr-managed'/);
+    assert.match(js, /SpeechRecognition|webkitSpeechRecognition/);
+    assert.match(js, /MediaRecorder/);
+    assert.match(js, /buildCrmRecord/);
+    assert.match(js, /buildProposal/);
+    assert.match(js, /renderProposals/);
+    assert.match(js, /subscribeProposals/);
+    assert.match(js, /buildAgentTask/);
+    assert.match(js, /taskQueue/);
+    assert.match(js, /requiredCapabilities: 'codex,crm,gun'/);
+  });
+
+  it('keeps the app discoverable from the portal and sales hub', async () => {
+    const portalHtml = await readFile(portalUrl, 'utf8');
+    const salesHtml = await readFile(salesUrl, 'utf8');
+
+    assert.match(portalHtml, /href="memory-capture\/"/);
+    assert.match(portalHtml, /<span class="app-card__title">Memory Capture<\/span>/);
+    assert.match(portalHtml, /Brain dump conversations into CRM leads, proposals, and 3dvr-agent cleanup tasks/);
+    assert.match(salesHtml, /href="..\/memory-capture\/"/);
+    assert.match(salesHtml, /Memory Capture/);
+  });
+
+  it('uses a mobile-friendly dark layout', async () => {
+    const css = await readFile(styleUrl, 'utf8');
+
+    assert.match(css, /--bg: #0d1117/);
+    assert.match(css, /@media \(max-width: 980px\)/);
+    assert.match(css, /@media \(max-width: 680px\)/);
+    assert.match(css, /grid-template-columns: 1fr/);
+  });
+});


### PR DESCRIPTION
## Summary
- adds a Memory Capture portal app for low-energy voice/text brain dumps
- turns captures into Gun-backed CRM leads, touch-log notes, proposal records, and managed DigitalOcean agent tasks
- adds app dock and sales hub links so the workflow is easy to reach
- adds focused regression coverage for the new app and infrastructure paths

## Tests
- `node --check memory-capture/app.js`
- `node --test tests/memory-capture.test.js`
- `git diff --check`
- smoke checked `/memory-capture/`, `/memory-capture/app.js`, and the portal app dock with a local static server