### PR TITLE
[codex] fix WebRTC lab room signaling

### DIFF
--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -41,10 +41,19 @@ describe('WebRTC Lab app', () => {
     assert.match(html, /<script src="\.\/app\.js"><\/script>/);
     assert.match(js, /new RTCPeerConnection\(\{ iceServers: ICE_SERVERS \}\)/);
     assert.match(js, /navigator\.mediaDevices\.getUserMedia/);
-    assert.match(js, /ROOM_ROOT = '3dvr-webrtc-lab'/);
+    assert.match(js, /ROOM_ROOT = '3dvr-webrtc-lab-v2'/);
+    assert.match(js, /PEER_SESSION_KEY = 'webrtcLabParticipantId'/);
+    assert.match(js, /sessionStorage\.setItem\(PEER_SESSION_KEY, next\)/);
+    assert.match(js, /connection\.onnegotiationneeded/);
+    assert.match(js, /payloadJson: serializePayload\(payload\)/);
+    assert.match(js, /if \(signal\.type === 'announce'\) return handleAnnounce\(signal\)/);
+    assert.match(js, /await startCamera\(\)/);
     assert.match(js, /signalsNode\.map\(\)\.on\(handleSignal\)/);
     assert.match(js, /participantsNode\.map\(\)\.on/);
+    assert.match(html, /id="peer-count"/);
+    assert.match(html, /id="signal-count"/);
     assert.match(readme, /Mesh WebRTC/);
+    assert.match(readme, /3dvr-webrtc-lab-v2\/<room>/);
   });
 
   it('registers the lab in the portal and existing video hub', async () => {

--- a/webrtc-lab/README.md
+++ b/webrtc-lab/README.md
@@ -6,7 +6,11 @@ This app uses:
 
 - WebRTC peer connections for media.
 - Browser `getUserMedia()` for camera and microphone access.
-- Gun at `3dvr-webrtc-lab/<room>` for lightweight signaling and room presence.
+- Gun at `3dvr-webrtc-lab-v2/<room>` for lightweight signaling and room presence.
 - Public STUN servers for NAT discovery.
+
+The v2 room root uses tab-scoped peer IDs, starts media before signaling, sends explicit room
+announcements, and stores offer/answer/candidate payloads as JSON strings so Gun does not have to
+serialize browser-native WebRTC objects.
 
 It is intentionally not a production replacement for a Selective Forwarding Unit. Mesh WebRTC is useful for two or three people while testing connection behavior, but larger meetings need an SFU or other managed media layer.

--- a/webrtc-lab/app.js
+++ b/webrtc-lab/app.js
@@ -14,6 +14,9 @@
     localLabel: document.getElementById('local-label'),
     localState: document.getElementById('local-state'),
     videoGrid: document.getElementById('video-grid'),
+    localPeerId: document.getElementById('local-peer-id'),
+    peerCount: document.getElementById('peer-count'),
+    signalCount: document.getElementById('signal-count'),
     eventLog: document.getElementById('event-log')
   };
 
@@ -21,8 +24,9 @@
     { urls: 'stun:stun.l.google.com:19302' },
     { urls: 'stun:stun1.l.google.com:19302' }
   ];
-  const ROOM_ROOT = '3dvr-webrtc-lab';
+  const ROOM_ROOT = '3dvr-webrtc-lab-v2';
   const SIGNAL_TTL_MS = 1000 * 60 * 20;
+  const PEER_SESSION_KEY = 'webrtcLabParticipantId';
 
   let gun = null;
   let roomNode = null;
@@ -34,6 +38,7 @@
   let localStream = null;
   let joined = false;
   let heartbeatTimer = null;
+  let signalsHandled = 0;
   const peers = new Map();
   const seenSignals = new Set();
 
