### PR TITLE
Fix CRM mobile overflow

### DIFF
--- a/crm/index.html
+++ b/crm/index.html
@@ -14,6 +14,97 @@
   <script src="../oauth.js"></script>
   <script type="module" src="./app.js"></script>
   <script defer src="/_vercel/insights/script.js"></script>
+  <style>
+    html,
+    body {
+      max-width: 100%;
+      overflow-x: hidden;
+    }
+
+    body,
+    main,
+    section,
+    article,
+    form,
+    input,
+    select,
+    textarea,
+    button,
+    a {
+      min-width: 0;
+    }
+
+    #contactList,
+    #crmDuplicateSummary,
+    #crmDetailCard,
+    #crmCreateOverlay > div,
+    .crm-card {
+      max-width: 100%;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    #contactList .crm-card a,
+    #contactList .crm-card p,
+    #contactList .crm-card span,
+    #crmDetailCard p,
+    #crmDetailCard span,
+    #crmDetailCard a {
+      overflow-wrap: anywhere;
+    }
+
+    @media (max-width: 640px) {
+      main {
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+      }
+
+      #quickConversationCapture,
+      #crmPrimaryActions,
+      #crmSalesMovesPanel,
+      #crmAdvancedTools,
+      #crm-capture,
+      #contactList + div,
+      .crm-card {
+        border-radius: 1rem;
+      }
+
+      #crmFloatingIdentity {
+        max-width: calc(100vw - 2rem);
+        right: 1rem;
+      }
+
+      #crmCreateOverlay,
+      #crmDetailOverlay {
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+      }
+
+      #crmCreateOverlay > div,
+      #crmDetailCard {
+        padding: 1rem;
+      }
+
+      [class*="tracking-"] {
+        letter-spacing: 0.12em;
+      }
+
+      button,
+      a,
+      summary,
+      label {
+        max-width: 100%;
+        white-space: normal;
+      }
+
+      .crm-card .truncate,
+      #crmDetailName {
+        overflow: visible;
+        text-overflow: clip;
+        white-space: normal;
+      }
+    }
+  </style>
 </head>
 <body class="bg-gray-900 text-white font-sans min-h-screen">
   <header class="bg-gray-950/70 border-b border-white/10">

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -18,6 +18,10 @@ test('CRM page exposes workflow filters and import controls for fast lead retrie
   assert.match(html, /id="quickConversationChannel"/);
   assert.match(html, /id="quickConversationNextStep"/);
   assert.match(html, /Drop the note\. Keep moving\./);
+  assert.match(html, /overflow-x: hidden/);
+  assert.match(html, /overflow-wrap: anywhere/);
+  assert.match(html, /#crmFloatingIdentity/);
+  assert.match(html, /\.crm-card \.truncate/);
   assert.match(html, /id="crmPrimaryActions"/);
   assert.match(html, /Add person/);
   assert.match(html, /Open contacts/);


### PR DESCRIPTION
## Summary
- Add CRM page overflow guards so mobile does not get a wide horizontal viewport
- Let long names, emails, tags, and card titles wrap on small screens
- Reduce mobile letter spacing and modal/card padding so controls fit better

## Validation
- `node --test tests/crm-contacts-workflow.test.js tests/crm-sales-cockpit.test.js tests/roadmap-market.test.js`