### PR TITLE
[codex] Add growth operator app

### DIFF
--- a/email-operator/index.html
+++ b/email-operator/index.html
@@ -29,6 +29,7 @@
     <a href="../index.html">Portal</a>
     <a href="../contacts/index.html">Contacts</a>
     <a href="../crm/index.html">CRM</a>
+    <a href="../growth-operator/">Growth Operator</a>
     <a href="../calendar/index.html">Calendar</a>
     <a href="../openai-app/index.html">OpenAI Workbench</a>
   </nav>

--- a/growth-operator/app.js
+++ b/growth-operator/app.js
@@ -1,0 +1,596 @@
+const STORAGE_KEY = '3dvr.growthOperator.items.v1';
+const TOKEN_STORAGE_KEY = '3dvr.growthOperator.operatorEmailToken.v1';
+const ROOT_KEY = '3dvr-portal';
+const OPERATOR_NODE = 'growthOperator';
+const AGENT_OWNER_ALIAS = '3dvr-managed';
+const DEFAULT_PEERS = [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+];
+
+const LANE_LABELS = Object.freeze({
+  lead: 'Lead',
+  support: 'Support',
+  delivery: 'Delivery'
+});
+
+const STAGE_LABELS = Object.freeze({
+  new: 'New',
+  drafted: 'Drafted',
+  approved: 'Approved',
+  sent: 'Sent',
+  working: 'Working',
+  done: 'Done'
+});
+
+const state = {
+  items: loadItems(),
+  sendingId: '',
+  queueing: false
+};
+
+const gun = typeof Gun === 'function' ? Gun(window.__GUN_PEERS__ || DEFAULT_PEERS) : null;
+const portalRoot = gun ? gun.get(ROOT_KEY) : null;
+const operatorRoot = portalRoot ? portalRoot.get(OPERATOR_NODE) : null;
+const itemsRoot = operatorRoot ? operatorRoot.get('items') : null;
+const agentQueueRoot = portalRoot
+  ? portalRoot.get('agentOps').get(AGENT_OWNER_ALIAS).get('taskQueue')
+  : null;
+
+const els = {
+  syncStatus: document.getElementById('syncStatus'),
+  form: document.getElementById('operatorForm'),
+  itemName: document.getElementById('itemName'),
+  itemEmail: document.getElementById('itemEmail'),
+  itemLane: document.getElementById('itemLane'),
+  itemOffer: document.getElementById('itemOffer'),
+  itemContext: document.getElementById('itemContext'),
+  operatorEmailToken: document.getElementById('operatorEmailToken'),
+  findLeadsButton: document.getElementById('findLeadsButton'),
+  supportTriageButton: document.getElementById('supportTriageButton'),
+  deliveryPassButton: document.getElementById('deliveryPassButton'),
+  draftAllButton: document.getElementById('draftAllButton'),
+  queue: document.getElementById('operatorQueue'),
+  leadQueueCount: document.getElementById('leadQueueCount'),
+  readyEmailCount: document.getElementById('readyEmailCount'),
+  supportQueueCount: document.getElementById('supportQueueCount'),
+  deliveryQueueCount: document.getElementById('deliveryQueueCount'),
+  mobileActions: Array.from(document.querySelectorAll('[data-mobile-action]'))
+};
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeEmail(value) {
+  return normalizeText(value).toLowerCase();
+}
+
+function slug(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'item';
+}
+
+function makeId(prefix, seed = '') {
+  return `${prefix}-${slug(seed)}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function safe(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function loadJson(key, fallback) {
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+function saveJson(key, value) {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('Growth Operator local save failed.', error);
+  }
+}
+
+function readStorageText(key) {
+  try {
+    return normalizeText(window.localStorage.getItem(key));
+  } catch (_error) {
+    return '';
+  }
+}
+
+function loadItems() {
+  const stored = loadJson(STORAGE_KEY, []);
+  if (!Array.isArray(stored)) return {};
+  return stored.reduce((output, item) => {
+    const clean = normalizeItem(item);
+    if (clean?.id) output[clean.id] = clean;
+    return output;
+  }, {});
+}
+
+function persistLocalItems() {
+  saveJson(STORAGE_KEY, getItems().slice(0, 100));
+}
+
+function normalizeLane(value) {
+  const lane = normalizeText(value).toLowerCase();
+  return LANE_LABELS[lane] ? lane : 'lead';
+}
+
+function normalizeStage(value) {
+  const stage = normalizeText(value).toLowerCase();
+  return STAGE_LABELS[stage] ? stage : 'new';
+}
+
+function normalizeItem(value) {
+  if (!value || typeof value !== 'object') return null;
+  const name = normalizeText(value.name || value.business || value.title);
+  const id = normalizeText(value.id);
+  if (!id || !name) return null;
+  return {
+    id,
+    name,
+    email: normalizeEmail(value.email),
+    lane: normalizeLane(value.lane || value.type),
+    stage: normalizeStage(value.stage),
+    offer: normalizeText(value.offer),
+    context: normalizeText(value.context || value.notes || value.summary),
+    draft: normalizeText(value.draft),
+    nextStep: normalizeText(value.nextStep),
+    source: normalizeText(value.source) || 'growth-operator',
+    approvedAt: normalizeText(value.approvedAt),
+    sentAt: normalizeText(value.sentAt),
+    createdAt: normalizeText(value.createdAt),
+    updatedAt: normalizeText(value.updatedAt)
+  };
+}
+
+function getItems() {
+  return Object.values(state.items)
+    .map(normalizeItem)
+    .filter(Boolean)
+    .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)));
+}
+
+function updateStatus(message) {
+  if (els.syncStatus) {
+    els.syncStatus.textContent = message;
+  }
+}
+
+function putGun(node, payload) {
+  return new Promise((resolve, reject) => {
+    if (!node || typeof node.put !== 'function') {
+      reject(new Error('Gun is unavailable.'));
+      return;
+    }
+    const timer = window.setTimeout(() => resolve({ timedOut: true }), 6000);
+    node.put(payload, (ack) => {
+      window.clearTimeout(timer);
+      if (ack?.err) {
+        reject(new Error(String(ack.err)));
+      } else {
+        resolve(ack || {});
+      }
+    });
+  });
+}
+
+function cleanGunRecord(record) {
+  if (!record || typeof record !== 'object') return null;
+  const { _, ...clean } = record;
+  return clean;
+}
+
+function firstName(value) {
+  return normalizeText(value).split(/\s+/)[0] || 'there';
+}
+
+function planFromOffer(offer) {
+  const text = normalizeText(offer).toLowerCase();
+  if (text.includes('200') || text.includes('embedded') || text.includes('enterprise')) return 'embedded';
+  if (text.includes('50') || text.includes('builder')) return 'builder';
+  if (text.includes('20') || text.includes('launch') || text.includes('founder')) return 'pro';
+  if (text.includes('5') || text.includes('starter') || text.includes('friend')) return 'starter';
+  return '';
+}
+
+function billingPlanUrl(offer) {
+  const plan = planFromOffer(offer);
+  return plan ? `${window.location.origin}/billing/?plan=${encodeURIComponent(plan)}` : '';
+}
+
+function buildDraft(item) {
+  const name = firstName(item.name);
+  if (item.lane === 'support') {
+    return [
+      `Hey ${name}, I saw this and I am checking it now.`,
+      '',
+      item.context || 'I am going to confirm what changed, what account or workflow it affects, and the next fix.',
+      '',
+      'I will keep the next step clear so this does not get lost.'
+    ].join('\n');
+  }
+
+  if (item.lane === 'delivery') {
+    return [
+      `Hey ${name}, quick delivery update from 3dvr.tech.`,
+      '',
+      item.context || 'I am turning this into the next visible result and will keep the scope small enough to finish.',
+      '',
+      'The next useful update will be a link, screenshot, or checklist item you can react to.'
+    ].join('\n');
+  }
+
+  const billingUrl = billingPlanUrl(item.offer);
+  return [
+    `Hey ${name}, quick 3dvr.tech thought.`,
+    '',
+    item.context || 'I think there is a simple way to help with your site, tech setup, or follow-up flow without making it complicated.',
+    item.offer ? `The smallest useful lane looks like ${item.offer}.` : 'The first step can stay small.',
+    '',
+    billingUrl ? `Start here if you want to make it official: ${billingUrl}` : 'Want me to send the simplest next step?'
+  ].filter(Boolean).join('\n');
+}
+
+function buildItemFromForm() {
+  const name = normalizeText(els.itemName.value);
+  if (!name) {
+    throw new Error('Add a name or business first.');
+  }
+
+  const now = new Date().toISOString();
+  const lane = normalizeLane(els.itemLane.value);
+  const item = {
+    id: makeId('growth', name),
+    name,
+    email: normalizeEmail(els.itemEmail.value),
+    lane,
+    stage: 'new',
+    offer: normalizeText(els.itemOffer.value),
+    context: normalizeText(els.itemContext.value),
+    draft: '',
+    nextStep: lane === 'lead' ? 'Draft one specific outreach note.' : 'Clarify the next customer-visible step.',
+    source: 'growth-operator',
+    approvedAt: '',
+    sentAt: '',
+    createdAt: now,
+    updatedAt: now
+  };
+  item.draft = buildDraft(item);
+  item.stage = lane === 'lead' ? 'drafted' : 'working';
+  return item;
+}
+
+async function saveItem(item, statusMessage = '') {
+  const clean = normalizeItem(item);
+  if (!clean) return;
+  state.items[clean.id] = clean;
+  persistLocalItems();
+  render();
+
+  try {
+    await putGun(itemsRoot.get(clean.id), clean);
+    updateStatus(statusMessage || `Saved ${clean.name} to 3dvr-portal/growthOperator/items.`);
+  } catch (error) {
+    updateStatus(`${statusMessage || `Saved ${clean.name} locally.`} ${error.message || 'Gun sync failed.'}`);
+  }
+}
+
+async function addItem(event) {
+  event.preventDefault();
+  let item;
+  try {
+    item = buildItemFromForm();
+  } catch (error) {
+    updateStatus(error.message);
+    return;
+  }
+
+  await saveItem(item, `Added ${item.name} to the ${LANE_LABELS[item.lane]} lane.`);
+  els.form.reset();
+}
+
+function buildAgentTask(kind, item = null) {
+  const now = new Date().toISOString();
+  const taskId = makeId(`growth-${kind}`, item?.name || kind);
+  const taskLines = [
+    `Run the 3DVR Growth Operator task: ${kind}.`,
+    '',
+    'Use these source paths first:',
+    '- 3dvr-portal/growthOperator/items',
+    '- 3dvr-portal/money-ai/opportunities',
+    '- 3dvr-portal/proposals',
+    '- 3dvr-portal/memoryCapture/captures',
+    '- 3dvr-crm',
+    '- 3dvr-portal/emailOperator/operators',
+    '- 3dvr-portal/finance/stripe/metrics/latest',
+    '',
+    'Rules:',
+    '- Do not mass email.',
+    '- Prefer warm, relevant, publicly contactable leads.',
+    '- Prepare short personal drafts and wait for approval before sending.',
+    '- If doing support or delivery, create the next visible customer result.',
+    '',
+    item ? `Target item: ${JSON.stringify(item)}` : '',
+    '',
+    'Return practical output: records to add, drafts to review, support issues, delivery tasks, and one recommended next action.'
+  ];
+
+  if (kind === 'find-leads') {
+    taskLines.push('Find 10 likely-fit 3dvr.tech leads from public sources, existing CRM gaps, market research, and referral context.');
+  }
+  if (kind === 'draft-outreach') {
+    taskLines.push('Draft the next approved outreach note for each lead with an email or clear contact path.');
+  }
+  if (kind === 'support-triage') {
+    taskLines.push('Review customer service issues, billing confusion, account problems, and unanswered replies. Draft replies, do not send.');
+  }
+  if (kind === 'delivery-pass') {
+    taskLines.push('Review paid or promising customers and create delivery steps that produce visible progress this week.');
+  }
+
+  return {
+    id: taskId,
+    task: taskLines.filter(Boolean).join('\n'),
+    tenantId: 'portal:growth-operator',
+    tenantAlias: readStorageText('alias') || readStorageText('username') || 'growth-operator',
+    tenantPlan: 'builder',
+    backend: 'codex',
+    repo: 'tmsteph/3dvr-portal',
+    model: '',
+    thinking: 'high',
+    unsafe: false,
+    riskClass: 'workspace_write',
+    approvalStatus: 'not_required',
+    requiredCapabilities: 'codex,crm,email,gun,stripe',
+    maxRuntimeMs: 0,
+    status: 'queued',
+    requestedBy: 'growth-operator',
+    createdAt: now,
+    updatedAt: now,
+    resultSummary: '',
+    error: '',
+    workerDeviceId: ''
+  };
+}
+
+async function queueAgentTask(kind, item = null) {
+  if (state.queueing) return;
+  state.queueing = true;
+  const task = buildAgentTask(kind, item);
+  try {
+    await putGun(agentQueueRoot.get(task.id), task);
+    await putGun(agentQueueRoot.get('latest'), { id: task.id, kind, updatedAt: task.updatedAt });
+    updateStatus(`Queued agent task: ${kind}.`);
+  } catch (error) {
+    updateStatus(`Agent task not queued. ${error.message || 'Gun sync failed.'}`);
+  } finally {
+    state.queueing = false;
+  }
+}
+
+async function updateItem(id, patch) {
+  const existing = normalizeItem(state.items[id]);
+  if (!existing) return;
+  const updated = {
+    ...existing,
+    ...patch,
+    updatedAt: new Date().toISOString()
+  };
+  await saveItem(updated);
+}
+
+async function draftAll() {
+  const targets = getItems().filter(item => item.lane === 'lead' && item.stage !== 'sent' && item.stage !== 'done');
+  for (const item of targets) {
+    await updateItem(item.id, {
+      draft: buildDraft(item),
+      stage: item.stage === 'approved' ? 'approved' : 'drafted'
+    });
+  }
+  await queueAgentTask('draft-outreach');
+}
+
+function readOperatorToken() {
+  return normalizeText(els.operatorEmailToken?.value) || readStorageText(TOKEN_STORAGE_KEY);
+}
+
+function persistOperatorToken() {
+  try {
+    const token = normalizeText(els.operatorEmailToken?.value);
+    if (token) {
+      window.localStorage.setItem(TOKEN_STORAGE_KEY, token);
+    } else {
+      window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+    }
+  } catch (_error) {
+    // Ignore private mode storage failures.
+  }
+}
+
+async function sendApprovedEmail(item) {
+  if (!item.email) {
+    updateStatus(`Add an email before sending to ${item.name}.`);
+    return;
+  }
+  if (item.stage !== 'approved') {
+    updateStatus(`Approve ${item.name}'s draft before sending.`);
+    return;
+  }
+
+  const token = readOperatorToken();
+  if (!token) {
+    updateStatus('Add the operator email token before using direct send.');
+    return;
+  }
+
+  state.sendingId = item.id;
+  render();
+  try {
+    const response = await fetch('/api/calendar/reminder-email', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        mode: 'lead-outreach',
+        to: [item.email],
+        subject: `3dvr.tech next step for ${item.name}`,
+        headline: 'Quick note from 3DVR',
+        text: item.draft || buildDraft(item),
+        senderName: 'Thomas @ 3DVR',
+        senderEmail: '3dvr.tech@gmail.com'
+      })
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(payload?.error || `Email route responded with ${response.status}`);
+    }
+    await updateItem(item.id, {
+      stage: 'sent',
+      sentAt: new Date().toISOString(),
+      nextStep: 'Watch for reply and log the next real response.'
+    });
+    updateStatus(`Sent approved email to ${item.name}.`);
+  } catch (error) {
+    updateStatus(`Email not sent. ${error.message || 'Check mail configuration.'}`);
+  } finally {
+    state.sendingId = '';
+    render();
+  }
+}
+
+function renderMetrics() {
+  const items = getItems();
+  els.leadQueueCount.textContent = String(items.filter(item => item.lane === 'lead' && item.stage !== 'done').length);
+  els.readyEmailCount.textContent = String(items.filter(item => item.stage === 'approved').length);
+  els.supportQueueCount.textContent = String(items.filter(item => item.lane === 'support' && item.stage !== 'done').length);
+  els.deliveryQueueCount.textContent = String(items.filter(item => item.lane === 'delivery' && item.stage !== 'done').length);
+}
+
+function renderQueue() {
+  const items = getItems();
+  if (!items.length) {
+    els.queue.innerHTML = '<p class="empty">No operator items yet.</p>';
+    return;
+  }
+
+  els.queue.innerHTML = items.map(item => {
+    const isSending = state.sendingId === item.id;
+    return `
+      <article class="queue-item" data-item-id="${safe(item.id)}" data-lane="${safe(item.lane)}">
+        <div class="queue-top">
+          <div>
+            <small>${safe(LANE_LABELS[item.lane])} / ${safe(STAGE_LABELS[item.stage])}</small>
+            <strong>${safe(item.name)}</strong>
+            <p>${safe(item.context || item.nextStep || 'No context yet.')}</p>
+          </div>
+          <div class="queue-meta">
+            ${item.email ? `<span>${safe(item.email)}</span>` : '<span>No email</span>'}
+            ${item.offer ? `<span>${safe(item.offer)}</span>` : ''}
+          </div>
+        </div>
+        <div class="draft-box">${safe(item.draft || buildDraft(item))}</div>
+        <div class="item-actions">
+          <button type="button" data-action="draft" data-item-id="${safe(item.id)}">Draft</button>
+          <button type="button" data-action="approve" data-item-id="${safe(item.id)}">Approve</button>
+          <button type="button" data-action="send" data-item-id="${safe(item.id)}" ${isSending ? 'disabled' : ''}>${isSending ? 'Sending...' : 'Send approved'}</button>
+          <button type="button" data-action="queue-agent" data-item-id="${safe(item.id)}">Queue agent</button>
+          <button type="button" data-action="done" data-item-id="${safe(item.id)}">Done</button>
+        </div>
+      </article>
+    `;
+  }).join('');
+}
+
+function render() {
+  renderMetrics();
+  renderQueue();
+}
+
+function subscribeGun() {
+  if (!itemsRoot) {
+    updateStatus('Gun unavailable. Growth Operator is using local storage only.');
+    return;
+  }
+
+  itemsRoot.map().on((item) => {
+    const clean = normalizeItem(cleanGunRecord(item));
+    if (!clean?.id) return;
+    state.items[clean.id] = clean;
+    persistLocalItems();
+    render();
+  });
+
+  updateStatus('Gun sync: connected to 3dvr-portal/growthOperator/items.');
+}
+
+function bindEvents() {
+  els.form?.addEventListener('submit', addItem);
+  els.operatorEmailToken?.addEventListener('input', persistOperatorToken);
+  els.findLeadsButton?.addEventListener('click', () => queueAgentTask('find-leads'));
+  els.supportTriageButton?.addEventListener('click', () => queueAgentTask('support-triage'));
+  els.deliveryPassButton?.addEventListener('click', () => queueAgentTask('delivery-pass'));
+  els.draftAllButton?.addEventListener('click', draftAll);
+  els.mobileActions.forEach(button => {
+    button.addEventListener('click', () => {
+      const action = button.dataset.mobileAction;
+      if (action === 'find-leads') queueAgentTask('find-leads');
+      if (action === 'draft-all') draftAll();
+      if (action === 'support') queueAgentTask('support-triage');
+      if (action === 'delivery') queueAgentTask('delivery-pass');
+    });
+  });
+
+  els.queue?.addEventListener('click', async (event) => {
+    const button = event.target.closest('[data-action][data-item-id]');
+    if (!button) return;
+    const item = normalizeItem(state.items[button.dataset.itemId]);
+    if (!item) return;
+    const action = button.dataset.action;
+    if (action === 'draft') {
+      await updateItem(item.id, { draft: buildDraft(item), stage: item.stage === 'approved' ? 'approved' : 'drafted' });
+    }
+    if (action === 'approve') {
+      await updateItem(item.id, { draft: item.draft || buildDraft(item), stage: 'approved', approvedAt: new Date().toISOString() });
+    }
+    if (action === 'send') {
+      await sendApprovedEmail(item);
+    }
+    if (action === 'queue-agent') {
+      await queueAgentTask(item.lane === 'support' ? 'support-triage' : item.lane === 'delivery' ? 'delivery-pass' : 'draft-outreach', item);
+    }
+    if (action === 'done') {
+      await updateItem(item.id, { stage: 'done', nextStep: 'Done for now.' });
+    }
+  });
+}
+
+function init() {
+  const storedToken = readStorageText(TOKEN_STORAGE_KEY);
+  if (els.operatorEmailToken && storedToken) {
+    els.operatorEmailToken.value = storedToken;
+  }
+  bindEvents();
+  render();
+  subscribeGun();
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', init);
+}