@@ -52,10 +57,10 @@
 
   function getOrCreateLocalId() {
     try {
-      const stored = localStorage.getItem('webrtcLabParticipantId');
+      const stored = sessionStorage.getItem(PEER_SESSION_KEY);
       if (stored) return stored;
       const next = createId('peer');
-      localStorage.setItem('webrtcLabParticipantId', next);
+      sessionStorage.setItem(PEER_SESSION_KEY, next);
       return next;
     } catch (_error) {
       return createId('peer');
@@ -74,6 +79,12 @@
   function setStatus(message) {
     refs.statusLine.textContent = message;
     logEvent(message);
+  }
+
+  function updateDiagnostics() {
+    refs.localPeerId.textContent = joined ? localId.replace(/^peer_/, '') : 'Not joined';
+    refs.peerCount.textContent = String(peers.size);
+    refs.signalCount.textContent = String(signalsHandled);
   }
 
   function resolveInitialRoom() {
@@ -133,9 +144,21 @@
     refs.toggleCamera.disabled = false;
     refs.localState.textContent = 'Camera on';
     setStatus('Camera ready.');
-    peers.forEach(peer => {
-      localStream.getTracks().forEach(track => peer.connection.addTrack(track, localStream));
+    peers.forEach((peer, remoteId) => {
+      const senders = peer.connection.getSenders();
+      localStream.getTracks().forEach(track => {
+        if (!senders.some(sender => sender.track && sender.track.id === track.id)) {
+          peer.connection.addTrack(track, localStream);
+        }
+      });
+      if (joined && shouldInitiateOffer(remoteId)) {
+        makeOffer(remoteId, peer.name).catch(error => {
+          console.error('Renegotiation failed', error);
+          setStatus(`Renegotiation failed: ${error.message || error}`);
+        });
+      }
     });
+    announcePresence('media-ready');
     return localStream;
   }
 
@@ -161,10 +184,19 @@
       tile: createRemoteTile(remoteId, remoteName)
     };
     peers.set(remoteId, peer);
+    updateDiagnostics();
 
     if (localStream) {
       localStream.getTracks().forEach(track => connection.addTrack(track, localStream));
     }
+
+    connection.onnegotiationneeded = () => {
+      if (!joined || !shouldInitiateOffer(remoteId)) return;
+      makeOffer(remoteId, peer.name).catch(error => {
+        console.error('Negotiation failed', error);
+        setStatus(`Negotiation failed: ${error.message || error}`);
+      });
+    };
 
     connection.ontrack = event => {
       event.streams[0].getTracks().forEach(track => peer.stream.addTrack(track));
@@ -210,14 +242,22 @@
 
   async function makeOffer(remoteId, remoteName) {
     const peer = createPeer(remoteId, remoteName);
-    const offer = await peer.connection.createOffer();
-    await peer.connection.setLocalDescription(offer);
-    sendSignal(remoteId, 'offer', peer.connection.localDescription);
-    logEvent(`Offer sent to ${remoteName || remoteId}.`);
+    if (peer.makingOffer || peer.connection.signalingState !== 'stable') return;
+    peer.makingOffer = true;
+    if (!localStream) await startCamera();
+    try {
+      const offer = await peer.connection.createOffer();
+      await peer.connection.setLocalDescription(offer);
+      sendSignal(remoteId, 'offer', peer.connection.localDescription);
+      logEvent(`Offer sent to ${remoteName || remoteId}.`);
+    } finally {
+      peer.makingOffer = false;
+    }
   }
 
   async function handleOffer(signal) {
     const peer = createPeer(signal.from, signal.fromName);
+    if (!localStream) await startCamera();
     await peer.connection.setRemoteDescription(new RTCSessionDescription(signal.payload));
     const answer = await peer.connection.createAnswer();
     await peer.connection.setLocalDescription(answer);
@@ -241,6 +281,17 @@
     }
   }
 
+  function serializePayload(payload) {
+    if (!payload) return '';
+    const value = typeof payload.toJSON === 'function' ? payload.toJSON() : payload;
+    return JSON.stringify(value);
+  }
+
+  function parsePayload(signal) {
+    if (signal.payloadJson) return JSON.parse(signal.payloadJson);
+    return signal.payload || null;
+  }
+
   function sendSignal(to, type, payload) {
     if (!signalsNode) return;
     const id = createId('signal');
@@ -251,18 +302,23 @@
       fromName: localName,
       to,
       type,
-      payload,
+      payloadJson: serializePayload(payload),
       createdAt: Date.now()
     });
   }
 
   function handleSignal(signal, id) {
     if (!signal || id === '_' || seenSignals.has(id)) return;
-    if (signal.to !== localId || signal.from === localId) return;
+    if (signal.from === localId) return;
+    if (signal.to !== localId && signal.to !== '*') return;
     if (Date.now() - Number(signal.createdAt || 0) > SIGNAL_TTL_MS) return;
     seenSignals.add(id);
+    signalsHandled += 1;
+    updateDiagnostics();
     Promise.resolve()
       .then(() => {
+        signal.payload = parsePayload(signal);
+        if (signal.type === 'announce') return handleAnnounce(signal);
         if (signal.type === 'offer') return handleOffer(signal);
         if (signal.type === 'answer') return handleAnswer(signal);
         if (signal.type === 'candidate') return handleCandidate(signal);
@@ -279,9 +335,39 @@
     participantsNode.get(localId).put({
       id: localId,
       name: localName,
+      hasMedia: Boolean(localStream),
       joinedAt: Date.now(),
       lastSeen: Date.now()
     });
+  }
+
+  function announcePresence(reason = 'announce') {
+    publishPresence();
+    sendSignal('*', 'announce', {
+      reason,
+      hasMedia: Boolean(localStream)
+    });
+  }
+
+  function shouldInitiateOffer(remoteId) {
+    return String(localId) < String(remoteId);
+  }
+
+  function connectToParticipant(remoteId, remoteName) {
+    if (!remoteId || remoteId === localId) return;
+    createPeer(remoteId, remoteName);
+    if (shouldInitiateOffer(remoteId)) {
+      makeOffer(remoteId, remoteName).catch(error => {
+        console.error('Offer failed', error);
+        setStatus(`Offer failed: ${error.message || error}`);
+      });
+    }
+  }
+
+  function handleAnnounce(signal) {
+    if (!joined) return null;
+    connectToParticipant(signal.from, signal.fromName);
+    return null;
   }
 
   function watchParticipants() {
@@ -289,17 +375,16 @@
       if (!joined || !participant || id === '_' || id === localId) return;
       const lastSeen = Number(participant.lastSeen || 0);
       if (Date.now() - lastSeen > 45000) return;
-      if (!peers.has(id) && localId < id) {
-        makeOffer(id, participant.name).catch(error => {
-          console.error('Offer failed', error);
-          setStatus(`Offer failed: ${error.message || error}`);
-        });
-      }
+      connectToParticipant(id, participant.name);
     });
   }
 
   async function joinRoom(event) {
     if (event) event.preventDefault();
+    if (!localStream) {
+      setStatus('Starting camera before room signaling.');
+      await startCamera();
+    }
     roomId = normalizeRoom(refs.roomId.value) || resolveInitialRoom();
     refs.roomId.value = roomId;
     localName = String(refs.displayName.value || '').trim() || `Guest ${localId.slice(-4)}`;
@@ -311,11 +396,12 @@
     updateRoomUrl();
     joined = true;
     refs.leaveRoom.disabled = false;
-    publishPresence();
-    heartbeatTimer = setInterval(publishPresence, 10000);
+    updateDiagnostics();
     signalsNode.map().on(handleSignal);
     watchParticipants();
-    setStatus(`Joined room ${roomId}. Start camera if it is not already on.`);
+    announcePresence('join');
+    heartbeatTimer = setInterval(() => announcePresence('heartbeat'), 10000);
+    setStatus(`Joined room ${roomId}. Waiting for peers.`);
   }
 
   function leaveRoom() {
@@ -332,6 +418,7 @@
       peer.tile.tile.remove();
     });
     peers.clear();
