### PR TITLE
[codex] cache bust Gun live room assets

### DIFF
--- a/gun-live-room/index.html
+++ b/gun-live-room/index.html
@@ -11,7 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/gun-init.js"></script>
   <link rel="stylesheet" href="../style.css?v=gun-live-room">
-  <link rel="stylesheet" href="./styles.css?v=20260519">
+  <link rel="stylesheet" href="./styles.css?v=20260522-v2">
 </head>
 <body class="gun-live-page">
   <header class="live-header">
@@ -102,6 +102,7 @@
         <div><dt>Frames received</dt><dd id="frames-received">0</dd></div>
         <div><dt>Audio chunks sent</dt><dd id="audio-sent">0</dd></div>
         <div><dt>Audio chunks received</dt><dd id="audio-received">0</dd></div>
+        <div><dt>Build</dt><dd id="build-version">Gun Live v2.1</dd></div>
       </dl>
     </section>
 
@@ -118,6 +119,6 @@
     <p>Pure Gun live rooms send tiny frames and short audio chunks through the graph. Use the clip lab when you need a more reliable audio/video handoff.</p>
   </footer>
 
-  <script src="./app.js"></script>
+  <script src="./app.js?v=20260522-v2"></script>
 </body>
 </html>

--- a/gun-live-room/styles.css
+++ b/gun-live-room/styles.css
@@ -256,7 +256,7 @@ select {
 
 .metrics-panel dl {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 0.6rem;
   margin: 1rem 0 0;
 }

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -198,6 +198,9 @@ describe('Gun Live Room app', () => {
     assert.match(html, /id="mic-select"/);
     assert.match(html, /id="live-grid"/);
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260522-v2">/);
+    assert.match(html, /id="build-version">Gun Live v2\.1</);
+    assert.match(html, /<script src="\.\/app\.js\?v=20260522-v2"><\/script>/);
     assert.match(js, /ROOM_ROOT = '3dvr-gun-live-room'/);
     assert.match(js, /enumerateDevices/);
     assert.match(js, /deviceId: \{ exact: deviceId \}/);


### PR DESCRIPTION
## Summary
- Version the Gun Live Room stylesheet and script URLs so browsers fetch the current room client instead of a cached immutable `app.js`.
- Add a visible `Gun Live v2.1` build marker in the transport stats.
- Update the video lab regression test to require the versioned Gun Live Room assets.

## Root cause
`/gun-live-room/app.js` is served with `cache-control: public, max-age=31536000, immutable`, but the page referenced `./app.js` without a version. As with the WebRTC lab, devices could keep running stale room code after a deployment.

## Validation
- `node --test tests/webrtc-lab.test.js`
- `git diff --check`