### PR TITLE
Add interactive portal swirl logo

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -346,6 +346,91 @@ body.landing {
   text-align: left;
 }
 
+.portal-swirl-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  width: fit-content;
+  margin-bottom: 0.1rem;
+}
+
+.portal-swirl-logo {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: clamp(5.4rem, 15vw, 8.2rem);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  isolation: isolate;
+  touch-action: none;
+  cursor: grab;
+  background:
+    radial-gradient(circle at 32% 25%, rgba(248, 250, 252, 0.2), transparent 22%),
+    radial-gradient(circle at 62% 68%, rgba(251, 191, 36, 0.18), transparent 26%),
+    #06111f;
+  box-shadow:
+    0 24px 55px rgba(8, 13, 29, 0.42),
+    inset 0 0 0 1px rgba(186, 230, 253, 0.16);
+}
+
+.portal-swirl-logo::after {
+  content: '';
+  position: absolute;
+  inset: 0.4rem;
+  z-index: -1;
+  border-radius: inherit;
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.3), transparent 70%);
+  filter: blur(18px);
+  opacity: 0.72;
+}
+
+.portal-swirl-logo:active {
+  cursor: grabbing;
+}
+
+.portal-swirl-logo:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.45);
+  outline-offset: 5px;
+}
+
+.portal-swirl-logo__canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.portal-swirl-logo__fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  gap: 0;
+  align-content: center;
+  color: rgba(248, 250, 252, 0.92);
+  font-size: 0.85rem;
+  font-weight: 800;
+  line-height: 1.1;
+  pointer-events: none;
+}
+
+.portal-swirl-logo__fallback span:last-child {
+  color: rgba(186, 230, 253, 0.72);
+  font-size: 0.52rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.portal-swirl-logo--ready .portal-swirl-logo__fallback {
+  opacity: 0;
+}
+
+.portal-swirl-brand__name {
+  color: rgba(248, 250, 252, 0.92);
+  font-size: clamp(1.08rem, 2.4vw, 1.35rem);
+  letter-spacing: 0.01em;
+}
+
 .hero-shortcuts {
   display: grid;
   gap: 0.85rem;
@@ -1295,6 +1380,11 @@ footer a {
 @media (max-width: 640px) {
   .landing-shell {
     padding: 4.5rem 1rem 3rem;
+  }
+
+  .portal-swirl-brand {
+    width: 100%;
+    justify-content: center;
   }
 
   .hero-eyebrow {

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <script src="/pwa-install.js" defer></script>
   <link rel="stylesheet" href="styles/global.css">
   <link rel="stylesheet" href="index-style.css">
+  <script src="portal-swirl-logo.js" defer></script>
   <link rel="manifest" href="/manifest.webmanifest">
   <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
   <meta name="theme-color" content="#0e1116">
@@ -98,6 +99,22 @@
         </div>
         <div class="hero-panel">
           <div class="hero-main">
+            <div class="portal-swirl-brand">
+              <div
+                class="portal-swirl-logo"
+                data-portal-swirl-logo
+                role="img"
+                tabindex="0"
+                aria-label="Interactive 3dvr portal swirl logo. Drag or touch to wind it up, tilt it, and twist the spin."
+              >
+                <canvas class="portal-swirl-logo__canvas" data-portal-swirl-canvas></canvas>
+                <span class="portal-swirl-logo__fallback" aria-hidden="true">
+                  <span>3dvr</span>
+                  <span>portal</span>
+                </span>
+              </div>
+              <strong class="portal-swirl-brand__name">3dvr portal</strong>
+            </div>
             <span class="hero-eyebrow">Apps. Tools. People.</span>
             <h1 id="landing-title">One portal. Fast access.</h1>
             <p class="hero-tagline">

--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -1,0 +1,291 @@
+(() => {
+  const TAU = Math.PI * 2;
+  const BASE_SPEED = 0.011;
+  const MAX_SPEED = 0.095;
+  const MIN_SIZE = 72;
+  const WIND_FORCE = 0.0018;
+
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+  const lerp = (from, to, amount) => from + (to - from) * amount;
+
+  const setupPortalSwirlLogo = (root) => {
+    const canvas = root.querySelector('[data-portal-swirl-canvas]');
+    if (!canvas) return null;
+
+    const context = canvas.getContext('2d');
+    if (!context) return null;
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const state = {
+      ready: false,
+      dragging: false,
+      spin: 0,
+      spinVelocity: reducedMotion ? BASE_SPEED * 0.35 : BASE_SPEED,
+      tiltX: 0,
+      tiltY: 0,
+      twist: 0,
+      targetTiltX: 0,
+      targetTiltY: 0,
+      targetTwist: 0,
+      lastX: 0,
+      lastY: 0,
+      dpr: 1,
+      size: MIN_SIZE,
+    };
+
+    const resize = () => {
+      const rect = root.getBoundingClientRect();
+      const measured = Math.min(rect.width || MIN_SIZE, rect.height || rect.width || MIN_SIZE);
+      const size = Math.max(MIN_SIZE, measured);
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      if (state.size === size && state.dpr === dpr) return;
+
+      state.size = size;
+      state.dpr = dpr;
+      canvas.width = Math.round(size * dpr);
+      canvas.height = Math.round(size * dpr);
+      canvas.style.width = `${size}px`;
+      canvas.style.height = `${size}px`;
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    const drawSwirlArm = (radius, armIndex, arms) => {
+      context.beginPath();
+      for (let index = 0; index <= 92; index += 1) {
+        const progress = index / 92;
+        const curl = 1.18 + state.twist * 0.42;
+        const angle = state.spin + armIndex * (TAU / arms) + progress * TAU * curl;
+        const wave = Math.sin(progress * TAU * 1.2 + state.spin * 0.7) * radius * 0.018;
+        const r = radius * (0.11 + progress * 0.77) + wave;
+        const x = Math.cos(angle) * r;
+        const y = Math.sin(angle) * r;
+        if (index === 0) {
+          context.moveTo(x, y);
+        } else {
+          context.lineTo(x, y);
+        }
+      }
+
+      const gradient = context.createLinearGradient(-radius, -radius * 0.35, radius, radius * 0.35);
+      gradient.addColorStop(0, 'rgba(45, 212, 191, 0.25)');
+      gradient.addColorStop(0.5, 'rgba(125, 211, 252, 0.96)');
+      gradient.addColorStop(1, 'rgba(251, 191, 36, 0.66)');
+      context.strokeStyle = gradient;
+      context.lineWidth = Math.max(5, radius * 0.09);
+      context.lineCap = 'round';
+      context.stroke();
+    };
+
+    const draw = () => {
+      resize();
+
+      const size = state.size;
+      const center = size / 2;
+      const radius = size * 0.42;
+      const tiltDepthX = Math.cos(state.tiltX) * 0.18 + 0.82;
+      const tiltDepthY = Math.cos(state.tiltY) * 0.2 + 0.8;
+
+      context.clearRect(0, 0, size, size);
+
+      context.save();
+      context.translate(center, center);
+      context.rotate(state.tiltY * 0.18);
+      context.scale(tiltDepthY, tiltDepthX);
+
+      const shell = context.createRadialGradient(-radius * 0.32, -radius * 0.38, radius * 0.16, 0, 0, radius * 1.12);
+      shell.addColorStop(0, 'rgba(248, 250, 252, 0.2)');
+      shell.addColorStop(0.32, 'rgba(14, 165, 233, 0.2)');
+      shell.addColorStop(0.72, 'rgba(15, 23, 42, 0.98)');
+      shell.addColorStop(1, 'rgba(4, 10, 21, 1)');
+
+      context.beginPath();
+      context.arc(0, 0, radius, 0, TAU);
+      context.fillStyle = shell;
+      context.fill();
+
+      context.lineWidth = Math.max(2, radius * 0.035);
+      context.strokeStyle = 'rgba(186, 230, 253, 0.22)';
+      context.stroke();
+
+      context.save();
+      context.rotate(state.spin * 0.45);
+      for (let armIndex = 0; armIndex < 6; armIndex += 1) {
+        drawSwirlArm(radius, armIndex, 6);
+      }
+      context.restore();
+
+      context.beginPath();
+      context.arc(0, 0, radius * 0.28, 0, TAU);
+      context.fillStyle = 'rgba(2, 6, 23, 0.82)';
+      context.fill();
+      context.strokeStyle = 'rgba(251, 191, 36, 0.38)';
+      context.lineWidth = Math.max(1.5, radius * 0.018);
+      context.stroke();
+
+      context.fillStyle = 'rgba(248, 250, 252, 0.96)';
+      context.font = `800 ${Math.max(17, radius * 0.17)}px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+      context.fillText('3dvr', 0, -radius * 0.035);
+
+      context.fillStyle = 'rgba(186, 230, 253, 0.72)';
+      context.font = `700 ${Math.max(9, radius * 0.072)}px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+      context.fillText('portal', 0, radius * 0.135);
+      context.restore();
+    };
+
+    const animate = () => {
+      const restingSpeed = reducedMotion ? BASE_SPEED * 0.35 : BASE_SPEED;
+      if (!state.dragging) {
+        state.spinVelocity = lerp(state.spinVelocity, restingSpeed, 0.026);
+        state.targetTiltX = lerp(state.targetTiltX, 0, 0.052);
+        state.targetTiltY = lerp(state.targetTiltY, 0, 0.052);
+        state.targetTwist = lerp(state.targetTwist, 0, 0.045);
+      }
+
+      state.tiltX = lerp(state.tiltX, state.targetTiltX, 0.16);
+      state.tiltY = lerp(state.tiltY, state.targetTiltY, 0.16);
+      state.twist = lerp(state.twist, state.targetTwist, 0.14);
+      state.spin += state.spinVelocity;
+      draw();
+      window.requestAnimationFrame(animate);
+    };
+
+    const pointerPosition = (event) => {
+      const rect = root.getBoundingClientRect();
+      return {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+        rect,
+      };
+    };
+
+    const windFromPointer = (event) => {
+      const point = pointerPosition(event);
+      const dx = point.x - state.lastX;
+      const dy = point.y - state.lastY;
+      const centerX = point.rect.width / 2;
+      const centerY = point.rect.height / 2;
+      const distance = Math.hypot(dx, dy);
+      const directionBias = dx * 0.00045 + Math.abs(dy) * 0.00022;
+
+      state.spinVelocity = clamp(
+        state.spinVelocity + distance * WIND_FORCE + directionBias,
+        BASE_SPEED * 0.3,
+        MAX_SPEED,
+      );
+      state.targetTiltY = clamp((point.x - centerX) / centerX, -1, 1) * 0.9;
+      state.targetTiltX = clamp((centerY - point.y) / centerY, -1, 1) * 0.75;
+      state.targetTwist = clamp(state.targetTwist + (dx - dy) * 0.012, -1.2, 1.2);
+      state.lastX = point.x;
+      state.lastY = point.y;
+    };
+
+    root.addEventListener('pointerdown', (event) => {
+      const point = pointerPosition(event);
+      state.dragging = true;
+      state.lastX = point.x;
+      state.lastY = point.y;
+      state.spinVelocity = clamp(state.spinVelocity + BASE_SPEED * 1.5, BASE_SPEED, MAX_SPEED);
+      root.setPointerCapture?.(event.pointerId);
+      event.preventDefault();
+    });
+
+    root.addEventListener('pointermove', (event) => {
+      if (!state.dragging) return;
+      windFromPointer(event);
+      event.preventDefault();
+    });
+
+    const releasePointer = (event) => {
+      if (!state.dragging) return;
+      state.dragging = false;
+      root.releasePointerCapture?.(event.pointerId);
+    };
+
+    root.addEventListener('pointerup', releasePointer);
+    root.addEventListener('pointercancel', releasePointer);
+    root.addEventListener('pointerleave', () => {
+      state.dragging = false;
+    });
+
+    root.addEventListener('mousedown', (event) => {
+      const point = pointerPosition(event);
+      state.dragging = true;
+      state.lastX = point.x;
+      state.lastY = point.y;
+      state.spinVelocity = clamp(state.spinVelocity + BASE_SPEED * 1.5, BASE_SPEED, MAX_SPEED);
+      event.preventDefault();
+    });
+
+    window.addEventListener('mousemove', (event) => {
+      if (!state.dragging) return;
+      windFromPointer(event);
+    });
+
+    window.addEventListener('mouseup', () => {
+      state.dragging = false;
+    });
+
+    root.addEventListener('touchstart', (event) => {
+      const touch = event.touches[0];
+      if (!touch) return;
+      const point = pointerPosition(touch);
+      state.dragging = true;
+      state.lastX = point.x;
+      state.lastY = point.y;
+      state.spinVelocity = clamp(state.spinVelocity + BASE_SPEED * 1.5, BASE_SPEED, MAX_SPEED);
+      event.preventDefault();
+    }, { passive: false });
+
+    root.addEventListener('touchmove', (event) => {
+      const touch = event.touches[0];
+      if (!state.dragging || !touch) return;
+      windFromPointer(touch);
+      event.preventDefault();
+    }, { passive: false });
+
+    root.addEventListener('touchend', () => {
+      state.dragging = false;
+    });
+
+    root.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowRight' || event.key === ' ') {
+        state.spinVelocity = clamp(state.spinVelocity + BASE_SPEED * 2, BASE_SPEED, MAX_SPEED);
+        state.targetTwist = clamp(state.targetTwist + 0.22, -1.2, 1.2);
+        event.preventDefault();
+      }
+      if (event.key === 'ArrowLeft') {
+        state.spinVelocity = clamp(state.spinVelocity + BASE_SPEED, BASE_SPEED, MAX_SPEED);
+        state.targetTwist = clamp(state.targetTwist - 0.22, -1.2, 1.2);
+        event.preventDefault();
+      }
+      if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+        const direction = event.key === 'ArrowUp' ? 1 : -1;
+        state.targetTiltX = clamp(state.targetTiltX + direction * 0.22, -1, 1);
+        event.preventDefault();
+      }
+    });
+
+    window.addEventListener('resize', resize);
+    root.classList.add('portal-swirl-logo--ready');
+    state.ready = true;
+    animate();
+    return state;
+  };
+
+  const init = () => {
+    const roots = Array.from(document.querySelectorAll('[data-portal-swirl-logo]'));
+    const states = roots.map(setupPortalSwirlLogo).filter(Boolean);
+    window.__portalSwirlLogo = {
+      ready: states.length > 0,
+      getState: () => states[0] ? { ...states[0] } : null,
+    };
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -7,6 +7,7 @@ describe('portal logo branding', () => {
     const logo = await readFile(new URL('../brand/portal-logo.svg', import.meta.url), 'utf8');
     const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
     const css = await readFile(new URL('../index-style.css', import.meta.url), 'utf8');
+    const swirlScript = await readFile(new URL('../portal-swirl-logo.js', import.meta.url), 'utf8');
 
     assert.match(logo, /3dvr portal logo/);
     assert.match(logo, />3dvr</);
@@ -17,5 +18,13 @@ describe('portal logo branding', () => {
     assert.match(html, /display-mode: standalone/);
     assert.match(html, /document\.referrer\.startsWith\('android-app:\/\/'\)/);
     assert.match(css, /\.app-boot-enabled \.app-boot/);
+    assert.match(html, /portal-swirl-logo\.js/);
+    assert.match(html, /data-portal-swirl-logo/);
+    assert.match(html, /3dvr portal swirl logo/);
+    assert.match(css, /\.portal-swirl-logo/);
+    assert.match(swirlScript, /BASE_SPEED/);
+    assert.match(swirlScript, /MAX_SPEED/);
+    assert.match(swirlScript, /spinVelocity \+ distance \* WIND_FORCE/);
+    assert.match(swirlScript, /window\.__portalSwirlLogo/);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a canvas-based hypnotic swirl logo to the portal homepage hero.
- Supports clockwise idle motion, pointer/mouse/touch winding, tilt, twist, keyboard winding, and reduced-motion behavior.
- Extends the portal logo branding test to cover the new interactive mark.

## Verification
- `node --check portal-swirl-logo.js`
- `node --test tests/portal-logo-branding.test.js`
- `git diff --check`
- `xvfb-run -a node <portal swirl smoke>`: verified desktop/mobile render, nonblank canvas, drag wind-up, tilt/twist response, and speed decay.

## Notes
- `npm test` was attempted after checkout before dependencies had finished installing and produced unrelated failures in existing suites, including missing issue-launcher/insights tags on older pages. Focused checks for this change passed.