### PR TITLE
[codex] Clean up WebRTC relay-only diagnostics

### DIFF
--- a/tests/webrtc-lab.test.js
+++ b/tests/webrtc-lab.test.js
@@ -40,18 +40,19 @@ describe('WebRTC Lab app', () => {
     assert.match(html, /id="local-video"/);
     assert.match(html, /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"><\/script>/);
     assert.match(html, /<script src="\/gun-init\.js\?v=20260527-v1"><\/script>/);
-    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260527-v4">/);
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css\?v=20260527-v5">/);
     assert.match(html, /id="turn-status">STUN only</);
     assert.match(html, /id="ice-status">Idle</);
     assert.match(html, /id="relay-candidates">0 local \/ 0 remote</);
     assert.match(html, /id="video-profile">180p \/ 10fps</);
     assert.match(html, /id="gun-status">Not connected</);
     assert.match(html, /id="announce-count">0</);
-    assert.match(html, /id="build-version">WebRTC v2\.7</);
-    assert.match(html, /<script src="\.\/app\.js\?v=20260527-v4"><\/script>/);
+    assert.match(html, /id="build-version">WebRTC v2\.8</);
+    assert.match(html, /<script src="\.\/app\.js\?v=20260527-v5"><\/script>/);
     assert.match(js, /fetch\('\/api\/session\?route=turn-credentials', \{ cache: 'no-store' \}\)/);
     assert.match(js, /new RTCPeerConnection\(connectionConfig\)/);
     assert.match(js, /connectionConfig\.iceTransportPolicy = 'relay'/);
+    assert.match(js, /function relayOnlyIceServers/);
     assert.match(js, /navigator\.mediaDevices\.getUserMedia/);
     assert.match(js, /LOW_BANDWIDTH_VIDEO = Object\.freeze/);
     assert.match(js, /width: \{ ideal: LOW_BANDWIDTH_VIDEO\.width \}/);
@@ -60,6 +61,7 @@ describe('WebRTC Lab app', () => {
     assert.match(js, /ROOM_ROOT = '3dvr-webrtc-lab-v2'/);
     assert.match(js, /PEER_SESSION_KEY = 'webrtcLabParticipantId'/);
     assert.match(js, /sessionStorage\.setItem\(PEER_SESSION_KEY, next\)/);
+    assert.doesNotMatch(js, /sessionStorage\.getItem\(PEER_SESSION_KEY\)/);
     assert.match(js, /DEFAULT_GUN_PEERS = Object\.freeze/);
     assert.match(js, /https:\/\/gun-relay-3dvr\.fly\.dev\/gun/);
     assert.match(js, /function configuredGunPeers\(\)/);
@@ -75,6 +77,7 @@ describe('WebRTC Lab app', () => {
     assert.match(js, /connection\.onnegotiationneeded/);
     assert.match(js, /connection\.onicecandidateerror/);
     assert.match(js, /connection\.oniceconnectionstatechange/);
+    assert.match(js, /function logIceCandidateError/);
     assert.match(js, /recordCandidate\('local'/);
     assert.match(js, /recordCandidate\('remote'/);
     assert.match(js, /signalQueue: Promise\.resolve\(\)/);
@@ -96,7 +99,8 @@ describe('WebRTC Lab app', () => {
     assert.match(readme, /320 x 180 video at about 10 fps/);
     assert.match(readme, /near 240 kbps/);
     assert.match(readme, /Gun relay status/);
-    assert.match(readme, /ICE state, and relay candidate counts/);
+    assert.match(readme, /ICE connection\/gathering state, and relay candidate counts/);
+    assert.match(readme, /strips STUN URLs/);
     assert.match(readme, /TURN only affects media\s+connectivity after peers can see each other/);
     assert.match(readme, /localStorage: false/);
     assert.match(readme, /waits for the Gun relay `hi` event/);

--- a/webrtc-lab/README.md
+++ b/webrtc-lab/README.md
@@ -9,11 +9,11 @@ This app uses:
 - Gun at `3dvr-webrtc-lab-v2/<room>` for lightweight signaling and room presence.
 - Public STUN servers for NAT discovery.
 
-The v2 room root uses tab-scoped peer IDs, starts media before signaling, sends explicit room
+The v2 room root uses page-load peer IDs, starts media before signaling, sends explicit room
 announcements, and stores offer/answer/candidate payloads as JSON strings so Gun does not have to
 serialize browser-native WebRTC objects.
 
-The page shows Gun relay status, announce count, peer count, ICE state, and relay candidate counts in the
+The page shows Gun relay status, announce count, peer count, ICE connection/gathering state, and relay candidate counts in the
 diagnostics bar. If peer count stays at zero on two devices in the same room, the issue is usually room URL
 mismatch, stale cached assets, or Gun signaling reachability rather than TURN. TURN only affects media
 connectivity after peers can see each other.
@@ -35,5 +35,6 @@ When `/api/session?route=turn-credentials` is configured with `TURN_URLS` and `T
 loads short-lived TURN credentials before joining a room. Add `?relay=1` or `?ice=relay` to the room
 URL to force relay-only ICE while testing the TURN server. In relay-only mode, a laptop-to-phone-on-5G test
 should show at least one local relay candidate and at least one remote relay candidate after both peers join.
+Relay-only mode strips STUN URLs from the browser ICE configuration so the log stays focused on TURN behavior.
 
 It is intentionally not a production replacement for a Selective Forwarding Unit. Mesh WebRTC is useful for two or three people while testing connection behavior, but larger meetings need an SFU or other managed media layer.

--- a/webrtc-lab/app.js
+++ b/webrtc-lab/app.js
@@ -58,7 +58,8 @@
   let iceServers = DEFAULT_ICE_SERVERS;
   let iceServersLoaded = false;
   let turnStatus = 'STUN only';
-  let iceStatus = 'Idle';
+  let iceConnectionStatus = 'Idle';
+  let iceGatheringStatus = 'Idle';
   let localRelayCandidateCount = 0;
   let remoteRelayCandidateCount = 0;
   let gunStatus = 'Not connected';
@@ -69,6 +70,7 @@
   const seenSignals = new Set();
   const localCandidateKeys = new Set();
   const remoteCandidateKeys = new Set();
+  const iceCandidateErrorKeys = new Set();
 
   function normalizeRoom(value = '') {
     return String(value || '')
@@ -84,15 +86,13 @@
   }
 
   function getOrCreateLocalId() {
+    const next = createId('peer');
     try {
-      const stored = sessionStorage.getItem(PEER_SESSION_KEY);
-      if (stored) return stored;
-      const next = createId('peer');
       sessionStorage.setItem(PEER_SESSION_KEY, next);
-      return next;
     } catch (_error) {
-      return createId('peer');
+      // Duplicated mobile tabs can clone sessionStorage, so the active ID is per page load.
     }
+    return next;
   }
 
   function logEvent(message) {
@@ -116,7 +116,11 @@
     if (refs.gunStatus) refs.gunStatus.textContent = gunStatus;
     if (refs.announceCount) refs.announceCount.textContent = String(announcesHandled);
     refs.turnStatus.textContent = turnStatus;
-    if (refs.iceStatus) refs.iceStatus.textContent = iceStatus;
+    if (refs.iceStatus) {
+      refs.iceStatus.textContent = iceConnectionStatus === 'Idle' && iceGatheringStatus === 'Idle'
+        ? 'Idle'
+        : `${iceConnectionStatus} / gather ${iceGatheringStatus}`;
+    }
     if (refs.relayCandidates) {
       refs.relayCandidates.textContent = `${localRelayCandidateCount} local / ${remoteRelayCandidateCount} remote`;
     }
@@ -232,6 +236,20 @@
       .filter(Boolean);
   }
 
+  function relayOnlyIceServers(servers) {
+    const turnServers = servers
+      .map(server => {
+        const urls = server.urls.filter(url => /^turns?:/i.test(url));
+        if (!urls.length) return null;
+        const normalized = { urls };
+        if (server.username) normalized.username = server.username;
+        if (server.credential) normalized.credential = server.credential;
+        return normalized;
+      })
+      .filter(Boolean);
+    return turnServers.length ? turnServers : servers;
+  }
+
   async function loadIceServers() {
     if (iceServersLoaded) return iceServers;
     iceServersLoaded = true;
@@ -243,7 +261,10 @@
       }
 
       const data = await response.json();
-      const nextServers = normalizeIceServers(data.iceServers);
+      const normalizedServers = normalizeIceServers(data.iceServers);
+      const nextServers = shouldForceRelayOnly()
+        ? relayOnlyIceServers(normalizedServers)
+        : normalizedServers;
       if (nextServers.length) {
         iceServers = nextServers;
       }
@@ -253,6 +274,10 @@
         : 'STUN only';
       updateDiagnostics();
       logEvent(data.configured ? 'TURN relay credentials loaded.' : 'Using STUN only.');
+      if (data.configured && shouldForceRelayOnly()) {
+        const urlCount = iceServers.reduce((count, server) => count + server.urls.length, 0);
+        logEvent(`Relay-only test using ${urlCount} TURN URL${urlCount === 1 ? '' : 's'}.`);
+      }
     } catch (error) {
       console.warn('TURN credential load failed', error);
       turnStatus = 'STUN only';
@@ -352,18 +377,16 @@
     };
 
     connection.onicecandidateerror = event => {
-      const target = event.url || 'ICE server';
-      const detail = event.errorText || event.errorCode || 'candidate error';
-      logEvent(`${target} failed: ${detail}.`);
+      logIceCandidateError(event);
     };
 
     connection.onicegatheringstatechange = () => {
-      iceStatus = `Gathering ${connection.iceGatheringState}`;
+      iceGatheringStatus = connection.iceGatheringState;
       updateDiagnostics();
     };
 
     connection.oniceconnectionstatechange = () => {
-      iceStatus = connection.iceConnectionState;
+      iceConnectionStatus = connection.iceConnectionState;
       updateDiagnostics();
       if (['failed', 'disconnected'].includes(connection.iceConnectionState)) {
         logEvent(`${peer.name} ICE ${connection.iceConnectionState}.`);
@@ -388,6 +411,15 @@
     const address = candidate.match(/candidate:\S+\s+\d+\s+\S+\s+\d+\s+([^\s]+)\s+(\d+)/i);
     const endpoint = address ? `${address[1]}:${address[2]}` : '';
     return { type, protocol, endpoint };
+  }
+
+  function logIceCandidateError(event) {
+    const target = event.url || 'ICE server';
+    const detail = event.errorText || event.errorCode || 'candidate error';
+    const key = `${target}:${detail}`;
+    if (iceCandidateErrorKeys.has(key)) return;
+    iceCandidateErrorKeys.add(key);
+    logEvent(`${target} failed: ${detail}.`);
   }
 
   function recordCandidate(kind, candidateText = '', remoteName = '') {

--- a/webrtc-lab/index.html
+++ b/webrtc-lab/index.html
@@ -11,7 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/gun-init.js?v=20260527-v1"></script>
   <link rel="stylesheet" href="../style.css?v=webrtc-lab">
-  <link rel="stylesheet" href="./styles.css?v=20260527-v4">
+  <link rel="stylesheet" href="./styles.css?v=20260527-v5">
 </head>
 <body class="webrtc-page">
   <header class="lab-header">
@@ -104,7 +104,7 @@
         </div>
         <div>
           <dt>Build</dt>
-          <dd id="build-version">WebRTC v2.7</dd>
+          <dd id="build-version">WebRTC v2.8</dd>
         </div>
       </dl>
     </section>
@@ -132,6 +132,6 @@
     <p>Built as a 3DVR WebRTC proof of concept. Use HTTPS or localhost so browser camera permissions work.</p>
   </footer>
 
-  <script src="./app.js?v=20260527-v4"></script>
+  <script src="./app.js?v=20260527-v5"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make relay-only WebRTC tests pass only TURN URLs to `RTCPeerConnection`
- show ICE connection state separately from gathering state in the diagnostics line
- generate a fresh peer ID per page load so duplicated Android tabs do not reuse the same room identity
- dedupe repeated ICE candidate errors in the connection log

## Why
The Android test shows local and remote TURN relay candidates, so TURN is working. The remaining logs were noisy: STUN failures appeared even in relay-only mode, and `Gathering complete` could hide the actual ICE connection state.

## Validation
- `node --check webrtc-lab/app.js`
- `node --test tests/webrtc-lab.test.js tests/turn-credentials.test.js`
