### PR TITLE
Add Body Mode wellness section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Contacts](https://3dvr-portal.vercel.app/contacts/)
 - [Life](https://3dvr-portal.vercel.app/life/)
 - [Alive System](https://3dvr-portal.vercel.app/alive-system/)
+- [Body Mode](https://3dvr-portal.vercel.app/body-mode/)
 - [Education Suite](https://3dvr-portal.vercel.app/education-suite/)
 - [Attention Visualized](https://3dvr-portal.vercel.app/attention-visualized/)
 - [Logic Lab](https://3dvr-portal.vercel.app/logic-lab/)

--- a/app-manifests/body-mode.webmanifest
+++ b/app-manifests/body-mode.webmanifest
@@ -1,0 +1,16 @@
+{
+  "id": "/body-mode/",
+  "name": "3DVR Body Mode",
+  "short_name": "Body Mode",
+  "description": "A sensory-friendly reset system for people who live through screens.",
+  "start_url": "/body-mode/?source=pwa",
+  "scope": "/body-mode/",
+  "display": "standalone",
+  "background_color": "#17120f",
+  "theme_color": "#17120f",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/body-mode/body-mode.js
+++ b/body-mode/body-mode.js
@@ -1,0 +1,172 @@
+export const BODY_MODE_KEYS = Object.freeze({
+  reduceMotion: 'bodyMode.reduceMotion',
+  preferredMode: 'bodyMode.preferredMode',
+  lastUsedApp: 'bodyMode.lastUsedApp',
+});
+
+export const BODY_MODE_DEFAULTS = Object.freeze({
+  reduceMotion: false,
+  preferredMode: 'work-reset',
+  lastUsedApp: '',
+});
+
+export const BODY_MODE_APPS = Object.freeze([
+  {
+    id: 'seated-spine-reset',
+    title: 'Seated Spine Reset',
+    href: '/body-mode/seated-spine-reset/',
+    status: 'Ready',
+    description: 'A quiet 3-5 minute posture and mobility reset for neck, shoulders, spine, hips, and breath.',
+  },
+  {
+    id: 'breathing-room',
+    title: 'Breathing Room',
+    href: '/meditation/',
+    status: 'Available',
+    description: 'Guided breathing for calming, focusing, and returning to the present.',
+  },
+  {
+    id: 'integration-journal',
+    title: 'Integration Journal',
+    href: '#integration-journal',
+    status: 'Planned',
+    description: 'Reflect on dreams, meditation, emotional breakthroughs, and psychedelic experiences with grounded prompts.',
+  },
+  {
+    id: 'one-next-action',
+    title: 'One Next Action',
+    href: '#one-next-action',
+    status: 'Planned',
+    description: 'Turn an insight into one small real-world step.',
+  },
+  {
+    id: 'sleep-wind-down',
+    title: 'Sleep Wind-Down',
+    href: '#sleep-wind-down',
+    status: 'Planned',
+    description: 'A low-light routine for relaxing your body and reducing screen intensity before bed.',
+  },
+]);
+
+export function readBodyModePreferences(storage = globalThis.localStorage) {
+  return {
+    reduceMotion: readBoolean(storage, BODY_MODE_KEYS.reduceMotion, BODY_MODE_DEFAULTS.reduceMotion),
+    preferredMode: readString(storage, BODY_MODE_KEYS.preferredMode, BODY_MODE_DEFAULTS.preferredMode),
+    lastUsedApp: readString(storage, BODY_MODE_KEYS.lastUsedApp, BODY_MODE_DEFAULTS.lastUsedApp),
+  };
+}
+
+export function writeBodyModePreference(name, value, storage = globalThis.localStorage) {
+  if (!storage || typeof storage.setItem !== 'function') {
+    return readBodyModePreferences(storage);
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(BODY_MODE_KEYS, name)) {
+    throw new Error(`Unknown Body Mode preference: ${name}`);
+  }
+
+  storage.setItem(BODY_MODE_KEYS[name], serializePreference(name, value));
+  return readBodyModePreferences(storage);
+}
+
+export function setBodyModeLastUsed(appId, storage = globalThis.localStorage) {
+  return writeBodyModePreference('lastUsedApp', appId, storage);
+}
+
+export function getBodyModeApp(appId) {
+  return BODY_MODE_APPS.find(app => app.id === appId) || null;
+}
+
+export function applyBodyModePreferences(documentRef = globalThis.document, preferences = readBodyModePreferences()) {
+  if (!documentRef || !documentRef.body) {
+    return;
+  }
+  documentRef.body.dataset.reduceMotion = preferences.reduceMotion ? 'true' : 'false';
+}
+
+function readBoolean(storage, key, fallback) {
+  if (!storage || typeof storage.getItem !== 'function') {
+    return fallback;
+  }
+  const value = storage.getItem(key);
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return fallback;
+}
+
+function readString(storage, key, fallback) {
+  if (!storage || typeof storage.getItem !== 'function') {
+    return fallback;
+  }
+  const value = storage.getItem(key);
+  return typeof value === 'string' && value ? value : fallback;
+}
+
+function serializePreference(name, value) {
+  if (name === 'reduceMotion') {
+    return value ? 'true' : 'false';
+  }
+  return String(value || '');
+}
+
+function updateLastUsedLabel(documentRef, preferences) {
+  const label = documentRef.getElementById('lastUsedApp');
+  if (!label) {
+    return;
+  }
+  const app = getBodyModeApp(preferences.lastUsedApp);
+  label.textContent = app ? app.title : 'None yet';
+}
+
+function bindPreferenceControls(documentRef) {
+  const reduceMotionToggle = documentRef.getElementById('reduceMotionToggle');
+  const preferredModeSelect = documentRef.getElementById('preferredMode');
+  const preferences = readBodyModePreferences();
+
+  applyBodyModePreferences(documentRef, preferences);
+  updateLastUsedLabel(documentRef, preferences);
+
+  if (reduceMotionToggle) {
+    reduceMotionToggle.checked = preferences.reduceMotion;
+    reduceMotionToggle.addEventListener('change', event => {
+      const next = writeBodyModePreference('reduceMotion', event.target.checked);
+      applyBodyModePreferences(documentRef, next);
+      updateLastUsedLabel(documentRef, next);
+    });
+  }
+
+  if (preferredModeSelect) {
+    preferredModeSelect.value = preferences.preferredMode;
+    preferredModeSelect.addEventListener('change', event => {
+      const next = writeBodyModePreference('preferredMode', event.target.value);
+      applyBodyModePreferences(documentRef, next);
+      updateLastUsedLabel(documentRef, next);
+    });
+  }
+}
+
+function bindBodyModeCards(documentRef) {
+  documentRef.querySelectorAll('[data-body-app]').forEach(card => {
+    card.addEventListener('click', () => {
+      const appId = card.getAttribute('data-body-app') || '';
+      const next = setBodyModeLastUsed(appId);
+      updateLastUsedLabel(documentRef, next);
+    });
+  });
+}
+
+function initBodyMode() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  bindPreferenceControls(document);
+  bindBodyModeCards(document);
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initBodyMode, { once: true });
+  } else {
+    initBodyMode();
+  }
+}

--- a/body-mode/index.html
+++ b/body-mode/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Body Mode | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="A sensory-friendly reset system for people who live through screens."
+  >
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="./styles.css">
+  <link rel="manifest" href="/app-manifests/body-mode.webmanifest">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
+  <meta name="theme-color" content="#17120f">
+  <script type="module" src="./body-mode.js"></script>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="body-mode-page">
+  <a class="skip-link" href="#bodyModeMain">Skip to Body Mode apps</a>
+
+  <header class="body-top">
+    <nav class="body-nav" aria-label="Body Mode navigation">
+      <a class="body-brand" href="/">
+        <span class="body-brand__mark" aria-hidden="true">BODY</span>
+        <span>
+          <strong>Body Mode</strong>
+          <small>3DVR wellness-tech</small>
+        </span>
+      </a>
+      <div class="body-nav__links">
+        <a href="/">Portal</a>
+        <a href="/meditation/">Breathing Room</a>
+        <a href="/intention-lab/">Intention Lab</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="bodyModeMain" class="body-shell">
+    <section class="body-hero" aria-labelledby="body-mode-title">
+      <div class="body-hero__copy">
+        <p class="kicker">Sensory-friendly reset system</p>
+        <h1 id="body-mode-title">Body Mode</h1>
+        <p class="lead">A sensory-friendly reset system for people who live through screens.</p>
+        <p class="muted">
+          Technology should help us return to the body, not escape it. Body Mode gives you simple breath,
+          posture, reflection, and action tools for work, stress, and creative life.
+        </p>
+      </div>
+      <div class="body-actions">
+        <a class="body-button body-button--primary" href="/body-mode/seated-spine-reset/">Start spine reset</a>
+        <a class="body-button" href="/meditation/">Open Breathing Room</a>
+      </div>
+    </section>
+
+    <section class="preference-panel" aria-labelledby="preferences-title">
+      <div class="section-heading">
+        <p class="kicker">Comfort settings</p>
+        <h2 id="preferences-title">Keep the interface low-friction.</h2>
+      </div>
+      <div class="preference-row">
+        <label class="switch-field" for="reduceMotionToggle">
+          <input id="reduceMotionToggle" type="checkbox">
+          <span>Reduce Motion</span>
+        </label>
+        <label class="select-field" for="preferredMode">
+          <span>Preferred mode</span>
+          <select id="preferredMode">
+            <option value="work-reset">Work reset</option>
+            <option value="stress-downshift">Stress downshift</option>
+            <option value="creative-return">Creative return</option>
+            <option value="sleep-wind-down">Sleep wind-down</option>
+          </select>
+        </label>
+        <p class="preference-note">Last used app: <strong id="lastUsedApp">None yet</strong></p>
+      </div>
+    </section>
+
+    <section class="body-panel" aria-labelledby="apps-title">
+      <div class="section-heading">
+        <p class="kicker">Small tools</p>
+        <h2 id="apps-title">Choose the reset that fits this moment.</h2>
+      </div>
+
+      <div class="app-grid" aria-label="Body Mode apps">
+        <a class="body-card" href="/body-mode/seated-spine-reset/" data-body-app="seated-spine-reset">
+          <span class="body-card__tag">Ready</span>
+          <h3>Seated Spine Reset</h3>
+          <p>A quiet 3-5 minute posture and mobility reset for neck, shoulders, spine, hips, and breath.</p>
+        </a>
+        <a class="body-card" href="/meditation/" data-body-app="breathing-room">
+          <span class="body-card__tag">Available</span>
+          <h3>Breathing Room</h3>
+          <p>Guided breathing for calming, focusing, and returning to the present.</p>
+        </a>
+        <a class="body-card" href="#integration-journal" data-body-app="integration-journal">
+          <span class="body-card__tag">Planned</span>
+          <h3>Integration Journal</h3>
+          <p>
+            Reflect on dreams, meditation, emotional breakthroughs, and psychedelic experiences with grounded prompts.
+          </p>
+        </a>
+        <a class="body-card" href="#one-next-action" data-body-app="one-next-action">
+          <span class="body-card__tag">Planned</span>
+          <h3>One Next Action</h3>
+          <p>Turn an insight into one small real-world step.</p>
+        </a>
+        <a class="body-card" href="#sleep-wind-down" data-body-app="sleep-wind-down">
+          <span class="body-card__tag">Planned</span>
+          <h3>Sleep Wind-Down</h3>
+          <p>A low-light routine for relaxing your body and reducing screen intensity before bed.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="body-panel" aria-labelledby="roadmap-title">
+      <div class="section-heading">
+        <p class="kicker">Expansion path</p>
+        <h2 id="roadmap-title">The cards are ready to become apps.</h2>
+        <p>
+          Each Body Mode card has a stable route target, preference behavior, and a clear use case so the section can
+          grow one tool at a time.
+        </p>
+      </div>
+      <div class="quick-grid">
+        <article id="integration-journal" class="quiet-box">
+          <h3>Integration Journal</h3>
+          <p>Future prompts will separate memory, meaning, body state, and next action.</p>
+        </article>
+        <article id="one-next-action" class="quiet-box">
+          <h3>One Next Action</h3>
+          <p>Future flow will turn a thought into a small grounded task.</p>
+        </article>
+        <article id="sleep-wind-down" class="quiet-box">
+          <h3>Sleep Wind-Down</h3>
+          <p>Future routine will lower contrast, slow pacing, and reduce screen intensity.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="disclaimer" aria-label="Body Mode disclaimer">
+      These tools support reflection, relaxation, and self-care. They are not medical advice or a substitute for
+      professional care.
+    </section>
+  </main>
+
+  <footer class="body-footer">
+    <a href="/">Portal</a>
+    <a href="/wellness.html">Wellness Directory</a>
+    <a href="/meditation/">Breathing Room</a>
+    <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>
+  </footer>
+</body>
+</html>

--- a/body-mode/seated-spine-reset/index.html
+++ b/body-mode/seated-spine-reset/index.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Seated Spine Reset | Body Mode</title>
+  <meta
+    name="description"
+    content="A quiet seated posture and mobility reset for neck, shoulders, spine, hips, and breath."
+  >
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
+  <meta name="theme-color" content="#17120f">
+  <script type="module" src="./seated-spine-reset.js"></script>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="body-mode-page">
+  <a class="skip-link" href="#resetMain">Skip to seated spine reset</a>
+
+  <header class="body-top">
+    <nav class="body-nav" aria-label="Seated Spine Reset navigation">
+      <a class="body-brand" href="/body-mode/">
+        <span class="body-brand__mark" aria-hidden="true">BODY</span>
+        <span>
+          <strong>Seated Spine Reset</strong>
+          <small>Body Mode</small>
+        </span>
+      </a>
+      <div class="body-nav__links">
+        <a href="/body-mode/">Body Mode</a>
+        <a href="/meditation/">Breathing Room</a>
+        <a href="/">Portal</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="resetMain" class="body-shell">
+    <section class="body-hero" aria-labelledby="reset-title">
+      <div class="body-hero__copy">
+        <p class="kicker">3-5 minute body reset</p>
+        <h1 id="reset-title">Seated Spine Reset</h1>
+        <p class="lead">
+          A quiet posture and mobility sequence for neck, shoulders, spine, hips, and breath.
+        </p>
+        <p class="muted">
+          Stay inside a comfortable range. Skip anything that feels sharp, forced, or wrong for your body today.
+        </p>
+      </div>
+      <div class="body-actions">
+        <a class="body-button" href="/body-mode/">Back to Body Mode</a>
+        <a class="body-button" href="/meditation/">Longer breathing</a>
+      </div>
+    </section>
+
+    <section class="preference-panel" aria-labelledby="reset-preferences-title">
+      <div class="section-heading">
+        <p class="kicker">Comfort settings</p>
+        <h2 id="reset-preferences-title">Use the same Body Mode preferences.</h2>
+      </div>
+      <div class="preference-row">
+        <label class="switch-field" for="reduceMotionToggle">
+          <input id="reduceMotionToggle" type="checkbox">
+          <span>Reduce Motion</span>
+        </label>
+        <label class="select-field" for="preferredMode">
+          <span>Preferred mode</span>
+          <select id="preferredMode">
+            <option value="work-reset">Work reset</option>
+            <option value="stress-downshift">Stress downshift</option>
+            <option value="creative-return">Creative return</option>
+            <option value="sleep-wind-down">Sleep wind-down</option>
+          </select>
+        </label>
+        <p class="preference-note">Last used app: <strong id="lastUsedApp">None yet</strong></p>
+      </div>
+    </section>
+
+    <section class="body-panel" aria-labelledby="routine-title">
+      <div class="section-heading">
+        <p class="kicker">Guided routine</p>
+        <h2 id="routine-title">Move gently from screen posture back into body awareness.</h2>
+      </div>
+
+      <div class="routine-layout">
+        <aside class="routine-card" aria-label="Routine controls">
+          <div class="timer-readout" aria-live="polite">
+            <strong id="timeRemaining">04:05</strong>
+            <span id="stepCounter">Step 1 of 7</span>
+          </div>
+          <div class="routine-meter" aria-label="Routine progress">
+            <span id="routineProgress"></span>
+          </div>
+          <div class="button-row">
+            <button id="startPauseButton" class="body-button body-button--primary" type="button">Start</button>
+            <button id="previousStepButton" class="body-button" type="button">Previous</button>
+            <button id="nextStepButton" class="body-button" type="button">Next</button>
+            <button id="resetButton" class="body-button" type="button">Reset</button>
+          </div>
+          <ol id="stepList" class="step-list" aria-label="Reset steps"></ol>
+        </aside>
+
+        <section class="routine-card" aria-labelledby="currentStepTitle">
+          <div class="posture-visual" aria-hidden="true">
+            <div class="body-line">
+              <span class="body-line__shoulders"></span>
+              <span class="body-line__hips"></span>
+              <span class="body-line__seat"></span>
+            </div>
+          </div>
+
+          <div class="step-copy">
+            <p class="kicker" id="currentStepArea">Arrive</p>
+            <h2 id="currentStepTitle">Feet, seat, screen distance</h2>
+            <p id="currentStepInstruction">
+              Place both feet on the ground. Let the chair support you. Move the screen a little farther away.
+            </p>
+            <ul id="currentStepCues" class="cue-list"></ul>
+            <div class="quiet-box">
+              <h3>Breath cue</h3>
+              <p id="currentBreathCue">Breathe through the nose if comfortable. Let the exhale be easy.</p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <section class="disclaimer" aria-label="Seated Spine Reset disclaimer">
+      These tools support reflection, relaxation, and self-care. They are not medical advice or a substitute for
+      professional care.
+    </section>
+  </main>
+
+  <footer class="body-footer">
+    <a href="/body-mode/">Body Mode</a>
+    <a href="/wellness.html">Wellness Directory</a>
+    <a href="/meditation/">Breathing Room</a>
+    <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>
+  </footer>
+</body>
+</html>

--- a/body-mode/seated-spine-reset/seated-spine-reset.js
+++ b/body-mode/seated-spine-reset/seated-spine-reset.js
@@ -1,0 +1,319 @@
+import {
+  readBodyModePreferences,
+  setBodyModeLastUsed,
+  getBodyModeApp,
+} from '../body-mode.js';
+
+export const SEATED_SPINE_STEPS = Object.freeze([
+  {
+    area: 'Arrive',
+    title: 'Feet, seat, screen distance',
+    duration: 35,
+    instruction: 'Place both feet on the ground. Let the chair support you. Move the screen a little farther away.',
+    cues: [
+      'Let your hands rest somewhere easy.',
+      'Notice the weight of your body on the chair.',
+      'Unclench the jaw and let the tongue soften.',
+    ],
+    breath: 'Breathe through the nose if comfortable. Let the exhale be easy.',
+  },
+  {
+    area: 'Neck',
+    title: 'Slow side glides',
+    duration: 35,
+    instruction: 'Keep the chest quiet. Let the right ear drift toward the right shoulder, then return and switch sides.',
+    cues: [
+      'Move at half speed.',
+      'Do not pull on the head.',
+      'Keep both shoulders heavy.',
+    ],
+    breath: 'Exhale as the head returns to center.',
+  },
+  {
+    area: 'Shoulders',
+    title: 'Shoulder rolls and release',
+    duration: 35,
+    instruction: 'Lift the shoulders gently, roll them back, then let them settle down without forcing posture.',
+    cues: [
+      'Make the circles small enough to feel safe.',
+      'Let the shoulder blades slide instead of pinch.',
+      'Pause after each roll.',
+    ],
+    breath: 'Inhale as the shoulders rise. Exhale as they settle.',
+  },
+  {
+    area: 'Spine',
+    title: 'Seated cat and neutral',
+    duration: 35,
+    instruction: 'Round the upper back slightly, then return to a tall neutral seat. Keep the movement smooth.',
+    cues: [
+      'Move from the ribs, not only the neck.',
+      'Keep the pelvis supported.',
+      'Stop before strain.',
+    ],
+    breath: 'Exhale into the round shape. Inhale toward neutral.',
+  },
+  {
+    area: 'Hips',
+    title: 'Pelvic rock',
+    duration: 35,
+    instruction: 'Rock the pelvis forward and back in a small range so the low back remembers it can move.',
+    cues: [
+      'Keep feet planted.',
+      'Let the motion be subtle.',
+      'Notice if one side feels different.',
+    ],
+    breath: 'Let the breath stay quiet and unforced.',
+  },
+  {
+    area: 'Breath',
+    title: 'Wide ribs, soft belly',
+    duration: 35,
+    instruction: 'Place attention around the lower ribs. Let the inhale widen the body and the exhale soften it.',
+    cues: [
+      'No breath holds are needed.',
+      'Let the belly move if it wants to.',
+      'Let the face stay easy.',
+    ],
+    breath: 'Inhale for comfort. Exhale a little longer if that feels calming.',
+  },
+  {
+    area: 'Return',
+    title: 'Choose one grounded action',
+    duration: 35,
+    instruction: 'Look away from the screen. Name one small action you can do next with your body involved.',
+    cues: [
+      'Drink water.',
+      'Stand and take ten steps.',
+      'Send one clear message.',
+    ],
+    breath: 'Take one ordinary breath before returning to work.',
+  },
+]);
+
+export function getRoutineDuration(steps = SEATED_SPINE_STEPS) {
+  return steps.reduce((total, step) => total + step.duration, 0);
+}
+
+export function formatDuration(seconds) {
+  const safeSeconds = Math.max(0, Math.round(Number(seconds) || 0));
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainder = safeSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(remainder).padStart(2, '0')}`;
+}
+
+export function calculateRoutineProgress(stepIndex, remainingInStep, steps = SEATED_SPINE_STEPS) {
+  const total = getRoutineDuration(steps);
+  const completedBeforeStep = steps
+    .slice(0, Math.max(0, stepIndex))
+    .reduce((sum, step) => sum + step.duration, 0);
+  const currentStep = steps[stepIndex] || steps[steps.length - 1];
+  const completedInStep = currentStep ? currentStep.duration - Math.max(0, remainingInStep) : 0;
+  return Math.max(0, Math.min(1, (completedBeforeStep + completedInStep) / total));
+}
+
+function initSeatedSpineReset() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const refs = {
+    timeRemaining: document.getElementById('timeRemaining'),
+    stepCounter: document.getElementById('stepCounter'),
+    routineProgress: document.getElementById('routineProgress'),
+    startPauseButton: document.getElementById('startPauseButton'),
+    previousStepButton: document.getElementById('previousStepButton'),
+    nextStepButton: document.getElementById('nextStepButton'),
+    resetButton: document.getElementById('resetButton'),
+    stepList: document.getElementById('stepList'),
+    currentStepArea: document.getElementById('currentStepArea'),
+    currentStepTitle: document.getElementById('currentStepTitle'),
+    currentStepInstruction: document.getElementById('currentStepInstruction'),
+    currentStepCues: document.getElementById('currentStepCues'),
+    currentBreathCue: document.getElementById('currentBreathCue'),
+    lastUsedApp: document.getElementById('lastUsedApp'),
+  };
+
+  if (!refs.timeRemaining || !refs.stepList || !refs.startPauseButton) {
+    return;
+  }
+
+  const state = {
+    stepIndex: 0,
+    remainingInStep: SEATED_SPINE_STEPS[0].duration,
+    running: false,
+    completed: false,
+    intervalId: null,
+  };
+
+  setBodyModeLastUsed('seated-spine-reset');
+  updateLastUsedLabel(refs);
+  renderStepList(refs, state);
+  bindEvents(refs, state);
+  renderRoutine(refs, state);
+}
+
+function bindEvents(refs, state) {
+  refs.startPauseButton.addEventListener('click', () => {
+    if (state.completed) {
+      resetRoutine(state);
+    }
+    if (state.running) {
+      pauseRoutine(state);
+    } else {
+      startRoutine(refs, state);
+    }
+    renderRoutine(refs, state);
+  });
+
+  refs.previousStepButton.addEventListener('click', () => {
+    pauseRoutine(state);
+    goToStep(state, Math.max(0, state.stepIndex - 1));
+    renderRoutine(refs, state);
+  });
+
+  refs.nextStepButton.addEventListener('click', () => {
+    pauseRoutine(state);
+    goToStep(state, Math.min(SEATED_SPINE_STEPS.length - 1, state.stepIndex + 1));
+    renderRoutine(refs, state);
+  });
+
+  refs.resetButton.addEventListener('click', () => {
+    pauseRoutine(state);
+    resetRoutine(state);
+    renderRoutine(refs, state);
+  });
+}
+
+function startRoutine(refs, state) {
+  state.running = true;
+  state.completed = false;
+  if (state.intervalId) {
+    clearInterval(state.intervalId);
+  }
+  state.intervalId = setInterval(() => {
+    tickRoutine(state);
+    renderRoutine(refs, state);
+  }, 1000);
+}
+
+function pauseRoutine(state) {
+  state.running = false;
+  if (state.intervalId) {
+    clearInterval(state.intervalId);
+    state.intervalId = null;
+  }
+}
+
+function resetRoutine(state) {
+  state.stepIndex = 0;
+  state.remainingInStep = SEATED_SPINE_STEPS[0].duration;
+  state.running = false;
+  state.completed = false;
+}
+
+function goToStep(state, stepIndex) {
+  state.stepIndex = stepIndex;
+  state.remainingInStep = SEATED_SPINE_STEPS[stepIndex].duration;
+  state.completed = false;
+}
+
+function tickRoutine(state) {
+  if (state.completed) {
+    pauseRoutine(state);
+    return;
+  }
+
+  state.remainingInStep -= 1;
+  if (state.remainingInStep > 0) {
+    return;
+  }
+
+  if (state.stepIndex < SEATED_SPINE_STEPS.length - 1) {
+    goToStep(state, state.stepIndex + 1);
+    return;
+  }
+
+  state.remainingInStep = 0;
+  state.completed = true;
+  pauseRoutine(state);
+}
+
+function getTotalRemaining(state) {
+  const afterCurrent = SEATED_SPINE_STEPS
+    .slice(state.stepIndex + 1)
+    .reduce((total, step) => total + step.duration, 0);
+  return state.remainingInStep + afterCurrent;
+}
+
+function renderStepList(refs, state) {
+  refs.stepList.innerHTML = SEATED_SPINE_STEPS.map((step, index) => `
+    <li>
+      <button type="button" data-step-index="${index}">
+        <strong>${index + 1}. ${escapeHtml(step.area)}</strong><br>
+        <span>${escapeHtml(step.title)}</span>
+      </button>
+    </li>
+  `).join('');
+
+  refs.stepList.querySelectorAll('button[data-step-index]').forEach(button => {
+    button.addEventListener('click', () => {
+      pauseRoutine(state);
+      goToStep(state, Number(button.getAttribute('data-step-index')));
+      renderRoutine(refs, state);
+    });
+  });
+}
+
+function renderRoutine(refs, state) {
+  const step = SEATED_SPINE_STEPS[state.stepIndex];
+  const totalRemaining = getTotalRemaining(state);
+  const progress = calculateRoutineProgress(state.stepIndex, state.remainingInStep);
+
+  refs.timeRemaining.textContent = formatDuration(totalRemaining);
+  refs.stepCounter.textContent = state.completed
+    ? 'Routine complete'
+    : `Step ${state.stepIndex + 1} of ${SEATED_SPINE_STEPS.length}`;
+  refs.routineProgress.style.setProperty('--progress', `${Math.round(progress * 100)}%`);
+  refs.startPauseButton.textContent = state.completed ? 'Restart' : (state.running ? 'Pause' : 'Start');
+  refs.previousStepButton.disabled = state.stepIndex === 0;
+  refs.nextStepButton.disabled = state.stepIndex === SEATED_SPINE_STEPS.length - 1;
+
+  refs.currentStepArea.textContent = step.area;
+  refs.currentStepTitle.textContent = step.title;
+  refs.currentStepInstruction.textContent = step.instruction;
+  refs.currentBreathCue.textContent = step.breath;
+  refs.currentStepCues.innerHTML = step.cues.map(cue => `<li>${escapeHtml(cue)}</li>`).join('');
+
+  refs.stepList.querySelectorAll('button[data-step-index]').forEach(button => {
+    const isActive = Number(button.getAttribute('data-step-index')) === state.stepIndex;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-current', isActive ? 'step' : 'false');
+  });
+}
+
+function updateLastUsedLabel(refs) {
+  if (!refs.lastUsedApp) {
+    return;
+  }
+  const preferences = readBodyModePreferences();
+  const app = getBodyModeApp(preferences.lastUsedApp);
+  refs.lastUsedApp.textContent = app ? app.title : 'None yet';
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initSeatedSpineReset, { once: true });
+  } else {
+    initSeatedSpineReset();
+  }
+}

--- a/body-mode/styles.css
+++ b/body-mode/styles.css
@@ -1,0 +1,586 @@
+:root {
+  color-scheme: dark;
+  --body-bg: #0d0b09;
+  --body-surface: #17120f;
+  --body-surface-soft: #211916;
+  --body-surface-strong: #2a211d;
+  --body-border: rgba(238, 213, 177, 0.18);
+  --body-text: #f4eadb;
+  --body-muted: #b9a995;
+  --body-warm: #e7b77a;
+  --body-green: #9fca9a;
+  --body-blue: #96b6c4;
+  --body-rose: #d79b90;
+  --body-shadow: 0 22px 60px rgba(0, 0, 0, 0.34);
+  --body-radius: 8px;
+  --body-max: 1160px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--body-bg);
+}
+
+body.body-mode-page {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(231, 183, 122, 0.08), transparent 280px),
+    linear-gradient(135deg, #0d0b09 0%, #14100d 54%, #0d1010 100%);
+  color: var(--body-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+body.body-mode-page[data-reduce-motion="true"] *,
+body.body-mode-page[data-reduce-motion="true"] *::before,
+body.body-mode-page[data-reduce-motion="true"] *::after {
+  scroll-behavior: auto !important;
+  transition-duration: 0.01ms !important;
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: var(--body-warm);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--body-warm);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 20;
+  transform: translateY(-140%);
+  padding: 10px 14px;
+  border-radius: var(--body-radius);
+  background: var(--body-warm);
+  color: #17100c;
+  font-weight: 800;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.body-nav,
+.body-shell,
+.body-footer {
+  width: min(100% - 28px, var(--body-max));
+  margin: 0 auto;
+}
+
+.body-top {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--body-border);
+  background: rgba(13, 11, 9, 0.9);
+  backdrop-filter: blur(14px);
+}
+
+.body-nav {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.body-brand,
+.body-nav__links,
+.body-actions,
+.button-row,
+.preference-row,
+.step-controls,
+.body-footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.body-brand {
+  text-decoration: none;
+}
+
+.body-brand__mark {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(231, 183, 122, 0.42);
+  border-radius: var(--body-radius);
+  background: rgba(231, 183, 122, 0.12);
+  color: var(--body-warm);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.body-brand strong,
+.body-brand small {
+  display: block;
+}
+
+.body-brand small {
+  color: var(--body-muted);
+  font-size: 0.78rem;
+}
+
+.body-nav__links a,
+.body-footer a {
+  padding: 8px 10px;
+  border: 1px solid var(--body-border);
+  border-radius: var(--body-radius);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--body-muted);
+  text-decoration: none;
+}
+
+.body-nav__links a:hover,
+.body-footer a:hover {
+  color: var(--body-text);
+  border-color: rgba(231, 183, 122, 0.46);
+}
+
+.body-shell {
+  padding: 24px 0 36px;
+  display: grid;
+  gap: 18px;
+}
+
+.body-hero,
+.body-panel,
+.body-card,
+.routine-card {
+  border: 1px solid var(--body-border);
+  border-radius: var(--body-radius);
+  background: rgba(23, 18, 15, 0.9);
+  box-shadow: var(--body-shadow);
+}
+
+.body-hero {
+  display: grid;
+  gap: 18px;
+  padding: 22px;
+}
+
+.body-hero__copy,
+.section-heading,
+.body-card,
+.routine-card,
+.step-copy,
+.quiet-box {
+  display: grid;
+  gap: 10px;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--body-warm);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 2.45rem;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 1.38rem;
+  line-height: 1.15;
+}
+
+h3 {
+  margin-bottom: 0;
+}
+
+.lead {
+  max-width: 780px;
+  margin-bottom: 0;
+  color: #ead9c3;
+  font-size: 1.08rem;
+}
+
+.muted,
+.section-heading p,
+.body-card p,
+.routine-card p,
+.preference-note {
+  color: var(--body-muted);
+}
+
+.muted,
+.preference-note {
+  margin-bottom: 0;
+}
+
+.body-button,
+.mode-button {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 13px;
+  border: 1px solid var(--body-border);
+  border-radius: var(--body-radius);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--body-text);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.body-button:hover:not(:disabled),
+.mode-button:hover:not(:disabled) {
+  border-color: rgba(231, 183, 122, 0.5);
+  background: rgba(231, 183, 122, 0.12);
+}
+
+.body-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.body-button--primary,
+.mode-button.is-active {
+  border-color: rgba(231, 183, 122, 0.72);
+  background: var(--body-warm);
+  color: #17100c;
+  font-weight: 850;
+}
+
+.preference-panel {
+  padding: 16px;
+  border: 1px solid var(--body-border);
+  border-radius: var(--body-radius);
+  background: rgba(33, 25, 22, 0.86);
+}
+
+.preference-row {
+  justify-content: space-between;
+}
+
+.switch-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--body-text);
+  font-weight: 700;
+}
+
+.switch-field input {
+  width: 46px;
+  height: 26px;
+  accent-color: var(--body-warm);
+}
+
+.select-field {
+  display: grid;
+  gap: 6px;
+  min-width: min(100%, 220px);
+  color: var(--body-text);
+  font-weight: 700;
+}
+
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--body-border);
+  border-radius: var(--body-radius);
+  background: #100c0a;
+  color: var(--body-text);
+  padding: 10px 11px;
+}
+
+.app-grid,
+.quick-grid,
+.routine-layout,
+.step-list {
+  display: grid;
+  gap: 14px;
+}
+
+.body-card {
+  padding: 16px;
+  min-height: 180px;
+  text-decoration: none;
+  box-shadow: none;
+}
+
+.body-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(231, 183, 122, 0.44);
+  color: var(--body-text);
+}
+
+.body-card__tag {
+  width: fit-content;
+  padding: 4px 8px;
+  border: 1px solid rgba(231, 183, 122, 0.28);
+  border-radius: var(--body-radius);
+  color: var(--body-warm);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.body-panel {
+  padding: 18px;
+}
+
+.disclaimer {
+  padding: 14px;
+  border: 1px solid rgba(150, 182, 196, 0.3);
+  border-radius: var(--body-radius);
+  background: rgba(150, 182, 196, 0.08);
+  color: #d8e5e8;
+}
+
+.routine-layout {
+  grid-template-columns: 1fr;
+}
+
+.routine-card {
+  padding: 16px;
+}
+
+.routine-meter {
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.routine-meter span {
+  display: block;
+  width: var(--progress, 0%);
+  height: 100%;
+  background: linear-gradient(90deg, var(--body-warm), var(--body-green));
+}
+
+.timer-readout {
+  display: grid;
+  gap: 4px;
+  padding: 18px;
+  border: 1px solid var(--body-border);
+  border-radius: var(--body-radius);
+  background: var(--body-surface-soft);
+  text-align: center;
+}
+
+.timer-readout strong {
+  font-size: 2.55rem;
+  line-height: 1;
+  letter-spacing: 0.02em;
+}
+
+.timer-readout span {
+  color: var(--body-muted);
+}
+
+.posture-visual {
+  min-height: 240px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--body-border);
+  border-radius: var(--body-radius);
+  background: #100c0a;
+}
+
+.body-line {
+  width: min(56vw, 180px);
+  height: 210px;
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.body-line::before {
+  content: '';
+  position: absolute;
+  width: 4px;
+  height: 172px;
+  top: 30px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--body-blue), var(--body-warm), var(--body-green));
+}
+
+.body-line::after {
+  content: '';
+  position: absolute;
+  width: 58px;
+  height: 58px;
+  top: 0;
+  border: 3px solid var(--body-blue);
+  border-radius: 999px;
+  background: rgba(150, 182, 196, 0.08);
+}
+
+.body-line__shoulders,
+.body-line__hips,
+.body-line__seat {
+  position: absolute;
+  border-radius: 999px;
+  background: rgba(231, 183, 122, 0.78);
+}
+
+.body-line__shoulders {
+  width: 128px;
+  height: 5px;
+  top: 72px;
+}
+
+.body-line__hips {
+  width: 92px;
+  height: 5px;
+  bottom: 58px;
+  background: rgba(159, 202, 154, 0.76);
+}
+
+.body-line__seat {
+  width: 150px;
+  height: 6px;
+  bottom: 20px;
+  background: rgba(244, 234, 219, 0.28);
+}
+
+.step-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.step-list button {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid var(--body-border);
+  border-radius: var(--body-radius);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--body-muted);
+  text-align: left;
+  cursor: pointer;
+}
+
+.step-list button.is-active {
+  border-color: rgba(231, 183, 122, 0.58);
+  background: rgba(231, 183, 122, 0.12);
+  color: var(--body-text);
+}
+
+.step-copy h2 {
+  font-size: 1.65rem;
+}
+
+.step-copy p {
+  margin-bottom: 0;
+}
+
+.cue-list {
+  margin: 0;
+  padding-left: 20px;
+  color: #ead9c3;
+}
+
+.quiet-box {
+  padding: 14px;
+  border: 1px solid rgba(159, 202, 154, 0.28);
+  border-radius: var(--body-radius);
+  background: rgba(159, 202, 154, 0.08);
+}
+
+.body-footer {
+  justify-content: center;
+  padding: 0 0 40px;
+}
+
+@media (min-width: 720px) {
+  .body-hero {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+  }
+
+  .app-grid,
+  .quick-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .routine-layout {
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  }
+}
+
+@media (min-width: 980px) {
+  h1 {
+    font-size: 3.05rem;
+  }
+
+  .app-grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .quick-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .body-nav {
+    min-height: auto;
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 12px 0;
+  }
+
+  .body-button,
+  .body-nav__links a,
+  .body-footer a {
+    flex: 1 1 auto;
+  }
+
+  .preference-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .body-card {
+    min-height: auto;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -563,6 +563,17 @@
             <span class="app-card__title">Wellness</span>
             <span class="app-card__meta">Explore mindfulness, nutrition, and lifestyle resources.</span>
           </a>
+          <a
+            href="body-mode/"
+            class="app-card"
+            data-app-keywords="body mode wellness posture breathing nervous system sensory reset sleep action"
+          >
+            <span class="app-card__icon" aria-hidden="true">BODY</span>
+            <span class="app-card__title">Body Mode</span>
+            <span class="app-card__meta">
+              Open sensory-friendly breath, posture, reflection, and action tools for screen-heavy days.
+            </span>
+          </a>
           <a href="herbal-nervous-system/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌿</span>
             <span class="app-card__title">Herbal Toolkit</span>

--- a/tests/body-mode.test.js
+++ b/tests/body-mode.test.js
@@ -1,0 +1,150 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import {
+  BODY_MODE_KEYS,
+  getBodyModeApp,
+  readBodyModePreferences,
+  setBodyModeLastUsed,
+  writeBodyModePreference,
+} from '../body-mode/body-mode.js';
+import {
+  SEATED_SPINE_STEPS,
+  calculateRoutineProgress,
+  formatDuration,
+  getRoutineDuration,
+} from '../body-mode/seated-spine-reset/seated-spine-reset.js';
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function createMemoryStorage(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+  };
+}
+
+test('Body Mode landing page ships the requested wellness-tech section', async () => {
+  const appDir = new URL('../body-mode/', import.meta.url);
+  assert.equal(await fileExists(new URL('index.html', appDir)), true);
+  assert.equal(await fileExists(new URL('styles.css', appDir)), true);
+  assert.equal(await fileExists(new URL('body-mode.js', appDir)), true);
+
+  const html = await readFile(new URL('index.html', appDir), 'utf8');
+  const css = await readFile(new URL('styles.css', appDir), 'utf8');
+  const js = await readFile(new URL('body-mode.js', appDir), 'utf8');
+
+  assert.match(html, /<title>Body Mode \| 3DVR Portal<\/title>/);
+  assert.match(html, /A sensory-friendly reset system for people who live through screens\./);
+  assert.match(html, /Technology should help us return to the body, not escape it\./);
+  assert.match(html, /Seated Spine Reset/);
+  assert.match(html, /Breathing Room/);
+  assert.match(html, /Integration Journal/);
+  assert.match(html, /One Next Action/);
+  assert.match(html, /Sleep Wind-Down/);
+  assert.match(html, /These tools support reflection, relaxation, and self-care/);
+  assert.match(html, /They are not medical advice or a substitute for\s+professional care/);
+  assert.match(html, /id="reduceMotionToggle"/);
+  assert.match(html, /id="preferredMode"/);
+  assert.match(html, /id="lastUsedApp"/);
+  assert.match(html, /href="\/app-manifests\/body-mode\.webmanifest"/);
+  assert.match(html, /<script defer src="\/_vercel\/insights\/script\.js"><\/script>/);
+  assert.doesNotMatch(html, /DMT|curing|cures|treating trauma/i);
+
+  assert.match(css, /--body-bg: #0d0b09/);
+  assert.match(css, /\[data-reduce-motion="true"\]/);
+  assert.match(css, /\.app-grid/);
+  assert.match(css, /\.routine-layout/);
+
+  assert.match(js, /bodyMode\.reduceMotion/);
+  assert.match(js, /bodyMode\.preferredMode/);
+  assert.match(js, /bodyMode\.lastUsedApp/);
+  assert.match(js, /data-body-app/);
+});
+
+test('Seated Spine Reset ships a working guided reset route', async () => {
+  const resetDir = new URL('../body-mode/seated-spine-reset/', import.meta.url);
+  assert.equal(await fileExists(new URL('index.html', resetDir)), true);
+  assert.equal(await fileExists(new URL('seated-spine-reset.js', resetDir)), true);
+
+  const html = await readFile(new URL('index.html', resetDir), 'utf8');
+  const js = await readFile(new URL('seated-spine-reset.js', resetDir), 'utf8');
+
+  assert.match(html, /Seated Spine Reset \| Body Mode/);
+  assert.match(html, /neck, shoulders, spine, hips, and breath/);
+  assert.match(html, /id="timeRemaining"/);
+  assert.match(html, /id="stepList"/);
+  assert.match(html, /id="startPauseButton"/);
+  assert.match(html, /id="routineProgress"/);
+  assert.match(html, /body-line__shoulders/);
+  assert.match(html, /They are not medical advice or a substitute for\s+professional care/);
+  assert.match(html, /<script defer src="\/_vercel\/insights\/script\.js"><\/script>/);
+  assert.doesNotMatch(html, /DMT|curing|cures|treating trauma/i);
+
+  assert.match(js, /SEATED_SPINE_STEPS/);
+  assert.match(js, /setBodyModeLastUsed\('seated-spine-reset'\)/);
+  assert.match(js, /setInterval/);
+  assert.match(js, /Step \$\{state\.stepIndex \+ 1\} of/);
+});
+
+test('Body Mode preferences use the requested localStorage keys', () => {
+  const storage = createMemoryStorage();
+  let preferences = readBodyModePreferences(storage);
+  assert.equal(preferences.reduceMotion, false);
+  assert.equal(preferences.preferredMode, 'work-reset');
+  assert.equal(preferences.lastUsedApp, '');
+
+  preferences = writeBodyModePreference('reduceMotion', true, storage);
+  assert.equal(preferences.reduceMotion, true);
+  assert.equal(storage.getItem(BODY_MODE_KEYS.reduceMotion), 'true');
+
+  preferences = writeBodyModePreference('preferredMode', 'sleep-wind-down', storage);
+  assert.equal(preferences.preferredMode, 'sleep-wind-down');
+  assert.equal(storage.getItem(BODY_MODE_KEYS.preferredMode), 'sleep-wind-down');
+
+  preferences = setBodyModeLastUsed('seated-spine-reset', storage);
+  assert.equal(preferences.lastUsedApp, 'seated-spine-reset');
+  assert.equal(storage.getItem(BODY_MODE_KEYS.lastUsedApp), 'seated-spine-reset');
+  assert.equal(getBodyModeApp(preferences.lastUsedApp).title, 'Seated Spine Reset');
+});
+
+test('Seated Spine Reset timing helpers stay inside a 3-5 minute routine', () => {
+  const totalDuration = getRoutineDuration(SEATED_SPINE_STEPS);
+  assert.equal(SEATED_SPINE_STEPS.length, 7);
+  assert.ok(totalDuration >= 180);
+  assert.ok(totalDuration <= 300);
+  assert.equal(formatDuration(totalDuration), '04:05');
+  assert.equal(formatDuration(0), '00:00');
+  assert.equal(formatDuration(65), '01:05');
+  assert.equal(calculateRoutineProgress(0, SEATED_SPINE_STEPS[0].duration), 0);
+  assert.equal(calculateRoutineProgress(SEATED_SPINE_STEPS.length - 1, 0), 1);
+});
+
+test('Portal registry and docs link to Body Mode', async () => {
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const wellness = await readFile(new URL('../wellness.html', import.meta.url), 'utf8');
+  const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+  const manifest = await readFile(new URL('../app-manifests/body-mode.webmanifest', import.meta.url), 'utf8');
+
+  assert.match(portal, /href="body-mode\/"/);
+  assert.match(portal, />Body Mode</);
+  assert.match(portal, /sensory-friendly breath, posture, reflection, and action tools/);
+  assert.match(wellness, /href="body-mode\/"/);
+  assert.match(readme, /\[Body Mode\]\(https:\/\/3dvr-portal\.vercel\.app\/body-mode\/\)/);
+  assert.match(manifest, /3DVR Body Mode/);
+  assert.match(manifest, /"start_url": "\/body-mode\/\?source=pwa"/);
+  assert.match(manifest, /"scope": "\/body-mode\/"/);
+});

--- a/wellness.html
+++ b/wellness.html
@@ -156,6 +156,7 @@
   <main id="wellnessDirectory" class="directory" aria-label="Wellness directory sections">
     <nav class="directory-nav" aria-label="Wellness quick links">
       <a href="#mindfulness">Mindfulness</a>
+      <a href="body-mode/">Body Mode</a>
       <a href="meditation/">Breathing Room</a>
       <a href="#meditation">Meditation</a>
       <a href="#nutrition">Food &amp; Nutrition</a>
@@ -175,6 +176,7 @@
           <li>Keep a gratitude log that highlights team wins and personal growth.</li>
         </ul>
         <div class="resource-links">
+          <a href="body-mode/">Body Mode resets →</a>
           <a href="meditation/">3DVR breathing room →</a>
           <a href="https://www.mindful.org/category/mindfulness-practice/" target="_blank" rel="noopener">Guided practices →</a>
           <a href="https://www.headspace.com/mindfulness" target="_blank" rel="noopener">Headspace tips →</a>


### PR DESCRIPTION
## Summary
- Adds `/body-mode/`, a sensory-friendly wellness-tech section with cards for Seated Spine Reset, Breathing Room, Integration Journal, One Next Action, and Sleep Wind-Down.
- Adds `/body-mode/seated-spine-reset/` as the first working Body Mode app with a 4:05 seated routine, timer controls, step navigation, posture visual, and gentle safety copy.
- Adds shared Body Mode preferences in localStorage for `reduceMotion`, `preferredMode`, and `lastUsedApp`.
- Registers Body Mode in the portal app dock, Wellness Directory, README install list, and PWA manifests.

## Safety framing
- Includes the requested disclaimer: tools support reflection, relaxation, and self-care; they are not medical advice or a substitute for professional care.
- Avoids claims about curing illness, releasing DMT, or treating trauma.
- Keeps motion minimal and provides a Reduce Motion toggle.

## Verification
- `node --test tests/body-mode.test.js` passes.
- `git diff --check` passes.
- Local browser smoke on `http://127.0.0.1:3000/body-mode/` passed for landing page navigation, preference persistence, Seated Spine Reset timer controls, and last-used app storage. The only console errors were expected local 404s for Vercel's injected insights script on the local dev server.

## Billing
- No Stripe or billing changes.
