### PR TITLE
Add Community Farming Network project

### DIFF
--- a/community-farming-network/app.js
+++ b/community-farming-network/app.js
@@ -1,0 +1,170 @@
+const FARMING_ROOT = 'communityFarmingNetwork';
+const LOCAL_KEY = '3dvr-community-farming-network';
+
+const state = {
+  entries: new Map(),
+  filter: 'all',
+};
+
+const els = {
+  form: document.getElementById('shareForm'),
+  type: document.getElementById('entryType'),
+  title: document.getElementById('entryTitle'),
+  neighborhood: document.getElementById('entryNeighborhood'),
+  timing: document.getElementById('entryTiming'),
+  details: document.getElementById('entryDetails'),
+  list: document.getElementById('entryList'),
+  status: document.getElementById('syncStatus'),
+  filters: Array.from(document.querySelectorAll('[data-filter]')),
+};
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function createId() {
+  return `farm_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function getGunRoot() {
+  if (typeof window.Gun !== 'function') {
+    els.status.textContent = 'Gun is not available. Saving locally in this browser.';
+    return null;
+  }
+
+  const gun = window.gun || window.Gun(window.__GUN_PEERS__ || ['https://gun-relay-3dvr.fly.dev/gun']);
+  window.gun = gun;
+  els.status.textContent = 'Connected to the portal Gun graph.';
+
+  // Future backend hook:
+  // gun.get('3dvr-portal').get('communityFarmingNetwork').get('entries').get(id)
+  return gun.get('3dvr-portal').get(FARMING_ROOT);
+}
+
+const root = getGunRoot();
+
+function saveLocalBackup() {
+  try {
+    const entries = Array.from(state.entries.values());
+    localStorage.setItem(LOCAL_KEY, JSON.stringify(entries));
+  } catch (_error) {
+    // Gun remains the primary shared store when available.
+  }
+}
+
+function loadLocalBackup() {
+  try {
+    const entries = JSON.parse(localStorage.getItem(LOCAL_KEY) || '[]');
+    if (!Array.isArray(entries)) return;
+    entries.forEach(entry => {
+      if (entry && entry.id && entry.title) state.entries.set(entry.id, entry);
+    });
+  } catch (_error) {
+    // Ignore malformed local drafts.
+  }
+}
+
+function typeLabel(value) {
+  const labels = {
+    harvest: 'Harvest',
+    garden: 'Garden',
+    labor: 'Labor',
+    resource: 'Tool',
+  };
+  return labels[value] || 'Post';
+}
+
+function formatDate(timestamp) {
+  const date = new Date(Number(timestamp || 0));
+  if (Number.isNaN(date.getTime())) return 'Recently';
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function renderEntries() {
+  const entries = Array.from(state.entries.values())
+    .filter(entry => entry && entry.title)
+    .filter(entry => state.filter === 'all' || entry.type === state.filter)
+    .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0));
+
+  els.list.innerHTML = '';
+  if (!entries.length) {
+    els.list.innerHTML = '<article class="entry-card"><p>No posts in this lane yet. Add the first food, labor, land, or tool note.</p></article>';
+    return;
+  }
+
+  entries.slice(0, 30).forEach(entry => {
+    const card = document.createElement('article');
+    card.className = 'entry-card';
+    card.innerHTML = `
+      <div class="entry-card__top">
+        <div>
+          <span class="entry-type"></span>
+          <h3></h3>
+        </div>
+        <small></small>
+      </div>
+      <p></p>
+      <div class="entry-meta"></div>
+    `;
+    card.querySelector('.entry-type').textContent = typeLabel(entry.type);
+    card.querySelector('h3').textContent = entry.title;
+    card.querySelector('small').textContent = formatDate(entry.createdAt);
+    card.querySelector('p').textContent = entry.details || 'No details yet.';
+
+    const meta = card.querySelector('.entry-meta');
+    [entry.neighborhood, entry.timing].filter(Boolean).forEach(value => {
+      const chip = document.createElement('span');
+      chip.textContent = value;
+      meta.append(chip);
+    });
+
+    els.list.append(card);
+  });
+}
+
+function addEntry(event) {
+  event.preventDefault();
+  const entry = {
+    id: createId(),
+    type: clean(els.type.value) || 'harvest',
+    title: clean(els.title.value),
+    neighborhood: clean(els.neighborhood.value),
+    timing: clean(els.timing.value),
+    details: clean(els.details.value),
+    createdAt: Date.now(),
+  };
+
+  if (!entry.title) return;
+  state.entries.set(entry.id, entry);
+  saveLocalBackup();
+  renderEntries();
+  root?.get('entries').get(entry.id).put(entry);
+  els.form.reset();
+  els.status.textContent = root ? 'Saved to the Community Farming Network.' : 'Saved locally.';
+}
+
+function bindFilters() {
+  els.filters.forEach(button => {
+    button.addEventListener('click', () => {
+      state.filter = button.dataset.filter || 'all';
+      els.filters.forEach(item => item.classList.toggle('active', item === button));
+      renderEntries();
+    });
+  });
+}
+
+function bindGun() {
+  if (!root) return;
+  root.get('entries').map().on((entry, id) => {
+    if (!entry || !entry.title) return;
+    state.entries.set(entry.id || id, { ...entry, id: entry.id || id });
+    saveLocalBackup();
+    renderEntries();
+  });
+}
+
+loadLocalBackup();
+bindFilters();
+els.form.addEventListener('submit', addEntry);
+renderEntries();
+bindGun();

--- a/community-farming-network/index.html
+++ b/community-farming-network/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Community Farming Network | 3dvr portal</title>
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <link rel="stylesheet" href="./styles.css" />
+  <script defer src="./app.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <nav class="nav" aria-label="Community Farming Network navigation">
+      <a href="../index.html">Portal</a>
+      <a href="../community/">Community</a>
+      <a href="../contacts/">Contacts</a>
+      <a href="../projects/">Projects</a>
+    </nav>
+    <section class="hero" aria-labelledby="pageTitle">
+      <div class="hero-copy">
+        <p class="eyebrow">3DVR local resilience project</p>
+        <h1 id="pageTitle">Community Farming Network</h1>
+        <p>
+          A neighborhood coordination layer for growing food, sharing harvests, trading labor,
+          and making unused land useful without turning it into another noisy social feed.
+          Use it to grow and share food and labor across the neighborhood.
+        </p>
+        <div class="hero-actions">
+          <a class="button primary" href="#shareForm">Log food or labor</a>
+          <a class="button secondary" href="#networkBoard">View network board</a>
+        </div>
+      </div>
+      <aside class="season-card" aria-labelledby="seasonTitle">
+        <p class="eyebrow">Operating idea</p>
+        <h2 id="seasonTitle">Food, skills, tools, and time should move locally.</h2>
+        <ol>
+          <li><strong>Grow</strong><span>Map yards, patios, gardens, and raised beds.</span></li>
+          <li><strong>Share</strong><span>Post surplus harvests before they go to waste.</span></li>
+          <li><strong>Help</strong><span>Trade labor for planting, watering, compost, and repairs.</span></li>
+        </ol>
+      </aside>
+    </section>
+  </header>
+
+  <main>
+    <section class="panel intro-grid" aria-labelledby="networkPurpose">
+      <div>
+        <p class="eyebrow">Why it belongs in the portal</p>
+        <h2 id="networkPurpose">A practical community layer.</h2>
+        <p>
+          The portal already tracks people, projects, notes, and community circles. This adds a
+          local food and labor graph: who can grow, who needs food, who has tools, and who can help.
+        </p>
+      </div>
+      <div class="principles">
+        <article>
+          <span>1</span>
+          <h3>Low-friction offers</h3>
+          <p>Post what exists today: tomatoes, seedlings, compost, a mower, or two hours of help.</p>
+        </article>
+        <article>
+          <span>2</span>
+          <h3>Neighborhood trust</h3>
+          <p>Start with known people, small circles, and clear handoffs before scaling outward.</p>
+        </article>
+        <article>
+          <span>3</span>
+          <h3>Visible next steps</h3>
+          <p>Every post should make the next move obvious: pick up, request help, join a work day.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="workspace-grid">
+      <form id="shareForm" class="panel form-panel" aria-labelledby="shareTitle">
+        <div>
+          <p class="eyebrow">Quick log</p>
+          <h2 id="shareTitle">Add food, land, labor, or tools.</h2>
+          <p>Keep it simple. A rough note is enough to start coordinating.</p>
+        </div>
+        <label>
+          Type
+          <select id="entryType" required>
+            <option value="harvest">Harvest share</option>
+            <option value="garden">Growing space</option>
+            <option value="labor">Labor request</option>
+            <option value="resource">Tool or resource</option>
+          </select>
+        </label>
+        <label>
+          Title
+          <input id="entryTitle" required placeholder="Extra basil, raised bed help, compost pile..." />
+        </label>
+        <div class="field-row">
+          <label>
+            Neighborhood
+            <input id="entryNeighborhood" placeholder="Street, block, town, or circle" />
+          </label>
+          <label>
+            Timing
+            <input id="entryTiming" placeholder="Today, Saturday morning, this season..." />
+          </label>
+        </div>
+        <label>
+          Details
+          <textarea id="entryDetails" rows="4" placeholder="What is available or needed? How should someone respond?"></textarea>
+        </label>
+        <button class="button primary" type="submit">Save to network</button>
+        <p id="syncStatus" class="sync-status" role="status" aria-live="polite">Connecting to Gun...</p>
+      </form>
+
+      <aside class="panel map-panel" aria-labelledby="starterMapTitle">
+        <p class="eyebrow">Starter map</p>
+        <h2 id="starterMapTitle">Four lanes to test first.</h2>
+        <div class="lane-list">
+          <article>
+            <strong>Backyard growers</strong>
+            <span>People with soil, sun, water, and a willingness to plant more.</span>
+          </article>
+          <article>
+            <strong>Harvest pickups</strong>
+            <span>Simple claims for excess produce, herbs, eggs, seedlings, or prepared food.</span>
+          </article>
+          <article>
+            <strong>Work days</strong>
+            <span>Small crews for raised beds, watering, weeding, compost, fences, and cleanup.</span>
+          </article>
+          <article>
+            <strong>Shared kit</strong>
+            <span>Tools, seeds, soil, starts, jars, buckets, and transport help.</span>
+          </article>
+        </div>
+      </aside>
+    </section>
+
+    <section id="networkBoard" class="panel board-panel" aria-labelledby="boardTitle">
+      <div class="board-head">
+        <div>
+          <p class="eyebrow">Live board</p>
+          <h2 id="boardTitle">Neighborhood food and labor posts</h2>
+        </div>
+        <div class="filters" aria-label="Filter board">
+          <button type="button" class="filter active" data-filter="all">All</button>
+          <button type="button" class="filter" data-filter="harvest">Harvest</button>
+          <button type="button" class="filter" data-filter="garden">Gardens</button>
+          <button type="button" class="filter" data-filter="labor">Labor</button>
+          <button type="button" class="filter" data-filter="resource">Tools</button>
+        </div>
+      </div>
+      <div id="entryList" class="entry-list" aria-live="polite"></div>
+    </section>
+
+    <section class="panel next-panel" aria-labelledby="nextTitle">
+      <p class="eyebrow">Next build steps</p>
+      <h2 id="nextTitle">How this can grow from project page to real network.</h2>
+      <div class="next-grid">
+        <article>
+          <h3>1. Tie posts to contacts</h3>
+          <p>Connect offers and requests to the People Log so neighbors, volunteers, and growers do not disappear.</p>
+        </article>
+        <article>
+          <h3>2. Add simple location privacy</h3>
+          <p>Use neighborhood labels first. Exact addresses should only be shared after a person opts in.</p>
+        </article>
+        <article>
+          <h3>3. Create work-day flows</h3>
+          <p>Turn labor requests into small scheduled events with tools, people, tasks, and follow-up notes.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/community-farming-network/styles.css
+++ b/community-farming-network/styles.css
@@ -1,0 +1,377 @@
+:root {
+  --bg: #07110c;
+  --panel: rgba(14, 34, 23, 0.86);
+  --panel-strong: rgba(18, 45, 30, 0.96);
+  --text: #f4f1df;
+  --muted: #c9c1a8;
+  --line: rgba(222, 238, 203, 0.16);
+  --soil: #9a6b3d;
+  --leaf: #8ed36d;
+  --mint: #b6e8b4;
+  --gold: #e6c15d;
+  --shadow: 0 22px 70px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(120deg, rgba(7, 17, 12, 0.92), rgba(7, 17, 12, 0.72)),
+    url("https://images.unsplash.com/photo-1464226184884-fa280b87c399?auto=format&fit=crop&w=1800&q=80") center/cover fixed;
+  line-height: 1.55;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent 80%);
+}
+
+a {
+  color: inherit;
+}
+
+.site-header,
+main {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.site-header {
+  padding: 22px 0 0;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.nav a,
+.button,
+.filter {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 10px 14px;
+  color: var(--text);
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.07);
+  font: inherit;
+  font-weight: 800;
+}
+
+.hero,
+.workspace-grid,
+.intro-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(300px, 0.85fr);
+  gap: 18px;
+}
+
+.hero {
+  align-items: stretch;
+}
+
+.hero-copy,
+.panel,
+.season-card {
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.hero-copy {
+  min-height: 440px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(26px, 5vw, 58px);
+}
+
+.season-card,
+.panel {
+  padding: 24px;
+}
+
+.season-card {
+  background: var(--panel-strong);
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--mint);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 10ch;
+  margin-bottom: 18px;
+  font-size: clamp(3rem, 9vw, 6.7rem);
+  line-height: 0.88;
+  letter-spacing: -0.07em;
+}
+
+h2 {
+  margin-bottom: 10px;
+  font-size: clamp(1.6rem, 4vw, 2.8rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+h3 {
+  margin-bottom: 8px;
+}
+
+.hero-copy p,
+.panel p,
+.season-card span,
+.entry-card p,
+.lane-list span {
+  color: var(--muted);
+}
+
+.hero-copy > p:not(.eyebrow) {
+  max-width: 62ch;
+  font-size: clamp(1.06rem, 2vw, 1.24rem);
+}
+
+.hero-actions,
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.hero-actions {
+  margin-top: 24px;
+}
+
+.button,
+.filter {
+  cursor: pointer;
+}
+
+.button.primary,
+.filter.active {
+  border-color: transparent;
+  color: #09120b;
+  background: linear-gradient(135deg, var(--leaf), var(--gold));
+}
+
+main {
+  display: grid;
+  gap: 18px;
+  padding: 18px 0 64px;
+}
+
+.season-card ol {
+  display: grid;
+  gap: 16px;
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.season-card strong,
+.season-card span {
+  display: block;
+}
+
+.principles,
+.next-grid,
+.lane-list,
+.entry-list {
+  display: grid;
+  gap: 12px;
+}
+
+.principles {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.principles article,
+.lane-list article,
+.entry-card,
+.next-grid article {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.principles span {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 12px;
+  border-radius: 999px;
+  color: #07110c;
+  background: var(--leaf);
+  font-weight: 900;
+}
+
+.form-panel {
+  display: grid;
+  gap: 14px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 0.94rem;
+  font-weight: 800;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  padding: 12px 14px;
+  color: var(--text);
+  background: rgba(3, 12, 8, 0.78);
+  font: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.field-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.sync-status {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.board-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.entry-card {
+  display: grid;
+  gap: 8px;
+}
+
+.entry-card__top {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.entry-type {
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  border-radius: 999px;
+  padding: 5px 9px;
+  color: #07110c;
+  background: var(--mint);
+  font-size: 0.76rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.entry-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.entry-meta span {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.next-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 860px) {
+  .hero,
+  .workspace-grid,
+  .intro-grid,
+  .principles,
+  .next-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-copy {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 620px) {
+  .site-header,
+  main {
+    width: min(100% - 20px, 1160px);
+  }
+
+  .hero-copy,
+  .panel,
+  .season-card {
+    border-radius: 18px;
+    padding: 18px;
+  }
+
+  .field-row,
+  .board-head {
+    grid-template-columns: 1fr;
+  }
+
+  .board-head,
+  .entry-card__top {
+    display: grid;
+  }
+
+  h1 {
+    letter-spacing: -0.04em;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -276,6 +276,11 @@
             <span class="app-card__title">Community</span>
             <span class="app-card__meta">Create builder circles, weekly check-ins, and focused project support threads.</span>
           </a>
+          <a href="community-farming-network/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">GROW</span>
+            <span class="app-card__title">Community Farming</span>
+            <span class="app-card__meta">Coordinate neighborhood food, growing space, tools, and labor sharing.</span>
+          </a>
           <a href="life/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌿</span>
             <span class="app-card__title">Life</span>

--- a/tests/community-farming-network.test.js
+++ b/tests/community-farming-network.test.js
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const baseDir = new URL('../community-farming-network/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+describe('Community Farming Network', () => {
+  it('ships a portal project page for neighborhood food and labor sharing', async () => {
+    const html = await readFile(new URL('index.html', baseDir), 'utf8');
+
+    assert.equal(await fileExists(new URL('index.html', baseDir)), true);
+    assert.equal(await fileExists(new URL('styles.css', baseDir)), true);
+    assert.equal(await fileExists(new URL('app.js', baseDir)), true);
+    assert.match(html, /Community Farming Network/);
+    assert.match(html, /grow and share food and labor/i);
+    assert.match(html, /id="shareForm"/);
+    assert.match(html, /id="entryType"/);
+    assert.match(html, /id="entryNeighborhood"/);
+    assert.match(html, /id="networkBoard"/);
+    assert.match(html, /Harvest share/);
+    assert.match(html, /Growing space/);
+    assert.match(html, /Labor request/);
+    assert.match(html, /Tool or resource/);
+    assert.match(html, /<script[^>]+src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"/);
+    assert.match(html, /<script[^>]+src="\.{2}\/gun-init\.js"/);
+  });
+
+  it('backs the first version with Gun plus a local browser backup', async () => {
+    const js = await readFile(new URL('app.js', baseDir), 'utf8');
+
+    assert.match(js, /FARMING_ROOT = 'communityFarmingNetwork'/);
+    assert.match(js, /LOCAL_KEY = '3dvr-community-farming-network'/);
+    assert.match(js, /gun\.get\('3dvr-portal'\)\.get\(FARMING_ROOT\)/);
+    assert.match(js, /root\?\.get\('entries'\)\.get\(entry\.id\)\.put\(entry\)/);
+    assert.match(js, /localStorage\.setItem\(LOCAL_KEY/);
+    assert.match(js, /data-filter/);
+  });
+
+  it('registers the project in the portal dock near Community', async () => {
+    const html = await readFile(new URL('../index.html', baseDir), 'utf8');
+    const communityIndex = html.indexOf('>Community<');
+    const farmingIndex = html.indexOf('>Community Farming<');
+    const lifeIndex = html.indexOf('>Life<');
+
+    assert.ok(communityIndex !== -1, 'Community app card should still be listed');
+    assert.ok(farmingIndex !== -1, 'Community Farming app card should be listed');
+    assert.ok(lifeIndex !== -1, 'Life app card should still be listed');
+    assert.ok(communityIndex < farmingIndex, 'Community Farming should render after Community');
+    assert.ok(farmingIndex < lifeIndex, 'Community Farming should render before Life');
+    assert.match(html, /href="community-farming-network\/"/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a new Community Farming Network portal project route
- Let neighbors log harvest shares, growing spaces, labor requests, and shared tools/resources
- Save posts to the portal Gun graph with localStorage as a browser backup
- Register the project in the portal app dock near Community

## Validation
- `node --test tests/community-farming-network.test.js tests/community-page.test.js`