### PR TITLE
[codex] lower WebRTC lab video bandwidth

### DIFF
--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -38,11 +38,16 @@ describe('WebRTC Lab app', () => {
     assert.match(html, /Native WebRTC POC/);
     assert.match(html, /id="local-video"/);
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
-    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260522-v2">/);
-    assert.match(html, /id="build-version">WebRTC v2\.1</);
-    assert.match(html, /<script src="\.\/app\.js\?v=20260522-v2"><\/script>/);
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260522-v3">/);
+    assert.match(html, /id="video-profile">180p \/ 10fps</);
+    assert.match(html, /id="build-version">WebRTC v2\.2</);
+    assert.match(html, /<script src="\.\/app\.js\?v=20260522-v3"><\/script>/);
     assert.match(js, /new RTCPeerConnection\(\{ iceServers: ICE_SERVERS \}\)/);
     assert.match(js, /navigator\.mediaDevices\.getUserMedia/);
+    assert.match(js, /LOW_BANDWIDTH_VIDEO = Object\.freeze/);
+    assert.match(js, /width: \{ ideal: LOW_BANDWIDTH_VIDEO\.width \}/);
+    assert.match(js, /maxBitrate: LOW_BANDWIDTH_VIDEO\.maxBitrate/);
+    assert.match(js, /addTransceiver\(track/);
     assert.match(js, /ROOM_ROOT = '3dvr-webrtc-lab-v2'/);
     assert.match(js, /PEER_SESSION_KEY = 'webrtcLabParticipantId'/);
     assert.match(js, /sessionStorage\.setItem\(PEER_SESSION_KEY, next\)/);
@@ -54,6 +59,8 @@ describe('WebRTC Lab app', () => {
     assert.match(js, /participantsNode\.map\(\)\.on/);
     assert.match(html, /id="peer-count"/);
     assert.match(html, /id="signal-count"/);
+    assert.match(readme, /320 x 180 video at about 10 fps/);
+    assert.match(readme, /near 240 kbps/);
     assert.match(readme, /Mesh WebRTC/);
     assert.match(readme, /3dvr-webrtc-lab-v2\/<room>/);
   });

--- a/webrtc-lab/README.md
+++ b/webrtc-lab/README.md
@@ -13,4 +13,7 @@ The v2 room root uses tab-scoped peer IDs, starts media before signaling, sends 
 announcements, and stores offer/answer/candidate payloads as JSON strings so Gun does not have to
 serialize browser-native WebRTC objects.
 
+The default camera profile is intentionally low bandwidth: it asks for 320 x 180 video at about 10 fps
+and caps the video sender near 240 kbps for weak mobile links.
+
 It is intentionally not a production replacement for a Selective Forwarding Unit. Mesh WebRTC is useful for two or three people while testing connection behavior, but larger meetings need an SFU or other managed media layer.

--- a/webrtc-lab/app.js
+++ b/webrtc-lab/app.js
@@ -27,6 +27,12 @@
   const ROOM_ROOT = '3dvr-webrtc-lab-v2';
   const SIGNAL_TTL_MS = 1000 * 60 * 20;
   const PEER_SESSION_KEY = 'webrtcLabParticipantId';
+  const LOW_BANDWIDTH_VIDEO = Object.freeze({
+    width: 320,
+    height: 180,
+    frameRate: 10,
+    maxBitrate: 240000
+  });
 
   let gun = null;
   let roomNode = null;
@@ -128,9 +134,9 @@
     }
     localStream = await navigator.mediaDevices.getUserMedia({
       video: {
-        width: { ideal: 640 },
-        height: { ideal: 360 },
-        frameRate: { ideal: 15, max: 24 }
+        width: { ideal: LOW_BANDWIDTH_VIDEO.width },
+        height: { ideal: LOW_BANDWIDTH_VIDEO.height },
+        frameRate: { ideal: LOW_BANDWIDTH_VIDEO.frameRate, max: 12 }
       },
       audio: {
         echoCancellation: true,
@@ -145,12 +151,7 @@
     refs.localState.textContent = 'Camera on';
     setStatus('Camera ready.');
     peers.forEach((peer, remoteId) => {
-      const senders = peer.connection.getSenders();
-      localStream.getTracks().forEach(track => {
-        if (!senders.some(sender => sender.track && sender.track.id === track.id)) {
-          peer.connection.addTrack(track, localStream);
-        }
-      });
+      addLocalTracksToConnection(peer.connection);
       if (joined && shouldInitiateOffer(remoteId)) {
         makeOffer(remoteId, peer.name).catch(error => {
           console.error('Renegotiation failed', error);
@@ -186,9 +187,7 @@
     peers.set(remoteId, peer);
     updateDiagnostics();
 
-    if (localStream) {
-      localStream.getTracks().forEach(track => connection.addTrack(track, localStream));
-    }
+    addLocalTracksToConnection(connection);
 
     connection.onnegotiationneeded = () => {
       if (!joined || !shouldInitiateOffer(remoteId)) return;
@@ -238,6 +237,58 @@
     tile.append(video, label);
     refs.videoGrid.appendChild(tile);
     return { tile, video, state, title };
+  }
+
+  function addLocalTracksToConnection(connection) {
+    if (!localStream) return;
+    const senders = connection.getSenders();
+    localStream.getTracks().forEach(track => {
+      const existing = senders.find(sender => sender.track && sender.track.id === track.id);
+      const sender = existing || addTrackToConnection(connection, track);
+      if (track.kind === 'video') configureVideoSender(sender);
+    });
+  }
+
+  function addTrackToConnection(connection, track) {
+    if (
+      track.kind === 'video' &&
+      typeof connection.addTransceiver === 'function'
+    ) {
+      const transceiver = connection.addTransceiver(track, {
+        streams: [localStream],
+        sendEncodings: [{
+          maxBitrate: LOW_BANDWIDTH_VIDEO.maxBitrate,
+          maxFramerate: LOW_BANDWIDTH_VIDEO.frameRate
+        }]
+      });
+      return transceiver.sender;
+    }
+    return connection.addTrack(track, localStream);
+  }
+
+  function configureVideoSender(sender) {
+    if (
+      !sender ||
+      !sender.track ||
+      sender.track.kind !== 'video' ||
+      typeof sender.getParameters !== 'function' ||
+      typeof sender.setParameters !== 'function'
+    ) {
+      return;
+    }
+
+    const parameters = sender.getParameters();
+    const encodings = parameters.encodings && parameters.encodings.length
+      ? parameters.encodings
+      : [{}];
+    parameters.encodings = encodings.map(encoding => ({
+      ...encoding,
+      maxBitrate: LOW_BANDWIDTH_VIDEO.maxBitrate,
+      maxFramerate: LOW_BANDWIDTH_VIDEO.frameRate
+    }));
+    sender.setParameters(parameters).catch(error => {
+      console.warn('Unable to apply low-bandwidth video sender settings', error);
+    });
   }
 
   async function makeOffer(remoteId, remoteName) {

--- a/webrtc-lab/index.html
+++ b/webrtc-lab/index.html
@@ -11,7 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/gun-init.js"></script>
   <link rel="stylesheet" href="../style.css?v=webrtc-lab">
-  <link rel="stylesheet" href="./styles.css?v=20260522-v2">
+  <link rel="stylesheet" href="./styles.css?v=20260522-v3">
 </head>
 <body class="webrtc-page">
   <header class="lab-header">
@@ -27,7 +27,8 @@
         <p>
           A small browser-to-browser conferencing experiment. Gun relays the room signals; WebRTC carries
           the audio and video directly between participants. Joining now starts media before signaling so
-          peers negotiate with real tracks.
+          peers negotiate with real tracks. The default profile now favors weak mobile links with
+          lower video resolution and bitrate.
         </p>
       </div>
       <aside class="lab-note">
@@ -78,8 +79,12 @@
           <dd id="signal-count">0</dd>
         </div>
         <div>
+          <dt>Video</dt>
+          <dd id="video-profile">180p / 10fps</dd>
+        </div>
+        <div>
           <dt>Build</dt>
-          <dd id="build-version">WebRTC v2.1</dd>
+          <dd id="build-version">WebRTC v2.2</dd>
         </div>
       </dl>
     </section>
@@ -107,6 +112,6 @@
     <p>Built as a 3DVR WebRTC proof of concept. Use HTTPS or localhost so browser camera permissions work.</p>
   </footer>
 
-  <script src="./app.js?v=20260522-v2"></script>
+  <script src="./app.js?v=20260522-v3"></script>
 </body>
 </html>

--- a/webrtc-lab/styles.css
+++ b/webrtc-lab/styles.css
@@ -197,7 +197,7 @@ input {
 
 .room-stats {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 0.45rem;
   margin: 0.45rem 0 0;
 }


### PR DESCRIPTION
## Summary
- Lower the WebRTC lab camera target from 640x360/15fps to a 320x180/10fps mobile-friendly profile.
- Add a video sender encoding cap near 240kbps with 10fps max framerate.
- Bump the WebRTC lab asset cache key to `20260522-v3` and add visible `Video` and `WebRTC v2.2` diagnostics.
- Document the low-bandwidth profile in the WebRTC lab README.

## Notes
This should help weak mobile links after peers connect. If 5G still fails to connect at all, the next likely issue is cellular NAT traversal, which usually requires a TURN relay in addition to public STUN.

## Validation
- `node --test tests/webrtc-lab.test.js`
- `git diff --check`
- Browser check confirmed fake camera constraints at 320x180/10fps and sender encoding at 240kbps/10fps.