### PR TITLE
Add growth operator cycle log

### DIFF
--- a/ops/growth-cycles/2026-05-27.md
+++ b/ops/growth-cycles/2026-05-27.md
@@ -1,0 +1,134 @@
+# Growth Operator Cycle: 2026-05-27
+
+## Outcome
+
+This was a controlled sales and service operator pass using the existing `3dvr-agent` pipeline and the new
+`portal.3dvr.tech/growth-operator/` queue.
+
+- Checked the 3DVR inbox.
+- Found no customer replies requiring a response.
+- Found three delivery-failure notices and one unrelated CGTrader update.
+- Sent one first-touch outreach message through the configured 3DVR mail path.
+- Marked the sent lead as contacted in the local agent pipeline.
+- Caught one duplicate lead before sending and moved it to nurture instead of emailing the same address again.
+- Enriched the next lead from site-only to form-ready.
+- Synced non-sensitive Growth Operator records to Gun.
+
+## Sent
+
+Lead:
+
+- Point Loma Estate Planning Law APC
+
+Message shape:
+
+> Thomas from 3DVR introduced `3dvr.tech` as practical help with websites, booking, lead follow-up, and customer
+> flow, then asked whether they are running into any of those problems right now.
+
+Local command used:
+
+```sh
+ask-send --auto --mark "Point Loma Estate Planning Law APC"
+```
+
+Result:
+
+- MX probe passed.
+- Outreach email sent.
+- Lead marked contacted.
+- Outreach log written locally in `3dvr-agent`.
+
+## Skipped
+
+Lead:
+
+- Silver Law LLP
+
+Reason:
+
+- Same email/contact route had already been contacted under the existing Silver Law PLC record.
+
+Action:
+
+```sh
+ask-track nurture "Silver Law LLP" "duplicate-email-already-contacted-2026-05-03"
+```
+
+## Next Lead
+
+Lead:
+
+- Finest City Home and Loans
+
+Action taken:
+
+```sh
+ask-enrich --name "Finest City Home and Loans" --refresh
+```
+
+Result:
+
+- Updated from site-only to form-ready.
+
+Next recommended action:
+
+```sh
+ask-form --dry-run "Finest City Home and Loans"
+```
+
+Only submit after verifying the form is a normal business contact form and the message is still short and relevant.
+
+## Growth Operator Sync
+
+Synced five non-sensitive records to Gun under:
+
+```text
+3dvr-portal/growthOperator/items
+```
+
+Records:
+
+- Point Loma Estate Planning Law APC: sent
+- Finest City Home and Loans: drafted / form review next
+- Victor Alibaba reseller: warm lead / ask for one product link
+- Brenda lake house: delivery / ask for photos, measurements, inspiration
+- Mark referral source: referral lane / ask for one warm intro
+
+Queued one agent task under:
+
+```text
+3dvr-portal/agentOps/3dvr-managed/taskQueue
+```
+
+Task:
+
+- Run a daily sales cycle from the Growth Operator queue.
+
+## Warm Network Next Messages
+
+Victor:
+
+```text
+Hey Victor, send me the first Alibaba item you want to test and we will start building around that one product.
+```
+
+Brenda:
+
+```text
+Can you send three current photos, rough measurements, and three inspiration images for the lake house area?
+```
+
+Mark:
+
+```text
+If you think of one person with a website, product, or tech setup problem, send them my way and I will keep it simple.
+```
+
+## Guardrails
+
+- Do not mass email.
+- Do not commit raw lead emails or private lead CSVs into public repos.
+- Check duplicates before sending.
+- Prefer warm-network leads before more cold outreach.
+- Keep every customer or lead at one visible next step.
+- Use `portal.3dvr.tech/growth-operator/` for the live operator queue.

--- a/ops/growth-cycles/README.md
+++ b/ops/growth-cycles/README.md
@@ -1,0 +1,15 @@
+# Growth Cycles
+
+Repo-backed summaries of 3DVR sales, support, and delivery operator passes.
+
+Keep these files scannable and non-sensitive:
+
+- Include what was done.
+- Include what was skipped and why.
+- Include the next concrete action.
+- Do not include raw private emails, passwords, tokens, or full lead exports.
+
+Live queue:
+
+- https://portal.3dvr.tech/growth-operator/
+


### PR DESCRIPTION
## Summary
- Add a repo-backed growth cycle record for the May 27 operator pass
- Document the controlled outreach send, duplicate skip, next form-ready lead, Gun sync, and warm-network next asks
- Add a short README for future non-sensitive growth cycle logs

## Validation
- `git diff --check`
- `node --test tests/growth-operator.test.js`