### PR TITLE
Simplify People Log quick capture

### DIFF
--- a/crm/app.js
+++ b/crm/app.js
@@ -137,6 +137,8 @@ const DRAFT_TYPE_OPTIONS = Object.freeze([
   }),
 ]);
 const TOUCH_TYPE_OPTIONS = Object.freeze([
+  Object.freeze({ value: 'conversation', label: 'Conversation' }),
+  Object.freeze({ value: 'message', label: 'Message' }),
   Object.freeze({ value: 'drafted', label: 'Drafted' }),
   Object.freeze({ value: 'outreach-sent', label: 'Outreach sent' }),
   Object.freeze({ value: 'reply-received', label: 'Reply received' }),
@@ -160,6 +162,12 @@ const elements = {
   visibleCount: document.getElementById('visibleCount'),
   emptyState: document.getElementById('emptyState'),
   duplicateSummary: document.getElementById('crmDuplicateSummary'),
+  quickConversationForm: document.getElementById('quickConversationForm'),
+  quickConversationNote: document.getElementById('quickConversationNote'),
+  quickConversationPerson: document.getElementById('quickConversationPerson'),
+  quickConversationChannel: document.getElementById('quickConversationChannel'),
+  quickConversationNextStep: document.getElementById('quickConversationNextStep'),
+  quickConversationStatus: document.getElementById('quickConversationStatus'),
   quickLeadForm: document.getElementById('quickLeadForm'),
   quickLeadName: document.getElementById('quickLeadName'),
   quickLeadEmail: document.getElementById('quickLeadEmail'),
@@ -456,6 +464,101 @@ function mergeImportedNotes(existingValue = '', importedValue = '') {
   if (!existing) return imported;
   if (existing.includes(imported)) return existing;
   return `${existing}\n\nImported note:\n${imported}`;
+}
+
+function getQuickConversationChannelLabel(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'message') return 'Text / DM';
+  if (normalized === 'call') return 'Call';
+  if (normalized === 'email') return 'Email';
+  if (normalized === 'group-chat') return 'Group chat';
+  return 'Conversation';
+}
+
+function getQuickConversationTouchType(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized === 'message' || normalized === 'email' || normalized === 'group-chat'
+    ? 'message'
+    : 'conversation';
+}
+
+function appendConversationNote(existingValue = '', {
+  timestamp = new Date().toISOString(),
+  channelLabel = 'Conversation',
+  note = '',
+  nextStep = '',
+} = {}) {
+  const existing = String(existingValue || '').trim();
+  const pieces = [
+    `[${channelLabel} ${new Date(timestamp).toLocaleString()}]`,
+    String(note || '').trim(),
+    nextStep ? `Next: ${String(nextStep).trim()}` : '',
+  ].filter(Boolean);
+  const entry = pieces.join('\n');
+  if (!entry) return existing;
+  return existing ? `${existing}\n\n${entry}` : entry;
+}
+
+function getQuickConversationPeople() {
+  return Object.values(crmIndex)
+    .map(sanitizeCrmRecord)
+    .filter(record => record.recordType === 'person' && String(record.id || '').trim());
+}
+
+function deriveQuickConversationName(note = '') {
+  const firstLine = String(note || '').trim().split(/\n+/)[0] || '';
+  const relationshipMatch = firstLine.match(/\b(?:talked to|spoke with|met|texted|messaged|called|emailed|saw|heard from)\s+([A-Za-z][A-Za-z'’-]{1,32})/i);
+  if (relationshipMatch) {
+    const raw = relationshipMatch[1];
+    return `${raw.slice(0, 1).toUpperCase()}${raw.slice(1)}`;
+  }
+  const nameMatch = firstLine.match(/\b([A-Z][A-Za-z'’-]{1,32})(?:\b|:)/);
+  if (nameMatch) return nameMatch[1];
+  const fallback = firstLine.split(/\s+/).slice(0, 5).join(' ').replace(/[^\w\s'’-]/g, '').trim();
+  return fallback || `Quick note ${new Date().toLocaleString()}`;
+}
+
+function findQuickConversationRecord(personValue = '', note = '') {
+  const people = getQuickConversationPeople();
+  const explicit = String(personValue || '').trim().toLowerCase();
+  if (explicit) {
+    const exact = people.find(record => {
+      const name = String(record.name || '').trim().toLowerCase();
+      const email = normaliseEmail(record.email);
+      return name === explicit || email === explicit;
+    });
+    if (exact) return exact;
+  }
+
+  const haystack = `${personValue} ${note}`.toLowerCase();
+  if (!haystack.trim()) return null;
+  return people
+    .slice()
+    .sort((a, b) => String(b.name || '').length - String(a.name || '').length)
+    .find(record => {
+      const name = String(record.name || '').trim().toLowerCase();
+      if (!name) return false;
+      const firstName = name.split(/\s+/)[0];
+      return haystack.includes(name) || (firstName.length > 2 && haystack.includes(firstName));
+    }) || null;
+}
+
+function showQuickConversationStatus(message = '', tone = 'info') {
+  if (!elements.quickConversationStatus) return;
+  const copy = String(message || '').trim();
+  if (!copy) {
+    elements.quickConversationStatus.className = 'hidden rounded-xl border px-3 py-2 text-sm';
+    elements.quickConversationStatus.textContent = '';
+    return;
+  }
+  const palettes = {
+    info: 'border-sky-500/30 bg-sky-950/40 text-sky-100',
+    success: 'border-emerald-500/30 bg-emerald-950/40 text-emerald-100',
+    warn: 'border-amber-500/30 bg-amber-950/40 text-amber-100',
+    error: 'border-rose-500/30 bg-rose-950/40 text-rose-100',
+  };
+  elements.quickConversationStatus.className = `rounded-xl border px-3 py-2 text-sm ${palettes[tone] || palettes.info}`;
+  elements.quickConversationStatus.textContent = copy;
 }
 
 function showImportStatus(message = '', tone = 'info') {
@@ -1450,7 +1553,7 @@ function updateCounts(total, visible) {
   if (elements.visibleCount) elements.visibleCount.textContent = String(visible);
   if (!elements.emptyState) return;
   if (total === 0) {
-    elements.emptyState.textContent = 'No records yet. Add a group, lead, or problem to get started.';
+    elements.emptyState.textContent = 'No notes yet. Save a quick conversation to get started.';
     elements.emptyState.classList.remove('hidden');
   } else if (visible === 0) {
     elements.emptyState.textContent = 'No records match this filter yet.';
@@ -1587,13 +1690,13 @@ function renderList() {
 
   const sections = [];
   if (state.board.groups.length) {
-    sections.push(renderSection('Groups', 'Accounts first. Keep the people nested under the right group.', state.board.groups.map(renderGroupCluster).join('')));
+    sections.push(renderSection('Companies and groups', 'People connected to the same business, family, team, or project.', state.board.groups.map(renderGroupCluster).join('')));
   }
   if (state.board.standalonePeople.length) {
-    sections.push(renderSection('Ungrouped leads', 'People you have not attached to a group yet.', state.board.standalonePeople.map(record => renderPersonCard(record)).join('')));
+    sections.push(renderSection('People', 'Recent conversations that are not attached to a group yet.', state.board.standalonePeople.map(record => renderPersonCard(record)).join('')));
   }
   if (state.board.problems.length) {
-    sections.push(renderSection('Problems', 'Track the pains that connect back to groups and people.', state.board.problems.map(renderProblemCard).join('')));
+    sections.push(renderSection('Repeated themes', 'Things people keep asking for or struggling with.', state.board.problems.map(renderProblemCard).join('')));
   }
 
   elements.list.innerHTML = sections.join('');
@@ -2685,6 +2788,69 @@ async function handleCreateSubmit(event) {
   }
 }
 
+async function handleQuickConversationSubmit(event) {
+  event.preventDefault();
+  const note = String(elements.quickConversationNote?.value || '').trim();
+  const personValue = String(elements.quickConversationPerson?.value || '').trim();
+  const nextStep = String(elements.quickConversationNextStep?.value || '').trim();
+
+  if (!note && !personValue && !nextStep) {
+    showQuickConversationStatus('Add a quick note first.', 'warn');
+    elements.quickConversationNote?.focus();
+    return;
+  }
+
+  const channel = String(elements.quickConversationChannel?.value || 'conversation').trim();
+  const channelLabel = getQuickConversationChannelLabel(channel);
+  const now = new Date().toISOString();
+  const existing = findQuickConversationRecord(personValue, note);
+  const name = existing?.name || personValue || deriveQuickConversationName(note || nextStep);
+  const body = note || nextStep || `Logged ${channelLabel.toLowerCase()} with ${name}.`;
+  const savedRecord = pruneRecordForType({
+    ...(existing || {}),
+    id: existing?.id || generateId(),
+    recordType: 'person',
+    name,
+    tags: mergeCommaSeparatedValues(existing?.tags, 'quick-capture'),
+    status: existing?.status || DEFAULT_PERSON_STATUS,
+    warmth: existing?.warmth || 'warm',
+    lastSignal: channelLabel,
+    nextBestAction: nextStep || existing?.nextBestAction || '',
+    notes: appendConversationNote(existing?.notes, {
+      timestamp: now,
+      channelLabel,
+      note: body,
+      nextStep,
+    }),
+    source: existing?.source || 'Quick capture',
+    created: existing?.created || now,
+    updated: now,
+    lastContacted: now,
+    activityCount: toActivityCount(existing?.activityCount) + 1,
+    contactId: existing?.contactId || '',
+  });
+
+  try {
+    await putCrmRecord(savedRecord);
+    appendTouchLogEntry(savedRecord, {
+      touchType: getQuickConversationTouchType(channel),
+      note: body,
+      source: 'Quick capture',
+      statusAfter: savedRecord.status || DEFAULT_PERSON_STATUS,
+      timestamp: now,
+    });
+    state.focusId = savedRecord.id;
+    state.focusApplied = false;
+    elements.quickConversationForm?.reset();
+    elements.quickConversationNote?.focus();
+    showQuickConversationStatus(`Saved ${existing ? 'another note for' : 'a note for'} ${savedRecord.name}.`, 'success');
+    if (scoreManager) scoreManager.increment(existing ? 1 : 5);
+  } catch (err) {
+    console.error('Unable to save quick conversation', err);
+    showQuickConversationStatus('Could not save this note right now.', 'error');
+  }
+}
+
 async function handleQuickLeadSubmit(event) {
   event.preventDefault();
   const name = String(elements.quickLeadName?.value || '').trim();
@@ -2920,6 +3086,7 @@ async function handleAction(action, recordId) {
 
 function attachEvents() {
   elements.form?.addEventListener('submit', handleCreateSubmit);
+  elements.quickConversationForm?.addEventListener('submit', handleQuickConversationSubmit);
   elements.quickLeadForm?.addEventListener('submit', handleQuickLeadSubmit);
   elements.filterInput?.addEventListener('input', applyFilter);
   elements.personWorkflowFilter?.addEventListener('change', applyFilter);

--- a/crm/index.html
+++ b/crm/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>3DVR CRM</title>
+  <title>People Log | 3dvr portal</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="https://fav.farm/🧠" />
   <script src="https://cdn.tailwindcss.com"></script>
@@ -19,16 +19,16 @@
   <header class="bg-gray-950/70 border-b border-white/10">
     <div class="max-w-5xl mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
       <div>
-        <p class="text-xs font-semibold tracking-[0.32em] text-teal-400 uppercase">Sales toolkit</p>
-        <h1 class="text-3xl font-bold">3DVR CRM</h1>
-        <p class="text-sm text-gray-300">Turn warm leads into the next human move without losing the shared portal context.</p>
-        <p class="text-xs text-gray-400 mt-2">This workspace is shared so the whole team can see who has been contacted and when.</p>
+        <p class="text-xs font-semibold tracking-[0.32em] text-teal-400 uppercase">People log</p>
+        <h1 class="text-3xl font-bold">Quick conversations</h1>
+        <p class="text-sm text-gray-300">Save who you talked to, what happened, and the next small step.</p>
+        <p class="text-xs text-gray-400 mt-2">Messy notes are fine. The goal is to get it out of your head quickly.</p>
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
-        <a href="../sales/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Sales home</a>
-        <a href="../sales/outreach.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Outreach CRM</a>
-        <a href="../sales/training/" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Training playbook</a>
-        <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Contacts workspace</a>
+        <a href="../sales/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Sales</a>
+        <a href="../sales/outreach.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Outreach</a>
+        <a href="../sales/training/" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Training</a>
+        <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Contacts</a>
         <a href="../cell/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Cell</a>
       </nav>
     </div>
@@ -56,6 +56,54 @@
   </a>
 
   <main class="max-w-6xl mx-auto px-4 py-8 space-y-8">
+    <section id="quickConversationCapture" class="rounded-3xl border border-teal-400/20 bg-gradient-to-br from-gray-800/85 to-gray-950/90 p-5 shadow-2xl shadow-black/20">
+      <div class="grid gap-5 lg:grid-cols-[0.75fr,1.25fr] lg:items-start">
+        <div class="space-y-2">
+          <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Quick capture</p>
+          <h2 class="text-2xl font-semibold">Drop the note. Keep moving.</h2>
+          <p class="text-sm text-gray-300">
+            Use this after a work chat, text, call, or random idea. Add the person if you remember. Add one next step if there is one.
+          </p>
+        </div>
+        <form id="quickConversationForm" class="grid gap-3">
+          <label for="quickConversationNote" class="sr-only">Conversation note</label>
+          <textarea
+            id="quickConversationNote"
+            rows="4"
+            class="w-full rounded-2xl border border-white/10 bg-white text-gray-950 p-4 text-base leading-relaxed"
+            placeholder="Example: Talked to Victor. He still wants the Alibaba store. Ask him to send one product link tomorrow."
+          ></textarea>
+          <div class="grid gap-3 md:grid-cols-[1fr,0.7fr]">
+            <div>
+              <label for="quickConversationPerson" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Who</label>
+              <input id="quickConversationPerson" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional name" autocomplete="name" />
+            </div>
+            <div>
+              <label for="quickConversationChannel" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Kind</label>
+              <select id="quickConversationChannel" class="w-full p-3 rounded-xl text-black">
+                <option value="conversation">Conversation</option>
+                <option value="message">Text / DM</option>
+                <option value="call">Call</option>
+                <option value="email">Email</option>
+                <option value="group-chat">Group chat</option>
+              </select>
+            </div>
+          </div>
+          <div class="grid gap-3 md:grid-cols-[1fr,auto] md:items-end">
+            <div>
+              <label for="quickConversationNextStep" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Next step</label>
+              <input id="quickConversationNextStep" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional: ask for product link, send examples, follow up Friday..." />
+            </div>
+            <button type="submit" class="rounded-xl bg-teal-500 px-5 py-3 font-semibold text-gray-950 hover:bg-teal-400">Save note</button>
+          </div>
+          <p id="quickConversationStatus" class="hidden rounded-xl border px-3 py-2 text-sm" role="status" aria-live="polite"></p>
+        </form>
+      </div>
+    </section>
+
+    <details id="crmAdvancedTools" class="rounded-2xl border border-white/10 bg-gray-900/55 p-4">
+      <summary class="cursor-pointer text-sm font-semibold text-gray-200">More tools, drafts, and sales helpers</summary>
+      <div class="mt-4 space-y-8">
     <section class="grid gap-4 lg:grid-cols-[1fr,320px]">
       <div class="bg-gray-800/60 border border-white/10 rounded-xl p-5 space-y-3">
         <div class="flex flex-wrap items-center justify-between gap-2">
@@ -128,26 +176,28 @@
         </div>
       </div>
     </section>
+      </div>
+    </details>
 
     <section id="crmPrimaryActions" class="bg-gray-800/60 border border-white/10 rounded-2xl p-5 space-y-4">
       <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div>
-          <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">CRM workspace</p>
-          <h2 class="text-xl font-semibold">Add the next lead or find the right record fast.</h2>
-          <p class="text-sm text-gray-300">Keep the main moves at the top. The workflow lanes can stay underneath.</p>
+          <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Find someone</p>
+          <h2 class="text-xl font-semibold">Search people and saved notes.</h2>
+          <p class="text-sm text-gray-300">Use the quick capture first. Search here when you need to find or clean something up.</p>
         </div>
         <div class="flex flex-wrap gap-2">
-          <button id="openCrmCreate" type="button" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded text-sm font-medium">Add CRM contact</button>
-          <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-4 py-2 rounded text-sm text-center border border-white/10">Search contacts</a>
+          <button id="openCrmCreate" type="button" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded text-sm font-medium">Add person</button>
+          <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-4 py-2 rounded text-sm text-center border border-white/10">Open contacts</a>
         </div>
       </div>
       <div class="grid gap-3 md:grid-cols-[1fr,240px] md:items-end">
         <div>
-          <label for="filter" class="block text-sm text-gray-300">Search CRM</label>
-          <input id="filter" type="search" placeholder="Filter by name, group, problem, tags, or notes" class="w-full p-2 rounded text-black" />
+          <label for="filter" class="block text-sm text-gray-300">Search</label>
+          <input id="filter" type="search" placeholder="Search names, notes, next steps, phone, email..." class="w-full p-2 rounded text-black" />
         </div>
         <div>
-          <label for="personWorkflowFilter" class="block text-sm text-gray-300">Person workflow</label>
+          <label for="personWorkflowFilter" class="block text-sm text-gray-300">Simple filter</label>
           <select id="personWorkflowFilter" class="w-full p-2 rounded text-black">
             <option value="">All people</option>
             <option value="linked">Linked to contacts</option>
@@ -166,7 +216,9 @@
       </div>
     </section>
 
-    <section class="bg-gray-800/60 border border-white/10 rounded-2xl p-5 space-y-4">
+    <details id="crmSalesMovesPanel" class="rounded-2xl border border-white/10 bg-gray-900/55 p-4">
+      <summary class="cursor-pointer text-sm font-semibold text-gray-200">Today's reminders and sales queue</summary>
+    <section class="mt-4 bg-gray-800/60 border border-white/10 rounded-2xl p-5 space-y-4">
       <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
         <div>
           <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Today's Sales Moves</p>
@@ -218,13 +270,14 @@
         </article>
       </div>
     </section>
+    </details>
 
     <section class="grid gap-6 lg:grid-cols-[360px,1fr]">
       <div id="crm-capture" class="bg-gray-800/60 border border-white/10 rounded-2xl p-5 space-y-4">
         <div class="space-y-2">
-          <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Capture lane</p>
-          <h2 class="text-xl font-semibold">Add the next real lead fast.</h2>
-          <p class="text-sm text-gray-300">The list stays compact. Use the detail view for edits, follow-up, and contact sync.</p>
+          <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Add a person</p>
+          <h2 class="text-xl font-semibold">Use this only when you know the basics.</h2>
+          <p class="text-sm text-gray-300">For normal day-to-day notes, use Quick capture at the top.</p>
         </div>
         <form id="quickLeadForm" class="grid gap-3">
           <input id="quickLeadName" type="text" placeholder="Lead name" class="w-full p-2 rounded text-black" />
@@ -267,7 +320,7 @@
           <p id="crmImportStatus" class="hidden rounded-lg border px-3 py-2 text-xs" role="status" aria-live="polite"></p>
         </div>
         <div class="grid gap-2 sm:grid-cols-2">
-          <span class="bg-white/10 text-white px-3 py-2 rounded text-sm text-center border border-white/10">Use top button for full lead form</span>
+          <span class="bg-white/10 text-white px-3 py-2 rounded text-sm text-center border border-white/10">Use Quick capture for messy notes</span>
           <button id="openGroupCreate" type="button" class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm">New group</button>
           <button id="openProblemCreate" type="button" class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm">Log problem</button>
           <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm text-center">Open contacts</a>
@@ -301,12 +354,12 @@
       <div class="space-y-6">
         <div class="bg-gray-800/60 border border-white/10 rounded-2xl p-5">
           <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-4">
-            <h2 class="text-xl font-semibold">Pipeline</h2>
+            <h2 class="text-xl font-semibold">Saved people and notes</h2>
             <span class="text-xs uppercase tracking-[0.32em] text-gray-400">Live</span>
           </div>
           <div id="crmDuplicateSummary" class="hidden bg-amber-900/40 border border-amber-500/30 rounded-lg p-3 text-sm text-amber-100 mb-4"></div>
           <div id="contactList" class="space-y-3"></div>
-          <div id="emptyState" class="text-sm text-gray-400 hidden">No records yet. Add a group, lead, or problem to get started.</div>
+          <div id="emptyState" class="text-sm text-gray-400 hidden">No notes yet. Save a quick conversation to get started.</div>
         </div>
       </div>
     </section>

--- a/home/script.js
+++ b/home/script.js
@@ -87,7 +87,7 @@ const apps = {
         <button class="button command" data-open-url="/tasks/">Open Tasks</button>
         <button class="button command" data-open-url="/calendar">View Calendar</button>
         <button class="button command" data-open-url="/chat/">Join Chat</button>
-        <button class="button command" data-open-url="/crm">CRM Tools</button>
+        <button class="button command" data-open-url="/crm">People Log</button>
       </div>
       <p class="muted">Command palette coming soon with GunDB integration.</p>
     `

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
               without digging through unfinished system layers.
             </p>
             <div class="hero-actions">
-              <a href="crm/index.html" class="cta primary">Open CRM</a>
+              <a href="crm/index.html" class="cta primary">Open People Log</a>
               <a href="sales/index.html" class="cta ghost">Open Sales</a>
               <a href="web-builder-app/index.html" class="cta ghost">Open Web Builder</a>
             </div>
@@ -228,7 +228,7 @@
                 type="search"
                 id="appSearch"
                 class="app-search__input"
-                placeholder="Calendar, CRM, billing…"
+                placeholder="Calendar, people, billing…"
                 aria-label="Search apps"
                 aria-describedby="appSearchHint"
                 autocomplete="off"
@@ -309,13 +309,13 @@
           </a>
           <a href="crm/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">📊</span>
-            <span class="app-card__title">CRM</span>
-            <span class="app-card__meta">Track deals and sync with contacts seamlessly.</span>
+            <span class="app-card__title">People Log</span>
+            <span class="app-card__meta">Save quick conversations, messages, and next steps before they leave your head.</span>
           </a>
           <a href="memory-capture/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🎙️</span>
             <span class="app-card__title">Memory Capture</span>
-            <span class="app-card__meta">Brain dump conversations into CRM leads, proposals, and 3dvr-agent cleanup tasks.</span>
+            <span class="app-card__meta">Brain dump conversations into people notes, proposals, and 3dvr-agent cleanup tasks.</span>
           </a>
           <a href="deployment-guides/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🛠️</span>

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -11,10 +11,19 @@ async function read(relativePath) {
 
 test('CRM page exposes workflow filters and import controls for fast lead retrieval', async () => {
   const html = await read('crm/index.html');
+  assert.match(html, /id="quickConversationCapture"/);
+  assert.match(html, /id="quickConversationForm"/);
+  assert.match(html, /id="quickConversationNote"/);
+  assert.match(html, /id="quickConversationPerson"/);
+  assert.match(html, /id="quickConversationChannel"/);
+  assert.match(html, /id="quickConversationNextStep"/);
+  assert.match(html, /Drop the note\. Keep moving\./);
   assert.match(html, /id="crmPrimaryActions"/);
-  assert.match(html, /Add CRM contact/);
-  assert.match(html, /Search contacts/);
-  assert.match(html, /Search CRM/);
+  assert.match(html, /Add person/);
+  assert.match(html, /Open contacts/);
+  assert.match(html, /Search people and saved notes/);
+  assert.match(html, /id="crmAdvancedTools"/);
+  assert.match(html, /id="crmSalesMovesPanel"/);
   assert.match(html, /id="filterAllRecords"/);
   assert.match(html, /id="filterWarmLeads"/);
   assert.match(html, /id="personWorkflowFilter"/);
@@ -60,6 +69,12 @@ test('CRM page exposes workflow filters and import controls for fast lead retrie
 
 test('CRM app includes keyboard search shortcut, workflow filters, and import wiring', async () => {
   const js = await read('crm/app.js');
+  assert.match(js, /handleQuickConversationSubmit/);
+  assert.match(js, /findQuickConversationRecord/);
+  assert.match(js, /appendConversationNote/);
+  assert.match(js, /source: 'Quick capture'/);
+  assert.match(js, /touchType: getQuickConversationTouchType\(channel\)/);
+  assert.match(js, /quickConversationForm\?\.addEventListener\('submit', handleQuickConversationSubmit\)/);
   assert.match(js, /personWorkflowFilter\?\.addEventListener\('change', applyFilter\)/);
   assert.match(js, /event\.key === '\/' && !isTypingContext/);
   assert.match(js, /data-contact-id=/);

--- a/tests/crm-touch-log-real.test.js
+++ b/tests/crm-touch-log-real.test.js
@@ -6,6 +6,8 @@ test('crm touch logging keeps explicit outcomes and reply metadata', async () =>
   const appJs = await readFile(new URL('../crm/app.js', import.meta.url), 'utf8');
 
   assert.match(appJs, /const TOUCH_TYPE_OPTIONS = Object\.freeze/);
+  assert.match(appJs, /conversation/);
+  assert.match(appJs, /message/);
   assert.match(appJs, /drafted/);
   assert.match(appJs, /reply-received/);
   assert.match(appJs, /follow-up-scheduled/);

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -8,7 +8,7 @@ describe('portal customer journey pages', () => {
     assert.match(html, /One portal\. Fast access\./);
     assert.match(html, /Find the apps, contacts, notes, websites, subscriptions, and support tools you need/);
     assert.doesNotMatch(html, /Grow into your own operating system/);
-    assert.match(html, /Open CRM/);
+    assert.match(html, /Open People Log/);
     assert.match(html, /Open Sales/);
     assert.match(html, /Open Web Builder/);
     assert.doesNotMatch(html, /System layers/);

--- a/tests/memory-capture.test.js
+++ b/tests/memory-capture.test.js
@@ -58,7 +58,7 @@ describe('Memory Capture app', () => {
 
     assert.match(portalHtml, /href="memory-capture\/"/);
     assert.match(portalHtml, /<span class="app-card__title">Memory Capture<\/span>/);
-    assert.match(portalHtml, /Brain dump conversations into CRM leads, proposals, and 3dvr-agent cleanup tasks/);
+    assert.match(portalHtml, /Brain dump conversations into people notes, proposals, and 3dvr-agent cleanup tasks/);
     assert.match(salesHtml, /href="..\/memory-capture\/"/);
     assert.match(salesHtml, /Memory Capture/);
   });

--- a/tests/roadmap-market.test.js
+++ b/tests/roadmap-market.test.js
@@ -28,7 +28,7 @@ describe('roadmap and CRM integration', () => {
 
   it('ships CRM capture for groups, people, problems, and quick leads', async () => {
     const html = await readFile(new URL('../crm/index.html', import.meta.url), 'utf8');
-    assert.match(html, /Add the next real lead fast\./);
+    assert.match(html, /Use this only when you know the basics\./);
     assert.match(html, /Use the full form when you need linked problems or more detailed notes\./);
     assert.match(html, /id="quickLeadForm"/);
     assert.match(html, /id="recordType"/);

--- a/tests/sales-outreach-crm.test.js
+++ b/tests/sales-outreach-crm.test.js
@@ -10,7 +10,7 @@ test('outreach CRM connects profiles, potential messages, and sent touches throu
   const outreachJs = await readFile(new URL('../sales/outreach.js', import.meta.url), 'utf8');
 
   assert.match(salesHubHtml, /Outreach CRM/);
-  assert.match(crmHtml, /Outreach CRM/);
+  assert.match(crmHtml, /Outreach/);
   assert.match(scoreboardHtml, /Outreach CRM/);
 
   assert.match(outreachHtml, /Customer profiles/);


### PR DESCRIPTION
## Summary
- Reframe the CRM page as a low-friction People Log with quick conversation capture at the top.
- Save messy day-to-day notes into existing person records when possible, otherwise create a person note with touch-log history.
- Collapse heavier sales helpers/reminders behind details panels and rename portal entry points from CRM language to People Log.

## Validation
- `npm ci`
- `node --check crm/app.js`
- `git diff --check`
- `node --test tests/crm-contacts-workflow.test.js tests/crm-touch-log-real.test.js tests/crm-sales-cockpit.test.js tests/sales-crm-handoff.test.js tests/sales-outreach-crm.test.js tests/roadmap-market.test.js tests/memory-capture.test.js tests/customer-journey-pages.test.js`
- Firefox browser smoke against local `/crm/` static page

Note: local Chromium opened but closed before creating a page in this container, so the browser smoke used Firefox. The only ignored console errors were expected Gun websocket attempts against the local static server.