### PR TITLE
[codex] Add CRM flow interface

### DIFF
--- a/crm/flow.css
+++ b/crm/flow.css
@@ -1,0 +1,770 @@
+:root {
+  color-scheme: light;
+  --ink: #172033;
+  --muted: #5d6575;
+  --paper: #f7f8fb;
+  --surface: #ffffff;
+  --line: #dfe4ec;
+  --line-strong: #c9d2df;
+  --blue: #2563eb;
+  --blue-dark: #1e40af;
+  --teal: #0f766e;
+  --green: #15803d;
+  --amber: #b45309;
+  --coral: #e25544;
+  --purple: #7c3aed;
+  --shadow: 0 18px 40px rgba(23, 32, 51, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+  letter-spacing: 0;
+}
+
+html {
+  min-height: 100%;
+  background: var(--paper);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(90deg, rgba(37, 99, 235, 0.06) 1px, transparent 1px),
+    linear-gradient(0deg, rgba(23, 32, 51, 0.05) 1px, transparent 1px),
+    var(--paper);
+  background-size: 48px 48px;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.flow-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 64px;
+  padding: 12px clamp(16px, 4vw, 36px);
+  border-bottom: 1px solid var(--line);
+  background: rgba(247, 248, 251, 0.92);
+  backdrop-filter: blur(18px);
+}
+
+.flow-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: max-content;
+  color: var(--ink);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.flow-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  color: #fff;
+  background: var(--ink);
+  font-size: 0.82rem;
+}
+
+.flow-nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.flow-button,
+.icon-button,
+.segment {
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 150ms ease, border-color 150ms ease, background 150ms ease, color 150ms ease;
+}
+
+.flow-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 0 14px;
+  color: var(--ink);
+  background: var(--surface);
+  border-color: var(--line);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.flow-button svg,
+.icon-button svg,
+.search-box svg {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+}
+
+.flow-button:hover,
+.icon-button:hover,
+.segment:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+}
+
+.flow-button.primary {
+  color: #fff;
+  background: var(--blue);
+  border-color: var(--blue);
+}
+
+.flow-button.primary:hover {
+  background: var(--blue-dark);
+}
+
+.flow-button.coral {
+  color: #fff;
+  background: var(--coral);
+  border-color: var(--coral);
+}
+
+.flow-button.green {
+  color: #fff;
+  background: var(--green);
+  border-color: var(--green);
+}
+
+.flow-button.ghost {
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.flow-button.compact {
+  min-height: 34px;
+  padding: 0 10px;
+  font-size: 0.9rem;
+}
+
+.flow-button.full {
+  width: 100%;
+}
+
+.icon-button {
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  color: var(--ink);
+  background: var(--surface);
+  border-color: var(--line);
+}
+
+.flow-shell {
+  width: min(1540px, 100%);
+  margin: 0 auto;
+  padding: clamp(18px, 3vw, 36px);
+}
+
+.flow-hero,
+.flow-map {
+  border-block: 1px solid var(--line);
+  padding: clamp(18px, 3vw, 28px) 0;
+}
+
+.flow-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 440px);
+  align-items: end;
+  gap: 24px;
+}
+
+.flow-kicker {
+  margin: 0 0 6px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  overflow-wrap: anywhere;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  line-height: 1.05;
+}
+
+h1 {
+  max-width: 900px;
+  font-size: clamp(2.15rem, 4vw, 4.7rem);
+}
+
+h2 {
+  font-size: 1.22rem;
+}
+
+h3 {
+  font-size: 1rem;
+}
+
+.hero-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.flow-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.flow-pill.blue {
+  color: #1d4ed8;
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.flow-pill.amber {
+  color: #92400e;
+  background: #fffbeb;
+  border-color: #fde68a;
+}
+
+.flow-pill.green {
+  color: #166534;
+  background: #ecfdf5;
+  border-color: #bbf7d0;
+}
+
+.flow-pill.coral {
+  color: #b42318;
+  background: #fff1f0;
+  border-color: #fecaca;
+}
+
+.flow-pill.purple {
+  color: #6d28d9;
+  background: #f5f3ff;
+  border-color: #ddd6fe;
+}
+
+.hero-search {
+  display: grid;
+  gap: 8px;
+}
+
+.hero-search label,
+.form-grid span,
+.drawer-form span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 52px;
+  padding: 0 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.search-box input,
+.form-grid input,
+.form-grid select,
+.drawer-form input,
+.drawer-form select,
+.drawer-form textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--ink);
+  background: #fff;
+}
+
+.search-box input {
+  min-height: 50px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+.flow-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-bottom: 1px solid var(--line);
+}
+
+.metric-cell {
+  display: grid;
+  gap: 3px;
+  padding: 18px 12px;
+  border-right: 1px solid var(--line);
+}
+
+.metric-cell:last-child {
+  border-right: 0;
+}
+
+.metric-value {
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.metric-label {
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.flow-workbench {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.82fr) minmax(300px, 1fr) minmax(360px, 1.35fr);
+  gap: 24px;
+  padding: 28px 0;
+}
+
+.flow-column {
+  min-width: 0;
+}
+
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.segment-control {
+  display: inline-flex;
+  padding: 3px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.segment {
+  min-height: 32px;
+  padding: 0 10px;
+  color: var(--muted);
+  background: transparent;
+  font-weight: 800;
+}
+
+.segment.is-active {
+  color: #fff;
+  background: var(--ink);
+}
+
+.lead-stack,
+.pipeline-board,
+.opportunity-map {
+  display: grid;
+  gap: 10px;
+}
+
+.pipeline-board {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.pipeline-lane {
+  min-width: 0;
+  border-top: 4px solid var(--line-strong);
+  padding-top: 10px;
+}
+
+.pipeline-lane[data-stage="now"] {
+  border-color: var(--coral);
+}
+
+.pipeline-lane[data-stage="hot"] {
+  border-color: var(--amber);
+}
+
+.pipeline-lane[data-stage="warm"] {
+  border-color: var(--blue);
+}
+
+.pipeline-lane[data-stage="won"] {
+  border-color: var(--green);
+}
+
+.lane-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.lead-card,
+.spotlight-card,
+.map-card,
+.empty-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 24px rgba(23, 32, 51, 0.08);
+}
+
+.lead-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.lead-card.is-priority {
+  border-color: #fecaca;
+  background: #fffafa;
+}
+
+.lead-card.is-hot {
+  border-color: #fde68a;
+  background: #fffbeb;
+}
+
+.lead-card.is-won {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.lead-topline,
+.lead-actions,
+.drawer-actions,
+.modal-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.lead-topline {
+  justify-content: space-between;
+}
+
+.lead-name {
+  min-width: 0;
+  margin: 0;
+  font-weight: 900;
+  line-height: 1.15;
+}
+
+.lead-subtitle,
+.lead-body,
+.empty-card,
+.map-meta,
+.drawer-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.lead-body {
+  margin: 0;
+}
+
+.lead-actions {
+  flex-wrap: wrap;
+}
+
+.lead-actions .icon-button {
+  width: 34px;
+  height: 34px;
+}
+
+.spotlight-card {
+  min-height: 454px;
+  padding: 18px;
+}
+
+.spotlight-card .lead-card {
+  height: 100%;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
+.spotlight-card .lead-name {
+  font-size: clamp(1.8rem, 3vw, 3.2rem);
+}
+
+.spotlight-card .lead-body {
+  font-size: 1.08rem;
+}
+
+.spotlight-card .lead-actions .flow-button {
+  flex: 1 1 150px;
+}
+
+.empty-card {
+  min-height: 96px;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  text-align: center;
+}
+
+.opportunity-map {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.map-card {
+  padding: 14px;
+}
+
+.map-card h3 {
+  margin-bottom: 8px;
+}
+
+.map-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 0;
+  border-top: 1px solid var(--line);
+}
+
+.map-row:first-of-type {
+  border-top: 0;
+}
+
+.flow-overlay,
+.lead-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: grid;
+  background: rgba(23, 32, 51, 0.38);
+  backdrop-filter: blur(10px);
+}
+
+.flow-overlay {
+  place-items: center;
+  padding: 18px;
+}
+
+.flow-modal,
+.drawer-panel {
+  width: min(720px, 100%);
+  max-height: min(860px, calc(100vh - 36px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.flow-modal {
+  padding: 20px;
+}
+
+.lead-drawer {
+  justify-items: end;
+}
+
+.drawer-panel {
+  width: min(500px, 100%);
+  height: 100vh;
+  max-height: 100vh;
+  border-block: 0;
+  border-right: 0;
+  border-radius: 8px 0 0 8px;
+  padding: 20px;
+}
+
+.modal-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.form-grid,
+.drawer-form {
+  display: grid;
+  gap: 12px;
+}
+
+.form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.form-grid label,
+.drawer-form label {
+  display: grid;
+  gap: 6px;
+}
+
+.form-grid .wide {
+  grid-column: 1 / -1;
+}
+
+.form-grid input,
+.form-grid select,
+.drawer-form input,
+.drawer-form select,
+.drawer-form textarea {
+  min-height: 42px;
+  padding: 9px 10px;
+}
+
+.drawer-form textarea {
+  resize: vertical;
+}
+
+.modal-actions {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  margin-top: 18px;
+}
+
+.drawer-meta {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.drawer-actions {
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.drawer-actions .flow-button {
+  flex: 1 1 130px;
+}
+
+@media (max-width: 1180px) {
+  .flow-workbench {
+    grid-template-columns: minmax(280px, 0.8fr) minmax(360px, 1.2fr);
+  }
+
+  .spotlight-column {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .spotlight-card {
+    min-height: 300px;
+  }
+
+  .opportunity-map {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 780px) {
+  .flow-topbar {
+    position: static;
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .flow-nav {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    justify-content: stretch;
+  }
+
+  .flow-button {
+    width: 100%;
+  }
+
+  .flow-hero,
+  .flow-workbench,
+  .pipeline-board,
+  .opportunity-map,
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .flow-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric-cell {
+    border-bottom: 1px solid var(--line);
+  }
+
+  .metric-cell:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .section-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .segment-control {
+    width: 100%;
+  }
+
+  .segment {
+    flex: 1 1 0;
+  }
+
+  .drawer-panel {
+    width: 100%;
+    border-radius: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/crm/flow.html
+++ b/crm/flow.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>3DVR CRM Flow</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="./flow.css" />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/axe.js"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+  <script type="module" src="./flow.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <header class="flow-topbar">
+    <a class="flow-brand" href="./index.html" aria-label="Open classic CRM">
+      <span class="flow-brand-mark">3D</span>
+      <span>CRM Flow</span>
+    </a>
+    <nav class="flow-nav" aria-label="CRM views">
+      <a class="flow-button ghost" href="./index.html">
+        <i data-lucide="table-2" aria-hidden="true"></i>
+        <span>Classic</span>
+      </a>
+      <a class="flow-button ghost" href="../contacts/index.html">
+        <i data-lucide="users" aria-hidden="true"></i>
+        <span>Contacts</span>
+      </a>
+      <a class="flow-button ghost" href="../sales/index.html">
+        <i data-lucide="line-chart" aria-hidden="true"></i>
+        <span>Sales</span>
+      </a>
+      <button id="openQuickAdd" class="flow-button primary" type="button">
+        <i data-lucide="plus" aria-hidden="true"></i>
+        <span>Add lead</span>
+      </button>
+    </nav>
+  </header>
+
+  <main class="flow-shell">
+    <section class="flow-hero" aria-labelledby="flowTitle">
+      <div class="hero-copy">
+        <p class="flow-kicker">Parallel CRM interface</p>
+        <h1 id="flowTitle">Today-first sales flow</h1>
+        <div class="hero-tags" aria-label="CRM status">
+          <span id="liveStatus" class="flow-pill neutral">Syncing</span>
+          <span id="leadCountPill" class="flow-pill blue">0 leads</span>
+          <span id="dueCountPill" class="flow-pill amber">0 due</span>
+        </div>
+      </div>
+      <div class="hero-search">
+        <label for="flowSearch">Search</label>
+        <div class="search-box">
+          <i data-lucide="search" aria-hidden="true"></i>
+          <input id="flowSearch" type="search" placeholder="Name, company, pain, action, tag" autocomplete="off" />
+        </div>
+      </div>
+    </section>
+
+    <section class="flow-metrics" aria-label="Pipeline metrics">
+      <div class="metric-cell">
+        <span id="metricToday" class="metric-value">0</span>
+        <span class="metric-label">Today</span>
+      </div>
+      <div class="metric-cell">
+        <span id="metricHot" class="metric-value">0</span>
+        <span class="metric-label">Hot</span>
+      </div>
+      <div class="metric-cell">
+        <span id="metricWarm" class="metric-value">0</span>
+        <span class="metric-label">Warm</span>
+      </div>
+      <div class="metric-cell">
+        <span id="metricWon" class="metric-value">0</span>
+        <span class="metric-label">Won</span>
+      </div>
+      <div class="metric-cell">
+        <span id="metricMoves" class="metric-value">0</span>
+        <span class="metric-label">Moves</span>
+      </div>
+    </section>
+
+    <section class="flow-workbench" aria-label="CRM workbench">
+      <section class="flow-column today-column" aria-labelledby="todayHeading">
+        <div class="section-head">
+          <div>
+            <p class="flow-kicker">Focus stack</p>
+            <h2 id="todayHeading">Today</h2>
+          </div>
+          <div class="segment-control" aria-label="Lead filter">
+            <button class="segment is-active" type="button" data-flow-mode="today">Today</button>
+            <button class="segment" type="button" data-flow-mode="hot">Hot</button>
+            <button class="segment" type="button" data-flow-mode="all">All</button>
+          </div>
+        </div>
+        <div id="todayList" class="lead-stack" aria-live="polite"></div>
+      </section>
+
+      <section class="flow-column spotlight-column" aria-labelledby="spotlightHeading">
+        <div class="section-head">
+          <div>
+            <p class="flow-kicker">Next play</p>
+            <h2 id="spotlightHeading">Spotlight</h2>
+          </div>
+          <button id="shuffleSpotlight" class="icon-button" type="button" aria-label="Shuffle spotlight">
+            <i data-lucide="shuffle" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div id="spotlightCard" class="spotlight-card" aria-live="polite"></div>
+      </section>
+
+      <section class="flow-column pipeline-column" aria-labelledby="pipelineHeading">
+        <div class="section-head">
+          <div>
+            <p class="flow-kicker">Deal board</p>
+            <h2 id="pipelineHeading">Pipeline</h2>
+          </div>
+          <button id="collapseDone" class="flow-button compact ghost" type="button">
+            <i data-lucide="archive" aria-hidden="true"></i>
+            <span>Hide done</span>
+          </button>
+        </div>
+        <div id="pipelineBoard" class="pipeline-board" aria-live="polite"></div>
+      </section>
+    </section>
+
+    <section class="flow-map" aria-labelledby="mapHeading">
+      <div class="section-head">
+        <div>
+          <p class="flow-kicker">Opportunity map</p>
+          <h2 id="mapHeading">Groups and pains</h2>
+        </div>
+        <a class="flow-button compact ghost" href="./index.html#crm-capture">
+          <i data-lucide="network" aria-hidden="true"></i>
+          <span>Full graph</span>
+        </a>
+      </div>
+      <div id="opportunityMap" class="opportunity-map" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <div id="quickAddOverlay" class="flow-overlay" hidden>
+    <form id="quickAddForm" class="flow-modal" aria-labelledby="quickAddTitle">
+      <div class="modal-head">
+        <div>
+          <p class="flow-kicker">Quick add</p>
+          <h2 id="quickAddTitle">New lead</h2>
+        </div>
+        <button id="closeQuickAdd" class="icon-button" type="button" aria-label="Close quick add">
+          <i data-lucide="x" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div class="form-grid">
+        <label>
+          <span>Name</span>
+          <input id="flowLeadName" type="text" autocomplete="name" required />
+        </label>
+        <label>
+          <span>Email</span>
+          <input id="flowLeadEmail" type="email" autocomplete="email" />
+        </label>
+        <label>
+          <span>Company</span>
+          <input id="flowLeadCompany" type="text" autocomplete="organization" />
+        </label>
+        <label>
+          <span>Warmth</span>
+          <select id="flowLeadWarmth"></select>
+        </label>
+        <label class="wide">
+          <span>Primary pain</span>
+          <input id="flowLeadPain" type="text" />
+        </label>
+        <label class="wide">
+          <span>Next best action</span>
+          <input id="flowLeadAction" type="text" />
+        </label>
+        <label>
+          <span>Follow-up</span>
+          <input id="flowLeadFollowUp" type="date" />
+        </label>
+        <label>
+          <span>Offer</span>
+          <input id="flowLeadOffer" type="text" />
+        </label>
+      </div>
+      <div class="modal-actions">
+        <button class="flow-button ghost" type="button" id="cancelQuickAdd">
+          <i data-lucide="x" aria-hidden="true"></i>
+          <span>Cancel</span>
+        </button>
+        <button class="flow-button primary" type="submit">
+          <i data-lucide="save" aria-hidden="true"></i>
+          <span>Save lead</span>
+        </button>
+      </div>
+    </form>
+  </div>
+
+  <aside id="leadDrawer" class="lead-drawer" hidden aria-labelledby="drawerTitle">
+    <div class="drawer-panel">
+      <div class="modal-head">
+        <div>
+          <p id="drawerKicker" class="flow-kicker">Lead</p>
+          <h2 id="drawerTitle">Lead</h2>
+        </div>
+        <button id="closeDrawer" class="icon-button" type="button" aria-label="Close lead drawer">
+          <i data-lucide="x" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div id="drawerMeta" class="drawer-meta"></div>
+      <div id="drawerActions" class="drawer-actions">
+        <button class="flow-button primary" type="button" data-drawer-action="log-touch">
+          <i data-lucide="check-circle-2" aria-hidden="true"></i>
+          <span>Log touch</span>
+        </button>
+        <button class="flow-button coral" type="button" data-drawer-action="snooze">
+          <i data-lucide="calendar-plus" aria-hidden="true"></i>
+          <span>Snooze</span>
+        </button>
+        <button class="flow-button green" type="button" data-drawer-action="mark-won">
+          <i data-lucide="badge-check" aria-hidden="true"></i>
+          <span>Won</span>
+        </button>
+      </div>
+      <form id="drawerForm" class="drawer-form">
+        <label>
+          <span>Status</span>
+          <select id="drawerStatus"></select>
+        </label>
+        <label>
+          <span>Warmth</span>
+          <select id="drawerWarmth"></select>
+        </label>
+        <label>
+          <span>Follow-up</span>
+          <input id="drawerFollowUp" type="date" />
+        </label>
+        <label>
+          <span>Next best action</span>
+          <input id="drawerAction" type="text" />
+        </label>
+        <label>
+          <span>Primary pain</span>
+          <input id="drawerPain" type="text" />
+        </label>
+        <label>
+          <span>Notes</span>
+          <textarea id="drawerNotes" rows="5"></textarea>
+        </label>
+        <button class="flow-button primary full" type="submit">
+          <i data-lucide="save" aria-hidden="true"></i>
+          <span>Save changes</span>
+        </button>
+      </form>
+    </div>
+  </aside>
+
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/crm/flow.js
+++ b/crm/flow.js
@@ -1,0 +1,756 @@
+import {
+  CRM_STATUS_OPTIONS,
+  CRM_WARMTH_OPTIONS,
+  buildCrmRelationshipBoard,
+  normalizeCrmWarmth,
+  sanitizeCrmRecord,
+} from './crm-editing.js';
+
+const gun = Gun(window.__GUN_PEERS__ || [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun',
+]);
+const portalRoot = gun.get('3dvr-portal');
+const crmRecords = gun.get('3dvr-crm');
+const touchLogRoot = portalRoot.get('crm-touch-log');
+
+const crmIndex = Object.create(null);
+const state = {
+  board: buildCrmRelationshipBoard([]),
+  renderTimer: null,
+  mode: 'today',
+  selectedId: '',
+  spotlightOffset: 0,
+  hideDone: false,
+};
+
+const els = {
+  liveStatus: document.getElementById('liveStatus'),
+  leadCountPill: document.getElementById('leadCountPill'),
+  dueCountPill: document.getElementById('dueCountPill'),
+  search: document.getElementById('flowSearch'),
+  todayList: document.getElementById('todayList'),
+  spotlightCard: document.getElementById('spotlightCard'),
+  pipelineBoard: document.getElementById('pipelineBoard'),
+  opportunityMap: document.getElementById('opportunityMap'),
+  quickAddOverlay: document.getElementById('quickAddOverlay'),
+  quickAddForm: document.getElementById('quickAddForm'),
+  quickAddOpen: document.getElementById('openQuickAdd'),
+  quickAddClose: document.getElementById('closeQuickAdd'),
+  quickAddCancel: document.getElementById('cancelQuickAdd'),
+  quickLeadName: document.getElementById('flowLeadName'),
+  quickLeadEmail: document.getElementById('flowLeadEmail'),
+  quickLeadCompany: document.getElementById('flowLeadCompany'),
+  quickLeadWarmth: document.getElementById('flowLeadWarmth'),
+  quickLeadPain: document.getElementById('flowLeadPain'),
+  quickLeadAction: document.getElementById('flowLeadAction'),
+  quickLeadFollowUp: document.getElementById('flowLeadFollowUp'),
+  quickLeadOffer: document.getElementById('flowLeadOffer'),
+  metricToday: document.getElementById('metricToday'),
+  metricHot: document.getElementById('metricHot'),
+  metricWarm: document.getElementById('metricWarm'),
+  metricWon: document.getElementById('metricWon'),
+  metricMoves: document.getElementById('metricMoves'),
+  collapseDone: document.getElementById('collapseDone'),
+  shuffleSpotlight: document.getElementById('shuffleSpotlight'),
+  drawer: document.getElementById('leadDrawer'),
+  drawerTitle: document.getElementById('drawerTitle'),
+  drawerKicker: document.getElementById('drawerKicker'),
+  drawerMeta: document.getElementById('drawerMeta'),
+  drawerClose: document.getElementById('closeDrawer'),
+  drawerActions: document.getElementById('drawerActions'),
+  drawerForm: document.getElementById('drawerForm'),
+  drawerStatus: document.getElementById('drawerStatus'),
+  drawerWarmth: document.getElementById('drawerWarmth'),
+  drawerFollowUp: document.getElementById('drawerFollowUp'),
+  drawerAction: document.getElementById('drawerAction'),
+  drawerPain: document.getElementById('drawerPain'),
+  drawerNotes: document.getElementById('drawerNotes'),
+};
+
+function safe(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function safeAttr(value) {
+  return safe(value).replace(/"/g, '&quot;');
+}
+
+function generateId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function normalizeFollowUpInput(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return raw;
+  return parsed.toISOString().slice(0, 10);
+}
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDays(days) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function toActivityCount(value) {
+  const numeric = Number.parseInt(value, 10);
+  return Number.isNaN(numeric) ? 0 : Math.max(0, numeric);
+}
+
+function resolveLeadWarmth(record = {}) {
+  return normalizeCrmWarmth(record.warmth, record.status);
+}
+
+function isClosed(record = {}) {
+  const status = String(record.status || '').trim().toLowerCase();
+  return status === 'won' || status === 'lost';
+}
+
+function hasDueFollowUp(record = {}) {
+  const followUp = normalizeFollowUpInput(record.nextFollowUp || '');
+  return Boolean(followUp && followUp <= todayKey());
+}
+
+function daysSince(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return Math.max(0, Math.floor((Date.now() - date.getTime()) / 86400000));
+}
+
+function formatShortDate(value) {
+  const raw = normalizeFollowUpInput(value);
+  if (!raw) return '';
+  const date = new Date(`${raw}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return raw;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function humanAge(value) {
+  const days = daysSince(value);
+  if (days == null) return 'No touch';
+  if (days === 0) return 'Today';
+  if (days === 1) return '1 day';
+  return `${days} days`;
+}
+
+function getAllRecords() {
+  return Object.values(crmIndex)
+    .map(sanitizeCrmRecord)
+    .filter(record => String(record.id || '').trim());
+}
+
+function getPeople() {
+  return state.board.people.slice();
+}
+
+function getOpenPeople() {
+  return getPeople().filter(record => !isClosed(record));
+}
+
+function getLeadScore(record = {}) {
+  let score = 0;
+  const warmth = resolveLeadWarmth(record);
+  if (hasDueFollowUp(record)) score += 90;
+  if (warmth === 'hot') score += 70;
+  if (warmth === 'warm') score += 35;
+  if (String(record.urgency || '').toLowerCase() === 'high') score += 30;
+  if (record.nextBestAction || record.nextExperiment) score += 18;
+  if (!record.lastContacted) score += 16;
+  const age = daysSince(record.lastContacted);
+  if (age != null && age >= 7) score += 14;
+  if (record.lastReplyAt) score += 24;
+  return score;
+}
+
+function comparePriority(a, b) {
+  const scoreDelta = getLeadScore(b) - getLeadScore(a);
+  if (scoreDelta !== 0) return scoreDelta;
+  const followA = normalizeFollowUpInput(a.nextFollowUp || '') || '9999-12-31';
+  const followB = normalizeFollowUpInput(b.nextFollowUp || '') || '9999-12-31';
+  if (followA !== followB) return followA.localeCompare(followB);
+  return String(a.name || '').localeCompare(String(b.name || ''));
+}
+
+function getFilteredPeople() {
+  const query = String(els.search?.value || '').trim().toLowerCase();
+  return getPeople().filter(record => {
+    const haystack = [
+      record.name,
+      record.email,
+      record.company,
+      record.tags,
+      record.status,
+      record.primaryPain,
+      record.nextBestAction,
+      record.nextExperiment,
+      record.notes,
+      record.offerAmount,
+      resolveLeadWarmth(record),
+    ].filter(Boolean).join(' ').toLowerCase();
+    return !query || haystack.includes(query);
+  });
+}
+
+function getTodayPeople() {
+  return getFilteredPeople()
+    .filter(record => !isClosed(record))
+    .filter(record => hasDueFollowUp(record) || getLeadScore(record) >= 70)
+    .sort(comparePriority);
+}
+
+function getHotPeople() {
+  return getFilteredPeople()
+    .filter(record => !isClosed(record))
+    .filter(record => resolveLeadWarmth(record) === 'hot')
+    .sort(comparePriority);
+}
+
+function getModePeople() {
+  if (state.mode === 'hot') return getHotPeople();
+  if (state.mode === 'all') return getFilteredPeople().sort(comparePriority);
+  return getTodayPeople();
+}
+
+function getStage(record = {}) {
+  if (String(record.status || '').trim().toLowerCase() === 'won') return 'won';
+  if (hasDueFollowUp(record)) return 'now';
+  const warmth = resolveLeadWarmth(record);
+  if (warmth === 'hot') return 'hot';
+  if (warmth === 'warm') return 'warm';
+  return 'parked';
+}
+
+function setStatus(message, tone = 'neutral') {
+  if (!els.liveStatus) return;
+  els.liveStatus.textContent = message;
+  els.liveStatus.className = `flow-pill ${tone}`;
+}
+
+function setSelectOptions(select, options, selectedValue = '') {
+  if (!select) return;
+  select.innerHTML = (Array.isArray(options) ? options : []).map(option => {
+    const value = typeof option === 'object' ? String(option.value || '') : String(option || '');
+    const label = typeof option === 'object' ? String(option.label || option.value || '') : String(option || '');
+    const selected = value === selectedValue ? 'selected' : '';
+    return `<option value="${safeAttr(value)}" ${selected}>${safe(label || 'Any')}</option>`;
+  }).join('');
+}
+
+function getLeadBadges(record = {}) {
+  const badges = [];
+  const warmth = resolveLeadWarmth(record);
+  if (hasDueFollowUp(record)) badges.push({ label: 'Due', tone: 'coral' });
+  if (warmth) badges.push({ label: warmth, tone: warmth === 'hot' ? 'amber' : 'blue' });
+  if (record.offerAmount) badges.push({ label: record.offerAmount, tone: 'green' });
+  if (String(record.urgency || '').toLowerCase() === 'high') badges.push({ label: 'High urgency', tone: 'purple' });
+  return badges;
+}
+
+function renderBadges(record = {}) {
+  const badges = getLeadBadges(record);
+  if (!badges.length) return '';
+  return `<div class="hero-tags">${badges.map(badge => `<span class="flow-pill ${safeAttr(badge.tone)}">${safe(badge.label)}</span>`).join('')}</div>`;
+}
+
+function renderLeadCard(record = {}, { spotlight = false } = {}) {
+  const stage = getStage(record);
+  const cardClasses = [
+    'lead-card',
+    stage === 'now' ? 'is-priority' : '',
+    stage === 'hot' ? 'is-hot' : '',
+    stage === 'won' ? 'is-won' : '',
+  ].filter(Boolean).join(' ');
+  const group = record.groupId ? state.board.index[record.groupId] : null;
+  const action = String(record.nextBestAction || record.nextExperiment || '').trim();
+  const body = action || record.primaryPain || record.objection || record.notes || 'No next action set.';
+  const subtitle = [
+    record.company || group?.name || '',
+    record.status || '',
+    record.nextFollowUp ? `Follow-up ${formatShortDate(record.nextFollowUp)}` : '',
+    `Last touch ${humanAge(record.lastContacted)}`,
+  ].filter(Boolean).join(' | ');
+
+  return `
+    <article class="${cardClasses}" data-record-id="${safeAttr(record.id)}">
+      <div class="lead-topline">
+        <h3 class="lead-name">${safe(record.name || '(untitled lead)')}</h3>
+        <button class="icon-button" type="button" data-flow-action="open" data-record-id="${safeAttr(record.id)}" aria-label="Open ${safeAttr(record.name || 'lead')}">
+          <i data-lucide="panel-right-open" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div class="lead-subtitle">${safe(subtitle || record.email || 'Lead')}</div>
+      ${renderBadges(record)}
+      <p class="lead-body">${safe(body)}</p>
+      <div class="lead-actions">
+        <button class="flow-button compact primary" type="button" data-flow-action="log-touch" data-record-id="${safeAttr(record.id)}">
+          <i data-lucide="check-circle-2" aria-hidden="true"></i>
+          <span>Touch</span>
+        </button>
+        <button class="flow-button compact coral" type="button" data-flow-action="snooze" data-record-id="${safeAttr(record.id)}">
+          <i data-lucide="calendar-plus" aria-hidden="true"></i>
+          <span>Snooze</span>
+        </button>
+        ${spotlight ? `
+          <a class="flow-button compact ghost" href="${safeAttr(buildEmailHref(record))}">
+            <i data-lucide="mail-plus" aria-hidden="true"></i>
+            <span>Email</span>
+          </a>
+        ` : ''}
+      </div>
+    </article>
+  `;
+}
+
+function renderMetrics() {
+  const people = getPeople();
+  const open = people.filter(record => !isClosed(record));
+  const today = open.filter(hasDueFollowUp);
+  const hot = open.filter(record => resolveLeadWarmth(record) === 'hot');
+  const warm = open.filter(record => resolveLeadWarmth(record) === 'warm');
+  const won = people.filter(record => String(record.status || '').trim().toLowerCase() === 'won');
+  const moves = open.filter(record => hasDueFollowUp(record) || !record.nextBestAction || !record.lastContacted);
+
+  if (els.metricToday) els.metricToday.textContent = String(today.length);
+  if (els.metricHot) els.metricHot.textContent = String(hot.length);
+  if (els.metricWarm) els.metricWarm.textContent = String(warm.length);
+  if (els.metricWon) els.metricWon.textContent = String(won.length);
+  if (els.metricMoves) els.metricMoves.textContent = String(moves.length);
+  if (els.leadCountPill) els.leadCountPill.textContent = `${people.length} lead${people.length === 1 ? '' : 's'}`;
+  if (els.dueCountPill) els.dueCountPill.textContent = `${today.length} due`;
+}
+
+function renderTodayList() {
+  if (!els.todayList) return;
+  const records = getModePeople();
+  if (!records.length) {
+    els.todayList.innerHTML = '<div class="empty-card">No leads in this slice.</div>';
+    return;
+  }
+  els.todayList.innerHTML = records.slice(0, 9).map(record => renderLeadCard(record)).join('');
+}
+
+function renderSpotlight() {
+  if (!els.spotlightCard) return;
+  const records = getOpenPeople().sort(comparePriority);
+  if (!records.length) {
+    els.spotlightCard.innerHTML = '<div class="empty-card">No open leads yet.</div>';
+    return;
+  }
+  const record = records[state.spotlightOffset % records.length];
+  state.selectedId = state.selectedId || record.id;
+  els.spotlightCard.innerHTML = renderLeadCard(record, { spotlight: true });
+}
+
+function renderPipeline() {
+  if (!els.pipelineBoard) return;
+  const stages = [
+    { id: 'now', label: 'Now' },
+    { id: 'hot', label: 'Hot' },
+    { id: 'warm', label: 'Warm' },
+    { id: 'parked', label: 'Parked' },
+    { id: 'won', label: 'Won' },
+  ].filter(stage => !(state.hideDone && stage.id === 'won'));
+  const people = getFilteredPeople().sort(comparePriority);
+
+  els.pipelineBoard.innerHTML = stages.map(stage => {
+    const records = people.filter(record => getStage(record) === stage.id).slice(0, 5);
+    return `
+      <section class="pipeline-lane" data-stage="${safeAttr(stage.id)}">
+        <div class="lane-title">
+          <span>${safe(stage.label)}</span>
+          <span>${safe(String(records.length))}</span>
+        </div>
+        <div class="lead-stack">
+          ${records.length ? records.map(record => renderLeadCard(record)).join('') : '<div class="empty-card">Empty</div>'}
+        </div>
+      </section>
+    `;
+  }).join('');
+}
+
+function renderOpportunityMap() {
+  if (!els.opportunityMap) return;
+  const groups = state.board.groups.slice(0, 4);
+  const standaloneProblems = state.board.standaloneProblems.slice(0, 4);
+  const cards = groups.map(cluster => {
+    const group = cluster.group;
+    return `
+      <article class="map-card">
+        <h3>${safe(group.name || '(untitled group)')}</h3>
+        <div class="map-meta">${safe(group.marketSegment || group.status || 'Group')}</div>
+        <div class="map-row"><span>People</span><strong>${safe(String(cluster.members.length))}</strong></div>
+        <div class="map-row"><span>Pains</span><strong>${safe(String(cluster.linkedProblems.length))}</strong></div>
+        <button class="flow-button compact ghost" type="button" data-flow-action="open" data-record-id="${safeAttr(group.id)}">
+          <i data-lucide="panel-right-open" aria-hidden="true"></i>
+          <span>Open</span>
+        </button>
+      </article>
+    `;
+  });
+
+  standaloneProblems.forEach(problem => {
+    cards.push(`
+      <article class="map-card">
+        <h3>${safe(problem.name || problem.primaryPain || '(untitled pain)')}</h3>
+        <div class="map-meta">${safe(problem.painSeverity || 'Problem')}</div>
+        <div class="map-row"><span>Offer</span><strong>${safe(problem.offerAmount || '-')}</strong></div>
+        <div class="map-row"><span>Signal</span><strong>${safe(problem.lastSignal || '-')}</strong></div>
+        <button class="flow-button compact ghost" type="button" data-flow-action="open" data-record-id="${safeAttr(problem.id)}">
+          <i data-lucide="panel-right-open" aria-hidden="true"></i>
+          <span>Open</span>
+        </button>
+      </article>
+    `);
+  });
+
+  els.opportunityMap.innerHTML = cards.length ? cards.join('') : '<div class="empty-card">No groups or pains yet.</div>';
+}
+
+function renderIcons() {
+  if (window.lucide && typeof window.lucide.createIcons === 'function') {
+    window.lucide.createIcons();
+  }
+}
+
+function render() {
+  const records = getAllRecords();
+  state.board = buildCrmRelationshipBoard(records);
+  renderMetrics();
+  renderTodayList();
+  renderSpotlight();
+  renderPipeline();
+  renderOpportunityMap();
+  refreshDrawer();
+  renderIcons();
+}
+
+function scheduleRender() {
+  window.clearTimeout(state.renderTimer);
+  state.renderTimer = window.setTimeout(render, 40);
+}
+
+function putCrmRecord(record) {
+  return new Promise((resolve, reject) => {
+    crmRecords.get(record.id).put(record, ack => {
+      if (ack && ack.err) {
+        reject(new Error(String(ack.err)));
+        return;
+      }
+      crmIndex[record.id] = { ...(crmIndex[record.id] || {}), ...sanitizeCrmRecord(record), id: record.id };
+      setStatus('Saved', 'green');
+      scheduleRender();
+      resolve(record);
+    });
+  });
+}
+
+function appendTouchLogEntry(record = {}, touchType = 'outreach-sent') {
+  const id = `${record.id || 'crm'}-${generateId()}`;
+  const entry = {
+    id,
+    recordId: record.contactId || record.id || '',
+    crmRecordId: record.id || '',
+    contactId: record.contactId || '',
+    contactName: record.name || record.email || 'Unnamed contact',
+    timestamp: new Date().toISOString(),
+    followUp: normalizeFollowUpInput(record.nextFollowUp || ''),
+    note: touchType === 'closed-won' ? 'Marked won from CRM Flow.' : 'Logged from CRM Flow.',
+    touchType,
+    touchTypeLabel: touchType === 'closed-won' ? 'Closed won' : 'Outreach sent',
+    source: 'CRM Flow',
+    statusAfter: record.status || '',
+  };
+  touchLogRoot.get(id).put(entry);
+  return entry;
+}
+
+function updateRecord(id, patch = {}) {
+  const current = sanitizeCrmRecord(crmIndex[id] || state.board.index[id] || {});
+  if (!current.id) return Promise.resolve(null);
+  const next = sanitizeCrmRecord({
+    ...current,
+    ...patch,
+    id: current.id,
+    recordType: current.recordType || 'person',
+    updated: new Date().toISOString(),
+  });
+  return putCrmRecord(next);
+}
+
+async function logTouch(id) {
+  const current = sanitizeCrmRecord(crmIndex[id] || {});
+  if (!current.id) return;
+  const next = {
+    lastContacted: new Date().toISOString(),
+    activityCount: toActivityCount(current.activityCount) + 1,
+    status: current.status || 'Warm - Follow-up',
+  };
+  const saved = await updateRecord(id, next);
+  if (saved) appendTouchLogEntry(saved, 'outreach-sent');
+}
+
+async function snoozeLead(id) {
+  await updateRecord(id, { nextFollowUp: addDays(3), status: 'Warm - Follow-up' });
+}
+
+async function markWon(id) {
+  const saved = await updateRecord(id, {
+    status: 'Won',
+    warmth: 'hot',
+    lastContacted: new Date().toISOString(),
+    activityCount: toActivityCount(crmIndex[id]?.activityCount) + 1,
+  });
+  if (saved) appendTouchLogEntry(saved, 'closed-won');
+}
+
+function buildEmailHref(record = {}) {
+  const params = new URLSearchParams();
+  params.set('draft', '1');
+  params.set('source', 'crm-flow');
+  if (record.id) params.set('recordId', record.id);
+  if (record.name) params.set('lead', record.name);
+  if (record.email) params.set('email', record.email);
+  if (record.company) params.set('company', record.company);
+  if (record.primaryPain) params.set('pain', record.primaryPain);
+  if (record.nextBestAction || record.nextExperiment) {
+    params.set('next', record.nextBestAction || record.nextExperiment);
+  }
+  return `../email-operator/index.html?${params.toString()}`;
+}
+
+function openQuickAdd() {
+  if (!els.quickAddOverlay) return;
+  els.quickAddOverlay.hidden = false;
+  window.requestAnimationFrame(() => els.quickLeadName?.focus());
+}
+
+function closeQuickAdd({ reset = false } = {}) {
+  if (!els.quickAddOverlay) return;
+  els.quickAddOverlay.hidden = true;
+  if (reset) els.quickAddForm?.reset();
+}
+
+async function handleQuickAddSubmit(event) {
+  event.preventDefault();
+  const now = new Date().toISOString();
+  const warmth = String(els.quickLeadWarmth?.value || '').trim();
+  const record = sanitizeCrmRecord({
+    id: generateId(),
+    recordType: 'person',
+    name: String(els.quickLeadName?.value || '').trim(),
+    email: String(els.quickLeadEmail?.value || '').trim(),
+    company: String(els.quickLeadCompany?.value || '').trim(),
+    warmth,
+    status: warmth === 'hot' ? 'Warm - Discovery' : 'Warm - Awareness',
+    primaryPain: String(els.quickLeadPain?.value || '').trim(),
+    nextBestAction: String(els.quickLeadAction?.value || '').trim(),
+    nextFollowUp: normalizeFollowUpInput(els.quickLeadFollowUp?.value || ''),
+    offerAmount: String(els.quickLeadOffer?.value || '').trim(),
+    source: 'CRM Flow',
+    created: now,
+    updated: now,
+    activityCount: 0,
+    replyCount: 0,
+  });
+
+  if (!record.name) {
+    setStatus('Name required', 'coral');
+    els.quickLeadName?.focus();
+    return;
+  }
+
+  await putCrmRecord(record);
+  state.selectedId = record.id;
+  closeQuickAdd({ reset: true });
+  openDrawer(record.id);
+}
+
+function openDrawer(id) {
+  const record = sanitizeCrmRecord(crmIndex[id] || state.board.index[id] || {});
+  if (!record.id || !els.drawer) return;
+  state.selectedId = record.id;
+  refreshDrawer();
+  els.drawer.hidden = false;
+}
+
+function closeDrawer() {
+  if (!els.drawer) return;
+  els.drawer.hidden = true;
+}
+
+function refreshDrawer() {
+  if (!state.selectedId || !els.drawer || els.drawer.hidden) return;
+  const record = sanitizeCrmRecord(crmIndex[state.selectedId] || state.board.index[state.selectedId] || {});
+  if (!record.id) return;
+  const isPerson = record.recordType === 'person';
+  if (els.drawerTitle) els.drawerTitle.textContent = record.name || '(untitled record)';
+  if (els.drawerKicker) els.drawerKicker.textContent = record.recordType === 'person' ? 'Lead' : record.recordType;
+  if (els.drawerActions) els.drawerActions.hidden = !isPerson;
+  if (els.drawerMeta) {
+    els.drawerMeta.innerHTML = [
+      record.company || record.email || '',
+      record.primaryPain ? `Pain: ${record.primaryPain}` : '',
+      record.nextFollowUp ? `Follow-up: ${formatShortDate(record.nextFollowUp)}` : '',
+      record.lastContacted ? `Last touch: ${humanAge(record.lastContacted)}` : 'Last touch: none',
+    ].filter(Boolean).map(item => `<div>${safe(item)}</div>`).join('');
+  }
+  if (els.drawerStatus) els.drawerStatus.value = record.status || '';
+  if (els.drawerWarmth) els.drawerWarmth.value = resolveLeadWarmth(record);
+  if (els.drawerFollowUp) els.drawerFollowUp.value = normalizeFollowUpInput(record.nextFollowUp || '');
+  if (els.drawerAction) els.drawerAction.value = record.nextBestAction || record.nextExperiment || '';
+  if (els.drawerPain) els.drawerPain.value = record.primaryPain || '';
+  if (els.drawerNotes) els.drawerNotes.value = record.notes || '';
+}
+
+async function handleDrawerSubmit(event) {
+  event.preventDefault();
+  if (!state.selectedId) return;
+  const current = sanitizeCrmRecord(crmIndex[state.selectedId] || state.board.index[state.selectedId] || {});
+  const isPerson = current.recordType === 'person';
+  await updateRecord(state.selectedId, isPerson ? {
+    status: String(els.drawerStatus?.value || '').trim(),
+    warmth: String(els.drawerWarmth?.value || '').trim(),
+    nextFollowUp: normalizeFollowUpInput(els.drawerFollowUp?.value || ''),
+    nextBestAction: String(els.drawerAction?.value || '').trim(),
+    primaryPain: String(els.drawerPain?.value || '').trim(),
+    notes: String(els.drawerNotes?.value || '').trim(),
+  } : {
+    status: String(els.drawerStatus?.value || current.status || '').trim(),
+    primaryPain: String(els.drawerPain?.value || current.primaryPain || '').trim(),
+    notes: String(els.drawerNotes?.value || '').trim(),
+  });
+}
+
+async function handleFlowAction(action, id) {
+  if (!id) return;
+  const current = sanitizeCrmRecord(crmIndex[id] || state.board.index[id] || {});
+  if ((action === 'log-touch' || action === 'snooze' || action === 'mark-won') && current.recordType !== 'person') {
+    setStatus('Open lead first', 'amber');
+    return;
+  }
+  if (action === 'open') openDrawer(id);
+  if (action === 'log-touch') await logTouch(id);
+  if (action === 'snooze') await snoozeLead(id);
+  if (action === 'mark-won') await markWon(id);
+}
+
+function setMode(mode) {
+  state.mode = mode === 'hot' || mode === 'all' ? mode : 'today';
+  document.querySelectorAll('[data-flow-mode]').forEach(button => {
+    button.classList.toggle('is-active', button.dataset.flowMode === state.mode);
+  });
+  renderTodayList();
+  renderIcons();
+}
+
+function bindEvents() {
+  els.quickAddOpen?.addEventListener('click', openQuickAdd);
+  els.quickAddClose?.addEventListener('click', () => closeQuickAdd());
+  els.quickAddCancel?.addEventListener('click', () => closeQuickAdd());
+  els.quickAddOverlay?.addEventListener('click', event => {
+    if (event.target === els.quickAddOverlay) closeQuickAdd();
+  });
+  els.quickAddForm?.addEventListener('submit', handleQuickAddSubmit);
+  els.search?.addEventListener('input', () => {
+    renderTodayList();
+    renderPipeline();
+    renderIcons();
+  });
+  els.shuffleSpotlight?.addEventListener('click', () => {
+    state.spotlightOffset += 1;
+    renderSpotlight();
+    renderIcons();
+  });
+  els.collapseDone?.addEventListener('click', () => {
+    state.hideDone = !state.hideDone;
+    els.collapseDone.querySelector('span').textContent = state.hideDone ? 'Show done' : 'Hide done';
+    renderPipeline();
+    renderIcons();
+  });
+  els.drawerClose?.addEventListener('click', closeDrawer);
+  els.drawer?.addEventListener('click', event => {
+    if (event.target === els.drawer) closeDrawer();
+  });
+  els.drawerForm?.addEventListener('submit', handleDrawerSubmit);
+  document.querySelectorAll('[data-flow-mode]').forEach(button => {
+    button.addEventListener('click', () => setMode(button.dataset.flowMode));
+  });
+  document.addEventListener('click', event => {
+    const actionButton = event.target.closest('[data-flow-action], [data-drawer-action]');
+    if (!actionButton) return;
+    const action = actionButton.dataset.flowAction || actionButton.dataset.drawerAction || '';
+    const id = actionButton.dataset.recordId || state.selectedId;
+    handleFlowAction(action, id);
+  });
+  document.addEventListener('keydown', event => {
+    const tag = String(event.target?.tagName || '').toLowerCase();
+    const isTyping = tag === 'input' || tag === 'select' || tag === 'textarea';
+    if (event.key === '/' && !isTyping) {
+      event.preventDefault();
+      els.search?.focus();
+    }
+    if (event.key.toLowerCase() === 'n' && !isTyping) {
+      openQuickAdd();
+    }
+    if (event.key === 'Escape') {
+      closeQuickAdd();
+      closeDrawer();
+    }
+  });
+}
+
+function initSelects() {
+  setSelectOptions(els.quickLeadWarmth, CRM_WARMTH_OPTIONS, 'warm');
+  setSelectOptions(els.drawerStatus, CRM_STATUS_OPTIONS, '');
+  setSelectOptions(els.drawerWarmth, CRM_WARMTH_OPTIONS, '');
+}
+
+function subscribeToCrm() {
+  crmRecords.map().on((data, id) => {
+    if (!data) {
+      delete crmIndex[id];
+      scheduleRender();
+      return;
+    }
+    const record = sanitizeCrmRecord({ ...data, id: data.id || id });
+    if (!record.id) return;
+    crmIndex[record.id] = record;
+    setStatus('Live', 'green');
+    scheduleRender();
+  });
+}
+
+function init() {
+  initSelects();
+  bindEvents();
+  subscribeToCrm();
+  render();
+  renderIcons();
+  window.setTimeout(() => {
+    if (Object.keys(crmIndex).length === 0) setStatus('Live', 'green');
+  }, 1200);
+}
+
+init();
+
+if (typeof window !== 'undefined') {
+  window.crmFlow = {
+    getLeadScore,
+    getStage,
+    normalizeFollowUpInput,
+    render,
+  };
+}

--- a/crm/index.html
+++ b/crm/index.html
@@ -117,6 +117,7 @@
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../sales/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Sales</a>
+        <a href="./flow.html" class="bg-teal-500 hover:bg-teal-400 text-gray-950 px-3 py-1.5 rounded transition font-semibold">Flow view</a>
         <a href="../sales/outreach.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Outreach</a>
         <a href="../sales/training/" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Training</a>
         <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Contacts</a>

--- a/tests/crm-flow-interface.test.js
+++ b/tests/crm-flow-interface.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+async function read(relativePath) {
+  return readFile(new URL(`../${relativePath}`, import.meta.url), 'utf8');
+}
+
+test('CRM exposes the parallel flow interface from the classic cockpit', async () => {
+  const html = await read('crm/index.html');
+  assert.match(html, /href="\.\/flow\.html"/);
+  assert.match(html, /Flow view/);
+});
+
+test('CRM Flow ships a today-first parallel interface', async () => {
+  const html = await read('crm/flow.html');
+  const css = await read('crm/flow.css');
+  const js = await read('crm/flow.js');
+
+  assert.match(html, /CRM Flow/);
+  assert.match(html, /Today-first sales flow/);
+  assert.match(html, /id="todayList"/);
+  assert.match(html, /id="spotlightCard"/);
+  assert.match(html, /id="pipelineBoard"/);
+  assert.match(html, /id="opportunityMap"/);
+  assert.match(html, /id="quickAddForm"/);
+  assert.match(html, /id="leadDrawer"/);
+  assert.match(html, /data-drawer-action="mark-won"/);
+  assert.match(html, /https:\/\/unpkg\.com\/lucide@latest/);
+
+  assert.match(css, /\.flow-workbench/);
+  assert.match(css, /\.pipeline-board/);
+  assert.match(css, /\.spotlight-card/);
+  assert.match(css, /@media \(max-width: 780px\)/);
+
+  assert.match(js, /const crmRecords = gun\.get\('3dvr-crm'\)/);
+  assert.match(js, /const touchLogRoot = portalRoot\.get\('crm-touch-log'\)/);
+  assert.match(js, /buildCrmRelationshipBoard/);
+  assert.match(js, /function getLeadScore\(/);
+  assert.match(js, /function renderSpotlight\(/);
+  assert.match(js, /function renderPipeline\(/);
+  assert.match(js, /function handleQuickAddSubmit\(event\)/);
+  assert.match(js, /function logTouch\(id\)/);
+  assert.match(js, /function markWon\(id\)/);
+  assert.match(js, /data-flow-action="log-touch"/);
+  assert.match(js, /window\.crmFlow/);
+});


### PR DESCRIPTION
## Summary
- Adds a parallel `crm/flow.html` CRM Flow interface for a today-first sales workflow.
- Reuses the existing `3dvr-crm` Gun records and `crm-touch-log` nodes.
- Adds quick lead capture, spotlight lead, pipeline board, opportunity map, and drawer actions for touch/snooze/won.
- Links the Flow view from the current People Log/CRM nav.

## Validation
- `node --test tests/crm-flow-interface.test.js`
- `node --check crm/flow.js`

## Impact
This keeps the existing CRM/People Log intact while adding a more playful, action-oriented workflow in parallel.