### PR TITLE
[codex] Add WebRTC relay diagnostics

### DIFF
--- a/ops/turn/README.md
+++ b/ops/turn/README.md
@@ -12,7 +12,7 @@ for a coturn server configured with the same shared secret.
    - `3478/tcp`
    - `3478/udp`
    - `5349/tcp`
-   - `49160-49200/udp`
+   - `49152-65535/udp`
 4. Install Docker and Docker Compose.
 5. Copy `turnserver.conf.example` to `turnserver.conf`.
 6. Replace `static-auth-secret` with a long random value:
@@ -48,3 +48,8 @@ TURN_USERNAME_PREFIX=portal
 
 Deploy the portal after setting the env vars. The WebRTC lab should then show `Relay: TURN ready`.
 Use `?relay=1` or `?ice=relay` on a room URL to force TURN-only testing.
+
+The current 3DVR test relay runs on the DigitalOcean server at `167.172.193.194` and is exposed through
+`selfhost.3dvr.tech`/`turn.3dvr.tech`. For mobile carrier testing, keep the relay UDP range wide enough
+for real calls and avoid blocking private or carrier-grade NAT peer ranges in coturn until the behavior is
+well understood; overly strict `denied-peer-ip` rules can make same-network calls work while 5G calls fail.

--- a/ops/turn/turnserver.conf.example
+++ b/ops/turn/turnserver.conf.example
@@ -1,7 +1,7 @@
 listening-port=3478
 tls-listening-port=5349
-min-port=49160
-max-port=49200
+min-port=49152
+max-port=65535
 
 realm=turn.3dvr.tech
 server-name=turn.3dvr.tech

