### PR TITLE
Add Intention Lab portal app

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Education Suite](https://3dvr-portal.vercel.app/education-suite/)
 - [Attention Visualized](https://3dvr-portal.vercel.app/attention-visualized/)
 - [Logic Lab](https://3dvr-portal.vercel.app/logic-lab/)
+- [Intention Lab](https://3dvr-portal.vercel.app/intention-lab/)
 
 Open the page you want and use your browser’s **Install** or **Add to Home Screen** option to pin it like a native app.
 

--- a/app-manifests/intention-lab.webmanifest
+++ b/app-manifests/intention-lab.webmanifest
@@ -1,0 +1,16 @@
+{
+  "id": "/intention-lab/",
+  "name": "3DVR Intention Lab",
+  "short_name": "Intention Lab",
+  "description": "Turn attention into action and run honest browser-randomness self-experiments.",
+  "start_url": "/intention-lab/?source=pwa",
+  "scope": "/intention-lab/",
+  "display": "standalone",
+  "background_color": "#0e1116",
+  "theme_color": "#0e1116",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -646,6 +646,19 @@
             <span class="app-card__title">Science Lab</span>
             <span class="app-card__meta">Run experiments, track signals, and publish VR-ready findings.</span>
           </a>
+          <a
+            href="intention-lab/"
+            class="app-card"
+            data-app-tier="experimental"
+            data-app-keywords="attention intention manifestation random rng science meditation action experiment"
+          >
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">LAB</span>
+            <span class="app-card__title">Intention Lab</span>
+            <span class="app-card__meta">
+              Turn attention into state, state into action, and test randomness honestly.
+            </span>
+          </a>
           <a href="xr-motion-lab/index.html" class="app-card" data-app-tier="experimental">
             <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">🥽</span>

--- a/intention-lab/index.html
+++ b/intention-lab/index.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Intention Lab | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="Turn attention into action and run honest browser-randomness self-experiments."
+  >
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="./intention-lab.css">
+  <link rel="manifest" href="/app-manifests/intention-lab.webmanifest">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
+  <meta name="theme-color" content="#0e1116">
+  <meta name="analytics" content="disabled">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script src="/auth-identity.js"></script>
+  <script src="/score.js"></script>
+  <script type="module" src="./intention-lab.js"></script>
+</head>
+<body class="intention-body">
+  <a class="skip-link" href="#mainContent">Skip to Intention Lab</a>
+
+  <header class="lab-header">
+    <nav class="lab-nav" aria-label="Intention Lab navigation">
+      <a class="lab-brand" href="/">
+        <span class="lab-brand__mark" aria-hidden="true">LAB</span>
+        <span>
+          <strong>Intention Lab</strong>
+          <small>3DVR experimental app</small>
+        </span>
+      </a>
+      <div class="lab-nav__links">
+        <a href="/science/">Science Lab</a>
+        <a href="/meditation/">Meditation</a>
+        <a href="/">Portal</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="mainContent" class="lab-shell">
+    <section class="hero-panel" aria-labelledby="intention-title">
+      <div class="hero-panel__copy">
+        <p class="kicker">Experimental self-study</p>
+        <h1 id="intention-title">Turn attention into action.</h1>
+        <p class="hero-panel__lead">
+          Attention selects. Thought rehearses. The body shifts. Action manifests.
+          Randomness experiments stay honest.
+        </p>
+        <p class="scope-note">
+          Exploratory self-experiment. Not medical advice. Not proof of mind-over-matter.
+        </p>
+      </div>
+      <div class="hero-panel__actions">
+        <a class="button button--primary" href="#state-check">Start a run</a>
+        <a class="button" href="/meditation/">Longer breathing work</a>
+      </div>
+    </section>
+
+    <section class="model-strip" aria-label="Intention Lab model">
+      <article>
+        <strong>Attention selects</strong>
+        <span>Choose the object of focus.</span>
+      </article>
+      <article>
+        <strong>Thought rehearses</strong>
+        <span>Name the belief being practiced.</span>
+      </article>
+      <article>
+        <strong>Body shifts</strong>
+        <span>Track calm, focus, energy, and mood.</span>
+      </article>
+      <article>
+        <strong>Action manifests</strong>
+        <span>Make the physical next step visible.</span>
+      </article>
+      <article>
+        <strong>Randomness stays honest</strong>
+        <span>Read the statistics without overclaiming.</span>
+      </article>
+    </section>
+
+    <form id="intentionForm" class="lab-grid">
+      <section class="panel panel--wide" id="state-check" aria-labelledby="state-title">
+        <div class="section-heading">
+          <p class="kicker">1. State Check</p>
+          <h2 id="state-title">Measure the starting point.</h2>
+          <p>Rate your state before and after the session. The delta is a simple observation.</p>
+        </div>
+
+        <div class="state-layout">
+          <fieldset class="state-card">
+            <legend>Before</legend>
+            <label class="range-field" for="preCalm">
+              <span>Calm <output id="preCalmValue" for="preCalm">3</output></span>
+              <input id="preCalm" name="preCalm" type="range" min="1" max="5" value="3" data-rating>
+            </label>
+            <label class="range-field" for="preFocus">
+              <span>Focus <output id="preFocusValue" for="preFocus">3</output></span>
+              <input id="preFocus" name="preFocus" type="range" min="1" max="5" value="3" data-rating>
+            </label>
+            <label class="range-field" for="preEnergy">
+              <span>Energy <output id="preEnergyValue" for="preEnergy">3</output></span>
+              <input id="preEnergy" name="preEnergy" type="range" min="1" max="5" value="3" data-rating>
+            </label>
+            <label class="range-field" for="preMood">
+              <span>Mood <output id="preMoodValue" for="preMood">3</output></span>
+              <input id="preMood" name="preMood" type="range" min="1" max="5" value="3" data-rating>
+            </label>
+          </fieldset>
+
+          <fieldset class="state-card">
+            <legend>After</legend>
+            <label class="range-field" for="postCalm">
+              <span>Calm <output id="postCalmValue" for="postCalm">3</output></span>
+              <input id="postCalm" name="postCalm" type="range" min="1" max="5" value="3" data-rating>
+            </label>
+            <label class="range-field" for="postFocus">
+              <span>Focus <output id="postFocusValue" for="postFocus">3</output></span>
+              <input id="postFocus" name="postFocus" type="range" min="1" max="5" value="3" data-rating>
+            </label>
+            <label class="range-field" for="postEnergy">
+              <span>Energy <output id="postEnergyValue" for="postEnergy">3</output></span>
+              <input id="postEnergy" name="postEnergy" type="range" min="1" max="5" value="3" data-rating>
+            </label>
+            <label class="range-field" for="postMood">
+              <span>Mood <output id="postMoodValue" for="postMood">3</output></span>
+              <input id="postMood" name="postMood" type="range" min="1" max="5" value="3" data-rating>
+            </label>
+          </fieldset>
+        </div>
+        <p class="delta-pill" id="stateDelta" aria-live="polite">calm: 0 | focus: 0 | energy: 0 | mood: 0</p>
+      </section>
+
+      <section class="panel panel--wide" aria-labelledby="intention-card-title">
+        <div class="section-heading">
+          <p class="kicker">2. Intention Card</p>
+          <h2 id="intention-card-title">Write the rehearsal and the action.</h2>
+          <p>Keep it practical. The strongest manifestation tool in this lab is action.</p>
+        </div>
+
+        <div class="field-grid">
+          <label class="text-field" for="intentionInput">
+            <span>Intention</span>
+            <textarea
+              id="intentionInput"
+              name="intention"
+              rows="3"
+              placeholder="Example: I will make one clean offer call today."
+            ></textarea>
+          </label>
+          <label class="text-field" for="thoughtInput">
+            <span>Belief or thought being rehearsed</span>
+            <textarea
+              id="thoughtInput"
+              name="thought"
+              rows="3"
+              placeholder="Example: I can move calmly and still be direct."
+            ></textarea>
+          </label>
+          <label class="text-field" for="desiredStateInput">
+            <span>Desired state</span>
+            <input
+              id="desiredStateInput"
+              name="desiredState"
+              type="text"
+              placeholder="Calm, focused, honest, steady"
+            >
+          </label>
+          <label class="text-field" for="nextActionInput">
+            <span>One physical action after the session</span>
+            <input
+              id="nextActionInput"
+              name="nextAction"
+              type="text"
+              placeholder="Send the message, wash the dishes, write the offer, take the walk"
+            >
+          </label>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="mode-title">
+        <div class="section-heading">
+          <p class="kicker">3. Mode</p>
+          <h2 id="mode-title">Choose the run type.</h2>
+        </div>
+        <label class="text-field" for="sessionMode">
+          <span>Session mode</span>
+          <select id="sessionMode" name="mode">
+            <option value="baseline">Baseline</option>
+            <option value="intention-more-ones">Intention: more ones</option>
+            <option value="intention-fewer-ones">Intention: fewer ones</option>
+            <option value="action-only">Action-only reflection</option>
+          </select>
+        </label>
+        <p class="muted">
+          Mode labels help compare sessions later. A single RNG result should not be treated as a conclusion.
+        </p>
+      </section>
+
+      <section class="panel" aria-labelledby="timer-title">
+        <div class="section-heading">
+          <p class="kicker">4. Grounding Timer</p>
+          <h2 id="timer-title">Regulate before testing.</h2>
+        </div>
+
+        <div class="timer-card">
+          <div class="timer-ring" id="timerRing" aria-hidden="true">
+            <span id="timerDisplay">00:30</span>
+          </div>
+          <p id="timerCue" class="timer-cue" aria-live="polite">Settle your attention before the next step.</p>
+          <p id="timerStatus" class="muted">Timer paused</p>
+        </div>
+
+        <div class="segmented" aria-label="Timer duration">
+          <button type="button" data-timer-seconds="30" class="is-active" aria-pressed="true">30 sec</button>
+          <button type="button" data-timer-seconds="60" aria-pressed="false">60 sec</button>
+          <button type="button" data-timer-seconds="180" aria-pressed="false">180 sec</button>
+        </div>
+        <div class="button-row">
+          <button type="button" id="startTimer" class="button button--primary">Start</button>
+          <button type="button" id="pauseTimer" class="button">Pause</button>
+          <button type="button" id="resetTimer" class="button">Reset</button>
+        </div>
+        <p class="muted">For longer breathing work, open <a href="/meditation/">Meditation</a>.</p>
+      </section>
+
+      <section class="panel panel--wide" aria-labelledby="rng-title">
+        <div class="section-heading">
+          <p class="kicker">5. RNG Lab</p>
+          <h2 id="rng-title">Run browser cryptographic randomness.</h2>
+          <p>
+            This uses <code>crypto.getRandomValues</code>. It is browser cryptographic randomness,
+            not quantum or hardware RNG.
+          </p>
+        </div>
+
+        <div class="rng-controls">
+          <label class="text-field" for="bitCount">
+            <span>Sample size</span>
+            <select id="bitCount" name="bitCount">
+              <option value="256">256 bits</option>
+              <option value="1024" selected>1,024 bits</option>
+              <option value="4096">4,096 bits</option>
+              <option value="16384">16,384 bits</option>
+            </select>
+          </label>
+          <button type="button" id="runRng" class="button button--primary">Run RNG trial</button>
+          <p id="rngStatus" class="status-line" data-tone="neutral" aria-live="polite">
+            Ready to sample browser cryptographic randomness.
+          </p>
+        </div>
+
+        <div class="rng-layout">
+          <div class="bit-grid" id="rngGrid" aria-label="Sample bit preview"></div>
+          <article class="result-card" id="rngResults" aria-live="polite">
+            <p class="muted">Run a sample to see neutral statistics.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel panel--wide" aria-labelledby="action-title">
+        <div class="section-heading">
+          <p class="kicker">6. Action Bridge</p>
+          <h2 id="action-title">Make the evidence behavioral.</h2>
+          <p>What physical action will prove this intention today?</p>
+        </div>
+        <div class="field-grid">
+          <label class="text-field" for="actionStatus">
+            <span>Action status</span>
+            <select id="actionStatus" name="actionStatus">
+              <option value="planned">Planned</option>
+              <option value="completed">Completed</option>
+              <option value="skipped">Skipped</option>
+            </select>
+          </label>
+          <label class="text-field" for="actionNote">
+            <span>Action note</span>
+            <input
+              id="actionNote"
+              name="actionNote"
+              type="text"
+              placeholder="What happened in the physical world?"
+            >
+          </label>
+          <label class="text-field text-field--full" for="notes">
+            <span>Session notes</span>
+            <textarea
+              id="notes"
+              name="notes"
+              rows="4"
+              placeholder="Patterns, context, or what to repeat next time."
+            ></textarea>
+          </label>
+        </div>
+      </section>
+
+      <section class="panel panel--wide" aria-labelledby="save-title">
+        <div class="section-heading">
+          <p class="kicker">7. Save and Export</p>
+          <h2 id="save-title">Sync the run and keep exports portable.</h2>
+          <p>
+            Runs sync under <code>3dvr-portal/intention-lab</code>. A summary also mirrors to Science Lab
+            without freeform notes.
+          </p>
+        </div>
+
+        <label class="check-field" for="safetyAcknowledged">
+          <input id="safetyAcknowledged" name="safetyAcknowledged" type="checkbox" checked>
+          <span>
+            This lab helps observe attention, body state, randomness, and action. It does not diagnose,
+            treat, or prove supernatural causation.
+          </span>
+        </label>
+
+        <div class="button-row">
+          <button type="button" id="saveRun" class="button button--primary">Save to Gun</button>
+          <button type="button" id="copyJson" class="button">Copy JSON</button>
+          <button type="button" id="downloadCsv" class="button">Download CSV</button>
+          <button type="button" id="clearSession" class="button">Clear session</button>
+        </div>
+        <p id="syncStatus" class="status-line" data-tone="neutral" aria-live="polite">
+          Resolving Gun sync.
+        </p>
+      </section>
+    </form>
+
+    <section class="panel panel--wide" aria-labelledby="recent-title">
+      <div class="section-heading">
+        <p class="kicker">Recent synced runs</p>
+        <h2 id="recent-title">Evidence loop dashboard.</h2>
+        <p>Look for patterns across many sessions, not one dramatic result.</p>
+      </div>
+      <div id="recentRuns" class="recent-list" aria-live="polite">
+        <p class="muted">No synced runs yet.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <a href="/science/">Science Lab</a>
+    <a href="/meditation/">Meditation</a>
+    <a href="/field-simulation/">Field Simulation</a>
+    <a href="/tasks/">Tasks</a>
+    <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>
+  </footer>
+</body>
+</html>

--- a/intention-lab/intention-lab.css
+++ b/intention-lab/intention-lab.css
@@ -1,0 +1,663 @@
+:root {
+  color-scheme: dark;
+  --lab-bg: #090d12;
+  --lab-surface: #111821;
+  --lab-surface-strong: #162231;
+  --lab-surface-soft: #0d131b;
+  --lab-border: rgba(184, 197, 214, 0.18);
+  --lab-text: #eef4f8;
+  --lab-muted: #9ba9b8;
+  --lab-cyan: #5dd4d8;
+  --lab-amber: #f3c96b;
+  --lab-green: #8ed9a2;
+  --lab-rose: #e8a0a8;
+  --lab-shadow: 0 24px 70px rgba(0, 0, 0, 0.38);
+  --lab-radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--lab-bg);
+}
+
+body.intention-body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(93, 212, 216, 0.08), transparent 320px),
+    linear-gradient(135deg, #090d12 0%, #0d131b 52%, #101016 100%);
+  color: var(--lab-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.55;
+}
+
+body.intention-body a {
+  color: inherit;
+}
+
+body.intention-body a:hover {
+  color: var(--lab-cyan);
+}
+
+.skip-link {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 10;
+  transform: translateY(-140%);
+  padding: 10px 14px;
+  border-radius: var(--lab-radius);
+  background: var(--lab-cyan);
+  color: #051014;
+  font-weight: 700;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--lab-cyan);
+  outline-offset: 2px;
+}
+
+.lab-header {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  border-bottom: 1px solid var(--lab-border);
+  background: rgba(9, 13, 18, 0.88);
+  backdrop-filter: blur(14px);
+}
+
+.lab-nav,
+.lab-shell,
+.lab-footer {
+  width: min(100% - 28px, 1180px);
+  margin: 0 auto;
+}
+
+.lab-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 72px;
+}
+
+.lab-brand,
+.lab-nav__links,
+.hero-panel__actions,
+.button-row,
+.segmented,
+.rng-controls,
+.lab-footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.lab-brand {
+  text-decoration: none;
+}
+
+.lab-brand__mark,
+.app-badge {
+  display: inline-grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(93, 212, 216, 0.42);
+  border-radius: var(--lab-radius);
+  background: rgba(93, 212, 216, 0.1);
+  color: var(--lab-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.lab-brand strong,
+.lab-brand small {
+  display: block;
+}
+
+.lab-brand small {
+  color: var(--lab-muted);
+  font-size: 0.78rem;
+}
+
+.lab-nav__links a,
+.lab-footer a {
+  padding: 8px 10px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  color: var(--lab-muted);
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.lab-nav__links a:hover,
+.lab-footer a:hover {
+  border-color: rgba(93, 212, 216, 0.38);
+  color: var(--lab-text);
+}
+
+.lab-shell {
+  padding: 24px 0 36px;
+  display: grid;
+  gap: 18px;
+}
+
+.hero-panel,
+.panel,
+.model-strip article {
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: rgba(17, 24, 33, 0.86);
+  box-shadow: var(--lab-shadow);
+}
+
+.hero-panel {
+  display: grid;
+  gap: 18px;
+  padding: 22px;
+}
+
+.hero-panel__copy {
+  display: grid;
+  gap: 12px;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--lab-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 2.4rem;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 1.35rem;
+  line-height: 1.15;
+}
+
+.hero-panel__lead {
+  max-width: 760px;
+  margin: 0;
+  color: #dce8ed;
+  font-size: 1.1rem;
+}
+
+.scope-note,
+.muted,
+.section-heading p,
+.result-note {
+  color: var(--lab-muted);
+}
+
+.scope-note,
+.muted,
+.result-note {
+  margin-bottom: 0;
+}
+
+.button {
+  min-height: 42px;
+  padding: 9px 13px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--lab-text);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.button:hover:not(:disabled) {
+  border-color: rgba(93, 212, 216, 0.46);
+  background: rgba(93, 212, 216, 0.12);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.button--primary {
+  border-color: rgba(93, 212, 216, 0.72);
+  background: #5dd4d8;
+  color: #061014;
+  font-weight: 800;
+}
+
+.button--primary:hover:not(:disabled) {
+  background: #7de3e5;
+  color: #061014;
+}
+
+.model-strip {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr;
+}
+
+.model-strip article {
+  min-height: 112px;
+  padding: 14px;
+  box-shadow: none;
+}
+
+.model-strip strong,
+.model-strip span {
+  display: block;
+}
+
+.model-strip strong {
+  margin-bottom: 6px;
+}
+
+.model-strip span {
+  color: var(--lab-muted);
+}
+
+.lab-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: 1fr;
+}
+
+.panel {
+  padding: 18px;
+}
+
+.panel--wide {
+  grid-column: 1 / -1;
+}
+
+.section-heading {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.state-layout,
+.field-grid,
+.rng-layout {
+  display: grid;
+  gap: 14px;
+}
+
+.state-card {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: var(--lab-surface-soft);
+}
+
+.state-card legend {
+  padding: 0 6px;
+  color: var(--lab-amber);
+  font-weight: 800;
+}
+
+.range-field,
+.text-field,
+.check-field {
+  display: grid;
+  gap: 8px;
+}
+
+.range-field span,
+.text-field span {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: #dce8ed;
+  font-weight: 700;
+}
+
+input[type="range"] {
+  width: 100%;
+  accent-color: var(--lab-cyan);
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: #0b1118;
+  color: var(--lab-text);
+  padding: 10px 11px;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.text-field--full {
+  grid-column: 1 / -1;
+}
+
+.delta-pill,
+.status-line {
+  margin: 14px 0 0;
+  padding: 10px 12px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: rgba(255, 255, 255, 0.04);
+  color: #dce8ed;
+}
+
+.status-line[data-tone="ok"] {
+  border-color: rgba(142, 217, 162, 0.42);
+  color: #dff8e6;
+}
+
+.status-line[data-tone="warn"] {
+  border-color: rgba(243, 201, 107, 0.48);
+  color: #ffe4a7;
+}
+
+.timer-card {
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: var(--lab-surface-soft);
+}
+
+.timer-ring {
+  --timer-progress: 0;
+  --timer-angle: 0deg;
+  width: 168px;
+  height: 168px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background:
+    conic-gradient(var(--lab-cyan) var(--timer-angle), rgba(255, 255, 255, 0.08) 0),
+    #0b1118;
+  position: relative;
+}
+
+.timer-ring::before {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: inherit;
+  background: var(--lab-surface);
+}
+
+.timer-ring span {
+  position: relative;
+  font-size: 2rem;
+  font-weight: 850;
+  letter-spacing: 0.02em;
+}
+
+.timer-cue {
+  margin: 0;
+  color: #dce8ed;
+  font-weight: 700;
+  text-align: center;
+}
+
+.segmented {
+  margin-top: 14px;
+}
+
+.segmented button {
+  min-height: 38px;
+  padding: 8px 11px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--lab-muted);
+  cursor: pointer;
+}
+
+.segmented button.is-active {
+  border-color: rgba(93, 212, 216, 0.62);
+  color: var(--lab-text);
+  background: rgba(93, 212, 216, 0.12);
+}
+
+.button-row {
+  margin-top: 14px;
+}
+
+.rng-controls {
+  align-items: end;
+}
+
+.rng-controls .text-field {
+  min-width: min(100%, 220px);
+}
+
+.bit-grid {
+  min-height: 164px;
+  display: grid;
+  grid-template-columns: repeat(16, minmax(0, 1fr));
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: #070b10;
+}
+
+.bit-cell {
+  min-height: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.bit-cell--1 {
+  background: rgba(93, 212, 216, 0.16);
+  color: #bdf6f7;
+}
+
+.bit-cell--0 {
+  background: rgba(243, 201, 107, 0.12);
+  color: #ffe3a3;
+}
+
+.result-card {
+  padding: 14px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: var(--lab-surface-soft);
+}
+
+.stats-grid,
+.recent-run dl {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.stats-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.stats-grid div,
+.recent-run dl div {
+  padding: 10px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.stats-grid dt,
+.recent-run dt {
+  color: var(--lab-muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stats-grid dd,
+.recent-run dd {
+  margin: 3px 0 0;
+  color: var(--lab-text);
+  font-weight: 800;
+}
+
+.result-note {
+  margin-top: 12px;
+}
+
+.check-field {
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  padding: 12px;
+  border: 1px solid rgba(243, 201, 107, 0.36);
+  border-radius: var(--lab-radius);
+  background: rgba(243, 201, 107, 0.08);
+}
+
+.check-field input {
+  width: auto;
+  margin-top: 4px;
+}
+
+.recent-list {
+  display: grid;
+  gap: 10px;
+}
+
+.recent-run {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: var(--lab-surface-soft);
+}
+
+.recent-run strong,
+.recent-run span {
+  display: block;
+}
+
+.recent-run span {
+  color: var(--lab-muted);
+}
+
+.recent-run dl {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.lab-footer {
+  justify-content: center;
+  padding: 0 0 40px;
+}
+
+@media (min-width: 720px) {
+  .hero-panel {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+  }
+
+  .model-strip {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .lab-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .state-layout,
+  .field-grid,
+  .rng-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .recent-run {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 0.65fr);
+    align-items: center;
+  }
+}
+
+@media (min-width: 1040px) {
+  h1 {
+    font-size: 3rem;
+  }
+
+  .lab-shell {
+    padding-top: 32px;
+  }
+}
+
+@media (max-width: 680px) {
+  .lab-nav {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 12px 0;
+  }
+
+  .lab-nav__links a,
+  .lab-footer a,
+  .button {
+    flex: 1 1 auto;
+  }
+
+  .bit-grid {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/intention-lab/intention-lab.js
+++ b/intention-lab/intention-lab.js
@@ -1,0 +1,920 @@
+export const ALLOWED_BIT_COUNTS = Object.freeze([256, 1024, 4096, 16384]);
+const ALLOWED_MODES = Object.freeze([
+  'baseline',
+  'intention-more-ones',
+  'intention-fewer-ones',
+  'action-only',
+]);
+const ACTION_STATUSES = Object.freeze(['completed', 'planned', 'skipped']);
+const DEFAULT_PEERS = Object.freeze([
+  'wss://gun-relay-3dvr.fly.dev/gun',
+  'https://gun-relay-3dvr.fly.dev/gun',
+]);
+const RECENT_RUN_LIMIT = 8;
+
+let fallbackRunCounter = 0;
+
+export function countBitsFromUint32Array(words, requestedBitCount) {
+  if (!words || typeof words.length !== 'number') {
+    throw new TypeError('words must be an array-like collection of unsigned 32-bit values');
+  }
+
+  const bitCount = normalizePositiveInteger(requestedBitCount, 'requestedBitCount');
+  if (bitCount > words.length * 32) {
+    throw new RangeError('requestedBitCount exceeds the available bits');
+  }
+
+  let ones = 0;
+  for (let bitIndex = 0; bitIndex < bitCount; bitIndex += 1) {
+    const word = Number(words[Math.floor(bitIndex / 32)]) >>> 0;
+    const shift = bitIndex % 32;
+    ones += (word >>> shift) & 1;
+  }
+  return ones;
+}
+
+export function makeRandomBitSample(bitCount, cryptoProvider = globalThis.crypto) {
+  const normalizedBitCount = normalizeAllowedBitCount(bitCount);
+  if (!cryptoProvider || typeof cryptoProvider.getRandomValues !== 'function') {
+    throw new Error('crypto.getRandomValues is required for browser randomness trials');
+  }
+
+  const words = new Uint32Array(Math.ceil(normalizedBitCount / 32));
+  cryptoProvider.getRandomValues(words);
+  const ones = countBitsFromUint32Array(words, normalizedBitCount);
+  return {
+    source: 'browser-crypto-getRandomValues',
+    bitCount: normalizedBitCount,
+    ones,
+    zeros: normalizedBitCount - ones,
+    words,
+  };
+}
+
+export function analyzeBitBalance(ones, bitCount) {
+  const normalizedBitCount = normalizePositiveInteger(bitCount, 'bitCount');
+  const normalizedOnes = normalizeInteger(ones, 'ones');
+  if (normalizedOnes < 0 || normalizedOnes > normalizedBitCount) {
+    throw new RangeError('ones must be between 0 and bitCount');
+  }
+
+  const expectedOnes = normalizedBitCount / 2;
+  const difference = normalizedOnes - expectedOnes;
+  const zScore = difference / Math.sqrt(normalizedBitCount * 0.25);
+  const pTwoTailed = twoTailedPFromZ(zScore);
+  return {
+    source: 'browser-crypto-getRandomValues',
+    bitCount: normalizedBitCount,
+    ones: normalizedOnes,
+    zeros: normalizedBitCount - normalizedOnes,
+    expectedOnes,
+    difference,
+    zScore,
+    pTwoTailed,
+    interpretation: buildNeutralInterpretation(pTwoTailed),
+  };
+}
+
+export function normalCdfApprox(z) {
+  const value = Number(z);
+  if (!Number.isFinite(value)) {
+    throw new TypeError('z must be a finite number');
+  }
+
+  return 0.5 * (1 + erfApprox(value / Math.SQRT2));
+}
+
+export function twoTailedPFromZ(z) {
+  const value = Math.abs(Number(z));
+  if (!Number.isFinite(value)) {
+    throw new TypeError('z must be a finite number');
+  }
+
+  const p = 2 * (1 - normalCdfApprox(value));
+  return Math.max(0, Math.min(1, p));
+}
+
+export function buildRunRecord(input = {}, identity = {}) {
+  const now = new Date().toISOString();
+  const mode = ALLOWED_MODES.includes(input.mode) ? input.mode : 'baseline';
+  const rng = normalizeRngResult(input.rng);
+  const author = normalizeAuthor(identity);
+
+  return {
+    id: normalizeText(input.id) || makeRunId(),
+    app: 'intention-lab',
+    version: 1,
+    createdAt: normalizeText(input.createdAt) || now,
+    updatedAt: normalizeText(input.updatedAt) || now,
+    author,
+    mode,
+    intention: {
+      statement: normalizeText(input.intention?.statement),
+      thought: normalizeText(input.intention?.thought),
+      desiredState: normalizeText(input.intention?.desiredState),
+      nextAction: normalizeText(input.intention?.nextAction),
+    },
+    preState: normalizeStateRatings(input.preState),
+    grounding: {
+      seconds: normalizeTimerSeconds(input.grounding?.seconds),
+      completed: Boolean(input.grounding?.completed),
+    },
+    rng,
+    postState: normalizeStateRatings(input.postState),
+    action: {
+      status: ACTION_STATUSES.includes(input.action?.status) ? input.action.status : 'planned',
+      note: normalizeText(input.action?.note),
+    },
+    notes: normalizeText(input.notes),
+    safetyAcknowledged: Boolean(input.safetyAcknowledged),
+  };
+}
+
+export function escapeCsvValue(value) {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+  const stringValue = String(value);
+  if (!/[",\n\r]/.test(stringValue)) {
+    return stringValue;
+  }
+  return `"${stringValue.replace(/"/g, '""')}"`;
+}
+
+export function runRecordToCsv(run) {
+  const record = buildRunRecord(run, run?.author || {});
+  const headers = [
+    'id',
+    'createdAt',
+    'authorId',
+    'mode',
+    'intention',
+    'nextAction',
+    'preCalm',
+    'preFocus',
+    'preEnergy',
+    'preMood',
+    'postCalm',
+    'postFocus',
+    'postEnergy',
+    'postMood',
+    'bitCount',
+    'ones',
+    'zeros',
+    'difference',
+    'zScore',
+    'pTwoTailed',
+    'actionStatus',
+    'actionNote',
+    'notes',
+  ];
+  const values = [
+    record.id,
+    record.createdAt,
+    record.author.id,
+    record.mode,
+    record.intention.statement,
+    record.intention.nextAction,
+    record.preState.calm,
+    record.preState.focus,
+    record.preState.energy,
+    record.preState.mood,
+    record.postState.calm,
+    record.postState.focus,
+    record.postState.energy,
+    record.postState.mood,
+    record.rng.bitCount,
+    record.rng.ones,
+    record.rng.zeros,
+    record.rng.difference,
+    record.rng.zScore,
+    record.rng.pTwoTailed,
+    record.action.status,
+    record.action.note,
+    record.notes,
+  ];
+
+  return `${headers.join(',')}\n${values.map(escapeCsvValue).join(',')}\n`;
+}
+
+function normalizeInteger(value, label) {
+  const number = Number(value);
+  if (!Number.isInteger(number)) {
+    throw new TypeError(`${label} must be an integer`);
+  }
+  return number;
+}
+
+function normalizePositiveInteger(value, label) {
+  const number = normalizeInteger(value, label);
+  if (number <= 0) {
+    throw new RangeError(`${label} must be greater than zero`);
+  }
+  return number;
+}
+
+function normalizeAllowedBitCount(value) {
+  const bitCount = normalizePositiveInteger(value, 'bitCount');
+  if (!ALLOWED_BIT_COUNTS.includes(bitCount)) {
+    throw new RangeError(`bitCount must be one of: ${ALLOWED_BIT_COUNTS.join(', ')}`);
+  }
+  return bitCount;
+}
+
+function erfApprox(value) {
+  const sign = value < 0 ? -1 : 1;
+  const x = Math.abs(value);
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const t = 1 / (1 + p * x);
+  const y = 1 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
+  return sign * y;
+}
+
+function buildNeutralInterpretation(pTwoTailed) {
+  if (pTwoTailed < 0.01) {
+    return 'This run shows an uncommon statistical deviation. It does not prove intention caused the result.';
+  }
+  if (pTwoTailed < 0.05) {
+    return 'This run shows a noticeable statistical deviation. Treat it as one data point, not a conclusion.';
+  }
+  return 'This is a small statistical deviation summary. It does not prove intention caused the result.';
+}
+
+function normalizeRngResult(rng = {}) {
+  const source = 'browser-crypto-getRandomValues';
+  const bitCount = Number(rng.bitCount || 0);
+  const ones = Number(rng.ones || 0);
+
+  if (Number.isInteger(bitCount) && bitCount > 0 && Number.isInteger(ones)) {
+    return analyzeBitBalance(ones, bitCount);
+  }
+
+  return {
+    source,
+    bitCount: 0,
+    ones: 0,
+    zeros: 0,
+    expectedOnes: 0,
+    difference: 0,
+    zScore: 0,
+    pTwoTailed: 1,
+    interpretation: 'No randomness trial was run for this session.',
+  };
+}
+
+function normalizeStateRatings(source = {}) {
+  return {
+    calm: clampRating(source.calm),
+    focus: clampRating(source.focus),
+    energy: clampRating(source.energy),
+    mood: clampRating(source.mood),
+  };
+}
+
+function clampRating(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return 3;
+  }
+  return Math.max(1, Math.min(5, Math.round(number)));
+}
+
+function normalizeTimerSeconds(value) {
+  const seconds = Number(value);
+  return [30, 60, 180].includes(seconds) ? seconds : 30;
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeAuthor(identity = {}) {
+  const pub = normalizeText(identity.pub);
+  const alias = normalizeText(identity.alias);
+  const id = normalizeText(identity.id) || pub || alias || 'guest';
+  return {
+    id,
+    ...(pub ? { pub } : {}),
+    ...(alias ? { alias } : {}),
+    isGuest: typeof identity.isGuest === 'boolean' ? identity.isGuest : !pub,
+  };
+}
+
+function makeRunId() {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    return `intention-${cryptoApi.randomUUID()}`;
+  }
+  fallbackRunCounter += 1;
+  return `intention-${Date.now()}-${fallbackRunCounter}`;
+}
+
+function safeStringify(value) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (_error) {
+    return '{}';
+  }
+}
+
+function formatNumber(value, digits = 3) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return '0';
+  }
+  return number.toLocaleString(undefined, {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  });
+}
+
+function formatPValue(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return 'n/a';
+  }
+  if (number < 0.0001) {
+    return '< 0.0001';
+  }
+  return number.toLocaleString(undefined, {
+    maximumFractionDigits: 4,
+    minimumFractionDigits: 4,
+  });
+}
+
+function safeLocalStorageGet(key) {
+  try {
+    return window.localStorage.getItem(key) || '';
+  } catch (_error) {
+    return '';
+  }
+}
+
+function safeSetText(element, value) {
+  if (element) {
+    element.textContent = value;
+  }
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function initBrowserApp() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  const refs = {
+    form: document.getElementById('intentionForm'),
+    mode: document.getElementById('sessionMode'),
+    bitCount: document.getElementById('bitCount'),
+    runRng: document.getElementById('runRng'),
+    rngStatus: document.getElementById('rngStatus'),
+    rngGrid: document.getElementById('rngGrid'),
+    rngResults: document.getElementById('rngResults'),
+    timerDisplay: document.getElementById('timerDisplay'),
+    timerCue: document.getElementById('timerCue'),
+    timerRing: document.getElementById('timerRing'),
+    timerStatus: document.getElementById('timerStatus'),
+    startTimer: document.getElementById('startTimer'),
+    pauseTimer: document.getElementById('pauseTimer'),
+    resetTimer: document.getElementById('resetTimer'),
+    saveRun: document.getElementById('saveRun'),
+    copyJson: document.getElementById('copyJson'),
+    downloadCsv: document.getElementById('downloadCsv'),
+    clearSession: document.getElementById('clearSession'),
+    syncStatus: document.getElementById('syncStatus'),
+    recentRuns: document.getElementById('recentRuns'),
+    stateDelta: document.getElementById('stateDelta'),
+    preOutputs: Array.from(document.querySelectorAll('[data-rating-output="pre"]')),
+    postOutputs: Array.from(document.querySelectorAll('[data-rating-output="post"]')),
+    timerOptions: Array.from(document.querySelectorAll('[data-timer-seconds]')),
+    ratingInputs: Array.from(document.querySelectorAll('input[type="range"][data-rating]')),
+  };
+
+  if (!refs.form || !refs.runRng) {
+    return;
+  }
+
+  const state = {
+    timerDuration: 30,
+    timerRemaining: 30,
+    timerId: null,
+    timerCompleted: false,
+    latestSample: null,
+    latestRun: null,
+    recentRuns: new Map(),
+    gunContext: null,
+    gunRoot: null,
+    author: { id: 'guest', isGuest: true },
+  };
+
+  bindEvents(refs, state);
+  connectGun(refs, state);
+  renderTimer(refs, state);
+  renderRatings(refs);
+  renderStateDelta(refs);
+  renderRecentRuns(refs, state);
+  renderCryptoStatus(refs);
+}
+
+function bindEvents(refs, state) {
+  refs.timerOptions.forEach(button => {
+    button.addEventListener('click', () => {
+      const seconds = normalizeTimerSeconds(button.getAttribute('data-timer-seconds'));
+      stopTimer(state);
+      state.timerDuration = seconds;
+      state.timerRemaining = seconds;
+      state.timerCompleted = false;
+      renderTimer(refs, state);
+    });
+  });
+
+  refs.startTimer.addEventListener('click', () => startTimer(refs, state));
+  refs.pauseTimer.addEventListener('click', () => {
+    stopTimer(state);
+    renderTimer(refs, state);
+  });
+  refs.resetTimer.addEventListener('click', () => {
+    stopTimer(state);
+    state.timerRemaining = state.timerDuration;
+    state.timerCompleted = false;
+    renderTimer(refs, state);
+  });
+
+  refs.ratingInputs.forEach(input => {
+    input.addEventListener('input', () => {
+      renderRatings(refs);
+      renderStateDelta(refs);
+    });
+  });
+
+  refs.runRng.addEventListener('click', () => runRngTrial(refs, state));
+  refs.saveRun.addEventListener('click', () => saveCurrentRun(refs, state));
+  refs.copyJson.addEventListener('click', () => copyCurrentJson(refs, state));
+  refs.downloadCsv.addEventListener('click', () => downloadCurrentCsv(refs, state));
+  refs.clearSession.addEventListener('click', () => clearSession(refs, state));
+
+  refs.form.addEventListener('input', () => {
+    state.latestRun = null;
+  });
+}
+
+function connectGun(refs, state) {
+  const context = getGunContext();
+  state.gunContext = context;
+  state.author = resolveAuthor(context.user);
+
+  if (!context.gun || typeof context.gun.get !== 'function') {
+    setSyncStatus(refs, 'Sync helper unavailable. Copy JSON or CSV to keep this run.', 'warn');
+    return;
+  }
+
+  state.gunRoot = context.gun.get('3dvr-portal').get('intention-lab');
+  setSyncStatus(
+    refs,
+    context.isStub ? 'Offline sync mode. Export is available.' : `Gun sync ready as ${state.author.alias || state.author.id}.`,
+    context.isStub ? 'warn' : 'ok'
+  );
+  subscribeRecentRuns(refs, state);
+}
+
+function getGunContext() {
+  const factory = () => {
+    if (typeof window.Gun !== 'function') {
+      return null;
+    }
+    const peers = Array.isArray(window.__GUN_PEERS__) ? window.__GUN_PEERS__ : DEFAULT_PEERS;
+    try {
+      return window.Gun({ peers, axe: true });
+    } catch (error) {
+      console.warn('Intention Lab Gun init failed', error);
+      return null;
+    }
+  };
+
+  if (window.ScoreSystem && typeof window.ScoreSystem.ensureGun === 'function') {
+    return window.ScoreSystem.ensureGun(factory, { label: 'intention-lab' });
+  }
+
+  const gun = factory();
+  if (gun) {
+    return {
+      gun,
+      user: typeof gun.user === 'function' ? gun.user() : null,
+      isStub: !!gun.__isGunStub,
+    };
+  }
+
+  return {
+    gun: null,
+    user: null,
+    isStub: true,
+  };
+}
+
+function resolveAuthor(user) {
+  if (window.AuthIdentity && typeof window.AuthIdentity.syncStorageFromSharedIdentity === 'function') {
+    try {
+      window.AuthIdentity.syncStorageFromSharedIdentity(window.localStorage);
+    } catch (error) {
+      console.warn('Failed to sync shared identity', error);
+    }
+  }
+
+  if (user && user.is && user.is.pub) {
+    return {
+      id: user.is.pub,
+      pub: user.is.pub,
+      alias: normalizeText(user.is.alias) || normalizeText(safeLocalStorageGet('alias')),
+      isGuest: false,
+    };
+  }
+
+  const signedIn = safeLocalStorageGet('signedIn') === 'true';
+  const alias = normalizeText(safeLocalStorageGet('alias'));
+  if (signedIn && alias) {
+    return {
+      id: alias.toLowerCase(),
+      alias,
+      isGuest: false,
+    };
+  }
+
+  const guestId = window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function'
+    ? window.ScoreSystem.ensureGuestIdentity()
+    : safeLocalStorageGet('guestId') || 'guest';
+  return {
+    id: guestId || 'guest',
+    alias: normalizeText(safeLocalStorageGet('guestDisplayName')) || 'Guest',
+    isGuest: true,
+  };
+}
+
+function subscribeRecentRuns(refs, state) {
+  if (!state.gunRoot || typeof state.gunRoot.get !== 'function') {
+    return;
+  }
+
+  const runsNode = state.gunRoot.get('runs');
+  if (!runsNode || typeof runsNode.map !== 'function') {
+    return;
+  }
+
+  runsNode.map().on((run, key) => {
+    if (!run || run.app !== 'intention-lab') {
+      return;
+    }
+    const runId = normalizeText(run.id) || key;
+    state.recentRuns.set(runId, run);
+    renderRecentRuns(refs, state);
+  });
+}
+
+function renderCryptoStatus(refs) {
+  const cryptoReady = !!(window.crypto && typeof window.crypto.getRandomValues === 'function');
+  refs.runRng.disabled = !cryptoReady;
+  if (!cryptoReady) {
+    setRngStatus(refs, 'Browser crypto is unavailable here, so RNG trials are disabled.', 'warn');
+    return;
+  }
+  setRngStatus(refs, 'Ready to sample browser cryptographic randomness.', 'neutral');
+}
+
+function startTimer(refs, state) {
+  if (state.timerId) {
+    return;
+  }
+  if (state.timerRemaining <= 0) {
+    state.timerRemaining = state.timerDuration;
+    state.timerCompleted = false;
+  }
+  state.timerId = window.setInterval(() => {
+    state.timerRemaining = Math.max(0, state.timerRemaining - 1);
+    if (state.timerRemaining === 0) {
+      stopTimer(state);
+      state.timerCompleted = true;
+    }
+    renderTimer(refs, state);
+  }, 1000);
+  renderTimer(refs, state);
+}
+
+function stopTimer(state) {
+  if (state.timerId) {
+    window.clearInterval(state.timerId);
+    state.timerId = null;
+  }
+}
+
+function renderTimer(refs, state) {
+  const minutes = String(Math.floor(state.timerRemaining / 60)).padStart(2, '0');
+  const seconds = String(state.timerRemaining % 60).padStart(2, '0');
+  const progress = state.timerDuration
+    ? (state.timerDuration - state.timerRemaining) / state.timerDuration
+    : 0;
+  refs.timerDisplay.textContent = `${minutes}:${seconds}`;
+  refs.timerRing.style.setProperty('--timer-progress', String(Math.max(0, Math.min(1, progress))));
+  refs.timerRing.style.setProperty('--timer-angle', `${Math.max(0, Math.min(1, progress)) * 360}deg`);
+  refs.timerOptions.forEach(button => {
+    const isActive = Number(button.getAttribute('data-timer-seconds')) === state.timerDuration;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+
+  const cue = state.timerCompleted ? 'Complete. Take the next action.' : getBreathingCue(state);
+  refs.timerCue.textContent = cue;
+  refs.timerStatus.textContent = state.timerId
+    ? 'Timer running'
+    : (state.timerCompleted ? 'Grounding completed' : 'Timer paused');
+}
+
+function getBreathingCue(state) {
+  if (!state.timerId) {
+    return 'Settle your attention before the next step.';
+  }
+  const elapsed = state.timerDuration - state.timerRemaining;
+  return elapsed % 8 < 4 ? 'Inhale slowly' : 'Exhale and soften';
+}
+
+function runRngTrial(refs, state) {
+  try {
+    const sample = makeRandomBitSample(Number(refs.bitCount.value), window.crypto);
+    const analysis = analyzeBitBalance(sample.ones, sample.bitCount);
+    state.latestSample = {
+      ...analysis,
+      words: sample.words,
+    };
+    state.latestRun = null;
+    renderRngResults(refs, state.latestSample);
+    renderBitGrid(refs, sample);
+    setRngStatus(refs, 'RNG trial complete. The stats are descriptive, not proof of causation.', 'ok');
+  } catch (error) {
+    state.latestSample = null;
+    renderRngResults(refs, null);
+    refs.rngGrid.innerHTML = '';
+    setRngStatus(refs, error.message || 'RNG trial failed.', 'warn');
+  }
+}
+
+function renderRngResults(refs, result) {
+  if (!result) {
+    refs.rngResults.innerHTML = '<p class="muted">Run a sample to see neutral statistics.</p>';
+    return;
+  }
+
+  refs.rngResults.innerHTML = `
+    <dl class="stats-grid">
+      <div><dt>Ones</dt><dd>${result.ones.toLocaleString()}</dd></div>
+      <div><dt>Zeros</dt><dd>${result.zeros.toLocaleString()}</dd></div>
+      <div><dt>Expected ones</dt><dd>${result.expectedOnes.toLocaleString()}</dd></div>
+      <div><dt>Difference</dt><dd>${formatNumber(result.difference, 0)}</dd></div>
+      <div><dt>z-score</dt><dd>${formatNumber(result.zScore)}</dd></div>
+      <div><dt>two-tailed p</dt><dd>${formatPValue(result.pTwoTailed)}</dd></div>
+    </dl>
+    <p class="result-note">${escapeHtml(result.interpretation)}</p>
+  `;
+}
+
+function renderBitGrid(refs, sample) {
+  const visibleBits = Math.min(160, sample.bitCount);
+  const step = Math.max(1, Math.floor(sample.bitCount / visibleBits));
+  const cells = [];
+  for (let bitIndex = 0; bitIndex < sample.bitCount && cells.length < visibleBits; bitIndex += step) {
+    const word = sample.words[Math.floor(bitIndex / 32)] >>> 0;
+    const value = (word >>> (bitIndex % 32)) & 1;
+    cells.push(`<span class="bit-cell bit-cell--${value}" title="Bit ${bitIndex + 1}: ${value}">${value}</span>`);
+  }
+  refs.rngGrid.innerHTML = cells.join('');
+}
+
+function saveCurrentRun(refs, state) {
+  const input = collectRunInput(refs, state);
+  if (input.mode !== 'action-only' && !state.latestSample) {
+    setSyncStatus(refs, 'Run an RNG trial first, or choose action-only reflection.', 'warn');
+    return;
+  }
+
+  const run = buildRunRecord(input, state.author);
+  state.latestRun = run;
+  state.recentRuns.set(run.id, run);
+  renderRecentRuns(refs, state);
+
+  if (!state.gunRoot || typeof state.gunRoot.get !== 'function') {
+    setSyncStatus(refs, 'Run prepared. Gun sync is unavailable, so use copy or CSV export.', 'warn');
+    return;
+  }
+
+  const runsNode = state.gunRoot.get('runs');
+  const authorsNode = state.gunRoot.get('authors').get(run.author.id).get('runs');
+  runsNode.get(run.id).put(run, ack => {
+    if (ack && ack.err) {
+      setSyncStatus(refs, 'Run prepared. Gun sync will retry when the relay is reachable.', 'warn');
+      return;
+    }
+    setSyncStatus(refs, 'Saved to Gun at 3dvr-portal/intention-lab/runs.', 'ok');
+  });
+  authorsNode.get(run.id).put(true);
+  mirrorScienceSummary(state, run);
+}
+
+function mirrorScienceSummary(state, run) {
+  if (!state.gunContext?.gun || typeof state.gunContext.gun.get !== 'function') {
+    return;
+  }
+  const summary = {
+    id: run.id,
+    app: run.app,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    mode: run.mode,
+    authorId: run.author.id,
+    bitCount: run.rng.bitCount,
+    ones: run.rng.ones,
+    zeros: run.rng.zeros,
+    zScore: run.rng.zScore,
+    pTwoTailed: run.rng.pTwoTailed,
+    actionStatus: run.action.status,
+    sourcePath: `3dvr-portal/intention-lab/runs/${run.id}`,
+  };
+  state.gunContext.gun.get('science').get('runs').get(run.id).put(summary);
+}
+
+function collectRunInput(refs, state) {
+  const formData = new FormData(refs.form);
+  return {
+    mode: normalizeText(formData.get('mode')),
+    intention: {
+      statement: normalizeText(formData.get('intention')),
+      thought: normalizeText(formData.get('thought')),
+      desiredState: normalizeText(formData.get('desiredState')),
+      nextAction: normalizeText(formData.get('nextAction')),
+    },
+    preState: readStateRatings(formData, 'pre'),
+    grounding: {
+      seconds: state.timerDuration,
+      completed: state.timerCompleted,
+    },
+    rng: state.latestSample,
+    postState: readStateRatings(formData, 'post'),
+    action: {
+      status: normalizeText(formData.get('actionStatus')),
+      note: normalizeText(formData.get('actionNote')),
+    },
+    notes: normalizeText(formData.get('notes')),
+    safetyAcknowledged: formData.get('safetyAcknowledged') === 'on',
+  };
+}
+
+function readStateRatings(formData, prefix) {
+  return {
+    calm: Number(formData.get(`${prefix}Calm`)),
+    focus: Number(formData.get(`${prefix}Focus`)),
+    energy: Number(formData.get(`${prefix}Energy`)),
+    mood: Number(formData.get(`${prefix}Mood`)),
+  };
+}
+
+function copyCurrentJson(refs, state) {
+  const run = state.latestRun || buildRunRecord(collectRunInput(refs, state), state.author);
+  state.latestRun = run;
+  const text = safeStringify(run);
+  copyText(text)
+    .then(() => setSyncStatus(refs, 'JSON copied.', 'ok'))
+    .catch(() => setSyncStatus(refs, 'Could not copy automatically. Use CSV export instead.', 'warn'));
+}
+
+function downloadCurrentCsv(refs, state) {
+  const run = state.latestRun || buildRunRecord(collectRunInput(refs, state), state.author);
+  state.latestRun = run;
+  const csv = runRecordToCsv(run);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${run.id}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  setSyncStatus(refs, 'CSV export downloaded.', 'ok');
+}
+
+async function copyText(value) {
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  textarea.remove();
+}
+
+function clearSession(refs, state) {
+  refs.form.reset();
+  stopTimer(state);
+  state.timerDuration = 30;
+  state.timerRemaining = 30;
+  state.timerCompleted = false;
+  state.latestSample = null;
+  state.latestRun = null;
+  renderTimer(refs, state);
+  renderRatings(refs);
+  renderStateDelta(refs);
+  renderRngResults(refs, null);
+  refs.rngGrid.innerHTML = '';
+  setSyncStatus(refs, 'Session cleared. Synced runs are unchanged.', 'neutral');
+  renderCryptoStatus(refs);
+}
+
+function renderRatings(refs) {
+  refs.ratingInputs.forEach(input => {
+    const output = document.getElementById(`${input.id}Value`);
+    if (output) {
+      output.textContent = input.value;
+    }
+  });
+}
+
+function renderStateDelta(refs) {
+  const formData = new FormData(refs.form);
+  const pre = readStateRatings(formData, 'pre');
+  const post = readStateRatings(formData, 'post');
+  const delta = {
+    calm: post.calm - pre.calm,
+    focus: post.focus - pre.focus,
+    energy: post.energy - pre.energy,
+    mood: post.mood - pre.mood,
+  };
+  const parts = Object.entries(delta).map(([label, value]) => {
+    const sign = value > 0 ? '+' : '';
+    return `${label}: ${sign}${value}`;
+  });
+  refs.stateDelta.textContent = parts.join(' | ');
+}
+
+function renderRecentRuns(refs, state) {
+  const runs = Array.from(state.recentRuns.values())
+    .filter(run => run && run.app === 'intention-lab')
+    .sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')))
+    .slice(0, RECENT_RUN_LIMIT);
+
+  if (!runs.length) {
+    refs.recentRuns.innerHTML = '<p class="muted">No synced runs yet.</p>';
+    return;
+  }
+
+  refs.recentRuns.innerHTML = runs.map(run => {
+    const title = run.intention?.statement || run.mode || 'Untitled run';
+    const pValue = typeof run.rng?.pTwoTailed === 'number' ? formatPValue(run.rng.pTwoTailed) : 'n/a';
+    const bitCount = Number(run.rng?.bitCount || 0).toLocaleString();
+    return `
+      <article class="recent-run">
+        <div>
+          <strong>${escapeHtml(title)}</strong>
+          <span>${escapeHtml(run.mode)} | ${escapeHtml(new Date(run.createdAt).toLocaleString())}</span>
+        </div>
+        <dl>
+          <div><dt>bits</dt><dd>${bitCount}</dd></div>
+          <div><dt>z</dt><dd>${formatNumber(run.rng?.zScore || 0)}</dd></div>
+          <div><dt>p</dt><dd>${pValue}</dd></div>
+        </dl>
+      </article>
+    `;
+  }).join('');
+}
+
+function setSyncStatus(refs, message, tone = 'neutral') {
+  refs.syncStatus.textContent = message;
+  refs.syncStatus.dataset.tone = tone;
+}
+
+function setRngStatus(refs, message, tone = 'neutral') {
+  refs.rngStatus.textContent = message;
+  refs.rngStatus.dataset.tone = tone;
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initBrowserApp, { once: true });
+  } else {
+    initBrowserApp();
+  }
+}

--- a/science/index.html
+++ b/science/index.html
@@ -125,6 +125,13 @@
           <h2 id="resources-title">Jump to the tools that keep experiments moving</h2>
         </div>
         <div class="resource-links">
+          <a class="resource" href="/intention-lab/">
+            <div class="resource__title">
+              <span>Intention Lab</span>
+              <span>Run attention, state, action, and browser-randomness self-experiments</span>
+            </div>
+            <span aria-hidden="true">↗</span>
+          </a>
           <a class="resource" href="/notes/">
             <div class="resource__title">
               <span>Notes</span>

--- a/tests/intention-lab-rng.test.js
+++ b/tests/intention-lab-rng.test.js
@@ -1,0 +1,161 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import {
+  analyzeBitBalance,
+  buildRunRecord,
+  countBitsFromUint32Array,
+  escapeCsvValue,
+  makeRandomBitSample,
+  runRecordToCsv,
+} from '../intention-lab/intention-lab.js';
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+test('countBitsFromUint32Array counts only the requested bits', () => {
+  const words = new Uint32Array([
+    0xffffffff,
+    0x00000000,
+    0x0000000f,
+  ]);
+
+  assert.equal(countBitsFromUint32Array(words, 32), 32);
+  assert.equal(countBitsFromUint32Array(words, 64), 32);
+  assert.equal(countBitsFromUint32Array(words, 68), 36);
+});
+
+test('analyzeBitBalance returns neutral statistics for a balanced 1024-bit sample', () => {
+  const result = analyzeBitBalance(512, 1024);
+
+  assert.equal(result.ones, 512);
+  assert.equal(result.zeros, 512);
+  assert.equal(result.expectedOnes, 512);
+  assert.equal(result.difference, 0);
+  assert.equal(result.zScore, 0);
+  assert.ok(result.pTwoTailed > 0.999);
+  assert.match(result.interpretation, /does not prove intention caused the result/i);
+});
+
+test('analyzeBitBalance returns a positive z-score when ones exceed expected value', () => {
+  const result = analyzeBitBalance(600, 1024);
+
+  assert.equal(result.ones, 600);
+  assert.ok(result.difference > 0);
+  assert.ok(result.zScore > 0);
+  assert.ok(result.pTwoTailed < 1);
+});
+
+test('makeRandomBitSample rejects unsupported bit counts and does not use Math.random', () => {
+  const cryptoProvider = {
+    getRandomValues(words) {
+      words.fill(0xffffffff);
+      return words;
+    },
+  };
+
+  assert.throws(() => makeRandomBitSample(128, cryptoProvider), /bitCount must be one of/);
+  const sample = makeRandomBitSample(256, cryptoProvider);
+  assert.equal(sample.bitCount, 256);
+  assert.equal(sample.ones, 256);
+  assert.equal(sample.zeros, 0);
+});
+
+test('buildRunRecord includes required fields and neutral RNG source', () => {
+  const run = buildRunRecord({
+    id: 'run-test',
+    mode: 'intention-more-ones',
+    intention: {
+      statement: 'Call one customer',
+      thought: 'Calm action compounds',
+      desiredState: 'steady',
+      nextAction: 'Send the message',
+    },
+    preState: { calm: 2, focus: 3, energy: 4, mood: 2 },
+    grounding: { seconds: 60, completed: true },
+    rng: { bitCount: 1024, ones: 512 },
+    postState: { calm: 4, focus: 4, energy: 4, mood: 3 },
+    action: { status: 'planned', note: 'Message drafted' },
+    notes: 'One small run',
+    safetyAcknowledged: true,
+  }, {
+    id: 'guest_123',
+    alias: 'Guest',
+    isGuest: true,
+  });
+
+  assert.equal(run.id, 'run-test');
+  assert.equal(run.app, 'intention-lab');
+  assert.equal(run.version, 1);
+  assert.equal(run.author.id, 'guest_123');
+  assert.equal(run.author.isGuest, true);
+  assert.equal(run.mode, 'intention-more-ones');
+  assert.equal(run.rng.source, 'browser-crypto-getRandomValues');
+  assert.equal(run.rng.bitCount, 1024);
+  assert.equal(run.action.status, 'planned');
+  assert.equal(run.safetyAcknowledged, true);
+});
+
+test('CSV export escapes commas, newlines, and quotes safely', () => {
+  assert.equal(escapeCsvValue('plain'), 'plain');
+  assert.equal(escapeCsvValue('a,b'), '"a,b"');
+  assert.equal(escapeCsvValue('line\nbreak'), '"line\nbreak"');
+  assert.equal(escapeCsvValue('say "yes"'), '"say ""yes"""');
+
+  const csv = runRecordToCsv(buildRunRecord({
+    id: 'csv-test',
+    intention: { statement: 'Call, write, ship', nextAction: 'Say "yes"' },
+    notes: 'first line\nsecond line',
+    rng: { bitCount: 1024, ones: 512 },
+  }, { id: 'guest_csv', isGuest: true }));
+
+  assert.match(csv, /"Call, write, ship"/);
+  assert.match(csv, /"Say ""yes"""/);
+  assert.match(csv, /"first line\nsecond line"/);
+});
+
+test('Intention Lab ships the standalone app, manifest, and portal integrations', async () => {
+  const appDir = new URL('../intention-lab/', import.meta.url);
+  assert.equal(await fileExists(new URL('index.html', appDir)), true);
+  assert.equal(await fileExists(new URL('intention-lab.css', appDir)), true);
+  assert.equal(await fileExists(new URL('intention-lab.js', appDir)), true);
+  assert.equal(await fileExists(new URL('../app-manifests/intention-lab.webmanifest', import.meta.url)), true);
+
+  const html = await readFile(new URL('index.html', appDir), 'utf8');
+  const js = await readFile(new URL('intention-lab.js', appDir), 'utf8');
+  const manifest = await readFile(new URL('../app-manifests/intention-lab.webmanifest', import.meta.url), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /Intention Lab \| 3DVR Portal/);
+  assert.match(html, /Attention selects\. Thought rehearses\. The body shifts\. Action manifests\./);
+  assert.match(html, /Not proof of mind-over-matter/);
+  assert.match(html, /crypto\.getRandomValues/);
+  assert.match(html, /id="rngResults"/);
+  assert.match(html, /id="recentRuns"/);
+  assert.match(html, /<meta name="analytics" content="disabled">/);
+  assert.doesNotMatch(html, /_vercel\/insights/);
+
+  assert.match(js, /window\.ScoreSystem\.ensureGun/);
+  assert.match(js, /window\.ScoreSystem\.ensureGuestIdentity/);
+  assert.match(js, /get\('3dvr-portal'\)\.get\('intention-lab'\)/);
+  assert.match(js, /const runsNode = state\.gunRoot\.get\('runs'\)/);
+  assert.match(js, /runsNode\.get\(run\.id\)\.put\(run/);
+  assert.match(js, /get\('authors'\)\.get\(run\.author\.id\)\.get\('runs'\)/);
+  assert.match(js, /get\('science'\)\.get\('runs'\)\.get\(run\.id\)\.put\(summary\)/);
+  assert.doesNotMatch(js, /Math\.random/);
+
+  assert.match(manifest, /3DVR Intention Lab/);
+  assert.match(manifest, /"start_url": "\/intention-lab\/\?source=pwa"/);
+  assert.match(manifest, /"scope": "\/intention-lab\/"/);
+
+  assert.match(portal, /href="intention-lab\/"/);
+  assert.match(portal, />Intention Lab</);
+  assert.match(portal, /data-app-tier="experimental"/);
+});

--- a/tests/vercel-insights-tag.test.js
+++ b/tests/vercel-insights-tag.test.js
@@ -10,6 +10,7 @@ const repoRoot = path.resolve(testDir, '..');
 const insightsTag = '<script defer src="/_vercel/insights/script.js"></script>';
 const insightsTagPattern = /<script defer src="\/_vercel\/insights\/script\.js"><\/script>/g;
 const closingHeadPattern = /<\/head>/i;
+const analyticsOptOutPattern = /<meta\s+name="analytics"\s+content="disabled"\s*\/?>/i;
 
 function listTrackedHtmlFiles() {
   const stdout = execFileSync('git', ['-C', repoRoot, 'ls-files', '*.html'], { encoding: 'utf8' }).trim();
@@ -22,6 +23,10 @@ test('tracked html files include one vercel insights tag before the closing head
   for (const relativePath of listTrackedHtmlFiles()) {
     const absolutePath = path.join(repoRoot, relativePath);
     const source = readFileSync(absolutePath, 'utf8');
+    if (analyticsOptOutPattern.test(source)) {
+      continue;
+    }
+
     const matches = source.match(insightsTagPattern) || [];
 
     if (matches.length !== 1) {


### PR DESCRIPTION
## Summary
- Adds `/intention-lab/`, a standalone static portal app for state checks, intention journaling, grounding, browser RNG trials, action logging, Gun sync, JSON copy, CSV export, and recent synced runs.
- Adds the Intention Lab PWA manifest and registers the app in the portal dock as Experimental.
- Adds a small Science Lab resource link and README install-list entry.
- Adds Node tests for RNG bit counting, statistical analysis, run record construction, CSV escaping, app structure, and Gun path integration.

## Gun paths
- Primary runs: `gun.get('3dvr-portal').get('intention-lab').get('runs').get(run.id).put(run)`
- Per-author index: `gun.get('3dvr-portal').get('intention-lab').get('authors').get(authorId).get('runs').get(run.id).put(true)`
- Science summary mirror: `gun.get('science').get('runs').get(run.id).put(summaryOnly)` with no freeform notes.

## Safety framing
- Frames RNG as browser `crypto.getRandomValues`, not quantum or hardware RNG.
- Uses neutral statistical copy and states the result does not prove intention caused the result.
- Includes the visible note: this lab observes attention, body state, randomness, and action; it does not diagnose, treat, or prove supernatural causation.
- Adds an explicit analytics opt-out meta tag for this no-analytics app and updates the insights-tag test to honor that opt-out.

## Verification
- `node --test tests/intention-lab-rng.test.js` passes.
- `git diff --check` passes.
- Browser smoke on `http://127.0.0.1:3000/intention-lab/` passed: page loaded, RNG trial produced stats, Save to Gun updated recent runs, and no app console errors were reported.
- Full `npm test` was run after `npm install`; it still has existing baseline failures unrelated to this app: homepage auth-entrypoint regex, Playwright installer helper expectations, and older pages missing Vercel insights tags.

## Billing
- No Stripe or billing changes.

## Notes
- Experimental app only. It does not make medical, financial, or supernatural certainty claims.
