### PR TITLE
Make portal logo tilt gentler

### DIFF
--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -7,6 +7,18 @@
   const SPIN_DECAY = 0.985;
   const FLIP_DECAY = 0.945;
   const MIN_FLIP_VELOCITY = 0.0025;
+  const TILT_X_LIMIT = 0.22;
+  const TILT_Y_LIMIT = 0.28;
+  const TWIST_LIMIT = 0.08;
+  const TWIST_FACTOR = 0.002;
+  const FLIP_DISTANCE_THRESHOLD = 28;
+  const FLIP_DISTANCE_FULL_CHARGE = 75;
+  const FLIP_ENERGY_THRESHOLD = 1;
+  const FLIP_ENERGY_DECAY = 0.45;
+  const FLIP_STREAK_WINDOW = 1400;
+  const MAX_FLIP_ENERGY = 1.65;
+  const FLIP_IMPULSE_X = 0.32;
+  const FLIP_IMPULSE_Y = 0.38;
   const ROOT_SELECTOR = '[data-portal-swirl-logo]';
   const CANVAS_SELECTOR = '[data-portal-swirl-canvas]';
 
@@ -218,6 +230,8 @@
       lastY: 0,
       dragDX: 0,
       dragDY: 0,
+      gestureDX: 0,
+      gestureDY: 0,
       lastTimestamp: 0,
       faceSpin: 0,
       extraFaceSpin: 0,
@@ -231,6 +245,10 @@
       flipY: 0,
       flipVelocityX: 0,
       flipVelocityY: 0,
+      flipStreakAxis: '',
+      flipStreakDirection: 0,
+      flipStreakEnergy: 0,
+      lastFlipGestureAt: 0,
       renderer: null,
       scene: null,
       camera: null,
@@ -293,9 +311,50 @@
       const point = getPointer(event);
       const centerX = point.rect.width / 2;
       const centerY = point.rect.height / 2;
-      state.targetY = clamp((point.x - centerX) / centerX, -1, 1) * 0.58;
-      state.targetX = clamp((centerY - point.y) / centerY, -1, 1) * 0.44;
-      state.targetZ = clamp((dx - dy) * 0.004, -0.18, 0.18);
+      state.targetY = clamp((point.x - centerX) / centerX, -1, 1) * TILT_Y_LIMIT;
+      state.targetX = clamp((centerY - point.y) / centerY, -1, 1) * TILT_X_LIMIT;
+      state.targetZ = clamp((dx - dy) * TWIST_FACTOR, -TWIST_LIMIT, TWIST_LIMIT);
+    };
+
+    const addDirectionalFlipImpulse = () => {
+      const absX = Math.abs(state.gestureDX);
+      const absY = Math.abs(state.gestureDY);
+      const axis = absX >= absY ? 'y' : 'x';
+      const distance = Math.max(absX, absY);
+      const direction = axis === 'y' ? Math.sign(state.gestureDX) : Math.sign(-state.gestureDY);
+
+      if (!direction || distance < FLIP_DISTANCE_THRESHOLD) {
+        state.flipStreakEnergy *= FLIP_ENERGY_DECAY;
+        return;
+      }
+
+      const now = window.performance?.now?.() ?? Date.now();
+      const sameGesture =
+        state.flipStreakAxis === axis &&
+        state.flipStreakDirection === direction &&
+        now - state.lastFlipGestureAt < FLIP_STREAK_WINDOW;
+      const energyGain = clamp(
+        (distance - FLIP_DISTANCE_THRESHOLD) / FLIP_DISTANCE_FULL_CHARGE,
+        0.16,
+        1,
+      );
+
+      state.flipStreakEnergy = sameGesture
+        ? clamp(state.flipStreakEnergy + energyGain, 0, MAX_FLIP_ENERGY)
+        : energyGain;
+      state.flipStreakAxis = axis;
+      state.flipStreakDirection = direction;
+      state.lastFlipGestureAt = now;
+
+      if (state.flipStreakEnergy < FLIP_ENERGY_THRESHOLD) return;
+
+      const impulseScale = clamp(state.flipStreakEnergy, 1, MAX_FLIP_ENERGY);
+      if (axis === 'y') {
+        state.flipVelocityY += direction * FLIP_IMPULSE_Y * impulseScale;
+      } else {
+        state.flipVelocityX += direction * FLIP_IMPULSE_X * impulseScale;
+      }
+      state.flipStreakEnergy *= FLIP_ENERGY_DECAY;
     };
 
     const startDrag = (event) => {
@@ -305,6 +364,8 @@
       state.lastY = point.y;
       state.dragDX = 0;
       state.dragDY = 0;
+      state.gestureDX = 0;
+      state.gestureDY = 0;
       capturePointer(event);
       event.preventDefault();
     };