--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -40,13 +40,15 @@ describe('WebRTC Lab app', () => {
     assert.match(html, /id="local-video"/);
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
     assert.match(html, /<script src="\/gun-init\.js\?v=20260527-v1"><\/script>/);
-    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260527-v3">/);
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260527-v4">/);
     assert.match(html, /id="turn-status">STUN only</);
+    assert.match(html, /id="ice-status">Idle</);
+    assert.match(html, /id="relay-candidates">0 local \/ 0 remote</);
     assert.match(html, /id="video-profile">180p \/ 10fps</);
     assert.match(html, /id="gun-status">Not connected</);
     assert.match(html, /id="announce-count">0</);
-    assert.match(html, /id="build-version">WebRTC v2\.6</);
-    assert.match(html, /<script src="\.\/app\.js\?v=20260527-v3"><\/script>/);
+    assert.match(html, /id="build-version">WebRTC v2\.7</);
+    assert.match(html, /<script src="\.\/app\.js\?v=20260527-v4"><\/script>/);
     assert.match(js, /fetch\('\/api\/session\?route=turn-credentials', \{ cache: 'no-store' \}\)/);
     assert.match(js, /new RTCPeerConnection\(connectionConfig\)/);
     assert.match(js, /connectionConfig\.iceTransportPolicy = 'relay'/);
@@ -71,6 +73,10 @@ describe('WebRTC Lab app', () => {
     assert.match(js, /const isNewPeer = !peers\.has\(remoteId\)/);
     assert.match(js, /if \(isNewPeer && shouldInitiateOffer\(remoteId\)\)/);
     assert.match(js, /connection\.onnegotiationneeded/);
+    assert.match(js, /connection\.onicecandidateerror/);
+    assert.match(js, /connection\.oniceconnectionstatechange/);
+    assert.match(js, /recordCandidate\('local'/);
+    assert.match(js, /recordCandidate\('remote'/);
     assert.match(js, /signalQueue: Promise\.resolve\(\)/);
     assert.match(js, /queuePeerSignal\(peer, async \(\) =>/);
     assert.match(js, /peer\.connection\.signalingState !== 'have-local-offer'/);
@@ -90,7 +96,8 @@ describe('WebRTC Lab app', () => {
     assert.match(readme, /320 x 180 video at about 10 fps/);
     assert.match(readme, /near 240 kbps/);
     assert.match(readme, /Gun relay status/);
-    assert.match(readme, /TURN only affects media connectivity after peers can see each other/);
+    assert.match(readme, /ICE state, and relay candidate counts/);
+    assert.match(readme, /TURN only affects media\s+connectivity after peers can see each other/);
     assert.match(readme, /localStorage: false/);
     assert.match(readme, /waits for the Gun relay `hi` event/);
     assert.match(readme, /https:\/\/gun-relay-3dvr\.fly\.dev\/gun/);
@@ -129,6 +136,8 @@ describe('WebRTC Lab app', () => {
     assert.match(compose, /coturn\/coturn:latest/);
     assert.match(config, /use-auth-secret/);
     assert.match(config, /static-auth-secret=replace_me_with_same_value_as_TURN_STATIC_AUTH_SECRET/);
+    assert.match(config, /min-port=49152/);
+    assert.match(config, /max-port=65535/);
   });
 });
 

--- a/webrtc-lab/README.md
+++ b/webrtc-lab/README.md
@@ -13,9 +13,10 @@ The v2 room root uses tab-scoped peer IDs, starts media before signaling, sends 
 announcements, and stores offer/answer/candidate payloads as JSON strings so Gun does not have to
 serialize browser-native WebRTC objects.
 
-The page shows Gun relay status, announce count, and peer count in the diagnostics bar. If peer count stays
-at zero on two devices in the same room, the issue is usually room URL mismatch, stale cached assets, or
-Gun signaling reachability rather than TURN. TURN only affects media connectivity after peers can see each other.
+The page shows Gun relay status, announce count, peer count, ICE state, and relay candidate counts in the
+diagnostics bar. If peer count stays at zero on two devices in the same room, the issue is usually room URL
+mismatch, stale cached assets, or Gun signaling reachability rather than TURN. TURN only affects media
+connectivity after peers can see each other.
 
 After joining, the lab re-announces presence and sweeps the room a few times so a phone and laptop can recover
 from slow relay startup or a late Gun map subscription.
@@ -32,6 +33,7 @@ and caps the video sender near 240 kbps for weak mobile links.
 
 When `/api/session?route=turn-credentials` is configured with `TURN_URLS` and `TURN_STATIC_AUTH_SECRET`, the lab
 loads short-lived TURN credentials before joining a room. Add `?relay=1` or `?ice=relay` to the room
-URL to force relay-only ICE while testing the TURN server.
+URL to force relay-only ICE while testing the TURN server. In relay-only mode, a laptop-to-phone-on-5G test
+should show at least one local relay candidate and at least one remote relay candidate after both peers join.
 
 It is intentionally not a production replacement for a Selective Forwarding Unit. Mesh WebRTC is useful for two or three people while testing connection behavior, but larger meetings need an SFU or other managed media layer.

--- a/webrtc-lab/app.js
+++ b/webrtc-lab/app.js
@@ -20,6 +20,8 @@
     gunStatus: document.getElementById('gun-status'),
     announceCount: document.getElementById('announce-count'),
     turnStatus: document.getElementById('turn-status'),
+    iceStatus: document.getElementById('ice-status'),
+    relayCandidates: document.getElementById('relay-candidates'),
     eventLog: document.getElementById('event-log')
   };
 
@@ -56,12 +58,17 @@
   let iceServers = DEFAULT_ICE_SERVERS;
   let iceServersLoaded = false;
   let turnStatus = 'STUN only';
+  let iceStatus = 'Idle';
+  let localRelayCandidateCount = 0;
+  let remoteRelayCandidateCount = 0;
   let gunStatus = 'Not connected';
   let gunPeers = [];
   let gunConnected = false;
   let gunConnectionWaiters = [];
   const peers = new Map();
   const seenSignals = new Set();
+  const localCandidateKeys = new Set();
+  const remoteCandidateKeys = new Set();
 
   function normalizeRoom(value = '') {
     return String(value || '')
@@ -109,6 +116,10 @@
     if (refs.gunStatus) refs.gunStatus.textContent = gunStatus;
     if (refs.announceCount) refs.announceCount.textContent = String(announcesHandled);
     refs.turnStatus.textContent = turnStatus;
+    if (refs.iceStatus) refs.iceStatus.textContent = iceStatus;
+    if (refs.relayCandidates) {
+      refs.relayCandidates.textContent = `${localRelayCandidateCount} local / ${remoteRelayCandidateCount} remote`;
+    }
   }
 
   function resolveInitialRoom() {
@@ -335,7 +346,27 @@
 
     connection.onicecandidate = event => {
       if (event.candidate) {
+        recordCandidate('local', event.candidate.candidate, peer.name);
         sendSignal(remoteId, 'candidate', event.candidate);
+      }
+    };
+
+    connection.onicecandidateerror = event => {
+      const target = event.url || 'ICE server';
+      const detail = event.errorText || event.errorCode || 'candidate error';
+      logEvent(`${target} failed: ${detail}.`);
+    };
+
+    connection.onicegatheringstatechange = () => {
+      iceStatus = `Gathering ${connection.iceGatheringState}`;
+      updateDiagnostics();
+    };
+
+    connection.oniceconnectionstatechange = () => {
+      iceStatus = connection.iceConnectionState;
+      updateDiagnostics();
+      if (['failed', 'disconnected'].includes(connection.iceConnectionState)) {
+        logEvent(`${peer.name} ICE ${connection.iceConnectionState}.`);
       }
     };
 
@@ -348,6 +379,35 @@
 
     logEvent(`Peer ready: ${peer.name}.`);
     return peer;
+  }
+
+  function describeIceCandidate(candidateText = '') {
+    const candidate = String(candidateText || '');
+    const type = candidate.match(/\btyp\s+([a-z0-9]+)/i)?.[1] || 'unknown';
+    const protocol = candidate.match(/\b(udp|tcp)\b/i)?.[1]?.toUpperCase() || 'ICE';
+    const address = candidate.match(/candidate:\S+\s+\d+\s+\S+\s+\d+\s+([^\s]+)\s+(\d+)/i);
+    const endpoint = address ? `${address[1]}:${address[2]}` : '';
+    return { type, protocol, endpoint };
+  }
+
+  function recordCandidate(kind, candidateText = '', remoteName = '') {
+    const candidate = String(candidateText || '');
+    if (!candidate) return;
+
+    const seen = kind === 'local' ? localCandidateKeys : remoteCandidateKeys;
+    const key = `${kind}:${candidate}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    const detail = describeIceCandidate(candidate);
+    if (detail.type === 'relay') {
+      if (kind === 'local') localRelayCandidateCount += 1;
+      else remoteRelayCandidateCount += 1;
+
+      const source = kind === 'local' ? 'Local' : `Remote${remoteName ? ` ${remoteName}` : ''}`;
+      logEvent(`${source} relay candidate found (${detail.protocol}${detail.endpoint ? ` ${detail.endpoint}` : ''}).`);
+    }
+    updateDiagnostics();
   }
 
   function createRemoteTile(remoteId, name) {
@@ -488,6 +548,7 @@
 
   async function handleCandidate(signal) {
     const peer = peers.get(signal.from) || createPeer(signal.from, signal.fromName);
+    recordCandidate('remote', signal.payload?.candidate || '', signal.fromName);
     try {
       await peer.connection.addIceCandidate(new RTCIceCandidate(signal.payload));
     } catch (error) {

--- a/webrtc-lab/index.html
+++ b/webrtc-lab/index.html
@@ -11,7 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/gun-init.js?v=20260527-v1"></script>
   <link rel="stylesheet" href="../style.css?v=webrtc-lab">
-  <link rel="stylesheet" href="./styles.css?v=20260527-v3">
+  <link rel="stylesheet" href="./styles.css?v=20260527-v4">
 </head>
 <body class="webrtc-page">
   <header class="lab-header">
@@ -91,12 +91,20 @@
           <dd id="turn-status">STUN only</dd>
         </div>
         <div>
+          <dt>ICE</dt>
+          <dd id="ice-status">Idle</dd>
+        </div>
+        <div>
+          <dt>Relay candidates</dt>
+          <dd id="relay-candidates">0 local / 0 remote</dd>
+        </div>
+        <div>
           <dt>Video</dt>
           <dd id="video-profile">180p / 10fps</dd>
         </div>
         <div>
           <dt>Build</dt>
-          <dd id="build-version">WebRTC v2.6</dd>
+          <dd id="build-version">WebRTC v2.7</dd>
         </div>
       </dl>
     </section>
@@ -124,6 +132,6 @@
     <p>Built as a 3DVR WebRTC proof of concept. Use HTTPS or localhost so browser camera permissions work.</p>
   </footer>
 
-  <script src="./app.js?v=20260527-v3"></script>
+  <script src="./app.js?v=20260527-v4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add ICE state and relay candidate diagnostics to the WebRTC lab
- bump the WebRTC lab asset versions to v2.7/v4 so production gets fresh JS/CSS
- document the wider coturn relay range needed for mobile/5G testing

## Why
Laptop-to-phone tests worked on the same network but became brittle or one-way on 5G. The live coturn logs showed denied private/CGNAT peer ranges and a tiny relay port range, so the next test needs clear page-level evidence of whether each browser actually gathers local and remote relay candidates.

## Validation
- `node --check webrtc-lab/app.js`
- `node --test tests/webrtc-lab.test.js tests/turn-credentials.test.js`
- external `turnutils_uclient` UDP and TCP relay checks against `selfhost.3dvr.tech:3478` both completed with 20 sent / 20 received and 0% packet loss
