### PR TITLE
Expand memory capture proposal board

### DIFF
--- a/memory-capture/app.js
+++ b/memory-capture/app.js
@@ -7,6 +7,15 @@ const CRM_NODE = '3dvr-crm';
 const TOUCH_LOG_NODE = 'crm-touch-log';
 const MANAGED_AGENT_OWNER_ALIAS = '3dvr-managed';
 const DEFAULT_SOURCE = 'memory-capture';
+const PROPOSAL_STAGES = [
+  { id: 'idea', label: 'Idea' },
+  { id: 'draft', label: 'Draft' },
+  { id: 'sent', label: 'Sent' },
+  { id: 'follow-up', label: 'Follow-up' },
+  { id: 'won', label: 'Won' },
+  { id: 'lost', label: 'Lost' }
+];
+const OPEN_PROPOSAL_STAGES = ['idea', 'draft', 'sent', 'follow-up'];
 const DEFAULT_PEERS = [
   'wss://relay.3dvr.tech/gun',
   'wss://gun-relay-3dvr.fly.dev/gun'
@@ -50,6 +59,10 @@ const els = {
   inferenceList: document.getElementById('inferenceList'),
   recentList: document.getElementById('recentList'),
   proposalList: document.getElementById('proposalList'),
+  proposalOpenCount: document.getElementById('proposalOpenCount'),
+  proposalSentCount: document.getElementById('proposalSentCount'),
+  proposalWonCount: document.getElementById('proposalWonCount'),
+  proposalValue: document.getElementById('proposalValue'),
   crmDraftLink: document.getElementById('crmDraftLink'),
   audioPreview: document.getElementById('audioPreview')
 };
@@ -76,6 +89,37 @@ function slug(value) {
 function makeId(prefix, seed = '') {
   const random = Math.random().toString(36).slice(2, 8);
   return `${prefix}-${slug(seed)}-${Date.now().toString(36)}-${random}`;
+}
+
+function addDays(date, days) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function formatDateInput(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function estimateProposalValue(offer = '') {
+  const explicit = String(offer).match(/\$([0-9][0-9,]*(?:\.\d{1,2})?)/);
+  if (explicit?.[1]) return Number(explicit[1].replace(/,/g, ''));
+  if (/custom|interactive|walkthrough|spatial|render/i.test(offer)) return 500;
+  if (/builder|\$50/i.test(offer)) return 50;
+  if (/\$20|founder|launch/i.test(offer)) return 20;
+  if (/\$5|starter|family/i.test(offer)) return 5;
+  return 0;
+}
+
+function normalizeProposalStage(status) {
+  const normalized = slug(status || 'idea');
+  return PROPOSAL_STAGES.some(stage => stage.id === normalized) ? normalized : 'idea';
+}
+
+function formatMoney(value) {
+  const amount = Number(value || 0);
+  if (!Number.isFinite(amount) || amount <= 0) return '$0';
+  return `$${amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
 }
 
 function safe(value) {
@@ -384,6 +428,7 @@ function buildProposal(capture) {
   const now = new Date().toISOString();
   const inference = capture.inference;
   const id = capture.proposalId || makeId('proposal', inference.name);
+  const estimatedValue = estimateProposalValue(inference.offerAmount);
   return {
     id,
     title: `${inference.name} proposal`,
@@ -393,9 +438,10 @@ function buildProposal(capture) {
     offer: inference.offerAmount,
     scope: inference.primaryPain,
     nextBestAction: inference.nextBestAction,
-    price: '',
+    price: estimatedValue ? String(estimatedValue) : '',
+    estimatedValue,
     sentAt: '',
-    followUpAt: '',
+    followUpAt: formatDateInput(addDays(new Date(), 3)),
     tags: inference.tags,
     notes: capture.rawText,
     createdAt: now,
@@ -512,22 +558,109 @@ function renderRecent() {
 function renderProposals() {
   const proposals = Object.values(state.proposals || {})
     .filter(Boolean)
-    .sort((a, b) => String(b.updatedAt || b.createdAt || '').localeCompare(String(a.updatedAt || a.createdAt || '')))
-    .slice(0, 8);
+    .map(proposal => ({
+      ...proposal,
+      status: normalizeProposalStage(proposal.status),
+      estimatedValue: Number(proposal.estimatedValue || proposal.price || 0) || estimateProposalValue(proposal.offer)
+    }))
+    .sort((a, b) => String(b.updatedAt || b.createdAt || '').localeCompare(String(a.updatedAt || a.createdAt || '')));
 
   if (!els.proposalList) return;
+
+  const openCount = proposals.filter(proposal => OPEN_PROPOSAL_STAGES.includes(proposal.status)).length;
+  const sentCount = proposals.filter(proposal => proposal.status === 'sent' || proposal.status === 'follow-up').length;
+  const wonCount = proposals.filter(proposal => proposal.status === 'won').length;
+  const estimatedValue = proposals
+    .filter(proposal => proposal.status !== 'lost')
+    .reduce((total, proposal) => total + (Number(proposal.estimatedValue) || 0), 0);
+
+  if (els.proposalOpenCount) els.proposalOpenCount.textContent = String(openCount);
+  if (els.proposalSentCount) els.proposalSentCount.textContent = String(sentCount);
+  if (els.proposalWonCount) els.proposalWonCount.textContent = String(wonCount);
+  if (els.proposalValue) els.proposalValue.textContent = formatMoney(estimatedValue);
+
   if (!proposals.length) {
     els.proposalList.innerHTML = '<p class="empty">No proposals tracked yet.</p>';
     return;
   }
 
-  els.proposalList.innerHTML = proposals.map(proposal => `
-    <article class="recent-card">
-      <strong>${safe(proposal.title || 'Proposal')}</strong>
-      <p>${safe(proposal.scope || proposal.nextBestAction || '')}</p>
-      <span>${safe(proposal.status || 'idea')} | ${safe(proposal.offer || 'offer TBD')}</span>
-    </article>
+  const byStage = PROPOSAL_STAGES.map(stage => ({
+    ...stage,
+    proposals: proposals.filter(proposal => proposal.status === stage.id).slice(0, 12)
+  }));
+
+  els.proposalList.innerHTML = byStage.map(stage => `
+    <section class="proposal-column" aria-label="${safe(stage.label)} proposals">
+      <div class="proposal-column__head">
+        <strong>${safe(stage.label)}</strong>
+        <span>${stage.proposals.length}</span>
+      </div>
+      <div class="proposal-column__cards">
+        ${stage.proposals.length ? stage.proposals.map(renderProposalCard).join('') : '<p class="empty proposal-empty">No proposals.</p>'}
+      </div>
+    </section>
   `).join('');
+}
+
+function renderProposalCard(proposal) {
+  const crmHref = proposal.linkedCrmRecordId ? `../crm/?record=${encodeURIComponent(proposal.linkedCrmRecordId)}` : '../crm/';
+  const followUp = proposal.followUpAt ? `Follow up ${proposal.followUpAt}` : 'Follow-up date unset';
+  const value = Number(proposal.estimatedValue || proposal.price || 0);
+  return `
+    <article class="proposal-card" data-proposal-id="${safe(proposal.id)}">
+      <div class="proposal-card__top">
+        <strong>${safe(proposal.title || 'Proposal')}</strong>
+        <span>${safe(formatMoney(value))}</span>
+      </div>
+      <p>${safe(proposal.scope || proposal.nextBestAction || 'Scope needs a quick pass.')}</p>
+      <dl class="proposal-meta">
+        <div>
+          <dt>Offer</dt>
+          <dd>${safe(proposal.offer || 'TBD')}</dd>
+        </div>
+        <div>
+          <dt>Next</dt>
+          <dd>${safe(proposal.nextBestAction || followUp)}</dd>
+        </div>
+      </dl>
+      <div class="proposal-card__footer">
+        <span>${safe(followUp)}</span>
+        <a href="${crmHref}">CRM</a>
+      </div>
+      <div class="proposal-actions" aria-label="Update proposal stage">
+        ${proposal.status !== 'draft' ? `<button type="button" data-proposal-stage="draft" data-proposal-id="${safe(proposal.id)}">Draft</button>` : ''}
+        ${proposal.status !== 'sent' ? `<button type="button" data-proposal-stage="sent" data-proposal-id="${safe(proposal.id)}">Sent</button>` : ''}
+        ${proposal.status !== 'follow-up' ? `<button type="button" data-proposal-stage="follow-up" data-proposal-id="${safe(proposal.id)}">Follow-up</button>` : ''}
+        ${proposal.status !== 'won' ? `<button type="button" data-proposal-stage="won" data-proposal-id="${safe(proposal.id)}">Won</button>` : ''}
+        ${proposal.status !== 'lost' ? `<button type="button" data-proposal-stage="lost" data-proposal-id="${safe(proposal.id)}">Lost</button>` : ''}
+      </div>
+    </article>
+  `;
+}
+
+async function updateProposalStage(id, status) {
+  const proposal = state.proposals[id];
+  if (!proposal) {
+    throw new Error('Proposal not found.');
+  }
+
+  const now = new Date().toISOString();
+  const normalizedStatus = normalizeProposalStage(status);
+  const patch = {
+    ...proposal,
+    status: normalizedStatus,
+    sentAt: normalizedStatus === 'sent' && !proposal.sentAt ? now : proposal.sentAt || '',
+    followUpAt: normalizedStatus === 'follow-up' && !proposal.followUpAt
+      ? formatDateInput(addDays(new Date(), 2))
+      : proposal.followUpAt || '',
+    closedAt: normalizedStatus === 'won' || normalizedStatus === 'lost' ? now : proposal.closedAt || '',
+    updatedAt: now
+  };
+
+  state.proposals[id] = patch;
+  renderProposals();
+  await putGun(proposalRoot.get(id), patch);
+  setStatus('Proposal updated', `${patch.title || 'Proposal'} moved to ${normalizedStatus}.`);
 }
 
 function subscribeCaptures() {
@@ -651,6 +784,12 @@ els.crmButton.addEventListener('click', () => createCrmLead().catch(error => set
 els.proposalButton.addEventListener('click', () => createProposal().catch(error => setStatus('Proposal failed', error.message)));
 els.agentButton.addEventListener('click', () => queueAgentTask().catch(error => setStatus('Agent queue failed', error.message)));
 els.refreshButton.addEventListener('click', renderRecent);
+els.proposalList?.addEventListener('click', (event) => {
+  const button = event.target.closest('[data-proposal-stage]');
+  if (!button) return;
+  updateProposalStage(button.dataset.proposalId, button.dataset.proposalStage)
+    .catch(error => setStatus('Proposal update failed', error.message));
+});
 els.dictateButton.addEventListener('click', () => {
   if (!state.recognition) return;
   if (state.dictating) {

--- a/memory-capture/index.html
+++ b/memory-capture/index.html
@@ -141,11 +141,34 @@
       </section>
 
       <section class="panel" aria-labelledby="proposals-title">
-        <div class="section-head">
-          <p class="eyebrow">Sales process</p>
-          <h2 id="proposals-title">Proposal tracker</h2>
+        <div class="section-head row">
+          <div>
+            <p class="eyebrow">Sales process</p>
+            <h2 id="proposals-title">Proposal board</h2>
+            <p class="section-note">
+              Keep rough scope ideas moving until they become sent proposals, follow-ups, or closed work.
+            </p>
+          </div>
         </div>
-        <div id="proposalList" class="recent-list">
+        <div class="proposal-stats" aria-label="Proposal totals">
+          <div>
+            <span>Open</span>
+            <strong id="proposalOpenCount">0</strong>
+          </div>
+          <div>
+            <span>Sent</span>
+            <strong id="proposalSentCount">0</strong>
+          </div>
+          <div>
+            <span>Won</span>
+            <strong id="proposalWonCount">0</strong>
+          </div>
+          <div>
+            <span>Est. value</span>
+            <strong id="proposalValue">$0</strong>
+          </div>
+        </div>
+        <div id="proposalList" class="proposal-board">
           <p class="empty">No proposals tracked yet.</p>
         </div>
       </section>

--- a/memory-capture/style.css
+++ b/memory-capture/style.css
@@ -175,6 +175,12 @@ h2 {
   gap: 1rem;
 }
 
+.section-note {
+  max-width: 680px;
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+}
+
 .field,
 .field-grid {
   display: grid;
@@ -329,6 +335,172 @@ textarea {
   font-weight: 800;
 }
 
+.proposal-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.proposal-stats div {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 0.8rem;
+}
+
+.proposal-stats span,
+.proposal-meta dt {
+  display: block;
+  color: var(--quiet);
+  font-size: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.proposal-stats strong {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 1.45rem;
+  line-height: 1;
+}
+
+.proposal-board {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(180px, 1fr));
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+}
+
+.proposal-column {
+  min-width: 180px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(15, 22, 34, 0.72);
+  padding: 0.65rem;
+}
+
+.proposal-column__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.65rem;
+}
+
+.proposal-column__head strong {
+  font-size: 0.92rem;
+}
+
+.proposal-column__head span {
+  min-width: 1.55rem;
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  border-radius: 999px;
+  background: rgba(94, 234, 212, 0.08);
+  color: var(--teal);
+  padding: 0.05rem 0.45rem;
+  text-align: center;
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.proposal-column__cards {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.proposal-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  padding: 0.75rem;
+}
+
+.proposal-card__top,
+.proposal-card__footer,
+.proposal-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.proposal-card__top {
+  justify-content: space-between;
+}
+
+.proposal-card__top strong {
+  font-size: 0.96rem;
+  line-height: 1.25;
+}
+
+.proposal-card__top span {
+  color: var(--gold);
+  font-weight: 900;
+}
+
+.proposal-card p {
+  margin: 0.55rem 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.proposal-meta {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+}
+
+.proposal-meta dd {
+  margin: 0.12rem 0 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.proposal-card__footer {
+  justify-content: space-between;
+  margin-top: 0.65rem;
+}
+
+.proposal-card__footer span,
+.proposal-card__footer a {
+  color: var(--quiet);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.proposal-card__footer a {
+  color: var(--blue);
+  text-decoration: none;
+}
+
+.proposal-actions {
+  flex-wrap: wrap;
+  margin-top: 0.65rem;
+}
+
+.proposal-actions button {
+  min-height: 30px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--muted);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.76rem;
+  font-weight: 850;
+}
+
+.proposal-actions button:hover,
+.proposal-actions button:focus-visible {
+  border-color: rgba(94, 234, 212, 0.45);
+  color: var(--text);
+}
+
+.proposal-empty {
+  font-size: 0.85rem;
+}
+
 code {
   color: #fde68a;
 }
@@ -336,8 +508,13 @@ code {
 @media (max-width: 980px) {
   .hero-grid,
   .capture-layout,
-  .pipeline-grid {
+  .pipeline-grid,
+  .proposal-stats {
     grid-template-columns: 1fr;
+  }
+
+  .proposal-board {
+    grid-template-columns: repeat(6, minmax(220px, 1fr));
   }
 }
 

--- a/tests/memory-capture.test.js
+++ b/tests/memory-capture.test.js
@@ -19,7 +19,11 @@ describe('Memory Capture app', () => {
     assert.match(html, /Create CRM lead/);
     assert.match(html, /Create proposal/);
     assert.match(html, /Queue agent cleanup/);
-    assert.match(html, /Proposal tracker/);
+    assert.match(html, /Proposal board/);
+    assert.match(html, /proposalOpenCount/);
+    assert.match(html, /proposalSentCount/);
+    assert.match(html, /proposalWonCount/);
+    assert.match(html, /proposalValue/);
     assert.match(html, /3dvr-portal\/memoryCapture\/captures/);
     assert.match(html, /agentOps\/3dvr-managed\/taskQueue/);
     assert.match(html, /app\.js/);
@@ -39,6 +43,10 @@ describe('Memory Capture app', () => {
     assert.match(js, /buildProposal/);
     assert.match(js, /renderProposals/);
     assert.match(js, /subscribeProposals/);
+    assert.match(js, /PROPOSAL_STAGES/);
+    assert.match(js, /updateProposalStage/);
+    assert.match(js, /data-proposal-stage/);
+    assert.match(js, /estimateProposalValue/);
     assert.match(js, /buildAgentTask/);
     assert.match(js, /taskQueue/);
     assert.match(js, /requiredCapabilities: 'codex,crm,gun'/);
@@ -59,6 +67,9 @@ describe('Memory Capture app', () => {
     const css = await readFile(styleUrl, 'utf8');
 
     assert.match(css, /--bg: #0d1117/);
+    assert.match(css, /\.proposal-board/);
+    assert.match(css, /\.proposal-stats/);
+    assert.match(css, /\.proposal-actions/);
     assert.match(css, /@media \(max-width: 980px\)/);
     assert.match(css, /@media \(max-width: 680px\)/);
     assert.match(css, /grid-template-columns: 1fr/);


### PR DESCRIPTION
## Summary
- turns the Memory Capture proposal section into a stage-based proposal board
- adds proposal totals for open, sent, won, and estimated value
- adds one-click stage changes backed by the existing Gun proposal records
- seeds new proposals with a follow-up date and estimated value from the offer text

## Tests
- `node --check memory-capture/app.js`
- `node --test tests/memory-capture.test.js`
- `git diff --check`
- smoke checked `/memory-capture/`, `/memory-capture/app.js`, and `/memory-capture/style.css` with a local static server