### PR TITLE
[codex] Document path to profitability

### DIFF
--- a/docs/path-to-profitability.md
+++ b/docs/path-to-profitability.md
@@ -1,0 +1,409 @@
+# 3DVR Path To Profitability
+
+## Founder Thesis
+
+3dvr.tech should become profitable by selling practical launch and follow-up support before trying to sell the
+whole 3DVR universe.
+
+The business is not only a website, not only a portal, and not only an agent system. The first profitable shape is:
+
+> 3dvr.tech helps small businesses, creators, and warm-network leads launch a useful web presence and keep
+> follow-up from slipping.
+
+The portal, CRM, agent, open-source direction, hardware ideas, community tools, and labs all matter. They should
+support the business path, not compete with it on the first customer journey.
+
+## Core Business Rule
+
+Sell first. Build second. Keep it simple.
+
+Every active customer, lead, proposal, or internal product effort should have:
+
+- One owner.
+- One next step.
+- One expected business outcome.
+- One follow-up date.
+
+If a feature does not help win a customer, serve a customer, retain a customer, or create credible proof, it belongs
+in Labs until there is a business reason to promote it.
+
+## Current Position
+
+3DVR already has enough software to support early revenue:
+
+- `3dvr.tech` can explain the offer and route people to the portal.
+- `portal.3dvr.tech` can handle starts, billing, CRM, memory capture, proposals, releases, and support surfaces.
+- `3dvr-agent` can help with lead routing, outreach summaries, inbox monitoring, and operator workflows.
+- `3dvr-ops` can act as a private daily relationship layer for warm leads and follow-up.
+
+The constraint is not engineering capacity. The constraint is packaging, prioritization, and relationship throughput.
+
+## First Profitable Offer
+
+The first profitable offer should be simple enough to explain in one sentence:
+
+> I help you get your website, offer, or small business system live, then help you keep follow-up moving.
+
+This can be sold through several lanes:
+
+| Lane | Price | Best Fit | Promise |
+| --- | ---: | --- | --- |
+| Family & Friends | $5/month | Warm network, early believers, simple site/support continuity | Keep the relationship and light support active. |
+| Founder | $20/month | Creators, side hustlers, first offers, basic tech support | Move from rough idea to a live page or useful next step. |
+| Builder | $50/month | Active small businesses with customers, quotes, follow-up, or weekly operations | Maintain site, CRM rhythm, follow-up, and operating loop. |
+| Embedded | $200/month | Small teams or shared workflow pain | Help coordinate people, tools, scheduling, and repeatable workflows. |
+| Custom Sprint | $250-$1,500+ one-time | Scoped launch, landing page, render package, migration, automation, or urgent build | Ship a defined result quickly. |
+
+The monthly lanes create continuity. Custom sprints create cash and portfolio proof.
+
+## Ideal First Customers
+
+Prioritize customers who are already near the relationship graph:
+
+- Coworkers and coworkers' families.
+- Friends with side hustles.
+- Local service businesses.
+- Event vendors, party rentals, wedding vendors, AV-adjacent businesses.
+- Ecommerce and Alibaba reseller experiments.
+- Creators or small professionals who need a page, offer, CRM, or follow-up loop.
+- Existing subscribers who can be upgraded into a clearer lane.
+
+Avoid cold, abstract markets until the warm-network process is working.
+
+The strongest early customer is not the person who loves the whole vision. It is the person with a practical problem:
+
+- "I need a website."
+- "I need to launch this offer."
+- "I keep losing leads."
+- "I need someone to help with tech stuff."
+- "I need my business to look real."
+- "I need a simple system to follow up."
+
+## Positioning
+
+Use simple outward language:
+
+> Thomas helps small businesses with websites, branding, and tech stuff.
+
+Then let the deeper vision unfold after trust exists.
+
+Do not lead with:
+
+- Operating systems.
+- Decentralized infrastructure.
+- AI ecosystems.
+- Open-source society.
+- Hardware visions.
+- The full portal app list.
+
+Lead with a concrete result:
+
+- "Let's get your first page live."
+- "Let's make your business easier to send people to."
+- "Let's keep your leads from disappearing."
+- "Send me one product link and we will start there."
+
+## Customer Journey
+
+The target journey should be:
+
+1. Hear about 3dvr.tech through Thomas, a friend, a coworker, a card, or a link.
+2. Visit `https://3dvr.tech`.
+3. Pick a lane or start free.
+4. Continue into `https://portal.3dvr.tech`.
+5. Create one account.
+6. Pay or start free.
+7. Answer a tiny onboarding prompt.
+8. Get one visible first deliverable.
+9. Enter a weekly follow-up rhythm.
+
+The system should avoid forcing customers to understand the whole portal. They should know:
+
+- What they picked.
+- What happens next.
+- How to contact Thomas.
+- What result is being built.
+- When the next follow-up happens.
+
+## Portal Product Priority
+
+The portal should expose a smaller default business surface:
+
+1. Start
+2. People Log
+3. Memory Capture
+4. Projects / Proposals
+5. Billing
+
+Everything else should be secondary:
+
+- Labs
+- Community
+- Games
+- Experiments
+- Open-source research
+- Hardware prototypes
+
+This does not mean deleting the ecosystem. It means hiding complexity from the customer until it is relevant.
+
+## Operating Loop
+
+The business should run on a daily loop:
+
+1. Capture conversations quickly.
+2. Convert useful captures into People Log records.
+3. Attach one next step.
+4. Draft one short message.
+5. Send or approve the message.
+6. Record the outcome.
+7. Move proposals forward or close them.
+
+Memory Capture should become the default input. CRM should be the source of truth. `3dvr-agent` should become the
+operator that summarizes, reminds, and drafts, but Thomas should approve human messages.
+
+## Sales Process
+
+Use tiny asks. Avoid vague check-ins.
+
+Good asks:
+
+- "Can you send one product link?"
+- "Can you send three inspiration photos?"
+- "Can you send the business name and best contact?"
+- "Want to review one homepage tonight?"
+- "Can you send the current Facebook or Instagram page?"
+- "Can you upload the logo?"
+
+Bad asks:
+
+- "How's everything going?"
+- "Let me know if you need anything."
+- "We should talk sometime."
+- Long strategy dumps before the person has responded.
+
+Every warm lead should have a tiny next action and a follow-up date.
+
+## Proposal Pipeline
+
+The proposal system should stay simple:
+
+| Stage | Meaning | Next Action |
+| --- | --- | --- |
+| Idea | Possible project or customer problem noticed | Capture the person, problem, and one tiny ask. |
+| Draft | Offer is being shaped | Write scope, price, and first deliverable. |
+| Sent | Offer has been sent | Schedule follow-up within 2-5 days. |
+| Follow-up | Waiting on decision or missing input | Ask one concrete question. |
+| Won | Customer paid or verbally committed | Create project and first delivery task. |
+| Lost / Later | Not now or not a fit | Record why and set optional future reminder. |
+
+Proposal records should include:
+
+- Person
+- Business
+- Referrer
+- Problem
+- Offer
+- Price
+- Stage
+- Last contact
+- Next step
+- Follow-up date
+- Link to draft/message
+
+## Revenue Milestones
+
+Use revenue milestones instead of vague growth goals.
+
+### Milestone 1: First Reliable Signal
+
+Target:
+
+- 10 people on $5/month = $50 MRR
+- 3 people on $20/month = $60 MRR
+- 1 custom sprint at $250-$500
+
+Why it matters:
+
+- Confirms people will pay.
+- Creates testimonials and portfolio examples.
+- Forces the onboarding and follow-up process to become real.
+
+### Milestone 2: Side-Business Profitability
+
+Target:
+
+- 20 people on $5/month = $100 MRR
+- 10 people on $20/month = $200 MRR
+- 5 people on $50/month = $250 MRR
+- 1-2 custom sprints per month = $500-$2,000
+
+Expected revenue:
+
+- $550 MRR plus project revenue.
+
+Why it matters:
+
+- Covers basic software and hosting costs.
+- Proves the relationship loop can produce recurring support.
+- Creates enough activity to know which market is strongest.
+
+### Milestone 3: Real Monthly Engine
+
+Target:
+
+- 25 people on $5/month = $125 MRR
+- 15 people on $20/month = $300 MRR
+- 10 people on $50/month = $500 MRR
+- 2 teams on $200/month = $400 MRR
+- 2-4 custom sprints per month = $1,000-$6,000
+
+Expected revenue:
+
+- $1,325 MRR plus project revenue.
+
+Why it matters:
+
+- Creates a real business base.
+- Lets custom work fund product development.
+- Gives the portal enough usage to reveal what should become software.
+
+### Milestone 4: Productized Studio
+
+Target:
+
+- $3,000-$5,000 MRR
+- $3,000-$10,000 monthly project revenue
+- 3 repeatable service packages
+- 1 strong vertical or buyer segment
+
+At this point, 3DVR is no longer only freelance work. It becomes a productized studio with software leverage.
+
+## Weekly CEO Rhythm
+
+Every week should answer five questions:
+
+1. Who paid?
+2. Who almost paid?
+3. Who needs a follow-up?
+4. What proof did we create?
+5. What should we stop building?
+
+Suggested weekly cadence:
+
+- Monday: Review People Log, proposals, and billing.
+- Tuesday: Follow up with warm leads.
+- Wednesday: Ship one visible customer/proof asset.
+- Thursday: Improve one revenue path in portal or web.
+- Friday: Send updates, ask for referrals, and clean the pipeline.
+- Weekend: Explore labs only after customer follow-up is handled.
+
+## Product Strategy
+
+Treat the portal as internal leverage first, then external software second.
+
+The first job of the portal is to help Thomas:
+
+- Remember people.
+- Follow up.
+- Package offers.
+- Deliver work.
+- Keep billing attached to accounts.
+- Avoid dropping momentum.
+
+The second job is to help customers:
+
+- Start.
+- Pay.
+- See progress.
+- Send input.
+- Receive support.
+- Understand next steps.
+
+Do not expose every internal tool as a product. Promote a tool only when it helps a customer complete a business
+journey.
+
+## What To Stop Doing For Now
+
+Pause or hide anything that distracts from revenue unless it directly supports an active lead or proof asset:
+
+- New unrelated labs.
+- More public app cards without hierarchy.
+- Large platform rewrites.
+- Extra account complexity.
+- New payment flows before current billing is fully smooth.
+- Big philosophical landing pages without a business CTA.
+- Building for imaginary future users while warm leads need follow-up.
+
+The vision stays alive, but the company needs oxygen.
+
+## What To Build Next
+
+Highest leverage next builds:
+
+1. Today dashboard on `portal.3dvr.tech`
+   - Top follow-ups.
+   - Open proposals.
+   - Recent memory captures.
+   - Current revenue snapshot.
+   - One large "Log conversation" action.
+
+2. Proposal pipeline
+   - Built into Memory Capture or People Log first.
+   - Tracks amount, stage, next step, and follow-up date.
+
+3. Customer onboarding after billing
+   - "What are we building first?"
+   - "Send one link/photo/logo/product."
+   - "Best contact method."
+   - "What would count as launched?"
+
+4. Portal home hierarchy
+   - Business tools first.
+   - Labs collapsed.
+   - Experiments clearly separated.
+
+5. Agent daily brief
+   - Reads CRM, Memory Capture, proposals, and `3dvr-ops`.
+   - Produces top five follow-ups.
+   - Drafts messages for approval.
+
+## Key Metrics
+
+Track these weekly:
+
+- MRR by plan.
+- New paying customers.
+- Custom sprint revenue.
+- Number of warm leads captured.
+- Number of follow-ups sent.
+- Number of proposals sent.
+- Number of proposals won.
+- Time from conversation to next action.
+- Time from payment to first deliverable.
+- Churn or cancelled subscriptions.
+
+Avoid vanity metrics unless they support revenue:
+
+- App count.
+- Lab count.
+- Feature count.
+- Total ideas captured.
+- Total pages created.
+
+## Strategic Principle
+
+3DVR can still become a broad open-source, human-scale technology ecosystem.
+
+But the profitable path starts smaller:
+
+1. Help real people launch.
+2. Keep their follow-up alive.
+3. Turn repeated service patterns into software.
+4. Use revenue to fund the deeper vision.
+
+The first company is not "the future of computing."
+
+The first company is:
+
+> A practical, trusted tech partner for people who need to get unstuck and launch.
+


### PR DESCRIPTION
## Summary
- add a founder-level path to profitability document
- define first profitable offers, ideal customers, customer journey, revenue milestones, and operating cadence
- map portal, CRM, Memory Capture, agent, and 3dvr-ops into a focused revenue engine

## Validation
- git diff --check