--- a/growth-operator/index.html
+++ b/growth-operator/index.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Growth Operator | 3dvr portal</title>
+  <meta
+    name="description"
+    content="A 3DVR operator app for lead discovery, approved outreach, customer service triage, and delivery follow-through."
+  />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#0d1117" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+</head>
+<body>
+  <div class="shell">
+    <header class="hero">
+      <nav class="topbar" aria-label="Growth operator navigation">
+        <a href="../">Portal</a>
+        <a href="../revenue-desk/">Revenue Desk</a>
+        <a href="../crm/">People Log</a>
+        <a href="../email-operator/">Email Operator</a>
+        <a href="../money-ai/">Money AI</a>
+        <a href="../admin/#agent-ops-card">Agent Ops</a>
+      </nav>
+
+      <div class="hero-grid">
+        <div>
+          <p class="eyebrow">Approval-first operator</p>
+          <h1>Growth Operator</h1>
+          <p class="lead">
+            Find likely-fit leads, prepare email, handle support, and keep delivery moving without turning your day
+            into admin work.
+          </p>
+          <div class="hero-actions">
+            <button id="findLeadsButton" class="button primary" type="button">Find leads</button>
+            <button id="supportTriageButton" class="button" type="button">Check support</button>
+            <button id="deliveryPassButton" class="button" type="button">Delivery pass</button>
+          </div>
+        </div>
+        <aside class="status-card">
+          <span>Operating rule</span>
+          <strong>Prepare the work. Send only approved email.</strong>
+          <p id="syncStatus" role="status" aria-live="polite">Connecting to 3dvr-portal/growthOperator.</p>
+        </aside>
+      </div>
+    </header>
+
+    <main>
+      <section class="metric-grid" aria-label="Growth operator metrics">
+        <article>
+          <span>Lead queue</span>
+          <strong id="leadQueueCount">0</strong>
+        </article>
+        <article>
+          <span>Email ready</span>
+          <strong id="readyEmailCount">0</strong>
+        </article>
+        <article>
+          <span>Support</span>
+          <strong id="supportQueueCount">0</strong>
+        </article>
+        <article>
+          <span>Delivery</span>
+          <strong id="deliveryQueueCount">0</strong>
+        </article>
+      </section>
+
+      <section class="operator-grid">
+        <article class="panel">
+          <div class="section-head">
+            <p class="eyebrow">Quick add</p>
+            <h2>Add the person, problem, or customer.</h2>
+            <p>Minimum fields only. The operator can fill in the rest later.</p>
+          </div>
+
+          <form id="operatorForm" class="operator-form">
+            <label>
+              <span>Name or business</span>
+              <input id="itemName" type="text" autocomplete="name" placeholder="Victor / local contractor / customer" required />
+            </label>
+            <label>
+              <span>Email</span>
+              <input id="itemEmail" type="email" autocomplete="email" placeholder="optional until send" />
+            </label>
+            <label>
+              <span>Lane</span>
+              <select id="itemLane">
+                <option value="lead">Lead</option>
+                <option value="support">Support</option>
+                <option value="delivery">Delivery</option>
+              </select>
+            </label>
+            <label>
+              <span>Offer</span>
+              <input id="itemOffer" type="text" placeholder="$5, $20, $50, $200, or custom" />
+            </label>
+            <label class="wide">
+              <span>Context</span>
+              <textarea id="itemContext" rows="4" placeholder="What did they say? What do they need? What should happen next?"></textarea>
+            </label>
+            <button class="button primary" type="submit">Add to operator</button>
+          </form>
+        </article>
+
+        <aside class="panel">
+          <div class="section-head">
+            <p class="eyebrow">Direct email</p>
+            <h2>Send path</h2>
+            <p>Uses the existing unified mail route. Keep the token local and send only approved drafts.</p>
+          </div>
+          <label>
+            <span>Operator email token</span>
+            <input id="operatorEmailToken" type="password" autocomplete="off" placeholder="AGENT_OPERATOR_EMAIL_TOKEN" />
+          </label>
+          <p class="small">
+            API path: <code>/api/calendar/reminder-email</code>, mode <code>lead-outreach</code>.
+          </p>
+        </aside>
+      </section>
+
+      <section class="panel">
+        <div class="section-head row">
+          <div>
+            <p class="eyebrow">Operator queue</p>
+            <h2>Find, email, support, deliver.</h2>
+            <p>Everything saves locally first and mirrors to <code>3dvr-portal/growthOperator/items</code>.</p>
+          </div>
+          <button id="draftAllButton" class="button" type="button">Draft next emails</button>
+        </div>
+        <div id="operatorQueue" class="queue-list">
+          <p class="empty">No operator items yet.</p>
+        </div>
+      </section>
+
+      <section class="workflow-grid" aria-label="Operator workflow">
+        <article>
+          <span>1</span>
+          <strong>Discover</strong>
+          <p>Ask the agent for likely-fit leads from public sources, CRM gaps, referrals, and market research.</p>
+        </article>
+        <article>
+          <span>2</span>
+          <strong>Outreach</strong>
+          <p>Draft short, specific email with the right 3dvr.tech offer and a billing path when appropriate.</p>
+        </article>
+        <article>
+          <span>3</span>
+          <strong>Service</strong>
+          <p>Route replies, billing questions, account issues, and support promises into one visible queue.</p>
+        </article>
+        <article>
+          <span>4</span>
+          <strong>Delivery</strong>
+          <p>Turn paid work into checklists, customer updates, and a next visible result.</p>
+        </article>
+      </section>
+    </main>
+  </div>
+
+  <nav class="mobile-dock" aria-label="Growth operator mobile actions">
+    <button type="button" data-mobile-action="find-leads">Find</button>
+    <button type="button" data-mobile-action="draft-all">Draft</button>
+    <button type="button" data-mobile-action="support">Support</button>
+    <button type="button" data-mobile-action="delivery">Deliver</button>
+  </nav>
+
+  <script type="module" src="app.js"></script>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/growth-operator/style.css
+++ b/growth-operator/style.css
@@ -1,0 +1,407 @@
+:root {
+  --bg: #0d1117;
+  --surface: #151b25;
+  --surface-soft: #1b2431;
+  --line: rgba(226, 232, 240, 0.14);
+  --line-strong: rgba(226, 232, 240, 0.26);
+  --text: #f8fafc;
+  --muted: #b8c1cc;
+  --quiet: #8d99a8;
+  --teal: #5eead4;
+  --green: #9ae6b4;
+  --gold: #f6d365;
+  --rose: #fda4af;
+  --shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+}
+
+* { box-sizing: border-box; }
+
+html {
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(94, 234, 212, 0.1), transparent 24rem),
+    linear-gradient(180deg, rgba(246, 211, 101, 0.04), transparent 22rem),
+    var(--bg);
+}
+
+a { color: inherit; }
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button { cursor: pointer; }
+
+.shell {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1rem 0 calc(5rem + env(safe-area-inset-bottom));
+}
+
+.topbar,
+.hero-actions,
+.item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.topbar { margin-bottom: 1rem; }
+
+.topbar a,
+.button,
+.item-actions button,
+.mobile-dock button {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.045);
+  padding: 0.55rem 0.82rem;
+  font-size: 0.92rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.button.primary,
+.item-actions button[data-action="approve"],
+.item-actions button[data-action="send"] {
+  color: #102018;
+  background: var(--green);
+  border-color: transparent;
+}
+
+.topbar a:hover,
+.button:hover,
+.item-actions button:hover,
+.mobile-dock button:hover {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.hero { padding: 0.5rem 0 1rem; }
+
+.hero-grid,
+.operator-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 390px);
+  gap: clamp(1rem, 4vw, 2rem);
+  align-items: start;
+}
+
+.eyebrow {
+  margin: 0 0 0.65rem;
+  color: var(--teal);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h1 {
+  max-width: 780px;
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+}
+
+h2 {
+  font-size: clamp(1.5rem, 4vw, 2.3rem);
+}
+
+.lead {
+  max-width: 620px;
+  margin: 0.9rem 0 1rem;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.12rem);
+}
+
+.panel,
+.status-card,
+.metric-grid article,
+.workflow-grid article,
+.queue-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.status-card,
+.panel {
+  padding: 1rem;
+}
+
+.status-card {
+  background: linear-gradient(180deg, rgba(246, 211, 101, 0.12), rgba(21, 27, 37, 0.92));
+}
+
+.status-card span,
+.metric-grid span,
+label span,
+.queue-item small,
+.workflow-grid span {
+  color: var(--quiet);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.status-card strong {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 1.25rem;
+}
+
+.status-card p,
+.section-head p,
+.queue-item p,
+.workflow-grid p,
+.small {
+  color: var(--muted);
+}
+
+main {
+  display: grid;
+  gap: 1rem;
+}
+
+.section-head {
+  margin-bottom: 1rem;
+}
+
+.section-head.row {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-head p {
+  max-width: 760px;
+  margin: 0.75rem 0 0;
+}
+
+code {
+  color: var(--gold);
+  font-size: 0.92em;
+}
+
+.metric-grid,
+.workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.metric-grid article,
+.workflow-grid article {
+  padding: 0.95rem;
+}
+
+.metric-grid strong {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 1.7rem;
+}
+
+.operator-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.wide {
+  grid-column: 1 / -1;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #0f1622;
+  color: var(--text);
+  padding: 0.72rem 0.8rem;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.operator-form .button {
+  align-self: end;
+}
+
+.queue-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.queue-item {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.95rem;
+}
+
+.queue-item[data-lane="support"] {
+  border-color: rgba(94, 234, 212, 0.3);
+}
+
+.queue-item[data-lane="delivery"] {
+  border-color: rgba(246, 211, 101, 0.3);
+}
+
+.queue-top {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.queue-top strong,
+.workflow-grid strong {
+  display: block;
+  font-size: 1.05rem;
+}
+
+.queue-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.queue-meta span {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  padding: 0.2rem 0.5rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.draft-box {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #0f1622;
+  color: var(--text);
+  padding: 0.85rem;
+  white-space: pre-wrap;
+}
+
+.empty {
+  margin: 0;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  padding: 1rem;
+  color: var(--muted);
+}
+
+.mobile-dock {
+  position: fixed;
+  left: 0.75rem;
+  right: 0.75rem;
+  bottom: calc(0.75rem + env(safe-area-inset-bottom));
+  z-index: 20;
+  display: none;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.4rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(13, 17, 23, 0.92);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.42);
+  padding: 0.45rem;
+  backdrop-filter: blur(14px);
+}
+
+.mobile-dock button {
+  min-height: 44px;
+  padding: 0.45rem 0.35rem;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 900px) {
+  .hero-grid,
+  .operator-grid,
+  .metric-grid,
+  .workflow-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .shell {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  .topbar {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    margin-inline: -0.5rem;
+    padding: 0 0.5rem 0.35rem;
+    scrollbar-width: none;
+  }
+
+  .topbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .topbar a {
+    white-space: nowrap;
+  }
+
+  h1 {
+    font-size: clamp(2.35rem, 16vw, 3.6rem);
+  }
+
+  .hero-actions .button,
+  .hero-actions button,
+  .operator-form .button {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+
+  .operator-form {
+    grid-template-columns: 1fr;
+  }
+
+  .panel,
+  .status-card {
+    padding: 0.85rem;
+  }
+
+  .section-head.row,
+  .queue-top {
+    display: grid;
+  }
+
+  .mobile-dock {
+    display: grid;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -262,6 +262,11 @@
             <span class="app-card__title">Revenue Desk</span>
             <span class="app-card__meta">Run the daily founder loop: follow-ups, proposals, billing, and one revenue move.</span>
           </a>
+          <a href="growth-operator/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">GO</span>
+            <span class="app-card__title">Growth Operator</span>
+            <span class="app-card__meta">Find leads, prepare approved email, triage support, and keep delivery moving.</span>
+          </a>
           <a href="/admin/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🛠️</span>
             <span class="app-card__title">Agent Ops</span>

--- a/tests/growth-operator.test.js
+++ b/tests/growth-operator.test.js
@@ -1,0 +1,80 @@
+import { constants } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const baseDir = new URL('../growth-operator/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+test('growth operator ships a separate lead, email, support, and delivery app', async () => {
+  const html = await readFile(new URL('index.html', baseDir), 'utf8');
+
+  assert.equal(await fileExists(new URL('index.html', baseDir)), true);
+  assert.equal(await fileExists(new URL('style.css', baseDir)), true);
+  assert.equal(await fileExists(new URL('app.js', baseDir)), true);
+  assert.match(html, /Growth Operator \| 3dvr portal/);
+  assert.match(html, /<h1>Growth Operator<\/h1>/);
+  assert.match(html, /Find likely-fit leads, prepare email, handle support, and keep delivery moving/);
+  assert.match(html, /id="findLeadsButton"/);
+  assert.match(html, /id="supportTriageButton"/);
+  assert.match(html, /id="deliveryPassButton"/);
+  assert.match(html, /id="operatorForm"/);
+  assert.match(html, /id="operatorEmailToken"/);
+  assert.match(html, /id="operatorQueue"/);
+  assert.match(html, /id="leadQueueCount"/);
+  assert.match(html, /id="readyEmailCount"/);
+  assert.match(html, /id="supportQueueCount"/);
+  assert.match(html, /id="deliveryQueueCount"/);
+  assert.match(html, /\/api\/calendar\/reminder-email/);
+  assert.match(html, /3dvr-portal\/growthOperator\/items/);
+  assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+  assert.match(html, /type="module" src="app\.js"/);
+});
+
+test('growth operator app queues agent work and can send approved outreach through mail route', async () => {
+  const js = await readFile(new URL('app.js', baseDir), 'utf8');
+
+  assert.match(js, /OPERATOR_NODE = 'growthOperator'/);
+  assert.match(js, /AGENT_OWNER_ALIAS = '3dvr-managed'/);
+  assert.match(js, /portalRoot\.get\('agentOps'\)\.get\(AGENT_OWNER_ALIAS\)\.get\('taskQueue'\)/);
+  assert.match(js, /buildAgentTask/);
+  assert.match(js, /find-leads/);
+  assert.match(js, /support-triage/);
+  assert.match(js, /delivery-pass/);
+  assert.match(js, /Do not mass email/);
+  assert.match(js, /wait for approval before sending/);
+  assert.match(js, /fetch\('\/api\/calendar\/reminder-email'/);
+  assert.match(js, /mode: 'lead-outreach'/);
+  assert.match(js, /Authorization: `Bearer \$\{token\}`/);
+  assert.match(js, /billingPlanUrl/);
+  assert.match(js, /buildDraft/);
+  assert.match(js, /itemsRoot\.map\(\)\.on/);
+});
+
+test('growth operator is discoverable from the portal and email operator', async () => {
+  const portalHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const emailOperatorHtml = await readFile(new URL('../email-operator/index.html', import.meta.url), 'utf8');
+
+  assert.match(portalHtml, /href="growth-operator\/"/);
+  assert.match(portalHtml, /<span class="app-card__title">Growth Operator<\/span>/);
+  assert.match(portalHtml, /Find leads, prepare approved email, triage support, and keep delivery moving\./);
+  assert.match(emailOperatorHtml, /href="..\/growth-operator\/"/);
+
+  const revenueIndex = portalHtml.indexOf('>Revenue Desk<');
+  const growthIndex = portalHtml.indexOf('>Growth Operator<');
+  const agentIndex = portalHtml.indexOf('>Agent Ops<');
+
+  assert.ok(revenueIndex !== -1, 'Revenue Desk app card should be listed');
+  assert.ok(growthIndex !== -1, 'Growth Operator app card should be listed');
+  assert.ok(agentIndex !== -1, 'Agent Ops app card should be listed');
+  assert.ok(revenueIndex < growthIndex, 'Growth Operator should render after Revenue Desk');
+  assert.ok(growthIndex < agentIndex, 'Growth Operator should render before Agent Ops');
+});


### PR DESCRIPTION
## Summary
- Adds a separate Growth Operator portal app for lead discovery, approved outreach, support triage, and delivery follow-through.
- Queues managed agent tasks for `find-leads`, `draft-outreach`, `support-triage`, and `delivery-pass` under `3dvr-portal/agentOps/3dvr-managed/taskQueue`.
- Saves operator records locally and mirrors them to `3dvr-portal/growthOperator/items`.
- Adds an approved-send path through the existing unified mail route using `mode: lead-outreach` and an operator token.
- Links Growth Operator from the portal home and Email Operator.

## Validation
- `node --check growth-operator/app.js`
- `node --test tests/growth-operator.test.js tests/email-operator.test.js tests/account-recovery-email.test.js`
- `git diff --check`
- Local smoke: `curl` returned 200 for `/growth-operator/` and confirmed the operator queue + mail route content.