+    updateDiagnostics();
     refs.leaveRoom.disabled = true;
     setStatus('Left room.');
   }
@@ -386,6 +473,7 @@
     refs.toggleMic.addEventListener('click', toggleMic);
     refs.toggleCamera.addEventListener('click', toggleCamera);
     refs.leaveRoom.addEventListener('click', leaveRoom);
+    updateDiagnostics();
     window.addEventListener('beforeunload', () => {
       leaveRoom();
       stopLocalStream();

--- a/webrtc-lab/index.html
+++ b/webrtc-lab/index.html
@@ -26,7 +26,8 @@
         <h1>Simple video rooms without vdo.ninja.</h1>
         <p>
           A small browser-to-browser conferencing experiment. Gun relays the room signals; WebRTC carries
-          the audio and video directly between participants.
+          the audio and video directly between participants. Joining now starts media before signaling so
+          peers negotiate with real tracks.
         </p>
       </div>
       <aside class="lab-note">
@@ -63,6 +64,20 @@
       <button type="button" id="toggle-camera" disabled>Hide camera</button>
       <button type="button" id="leave-room" disabled>Leave</button>
       <p id="status-line" class="status-line" role="status">Choose a room and start your camera.</p>
+      <dl class="room-stats" aria-label="Room diagnostics">
+        <div>
+          <dt>Your peer</dt>
+          <dd id="local-peer-id">Not joined</dd>
+        </div>
+        <div>
+          <dt>Peers seen</dt>
+          <dd id="peer-count">0</dd>
+        </div>
+        <div>
+          <dt>Signals handled</dt>
+          <dd id="signal-count">0</dd>
+        </div>
+      </dl>
     </section>
 
     <section class="video-grid" id="video-grid" aria-label="Video tiles">

--- a/webrtc-lab/styles.css
+++ b/webrtc-lab/styles.css
@@ -195,6 +195,35 @@ input {
   font-size: 0.92rem;
 }
 
+.room-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+  margin: 0.45rem 0 0;
+}
+
+.room-stats div {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.55rem;
+  border: 1px solid var(--rtc-line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.room-stats dt {
+  color: var(--rtc-muted);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.room-stats dd {
+  margin: 0;
+  font-weight: 900;
+  overflow-wrap: anywhere;
+}
+
 .video-grid {
   grid-row: span 2;
   display: grid;
@@ -292,6 +321,10 @@ input {
   }
 
   .video-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .room-stats {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## What changed

- Updated the WebRTC lab to use a clean `3dvr-webrtc-lab-v2` Gun signaling root.
- Switched participant IDs from `localStorage` to tab-scoped `sessionStorage` so two tabs/devices do not collide during testing.
- Made join start camera/mic before room signaling so offers include real media tracks.
- Added explicit Gun `announce` signals plus periodic heartbeats so peers discover each other more reliably.
- Serialized offer/answer/candidate payloads into JSON strings before writing them to Gun.
- Added simple room diagnostics for peer count, signal count, and local peer ID.

## Validation

- `node --test tests/webrtc-lab.test.js`
- `git diff --check`
- Local Playwright smoke with fake camera/mic confirmed one-page join starts media.
- Local two-page Playwright smoke with fake cameras confirmed both pages saw one peer, handled signals, created remote tiles, and reached `connected`.