### PR TITLE
[codex] clean up homepage search actions

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -1242,6 +1242,10 @@ footer a {
     display: inline-flex;
   }
 
+  .top-nav .top-buttons a.top-buttons__search-shortcut {
+    display: none;
+  }
+
   .top-nav .top-buttons {
     margin-bottom: 0;
   }
@@ -1252,6 +1256,10 @@ footer a {
 }
 
 @media (min-width: 721px) {
+  .top-nav__primary {
+    display: none;
+  }
+
   .top-nav--collapsed .top-buttons,
   .top-nav--expanded .top-buttons {
     display: flex;

--- a/navbar.js
+++ b/navbar.js
@@ -38,21 +38,11 @@ function ensureHomepageSearchShortcuts() {
   if (topButtons && !topButtons.querySelector('[data-home-search-shortcut]')) {
     const searchLink = document.createElement('a');
     searchLink.href = '#appSearch';
+    searchLink.className = 'top-buttons__search-shortcut';
     searchLink.dataset.appSearchTrigger = 'true';
     searchLink.dataset.homeSearchShortcut = 'true';
     searchLink.textContent = 'Search apps';
     topButtons.insertAdjacentElement('afterbegin', searchLink);
-  }
-
-  const heroActions = document.querySelector('.hero-actions');
-  if (heroActions && !heroActions.querySelector('[data-home-search-shortcut]')) {
-    const searchAction = document.createElement('a');
-    searchAction.href = '#appSearch';
-    searchAction.className = 'cta primary';
-    searchAction.dataset.appSearchTrigger = 'true';
-    searchAction.dataset.homeSearchShortcut = 'true';
-    searchAction.textContent = 'Search apps';
-    heroActions.insertAdjacentElement('afterbegin', searchAction);
   }
 }
 

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('homepage search shortcuts stay scoped to one top-level control per viewport', async () => {
+  const [navbarJs, indexCss] = await Promise.all([
+    readFile(new URL('../navbar.js', import.meta.url), 'utf8'),
+    readFile(new URL('../index-style.css', import.meta.url), 'utf8'),
+  ]);
+
+  assert.match(navbarJs, /className = 'top-buttons__search-shortcut'/);
+  assert.match(navbarJs, /topButtons\.insertAdjacentElement\('afterbegin', searchLink\)/);
+  assert.doesNotMatch(navbarJs, /querySelector\('\.hero-actions'\)/);
+  assert.doesNotMatch(navbarJs, /className = 'cta primary'/);
+
+  assert.match(
+    indexCss,
+    /@media \(min-width: 721px\) \{[\s\S]*?\.top-nav__primary \{[\s\S]*?display: none;/
+  );
+  assert.match(
+    indexCss,
+    /@media \(max-width: 720px\) \{[\s\S]*?\.top-nav \.top-buttons a\.top-buttons__search-shortcut \{[\s\S]*?display: none;/
+  );
+});


### PR DESCRIPTION
## Summary

Cleans up duplicate `Search apps` entry points on the portal homepage so the first viewport has one clear search affordance per viewport.

## Changes

- Keep the desktop search action inside the main top nav instead of showing a separate pre-nav search row.
- Keep the mobile search action beside the Menu button and hide the duplicate injected nav search when the mobile menu expands.
- Stop injecting a `Search apps` CTA into the hero; the hero now focuses on direct workspace actions.
- Add a regression test for the responsive search shortcut rules.

## UX impact

Laptop/desktop now shows one visible `Search apps` control in the nav bar. Mobile shows one visible `Search apps` control beside Menu, even when the menu is expanded. Hero CTAs remain focused on CRM, Sales, and Web Builder.

## Validation

- `node --test tests/homepage-search-ux.test.js tests/homepage-scroll.test.js`
- Local Chromium checks at 1366x768 and 390x844 confirmed one visible search action per viewport and that each visible search action focuses the dock search input.