### PR TITLE
[codex] Add market pulse automation runner

### DIFF
--- a/.github/workflows/market-pulse.yml
+++ b/.github/workflows/market-pulse.yml
@@ -1,0 +1,51 @@
+name: Market Pulse Automation
+
+on:
+  schedule:
+    - cron: '23 */8 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run market research without writing to Gun'
+        required: false
+        default: 'false'
+
+jobs:
+  market-pulse:
+    name: Refresh market-fit signals
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      MARKET_PULSE_MARKET: ${{ vars.MARKET_PULSE_MARKET }}
+      MARKET_PULSE_KEYWORDS: ${{ vars.MARKET_PULSE_KEYWORDS }}
+      MARKET_PULSE_CHANNELS: ${{ vars.MARKET_PULSE_CHANNELS }}
+      MARKET_PULSE_LIMIT: ${{ vars.MARKET_PULSE_LIMIT }}
+      MARKET_PULSE_DRY_RUN: ${{ vars.MARKET_PULSE_DRY_RUN }}
+      GROWTH_GUN_PEERS: ${{ vars.GROWTH_GUN_PEERS }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run market pulse
+        run: |
+          mkdir -p artifacts/market-pulse
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm run market:pulse -- --dry-run --json | tee artifacts/market-pulse/latest.json
+          else
+            npm run market:pulse -- --json | tee artifacts/market-pulse/latest.json
+          fi
+
+      - name: Upload market pulse artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: market-pulse-${{ github.run_id }}
+          path: artifacts/market-pulse/latest.json

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "env:check": "node scripts/env/check.mjs",
     "money:loop": "node scripts/money/run-loop.mjs",
     "money:autopilot": "node scripts/money/run-autopilot.mjs",
+    "market:pulse": "node scripts/growth/run-market-pulse.mjs",
     "playwright:install:linux": "node scripts/playwright/install-runtime.mjs",
     "playwright:install:chrome-safari:linux": "PLAYWRIGHT_BROWSERS=\"chrome safari\" npm run playwright:install:linux",
     "playwright:install": "sh scripts/playwright/run-install.sh",

--- a/sales/market-pulse.html
+++ b/sales/market-pulse.html
@@ -69,6 +69,23 @@
       </article>
     </section>
 
+    <section class="rounded-md border border-white/10 bg-zinc-900/80 p-5">
+      <div class="grid gap-5 lg:grid-cols-[0.9fr,1.1fr]">
+        <div>
+          <p class="text-xs uppercase tracking-[0.22em] text-emerald-300">Automation</p>
+          <h2 class="mt-2 text-xl font-semibold">Market-fit runner</h2>
+          <p id="pulseAutomationMode" class="mt-3 text-sm text-zinc-300">Waiting for automation policy.</p>
+        </div>
+        <div class="space-y-3">
+          <pre id="pulseAutomationCommand" class="overflow-x-auto rounded-md border border-white/10 bg-zinc-950/80 p-4 text-xs text-emerald-100">npm run market:pulse -- --dry-run</pre>
+          <div id="pulseAutomationPolicy" class="grid gap-2 text-xs text-zinc-300 sm:grid-cols-2">
+            <span class="rounded bg-white/5 px-3 py-2">Market research: waiting</span>
+            <span class="rounded bg-white/5 px-3 py-2">Social posting: approval-gated</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section class="grid gap-5 xl:grid-cols-[0.95fr,1.05fr]">
       <article class="rounded-md border border-white/10 bg-zinc-900/80 p-5 space-y-4">
         <div class="flex flex-wrap items-center justify-between gap-3">

--- a/sales/market-pulse.js
+++ b/sales/market-pulse.js
@@ -1,5 +1,6 @@
 import { DEFAULT_GUN_PEERS, getNode } from '../src/growth/homepage-hero.js';
 import {
+  DEFAULT_MARKET_PULSE_PROFILE,
   MARKET_PULSE_DIRECTORY_PATH,
   MARKET_PULSE_LATEST_PATH,
   deserializeMarketPulseFromGun,
@@ -14,6 +15,9 @@ const refs = {
   pulseSignalCount: document.getElementById('pulseSignalCount'),
   pulseListingCount: document.getElementById('pulseListingCount'),
   pulseApprovalCount: document.getElementById('pulseApprovalCount'),
+  pulseAutomationMode: document.getElementById('pulseAutomationMode'),
+  pulseAutomationCommand: document.getElementById('pulseAutomationCommand'),
+  pulseAutomationPolicy: document.getElementById('pulseAutomationPolicy'),
   pulseTopOpportunity: document.getElementById('pulseTopOpportunity'),
   pulseTopProblem: document.getElementById('pulseTopProblem'),
   pulseMarket: document.getElementById('pulseMarket'),
@@ -85,6 +89,10 @@ function percentScore(value) {
   const score = Number(value || 0);
   if (!Number.isFinite(score)) return '0';
   return String(Math.round(score));
+}
+
+function shellQuote(value = '') {
+  return `'${String(value || '').replace(/'/g, `'"'"'`)}'`;
 }
 
 async function copyText(value = '') {
@@ -225,6 +233,49 @@ function renderReactions() {
   `).join('');
 }
 
+function automationCommand(latest = {}) {
+  const profile = latest.profile || {};
+  const market = profile.market || DEFAULT_MARKET_PULSE_PROFILE.market;
+  const keywords = Array.isArray(profile.keywords) && profile.keywords.length
+    ? profile.keywords.slice(0, 8)
+    : DEFAULT_MARKET_PULSE_PROFILE.keywords;
+  const channels = DEFAULT_MARKET_PULSE_PROFILE.channels;
+  return [
+    'npm run market:pulse --',
+    `--market ${shellQuote(market)}`,
+    `--keywords ${shellQuote(keywords.join(','))}`,
+    `--channels ${shellQuote(channels.join(','))}`,
+    `--limit ${Number(profile.limit || DEFAULT_MARKET_PULSE_PROFILE.limit)}`,
+  ].join(' ');
+}
+
+function renderAutomation() {
+  const latest = state.latest || {};
+  const policy = latest.automationPolicy || {};
+  if (refs.pulseAutomationMode) {
+    refs.pulseAutomationMode.textContent = latest.runId
+      ? `Latest run ${latest.runId} is ready for automatic refreshes. Social writes stay approval-gated.`
+      : 'Run the market-fit automation to populate public signals, social probes, and reaction radar.';
+  }
+  if (refs.pulseAutomationCommand) {
+    refs.pulseAutomationCommand.textContent = automationCommand(latest);
+  }
+  if (!refs.pulseAutomationPolicy) return;
+
+  const items = [
+    ['Market research', policy.marketResearch || 'Automatic when the runner executes.'],
+    ['Social listening', policy.socialListening || 'Automatic for supported public sources.'],
+    ['Social posting', policy.socialPosting || 'Draft only until approved.'],
+    ['Outreach', policy.outreach || 'Draft only until approved.'],
+  ];
+  refs.pulseAutomationPolicy.innerHTML = items.map(([label, value]) => `
+    <span class="rounded bg-white/5 px-3 py-2">
+      <strong class="block text-zinc-100">${safe(label)}</strong>
+      <span class="mt-1 block text-zinc-400">${safe(value)}</span>
+    </span>
+  `).join('');
+}
+
 function approveListing(id) {
   const listing = directoryItems().find((item) => item.id === id);
   if (!listing || !state.directoryNode) return;
@@ -356,6 +407,7 @@ function render() {
   if (refs.pulseMarket) refs.pulseMarket.textContent = latest.profile?.market || '--';
 
   renderOpportunityList();
+  renderAutomation();
   renderActions();
   renderSocialProbes();
   renderReactions();

--- a/scripts/growth/run-market-pulse.mjs
+++ b/scripts/growth/run-market-pulse.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { runMarketPulseCli } from '../../src/growth/market-pulse-runner.js';
+
+const { exitCode } = await runMarketPulseCli();
+process.exitCode = exitCode;

--- a/src/growth/market-pulse-runner.js
+++ b/src/growth/market-pulse-runner.js
@@ -1,0 +1,221 @@
+import { DEFAULT_GUN_PEERS } from './homepage-hero.js';
+import {
+  DEFAULT_MARKET_PULSE_PROFILE,
+  runMarketPulseCycle,
+} from './market-pulse.js';
+
+const HELP_TEXT = `Usage: npm run market:pulse -- [options]
+
+Options:
+  --market <text>       Market or audience to research.
+  --keywords <csv>      Comma-separated pains or phrases.
+  --channels <csv>      Comma-separated social probe channels.
+  --limit <number>      Maximum demand signals to analyze.
+  --gun-peers <csv>     Comma-separated Gun relay peers for persistence.
+  --dry-run             Research and score without writing to Gun.
+  --json                Print a machine-readable summary.
+  --help                Show this help.
+`;
+
+function normalizeText(value = '') {
+  return String(value || '').trim();
+}
+
+function splitList(value, fallback = []) {
+  const items = Array.isArray(value)
+    ? value
+    : String(value || '')
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  return items.length ? items : [...fallback];
+}
+
+function parseBoolEnv(value) {
+  return /^(1|true|yes|on)$/i.test(String(value || '').trim());
+}
+
+function readFlagValue(argv, index, flag) {
+  const next = argv[index + 1];
+  if (!next || String(next).startsWith('--')) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return next;
+}
+
+export function parseMarketPulseArgs(argv = []) {
+  const parsed = {
+    dryRun: false,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = String(argv[index] || '');
+    if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--market') {
+      parsed.market = readFlagValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--keywords') {
+      parsed.keywords = splitList(readFlagValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--channels') {
+      parsed.channels = splitList(readFlagValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--limit') {
+      parsed.limit = Number.parseInt(readFlagValue(argv, index, arg), 10);
+      index += 1;
+    } else if (arg === '--gun-peers') {
+      parsed.gunPeers = splitList(readFlagValue(argv, index, arg));
+      index += 1;
+    } else {
+      throw new Error(`Unknown market pulse option: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+export function buildMarketPulseRunOptions(parsed = {}, env = process.env) {
+  const keywords = parsed.keywords || splitList(env.MARKET_PULSE_KEYWORDS, DEFAULT_MARKET_PULSE_PROFILE.keywords);
+  const channels = parsed.channels || splitList(env.MARKET_PULSE_CHANNELS, DEFAULT_MARKET_PULSE_PROFILE.channels);
+  const peers = parsed.gunPeers || splitList(env.GROWTH_GUN_PEERS, DEFAULT_GUN_PEERS);
+  const envLimit = Number.parseInt(env.MARKET_PULSE_LIMIT, 10);
+  const parsedLimit = Number.parseInt(parsed.limit, 10);
+
+  return {
+    market: normalizeText(parsed.market || env.MARKET_PULSE_MARKET) || DEFAULT_MARKET_PULSE_PROFILE.market,
+    keywords,
+    channels,
+    limit: Number.isFinite(parsedLimit)
+      ? parsedLimit
+      : (Number.isFinite(envLimit) ? envLimit : DEFAULT_MARKET_PULSE_PROFILE.limit),
+    gunPeers: peers,
+    dryRun: Boolean(parsed.dryRun || parseBoolEnv(env.MARKET_PULSE_DRY_RUN)),
+  };
+}
+
+function summarizeProbes(probes = []) {
+  return probes
+    .slice(0, 4)
+    .map((probe) => ({
+      channel: probe.channelLabel || probe.channel || '',
+      approvalStatus: probe.approvalStatus || '',
+      title: probe.title || '',
+    }));
+}
+
+function summarizeReactions(reactions = []) {
+  return reactions
+    .slice(0, 4)
+    .map((item) => ({
+      channel: item.channelLabel || item.channel || '',
+      marketFitScore: Number(item.marketFitScore || 0),
+      signals: Number(item.signalCount || 0),
+      comments: Number(item.commentCount || 0),
+      reactions: Number(item.reactionCount || 0),
+    }));
+}
+
+export function buildMarketPulseCliSummary(result = {}) {
+  return {
+    runId: result.runId || '',
+    generatedAt: result.generatedAt || '',
+    dryRun: Boolean(result.dryRun),
+    market: result.profile?.market || '',
+    keywords: Array.isArray(result.profile?.keywords) ? result.profile.keywords : [],
+    signalsAnalyzed: Number(result.signalsAnalyzed || 0),
+    approvalsRequired: Number(result.approvalsRequired || 0),
+    marketFit: {
+      score: Number(result.marketFit?.score || 0),
+      verdict: result.marketFit?.verdict || '',
+      strongestChannel: result.marketFit?.strongestChannel || '',
+      nextAction: result.marketFit?.nextAction || '',
+    },
+    topOpportunity: {
+      title: result.topOpportunity?.title || '',
+      problem: result.topOpportunity?.problem || '',
+      score: Number(result.topOpportunity?.score || 0),
+    },
+    persist: result.persist || {},
+    socialProbes: summarizeProbes(result.socialProbeDrafts),
+    reactionRadar: summarizeReactions(result.reactionSnapshots),
+    warnings: Array.isArray(result.warnings) ? result.warnings : [],
+  };
+}
+
+function formatSummary(summary = {}) {
+  const lines = [
+    'Market Pulse automation complete',
+    `Run: ${summary.runId || 'unknown'}`,
+    `Mode: ${summary.dryRun ? 'dry run' : 'persisted to Gun'}`,
+    `Market: ${summary.market || 'unknown'}`,
+    `Fit: ${summary.marketFit.score} (${summary.marketFit.verdict || 'searching'})`,
+    `Signals: ${summary.signalsAnalyzed}`,
+    `Approvals: ${summary.approvalsRequired}`,
+  ];
+
+  if (summary.persist?.directoryListingsPublished != null) {
+    lines.push(`Directory listings published: ${summary.persist.directoryListingsPublished}`);
+  }
+  if (summary.topOpportunity.title) {
+    lines.push(`Top opportunity: ${summary.topOpportunity.title}`);
+  }
+  if (summary.marketFit.nextAction) {
+    lines.push(`Next action: ${summary.marketFit.nextAction}`);
+  }
+  if (summary.socialProbes.length) {
+    lines.push('Social probes:');
+    summary.socialProbes.forEach((probe) => {
+      lines.push(`- ${probe.channel}: ${probe.approvalStatus} - ${probe.title}`);
+    });
+  }
+  if (summary.reactionRadar.length) {
+    lines.push('Reaction radar:');
+    summary.reactionRadar.forEach((item) => {
+      lines.push(`- ${item.channel}: ${item.marketFitScore} fit, ${item.comments} comments, ${item.reactions} reactions`);
+    });
+  }
+  if (summary.warnings.length) {
+    lines.push('Warnings:');
+    summary.warnings.forEach((warning) => {
+      lines.push(`- ${warning}`);
+    });
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export async function runMarketPulseCli(options = {}) {
+  const argv = options.argv || process.argv.slice(2);
+  const stdout = options.stdout || process.stdout;
+  const stderr = options.stderr || process.stderr;
+  const env = options.env || process.env;
+  const runCycleImpl = options.runCycleImpl || runMarketPulseCycle;
+
+  try {
+    const parsed = parseMarketPulseArgs(argv);
+    if (parsed.help) {
+      stdout.write(HELP_TEXT);
+      return { exitCode: 0 };
+    }
+
+    const runOptions = {
+      ...buildMarketPulseRunOptions(parsed, env),
+      fetchImpl: options.fetchImpl,
+      now: options.now,
+    };
+    const result = await runCycleImpl(runOptions);
+    const summary = buildMarketPulseCliSummary(result);
+    stdout.write(parsed.json ? `${JSON.stringify(summary, null, 2)}\n` : formatSummary(summary));
+    return { exitCode: 0, result, summary };
+  } catch (error) {
+    stderr.write(`Market Pulse automation failed: ${error.message}\n`);
+    return { exitCode: 1, error };
+  }
+}

--- a/src/growth/market-pulse.js
+++ b/src/growth/market-pulse.js
@@ -29,7 +29,7 @@ export const DEFAULT_MARKET_PULSE_PROFILE = Object.freeze({
     'small business automation',
     'customer intake',
   ],
-  channels: ['reddit', 'hackernews', 'linkedin', 'email'],
+  channels: ['reddit', 'hackernews', 'facebook-groups', 'linkedin', 'tiktok-comments', 'email'],
   limit: 20,
 });
 
@@ -471,7 +471,7 @@ export function buildMarketPulse(demand = {}, options = {}) {
       + outreachDrafts.length
       + tests.filter((item) => item.approvalStatus === 'draft').length,
     automationPolicy: {
-      marketResearch: 'Automatic on the scheduled cron.',
+      marketResearch: 'Automatic when the market-pulse runner or scheduler executes.',
       socialListening: 'Automatic for supported public sources. Account-gated platforms require connected accounts or manual pasted URLs.',
       socialPosting: 'Draft only. Publishing and replies require human approval plus platform account authorization.',
       directory: 'Approved aggregate listings publish to the public directory node.',
@@ -584,6 +584,7 @@ export function deserializeMarketPulseFromGun(record = {}) {
     reactionSnapshots: parseJsonField(record.reactionSnapshotsJson),
     tests: parseJsonField(record.testsJson),
     salesActions: parseJsonField(record.salesActionsJson),
+    automationPolicy: parseJsonObjectField(record.automationPolicyJson, {}),
   };
 }
 

--- a/tests/market-pulse-runner.test.js
+++ b/tests/market-pulse-runner.test.js
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import {
+  buildMarketPulseRunOptions,
+  parseMarketPulseArgs,
+  runMarketPulseCli,
+} from '../src/growth/market-pulse-runner.js';
+
+test('parseMarketPulseArgs reads automation options', () => {
+  const parsed = parseMarketPulseArgs([
+    '--market',
+    'service businesses',
+    '--keywords',
+    'lead follow up,client onboarding',
+    '--channels',
+    'reddit,facebook-groups,tiktok-comments',
+    '--limit',
+    '7',
+    '--gun-peers',
+    'wss://one.example/gun,wss://two.example/gun',
+    '--dry-run',
+    '--json',
+  ]);
+
+  assert.equal(parsed.market, 'service businesses');
+  assert.deepEqual(parsed.keywords, ['lead follow up', 'client onboarding']);
+  assert.deepEqual(parsed.channels, ['reddit', 'facebook-groups', 'tiktok-comments']);
+  assert.equal(parsed.limit, 7);
+  assert.deepEqual(parsed.gunPeers, ['wss://one.example/gun', 'wss://two.example/gun']);
+  assert.equal(parsed.dryRun, true);
+  assert.equal(parsed.json, true);
+});
+
+test('buildMarketPulseRunOptions can be driven by environment defaults', () => {
+  const options = buildMarketPulseRunOptions({}, {
+    MARKET_PULSE_MARKET: 'home service teams',
+    MARKET_PULSE_KEYWORDS: 'missed calls,quote follow up',
+    MARKET_PULSE_CHANNELS: 'reddit,linkedin',
+    MARKET_PULSE_LIMIT: '12',
+    MARKET_PULSE_DRY_RUN: 'true',
+    GROWTH_GUN_PEERS: 'wss://relay.example/gun',
+  });
+
+  assert.equal(options.market, 'home service teams');
+  assert.deepEqual(options.keywords, ['missed calls', 'quote follow up']);
+  assert.deepEqual(options.channels, ['reddit', 'linkedin']);
+  assert.equal(options.limit, 12);
+  assert.equal(options.dryRun, true);
+  assert.deepEqual(options.gunPeers, ['wss://relay.example/gun']);
+});
+
+test('runMarketPulseCli runs the injected pulse cycle and prints a useful summary', async () => {
+  let capturedOptions;
+  const stdout = {
+    value: '',
+    write(chunk) {
+      this.value += chunk;
+    },
+  };
+  const stderr = {
+    value: '',
+    write(chunk) {
+      this.value += chunk;
+    },
+  };
+
+  const result = await runMarketPulseCli({
+    argv: ['--dry-run', '--market', 'service businesses'],
+    stdout,
+    stderr,
+    env: {},
+    async runCycleImpl(options) {
+      capturedOptions = options;
+      return {
+        runId: 'market-pulse-cli-test',
+        generatedAt: '2026-05-28T12:00:00.000Z',
+        dryRun: options.dryRun,
+        profile: {
+          market: options.market,
+          keywords: options.keywords,
+        },
+        signalsAnalyzed: 3,
+        approvalsRequired: 4,
+        marketFit: {
+          score: 72,
+          verdict: 'promising',
+          nextAction: 'Run the top social probe.',
+        },
+        topOpportunity: {
+          title: 'Follow-up cleanup',
+          problem: 'Leads are falling through.',
+          score: 74,
+        },
+        persist: {
+          skipped: true,
+          reason: 'dry run',
+          directoryListingsPublished: 0,
+        },
+        socialProbeDrafts: [
+          {
+            channelLabel: 'Reddit',
+            approvalStatus: 'required',
+            title: 'Follow-up cleanup',
+          },
+        ],
+        reactionSnapshots: [
+          {
+            channelLabel: 'Reddit',
+            marketFitScore: 68,
+            signalCount: 2,
+            commentCount: 14,
+            reactionCount: 90,
+          },
+        ],
+        warnings: [],
+      };
+    },
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(capturedOptions.dryRun, true);
+  assert.equal(capturedOptions.market, 'service businesses');
+  assert.match(stdout.value, /Market Pulse automation complete/);
+  assert.match(stdout.value, /Reaction radar/);
+  assert.equal(stderr.value, '');
+});
+
+test('market pulse automation is wired to npm and scheduled GitHub Actions', async () => {
+  const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+  const workflow = await readFile(new URL('../.github/workflows/market-pulse.yml', import.meta.url), 'utf8');
+
+  assert.equal(packageJson.scripts['market:pulse'], 'node scripts/growth/run-market-pulse.mjs');
+  assert.match(workflow, /Market Pulse Automation/);
+  assert.match(workflow, /cron: '23 \*\/8 \* \* \*'/);
+  assert.match(workflow, /workflow_dispatch/);
+  assert.match(workflow, /npm run market:pulse -- --json/);
+  assert.match(workflow, /MARKET_PULSE_MARKET/);
+});

--- a/tests/market-pulse.test.js
+++ b/tests/market-pulse.test.js
@@ -40,6 +40,8 @@ test('buildMarketPulse creates approved directory data while gating outreach', (
   assert.equal(pulse.directoryListings[0].approved, true);
   assert.equal(pulse.outreachDrafts[0].approvalStatus, 'required');
   assert.ok(pulse.socialProbeDrafts.some((item) => item.channel === 'reddit'));
+  assert.ok(pulse.socialProbeDrafts.some((item) => item.channel === 'facebook-groups'));
+  assert.ok(pulse.socialProbeDrafts.some((item) => item.channel === 'tiktok-comments'));
   assert.ok(pulse.socialProbeDrafts.every((item) => item.approvalStatus === 'required' || item.risk === 'external_read'));
   assert.equal(pulse.reactionSnapshots[0].channel, 'reddit');
   assert.ok(pulse.reactionSnapshots[0].marketFitScore > 0);
@@ -63,6 +65,7 @@ test('market pulse gun serialization keeps dashboard arrays recoverable', () => 
   assert.equal(restored.reactionSnapshots.length, 1);
   assert.equal(restored.marketFit.verdict.length > 0, true);
   assert.equal(restored.tests.length, 2);
+  assert.match(restored.automationPolicy.marketResearch, /runner|scheduler/i);
 });
 
 test('runMarketPulseCycle writes approved listings through the injected client', async () => {

--- a/tests/sales-market-pulse.test.js
+++ b/tests/sales-market-pulse.test.js
@@ -10,6 +10,8 @@ test('market pulse dashboard ships live Gun wiring and approval surfaces', async
   assert.match(html, /Market Pulse/);
   assert.match(html, /id="pulseDirectoryList"/);
   assert.match(html, /id="pulseMarketFitScore"/);
+  assert.match(html, /id="pulseAutomationCommand"/);
+  assert.match(html, /id="pulseAutomationPolicy"/);
   assert.match(html, /id="pulseSocialProbeList"/);
   assert.match(html, /id="pulseReactionList"/);
   assert.match(html, /id="pulseOutreachList"/);
@@ -20,6 +22,8 @@ test('market pulse dashboard ships live Gun wiring and approval surfaces', async
   assert.match(js, /MARKET_PULSE_LATEST_PATH/);
   assert.match(js, /MARKET_PULSE_DIRECTORY_PATH/);
   assert.match(js, /deserializeMarketPulseFromGun/);
+  assert.match(js, /automationPolicy/);
+  assert.match(js, /market:pulse/);
   assert.match(js, /data-copy-probe/);
   assert.match(js, /reactionSnapshots/);
   assert.match(js, /data-approve-listing/);


### PR DESCRIPTION
## Summary
- Add `npm run market:pulse` for automated market-fit research, social probe draft generation, reaction radar summaries, and Gun persistence.
- Add a scheduled GitHub Actions workflow that runs the pulse every 8 hours and supports manual dry runs.
- Add a dashboard automation panel showing the command and approval policy, plus tests for the runner and UI wiring.

## Validation
- `node --test tests/market-pulse.test.js tests/sales-market-pulse.test.js tests/market-pulse-runner.test.js`
- `node --check src/growth/market-pulse.js && node --check src/growth/market-pulse-runner.js && node --check sales/market-pulse.js && node --check scripts/growth/run-market-pulse.mjs`
- `node scripts/growth/run-market-pulse.mjs --dry-run --limit 3 --market 'owner-led service businesses' --keywords 'lead follow up,client onboarding'`
- `node scripts/growth/run-market-pulse.mjs --dry-run --json --limit 2 --market 'owner-led service businesses' --keywords 'lead follow up'`
- Firefox smoke on `http://127.0.0.1:3002/sales/market-pulse.html`