### PR TITLE
[codex] add TURN relay support for WebRTC lab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,10 @@ GROWTH_HOMEPAGE_CRON_ENABLED=false
 GROWTH_HOMEPAGE_CRON_DRY_RUN=false
 GROWTH_HOMEPAGE_CRON_SECRET=
 GROWTH_GUN_PEERS=
+
+# Optional WebRTC TURN relay. TURN_STATIC_AUTH_SECRET must match coturn static-auth-secret.
+TURN_URLS=turn:turn.3dvr.tech:3478?transport=udp,turn:turn.3dvr.tech:3478?transport=tcp,turns:turn.3dvr.tech:5349?transport=tcp
+TURN_REALM=turn.3dvr.tech
+TURN_STATIC_AUTH_SECRET=replace_me_with_a_long_random_secret
+TURN_TTL_SECONDS=3600
+TURN_USERNAME_PREFIX=portal

--- a/api/session.js
+++ b/api/session.js
@@ -1,5 +1,6 @@
 import { verifySignedSeaPayload, resolveSeaAuthMaxAgeMs } from '../src/auth/sea.js';
 import { chooseDeviceProfile, normalizeDeviceHints } from '../src/device/profile.js';
+import { buildTurnCredentialPayload } from '../src/webrtc/turn-credentials.js';
 
 function setCorsHeaders(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -127,6 +128,24 @@ function getRequestOrigin(req) {
   return host ? `${protocol}://${host}` : '';
 }
 
+function getRequestUrl(req) {
+  try {
+    return new URL(req?.url || '/api/session', getRequestOrigin(req) || 'http://localhost');
+  } catch (_error) {
+    return new URL('/api/session', 'http://localhost');
+  }
+}
+
+function isTurnCredentialRequest(req) {
+  const requestUrl = getRequestUrl(req);
+  const route = normalizeText(
+    requestUrl.searchParams.get('route') ||
+    requestUrl.searchParams.get('mode') ||
+    requestUrl.searchParams.get('kind')
+  );
+  return route === 'turn-credentials';
+}
+
 function resolveDeviceHints(req, body = {}) {
   const source = body?.device && typeof body.device === 'object' ? body.device : {};
   return normalizeDeviceHints({
@@ -218,6 +237,11 @@ export function createSessionHandler(options = {}) {
 
     if (req.method === 'OPTIONS') {
       return res.status(200).end();
+    }
+
+    if (req.method === 'GET' && isTurnCredentialRequest(req)) {
+      res.setHeader('Cache-Control', 'no-store');
+      return res.status(200).json(buildTurnCredentialPayload({ config }));
     }
 
     if (req.method === 'GET') {

--- a/ops/turn/.env.example
+++ b/ops/turn/.env.example
@@ -1,0 +1,2 @@
+TURN_REALM=turn.3dvr.tech
+TURN_SECRET=replace_me_with_same_value_as_TURN_STATIC_AUTH_SECRET

--- a/ops/turn/.gitignore
+++ b/ops/turn/.gitignore
@@ -1,0 +1,2 @@
+.env
+turnserver.conf

--- a/ops/turn/README.md
+++ b/ops/turn/README.md
@@ -1,0 +1,50 @@
+# 3DVR TURN Relay
+
+TURN gives WebRTC a fallback media path when peers cannot connect directly through NAT, carrier NAT,
+or restrictive Wi-Fi. The WebRTC lab uses `/api/session?route=turn-credentials` to mint short-lived credentials
+for a coturn server configured with the same shared secret.
+
+## Server Setup
+
+1. Create a small VPS near your users. A 1 vCPU / 1 GB server is enough for testing.
+2. Point `turn.3dvr.tech` at the VPS public IP.
+3. Open firewall ports:
+   - `3478/tcp`
+   - `3478/udp`
+   - `5349/tcp`
+   - `49160-49200/udp`
+4. Install Docker and Docker Compose.
+5. Copy `turnserver.conf.example` to `turnserver.conf`.
+6. Replace `static-auth-secret` with a long random value:
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+7. Use the same value in Vercel as `TURN_STATIC_AUTH_SECRET`.
+8. If using `turns:` URLs, install a certificate for `turn.3dvr.tech`:
+
+   ```bash
+   sudo certbot certonly --standalone -d turn.3dvr.tech
+   ```
+
+9. Start coturn:
+
+   ```bash
+   docker compose up -d
+   ```
+
+## Portal Environment
+
+Set these Vercel env vars for the portal deployment:
+
+```bash
+TURN_URLS=turn:turn.3dvr.tech:3478?transport=udp,turn:turn.3dvr.tech:3478?transport=tcp,turns:turn.3dvr.tech:5349?transport=tcp
+TURN_REALM=turn.3dvr.tech
+TURN_STATIC_AUTH_SECRET=<same secret as coturn static-auth-secret>
+TURN_TTL_SECONDS=3600
+TURN_USERNAME_PREFIX=portal
+```
+
+Deploy the portal after setting the env vars. The WebRTC lab should then show `Relay: TURN ready`.
+Use `?relay=1` or `?ice=relay` on a room URL to force TURN-only testing.

--- a/ops/turn/docker-compose.yml
+++ b/ops/turn/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  coturn:
+    image: coturn/coturn:latest
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./turnserver.conf:/etc/coturn/turnserver.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    command:
+      - -c
+      - /etc/coturn/turnserver.conf

--- a/ops/turn/turnserver.conf.example
+++ b/ops/turn/turnserver.conf.example
@@ -1,0 +1,27 @@
+listening-port=3478
+tls-listening-port=5349
+min-port=49160
+max-port=49200
+
+realm=turn.3dvr.tech
+server-name=turn.3dvr.tech
+fingerprint
+use-auth-secret
+static-auth-secret=replace_me_with_same_value_as_TURN_STATIC_AUTH_SECRET
+
+no-multicast-peers
+no-cli
+stale-nonce=600
+total-quota=100
+
+# Uncomment when the server is behind one-to-one NAT.
+# external-ip=PUBLIC_IP
+
+# TLS is optional for turn: URLs, but useful for turns: URLs.
+# Generate certificates for TURN_REALM before enabling these paths.
+cert=/etc/letsencrypt/live/turn.3dvr.tech/fullchain.pem
+pkey=/etc/letsencrypt/live/turn.3dvr.tech/privkey.pem
+
+# Disable legacy protocol versions for TLS TURN.
+no-tlsv1
+no-tlsv1_1

--- a/src/webrtc/turn-credentials.js
+++ b/src/webrtc/turn-credentials.js
@@ -1,0 +1,81 @@
+import { createHmac, randomBytes } from 'node:crypto';
+
+export const DEFAULT_STUN_URLS = [
+  'stun:stun.l.google.com:19302',
+  'stun:stun1.l.google.com:19302'
+];
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function parseUrlList(value) {
+  return String(value || '')
+    .split(/[\n,]+/)
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeTtlSeconds(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return 3600;
+  return Math.min(Math.max(parsed, 300), 86400);
+}
+
+function normalizeUsernamePrefix(value) {
+  const normalized = normalizeText(value)
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32);
+  return normalized || 'portal';
+}
+
+function createTurnCredential(username, secret) {
+  return createHmac('sha1', secret)
+    .update(username)
+    .digest('base64');
+}
+
+function createRandomId() {
+  return randomBytes(5).toString('hex');
+}
+
+export function buildTurnCredentialPayload(options = {}) {
+  const {
+    config = process.env,
+    nowMs = Date.now(),
+    randomId = createRandomId
+  } = options;
+
+  const configuredStunUrls = parseUrlList(config.TURN_STUN_URLS);
+  const iceServers = [{ urls: configuredStunUrls.length ? configuredStunUrls : DEFAULT_STUN_URLS }];
+  const turnUrls = parseUrlList(config.TURN_URLS);
+  const secret = normalizeText(config.TURN_STATIC_AUTH_SECRET);
+
+  if (!secret || !turnUrls.length) {
+    return {
+      configured: false,
+      reason: 'TURN_URLS and TURN_STATIC_AUTH_SECRET are required for relay credentials.',
+      iceServers
+    };
+  }
+
+  const ttlSeconds = normalizeTtlSeconds(config.TURN_TTL_SECONDS);
+  const expiresAt = Math.floor(nowMs / 1000) + ttlSeconds;
+  const username = `${expiresAt}:${normalizeUsernamePrefix(config.TURN_USERNAME_PREFIX)}-${randomId()}`;
+  const credential = createTurnCredential(username, secret);
+
+  iceServers.push({
+    urls: turnUrls,
+    username,
+    credential
+  });
+
+  return {
+    configured: true,
+    ttlSeconds,
+    expiresAt,
+    realm: normalizeText(config.TURN_REALM),
+    iceServers
+  };
+}

--- a/tests/turn-credentials.test.js
+++ b/tests/turn-credentials.test.js
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { describe, it } from 'node:test';
+import { createSessionHandler } from '../api/session.js';
+import { buildTurnCredentialPayload } from '../src/webrtc/turn-credentials.js';
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    ended: false,
+    setHeader(key, value) {
+      this.headers[key.toLowerCase()] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.ended = true;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    }
+  };
+}
+
+describe('TURN credentials', () => {
+  it('falls back to STUN when TURN env vars are missing', () => {
+    const payload = buildTurnCredentialPayload({ config: {} });
+
+    assert.equal(payload.configured, false);
+    assert.equal(payload.iceServers.length, 1);
+    assert.deepEqual(payload.iceServers[0].urls, [
+      'stun:stun.l.google.com:19302',
+      'stun:stun1.l.google.com:19302'
+    ]);
+  });
+
+  it('mints coturn REST credentials from the shared secret', () => {
+    const nowMs = Date.parse('2026-05-22T20:00:00Z');
+    const payload = buildTurnCredentialPayload({
+      nowMs,
+      randomId: () => 'abc123',
+      config: {
+        TURN_URLS: 'turn:turn.3dvr.tech:3478?transport=udp,turns:turn.3dvr.tech:5349?transport=tcp',
+        TURN_REALM: 'turn.3dvr.tech',
+        TURN_STATIC_AUTH_SECRET: 'shared-secret',
+        TURN_TTL_SECONDS: '600',
+        TURN_USERNAME_PREFIX: 'test'
+      }
+    });
+
+    const expiresAt = Math.floor(nowMs / 1000) + 600;
+    const username = `${expiresAt}:test-abc123`;
+    const expectedCredential = createHmac('sha1', 'shared-secret')
+      .update(username)
+      .digest('base64');
+
+    assert.equal(payload.configured, true);
+    assert.equal(payload.ttlSeconds, 600);
+    assert.equal(payload.expiresAt, expiresAt);
+    assert.equal(payload.realm, 'turn.3dvr.tech');
+    assert.equal(payload.iceServers.length, 2);
+    assert.equal(payload.iceServers[1].username, username);
+    assert.equal(payload.iceServers[1].credential, expectedCredential);
+    assert.deepEqual(payload.iceServers[1].urls, [
+      'turn:turn.3dvr.tech:3478?transport=udp',
+      'turns:turn.3dvr.tech:5349?transport=tcp'
+    ]);
+  });
+
+  it('serves no-store JSON from the shared session endpoint', async () => {
+    const handler = createSessionHandler({ config: {} });
+    const getResponse = createMockResponse();
+    await handler({
+      method: 'GET',
+      url: '/api/session?route=turn-credentials',
+      headers: {}
+    }, getResponse);
+
+    assert.equal(getResponse.statusCode, 200);
+    assert.equal(getResponse.headers['cache-control'], 'no-store');
+    assert.equal(getResponse.body.configured, false);
+  });
+});

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -8,6 +8,7 @@ const gunVideoDir = new URL('../gun-video-lab/', import.meta.url);
 const gunClipDir = new URL('../gun-clip-lab/', import.meta.url);
 const gunLiveDir = new URL('../gun-live-room/', import.meta.url);
 const gunChunkDir = new URL('../gun-chunk-stream/', import.meta.url);
+const turnOpsDir = new URL('../ops/turn/', import.meta.url);
 
 async function fileExists(path) {
   try {
@@ -38,11 +39,14 @@ describe('WebRTC Lab app', () => {
     assert.match(html, /Native WebRTC POC/);
     assert.match(html, /id="local-video"/);
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
-    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260522-v3">/);
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260522-v4">/);
+    assert.match(html, /id="turn-status">STUN only</);
     assert.match(html, /id="video-profile">180p \/ 10fps</);
-    assert.match(html, /id="build-version">WebRTC v2\.2</);
-    assert.match(html, /<script src="\.\/app\.js\?v=20260522-v3"><\/script>/);
-    assert.match(js, /new RTCPeerConnection\(\{ iceServers: ICE_SERVERS \}\)/);
+    assert.match(html, /id="build-version">WebRTC v2\.3</);
+    assert.match(html, /<script src="\.\/app\.js\?v=20260522-v4"><\/script>/);
+    assert.match(js, /fetch\('\/api\/session\?route=turn-credentials', \{ cache: 'no-store' \}\)/);
+    assert.match(js, /new RTCPeerConnection\(connectionConfig\)/);
+    assert.match(js, /connectionConfig\.iceTransportPolicy = 'relay'/);
     assert.match(js, /navigator\.mediaDevices\.getUserMedia/);
     assert.match(js, /LOW_BANDWIDTH_VIDEO = Object\.freeze/);
     assert.match(js, /width: \{ ideal: LOW_BANDWIDTH_VIDEO\.width \}/);
@@ -59,6 +63,8 @@ describe('WebRTC Lab app', () => {
     assert.match(js, /participantsNode\.map\(\)\.on/);
     assert.match(html, /id="peer-count"/);
     assert.match(html, /id="signal-count"/);
+    assert.match(readme, /\/api\/session\?route=turn-credentials/);
+    assert.match(readme, /\?relay=1/);
     assert.match(readme, /320 x 180 video at about 10 fps/);
     assert.match(readme, /near 240 kbps/);
     assert.match(readme, /Mesh WebRTC/);
@@ -75,6 +81,27 @@ describe('WebRTC Lab app', () => {
     assert.match(readme, /\[WebRTC Lab\]\(https:\/\/3dvr-portal\.vercel\.app\/webrtc-lab\/\)/);
     assert.match(videoHome, /href="\/webrtc-lab\/"/);
     assert.match(videoHome, /Native WebRTC Lab/);
+  });
+
+  it('documents the coturn relay setup for WebRTC testing', async () => {
+    const readmeUrl = new URL('README.md', turnOpsDir);
+    const composeUrl = new URL('docker-compose.yml', turnOpsDir);
+    const configUrl = new URL('turnserver.conf.example', turnOpsDir);
+
+    assert.equal(await fileExists(readmeUrl), true, 'TURN relay README should exist');
+    assert.equal(await fileExists(composeUrl), true, 'TURN docker compose should exist');
+    assert.equal(await fileExists(configUrl), true, 'TURN coturn config example should exist');
+
+    const readme = await readFile(readmeUrl, 'utf8');
+    const compose = await readFile(composeUrl, 'utf8');
+    const config = await readFile(configUrl, 'utf8');
+
+    assert.match(readme, /TURN_STATIC_AUTH_SECRET/);
+    assert.match(readme, /TURN_URLS=/);
+    assert.match(readme, /\?relay=1/);
+    assert.match(compose, /coturn\/coturn:latest/);
+    assert.match(config, /use-auth-secret/);
+    assert.match(config, /static-auth-secret=replace_me_with_same_value_as_TURN_STATIC_AUTH_SECRET/);
   });
 });
 

--- a/webrtc-lab/README.md
+++ b/webrtc-lab/README.md
@@ -16,4 +16,8 @@ serialize browser-native WebRTC objects.
 The default camera profile is intentionally low bandwidth: it asks for 320 x 180 video at about 10 fps
 and caps the video sender near 240 kbps for weak mobile links.
 
+When `/api/session?route=turn-credentials` is configured with `TURN_URLS` and `TURN_STATIC_AUTH_SECRET`, the lab
+loads short-lived TURN credentials before joining a room. Add `?relay=1` or `?ice=relay` to the room
+URL to force relay-only ICE while testing the TURN server.
+
 It is intentionally not a production replacement for a Selective Forwarding Unit. Mesh WebRTC is useful for two or three people while testing connection behavior, but larger meetings need an SFU or other managed media layer.

--- a/webrtc-lab/app.js
+++ b/webrtc-lab/app.js
@@ -17,12 +17,12 @@
     localPeerId: document.getElementById('local-peer-id'),
     peerCount: document.getElementById('peer-count'),
     signalCount: document.getElementById('signal-count'),
+    turnStatus: document.getElementById('turn-status'),
     eventLog: document.getElementById('event-log')
   };
 
-  const ICE_SERVERS = [
-    { urls: 'stun:stun.l.google.com:19302' },
-    { urls: 'stun:stun1.l.google.com:19302' }
+  const DEFAULT_ICE_SERVERS = [
+    { urls: ['stun:stun.l.google.com:19302', 'stun:stun1.l.google.com:19302'] }
   ];
   const ROOM_ROOT = '3dvr-webrtc-lab-v2';
   const SIGNAL_TTL_MS = 1000 * 60 * 20;
@@ -45,6 +45,9 @@
   let joined = false;
   let heartbeatTimer = null;
   let signalsHandled = 0;
+  let iceServers = DEFAULT_ICE_SERVERS;
+  let iceServersLoaded = false;
+  let turnStatus = 'STUN only';
   const peers = new Map();
   const seenSignals = new Set();
 
@@ -91,6 +94,7 @@
     refs.localPeerId.textContent = joined ? localId.replace(/^peer_/, '') : 'Not joined';
     refs.peerCount.textContent = String(peers.size);
     refs.signalCount.textContent = String(signalsHandled);
+    refs.turnStatus.textContent = turnStatus;
   }
 
   function resolveInitialRoom() {
@@ -125,6 +129,60 @@
       axe: true
     });
     return gun;
+  }
+
+  function shouldForceRelayOnly() {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('relay') === '1' || params.get('ice') === 'relay';
+  }
+
+  function normalizeIceServers(servers) {
+    if (!Array.isArray(servers)) return [];
+    return servers
+      .map(server => {
+        if (!server || typeof server !== 'object') return null;
+        const urls = Array.isArray(server.urls)
+          ? server.urls.filter(url => typeof url === 'string' && url.trim())
+          : (typeof server.urls === 'string' && server.urls.trim() ? [server.urls.trim()] : []);
+        if (!urls.length) return null;
+
+        const normalized = { urls };
+        if (typeof server.username === 'string') normalized.username = server.username;
+        if (typeof server.credential === 'string') normalized.credential = server.credential;
+        return normalized;
+      })
+      .filter(Boolean);
+  }
+
+  async function loadIceServers() {
+    if (iceServersLoaded) return iceServers;
+    iceServersLoaded = true;
+
+    try {
+      const response = await fetch('/api/session?route=turn-credentials', { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`TURN credentials returned ${response.status}`);
+      }
+
+      const data = await response.json();
+      const nextServers = normalizeIceServers(data.iceServers);
+      if (nextServers.length) {
+        iceServers = nextServers;
+      }
+
+      turnStatus = data.configured
+        ? (shouldForceRelayOnly() ? 'TURN relay-only' : 'TURN ready')
+        : 'STUN only';
+      updateDiagnostics();
+      logEvent(data.configured ? 'TURN relay credentials loaded.' : 'Using STUN only.');
+    } catch (error) {
+      console.warn('TURN credential load failed', error);
+      turnStatus = 'STUN only';
+      updateDiagnostics();
+      logEvent('TURN credentials unavailable; using STUN only.');
+    }
+
+    return iceServers;
   }
 
   async function startCamera() {
@@ -176,7 +234,11 @@
 
   function createPeer(remoteId, remoteName = 'Guest') {
     if (peers.has(remoteId)) return peers.get(remoteId);
-    const connection = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+    const connectionConfig = { iceServers };
+    if (shouldForceRelayOnly()) {
+      connectionConfig.iceTransportPolicy = 'relay';
+    }
+    const connection = new RTCPeerConnection(connectionConfig);
     const peer = {
       id: remoteId,
       name: remoteName || 'Guest',
@@ -441,6 +503,7 @@
     localName = String(refs.displayName.value || '').trim() || `Guest ${localId.slice(-4)}`;
     refs.localLabel.textContent = `${localName} (you)`;
     ensureGun();
+    await loadIceServers();
     roomNode = gun.get(ROOM_ROOT).get(roomId);
     participantsNode = roomNode.get('participants');
     signalsNode = roomNode.get('signals');

--- a/webrtc-lab/index.html
+++ b/webrtc-lab/index.html
@@ -11,7 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/gun-init.js"></script>
   <link rel="stylesheet" href="../style.css?v=webrtc-lab">
-  <link rel="stylesheet" href="./styles.css?v=20260522-v3">
+  <link rel="stylesheet" href="./styles.css?v=20260522-v4">
 </head>
 <body class="webrtc-page">
   <header class="lab-header">
@@ -28,7 +28,7 @@
           A small browser-to-browser conferencing experiment. Gun relays the room signals; WebRTC carries
           the audio and video directly between participants. Joining now starts media before signaling so
           peers negotiate with real tracks. The default profile now favors weak mobile links with
-          lower video resolution and bitrate.
+          lower video resolution and bitrate, and the lab can use a TURN relay when configured.
         </p>
       </div>
       <aside class="lab-note">
@@ -79,12 +79,16 @@
           <dd id="signal-count">0</dd>
         </div>
         <div>
+          <dt>Relay</dt>
+          <dd id="turn-status">STUN only</dd>
+        </div>
+        <div>
           <dt>Video</dt>
           <dd id="video-profile">180p / 10fps</dd>
         </div>
         <div>
           <dt>Build</dt>
-          <dd id="build-version">WebRTC v2.2</dd>
+          <dd id="build-version">WebRTC v2.3</dd>
         </div>
       </dl>
     </section>
@@ -112,6 +116,6 @@
     <p>Built as a 3DVR WebRTC proof of concept. Use HTTPS or localhost so browser camera permissions work.</p>
   </footer>
 
-  <script src="./app.js?v=20260522-v3"></script>
+  <script src="./app.js?v=20260522-v4"></script>
 </body>
 </html>

--- a/webrtc-lab/styles.css
+++ b/webrtc-lab/styles.css
@@ -197,7 +197,7 @@ input {
 
 .room-stats {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 0.45rem;
   margin: 0.45rem 0 0;
 }


### PR DESCRIPTION
## Summary
- Add TURN credential minting through the existing `/api/session?route=turn-credentials` endpoint so the portal stays within the Vercel Hobby function limit.
- Teach the WebRTC lab to load ICE servers before room signaling, show `Relay` diagnostics, and support `?relay=1` / `?ice=relay` for TURN-only testing.
- Add coturn deployment templates under `ops/turn/` plus env examples.
- Bump WebRTC lab assets to `20260522-v4` with `WebRTC v2.3` diagnostics.

## Why
The same-Wi-Fi success plus cellular failures point toward NAT traversal, not only bandwidth. A TURN relay gives WebRTC a server-routed fallback when direct peer paths fail behind carrier NAT or restrictive networks.

## Validation
- `node --test tests/turn-credentials.test.js tests/webrtc-lab.test.js tests/calendar-provider-api.test.js`
- `git diff --check`
- Browser load check against local static server confirmed the WebRTC lab cleanly falls back to STUN when the TURN credential route is unavailable.