### PR TITLE
Add HTTPS Gun fallback for mobile signaling

### DIFF
--- a/calendar/gun-init.js
+++ b/calendar/gun-init.js
@@ -1,6 +1,7 @@
 (function initGunPeers(global) {
   const defaultPeers = [
-    'wss://gun-relay-3dvr.fly.dev/gun'
+    'wss://gun-relay-3dvr.fly.dev/gun',
+    'https://gun-relay-3dvr.fly.dev/gun'
   ];
   const disabledPeers = new Set([
     'wss://relay.3dvr.tech/gun'

--- a/contacts/gun-init.js
+++ b/contacts/gun-init.js
@@ -1,6 +1,7 @@
 (function initGunPeers(global) {
   const defaultPeers = [
-    'wss://gun-relay-3dvr.fly.dev/gun'
+    'wss://gun-relay-3dvr.fly.dev/gun',
+    'https://gun-relay-3dvr.fly.dev/gun'
   ];
   const disabledPeers = new Set([
     'wss://relay.3dvr.tech/gun'

--- a/gun-init.js
+++ b/gun-init.js
@@ -1,6 +1,7 @@
 (function initGunPeers(global) {
   const defaultPeers = [
-    'wss://gun-relay-3dvr.fly.dev/gun'
+    'wss://gun-relay-3dvr.fly.dev/gun',
+    'https://gun-relay-3dvr.fly.dev/gun'
   ];
   const disabledPeers = new Set([
     'wss://relay.3dvr.tech/gun'

--- a/tests/gun-peer-config.test.js
+++ b/tests/gun-peer-config.test.js
@@ -14,11 +14,14 @@ describe('Gun peer configuration', () => {
     for (const path of ['gun-init.js', 'contacts/gun-init.js', 'calendar/gun-init.js']) {
       const source = await read(path);
       const flyIndex = source.indexOf('wss://gun-relay-3dvr.fly.dev/gun');
+      const flyHttpsIndex = source.indexOf('https://gun-relay-3dvr.fly.dev/gun');
       const disabledIndex = source.indexOf('wss://relay.3dvr.tech/gun');
 
       assert.notEqual(flyIndex, -1, `${path} should include the Fly relay`);
+      assert.notEqual(flyHttpsIndex, -1, `${path} should include the Fly HTTPS fallback`);
       assert.notEqual(disabledIndex, -1, `${path} should explicitly filter the dead relay`);
       assert.ok(flyIndex < disabledIndex, `${path} should prefer Fly before mentioning disabled relays`);
+      assert.ok(flyIndex < flyHttpsIndex, `${path} should try WebSocket before HTTPS fallback`);
       assert.match(source, /disabledPeers|DISABLED/);
       assert.match(source, /filter\(peer => !disabledPeers\.has\(peer\)\)/);
     }

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -39,13 +39,14 @@ describe('WebRTC Lab app', () => {
     assert.match(html, /Native WebRTC POC/);
     assert.match(html, /id="local-video"/);
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
-    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260527-v2">/);
+    assert.match(html, /<script src="\/gun-init\.js\?v=20260527-v1"><\/script>/);
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260527-v3">/);
     assert.match(html, /id="turn-status">STUN only</);
     assert.match(html, /id="video-profile">180p \/ 10fps</);
     assert.match(html, /id="gun-status">Not connected</);
     assert.match(html, /id="announce-count">0</);
-    assert.match(html, /id="build-version">WebRTC v2\.5</);
-    assert.match(html, /<script src="\.\/app\.js\?v=20260527-v2"><\/script>/);
+    assert.match(html, /id="build-version">WebRTC v2\.6</);
+    assert.match(html, /<script src="\.\/app\.js\?v=20260527-v3"><\/script>/);
     assert.match(js, /fetch\('\/api\/session\?route=turn-credentials', \{ cache: 'no-store' \}\)/);
     assert.match(js, /new RTCPeerConnection\(connectionConfig\)/);
     assert.match(js, /connectionConfig\.iceTransportPolicy = 'relay'/);
@@ -58,6 +59,7 @@ describe('WebRTC Lab app', () => {
     assert.match(js, /PEER_SESSION_KEY = 'webrtcLabParticipantId'/);
     assert.match(js, /sessionStorage\.setItem\(PEER_SESSION_KEY, next\)/);
     assert.match(js, /DEFAULT_GUN_PEERS = Object\.freeze/);
+    assert.match(js, /https:\/\/gun-relay-3dvr\.fly\.dev\/gun/);
     assert.match(js, /function configuredGunPeers\(\)/);
     assert.match(js, /gun\.on\('hi'/);
     assert.match(js, /radisk: false/);
@@ -91,6 +93,7 @@ describe('WebRTC Lab app', () => {
     assert.match(readme, /TURN only affects media connectivity after peers can see each other/);
     assert.match(readme, /localStorage: false/);
     assert.match(readme, /waits for the Gun relay `hi` event/);
+    assert.match(readme, /https:\/\/gun-relay-3dvr\.fly\.dev\/gun/);
     assert.match(readme, /Mesh WebRTC/);
     assert.match(readme, /3dvr-webrtc-lab-v2\/<room>/);
   });

--- a/webrtc-lab/README.md
+++ b/webrtc-lab/README.md
@@ -24,6 +24,8 @@ The lab creates its Gun client with `radisk: false` and `localStorage: false` be
 ephemeral. This avoids stale browser storage making a phone appear connected while its room writes stay local.
 Room signaling waits for the Gun relay `hi` event before writing presence so slower phones do not send their
 first join signals before the relay is ready.
+The shared Gun initializer includes both `wss://gun-relay-3dvr.fly.dev/gun` and
+`https://gun-relay-3dvr.fly.dev/gun` so browsers that struggle with one transport can try the other.
 
 The default camera profile is intentionally low bandwidth: it asks for 320 x 180 video at about 10 fps
 and caps the video sender near 240 kbps for weak mobile links.

--- a/webrtc-lab/app.js
+++ b/webrtc-lab/app.js
@@ -27,7 +27,8 @@
     { urls: ['stun:stun.l.google.com:19302', 'stun:stun1.l.google.com:19302'] }
   ];
   const DEFAULT_GUN_PEERS = Object.freeze([
-    'wss://gun-relay-3dvr.fly.dev/gun'
+    'wss://gun-relay-3dvr.fly.dev/gun',
+    'https://gun-relay-3dvr.fly.dev/gun'
   ]);
   const ROOM_ROOT = '3dvr-webrtc-lab-v2';
   const SIGNAL_TTL_MS = 1000 * 60 * 20;

--- a/webrtc-lab/index.html
+++ b/webrtc-lab/index.html
@@ -9,9 +9,9 @@
     content="A native WebRTC proof-of-concept for 3DVR video rooms with Gun-backed signaling."
   >
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
-  <script src="/gun-init.js"></script>
+  <script src="/gun-init.js?v=20260527-v1"></script>
   <link rel="stylesheet" href="../style.css?v=webrtc-lab">
-  <link rel="stylesheet" href="./styles.css?v=20260527-v2">
+  <link rel="stylesheet" href="./styles.css?v=20260527-v3">
 </head>
 <body class="webrtc-page">
   <header class="lab-header">
@@ -96,7 +96,7 @@
         </div>
         <div>
           <dt>Build</dt>
-          <dd id="build-version">WebRTC v2.5</dd>
+          <dd id="build-version">WebRTC v2.6</dd>
         </div>
       </dl>
     </section>
@@ -124,6 +124,6 @@
     <p>Built as a 3DVR WebRTC proof of concept. Use HTTPS or localhost so browser camera permissions work.</p>
   </footer>
 
-  <script src="./app.js?v=20260527-v2"></script>
+  <script src="./app.js?v=20260527-v3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add the HTTPS Fly Gun relay fallback beside the WebSocket relay in shared Gun initializers
- Version the WebRTC lab's /gun-init.js include so portal.3dvr.tech does not reuse the immutable cached single-peer initializer
- Bump the WebRTC lab to v2.6

## Verification
- node --check webrtc-lab/app.js
- node --test tests/webrtc-lab.test.js tests/gun-peer-config.test.js tests/turn-credentials.test.js
- Firefox two-client Gun smoke with https://gun-relay-3dvr.fly.dev/gun propagated a write across clients