### PR TITLE
[codex] Add market research memo

### DIFF
--- a/docs/market-research-2026.md
+++ b/docs/market-research-2026.md
@@ -1,0 +1,236 @@
+# 3dvr Market Research - May 27, 2026
+
+This memo turns current public market data into a practical selling path for 3dvr.tech. The short version: sell to service-heavy small businesses and warm-network founders who need customers, follow-up, and simple operating structure. Keep open-source computing as the brand moat, not the first revenue wedge.
+
+## Executive Read
+
+The best near-term market is not "everyone who needs a website." It is owner-led service businesses, professional-service operators, and small teams that are already trying to grow but keep losing momentum in follow-up, quotes, intake, scheduling, or basic weekly organization.
+
+The strongest promise is:
+
+> 3dvr.tech helps small businesses turn scattered conversations into customers, pages, follow-up, and simple systems.
+
+The strongest sales motion is:
+
+1. Capture the conversation in Memory Capture or People Log.
+2. Pick one tiny next ask.
+3. Move the person into Revenue Desk or Billing only when the next step is clear.
+4. Use Market Research Desk to track which segment gives the most replies, calls, and paid work.
+
+## What The Current Data Says
+
+The U.S. Census Bureau reported 503,171 seasonally adjusted business applications in April 2026, up 2.1 percent from March 2026. Census also projected 28,479 employer business formations within four quarters from that April application cohort.
+
+The SBA 2025 U.S. Small Business Profile reports 36.2 million U.S. small businesses, 99.9 percent of U.S. businesses, and 62.3 million small-business employees, equal to 45.9 percent of U.S. employees.
+
+The largest relevant small-business sectors for 3dvr are:
+
+| Segment | U.S. small businesses | Why it matters |
+| --- | ---: | --- |
+| Professional, scientific, and technical services | 4,881,738 | Consultants, studios, agencies, and solo specialists already sell expertise but often need clearer positioning and follow-up. |
+| Other services | 3,860,519 | Local owner-operators often need simple customer intake, booking, reminders, and trust-building web presence. |
+| Construction | 3,656,782 | Contractor workflows are lead, quote, schedule, and follow-up heavy. Small firms account for 80.7 percent of construction employment. |
+| Health care and social assistance | 2,945,484 | Support-heavy teams need calmer intake, scheduling, and shared workflow, but may require more care around privacy and process. |
+| Retail trade | 2,813,437 | Product sellers and resellers need product pages, trust, order routing, and customer follow-up. |
+
+The Federal Reserve 2026 Report on Employer Firms says the most common operational challenge was reaching customers and growing sales. It also says 46 percent of surveyed employer firms currently use AI and another 15 percent planned to begin within 12 months. For firms using AI, writing or marketing was the most common task.
+
+Inference: the best 3dvr buyer is not looking for a giant platform first. They are trying to get more business, respond faster, and make daily work less chaotic. AI is interesting to them when it helps with marketing, productivity, planning, and follow-up.
+
+## Priority Markets
+
+### 1. Owner-Led Local Services
+
+Examples: contractors, party rental companies, repair services, home services, event vendors, wellness providers, salons, trainers, small local operators.
+
+Why now:
+
+- Large market with concrete lead-flow pain.
+- Buyers understand missed calls, lost quotes, late follow-up, and scheduling confusion.
+- 3dvr can show value with a simple page, intake form, follow-up lane, and visible next step.
+
+Default offer:
+
+- Builder at $50/month when they already have customers.
+- Launch in 3 Days at $20/month when they need a first page or offer fast.
+- Custom sprint when the scope is bigger than a plan.
+
+Tiny ask:
+
+> Send me one service, product, or job you want more customers for.
+
+### 2. Professional Services And Creators
+
+Examples: consultants, small agencies, studios, freelancers, coaches, creative workers, local media people.
+
+Why now:
+
+- Large professional-service base.
+- Their product is often hard to explain, so messaging and follow-up matter.
+- They can pay for clarity if the offer makes them look more real and organized.
+
+Default offer:
+
+- Builder at $50/month as the default operating lane.
+- Custom setup sprint for a landing page, client intake, or proposal workflow.
+
+Tiny ask:
+
+> What is the one offer you wish people understood faster?
+
+### 3. Product Resellers And Side-Hustle Ecommerce
+
+Examples: Alibaba/reseller leads, local product ideas, hobby sellers, creators testing a physical product, small shops without clean order flow.
+
+Why now:
+
+- They need trust before they need advanced ecommerce.
+- A single product page can make the business feel real.
+- The first conversion step is usually simple: product link, photos, price, contact/order path.
+
+Default offer:
+
+- Launch in 3 Days when they have one product.
+- Builder when follow-up, inventory notes, or recurring content starts.
+
+Tiny ask:
+
+> Send me the first product link and one reason someone would buy it.
+
+Watch-out:
+
+- Do not sell a full store until they can commit to one product, one audience, and one fulfillment path.
+
+### 4. Personal Tech Department
+
+Examples: busy professionals, older adults, family/friends, nontechnical business owners, people who need help with accounts, setup, backups, websites, phones, and day-to-day tech confusion.
+
+Why it may work:
+
+- Trust matters more than software features.
+- It can produce referrals and recurring support revenue.
+- It fits the "technology should serve humans" philosophy.
+
+Default offer:
+
+- $20/month as a scoped support lane.
+- Use clear boundaries: response windows, covered tasks, and what requires a paid project.
+
+Tiny ask:
+
+> What tech problem would make your week easier if it stopped being confusing?
+
+Watch-out:
+
+- This can become unlimited support if scope is not explicit.
+
+### 5. Open Future Computing
+
+Examples: Linux/open-source people, makers, digital nomads, privacy-aware users, humane-computing supporters.
+
+Why it matters:
+
+- It is the long-term brand moat.
+- It helps 3dvr attract collaborators, community, and trust.
+- It differentiates 3dvr from generic web/CRM/AI agencies.
+
+Near-term role:
+
+- Use as content and community, not the primary cash wedge.
+- Mention open source after the buyer understands the practical result.
+
+Tiny ask:
+
+> What part of your digital life do you wish was more open, portable, or under your control?
+
+### 6. Spatial Design And 3D Visualization
+
+Examples: lake house concept, outdoor living, property visualization, event spaces, tiny homes, studios, camper vans, ergonomic offices.
+
+Why it may work:
+
+- Higher-ticket project potential.
+- Strong portfolio visuals.
+- Direct tie to 3DVR as spatial design, visualization, and future VR.
+
+Default offer:
+
+- Paid project sprint, not a subscription first.
+- Build one internal portfolio piece before broad outreach.
+
+Tiny ask:
+
+> Send photos, rough measurements, and three inspiration references.
+
+Watch-out:
+
+- Do not build a custom visualization platform before selling manual render/project work.
+
+## Recommended 30-Day Market Test
+
+Run one simple sprint:
+
+| Market | Target conversations | CTA | Success signal |
+| --- | ---: | --- | --- |
+| Owner-led local services | 10 | Send one service or product to improve | 3 replies, 1 paid plan or sprint |
+| Professional services | 10 | Clarify one offer | 3 replies, 1 proposal |
+| Product resellers | 5 | Send first product link | 2 replies, 1 launch page |
+| Personal tech department | 5 | Name the recurring tech pain | 2 replies, 1 support signup |
+| Spatial design | 3 | Send photos and references | 1 scoped paid project conversation |
+
+Do not judge by likes. Judge by replies, booked calls, billing starts, and people sending the one thing you asked for.
+
+## Positioning To Test
+
+Use plain language first:
+
+- "I help small businesses stop losing leads after the first message."
+- "Send me one product or offer and I will help you make the first page real."
+- "3dvr.tech is a practical tech department for websites, follow-up, and business systems."
+- "We keep the tech simple so the business keeps moving."
+
+Avoid leading with:
+
+- "AI operating system."
+- "Portal ecosystem."
+- "Open-source computing platform."
+- "CRM implementation."
+
+Those can come later, after the buyer already understands the immediate outcome.
+
+## What To Build Next
+
+Portal should keep being the operating desk:
+
+- Revenue Desk: daily CEO view for MRR, proposals, and the next revenue move.
+- Market Research Desk: interview sprint, segment scoreboard, and outreach playbooks.
+- People Log / CRM: one visible next step per person.
+- Memory Capture: lowest-friction daily conversation capture.
+- Market Lab: landing page tests and CTA clicks.
+
+3dvr-agent should become the operator:
+
+- Read new captures and proposals.
+- Suggest the top five follow-ups.
+- Flag stale warm leads.
+- Draft tiny asks.
+- Summarize which market has the most energy each week.
+
+3dvr-web should stay simpler:
+
+- Show the clearest current winning offer.
+- Route people to the right plan or conversation.
+- Do not explain the whole ecosystem on the homepage.
+
+## CEO Decision
+
+For the next 30 days, prioritize local services and professional services because they have the best mix of market size, urgency, simple messaging, and ability to pay for practical help.
+
+Keep ecommerce/reseller and spatial design as warm-network experiments. Keep open-source future computing as brand and community. Keep personal tech department scoped tightly so it builds trust without swallowing delivery time.
+
+## Sources
+
+- U.S. Census Bureau, Business Formation Statistics, May 13, 2026: https://www.census.gov/econ/bfs/current/index.html
+- U.S. Census Bureau, April 2026 BFS press release PDF: https://www.census.gov/econ/bfs/pdf/bfs_current.pdf
+- SBA Office of Advocacy, 2025 U.S. Small Business Profile: https://advocacy.sba.gov/wp-content/uploads/2025/06/United_States_2025-State-Profile.pdf
+- Federal Reserve Small Business, 2026 Report on Employer Firms: https://www.fedsmallbusiness.org/2026-report-on-employer-firms