@@ -319,6 +380,8 @@
       state.lastY = point.y;
       state.dragDX = dx;
       state.dragDY = dy;
+      state.gestureDX += dx;
+      state.gestureDY += dy;
       state.extraFaceSpin = clamp(state.extraFaceSpin - distance * DRAG_WIND_FACTOR, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
       setTiltFromPointer(event, dx, dy);
       event.preventDefault();
@@ -329,10 +392,7 @@
       state.dragging = false;
       releasePointer(event);
 
-      const horizontal = clamp(state.dragDX * 0.035, -0.62, 0.62);
-      const vertical = clamp(-state.dragDY * 0.03, -0.52, 0.52);
-      state.flipVelocityY += horizontal;
-      state.flipVelocityX += vertical;
+      addDirectionalFlipImpulse();
       state.extraFaceSpin = clamp(state.extraFaceSpin - Math.hypot(state.dragDX, state.dragDY) * 0.0018, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
     };
 
@@ -349,14 +409,14 @@
       root.addEventListener('keydown', (event) => {
         if (event.key === 'ArrowRight' || event.key === ' ') {
           state.extraFaceSpin = clamp(state.extraFaceSpin - 0.012, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
-          state.flipVelocityY += 0.34;
+          state.flipVelocityY += 0.18;
           event.preventDefault();
         } else if (event.key === 'ArrowLeft') {
           state.extraFaceSpin = clamp(state.extraFaceSpin - 0.008, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
-          state.flipVelocityY -= 0.34;
+          state.flipVelocityY -= 0.18;
           event.preventDefault();
         } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-          state.flipVelocityX += event.key === 'ArrowUp' ? 0.28 : -0.28;
+          state.flipVelocityX += event.key === 'ArrowUp' ? 0.14 : -0.14;
           event.preventDefault();
         }
       });
@@ -520,6 +580,7 @@
           flipY: state.flipY,
           flipVelocityX: state.flipVelocityX,
           flipVelocityY: state.flipVelocityY,
+          flipStreakEnergy: state.flipStreakEnergy,
         }),
       };
     };

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -38,8 +38,13 @@ describe('portal logo branding', () => {
     assert.doesNotMatch(swirlScript, /state\.token\.rotation\.set\(rotationX, rotationY, state\.faceSpin/);
     assert.match(swirlScript, /flipVelocityX/);
     assert.match(swirlScript, /flipVelocityY/);
-    assert.match(swirlScript, /state\.targetY = clamp\(\(point\.x - centerX\) \/ centerX/);
-    assert.match(swirlScript, /state\.flipVelocityY \+= horizontal/);
+    assert.match(swirlScript, /TILT_Y_LIMIT/);
+    assert.match(swirlScript, /TILT_X_LIMIT/);
+    assert.match(swirlScript, /FLIP_ENERGY_THRESHOLD/);
+    assert.match(swirlScript, /FLIP_STREAK_WINDOW/);
+    assert.match(swirlScript, /state\.targetY = clamp\(\(point\.x - centerX\) \/ centerX, -1, 1\) \* TILT_Y_LIMIT/);
+    assert.match(swirlScript, /const axis = absX >= absY \? 'y' : 'x'/);
+    assert.match(swirlScript, /state\.flipVelocityY \+= direction \* FLIP_IMPULSE_Y \* impulseScale/);
     assert.match(swirlScript, /window\.__portalSwirlLogo/);
   });
 });


### PR DESCRIPTION
## Summary
- Reduces the live pointer tilt and twist on the portal 3D logo so ordinary dragging feels subtle.
- Replaces single-release flip impulse with same-direction gesture energy, so repeated stronger drags can still flip the token.
- Lowers keyboard flip impulses and updates the branding test to cover the gentler tilt constants and flip-energy path.

## Validation
- `node --check portal-swirl-logo.js`
- `node --test tests/portal-logo-branding.test.js`
- `git diff --check`
- Focused Playwright smoke against local `http://127.0.0.1:4183/` verified idle face spin, gentle normal drag tilt with no flip, repeated same-direction drag flip impulse, and nonblank canvas pixels.

Note: `npm ci` reports the existing 3 dependency audit issues.