### PR TITLE
[codex] Add market fit social pulse

### DIFF
--- a/sales/index.html
+++ b/sales/index.html
@@ -27,6 +27,7 @@
         <a href="../billing/index.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Billing</a>
         <a href="training/" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Sales Training</a>
         <a href="analytics.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Growth Lab</a>
+        <a href="market-pulse.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Market Pulse</a>
         <a href="scoreboard.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Profitability Desk</a>
         <a href="research.html" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Market Research</a>
         <a href="../calendar" class="bg-white/10 hover:bg-white/20 border border-white/10 text-white px-4 py-2 rounded-lg transition">Calendar</a>
@@ -138,6 +139,7 @@
         <div class="flex flex-wrap gap-2">
           <a href="outreach.html" class="inline-flex items-center justify-center rounded-lg border border-amber-300/20 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-100 hover:bg-amber-500/20">Open outreach CRM</a>
           <a href="analytics.html" class="inline-flex items-center justify-center rounded-lg border border-cyan-300/20 bg-cyan-500/10 px-4 py-2 text-sm font-semibold text-cyan-100 hover:bg-cyan-500/20">Open growth lab</a>
+          <a href="market-pulse.html" class="inline-flex items-center justify-center rounded-lg border border-emerald-300/20 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-500/20">Open market pulse</a>
         </div>
       </aside>
     </section>