--- a/revenue-desk/index.html
+++ b/revenue-desk/index.html
@@ -156,6 +156,7 @@
           <div class="link-stack">
             <a href="../sales/scoreboard.html">Open profitability scoreboard</a>
             <a href="../sales/research.html">Open market research</a>
+            <a href="../docs/market-research-2026.md">Read market memo</a>
             <a href="../docs/path-to-profitability.md">Read CEO plan</a>
           </div>
         </aside>

--- a/tests/market-research-memo.test.js
+++ b/tests/market-research-memo.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('market research memo turns current sources into the revenue operating path', async () => {
+  const memo = await readFile(new URL('../docs/market-research-2026.md', import.meta.url), 'utf8');
+
+  assert.match(memo, /3dvr Market Research - May 27, 2026/);
+  assert.match(memo, /503,171/);
+  assert.match(memo, /28,479/);
+  assert.match(memo, /36\.2 million/);
+  assert.match(memo, /45\.9 percent/);
+  assert.match(memo, /reaching customers and growing sales/i);
+  assert.match(memo, /Owner-Led Local Services/);
+  assert.match(memo, /Professional Services And Creators/);
+  assert.match(memo, /Product Resellers And Side-Hustle Ecommerce/);
+  assert.match(memo, /Personal Tech Department/);
+  assert.match(memo, /Open Future Computing/);
+  assert.match(memo, /Spatial Design And 3D Visualization/);
+  assert.match(memo, /Revenue Desk/);
+  assert.match(memo, /Market Research Desk/);
+  assert.match(memo, /People Log \/ CRM/);
+  assert.match(memo, /Memory Capture/);
+  assert.match(memo, /Market Lab/);
+  assert.match(memo, /3dvr-agent should become the operator/);
+  assert.match(memo, /https:\/\/www\.census\.gov\/econ\/bfs\/current\/index\.html/);
+  assert.match(memo, /https:\/\/advocacy\.sba\.gov\/wp-content\/uploads\/2025\/06\/United_States_2025-State-Profile\.pdf/);
+  assert.match(memo, /https:\/\/www\.fedsmallbusiness\.org\/2026-report-on-employer-firms/);
+});

--- a/tests/revenue-desk.test.js
+++ b/tests/revenue-desk.test.js
@@ -35,6 +35,7 @@ test('revenue desk ships a founder operating surface for profitability', async (
   assert.match(html, /3dvr-portal\/revenue-desk\/state/);
   assert.match(html, /3dvr-portal\/proposals/);
   assert.match(html, /docs\/path-to-profitability\.md/);
+  assert.match(html, /docs\/market-research-2026\.md/);
   assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
   assert.match(html, /type="module" src="app\.js"/);
 });


### PR DESCRIPTION
## Summary
- add a May 27, 2026 market research memo for 3dvr.tech
- rank near-term market wedges and translate them into offers, tiny asks, and a 30-day test
- link the memo from Revenue Desk and cover it with focused tests

## Validation
- node --test tests/market-research-memo.test.js tests/sales-research.test.js tests/sales-research-scoreboard.test.js tests/sales-research-playbooks.test.js tests/sales-profitability-scoreboard.test.js tests/revenue-desk.test.js
- git diff --check

gh was unavailable/authless in this shell, so the branch was published through the GitHub connector.