### PR TITLE
[codex] Add revenue desk operating surface

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,8 @@
               without digging through unfinished system layers.
             </p>
             <div class="hero-actions">
-              <a href="crm/index.html" class="cta primary">Open People Log</a>
+              <a href="revenue-desk/" class="cta primary">Open Revenue Desk</a>
+              <a href="crm/index.html" class="cta ghost">Open People Log</a>
               <a href="sales/index.html" class="cta ghost">Open Sales</a>
               <a href="web-builder-app/index.html" class="cta ghost">Open Web Builder</a>
             </div>
@@ -255,6 +256,11 @@
             <span class="app-card__icon" aria-hidden="true">🧭</span>
             <span class="app-card__title">Start Here</span>
             <span class="app-card__meta">Choose the right path for your idea, offer, or next 3dvr.tech collaboration.</span>
+          </a>
+          <a href="revenue-desk/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">REV</span>
+            <span class="app-card__title">Revenue Desk</span>
+            <span class="app-card__meta">Run the daily founder loop: follow-ups, proposals, billing, and one revenue move.</span>
           </a>
           <a href="/admin/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🛠️</span>

--- a/revenue-desk/app.js
+++ b/revenue-desk/app.js
@@ -1,0 +1,608 @@
+const REVENUE_STORAGE_KEY = '3dvr.revenueDesk.snapshot.v1';
+const PROPOSAL_STORAGE_KEY = '3dvr.revenueDesk.proposals.v1';
+const ROOT_KEY = '3dvr-portal';
+const REVENUE_NODE = 'revenue-desk';
+const PROPOSALS_NODE = 'proposals';
+const MEMORY_CAPTURE_NODE = 'memoryCapture';
+const TOUCH_LOG_NODE = 'crm-touch-log';
+const AGENT_OWNER_ALIAS = '3dvr-managed';
+const DEFAULT_PEERS = [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+];
+
+const PLAN_PRICES = Object.freeze({
+  starter: 5,
+  pro: 20,
+  builder: 50,
+  embedded: 200
+});
+
+const OPEN_STAGES = ['idea', 'draft', 'sent', 'follow-up'];
+const STAGE_LABELS = Object.freeze({
+  idea: 'Idea',
+  draft: 'Draft',
+  sent: 'Sent',
+  'follow-up': 'Follow-up',
+  won: 'Won',
+  lost: 'Lost / later'
+});
+
+const state = {
+  snapshot: loadSnapshot(),
+  proposals: loadLocalProposals(),
+  recentCaptures: {},
+  touchLog: {}
+};
+
+const gun = typeof Gun === 'function' ? Gun(window.__GUN_PEERS__ || DEFAULT_PEERS) : null;
+const portalRoot = gun ? gun.get(ROOT_KEY) : null;
+const revenueRoot = portalRoot ? portalRoot.get(REVENUE_NODE) : null;
+const proposalRoot = portalRoot ? portalRoot.get(PROPOSALS_NODE) : null;
+const captureRoot = portalRoot ? portalRoot.get(MEMORY_CAPTURE_NODE).get('captures') : null;
+const touchLogRoot = portalRoot ? portalRoot.get(TOUCH_LOG_NODE) : null;
+const agentQueueRoot = portalRoot
+  ? portalRoot.get('agentOps').get(AGENT_OWNER_ALIAS).get('taskQueue')
+  : null;
+
+const els = {
+  syncStatus: document.getElementById('syncStatus'),
+  revenueForm: document.getElementById('revenueForm'),
+  customSprintRevenue: document.getElementById('customSprintRevenue'),
+  mrrValue: document.getElementById('mrrValue'),
+  projectRevenueValue: document.getElementById('projectRevenueValue'),
+  monthlyEngineValue: document.getElementById('monthlyEngineValue'),
+  milestoneValue: document.getElementById('milestoneValue'),
+  dailyBriefList: document.getElementById('dailyBriefList'),
+  proposalForm: document.getElementById('proposalForm'),
+  proposalPerson: document.getElementById('proposalPerson'),
+  proposalOffer: document.getElementById('proposalOffer'),
+  proposalAmount: document.getElementById('proposalAmount'),
+  proposalStage: document.getElementById('proposalStage'),
+  proposalFollowUp: document.getElementById('proposalFollowUp'),
+  proposalNextStep: document.getElementById('proposalNextStep'),
+  proposalBoard: document.getElementById('proposalBoard'),
+  openProposalCount: document.getElementById('openProposalCount'),
+  sentProposalCount: document.getElementById('sentProposalCount'),
+  wonProposalCount: document.getElementById('wonProposalCount'),
+  openProposalValue: document.getElementById('openProposalValue'),
+  agentBriefButton: document.getElementById('agentBriefButton')
+};
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeCount(value) {
+  const number = Number(value || 0);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+}
+
+function normalizeMoney(value) {
+  const number = Number(value || 0);
+  return Number.isFinite(number) && number > 0 ? Math.round(number) : 0;
+}
+
+function slug(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 54) || 'item';
+}
+
+function makeId(prefix, seed = '') {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${slug(seed)}-${Date.now().toString(36)}-${random}`;
+}
+
+function todayDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDays(days) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function safe(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatMoney(value) {
+  const amount = normalizeMoney(value);
+  return `$${amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+}
+
+function loadJson(key, fallback) {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw);
+  } catch (error) {
+    return fallback;
+  }
+}
+
+function saveJson(key, value) {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('Revenue Desk local save failed.', error);
+  }
+}
+
+function loadSnapshot() {
+  const fallback = {
+    planCounts: { starter: 0, pro: 0, builder: 0, embedded: 0 },
+    customSprintRevenue: 0,
+    updatedAt: ''
+  };
+  const stored = loadJson(REVENUE_STORAGE_KEY, fallback);
+  return {
+    planCounts: {
+      starter: normalizeCount(stored?.planCounts?.starter),
+      pro: normalizeCount(stored?.planCounts?.pro),
+      builder: normalizeCount(stored?.planCounts?.builder),
+      embedded: normalizeCount(stored?.planCounts?.embedded)
+    },
+    customSprintRevenue: normalizeMoney(stored?.customSprintRevenue),
+    updatedAt: normalizeText(stored?.updatedAt)
+  };
+}
+
+function loadLocalProposals() {
+  const stored = loadJson(PROPOSAL_STORAGE_KEY, []);
+  if (!Array.isArray(stored)) return {};
+  return stored.reduce((output, proposal) => {
+    const clean = normalizeProposal(proposal);
+    if (clean?.id) output[clean.id] = clean;
+    return output;
+  }, {});
+}
+
+function persistLocalProposals() {
+  saveJson(PROPOSAL_STORAGE_KEY, getProposals().slice(0, 100));
+}
+
+function calculateMrr(snapshot = state.snapshot) {
+  return Object.entries(PLAN_PRICES).reduce((total, [plan, price]) => {
+    return total + normalizeCount(snapshot.planCounts?.[plan]) * price;
+  }, 0);
+}
+
+function getMilestone(totalMonthlyRevenue) {
+  if (totalMonthlyRevenue >= 6000) return 'Productized studio';
+  if (totalMonthlyRevenue >= 1325) return 'Real monthly engine';
+  if (totalMonthlyRevenue >= 550) return 'Side-business profitability';
+  if (totalMonthlyRevenue >= 100) return 'First reliable signal';
+  return 'First signal';
+}
+
+function updateStatus(message) {
+  if (els.syncStatus) {
+    els.syncStatus.textContent = message;
+  }
+}
+
+function putGun(node, payload) {
+  return new Promise((resolve, reject) => {
+    if (!node || typeof node.put !== 'function') {
+      reject(new Error('Gun is unavailable.'));
+      return;
+    }
+    const timer = window.setTimeout(() => resolve({ timedOut: true }), 6000);
+    node.put(payload, (ack) => {
+      window.clearTimeout(timer);
+      if (ack && ack.err) {
+        reject(new Error(String(ack.err)));
+      } else {
+        resolve(ack || {});
+      }
+    });
+  });
+}
+
+function cleanGunRecord(record) {
+  if (!record || typeof record !== 'object') return null;
+  const { _, ...clean } = record;
+  return clean;
+}
+
+function normalizeProposal(value) {
+  if (!value || typeof value !== 'object') return null;
+  const id = normalizeText(value.id);
+  if (!id) return null;
+  const stage = normalizeText(value.status || value.stage || 'idea');
+  const amount = normalizeMoney(value.estimatedValue || value.price || value.amount);
+  return {
+    id,
+    title: normalizeText(value.title) || `${normalizeText(value.person || value.name) || 'Proposal'} proposal`,
+    person: normalizeText(value.person || value.name || value.title),
+    status: STAGE_LABELS[stage] ? stage : 'idea',
+    offer: normalizeText(value.offer),
+    scope: normalizeText(value.scope),
+    nextBestAction: normalizeText(value.nextBestAction || value.nextStep),
+    price: amount ? String(amount) : '',
+    estimatedValue: amount,
+    followUpAt: normalizeText(value.followUpAt || value.followUpDate),
+    source: normalizeText(value.source) || 'revenue-desk',
+    notes: normalizeText(value.notes),
+    createdAt: normalizeText(value.createdAt),
+    updatedAt: normalizeText(value.updatedAt)
+  };
+}
+
+function getProposals() {
+  return Object.values(state.proposals)
+    .map(normalizeProposal)
+    .filter(Boolean)
+    .sort((a, b) => String(b.updatedAt || '').localeCompare(String(a.updatedAt || '')));
+}
+
+function isDue(dateString) {
+  const date = normalizeText(dateString);
+  return Boolean(date) && date <= todayDate();
+}
+
+function hydrateForm() {
+  for (const [plan, count] of Object.entries(state.snapshot.planCounts)) {
+    const input = document.querySelector(`[data-plan-input="${plan}"]`);
+    if (input) input.value = String(count || '');
+  }
+  els.customSprintRevenue.value = state.snapshot.customSprintRevenue ? String(state.snapshot.customSprintRevenue) : '';
+  els.proposalFollowUp.value = addDays(3);
+}
+
+async function saveRevenueSnapshot(event) {
+  event?.preventDefault();
+  const snapshot = {
+    planCounts: {
+      starter: normalizeCount(document.querySelector('[data-plan-input="starter"]')?.value),
+      pro: normalizeCount(document.querySelector('[data-plan-input="pro"]')?.value),
+      builder: normalizeCount(document.querySelector('[data-plan-input="builder"]')?.value),
+      embedded: normalizeCount(document.querySelector('[data-plan-input="embedded"]')?.value)
+    },
+    customSprintRevenue: normalizeMoney(els.customSprintRevenue.value),
+    updatedAt: new Date().toISOString()
+  };
+
+  state.snapshot = snapshot;
+  saveJson(REVENUE_STORAGE_KEY, snapshot);
+  render();
+
+  try {
+    await putGun(revenueRoot.get('state'), snapshot);
+    updateStatus('Gun synced: saved revenue snapshot to 3dvr-portal/revenue-desk/state.');
+  } catch (error) {
+    updateStatus(`Local snapshot saved. ${error.message || 'Gun sync failed.'}`);
+  }
+}
+
+function buildProposalFromForm() {
+  const person = normalizeText(els.proposalPerson.value);
+  if (!person) {
+    throw new Error('Add the person or business before creating a proposal.');
+  }
+
+  const now = new Date().toISOString();
+  const amount = normalizeMoney(els.proposalAmount.value);
+  return {
+    id: makeId('proposal', person),
+    title: `${person} proposal`,
+    person,
+    status: normalizeText(els.proposalStage.value) || 'idea',
+    offer: normalizeText(els.proposalOffer.value) || 'Offer needs shape',
+    scope: 'Created from Revenue Desk.',
+    nextBestAction: normalizeText(els.proposalNextStep.value) || 'Ask one tiny next question.',
+    price: amount ? String(amount) : '',
+    estimatedValue: amount,
+    followUpAt: normalizeText(els.proposalFollowUp.value) || addDays(3),
+    source: 'revenue-desk',
+    notes: '',
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+async function addProposal(event) {
+  event.preventDefault();
+  let proposal;
+  try {
+    proposal = buildProposalFromForm();
+  } catch (error) {
+    updateStatus(error.message);
+    return;
+  }
+
+  state.proposals[proposal.id] = proposal;
+  persistLocalProposals();
+  render();
+
+  try {
+    await putGun(proposalRoot.get(proposal.id), proposal);
+    updateStatus(`Gun synced: added proposal for ${proposal.person}.`);
+  } catch (error) {
+    updateStatus(`Proposal saved locally. ${error.message || 'Gun sync failed.'}`);
+  }
+
+  els.proposalForm.reset();
+  els.proposalFollowUp.value = addDays(3);
+}
+
+async function updateProposalStage(id, stage) {
+  const proposal = normalizeProposal(state.proposals[id]);
+  if (!proposal || !STAGE_LABELS[stage]) return;
+
+  const updated = {
+    ...proposal,
+    status: stage,
+    updatedAt: new Date().toISOString(),
+    closedAt: stage === 'won' || stage === 'lost' ? new Date().toISOString() : ''
+  };
+
+  state.proposals[id] = updated;
+  persistLocalProposals();
+  render();
+
+  try {
+    await putGun(proposalRoot.get(id), updated);
+    updateStatus(`Gun synced: ${proposal.person || proposal.title} moved to ${STAGE_LABELS[stage]}.`);
+  } catch (error) {
+    updateStatus(`Stage saved locally. ${error.message || 'Gun sync failed.'}`);
+  }
+}
+
+function buildAgentDailyBriefTask() {
+  const mrr = calculateMrr();
+  const openProposals = getProposals().filter(proposal => OPEN_STAGES.includes(proposal.status));
+  const dueProposals = openProposals.filter(proposal => isDue(proposal.followUpAt));
+  const taskLines = [
+    'Create a practical 3DVR daily revenue brief.',
+    '',
+    'Use the portal state first: CRM, crm-touch-log, memoryCapture, proposals, sales scoreboard, and revenue-desk.',
+    'Also check private 3dvr-ops if available to compare people next steps.',
+    '',
+    `Current manual MRR: ${formatMoney(mrr)}`,
+    `Custom sprint revenue this period: ${formatMoney(state.snapshot.customSprintRevenue)}`,
+    `Open proposals: ${openProposals.length}`,
+    `Due proposals: ${dueProposals.length}`,
+    '',
+    'Return:',
+    '- top 5 people to follow up with',
+    '- one message draft per person',
+    '- proposals that need action',
+    '- one revenue move for today',
+    '- anything that should be hidden or paused'
+  ];
+
+  const id = makeId('revenue-brief', todayDate());
+  return {
+    id,
+    task: taskLines.join('\n'),
+    tenantId: 'portal:revenue-desk',
+    tenantAlias: window.localStorage.getItem('alias') || window.localStorage.getItem('username') || 'revenue-desk',
+    tenantPlan: 'builder',
+    backend: 'codex',
+    repo: 'tmsteph/3dvr-portal',
+    model: '',
+    thinking: 'high',
+    unsafe: false,
+    riskClass: 'workspace_write',
+    approvalStatus: 'not_required',
+    requiredCapabilities: 'codex,crm,gun',
+    maxRuntimeMs: 0,
+    status: 'queued',
+    requestedBy: 'revenue-desk',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    resultSummary: '',
+    error: '',
+    workerDeviceId: ''
+  };
+}
+
+async function queueAgentDailyBrief() {
+  const task = buildAgentDailyBriefTask();
+  try {
+    await putGun(agentQueueRoot.get(task.id), task);
+    await putGun(agentQueueRoot.get('latest'), { id: task.id, updatedAt: task.updatedAt });
+    updateStatus(`Agent daily brief queued: ${task.id}`);
+  } catch (error) {
+    updateStatus(`Agent brief not queued. ${error.message || 'Gun sync failed.'}`);
+  }
+}
+
+function renderMetrics() {
+  const mrr = calculateMrr();
+  const projectRevenue = normalizeMoney(state.snapshot.customSprintRevenue);
+  const total = mrr + projectRevenue;
+  els.mrrValue.textContent = formatMoney(mrr);
+  els.projectRevenueValue.textContent = formatMoney(projectRevenue);
+  els.monthlyEngineValue.textContent = formatMoney(total);
+  els.milestoneValue.textContent = getMilestone(total);
+}
+
+function renderDailyBrief() {
+  const proposals = getProposals();
+  const open = proposals.filter(proposal => OPEN_STAGES.includes(proposal.status));
+  const due = open.filter(proposal => isDue(proposal.followUpAt));
+  const mrr = calculateMrr();
+  const items = [];
+
+  if (due.length) {
+    items.push({
+      tone: 'urgent',
+      title: `${due.length} proposal${due.length === 1 ? '' : 's'} need follow-up`,
+      body: due.slice(0, 3).map(proposal => proposal.person || proposal.title).join(', ')
+    });
+  }
+
+  if (open.length) {
+    const top = open[0];
+    items.push({
+      tone: 'money',
+      title: 'Move the highest-value open proposal',
+      body: `${top.person || top.title}: ${top.nextBestAction || 'Ask one tiny next question.'}`
+    });
+  }
+
+  if (mrr < 100) {
+    items.push({
+      tone: 'money',
+      title: 'Milestone 1 needs more paid signal',
+      body: 'Ask one warm-network person to choose the $5 or $20 lane today.'
+    });
+  } else {
+    items.push({
+      tone: 'money',
+      title: `Current MRR is ${formatMoney(mrr)}`,
+      body: 'Protect retention by shipping one visible customer result this week.'
+    });
+  }
+
+  if (!Object.keys(state.recentCaptures).length) {
+    items.push({
+      tone: 'normal',
+      title: 'Capture the next real conversation',
+      body: 'Open Memory Capture after the next work, friend, or customer conversation.'
+    });
+  }
+
+  els.dailyBriefList.innerHTML = items.map(item => `
+    <article class="brief-item" data-tone="${safe(item.tone)}">
+      <strong>${safe(item.title)}</strong>
+      <p>${safe(item.body)}</p>
+    </article>
+  `).join('');
+}
+
+function renderProposals() {
+  const proposals = getProposals();
+  const open = proposals.filter(proposal => OPEN_STAGES.includes(proposal.status));
+  const sent = proposals.filter(proposal => proposal.status === 'sent' || proposal.status === 'follow-up');
+  const won = proposals.filter(proposal => proposal.status === 'won');
+  const openValue = open.reduce((total, proposal) => total + normalizeMoney(proposal.estimatedValue), 0);
+
+  els.openProposalCount.textContent = String(open.length);
+  els.sentProposalCount.textContent = String(sent.length);
+  els.wonProposalCount.textContent = String(won.length);
+  els.openProposalValue.textContent = formatMoney(openValue);
+
+  if (!proposals.length) {
+    els.proposalBoard.innerHTML = '<p class="empty">No proposals yet. Add the first warm lead or create one from Memory Capture.</p>';
+    return;
+  }
+
+  els.proposalBoard.innerHTML = proposals.slice(0, 40).map(proposal => {
+    const stageButtons = Object.keys(STAGE_LABELS)
+      .filter(stage => stage !== proposal.status)
+      .map(stage => `<button type="button" data-proposal-id="${safe(proposal.id)}" data-proposal-stage="${safe(stage)}">${safe(STAGE_LABELS[stage])}</button>`)
+      .join('');
+
+    return `
+      <article class="proposal-card" data-proposal-id="${safe(proposal.id)}">
+        <div>
+          <small>${safe(STAGE_LABELS[proposal.status] || proposal.status)}</small>
+          <strong>${safe(proposal.person || proposal.title)}</strong>
+          <p>${safe(proposal.nextBestAction || 'Ask one tiny next question.')}</p>
+        </div>
+        <dl class="proposal-meta">
+          <div><dt>Offer</dt><dd>${safe(proposal.offer || 'TBD')}</dd></div>
+          <div><dt>Value</dt><dd>${safe(formatMoney(proposal.estimatedValue))}</dd></div>
+          <div><dt>Follow-up</dt><dd>${safe(proposal.followUpAt || 'Unset')}</dd></div>
+          <div><dt>Source</dt><dd>${safe(proposal.source || 'revenue-desk')}</dd></div>
+        </dl>
+        <div class="proposal-actions">${stageButtons}</div>
+      </article>
+    `;
+  }).join('');
+}
+
+function render() {
+  renderMetrics();
+  renderProposals();
+  renderDailyBrief();
+}
+
+function subscribeGun() {
+  if (!revenueRoot || !proposalRoot) {
+    updateStatus('Gun unavailable. Revenue Desk is using local storage only.');
+    return;
+  }
+
+  revenueRoot.get('state').once((snapshot) => {
+    const clean = cleanGunRecord(snapshot);
+    if (!clean?.updatedAt) return;
+    if (!state.snapshot.updatedAt || clean.updatedAt > state.snapshot.updatedAt) {
+      state.snapshot = loadSnapshotFromRemote(clean);
+      saveJson(REVENUE_STORAGE_KEY, state.snapshot);
+      hydrateForm();
+      render();
+      updateStatus('Gun synced: loaded revenue snapshot.');
+    }
+  });
+
+  proposalRoot.map().on((proposal) => {
+    const clean = normalizeProposal(cleanGunRecord(proposal));
+    if (!clean?.id) return;
+    state.proposals[clean.id] = clean;
+    persistLocalProposals();
+    render();
+  });
+
+  captureRoot?.map().on((capture) => {
+    const clean = cleanGunRecord(capture);
+    if (!clean?.id) return;
+    state.recentCaptures[clean.id] = clean;
+    renderDailyBrief();
+  });
+
+  touchLogRoot?.map().on((touch) => {
+    const clean = cleanGunRecord(touch);
+    if (!clean?.id) return;
+    state.touchLog[clean.id] = clean;
+  });
+
+  updateStatus('Gun sync: connected to revenue, proposals, captures, and touch log nodes.');
+}
+
+function loadSnapshotFromRemote(clean) {
+  return {
+    planCounts: {
+      starter: normalizeCount(clean?.planCounts?.starter),
+      pro: normalizeCount(clean?.planCounts?.pro),
+      builder: normalizeCount(clean?.planCounts?.builder),
+      embedded: normalizeCount(clean?.planCounts?.embedded)
+    },
+    customSprintRevenue: normalizeMoney(clean?.customSprintRevenue),
+    updatedAt: normalizeText(clean?.updatedAt)
+  };
+}
+
+function bindEvents() {
+  els.revenueForm?.addEventListener('submit', saveRevenueSnapshot);
+  els.proposalForm?.addEventListener('submit', addProposal);
+  els.agentBriefButton?.addEventListener('click', queueAgentDailyBrief);
+  els.proposalBoard?.addEventListener('click', (event) => {
+    const button = event.target.closest('[data-proposal-stage][data-proposal-id]');
+    if (!button) return;
+    updateProposalStage(button.dataset.proposalId, button.dataset.proposalStage);
+  });
+}
+
+function init() {
+  hydrateForm();
+  bindEvents();
+  render();
+  subscribeGun();
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', init);
+}

--- a/revenue-desk/index.html
+++ b/revenue-desk/index.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Revenue Desk | 3dvr portal</title>
+  <meta
+    name="description"
+    content="The 3DVR founder operating desk for daily revenue moves, proposal follow-up, MRR tracking, and agent-assisted sales cleanup."
+  />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#0d1117" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+</head>
+<body>
+  <div class="shell">
+    <header class="hero">
+      <nav class="topbar" aria-label="Revenue desk navigation">
+        <a href="../">Portal</a>
+        <a href="../memory-capture/">Memory Capture</a>
+        <a href="../crm/">People Log</a>
+        <a href="../billing/">Billing</a>
+        <a href="../sales/">Sales</a>
+        <a href="../admin/#agent-ops-card">Agent Ops</a>
+        <a href="../docs/path-to-profitability.md">Profitability Plan</a>
+      </nav>
+
+      <div class="hero-grid">
+        <div>
+          <p class="eyebrow">Founder operating desk</p>
+          <h1>Run the company from one revenue move.</h1>
+          <p class="lead">
+            Use this desk to keep 3dvr.tech focused on cash, customers, follow-up, and proof. Sell first.
+            Build second. Keep it simple.
+          </p>
+          <div class="hero-actions" aria-label="Primary revenue actions">
+            <a class="button primary" href="../memory-capture/">Log conversation</a>
+            <a class="button" href="../crm/">Open People Log</a>
+            <a class="button" href="../billing/">Open Billing</a>
+          </div>
+        </div>
+
+        <aside class="status-card" aria-live="polite">
+          <span>Company rule</span>
+          <strong>One lead. One offer. One ask.</strong>
+          <p id="syncStatus">Gun sync: connecting to 3dvr-portal/revenue-desk/state.</p>
+        </aside>
+      </div>
+    </header>
+
+    <main>
+      <section class="panel command-panel" aria-labelledby="command-title">
+        <div class="section-head">
+          <p class="eyebrow">Today</p>
+          <h2 id="command-title">Do the next sales move before opening another lab.</h2>
+          <p>
+            Pick one warm lead, move one proposal, or ask one customer for the missing input that turns interest into
+            delivery.
+          </p>
+        </div>
+
+        <div class="command-grid">
+          <article>
+            <span>01</span>
+            <strong>Capture</strong>
+            <p>Brain dump a real conversation before it fades.</p>
+            <a href="../memory-capture/">Open Memory Capture</a>
+          </article>
+          <article>
+            <span>02</span>
+            <strong>Follow up</strong>
+            <p>Open People Log and send one tiny ask.</p>
+            <a href="../crm/">Open People Log</a>
+          </article>
+          <article>
+            <span>03</span>
+            <strong>Close</strong>
+            <p>Route a ready person into the correct billing lane.</p>
+            <a href="../billing/">Open Billing</a>
+          </article>
+          <article>
+            <span>04</span>
+            <strong>Delegate</strong>
+            <p>Queue a daily cleanup task for the managed agent path.</p>
+            <button id="agentBriefButton" type="button">Queue agent daily brief</button>
+          </article>
+        </div>
+      </section>
+
+      <section class="dashboard-grid" aria-label="Revenue dashboard">
+        <article class="panel" aria-labelledby="snapshot-title">
+          <div class="section-head">
+            <p class="eyebrow">Revenue snapshot</p>
+            <h2 id="snapshot-title">Manual numbers until Stripe sync is the default.</h2>
+            <p>
+              Track the weekly CEO view: MRR by plan plus custom sprint revenue. This saves locally and backs up to
+              <code>3dvr-portal/revenue-desk/state</code>.
+            </p>
+          </div>
+
+          <form id="revenueForm" class="revenue-form">
+            <label>
+              <span>$5 customers</span>
+              <input data-plan-input="starter" type="number" min="0" step="1" inputmode="numeric" />
+            </label>
+            <label>
+              <span>$20 customers</span>
+              <input data-plan-input="pro" type="number" min="0" step="1" inputmode="numeric" />
+            </label>
+            <label>
+              <span>$50 customers</span>
+              <input data-plan-input="builder" type="number" min="0" step="1" inputmode="numeric" />
+            </label>
+            <label>
+              <span>$200 teams</span>
+              <input data-plan-input="embedded" type="number" min="0" step="1" inputmode="numeric" />
+            </label>
+            <label>
+              <span>Custom sprint revenue</span>
+              <input id="customSprintRevenue" type="number" min="0" step="25" inputmode="decimal" />
+            </label>
+            <button class="button primary" type="submit">Save revenue snapshot</button>
+          </form>
+
+          <div class="metric-grid" aria-label="Revenue metrics">
+            <div>
+              <span>MRR</span>
+              <strong id="mrrValue">$0</strong>
+            </div>
+            <div>
+              <span>Project revenue</span>
+              <strong id="projectRevenueValue">$0</strong>
+            </div>
+            <div>
+              <span>Monthly engine</span>
+              <strong id="monthlyEngineValue">$0</strong>
+            </div>
+            <div>
+              <span>Milestone</span>
+              <strong id="milestoneValue">First signal</strong>
+            </div>
+          </div>
+        </article>
+
+        <aside class="panel" aria-labelledby="brief-title">
+          <div class="section-head">
+            <p class="eyebrow">Daily brief</p>
+            <h2 id="brief-title">What needs motion?</h2>
+            <p>Built from the proposal board, recent captures, and local revenue state.</p>
+          </div>
+          <div id="dailyBriefList" class="brief-list">
+            <p class="empty">Add a proposal or revenue snapshot to create the first daily brief.</p>
+          </div>
+          <div class="link-stack">
+            <a href="../sales/scoreboard.html">Open profitability scoreboard</a>
+            <a href="../sales/research.html">Open market research</a>
+            <a href="../docs/path-to-profitability.md">Read CEO plan</a>
+          </div>
+        </aside>
+      </section>
+
+      <section class="panel" aria-labelledby="proposal-title">
+        <div class="section-head row">
+          <div>
+            <p class="eyebrow">Pipeline</p>
+            <h2 id="proposal-title">Proposal pipeline</h2>
+            <p>
+              Keep every possible deal tied to an amount, stage, next step, and follow-up date. Proposal records are
+              written to <code>3dvr-portal/proposals</code> so Memory Capture can see them too.
+            </p>
+          </div>
+          <a class="button" href="../memory-capture/">Create from capture</a>
+        </div>
+
+        <form id="proposalForm" class="proposal-form">
+          <label>
+            <span>Person or business</span>
+            <input id="proposalPerson" type="text" autocomplete="off" placeholder="Victor / Brenda / local vendor" />
+          </label>
+          <label>
+            <span>Offer</span>
+            <input id="proposalOffer" type="text" autocomplete="off" placeholder="$20 launch, $50 builder, custom sprint" />
+          </label>
+          <label>
+            <span>Amount</span>
+            <input id="proposalAmount" type="number" min="0" step="5" inputmode="decimal" />
+          </label>
+          <label>
+            <span>Stage</span>
+            <select id="proposalStage">
+              <option value="idea">Idea</option>
+              <option value="draft">Draft</option>
+              <option value="sent">Sent</option>
+              <option value="follow-up">Follow-up</option>
+              <option value="won">Won</option>
+              <option value="lost">Lost / later</option>
+            </select>
+          </label>
+          <label>
+            <span>Follow-up date</span>
+            <input id="proposalFollowUp" type="date" />
+          </label>
+          <label class="wide">
+            <span>One next step</span>
+            <input id="proposalNextStep" type="text" autocomplete="off" placeholder="Ask for one product link." />
+          </label>
+          <button class="button primary" type="submit">Add proposal</button>
+        </form>
+
+        <div class="pipeline-stats" aria-label="Proposal totals">
+          <div>
+            <span>Open</span>
+            <strong id="openProposalCount">0</strong>
+          </div>
+          <div>
+            <span>Sent / follow-up</span>
+            <strong id="sentProposalCount">0</strong>
+          </div>
+          <div>
+            <span>Won</span>
+            <strong id="wonProposalCount">0</strong>
+          </div>
+          <div>
+            <span>Open value</span>
+            <strong id="openProposalValue">$0</strong>
+          </div>
+        </div>
+
+        <div id="proposalBoard" class="proposal-board">
+          <p class="empty">No proposals yet. Add the first warm lead or create one from Memory Capture.</p>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="ceo-title">
+        <div class="section-head">
+          <p class="eyebrow">CEO rhythm</p>
+          <h2 id="ceo-title">Review this every week.</h2>
+        </div>
+        <div class="question-grid">
+          <article><strong>Who paid?</strong><p>Update MRR and project revenue.</p></article>
+          <article><strong>Who almost paid?</strong><p>Move the proposal stage and ask one direct question.</p></article>
+          <article><strong>Who needs follow-up?</strong><p>Use People Log or Memory Capture before the lead cools.</p></article>
+          <article><strong>What proof did we create?</strong><p>Save screenshots, links, releases, or customer outcomes.</p></article>
+          <article><strong>What should we stop building?</strong><p>Hide or pause anything that does not help revenue right now.</p></article>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/revenue-desk/style.css
+++ b/revenue-desk/style.css
@@ -1,0 +1,416 @@
+:root {
+  --bg: #0d1117;
+  --surface: #151b25;
+  --surface-soft: #1b2431;
+  --line: rgba(226, 232, 240, 0.14);
+  --line-strong: rgba(226, 232, 240, 0.24);
+  --text: #f8fafc;
+  --muted: #b8c1cc;
+  --quiet: #8d99a8;
+  --teal: #5eead4;
+  --gold: #f6d365;
+  --green: #9ae6b4;
+  --rose: #fda4af;
+  --shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+}
+
+* { box-sizing: border-box; }
+
+html {
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(94, 234, 212, 0.1), transparent 26rem),
+    linear-gradient(180deg, rgba(246, 211, 101, 0.04), transparent 22rem),
+    var(--bg);
+}
+
+a { color: inherit; }
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button { cursor: pointer; }
+
+.shell {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1rem 0 4rem;
+}
+
+.topbar,
+.hero-actions,
+.link-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.topbar {
+  margin-bottom: 2rem;
+}
+
+.topbar a,
+.button,
+.link-stack a,
+.command-grid a,
+.command-grid button,
+.proposal-actions button {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.045);
+  padding: 0.55rem 0.82rem;
+  font-size: 0.92rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.topbar a:hover,
+.button:hover,
+.link-stack a:hover,
+.command-grid a:hover,
+.command-grid button:hover,
+.proposal-actions button:hover {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.button.primary,
+.command-grid button {
+  color: #102018;
+  background: var(--green);
+  border-color: transparent;
+}
+
+.hero {
+  padding: 1rem 0 3rem;
+}
+
+.hero-grid,
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 390px);
+  gap: clamp(1rem, 4vw, 2rem);
+  align-items: start;
+}
+
+.eyebrow {
+  margin: 0 0 0.65rem;
+  color: var(--teal);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h1 {
+  max-width: 780px;
+  font-size: clamp(3rem, 8vw, 6.2rem);
+}
+
+h2 {
+  font-size: clamp(1.7rem, 4vw, 2.5rem);
+}
+
+.lead {
+  max-width: 730px;
+  margin: 1.15rem 0 1.2rem;
+  color: var(--muted);
+  font-size: clamp(1.05rem, 2vw, 1.22rem);
+}
+
+.panel,
+.status-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.status-card {
+  padding: 1rem;
+  background: linear-gradient(180deg, rgba(246, 211, 101, 0.12), rgba(21, 27, 37, 0.92));
+}
+
+.status-card span,
+.metric-grid span,
+.pipeline-stats span,
+label span,
+.command-grid span {
+  color: var(--quiet);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.status-card strong {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 1.25rem;
+}
+
+.status-card p,
+.section-head p,
+.command-grid p,
+.question-grid p,
+.brief-list p,
+.proposal-card p {
+  color: var(--muted);
+}
+
+.panel {
+  padding: 1rem;
+}
+
+main {
+  display: grid;
+  gap: 1rem;
+}
+
+.section-head {
+  margin-bottom: 1rem;
+}
+
+.section-head.row {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-head p {
+  max-width: 760px;
+  margin: 0.75rem 0 0;
+}
+
+code {
+  color: var(--gold);
+  font-size: 0.92em;
+}
+
+.command-grid,
+.metric-grid,
+.pipeline-stats,
+.question-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.command-grid article,
+.metric-grid div,
+.pipeline-stats div,
+.question-grid article,
+.brief-item,
+.proposal-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.95rem;
+}
+
+.command-grid strong,
+.question-grid strong {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 1.15rem;
+}
+
+.command-grid p {
+  min-height: 3rem;
+}
+
+.revenue-form,
+.proposal-form {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.proposal-form {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  margin-bottom: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.proposal-form label {
+  grid-column: span 2;
+}
+
+.proposal-form .wide {
+  grid-column: span 4;
+}
+
+input,
+select {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #0f1622;
+  color: var(--text);
+  padding: 0.72rem 0.8rem;
+}
+
+.revenue-form .button,
+.proposal-form .button {
+  align-self: end;
+}
+
+.metric-grid,
+.pipeline-stats {
+  margin-top: 1rem;
+}
+
+.metric-grid strong,
+.pipeline-stats strong {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 1.45rem;
+}
+
+.brief-list,
+.proposal-board {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.brief-item strong,
+.proposal-card strong {
+  display: block;
+  font-size: 1.05rem;
+}
+
+.brief-item small,
+.proposal-card small {
+  color: var(--quiet);
+  font-weight: 800;
+}
+
+.brief-item[data-tone="urgent"] {
+  border-color: rgba(253, 164, 175, 0.45);
+}
+
+.brief-item[data-tone="money"] {
+  border-color: rgba(154, 230, 180, 0.45);
+}
+
+.proposal-card {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.proposal-meta {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.proposal-meta div {
+  border-top: 1px solid var(--line);
+  padding-top: 0.55rem;
+}
+
+.proposal-meta dt {
+  color: var(--quiet);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.proposal-meta dd {
+  margin: 0.15rem 0 0;
+  color: var(--text);
+}
+
+.proposal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.proposal-actions button[data-proposal-stage="won"] {
+  color: #102018;
+  background: var(--green);
+  border-color: transparent;
+}
+
+.empty {
+  margin: 0;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+@media (max-width: 980px) {
+  .hero-grid,
+  .dashboard-grid,
+  .command-grid,
+  .question-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-grid,
+  .pipeline-stats,
+  .revenue-form {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .proposal-form {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .proposal-form label,
+  .proposal-form .wide {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 680px) {
+  .shell {
+    width: min(100% - 1rem, 1180px);
+    padding-bottom: 2rem;
+  }
+
+  h1 {
+    font-size: clamp(2.35rem, 16vw, 3.6rem);
+  }
+
+  .panel,
+  .status-card {
+    padding: 0.85rem;
+  }
+
+  .metric-grid,
+  .pipeline-stats,
+  .revenue-form,
+  .proposal-meta {
+    grid-template-columns: 1fr;
+  }
+}

--- a/sales/index.html
+++ b/sales/index.html
@@ -18,6 +18,7 @@
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../start/" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Start Here</a>
+        <a href="../revenue-desk/" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Revenue Desk</a>
         <a href="../lead-generation.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Lead Capture</a>
         <a href="../memory-capture/" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Memory Capture</a>
         <a href="../contacts/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Contacts Workspace</a>

--- a/tests/revenue-desk.test.js
+++ b/tests/revenue-desk.test.js
@@ -1,0 +1,83 @@
+import { constants } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const baseDir = new URL('../revenue-desk/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+test('revenue desk ships a founder operating surface for profitability', async () => {
+  const html = await readFile(new URL('index.html', baseDir), 'utf8');
+
+  assert.equal(await fileExists(new URL('index.html', baseDir)), true);
+  assert.equal(await fileExists(new URL('style.css', baseDir)), true);
+  assert.equal(await fileExists(new URL('app.js', baseDir)), true);
+  assert.match(html, /Revenue Desk \| 3dvr portal/);
+  assert.match(html, /Run the company from one revenue move\./);
+  assert.match(html, /Sell first\./);
+  assert.match(html, /Build second\./);
+  assert.match(html, /Keep it simple\./);
+  assert.match(html, /Log conversation/);
+  assert.match(html, /Queue agent daily brief/);
+  assert.match(html, /id="revenueForm"/);
+  assert.match(html, /data-plan-input="starter"/);
+  assert.match(html, /id="customSprintRevenue"/);
+  assert.match(html, /id="proposalForm"/);
+  assert.match(html, /id="proposalBoard"/);
+  assert.match(html, /3dvr-portal\/revenue-desk\/state/);
+  assert.match(html, /3dvr-portal\/proposals/);
+  assert.match(html, /docs\/path-to-profitability\.md/);
+  assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+  assert.match(html, /type="module" src="app\.js"/);
+});
+
+test('revenue desk backs metrics, proposals, and agent daily briefs with Gun', async () => {
+  const js = await readFile(new URL('app.js', baseDir), 'utf8');
+
+  assert.match(js, /REVENUE_NODE = 'revenue-desk'/);
+  assert.match(js, /PROPOSALS_NODE = 'proposals'/);
+  assert.match(js, /MEMORY_CAPTURE_NODE = 'memoryCapture'/);
+  assert.match(js, /TOUCH_LOG_NODE = 'crm-touch-log'/);
+  assert.match(js, /AGENT_OWNER_ALIAS = '3dvr-managed'/);
+  assert.match(js, /REVENUE_STORAGE_KEY/);
+  assert.match(js, /PROPOSAL_STORAGE_KEY/);
+  assert.match(js, /planCounts/);
+  assert.match(js, /customSprintRevenue/);
+  assert.match(js, /revenueRoot\.get\('state'\)/);
+  assert.match(js, /proposalRoot\.get\(proposal\.id\)/);
+  assert.match(js, /agentOps/);
+  assert.match(js, /buildAgentDailyBriefTask/);
+  assert.match(js, /top 5 people to follow up with/);
+  assert.match(js, /calculateMrr/);
+  assert.match(js, /getMilestone/);
+});
+
+test('revenue desk is discoverable from the portal and sales hub', async () => {
+  const portalHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const salesHtml = await readFile(new URL('../sales/index.html', import.meta.url), 'utf8');
+
+  assert.match(portalHtml, /href="revenue-desk\/"/);
+  assert.match(portalHtml, /<span class="app-card__title">Revenue Desk<\/span>/);
+  assert.match(portalHtml, /Run the daily founder loop: follow-ups, proposals, billing, and one revenue move\./);
+  assert.match(portalHtml, /Open Revenue Desk/);
+  assert.match(salesHtml, /href="\.\.\/revenue-desk\/"/);
+  assert.match(salesHtml, /Revenue Desk/);
+
+  const startIndex = portalHtml.indexOf('>Start Here<');
+  const revenueIndex = portalHtml.indexOf('>Revenue Desk<');
+  const agentIndex = portalHtml.indexOf('>Agent Ops<');
+
+  assert.ok(startIndex !== -1, 'Start Here app card should be listed');
+  assert.ok(revenueIndex !== -1, 'Revenue Desk app card should be listed');
+  assert.ok(agentIndex !== -1, 'Agent Ops app card should be listed');
+  assert.ok(startIndex < revenueIndex, 'Revenue Desk should render after Start Here');
+  assert.ok(revenueIndex < agentIndex, 'Revenue Desk should render before Agent Ops');
+});


### PR DESCRIPTION
## Summary
- add a Revenue Desk app as the founder operating surface for the path-to-profitability plan
- track manual MRR/project revenue, proposal stages, follow-up dates, and daily revenue moves
- back up revenue state and proposals through Gun, and queue an agent daily brief task through the managed agent path
- surface Revenue Desk from the portal home and Sales hub

## Validation
- node --check revenue-desk/app.js
- node --test tests/revenue-desk.test.js tests/memory-capture.test.js tests/sales-index.test.js tests/sales-crm-handoff.test.js
- git diff --check