### PR TITLE
Increase portal logo drag tilt

### DIFF
--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -7,8 +7,8 @@
   const SPIN_DECAY = 0.99;
   const FLIP_DECAY = 0.965;
   const MIN_FLIP_VELOCITY = 0.0025;
-  const TILT_X_LIMIT = 0.14;
-  const TILT_Y_LIMIT = 0.18;
+  const TILT_X_LIMIT = 0.18;
+  const TILT_Y_LIMIT = 0.24;
   const TWIST_LIMIT = 0.045;
   const TWIST_FACTOR = 0.0012;
   const FLIP_DISTANCE_THRESHOLD = 42;

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -39,8 +39,8 @@ describe('portal logo branding', () => {
     assert.doesNotMatch(swirlScript, /state\.token\.rotation\.set\(rotationX, rotationY, state\.faceSpin/);
     assert.match(swirlScript, /flipVelocityX/);
     assert.match(swirlScript, /flipVelocityY/);
-    assert.match(swirlScript, /TILT_Y_LIMIT/);
-    assert.match(swirlScript, /TILT_X_LIMIT/);
+    assert.match(swirlScript, /TILT_Y_LIMIT = 0\.24/);
+    assert.match(swirlScript, /TILT_X_LIMIT = 0\.18/);
     assert.match(swirlScript, /FLIP_STREAK_REQUIRED = 4/);
     assert.match(swirlScript, /FLIP_STREAK_WINDOW/);
     assert.match(swirlScript, /FLIP_SPIN_BOOST/);


### PR DESCRIPTION
## Summary
- Increase the portal swirl logo drag tilt caps so touch and mouse drags lean a bit more in the drag direction.
- Keep the calmer four-gesture flip threshold, wobble, and slow return behavior unchanged.
- Tighten the branding test to assert the new tilt limits.

## Validation
- `node --check portal-swirl-logo.js`
- `node --test tests/portal-logo-branding.test.js`
- `git diff --check`
- Mobile Playwright smoke against local server: verified larger upward/rightward drag tilt, no single-drag flip, and sized canvas.