### PR TITLE
Gate portal boot screen to PWA

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -8,7 +8,7 @@ body.landing {
   position: fixed;
   inset: 0;
   z-index: 9999;
-  display: grid;
+  display: none;
   place-items: center;
   gap: 1rem;
   align-content: center;
@@ -20,7 +20,11 @@ body.landing {
   transition: opacity 280ms ease, visibility 280ms ease;
 }
 
-.app-ready .app-boot {
+.app-boot-enabled .app-boot {
+  display: grid;
+}
+
+.app-boot-enabled.app-ready .app-boot {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;

--- a/index.html
+++ b/index.html
@@ -20,9 +20,22 @@
   <link rel="apple-touch-icon" href="/icons/icon-192.png">
   <link rel="apple-touch-icon" sizes="512x512" href="/icons/icon-512.png">
   <script>
-    const hidePortalBoot = () => document.documentElement.classList.add('app-ready');
-    window.addEventListener('load', hidePortalBoot, { once: true });
-    window.setTimeout(hidePortalBoot, 3600);
+    (() => {
+      const isStandalone =
+        window.matchMedia('(display-mode: standalone)').matches ||
+        window.navigator.standalone === true ||
+        document.referrer.startsWith('android-app://');
+
+      if (!isStandalone) {
+        document.documentElement.classList.add('app-ready');
+        return;
+      }
+
+      document.documentElement.classList.add('app-boot-enabled');
+      const hidePortalBoot = () => document.documentElement.classList.add('app-ready');
+      window.addEventListener('load', hidePortalBoot, { once: true });
+      window.setTimeout(hidePortalBoot, 3600);
+    })();
   </script>
   <script>
     const prNumber = '{{PR_NUMBER}}';

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -6,11 +6,16 @@ describe('portal logo branding', () => {
   it('brands the SVG app logo and boot text as 3dvr portal', async () => {
     const logo = await readFile(new URL('../brand/portal-logo.svg', import.meta.url), 'utf8');
     const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+    const css = await readFile(new URL('../index-style.css', import.meta.url), 'utf8');
 
     assert.match(logo, /3dvr portal logo/);
     assert.match(logo, />3dvr</);
     assert.match(logo, />portal</);
     assert.match(html, /window\.__APP_NAME__ = window\.__APP_NAME__ \|\| '3dvr-portal'/);
     assert.match(html, /<strong>3dvr portal<\/strong>/);
+    assert.match(html, /app-boot-enabled/);
+    assert.match(html, /display-mode: standalone/);
+    assert.match(html, /document\.referrer\.startsWith\('android-app:\/\/'\)/);
+    assert.match(css, /\.app-boot-enabled \.app-boot/);
   });
 });


### PR DESCRIPTION
## Summary
- gates the portal boot/loading overlay behind standalone PWA display mode
- keeps normal browser visits from flashing the loading screen
- adds regression coverage for the PWA-only boot gate while preserving the `3dvr portal` branding

## Tests
- `node --test tests/portal-logo-branding.test.js`
- `git diff --check`