### PR TITLE
[codex] fix desktop portal scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1408,6 +1408,7 @@
 
     const focusSearchWhenReady = () => {
       if (!searchInput || isAuthModalVisible()) return;
+      if (window.location.hash !== '#appSearch') return;
       if (!isStickySearchInView()) return;
       window.requestAnimationFrame(() => focusSearch());
     };

--- a/styles/global.css
+++ b/styles/global.css
@@ -62,7 +62,8 @@ body {
 @media (hover: hover) and (pointer: fine) {
   html,
   body {
-    overscroll-behavior: none;
+    overscroll-behavior-x: none;
+    overscroll-behavior-y: auto;
   }
 }
 

--- a/tests/homepage-scroll.test.js
+++ b/tests/homepage-scroll.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('homepage desktop scroll is not blocked by overscroll or automatic search focus', async () => {
+  const [globalCss, homeHtml] = await Promise.all([
+    readFile(new URL('../styles/global.css', import.meta.url), 'utf8'),
+    readFile(new URL('../index.html', import.meta.url), 'utf8'),
+  ]);
+
+  assert.match(globalCss, /overscroll-behavior-x:\s*none;/);
+  assert.match(globalCss, /overscroll-behavior-y:\s*auto;/);
+  assert.doesNotMatch(
+    globalCss,
+    /@media\s*\(hover:\s*hover\)\s*and\s*\(pointer:\s*fine\)[\s\S]*?overscroll-behavior:\s*none;/
+  );
+
+  assert.match(homeHtml, /window\.location\.hash !== '#appSearch'/);
+  assert.match(homeHtml, /window\.addEventListener\('keydown'/);
+  assert.match(homeHtml, /focusSearch\(\)/);
+});


### PR DESCRIPTION
## Summary

Fixes the live portal desktop scrolling regression where dragging the scrollbar worked, but mouse wheel and keyboard scrolling could fail.

## Root cause

The global desktop rule set `overscroll-behavior: none` on both `html` and `body`, which suppressed vertical scroll handoff in Chromium desktop. On tall desktop viewports, the homepage could also auto-focus the app search on load, causing keyboard input to target the search field instead of the document.

## Changes

- Preserve horizontal overscroll protection while allowing vertical page scrolling on desktop.
- Only auto-focus homepage app search on load when the page is explicitly opened at `#appSearch`; `/`, Ctrl+K, and the Search button still focus search.
- Add a regression test covering the CSS and homepage focus guard.

## Validation

- `node --test tests/homepage-scroll.test.js`
- Local Chrome check confirmed desktop mouse wheel and Space scrolling from the hero on normal and tall desktop viewports.