--- a/sales/market-pulse.html
+++ b/sales/market-pulse.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Market Pulse | 3dvr Sales</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="bg-zinc-950 text-zinc-100 font-sans">
+  <header class="border-b border-white/10 bg-zinc-950">
+    <div class="max-w-7xl mx-auto px-6 py-6 space-y-4">
+      <nav class="text-xs uppercase tracking-[0.24em] text-emerald-200 flex flex-wrap items-center gap-2">
+        <a href="index.html" class="text-emerald-100 hover:text-white">Sales Directory</a>
+        <span aria-hidden="true">/</span>
+        <span>Market Pulse</span>
+      </nav>
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div class="space-y-2">
+          <p class="text-xs uppercase tracking-[0.24em] text-emerald-300">Scheduled research + approval queue</p>
+          <h1 class="text-3xl font-semibold">Market Pulse</h1>
+          <p id="marketPulseStatus" class="max-w-3xl text-sm text-zinc-300">Connecting to live market-pulse nodes...</p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <a
+            href="analytics.html"
+            class="inline-flex items-center justify-center rounded-md border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/15"
+          >Growth Lab</a>
+          <a
+            href="research.html"
+            class="inline-flex items-center justify-center rounded-md border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/15"
+          >Research Desk</a>
+          <a
+            href="https://3dvr.tech/market-directory/"
+            target="_blank"
+            rel="noopener"
+            class="inline-flex items-center justify-center rounded-md bg-emerald-400 px-4 py-2 text-sm font-semibold text-zinc-950 hover:bg-emerald-300"
+          >Public directory</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-7xl mx-auto px-6 py-8 space-y-6">
+    <section class="grid gap-4 md:grid-cols-5">
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-4">
+        <p class="text-xs uppercase tracking-[0.2em] text-zinc-400">Last update</p>
+        <p id="pulseUpdatedAt" class="mt-3 text-lg font-semibold text-zinc-100">--</p>
+      </article>
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-4">
+        <p class="text-xs uppercase tracking-[0.2em] text-zinc-400">Market fit</p>
+        <p id="pulseMarketFitScore" class="mt-3 text-3xl font-semibold text-fuchsia-200">0</p>
+        <p id="pulseMarketFitVerdict" class="mt-1 text-xs text-zinc-400">Searching</p>
+      </article>
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-4">
+        <p class="text-xs uppercase tracking-[0.2em] text-zinc-400">Signals</p>
+        <p id="pulseSignalCount" class="mt-3 text-3xl font-semibold text-emerald-200">0</p>
+      </article>
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-4">
+        <p class="text-xs uppercase tracking-[0.2em] text-zinc-400">Approved listings</p>
+        <p id="pulseListingCount" class="mt-3 text-3xl font-semibold text-sky-200">0</p>
+      </article>
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-4">
+        <p class="text-xs uppercase tracking-[0.2em] text-zinc-400">Approvals</p>
+        <p id="pulseApprovalCount" class="mt-3 text-3xl font-semibold text-amber-200">0</p>
+      </article>
+    </section>
+
+    <section class="grid gap-5 xl:grid-cols-[0.95fr,1.05fr]">
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-5 space-y-4">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-[0.22em] text-fuchsia-300">Social probes</p>
+            <h2 class="mt-2 text-xl font-semibold">Post drafts</h2>
+          </div>
+          <span class="text-xs text-zinc-400">Approval required before posting</span>
+        </div>
+        <div id="pulseSocialProbeList" class="space-y-3">
+          <div class="rounded-md border border-dashed border-white/15 bg-zinc-950/70 p-4 text-sm text-zinc-400">No social probes loaded yet.</div>
+        </div>
+      </article>
+
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-5 space-y-4">
+        <div>
+          <p class="text-xs uppercase tracking-[0.22em] text-cyan-300">Reaction radar</p>
+          <h2 class="mt-2 text-xl font-semibold">Fit signals by channel</h2>
+        </div>
+        <p id="pulseMarketFitNextAction" class="rounded-md border border-cyan-300/20 bg-cyan-500/10 p-3 text-sm text-cyan-100">
+          Waiting for market-fit data.
+        </p>
+        <div id="pulseReactionList" class="grid gap-3 lg:grid-cols-2">
+          <div class="rounded-md border border-dashed border-white/15 bg-zinc-950/70 p-4 text-sm text-zinc-400">No reactions loaded yet.</div>
+        </div>
+      </article>
+    </section>
+
+    <section class="grid gap-5 xl:grid-cols-[1.15fr,0.85fr]">
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-5 space-y-4">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-[0.22em] text-emerald-300">Top opportunity</p>
+            <h2 id="pulseTopOpportunity" class="mt-2 text-xl font-semibold">Waiting for pulse data</h2>
+          </div>
+          <span id="pulseMarket" class="rounded-md border border-white/10 bg-white/5 px-3 py-1 text-xs text-zinc-300">--</span>
+        </div>
+        <p id="pulseTopProblem" class="text-sm text-zinc-300">The next scheduled run will fill this from live demand signals.</p>
+        <div id="pulseOpportunityList" class="grid gap-3 md:grid-cols-2"></div>
+      </article>
+
+      <aside class="rounded-md border border-white/10 bg-zinc-900/80 p-5 space-y-4">
+        <div>
+          <p class="text-xs uppercase tracking-[0.22em] text-amber-300">Sales actions</p>
+          <h2 class="mt-2 text-xl font-semibold">Approval queue</h2>
+        </div>
+        <div id="pulseActionList" class="space-y-3">
+          <div class="rounded-md border border-dashed border-white/15 bg-zinc-950/70 p-4 text-sm text-zinc-400">No actions loaded yet.</div>
+        </div>
+      </aside>
+    </section>
+
+    <section class="grid gap-5 xl:grid-cols-2">
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-5 space-y-4">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-[0.22em] text-sky-300">Public directory</p>
+            <h2 class="mt-2 text-xl font-semibold">Listings</h2>
+          </div>
+          <span id="pulseDirectoryStatus" class="text-xs text-zinc-400">Waiting for directory nodes</span>
+        </div>
+        <div id="pulseDirectoryList" class="space-y-3">
+          <div class="rounded-md border border-dashed border-white/15 bg-zinc-950/70 p-4 text-sm text-zinc-400">No directory listings loaded yet.</div>
+        </div>
+      </article>
+
+      <article class="rounded-md border border-white/10 bg-zinc-900/80 p-5 space-y-4">
+        <div>
+          <p class="text-xs uppercase tracking-[0.22em] text-rose-300">Outreach</p>
+          <h2 class="mt-2 text-xl font-semibold">Drafts</h2>
+        </div>
+        <div id="pulseOutreachList" class="space-y-3">
+          <div class="rounded-md border border-dashed border-white/15 bg-zinc-950/70 p-4 text-sm text-zinc-400">No outreach drafts loaded yet.</div>
+        </div>
+      </article>
+    </section>
+
+    <section class="rounded-md border border-white/10 bg-zinc-900/80 p-5 space-y-4">
+      <div>
+        <p class="text-xs uppercase tracking-[0.22em] text-violet-300">Tests</p>
+        <h2 class="mt-2 text-xl font-semibold">Experiment backlog</h2>
+      </div>
+      <div id="pulseTestList" class="grid gap-3 lg:grid-cols-2">
+        <div class="rounded-md border border-dashed border-white/15 bg-zinc-950/70 p-4 text-sm text-zinc-400">No tests loaded yet.</div>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="./market-pulse.js"></script>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/sales/market-pulse.js
+++ b/sales/market-pulse.js
@@ -1,0 +1,415 @@
+import { DEFAULT_GUN_PEERS, getNode } from '../src/growth/homepage-hero.js';
+import {
+  MARKET_PULSE_DIRECTORY_PATH,
+  MARKET_PULSE_LATEST_PATH,
+  deserializeMarketPulseFromGun,
+} from '../src/growth/market-pulse.js';
+
+const refs = {
+  marketPulseStatus: document.getElementById('marketPulseStatus'),
+  pulseUpdatedAt: document.getElementById('pulseUpdatedAt'),
+  pulseMarketFitScore: document.getElementById('pulseMarketFitScore'),
+  pulseMarketFitVerdict: document.getElementById('pulseMarketFitVerdict'),
+  pulseMarketFitNextAction: document.getElementById('pulseMarketFitNextAction'),
+  pulseSignalCount: document.getElementById('pulseSignalCount'),
+  pulseListingCount: document.getElementById('pulseListingCount'),
+  pulseApprovalCount: document.getElementById('pulseApprovalCount'),
+  pulseTopOpportunity: document.getElementById('pulseTopOpportunity'),
+  pulseTopProblem: document.getElementById('pulseTopProblem'),
+  pulseMarket: document.getElementById('pulseMarket'),
+  pulseOpportunityList: document.getElementById('pulseOpportunityList'),
+  pulseActionList: document.getElementById('pulseActionList'),
+  pulseDirectoryStatus: document.getElementById('pulseDirectoryStatus'),
+  pulseDirectoryList: document.getElementById('pulseDirectoryList'),
+  pulseSocialProbeList: document.getElementById('pulseSocialProbeList'),
+  pulseReactionList: document.getElementById('pulseReactionList'),
+  pulseOutreachList: document.getElementById('pulseOutreachList'),
+  pulseTestList: document.getElementById('pulseTestList'),
+};
+
+const state = {
+  latest: null,
+  directory: Object.create(null),
+  directoryNode: null,
+};
+
+function createGun() {
+  if (typeof window.Gun !== 'function') {
+    return null;
+  }
+
+  try {
+    return window.Gun({ peers: window.__GUN_PEERS__ || DEFAULT_GUN_PEERS });
+  } catch (error) {
+    console.warn('Market pulse Gun init failed', error);
+    try {
+      return window.Gun({
+        peers: window.__GUN_PEERS__ || DEFAULT_GUN_PEERS,
+        radisk: false,
+        localStorage: false,
+      });
+    } catch (fallbackError) {
+      console.warn('Market pulse Gun fallback failed', fallbackError);
+      return null;
+    }
+  }
+}
+
+function safe(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function safeAttr(value) {
+  return safe(value).replace(/`/g, '&#96;');
+}
+
+function formatTimestamp(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '--';
+  }
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function percentScore(value) {
+  const score = Number(value || 0);
+  if (!Number.isFinite(score)) return '0';
+  return String(Math.round(score));
+}
+
+async function copyText(value = '') {
+  const text = String(value || '').trim();
+  if (!text) return false;
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', 'readonly');
+  textarea.className = 'fixed -left-[9999px] top-0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  textarea.remove();
+  return true;
+}
+
+function listFromLatest(key) {
+  const latest = state.latest || {};
+  return Array.isArray(latest[key]) ? latest[key] : [];
+}
+
+function directoryItems() {
+  const live = Object.values(state.directory).filter(Boolean);
+  if (live.length) {
+    return live.sort((left, right) => Number(right.confidenceScore || 0) - Number(left.confidenceScore || 0));
+  }
+  return listFromLatest('directoryListings');
+}
+
+function emptyBlock(message) {
+  return `<div class="rounded-md border border-dashed border-white/15 bg-zinc-950/70 p-4 text-sm text-zinc-400">${safe(message)}</div>`;
+}
+
+function renderOpportunityList() {
+  const opportunities = listFromLatest('opportunities').slice(0, 4);
+  if (!refs.pulseOpportunityList) return;
+  if (!opportunities.length) {
+    refs.pulseOpportunityList.innerHTML = emptyBlock('No opportunities loaded yet.');
+    return;
+  }
+
+  refs.pulseOpportunityList.innerHTML = opportunities.map((item) => `
+    <article class="rounded-md border border-white/10 bg-zinc-950/70 p-4">
+      <div class="flex items-start justify-between gap-3">
+        <h3 class="text-sm font-semibold text-zinc-100">${safe(item.title)}</h3>
+        <span class="rounded bg-emerald-400/10 px-2 py-1 text-xs text-emerald-200">${safe(percentScore(item.score))}</span>
+      </div>
+      <p class="mt-2 text-xs text-zinc-400">${safe(item.problem)}</p>
+      <p class="mt-3 text-xs uppercase tracking-[0.18em] text-zinc-500">${safe(item.suggestedPrice || '')}</p>
+    </article>
+  `).join('');
+}
+
+function renderActions() {
+  const actions = listFromLatest('salesActions');
+  if (!refs.pulseActionList) return;
+  if (!actions.length) {
+    refs.pulseActionList.innerHTML = emptyBlock('No actions loaded yet.');
+    return;
+  }
+
+  refs.pulseActionList.innerHTML = actions.map((item) => `
+    <article class="rounded-md border border-white/10 bg-zinc-950/70 p-4">
+      <div class="flex items-start justify-between gap-3">
+        <strong class="text-sm text-zinc-100">${safe(item.label)}</strong>
+        <span class="rounded px-2 py-1 text-xs ${item.approvalStatus === 'required' ? 'bg-amber-400/10 text-amber-200' : 'bg-emerald-400/10 text-emerald-200'}">${safe(item.approvalStatus)}</span>
+      </div>
+      <p class="mt-2 text-xs text-zinc-400">${safe(item.detail)}</p>
+      <p class="mt-3 text-xs uppercase tracking-[0.18em] text-zinc-500">${safe(item.risk)}</p>
+    </article>
+  `).join('');
+}
+
+function renderSocialProbes() {
+  const probes = listFromLatest('socialProbeDrafts');
+  if (!refs.pulseSocialProbeList) return;
+  if (!probes.length) {
+    refs.pulseSocialProbeList.innerHTML = emptyBlock('No social probes loaded yet.');
+    return;
+  }
+
+  refs.pulseSocialProbeList.innerHTML = probes.slice(0, 6).map((item) => `
+    <article class="rounded-md border border-white/10 bg-zinc-950/70 p-4">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <strong class="text-sm text-zinc-100">${safe(item.channelLabel || item.channel)}</strong>
+          <p class="mt-1 text-xs text-zinc-500">${safe(item.surface || 'social probe')}</p>
+        </div>
+        <span class="rounded px-2 py-1 text-xs ${item.risk === 'external_write' ? 'bg-amber-400/10 text-amber-200' : 'bg-cyan-400/10 text-cyan-200'}">${safe(item.approvalStatus || 'draft')}</span>
+      </div>
+      <p class="mt-3 whitespace-pre-wrap text-sm text-zinc-300">${safe(item.prompt)}</p>
+      <p class="mt-3 text-xs text-zinc-500">${safe(item.successMetric)}</p>
+      <button
+        type="button"
+        class="mt-3 rounded border border-white/15 px-3 py-1.5 text-xs font-semibold text-zinc-100 hover:bg-white/10"
+        data-copy-probe="${safeAttr(item.id)}"
+      >Copy draft</button>
+    </article>
+  `).join('');
+
+  refs.pulseSocialProbeList.querySelectorAll('[data-copy-probe]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const id = button.getAttribute('data-copy-probe');
+      const probe = probes.find((item) => item.id === id);
+      if (!probe) return;
+      await copyText(probe.prompt);
+      button.textContent = 'Copied';
+    });
+  });
+}
+
+function renderReactions() {
+  const snapshots = listFromLatest('reactionSnapshots');
+  if (!refs.pulseReactionList) return;
+  if (!snapshots.length) {
+    refs.pulseReactionList.innerHTML = emptyBlock('No reactions loaded yet.');
+    return;
+  }
+
+  refs.pulseReactionList.innerHTML = snapshots.map((item) => `
+    <article class="rounded-md border border-white/10 bg-zinc-950/70 p-4">
+      <div class="flex items-start justify-between gap-3">
+        <strong class="text-sm text-zinc-100">${safe(item.channelLabel || item.channel)}</strong>
+        <span class="rounded bg-fuchsia-400/10 px-2 py-1 text-xs text-fuchsia-200">${safe(percentScore(item.marketFitScore))}</span>
+      </div>
+      <div class="mt-3 grid grid-cols-3 gap-2 text-center text-xs text-zinc-400">
+        <span class="rounded bg-white/5 px-2 py-2">${safe(String(item.signalCount || 0))} signals</span>
+        <span class="rounded bg-white/5 px-2 py-2">${safe(String(item.commentCount || 0))} comments</span>
+        <span class="rounded bg-white/5 px-2 py-2">${safe(String(item.reactionCount || 0))} reactions</span>
+      </div>
+      <p class="mt-3 text-xs text-zinc-400">${safe(item.topSignalTitle || 'No top signal yet.')}</p>
+      ${item.topSignalUrl ? `<a href="${safeAttr(item.topSignalUrl)}" target="_blank" rel="noopener" class="mt-2 inline-flex text-xs font-semibold text-cyan-200 hover:text-white">Open signal</a>` : ''}
+    </article>
+  `).join('');
+}
+
+function approveListing(id) {
+  const listing = directoryItems().find((item) => item.id === id);
+  if (!listing || !state.directoryNode) return;
+  const approved = {
+    ...listing,
+    approved: true,
+    approvalStatus: 'approved',
+    approvedAt: new Date().toISOString(),
+    approvedBy: 'market-pulse-dashboard',
+  };
+  state.directory[id] = approved;
+  state.directoryNode.get(id).put(approved);
+  render();
+}
+
+function renderDirectory() {
+  const listings = directoryItems();
+  if (refs.pulseDirectoryStatus) {
+    refs.pulseDirectoryStatus.textContent = `${listings.filter((item) => item.approved).length} approved`;
+  }
+  if (!refs.pulseDirectoryList) return;
+  if (!listings.length) {
+    refs.pulseDirectoryList.innerHTML = emptyBlock('No directory listings loaded yet.');
+    return;
+  }
+
+  refs.pulseDirectoryList.innerHTML = listings.map((item) => {
+    const approved = item.approved || item.approvalStatus === 'approved';
+    const button = approved
+      ? '<span class="rounded bg-emerald-400/10 px-2 py-1 text-xs text-emerald-200">Approved</span>'
+      : `<button type="button" class="rounded bg-sky-400 px-3 py-1.5 text-xs font-semibold text-zinc-950 hover:bg-sky-300" data-approve-listing="${safeAttr(item.id)}">Approve</button>`;
+    return `
+      <article class="rounded-md border border-white/10 bg-zinc-950/70 p-4">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 class="text-sm font-semibold text-zinc-100">${safe(item.title)}</h3>
+            <p class="mt-1 text-xs text-zinc-400">${safe(item.market)}</p>
+          </div>
+          ${button}
+        </div>
+        <p class="mt-3 text-sm text-zinc-300">${safe(item.pain)}</p>
+        <p class="mt-2 text-xs text-sky-200">${safe(item.recommendedOffer)}</p>
+        <div class="mt-3 flex flex-wrap gap-2 text-xs text-zinc-400">
+          <span>${safe(item.confidence)} confidence</span>
+          <span>${safe(percentScore(item.confidenceScore))} score</span>
+          <span>${safe(formatTimestamp(item.updatedAt))}</span>
+        </div>
+      </article>
+    `;
+  }).join('');
+
+  refs.pulseDirectoryList.querySelectorAll('[data-approve-listing]').forEach((button) => {
+    button.addEventListener('click', () => approveListing(button.getAttribute('data-approve-listing')));
+  });
+}
+
+function renderOutreach() {
+  const drafts = listFromLatest('outreachDrafts');
+  if (!refs.pulseOutreachList) return;
+  if (!drafts.length) {
+    refs.pulseOutreachList.innerHTML = emptyBlock('No outreach drafts loaded yet.');
+    return;
+  }
+
+  refs.pulseOutreachList.innerHTML = drafts.map((item) => {
+    const params = new URLSearchParams({
+      draft: '1',
+      source: 'market-pulse',
+      lead: item.title || 'Market pulse lead',
+      subject: item.subject || '3dvr follow-up idea',
+      pain: item.opener || '',
+      next: 'Review and approve before sending',
+      tags: 'market-pulse,approval-required',
+    });
+    return `
+      <article class="rounded-md border border-white/10 bg-zinc-950/70 p-4">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <strong class="text-sm text-zinc-100">${safe(item.title)}</strong>
+          <span class="rounded bg-amber-400/10 px-2 py-1 text-xs text-amber-200">${safe(item.approvalStatus)}</span>
+        </div>
+        <p class="mt-2 text-xs text-zinc-400">${safe(item.opener)}</p>
+        <a href="../email-operator/index.html?${params.toString()}" class="mt-3 inline-flex rounded border border-white/15 px-3 py-1.5 text-xs font-semibold text-zinc-100 hover:bg-white/10">Open draft</a>
+      </article>
+    `;
+  }).join('');
+}
+
+function renderTests() {
+  const tests = listFromLatest('tests');
+  if (!refs.pulseTestList) return;
+  if (!tests.length) {
+    refs.pulseTestList.innerHTML = emptyBlock('No tests loaded yet.');
+    return;
+  }
+
+  refs.pulseTestList.innerHTML = tests.map((item) => `
+    <article class="rounded-md border border-white/10 bg-zinc-950/70 p-4">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <strong class="text-sm text-zinc-100">${safe(item.id || item.surface)}</strong>
+        <span class="rounded bg-violet-400/10 px-2 py-1 text-xs text-violet-200">${safe(item.approvalStatus)}</span>
+      </div>
+      <p class="mt-2 text-xs text-zinc-400">${safe(item.metric)}</p>
+      <p class="mt-3 text-xs uppercase tracking-[0.18em] text-zinc-500">${safe(item.surface)}</p>
+    </article>
+  `).join('');
+}
+
+function render() {
+  const latest = state.latest || {};
+  const top = latest.topOpportunity || {};
+  const listings = directoryItems();
+
+  if (refs.marketPulseStatus) {
+    refs.marketPulseStatus.textContent = latest.runId
+      ? `Run ${latest.runId} loaded. Outreach stays approval-gated; approved aggregate listings can feed the public directory.`
+      : 'Waiting for the latest market pulse.';
+  }
+  if (refs.pulseUpdatedAt) refs.pulseUpdatedAt.textContent = formatTimestamp(latest.generatedAt);
+  if (refs.pulseMarketFitScore) refs.pulseMarketFitScore.textContent = percentScore(latest.marketFit?.score);
+  if (refs.pulseMarketFitVerdict) refs.pulseMarketFitVerdict.textContent = latest.marketFit?.verdict || 'Searching';
+  if (refs.pulseMarketFitNextAction) {
+    refs.pulseMarketFitNextAction.textContent = latest.marketFit?.nextAction || 'Waiting for market-fit data.';
+  }
+  if (refs.pulseSignalCount) refs.pulseSignalCount.textContent = String(latest.signalsAnalyzed || 0);
+  if (refs.pulseListingCount) refs.pulseListingCount.textContent = String(listings.filter((item) => item.approved).length);
+  if (refs.pulseApprovalCount) refs.pulseApprovalCount.textContent = String(latest.approvalsRequired || 0);
+  if (refs.pulseTopOpportunity) refs.pulseTopOpportunity.textContent = top.title || 'Waiting for pulse data';
+  if (refs.pulseTopProblem) refs.pulseTopProblem.textContent = top.problem || 'The next scheduled run will fill this from live demand signals.';
+  if (refs.pulseMarket) refs.pulseMarket.textContent = latest.profile?.market || '--';
+
+  renderOpportunityList();
+  renderActions();
+  renderSocialProbes();
+  renderReactions();
+  renderDirectory();
+  renderOutreach();
+  renderTests();
+}
+
+function normalizeListing(data = {}, id = '') {
+  return {
+    id: String(data.id || id || '').trim(),
+    title: String(data.title || '').trim(),
+    market: String(data.market || '').trim(),
+    pain: String(data.pain || '').trim(),
+    recommendedOffer: String(data.recommendedOffer || '').trim(),
+    suggestedPrice: String(data.suggestedPrice || '').trim(),
+    confidence: String(data.confidence || '').trim(),
+    confidenceScore: Number(data.confidenceScore || 0),
+    approved: Boolean(data.approved || data.approvalStatus === 'approved'),
+    approvalStatus: String(data.approvalStatus || '').trim(),
+    evidence: Array.isArray(data.evidence) ? data.evidence : [],
+    updatedAt: String(data.updatedAt || '').trim(),
+    source: String(data.source || '').trim(),
+  };
+}
+
+function init() {
+  const gun = createGun();
+  if (!gun) {
+    if (refs.marketPulseStatus) {
+      refs.marketPulseStatus.textContent = 'Gun unavailable. Market pulse data cannot load.';
+    }
+    return;
+  }
+
+  const latestNode = getNode(gun, MARKET_PULSE_LATEST_PATH);
+  state.directoryNode = getNode(gun, MARKET_PULSE_DIRECTORY_PATH);
+
+  latestNode?.on((data) => {
+    state.latest = deserializeMarketPulseFromGun(data || {});
+    render();
+  });
+
+  state.directoryNode?.map().on((data, id) => {
+    if (!id) return;
+    if (!data) {
+      delete state.directory[id];
+    } else {
+      state.directory[id] = normalizeListing(data, id);
+    }
+    render();
+  });
+
+  render();
+}
+
+init();

--- a/src/growth/market-pulse.js
+++ b/src/growth/market-pulse.js
@@ -1,0 +1,653 @@
+import { deriveOpportunityFromSignal, rankOpportunities } from '../money/scoring.js';
+import { collectDemandSignals } from '../money/sources.js';
+import { DEFAULT_GUN_PEERS, getNode } from './homepage-hero.js';
+
+export const MARKET_PULSE_ROOT_PATH = Object.freeze([
+  '3dvr-portal',
+  'growth',
+  'market-pulse',
+]);
+export const MARKET_PULSE_LATEST_PATH = Object.freeze([
+  ...MARKET_PULSE_ROOT_PATH,
+  'latest',
+]);
+export const MARKET_PULSE_RUNS_PATH = Object.freeze([
+  ...MARKET_PULSE_ROOT_PATH,
+  'runs',
+]);
+export const MARKET_PULSE_DIRECTORY_PATH = Object.freeze([
+  ...MARKET_PULSE_ROOT_PATH,
+  'directory',
+]);
+
+export const DEFAULT_MARKET_PULSE_PROFILE = Object.freeze({
+  market: 'owner-led service businesses that need clearer lead follow-up',
+  keywords: [
+    'lead follow up',
+    'client onboarding',
+    'quote follow-up',
+    'small business automation',
+    'customer intake',
+  ],
+  channels: ['reddit', 'hackernews', 'linkedin', 'email'],
+  limit: 20,
+});
+
+const SOCIAL_PROBE_CHANNELS = Object.freeze([
+  Object.freeze({
+    id: 'facebook-groups',
+    label: 'Facebook Groups',
+    surface: 'group discussion',
+    risk: 'external_write',
+  }),
+  Object.freeze({
+    id: 'reddit',
+    label: 'Reddit',
+    surface: 'subreddit research post',
+    risk: 'external_write',
+  }),
+  Object.freeze({
+    id: 'linkedin',
+    label: 'LinkedIn',
+    surface: 'founder post',
+    risk: 'external_write',
+  }),
+  Object.freeze({
+    id: 'tiktok-comments',
+    label: 'TikTok comments',
+    surface: 'comment search',
+    risk: 'external_read',
+  }),
+]);
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function uniqueStrings(values = []) {
+  const seen = new Set();
+  const output = [];
+  values.forEach((value) => {
+    const normalized = normalizeText(value);
+    const key = normalized.toLowerCase();
+    if (!normalized || seen.has(key)) return;
+    seen.add(key);
+    output.push(normalized);
+  });
+  return output;
+}
+
+function slugify(value, fallback = 'market') {
+  const slug = normalizeText(value)
+    .toLowerCase()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 72);
+  return slug || fallback;
+}
+
+function makeRunId(date = new Date()) {
+  return `market-pulse-${date.toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}`;
+}
+
+function parseList(value, fallback = []) {
+  if (Array.isArray(value)) {
+    return uniqueStrings(value);
+  }
+  const parsed = String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return parsed.length ? uniqueStrings(parsed) : [...fallback];
+}
+
+function normalizeProfile(input = {}) {
+  return {
+    market: normalizeText(input.market) || DEFAULT_MARKET_PULSE_PROFILE.market,
+    keywords: parseList(input.keywords, DEFAULT_MARKET_PULSE_PROFILE.keywords),
+    channels: parseList(input.channels, DEFAULT_MARKET_PULSE_PROFILE.channels),
+    limit: Number.isFinite(Number(input.limit))
+      ? Math.max(1, Math.min(Number(input.limit), 50))
+      : DEFAULT_MARKET_PULSE_PROFILE.limit,
+  };
+}
+
+function fallbackOpportunities(market) {
+  return [
+    {
+      id: 'follow-up-operating-lane',
+      title: `Follow-up operating lane for ${market}`,
+      problem: `${market} teams lose qualified opportunities when follow-up, quoting, and reminders are spread across tools.`,
+      audience: market,
+      solution: 'A practical portal lane for intake, next steps, reminders, and weekly review.',
+      mvp: 'Directory landing page + intake form + CRM handoff + follow-up reminder.',
+      suggestedPrice: '$50/mo plus setup',
+      painScore: 62,
+      willingnessToPay: 58,
+      speedToBuild: 76,
+      competitionGap: 54,
+      evidence: ['Fallback opportunity generated when live demand sources did not return enough data.'],
+    },
+  ];
+}
+
+function buildOpportunities({ signals = [], market = '' } = {}) {
+  const raw = signals.length
+    ? signals.slice(0, 10).map((signal, index) => deriveOpportunityFromSignal(signal, index, market))
+    : fallbackOpportunities(market);
+  return rankOpportunities(raw).slice(0, 6);
+}
+
+function confidenceLabel(score) {
+  if (score >= 76) return 'high';
+  if (score >= 62) return 'medium';
+  return 'needs-evidence';
+}
+
+function offerForOpportunity(opportunity = {}) {
+  const text = `${opportunity.title || ''} ${opportunity.problem || ''} ${opportunity.audience || ''}`.toLowerCase();
+  if (/(team|clinic|support|handoff|intake|schedule)/.test(text)) {
+    return 'Embedded monthly lane for intake, shared follow-up, and handoff cleanup.';
+  }
+  if (/(quote|lead|follow|proposal|client|service)/.test(text)) {
+    return 'Builder setup for lead capture, quote follow-up, and CRM next steps.';
+  }
+  return 'Launch cleanup with one public path, one intake, and one follow-up loop.';
+}
+
+function evidenceFromOpportunity(opportunity = {}) {
+  return Array.isArray(opportunity.evidence)
+    ? opportunity.evidence.map((item) => normalizeText(item)).filter(Boolean).slice(0, 3)
+    : [];
+}
+
+function channelConfig(channelId = '') {
+  const normalized = normalizeText(channelId).toLowerCase();
+  const known = SOCIAL_PROBE_CHANNELS.find((item) => item.id === normalized);
+  if (known) return known;
+  if (normalized === 'hackernews') {
+    return {
+      id: 'hackernews',
+      label: 'Hacker News',
+      surface: 'discussion thread',
+      risk: 'external_read',
+    };
+  }
+  return {
+    id: normalized || 'unknown',
+    label: normalized || 'Unknown',
+    surface: 'market signal',
+    risk: 'external_read',
+  };
+}
+
+function buildResearchQuestion(opportunity = {}, channel = 'reddit') {
+  const problem = normalizeText(opportunity.problem) || 'follow-up falling through after a lead comes in';
+  const audience = normalizeText(opportunity.audience) || DEFAULT_MARKET_PULSE_PROFILE.market;
+
+  if (channel === 'facebook-groups') {
+    return [
+      `For people running ${audience}: where does ${problem.toLowerCase()} show up in your week?`,
+      'I am trying to understand the real workflow before building anything. What do you use now, and what is still annoying?'
+    ].join('\n\n');
+  }
+
+  if (channel === 'linkedin') {
+    return [
+      `Question for ${audience}: what happens between a qualified inquiry and the next follow-up?`,
+      `The pattern I am checking is: ${problem}`,
+      'What breaks first: reminders, quoting, ownership, or context?'
+    ].join('\n\n');
+  }
+
+  if (channel === 'tiktok-comments') {
+    return [
+      `Search comments around: "${opportunity.title || problem}"`,
+      `Look for repeated complaints about ${problem.toLowerCase()}, paid workaround mentions, and comments asking for templates or tools.`
+    ].join('\n\n');
+  }
+
+  return [
+    `How are you handling ${problem.toLowerCase()}?`,
+    `I am researching this for ${audience}. I am not trying to pitch yet; I want to know what people already tried, what failed, and what would be worth paying to avoid.`
+  ].join('\n\n');
+}
+
+export function buildSocialProbeDrafts(opportunities = [], options = {}) {
+  const channels = parseList(options.channels, ['facebook-groups', 'reddit', 'linkedin', 'tiktok-comments'])
+    .filter((channel) => channel !== 'hackernews' && channel !== 'email')
+    .slice(0, 4);
+  const topOpportunities = opportunities.slice(0, 2);
+
+  return channels.flatMap((channel) => {
+    const config = channelConfig(channel);
+    return topOpportunities.map((opportunity, index) => ({
+      id: `${slugify(opportunity.title || opportunity.problem, 'social-probe')}-${config.id}`,
+      channel: config.id,
+      channelLabel: config.label,
+      surface: config.surface,
+      risk: config.risk,
+      approvalStatus: config.risk === 'external_write' ? 'required' : 'ready',
+      linkedOpportunityId: opportunity.id || '',
+      title: opportunity.title || 'Market-fit probe',
+      prompt: buildResearchQuestion(opportunity, config.id),
+      successMetric: config.id === 'tiktok-comments'
+        ? 'Find 10+ repeated comment-level pains and 3+ workaround mentions.'
+        : 'Collect replies that describe a real workflow, current workaround, and willingness to pay.',
+      reactionCheck: config.risk === 'external_write'
+        ? 'After posting, paste the post URL and check reactions, comments, saves, and DMs within 24 hours.'
+        : 'Capture comment counts, repeated phrases, creator niches, and links back into Market Pulse.',
+      priority: index + 1,
+      generatedAt: options.generatedAt || new Date().toISOString(),
+    }));
+  });
+}
+
+function channelFromSignal(signal = {}) {
+  const source = normalizeText(signal.source).toLowerCase();
+  if (source.includes('reddit')) return 'reddit';
+  if (source.includes('hackernews')) return 'hackernews';
+  if (source.includes('facebook')) return 'facebook-groups';
+  if (source.includes('linkedin')) return 'linkedin';
+  if (source.includes('tiktok')) return 'tiktok-comments';
+  return source || 'unknown';
+}
+
+export function buildReactionSnapshots(signals = []) {
+  const grouped = new Map();
+  (Array.isArray(signals) ? signals : []).forEach((signal) => {
+    const channel = channelFromSignal(signal);
+    if (!grouped.has(channel)) {
+      grouped.set(channel, {
+        channel,
+        channelLabel: channelConfig(channel)?.label || channel,
+        signalCount: 0,
+        reactionCount: 0,
+        commentCount: 0,
+        topSignalTitle: '',
+        topSignalUrl: '',
+        marketFitScore: 0,
+      });
+    }
+    const current = grouped.get(channel);
+    const popularity = Number(signal.popularity || 0);
+    const comments = Number(signal.comments || 0);
+    current.signalCount += 1;
+    current.reactionCount += Math.max(0, popularity);
+    current.commentCount += Math.max(0, comments);
+    if (!current.topSignalTitle || (popularity + comments) > current.marketFitScore) {
+      current.topSignalTitle = signal.title || '';
+      current.topSignalUrl = signal.url || '';
+    }
+    current.marketFitScore = Math.min(100, Math.round(
+      (Math.min(current.signalCount * 18, 45))
+      + (Math.min(current.commentCount * 1.6, 35))
+      + (Math.min(current.reactionCount * 0.25, 20))
+    ));
+  });
+
+  return Array.from(grouped.values())
+    .sort((left, right) => right.marketFitScore - left.marketFitScore)
+    .slice(0, 6);
+}
+
+function buildMarketFitSummary({ opportunities = [], signals = [], reactionSnapshots = [] } = {}) {
+  const topOpportunity = opportunities[0] || {};
+  const topScore = Number(topOpportunity.score || 0);
+  const signalPressure = Math.min(100, signals.length * 9);
+  const commentPressure = Math.min(100, signals.reduce((sum, signal) => sum + Number(signal.comments || 0), 0) * 0.8);
+  const channelDiversity = Math.min(100, reactionSnapshots.length * 22);
+  const score = Math.round(
+    (topScore * 0.5)
+    + (signalPressure * 0.22)
+    + (commentPressure * 0.18)
+    + (channelDiversity * 0.1)
+  );
+
+  let verdict = 'searching';
+  if (score >= 76) verdict = 'strong signal';
+  else if (score >= 58) verdict = 'promising';
+  else if (score >= 40) verdict = 'needs replies';
+
+  return {
+    score,
+    verdict,
+    strongestChannel: reactionSnapshots[0]?.channelLabel || '',
+    nextAction: score >= 58
+      ? 'Run the top social probe and collect reaction snapshots before packaging the offer.'
+      : 'Broaden keyword search and ask lower-friction social questions before building.',
+  };
+}
+
+export function buildDirectoryListings(opportunities = [], options = {}) {
+  const generatedAt = normalizeText(options.generatedAt) || new Date().toISOString();
+  return opportunities.map((opportunity) => {
+    const confidenceScore = Number(opportunity.score || 0);
+    const id = slugify(opportunity.title || opportunity.problem, 'directory-listing');
+    const approvalStatus = confidenceScore >= 62 ? 'approved' : 'needs_review';
+    return {
+      id,
+      title: opportunity.title,
+      market: opportunity.audience || options.market || DEFAULT_MARKET_PULSE_PROFILE.market,
+      pain: opportunity.problem,
+      recommendedOffer: offerForOpportunity(opportunity),
+      suggestedPrice: opportunity.suggestedPrice || '$50/mo starter',
+      confidence: confidenceLabel(confidenceScore),
+      confidenceScore,
+      approvalStatus,
+      approved: approvalStatus === 'approved',
+      evidence: evidenceFromOpportunity(opportunity),
+      updatedAt: generatedAt,
+      source: 'market-pulse-cron',
+    };
+  });
+}
+
+function buildOutreachDrafts(opportunities = []) {
+  return opportunities.slice(0, 4).map((opportunity) => ({
+    id: `${slugify(opportunity.title, 'opportunity')}-outreach`,
+    title: opportunity.title,
+    channel: 'email-or-contact-form',
+    risk: 'external_write',
+    approvalStatus: 'required',
+    subject: `A quick follow-up cleanup idea`,
+    opener: opportunity.problem,
+    body: [
+      `I noticed a pattern around ${opportunity.audience || 'small teams'}: ${opportunity.problem}`,
+      offerForOpportunity(opportunity),
+      'Worth a short look this week?',
+    ].join('\n\n'),
+  }));
+}
+
+function buildTestPlans(opportunities = []) {
+  const top = opportunities[0] || {};
+  return [
+    {
+      id: 'homepage-hero',
+      surface: 'marketing-site',
+      metric: 'CTA click rate plus clarity feedback',
+      approvalStatus: 'auto_when_enabled',
+      action: 'Keep watching the homepage hero experiment and let the trusted cron promote a winner.',
+    },
+    {
+      id: `${slugify(top.title || 'directory-positioning')}-directory`,
+      surface: 'market-directory',
+      metric: 'directory CTA clicks and qualified CRM handoffs',
+      approvalStatus: 'draft',
+      variants: [
+        {
+          id: 'a',
+          angle: top.problem || 'Lead with the follow-up pain.',
+        },
+        {
+          id: 'b',
+          angle: top.solution || 'Lead with the operating lane offer.',
+        },
+      ],
+    },
+  ];
+}
+
+function buildSalesActions({ opportunities = [], outreachDrafts = [], directoryListings = [] } = {}) {
+  const top = opportunities[0] || {};
+  return [
+    {
+      id: 'approve-directory-refresh',
+      label: 'Review public directory listings',
+      risk: 'workspace_write',
+      approvalStatus: directoryListings.some((item) => item.approvalStatus === 'needs_review') ? 'required' : 'approved',
+      detail: `${directoryListings.filter((item) => item.approved).length} approved listings ready for the public directory.`,
+    },
+    {
+      id: 'approve-outreach-batch',
+      label: 'Approve outreach drafts',
+      risk: 'external_write',
+      approvalStatus: 'required',
+      detail: `${outreachDrafts.length} drafts are ready but will not send without approval.`,
+    },
+    {
+      id: 'approve-social-probes',
+      label: 'Approve social probe posts',
+      risk: 'external_write',
+      approvalStatus: 'required',
+      detail: 'Market-fit posts are drafted for review. Do not publish without human approval and the right account token.',
+    },
+    {
+      id: 'build-top-offer',
+      label: 'Package the top offer',
+      risk: 'workspace_write',
+      approvalStatus: 'draft',
+      detail: top.title ? `${top.title} is the current top opportunity.` : 'No opportunity is strong enough yet.',
+    },
+  ];
+}
+
+export function buildMarketPulse(demand = {}, options = {}) {
+  const now = typeof options.now === 'function' ? options.now() : new Date();
+  const generatedAt = normalizeText(options.generatedAt) || now.toISOString();
+  const profile = normalizeProfile(options.profile || options);
+  const signals = Array.isArray(demand.signals) ? demand.signals : [];
+  const warnings = Array.isArray(demand.warnings) ? demand.warnings.map(normalizeText).filter(Boolean) : [];
+  const keywords = uniqueStrings([
+    ...(Array.isArray(demand.keywords) ? demand.keywords : []),
+    ...profile.keywords,
+  ]).slice(0, 12);
+  const opportunities = buildOpportunities({ signals, market: profile.market });
+  const directoryListings = buildDirectoryListings(opportunities, {
+    generatedAt,
+    market: profile.market,
+  });
+  const outreachDrafts = buildOutreachDrafts(opportunities);
+  const socialProbeDrafts = buildSocialProbeDrafts(opportunities, {
+    channels: profile.channels,
+    generatedAt,
+  });
+  const reactionSnapshots = buildReactionSnapshots(signals);
+  const marketFit = buildMarketFitSummary({ opportunities, signals, reactionSnapshots });
+  const tests = buildTestPlans(opportunities);
+  const salesActions = buildSalesActions({ opportunities, outreachDrafts, directoryListings });
+
+  return {
+    runId: options.runId || makeRunId(now),
+    generatedAt,
+    profile: {
+      ...profile,
+      keywords,
+    },
+    signalsAnalyzed: signals.length,
+    warnings,
+    opportunities,
+    topOpportunity: opportunities[0] || null,
+    marketFit,
+    directoryListings,
+    outreachDrafts,
+    socialProbeDrafts,
+    reactionSnapshots,
+    tests,
+    salesActions,
+    approvalsRequired: salesActions.filter((item) => item.approvalStatus === 'required').length
+      + outreachDrafts.length
+      + tests.filter((item) => item.approvalStatus === 'draft').length,
+    automationPolicy: {
+      marketResearch: 'Automatic on the scheduled cron.',
+      socialListening: 'Automatic for supported public sources. Account-gated platforms require connected accounts or manual pasted URLs.',
+      socialPosting: 'Draft only. Publishing and replies require human approval plus platform account authorization.',
+      directory: 'Approved aggregate listings publish to the public directory node.',
+      outreach: 'Draft only. Sending requires human approval.',
+      website: 'Experiment winners can be promoted only by trusted cron or manual portal action.',
+    },
+  };
+}
+
+function onceNode(node) {
+  return new Promise((resolve) => {
+    if (!node || typeof node.once !== 'function') {
+      resolve(undefined);
+      return;
+    }
+    node.once((value) => resolve(value));
+  });
+}
+
+function putNode(node, value) {
+  return new Promise((resolve, reject) => {
+    if (!node || typeof node.put !== 'function') {
+      reject(new Error('Market pulse node is not writable.'));
+      return;
+    }
+    node.put(value, (ack) => {
+      if (ack?.err) {
+        reject(new Error(String(ack.err)));
+        return;
+      }
+      resolve(ack || {});
+    });
+  });
+}
+
+async function resolveGunImpl(explicitImpl) {
+  if (explicitImpl) return explicitImpl;
+  const moduleResult = await import('gun');
+  if (typeof moduleResult?.default === 'function') return moduleResult.default;
+  if (typeof moduleResult === 'function') return moduleResult;
+  throw new Error('Unable to load Gun for market pulse cron.');
+}
+
+function parseJsonField(value, fallback = []) {
+  try {
+    const parsed = JSON.parse(String(value || ''));
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+function parseJsonObjectField(value, fallback = {}) {
+  try {
+    const parsed = JSON.parse(String(value || ''));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+export function serializeMarketPulseForGun(pulse = {}) {
+  return {
+    runId: pulse.runId || '',
+    generatedAt: pulse.generatedAt || '',
+    market: pulse.profile?.market || '',
+    keywords: Array.isArray(pulse.profile?.keywords) ? pulse.profile.keywords.join(', ') : '',
+    signalsAnalyzed: Number(pulse.signalsAnalyzed || 0),
+    approvalsRequired: Number(pulse.approvalsRequired || 0),
+    topOpportunityTitle: pulse.topOpportunity?.title || '',
+    topOpportunityProblem: pulse.topOpportunity?.problem || '',
+    topOpportunityScore: Number(pulse.topOpportunity?.score || 0),
+    marketFitJson: JSON.stringify(pulse.marketFit || {}),
+    approvedListingCount: Array.isArray(pulse.directoryListings)
+      ? pulse.directoryListings.filter((item) => item.approved).length
+      : 0,
+    warningsJson: JSON.stringify(pulse.warnings || []),
+    opportunitiesJson: JSON.stringify(pulse.opportunities || []),
+    directoryListingsJson: JSON.stringify(pulse.directoryListings || []),
+    outreachDraftsJson: JSON.stringify(pulse.outreachDrafts || []),
+    socialProbeDraftsJson: JSON.stringify(pulse.socialProbeDrafts || []),
+    reactionSnapshotsJson: JSON.stringify(pulse.reactionSnapshots || []),
+    testsJson: JSON.stringify(pulse.tests || []),
+    salesActionsJson: JSON.stringify(pulse.salesActions || []),
+    automationPolicyJson: JSON.stringify(pulse.automationPolicy || {}),
+  };
+}
+
+export function deserializeMarketPulseFromGun(record = {}) {
+  return {
+    runId: normalizeText(record.runId),
+    generatedAt: normalizeText(record.generatedAt),
+    profile: {
+      market: normalizeText(record.market),
+      keywords: parseList(record.keywords, []),
+    },
+    signalsAnalyzed: Number(record.signalsAnalyzed || 0),
+    approvalsRequired: Number(record.approvalsRequired || 0),
+    topOpportunity: {
+      title: normalizeText(record.topOpportunityTitle),
+      problem: normalizeText(record.topOpportunityProblem),
+      score: Number(record.topOpportunityScore || 0),
+    },
+    marketFit: parseJsonObjectField(record.marketFitJson, {}),
+    warnings: parseJsonField(record.warningsJson),
+    opportunities: parseJsonField(record.opportunitiesJson),
+    directoryListings: parseJsonField(record.directoryListingsJson),
+    outreachDrafts: parseJsonField(record.outreachDraftsJson),
+    socialProbeDrafts: parseJsonField(record.socialProbeDraftsJson),
+    reactionSnapshots: parseJsonField(record.reactionSnapshotsJson),
+    tests: parseJsonField(record.testsJson),
+    salesActions: parseJsonField(record.salesActionsJson),
+  };
+}
+
+export async function createMarketPulseClient(options = {}) {
+  const GunImpl = await resolveGunImpl(options.GunImpl);
+  const peers = parseList(options.peers || options.gunPeers || options.config?.GROWTH_GUN_PEERS, DEFAULT_GUN_PEERS);
+  const gun = options.gun || GunImpl({
+    peers,
+    localStorage: false,
+    radisk: false,
+    file: false,
+    multicast: false,
+    axe: false,
+  });
+  const latestNode = getNode(gun, MARKET_PULSE_LATEST_PATH);
+  const runsNode = getNode(gun, MARKET_PULSE_RUNS_PATH);
+  const directoryNode = getNode(gun, MARKET_PULSE_DIRECTORY_PATH);
+
+  return {
+    async readLatest() {
+      return deserializeMarketPulseFromGun(await onceNode(latestNode));
+    },
+    async writePulse(pulse) {
+      const latestRecord = serializeMarketPulseForGun(pulse);
+      await putNode(latestNode, latestRecord);
+      await putNode(runsNode.get(pulse.runId), latestRecord);
+      const approvedListings = (pulse.directoryListings || []).filter((item) => item.approved);
+      for (const listing of approvedListings) {
+        await putNode(directoryNode.get(listing.id), listing);
+      }
+      return {
+        runId: pulse.runId,
+        directoryListingsPublished: approvedListings.length,
+      };
+    },
+  };
+}
+
+export async function runMarketPulseCycle(options = {}) {
+  const profile = normalizeProfile(options.profile || options);
+  const demandCollector = options.collectDemandSignalsImpl || collectDemandSignals;
+  const demand = options.demand || await demandCollector({
+    ...profile,
+    fetchImpl: options.fetchImpl || globalThis.fetch,
+  });
+  const pulse = buildMarketPulse(demand, {
+    ...options,
+    profile,
+  });
+  const dryRun = Boolean(options.dryRun);
+  const client = options.client || (dryRun ? null : await createMarketPulseClient(options));
+  let persist = {
+    skipped: true,
+    reason: dryRun ? 'dry run' : 'client unavailable',
+    directoryListingsPublished: 0,
+  };
+
+  if (!dryRun && client) {
+    persist = await client.writePulse(pulse);
+  }
+
+  return {
+    ...pulse,
+    dryRun,
+    persist,
+  };
+}

--- a/tests/market-pulse.test.js
+++ b/tests/market-pulse.test.js
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildMarketPulse,
+  deserializeMarketPulseFromGun,
+  runMarketPulseCycle,
+  serializeMarketPulseForGun,
+} from '../src/growth/market-pulse.js';
+
+const demand = {
+  keywords: ['lead follow up'],
+  warnings: [],
+  signals: [
+    {
+      id: 'signal-1',
+      source: 'reddit:r/smallbusiness',
+      title: 'Client follow-up keeps falling through the cracks',
+      summary: 'Owner operators need a simple reminder and quote workflow.',
+      url: 'https://example.com/signal-1',
+      popularity: 88,
+      comments: 35,
+      keyword: 'lead follow up',
+    },
+  ],
+};
+
+test('buildMarketPulse creates approved directory data while gating outreach', () => {
+  const pulse = buildMarketPulse(demand, {
+    generatedAt: '2026-05-14T10:00:00.000Z',
+    runId: 'market-pulse-test',
+    market: 'local service businesses',
+    keywords: ['lead follow up'],
+  });
+
+  assert.equal(pulse.runId, 'market-pulse-test');
+  assert.equal(pulse.signalsAnalyzed, 1);
+  assert.ok(pulse.marketFit.score > 0);
+  assert.match(pulse.marketFit.nextAction, /social probe|keyword/i);
+  assert.equal(pulse.directoryListings.length, 1);
+  assert.equal(pulse.directoryListings[0].approved, true);
+  assert.equal(pulse.outreachDrafts[0].approvalStatus, 'required');
+  assert.ok(pulse.socialProbeDrafts.some((item) => item.channel === 'reddit'));
+  assert.ok(pulse.socialProbeDrafts.every((item) => item.approvalStatus === 'required' || item.risk === 'external_read'));
+  assert.equal(pulse.reactionSnapshots[0].channel, 'reddit');
+  assert.ok(pulse.reactionSnapshots[0].marketFitScore > 0);
+  assert.equal(pulse.outreachDrafts[0].risk, 'external_write');
+  assert.match(pulse.automationPolicy.outreach, /requires human approval/i);
+  assert.match(pulse.automationPolicy.socialPosting, /human approval/i);
+});
+
+test('market pulse gun serialization keeps dashboard arrays recoverable', () => {
+  const pulse = buildMarketPulse(demand, {
+    generatedAt: '2026-05-14T10:00:00.000Z',
+    runId: 'market-pulse-test',
+  });
+  const serialized = serializeMarketPulseForGun(pulse);
+  const restored = deserializeMarketPulseFromGun(serialized);
+
+  assert.equal(serialized.runId, 'market-pulse-test');
+  assert.equal(restored.directoryListings.length, 1);
+  assert.equal(restored.outreachDrafts.length, 1);
+  assert.equal(restored.socialProbeDrafts.length > 0, true);
+  assert.equal(restored.reactionSnapshots.length, 1);
+  assert.equal(restored.marketFit.verdict.length > 0, true);
+  assert.equal(restored.tests.length, 2);
+});
+
+test('runMarketPulseCycle writes approved listings through the injected client', async () => {
+  const writes = [];
+  const result = await runMarketPulseCycle({
+    demand,
+    client: {
+      async writePulse(pulse) {
+        writes.push(pulse);
+        return {
+          runId: pulse.runId,
+          directoryListingsPublished: pulse.directoryListings.filter((item) => item.approved).length,
+        };
+      },
+    },
+    now: () => new Date('2026-05-14T12:00:00.000Z'),
+  });
+
+  assert.equal(writes.length, 1);
+  assert.equal(result.persist.directoryListingsPublished, 1);
+  assert.equal(result.dryRun, false);
+});
+
+test('runMarketPulseCycle dry run skips persistence', async () => {
+  const result = await runMarketPulseCycle({
+    demand,
+    dryRun: true,
+    now: () => new Date('2026-05-14T12:00:00.000Z'),
+  });
+
+  assert.equal(result.persist.skipped, true);
+  assert.equal(result.persist.reason, 'dry run');
+});

--- a/tests/sales-market-pulse.test.js
+++ b/tests/sales-market-pulse.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('market pulse dashboard ships live Gun wiring and approval surfaces', async () => {
+  const html = await readFile(new URL('../sales/market-pulse.html', import.meta.url), 'utf8');
+  const js = await readFile(new URL('../sales/market-pulse.js', import.meta.url), 'utf8');
+  const salesIndex = await readFile(new URL('../sales/index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /Market Pulse/);
+  assert.match(html, /id="pulseDirectoryList"/);
+  assert.match(html, /id="pulseMarketFitScore"/);
+  assert.match(html, /id="pulseSocialProbeList"/);
+  assert.match(html, /id="pulseReactionList"/);
+  assert.match(html, /id="pulseOutreachList"/);
+  assert.match(html, /id="pulseTestList"/);
+  assert.match(html, /https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+  assert.match(html, /type="module" src="\.\/market-pulse\.js"/);
+
+  assert.match(js, /MARKET_PULSE_LATEST_PATH/);
+  assert.match(js, /MARKET_PULSE_DIRECTORY_PATH/);
+  assert.match(js, /deserializeMarketPulseFromGun/);
+  assert.match(js, /data-copy-probe/);
+  assert.match(js, /reactionSnapshots/);
+  assert.match(js, /data-approve-listing/);
+  assert.match(js, /approval-required/);
+  assert.match(salesIndex, /href="market-pulse\.html"/);
+});


### PR DESCRIPTION
## Summary
- Adds a Market Pulse dashboard for automatic market-fit analysis and approval-gated social probe drafts.
- Builds market-fit scoring, reaction snapshots by channel, directory listings, outreach drafts, and experiment backlog data from demand signals.
- Links Market Pulse from the sales directory.

## Validation
- `node --test tests/market-pulse.test.js tests/sales-market-pulse.test.js`
- `node --check src/growth/market-pulse.js && node --check sales/market-pulse.js`
- Local smoke: `http://127.0.0.1:3001/sales/market-pulse.html` loaded with market fit, social probes, and reaction radar visible.

## Notes
Outbound social posting remains draft/approval gated. The market-fit engine can run against supported public demand sources, while account-gated platforms can be added after app credentials and platform permissions are configured.

This PR intentionally avoids adding another deployed API route or cron schedule after Vercel rejected the earlier preview. The dashboard and engine are mergeable now; the deployed runner should be a follow-up once Vercel limits/auth are clear.
