### PR TITLE
[codex] cache bust WebRTC lab assets

### DIFF
--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -38,7 +38,9 @@ describe('WebRTC Lab app', () => {
     assert.match(html, /Native WebRTC POC/);
     assert.match(html, /id="local-video"/);
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
-    assert.match(html, /<script src="\.\/app\.js"><\/script>/);
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260522-v2">/);
+    assert.match(html, /id="build-version">WebRTC v2\.1</);
+    assert.match(html, /<script src="\.\/app\.js\?v=20260522-v2"><\/script>/);
     assert.match(js, /new RTCPeerConnection\(\{ iceServers: ICE_SERVERS \}\)/);
     assert.match(js, /navigator\.mediaDevices\.getUserMedia/);
     assert.match(js, /ROOM_ROOT = '3dvr-webrtc-lab-v2'/);

--- a/webrtc-lab/index.html
+++ b/webrtc-lab/index.html
@@ -11,7 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/gun-init.js"></script>
   <link rel="stylesheet" href="../style.css?v=webrtc-lab">
-  <link rel="stylesheet" href="./styles.css?v=20260519">
+  <link rel="stylesheet" href="./styles.css?v=20260522-v2">
 </head>
 <body class="webrtc-page">
   <header class="lab-header">
@@ -77,6 +77,10 @@
           <dt>Signals handled</dt>
           <dd id="signal-count">0</dd>
         </div>
+        <div>
+          <dt>Build</dt>
+          <dd id="build-version">WebRTC v2.1</dd>
+        </div>
       </dl>
     </section>
 
@@ -103,6 +107,6 @@
     <p>Built as a 3DVR WebRTC proof of concept. Use HTTPS or localhost so browser camera permissions work.</p>
   </footer>
 
-  <script src="./app.js"></script>
+  <script src="./app.js?v=20260522-v2"></script>
 </body>
 </html>

--- a/webrtc-lab/styles.css
+++ b/webrtc-lab/styles.css
@@ -197,7 +197,7 @@ input {
 
 .room-stats {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.45rem;
   margin: 0.45rem 0 0;
 }


### PR DESCRIPTION
## Summary
- Version the WebRTC lab stylesheet and script URLs so deployed browsers fetch the latest signaling code instead of a cached immutable `app.js`.
- Add a visible `WebRTC v2.1` build marker beside the room diagnostics.
- Update the WebRTC lab regression test to require the cache-busted asset URLs and build marker.

## Root cause
The live `app.js` is served with `cache-control: public, max-age=31536000, immutable`, while the page previously referenced `./app.js` without a version. Devices could keep running the old signaling client even after the fixed deployment landed.

## Validation
- `node --test tests/webrtc-lab.test.js`
- `git diff --check`