### PR TITLE
Fix portal logo back text mirroring

### DIFF
--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -224,7 +224,7 @@
     const backText = new THREE.Mesh(
       textGeometry,
       new THREE.MeshBasicMaterial({
-        map: makeTextTexture(THREE, true),
+        map: makeTextTexture(THREE, false),
         transparent: true,
         depthWrite: false,
       }),

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -31,6 +31,11 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /extraFaceSpin/);
     assert.match(swirlScript, /MAX_EXTRA_SPIN = 0\.105/);
     assert.match(swirlScript, /makeTextTexture/);
+    assert.match(
+      swirlScript,
+      /const backText = new THREE\.Mesh\(\s*textGeometry,\s*new THREE\.MeshBasicMaterial\(\{\s*map: makeTextTexture\(THREE, false\),/,
+    );
+    assert.doesNotMatch(swirlScript, /map: makeTextTexture\(THREE, true\)/);
     assert.match(swirlScript, /texture\.rotation = state\.faceSpin/);
     assert.match(swirlScript, /const rotationX = state\.currentX \+ state\.flipX \+ state\.wobbleX/);
     assert.match(swirlScript, /const rotationY = state\.currentY \+ state\.flipY \+ state\.wobbleY/);


### PR DESCRIPTION
## Summary
- stop pre-mirroring the portal swirl logo back-side text texture
- keep the back text plane rotated to the rear face so the label reads normally when that face is forward
- add a branding regression assertion for the back text texture setup

## Validation
- `node --check portal-swirl-logo.js`
- `node --test tests/portal-logo-branding.test.js`
- `git diff --check`

Note: `npm test` was also attempted in a fresh worktree, but the full suite is not runnable there without installed packages such as Playwright, Stripe, Gun, and Nodemailer, and it reports unrelated existing page-coverage assertions.