### PR TITLE
[codex] Add seated spine reset app

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Attention Visualized](https://3dvr-portal.vercel.app/attention-visualized/)
 - [Logic Lab](https://3dvr-portal.vercel.app/logic-lab/)
 - [Intention Lab](https://3dvr-portal.vercel.app/intention-lab/)
+- [Seated Spine Reset](https://3dvr-portal.vercel.app/seated-spine-reset/)
 
 Open the page you want and use your browser’s **Install** or **Add to Home Screen** option to pin it like a native app.
 
@@ -100,6 +101,7 @@ Brave shields can block realtime sync. Click the 🛡️ icon and either turn Sh
 - Keep the portal node as the source of truth, and avoid device-local only storage for anything that should follow a user between browsers.
 - Ensure guest or SEA identities are initialized (via `ScoreSystem.ensureGuestIdentity`) before writing so contributions are properly attributed across apps.
 - Alive System state syncs through `gun.get('3dvr-portal').get('alive-system')`, with per-author dashboard state and append-only activity entries for redirects, check-ins, morning rituals, and social logs.
+- Seated Spine Reset is local-first in v1 and exposes `window.SeatedSpineReset.setPortalBridge(...)` so portal or Gun-backed completion sync can be added later without coupling the wellness app to login.
 
 ### Run Locally
 

--- a/index.html
+++ b/index.html
@@ -423,6 +423,11 @@
             <span class="app-card__title">Meditation</span>
             <span class="app-card__meta">Jump into the breathing room for guided calming cycles.</span>
           </a>
+          <a href="seated-spine-reset/" class="app-card" data-app-keywords="wellness posture spine stretch av tech conference laptop chair breathing">
+            <span class="app-card__icon" aria-hidden="true">AV</span>
+            <span class="app-card__title">Seated Spine Reset</span>
+            <span class="app-card__meta">Run a quiet chair-based posture reset for neck, shoulders, spine, hips, and breath.</span>
+          </a>
           <a href="meeting-notes/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🗒️</span>
             <span class="app-card__title">Meetings</span>

--- a/seated-spine-reset/app.js
+++ b/seated-spine-reset/app.js
@@ -1,0 +1,874 @@
+(() => {
+  const STORAGE_KEY = 'seated-spine-reset-preferences';
+  const COMPLETION_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+
+  const fullRoutine = [
+    {
+      id: 'crown-up',
+      title: 'Crown Up Posture Reset',
+      instruction: 'Sit toward the front of the chair. Feet flat. Imagine the crown of your head floating upward.',
+      cue: '3 slow breaths',
+      duration: 24,
+      visual: 'crown',
+      caption: 'Crown lifts while feet settle into the floor.'
+    },
+    {
+      id: 'chin-tucks',
+      title: 'Chin Tucks',
+      instruction: 'Gently slide your chin straight back, like making a small double chin. Keep your eyes level.',
+      cue: '5-10 reps',
+      reps: 8,
+      duration: 30,
+      visual: 'chin',
+      caption: 'Head glides straight back. Eyes stay level.'
+    },
+    {
+      id: 'shoulder-blades',
+      title: 'Shoulder Blade Squeezes',
+      instruction: 'Keep shoulders low. Gently pull shoulder blades back and slightly down.',
+      cue: '5-10 reps',
+      reps: 8,
+      duration: 30,
+      visual: 'shoulders',
+      caption: 'Shoulders stay low while the upper back wakes up.'
+    },
+    {
+      id: 'neck-side-stretch',
+      title: 'Neck Side Stretch',
+      instruction: 'Let one ear drift toward the same-side shoulder. Keep both shoulders relaxed. Switch sides.',
+      cue: '10-20 seconds each side',
+      duration: 40,
+      visual: 'side-stretch',
+      caption: 'A small side bend is enough. No forcing.'
+    },
+    {
+      id: 'neck-rotation',
+      title: 'Neck Rotation',
+      instruction: 'Slowly turn your head right, then left, only as far as comfortable.',
+      cue: '5 each side',
+      reps: 10,
+      duration: 30,
+      visual: 'rotation',
+      caption: 'Rotate inside an easy range. Jaw and shoulders stay quiet.'
+    },
+    {
+      id: 'chest-opener',
+      title: 'Seated Chest Opener',
+      instruction: 'Clasp hands behind your back or hold the chair. Open the chest gently.',
+      cue: '15-30 seconds',
+      duration: 32,
+      visual: 'chest',
+      caption: 'Collarbones widen while ribs stay soft.'
+    },
+    {
+      id: 'spinal-wave',
+      title: 'Seated Spinal Wave',
+      instruction: 'Round your back slightly, then slowly lift your chest. Move like a seated cat-cow.',
+      cue: '5-8 reps',
+      reps: 6,
+      duration: 32,
+      visual: 'wave',
+      caption: 'Round a little, then lift a little. Keep it smooth.'
+    },
+    {
+      id: 'figure-four',
+      title: 'Seated Figure-Four Hip Stretch',
+      instruction: 'Cross one ankle over the opposite knee. Sit tall. Lean forward gently. Switch sides.',
+      cue: '20-30 seconds each side',
+      duration: 50,
+      visual: 'figure-four',
+      caption: 'Hip stretch stays gentle. Spine keeps length.'
+    },
+    {
+      id: 'show-cue-reset',
+      title: 'Invisible Show-Cue Reset',
+      instruction: 'Exhale fully. Chin gently back. Shoulders down. Feet press into floor. Crown lifts.',
+      cue: '1 calm breath',
+      duration: 14,
+      visual: 'breath',
+      caption: 'Return to the room: upright, calm, and available.',
+      closing: 'You are upright, calm, and available.'
+    }
+  ];
+
+  const quickRoutine = [
+    {
+      id: 'quick-crown',
+      title: 'Crown Up',
+      instruction: 'Sit toward the front of the chair. Feet flat. Let the crown of your head float upward.',
+      cue: '2 slow breaths',
+      duration: 15,
+      visual: 'crown',
+      caption: 'Tall without stiffness.'
+    },
+    {
+      id: 'quick-chin',
+      title: 'Chin Tuck',
+      instruction: 'Slide your chin straight back once or twice. Keep your eyes level.',
+      cue: '5 reps',
+      reps: 5,
+      duration: 15,
+      visual: 'chin',
+      caption: 'Small glide. Neck stays long.'
+    },
+    {
+      id: 'quick-shoulder',
+      title: 'Shoulder Down/Back',
+      instruction: 'Let shoulders drop. Pull shoulder blades back and slightly down.',
+      cue: '5 reps',
+      reps: 5,
+      duration: 15,
+      visual: 'shoulders',
+      caption: 'Shoulders drop away from ears.'
+    },
+    {
+      id: 'quick-breath',
+      title: 'One Breath',
+      instruction: 'Exhale fully. Feel both feet press into the floor.',
+      cue: '1 calm breath',
+      duration: 8,
+      visual: 'breath',
+      caption: 'Empty the breath and let the room come back into focus.'
+    },
+    {
+      id: 'quick-close',
+      title: 'Closing Message',
+      instruction: 'Chin gently back. Shoulders down. Crown lifts.',
+      cue: 'Available',
+      duration: 7,
+      visual: 'crown',
+      caption: 'Ready for the next cue.',
+      closing: 'You are upright, calm, and available.'
+    }
+  ];
+
+  const screens = {
+    landing: document.querySelector('[data-screen="landing"]'),
+    routine: document.querySelector('[data-screen="routine"]')
+  };
+  const elements = {
+    shell: document.querySelector('[data-app-shell]'),
+    startButtons: [...document.querySelectorAll('[data-start-mode]')],
+    prefInputs: [...document.querySelectorAll('[data-pref]')],
+    lastCompleted: document.querySelector('[data-last-completed]'),
+    modeLabel: document.querySelector('[data-mode-label]'),
+    stepTitle: document.querySelector('[data-step-title]'),
+    stepInstruction: document.querySelector('[data-step-instruction]'),
+    stepCount: document.querySelector('[data-step-count]'),
+    totalTime: document.querySelector('[data-total-time]'),
+    routineProgress: document.querySelector('[data-routine-progress]'),
+    timerRing: document.querySelector('[data-timer-ring]'),
+    timerPrimary: document.querySelector('[data-timer-primary]'),
+    timerSecondary: document.querySelector('[data-timer-secondary]'),
+    closingMessage: document.querySelector('[data-closing-message]'),
+    visualCaption: document.querySelector('[data-visual-caption]'),
+    threeStage: document.querySelector('[data-three-stage]'),
+    fallbackSymbol: document.querySelector('[data-fallback-symbol]'),
+    controls: [...document.querySelectorAll('[data-action]')],
+    pauseButton: document.querySelector('[data-action="pause"]')
+  };
+
+  const defaultPrefs = {
+    reduceMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    silentMode: true,
+    preferredMode: 'full',
+    lastCompletedDate: ''
+  };
+
+  let prefs = loadPreferences();
+  let currentMode = prefs.preferredMode === 'quick' ? 'quick' : 'full';
+  let routine = currentMode === 'quick' ? quickRoutine : fullRoutine;
+  let currentIndex = 0;
+  let remainingMs = routine[0].duration * 1000;
+  let stepDurationMs = remainingMs;
+  let running = false;
+  let lastTick = 0;
+  let timerId = null;
+  let audioContext = null;
+  let visualController = null;
+
+  const portalBridge = {
+    onPreferenceChange: null,
+    onRoutineComplete: null
+  };
+
+  window.SeatedSpineReset = {
+    setPortalBridge(bridge = {}) {
+      portalBridge.onPreferenceChange = typeof bridge.onPreferenceChange === 'function'
+        ? bridge.onPreferenceChange
+        : null;
+      portalBridge.onRoutineComplete = typeof bridge.onRoutineComplete === 'function'
+        ? bridge.onRoutineComplete
+        : null;
+    },
+    getState() {
+      return {
+        mode: currentMode,
+        stepIndex: currentIndex,
+        running,
+        preferences: { ...prefs }
+      };
+    }
+  };
+
+  function loadPreferences() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      return {
+        ...defaultPrefs,
+        ...parsed,
+        reduceMotion: typeof parsed.reduceMotion === 'boolean' ? parsed.reduceMotion : defaultPrefs.reduceMotion,
+        silentMode: typeof parsed.silentMode === 'boolean' ? parsed.silentMode : true
+      };
+    } catch (error) {
+      console.warn('Unable to load Seated Spine Reset preferences', error);
+      return { ...defaultPrefs };
+    }
+  }
+
+  function savePreferences() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    } catch (error) {
+      console.warn('Unable to save Seated Spine Reset preferences', error);
+    }
+    if (portalBridge.onPreferenceChange) {
+      portalBridge.onPreferenceChange({ ...prefs });
+    }
+  }
+
+  function formatTime(seconds) {
+    const safeSeconds = Math.max(0, Math.ceil(seconds));
+    const minutes = Math.floor(safeSeconds / 60);
+    const remainder = safeSeconds % 60;
+    if (!minutes) return `${remainder}s`;
+    return `${minutes}:${String(remainder).padStart(2, '0')}`;
+  }
+
+  function formatRoutineLength(steps) {
+    const total = steps.reduce((sum, step) => sum + step.duration, 0);
+    if (total <= 75) return 'About 60 seconds';
+    const rounded = Math.max(1, Math.round(total / 60));
+    return `About ${rounded} minutes`;
+  }
+
+  function setScreen(name) {
+    Object.entries(screens).forEach(([screenName, screen]) => {
+      screen.classList.toggle('is-active', screenName === name);
+    });
+    window.requestAnimationFrame(() => {
+      if (visualController) {
+        visualController.resize();
+      }
+    });
+  }
+
+  function applyPreferences() {
+    document.body.dataset.reduceMotion = prefs.reduceMotion ? 'true' : 'false';
+    elements.prefInputs.forEach((input) => {
+      const key = input.dataset.pref;
+      input.checked = Boolean(prefs[key]);
+    });
+    if (prefs.lastCompletedDate && elements.lastCompleted) {
+      const date = new Date(prefs.lastCompletedDate);
+      elements.lastCompleted.hidden = false;
+      elements.lastCompleted.textContent = Number.isNaN(date.getTime())
+        ? `Last completed: ${prefs.lastCompletedDate}`
+        : `Last completed: ${COMPLETION_DATE_FORMAT.format(date)}`;
+    }
+    if (visualController) {
+      visualController.setReduceMotion(prefs.reduceMotion);
+    }
+  }
+
+  function updatePauseButton() {
+    elements.pauseButton.textContent = running ? 'Pause' : 'Continue';
+  }
+
+  function setCurrentStep(index, { resetTimer = true, cue = true } = {}) {
+    currentIndex = Math.min(Math.max(index, 0), routine.length - 1);
+    const step = routine[currentIndex];
+    if (resetTimer) {
+      stepDurationMs = step.duration * 1000;
+      remainingMs = stepDurationMs;
+      lastTick = performance.now();
+    }
+
+    elements.modeLabel.textContent = currentMode === 'quick' ? 'Quick Reset' : 'Full Routine';
+    elements.stepTitle.textContent = step.title;
+    elements.stepInstruction.textContent = step.instruction;
+    elements.stepCount.textContent = `Step ${currentIndex + 1} of ${routine.length}`;
+    elements.totalTime.textContent = formatRoutineLength(routine);
+    elements.timerSecondary.textContent = step.cue;
+    elements.closingMessage.hidden = !step.closing;
+    if (step.closing) {
+      elements.closingMessage.textContent = step.closing;
+    }
+    elements.visualCaption.textContent = step.caption;
+    elements.fallbackSymbol.textContent = fallbackTextForStep(step.visual);
+    if (elements.threeStage) {
+      elements.threeStage.dataset.visual = step.visual;
+    }
+
+    if (visualController) {
+      visualController.setStep(step.visual);
+    }
+    updateProgress();
+    updatePauseButton();
+
+    if (cue) {
+      cueStepChange();
+    }
+  }
+
+  function fallbackTextForStep(visual) {
+    const labels = {
+      crown: 'UP',
+      chin: 'CHIN',
+      shoulders: 'BACK',
+      'side-stretch': 'SIDE',
+      rotation: 'TURN',
+      chest: 'OPEN',
+      wave: 'WAVE',
+      'figure-four': 'HIP',
+      breath: 'BREATHE'
+    };
+    return labels[visual] || 'RESET';
+  }
+
+  function updateProgress() {
+    const step = routine[currentIndex];
+    const elapsed = Math.max(0, stepDurationMs - remainingMs);
+    const stepRatio = stepDurationMs > 0 ? Math.min(1, elapsed / stepDurationMs) : 1;
+    const remainingSeconds = remainingMs / 1000;
+    const routineRatio = routine.length > 1
+      ? (currentIndex + stepRatio) / routine.length
+      : stepRatio;
+
+    elements.timerRing.style.setProperty('--timer-progress', String(Math.max(0, 1 - stepRatio)));
+    elements.timerRing.setAttribute('aria-valuenow', String(Math.round((1 - stepRatio) * 100)));
+    elements.routineProgress.style.width = `${Math.min(100, Math.max(0, routineRatio * 100))}%`;
+
+    if (step.reps) {
+      const repsDone = Math.min(step.reps, Math.floor(stepRatio * step.reps));
+      elements.timerPrimary.textContent = `${Math.max(0, step.reps - repsDone)} reps`;
+      elements.timerSecondary.textContent = `${formatTime(remainingSeconds)} left`;
+    } else if (/breath/i.test(step.cue)) {
+      elements.timerPrimary.textContent = step.cue;
+      elements.timerSecondary.textContent = formatTime(remainingSeconds);
+    } else {
+      elements.timerPrimary.textContent = formatTime(remainingSeconds);
+      elements.timerSecondary.textContent = step.cue;
+    }
+  }
+
+  function startRoutine(mode) {
+    currentMode = mode === 'quick' ? 'quick' : 'full';
+    prefs.preferredMode = currentMode;
+    savePreferences();
+    routine = currentMode === 'quick' ? quickRoutine : fullRoutine;
+    setScreen('routine');
+    running = true;
+    setCurrentStep(0, { resetTimer: true, cue: false });
+    startTimer();
+    cueStepChange();
+  }
+
+  function startTimer() {
+    stopTimer();
+    lastTick = performance.now();
+    timerId = window.setInterval(tick, 250);
+    updatePauseButton();
+  }
+
+  function stopTimer() {
+    if (timerId) {
+      window.clearInterval(timerId);
+      timerId = null;
+    }
+  }
+
+  function tick() {
+    if (!running) return;
+    const now = performance.now();
+    const delta = now - lastTick;
+    lastTick = now;
+    remainingMs = Math.max(0, remainingMs - delta);
+    updateProgress();
+    if (remainingMs <= 0) {
+      goNext({ auto: true });
+    }
+  }
+
+  function togglePause() {
+    running = !running;
+    lastTick = performance.now();
+    updatePauseButton();
+  }
+
+  function goNext({ auto = false } = {}) {
+    if (currentIndex >= routine.length - 1) {
+      completeRoutine();
+      return;
+    }
+    setCurrentStep(currentIndex + 1, { resetTimer: true, cue: true });
+    if (auto) {
+      lastTick = performance.now();
+    }
+  }
+
+  function goBack() {
+    setCurrentStep(currentIndex - 1, { resetTimer: true, cue: false });
+    running = true;
+    lastTick = performance.now();
+    updatePauseButton();
+  }
+
+  function restartRoutine() {
+    running = true;
+    setCurrentStep(0, { resetTimer: true, cue: false });
+    startTimer();
+    cueStepChange();
+  }
+
+  function completeRoutine() {
+    running = false;
+    stopTimer();
+    remainingMs = 0;
+    updateProgress();
+    updatePauseButton();
+    prefs.lastCompletedDate = new Date().toISOString();
+    savePreferences();
+    applyPreferences();
+    const summary = {
+      mode: currentMode,
+      completedAt: prefs.lastCompletedDate,
+      steps: routine.map((step) => step.id)
+    };
+    if (portalBridge.onRoutineComplete) {
+      portalBridge.onRoutineComplete(summary);
+    }
+    cueStepChange();
+  }
+
+  function cueStepChange() {
+    if (prefs.silentMode) return;
+    if ('vibrate' in navigator) {
+      navigator.vibrate(18);
+    }
+    playSoftChime();
+  }
+
+  function getAudioContext() {
+    const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextClass) return null;
+    if (!audioContext) {
+      audioContext = new AudioContextClass();
+    }
+    if (audioContext.state === 'suspended') {
+      audioContext.resume().catch(() => {});
+    }
+    return audioContext;
+  }
+
+  function playSoftChime() {
+    const context = getAudioContext();
+    if (!context) return;
+    const now = context.currentTime;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(440, now);
+    oscillator.frequency.exponentialRampToValueAtTime(660, now + 0.18);
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.08, now + 0.03);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.42);
+    oscillator.connect(gain).connect(context.destination);
+    oscillator.start(now);
+    oscillator.stop(now + 0.45);
+  }
+
+  elements.startButtons.forEach((button) => {
+    button.addEventListener('click', () => startRoutine(button.dataset.startMode));
+  });
+
+  elements.prefInputs.forEach((input) => {
+    input.addEventListener('change', () => {
+      const key = input.dataset.pref;
+      prefs[key] = input.checked;
+      if (key === 'silentMode' && !prefs.silentMode) {
+        getAudioContext();
+      }
+      savePreferences();
+      applyPreferences();
+    });
+  });
+
+  elements.controls.forEach((button) => {
+    button.addEventListener('click', () => {
+      const action = button.dataset.action;
+      if (action === 'pause') togglePause();
+      if (action === 'next') goNext();
+      if (action === 'back') goBack();
+      if (action === 'restart') restartRoutine();
+    });
+  });
+
+  function createVisualController() {
+    const canvas = document.querySelector('[data-three-canvas]');
+    const stage = document.querySelector('[data-three-stage]');
+    const fallback = document.querySelector('[data-visual-fallback]');
+    const THREE = window.THREE;
+
+    if (!canvas || !stage || !THREE || !webGLAvailable()) {
+      if (fallback) fallback.hidden = false;
+      return {
+        setStep() {},
+        setReduceMotion() {},
+        resize() {}
+      };
+    }
+
+    let renderer;
+    try {
+      renderer = new THREE.WebGLRenderer({
+        canvas,
+        antialias: true,
+        alpha: true,
+        preserveDrawingBuffer: true
+      });
+    } catch (error) {
+      console.warn('Unable to initialize Seated Spine Reset 3D visual', error);
+      fallback.hidden = false;
+      return {
+        setStep() {},
+        setReduceMotion() {},
+        resize() {}
+      };
+    }
+
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.setClearColor(0x000000, 0);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(38, 1, 0.1, 100);
+    camera.position.set(0, 2.2, 8.4);
+
+    const root = new THREE.Group();
+    scene.add(root);
+
+    const body = new THREE.Group();
+    const cues = new THREE.Group();
+    root.add(body, cues);
+
+    scene.add(new THREE.HemisphereLight(0xf6dfbd, 0x1b201e, 1.5));
+    const key = new THREE.DirectionalLight(0xffd6a0, 2);
+    key.position.set(4, 5, 6);
+    scene.add(key);
+    const fill = new THREE.DirectionalLight(0x8dc8bd, 0.7);
+    fill.position.set(-5, 2, 4);
+    scene.add(fill);
+
+    const materials = {
+      line: new THREE.MeshStandardMaterial({ color: 0xf0b56d, roughness: 0.62, metalness: 0.05 }),
+      soft: new THREE.MeshStandardMaterial({ color: 0x9eb89a, roughness: 0.7, metalness: 0.02 }),
+      clay: new THREE.MeshStandardMaterial({ color: 0xce7a5b, roughness: 0.68, metalness: 0.02 }),
+      dim: new THREE.MeshStandardMaterial({ color: 0x4b4840, roughness: 0.8, metalness: 0.04 }),
+      floor: new THREE.MeshStandardMaterial({ color: 0x25231e, roughness: 0.9, metalness: 0.02 })
+    };
+
+    const makeBox = (w, h, d, material, x, y, z) => {
+      const mesh = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), material);
+      mesh.position.set(x, y, z);
+      return mesh;
+    };
+
+    const makeCylinder = (radius, height, material, x, y, z, axis = 'y') => {
+      const mesh = new THREE.Mesh(new THREE.CylinderGeometry(radius, radius, height, 28), material);
+      mesh.position.set(x, y, z);
+      if (axis === 'x') mesh.rotation.z = Math.PI / 2;
+      if (axis === 'z') mesh.rotation.x = Math.PI / 2;
+      return mesh;
+    };
+
+    const floor = makeBox(7.8, 0.08, 4.6, materials.floor, 0, -1.48, 0);
+    const chair = new THREE.Group();
+    chair.add(
+      makeBox(2.35, 0.16, 1.7, materials.dim, 0, -0.7, 0),
+      makeBox(2.35, 1.9, 0.16, materials.dim, 0, 0.18, -0.82),
+      makeCylinder(0.05, 1.5, materials.dim, -1.0, -1.2, -0.55),
+      makeCylinder(0.05, 1.5, materials.dim, 1.0, -1.2, -0.55),
+      makeCylinder(0.05, 1.5, materials.dim, -1.0, -1.2, 0.55),
+      makeCylinder(0.05, 1.5, materials.dim, 1.0, -1.2, 0.55)
+    );
+    root.add(floor, chair);
+
+    const torso = makeCylinder(0.44, 1.55, materials.line, 0, 0.28, 0);
+    torso.scale.x = 0.72;
+    torso.scale.z = 0.5;
+    const neck = makeCylinder(0.13, 0.38, materials.soft, 0, 1.2, 0.02);
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.34, 32, 24), materials.soft);
+    head.position.set(0, 1.66, 0.04);
+    const shoulderBar = makeCylinder(0.075, 1.55, materials.clay, 0, 0.92, 0.02, 'x');
+    const leftArm = makeCylinder(0.07, 1.25, materials.soft, -0.68, 0.34, 0.05);
+    leftArm.rotation.z = -0.16;
+    const rightArm = makeCylinder(0.07, 1.25, materials.soft, 0.68, 0.34, 0.05);
+    rightArm.rotation.z = 0.16;
+    const leftThigh = makeCylinder(0.09, 1.1, materials.soft, -0.44, -0.74, 0.48, 'z');
+    const rightThigh = makeCylinder(0.09, 1.1, materials.soft, 0.44, -0.74, 0.48, 'z');
+    const leftShin = makeCylinder(0.08, 1.15, materials.soft, -0.44, -1.12, 0.95);
+    leftShin.rotation.x = 0.12;
+    const rightShin = makeCylinder(0.08, 1.15, materials.soft, 0.44, -1.12, 0.95);
+    rightShin.rotation.x = 0.12;
+
+    body.add(torso, neck, head, shoulderBar, leftArm, rightArm, leftThigh, rightThigh, leftShin, rightShin);
+
+    const arrowMaterial = new THREE.MeshStandardMaterial({ color: 0x8dc8bd, roughness: 0.55, metalness: 0.05 });
+    const amberMaterial = new THREE.MeshStandardMaterial({ color: 0xf0b56d, roughness: 0.55, metalness: 0.05 });
+
+    function makeArrow(length = 1.1, material = arrowMaterial) {
+      const group = new THREE.Group();
+      const shaft = makeCylinder(0.035, length, material, 0, 0, 0);
+      const cone = new THREE.Mesh(new THREE.ConeGeometry(0.13, 0.28, 28), material);
+      cone.position.y = length / 2 + 0.14;
+      group.add(shaft, cone);
+      return group;
+    }
+
+    function makeRing(radius = 0.8) {
+      const ring = new THREE.Mesh(
+        new THREE.TorusGeometry(radius, 0.028, 12, 80),
+        new THREE.MeshStandardMaterial({ color: 0xf0b56d, transparent: true, opacity: 0.72 })
+      );
+      return ring;
+    }
+
+    const cueObjects = {
+      crown: makeArrow(0.9, arrowMaterial),
+      chin: makeArrow(0.64, amberMaterial),
+      shouldersLeft: makeArrow(0.7, arrowMaterial),
+      shouldersRight: makeArrow(0.7, arrowMaterial),
+      side: makeArrow(0.82, amberMaterial),
+      rotation: makeRing(0.58),
+      chestLeft: makeArrow(0.7, arrowMaterial),
+      chestRight: makeArrow(0.7, arrowMaterial),
+      wave: makeRing(0.78),
+      hip: makeArrow(0.78, amberMaterial),
+      breath: makeRing(1.18)
+    };
+
+    cueObjects.crown.position.set(0, 2.34, 0.04);
+    cueObjects.chin.position.set(0.12, 1.7, 0.84);
+    cueObjects.chin.rotation.x = Math.PI / 2;
+    cueObjects.shouldersLeft.position.set(-1.08, 0.94, 0.08);
+    cueObjects.shouldersLeft.rotation.z = -Math.PI / 2;
+    cueObjects.shouldersRight.position.set(1.08, 0.94, 0.08);
+    cueObjects.shouldersRight.rotation.z = Math.PI / 2;
+    cueObjects.side.position.set(-0.74, 1.78, 0.05);
+    cueObjects.side.rotation.z = 0.62;
+    cueObjects.rotation.position.set(0, 1.66, 0.06);
+    cueObjects.rotation.rotation.x = Math.PI / 2;
+    cueObjects.chestLeft.position.set(-1.0, 0.64, 0.12);
+    cueObjects.chestLeft.rotation.z = Math.PI / 2;
+    cueObjects.chestRight.position.set(1.0, 0.64, 0.12);
+    cueObjects.chestRight.rotation.z = -Math.PI / 2;
+    cueObjects.wave.position.set(0, 0.42, 0.1);
+    cueObjects.wave.scale.set(0.8, 1.18, 0.8);
+    cueObjects.hip.position.set(0.9, -0.42, 0.76);
+    cueObjects.hip.rotation.z = -0.72;
+    cueObjects.breath.position.set(0, 0.45, 0.18);
+    cueObjects.breath.scale.set(1, 1.25, 1);
+
+    Object.values(cueObjects).forEach((object) => cues.add(object));
+
+    let activeStep = 'crown';
+    let reduceMotion = prefs.reduceMotion;
+    let dragActive = false;
+    let dragStartX = 0;
+    let baseRotation = -0.14;
+    let targetRotation = baseRotation;
+    const clock = new THREE.Clock();
+
+    function setCueVisibility() {
+      Object.values(cueObjects).forEach((object) => {
+        object.visible = false;
+      });
+      if (activeStep === 'crown') cueObjects.crown.visible = true;
+      if (activeStep === 'chin') cueObjects.chin.visible = true;
+      if (activeStep === 'shoulders') {
+        cueObjects.shouldersLeft.visible = true;
+        cueObjects.shouldersRight.visible = true;
+      }
+      if (activeStep === 'side-stretch') cueObjects.side.visible = true;
+      if (activeStep === 'rotation') cueObjects.rotation.visible = true;
+      if (activeStep === 'chest') {
+        cueObjects.chestLeft.visible = true;
+        cueObjects.chestRight.visible = true;
+      }
+      if (activeStep === 'wave') cueObjects.wave.visible = true;
+      if (activeStep === 'figure-four') cueObjects.hip.visible = true;
+      if (activeStep === 'breath') cueObjects.breath.visible = true;
+    }
+
+    function applyPose(time) {
+      const motion = reduceMotion ? 0 : Math.sin(time * 1.4);
+      body.rotation.set(0, 0, 0);
+      torso.rotation.set(0, 0, 0);
+      neck.rotation.set(0, 0, 0);
+      head.rotation.set(0, 0, 0);
+      shoulderBar.position.y = 0.92;
+      leftArm.position.set(-0.68, 0.34, 0.05);
+      rightArm.position.set(0.68, 0.34, 0.05);
+      leftArm.rotation.set(0, 0, -0.16);
+      rightArm.rotation.set(0, 0, 0.16);
+      leftThigh.position.set(-0.44, -0.74, 0.48);
+      rightThigh.position.set(0.44, -0.74, 0.48);
+      leftThigh.rotation.set(Math.PI / 2, 0, 0);
+      rightThigh.rotation.set(Math.PI / 2, 0, 0);
+      root.rotation.y += (targetRotation - root.rotation.y) * 0.08;
+
+      if (activeStep === 'chin') {
+        head.position.z = -0.06 - motion * 0.025;
+        neck.position.z = -0.02;
+      } else {
+        head.position.z = 0.04;
+        neck.position.z = 0.02;
+      }
+
+      if (activeStep === 'shoulders') {
+        shoulderBar.position.y = 0.86 - Math.abs(motion) * 0.035;
+        shoulderBar.scale.x = 0.92;
+      } else {
+        shoulderBar.scale.x = 1;
+      }
+
+      if (activeStep === 'side-stretch') {
+        body.rotation.z = -0.12 - motion * 0.025;
+        head.rotation.z = -0.22 - motion * 0.025;
+      }
+
+      if (activeStep === 'rotation') {
+        head.rotation.y = motion * 0.42;
+      }
+
+      if (activeStep === 'chest') {
+        torso.rotation.x = -0.08;
+        leftArm.position.set(-0.72, 0.2, -0.28);
+        rightArm.position.set(0.72, 0.2, -0.28);
+        leftArm.rotation.z = 0.18;
+        rightArm.rotation.z = -0.18;
+      }
+
+      if (activeStep === 'wave') {
+        torso.rotation.x = motion * 0.16;
+        head.position.y = 1.63 + motion * 0.04;
+      }
+
+      if (activeStep === 'figure-four') {
+        rightThigh.position.set(0.22, -0.5, 0.56);
+        rightThigh.rotation.set(Math.PI / 2, 0, 1.12);
+        body.rotation.x = -0.05;
+      }
+
+      if (activeStep === 'breath') {
+        const scale = reduceMotion ? 1 : 1 + Math.sin(time * 1.15) * 0.045;
+        torso.scale.set(0.72 * scale, 1, 0.5 * scale);
+        cueObjects.breath.scale.set(scale, 1.25 * scale, scale);
+      } else {
+        torso.scale.set(0.72, 1, 0.5);
+      }
+    }
+
+    function resize() {
+      const rect = stage.getBoundingClientRect();
+      const width = Math.max(1, Math.floor(rect.width));
+      const height = Math.max(300, Math.floor(rect.height));
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.position.z = width < 520 ? 9.1 : 8.1;
+      camera.updateProjectionMatrix();
+    }
+
+    function render() {
+      const time = clock.getElapsedTime();
+      applyPose(time);
+      if (!reduceMotion) {
+        cues.children.forEach((object, index) => {
+          if (!object.visible) return;
+          const pulse = 1 + Math.sin(time * 1.8 + index) * 0.035;
+          object.scale.multiplyScalar(pulse / (object.userData.lastPulse || 1));
+          object.userData.lastPulse = pulse;
+        });
+      }
+      renderer.render(scene, camera);
+      window.requestAnimationFrame(render);
+    }
+
+    canvas.addEventListener('pointerdown', (event) => {
+      dragActive = true;
+      dragStartX = event.clientX;
+      canvas.setPointerCapture(event.pointerId);
+    });
+    canvas.addEventListener('pointermove', (event) => {
+      if (!dragActive) return;
+      const delta = Math.max(-120, Math.min(120, event.clientX - dragStartX));
+      targetRotation = baseRotation + delta / 260;
+    });
+    canvas.addEventListener('pointerup', (event) => {
+      dragActive = false;
+      baseRotation = targetRotation;
+      canvas.releasePointerCapture(event.pointerId);
+    });
+    canvas.addEventListener('pointercancel', () => {
+      dragActive = false;
+    });
+
+    window.addEventListener('resize', resize);
+    setCueVisibility();
+    resize();
+    render();
+
+    return {
+      setStep(step) {
+        activeStep = step;
+        setCueVisibility();
+      },
+      setReduceMotion(value) {
+        reduceMotion = Boolean(value);
+      },
+      resize
+    };
+  }
+
+  function webGLAvailable() {
+    try {
+      const probe = document.createElement('canvas');
+      return Boolean(
+        window.WebGLRenderingContext
+        && (
+          probe.getContext('webgl2')
+          || probe.getContext('webgl')
+          || probe.getContext('experimental-webgl')
+        )
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
+  visualController = createVisualController();
+
+  applyPreferences();
+  setCurrentStep(0, { resetTimer: true, cue: false });
+  setScreen('landing');
+
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/service-worker.js').catch((error) => {
+      console.warn('Service worker registration skipped', error);
+    });
+  }
+})();

--- a/seated-spine-reset/index.html
+++ b/seated-spine-reset/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Seated Spine Reset | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="A quiet seated posture and stretch reset for AV techs, conference work, laptop work, and long seated sessions."
+  >
+  <meta name="theme-color" content="#11110f">
+  <meta name="color-scheme" content="dark">
+  <link rel="manifest" href="./manifest.webmanifest">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
+  <link rel="apple-touch-icon" href="/icons/icon-192.png">
+  <link rel="stylesheet" href="./styles.css">
+  <script src="/pwa-install.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js" defer></script>
+  <script src="./app.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#routineTitle">Skip to routine</a>
+
+  <main class="app-shell" data-app-shell>
+    <section class="screen screen--landing is-active" data-screen="landing" aria-labelledby="landingTitle">
+      <div class="landing-grid">
+        <div class="landing-copy">
+          <p class="eyebrow">3DVR / tmsteph wellness tool</p>
+          <h1 id="landingTitle">Seated Spine Reset</h1>
+          <p class="subtitle">A quiet 3&ndash;5 minute reset for neck, shoulders, spine, hips, and breath.</p>
+          <p class="context-line">Built for the back of the conference room, a laptop cart, or any long seated session.</p>
+          <div class="landing-actions" aria-label="Start routine">
+            <button class="button button--primary" type="button" data-start-mode="full">Start Full Routine</button>
+            <button class="button button--secondary" type="button" data-start-mode="quick">Quick Reset</button>
+          </div>
+        </div>
+
+        <aside class="quiet-panel" aria-labelledby="landingPrefsTitle">
+          <h2 id="landingPrefsTitle">Session settings</h2>
+          <div class="toggle-stack">
+            <label class="switch-row">
+              <span>
+                <strong>Reduce Motion</strong>
+                <small>Keep the visual steady and low movement.</small>
+              </span>
+              <input type="checkbox" data-pref="reduceMotion">
+            </label>
+            <label class="switch-row">
+              <span>
+                <strong>Silent Mode</strong>
+                <small>No sound or vibration cues.</small>
+              </span>
+              <input type="checkbox" data-pref="silentMode">
+            </label>
+          </div>
+          <p class="last-done" data-last-completed hidden></p>
+        </aside>
+      </div>
+
+      <p class="safety-note">
+        Move gently. Stop if you feel sharp pain, dizziness, numbness, tingling, or symptoms down the arm. This is not medical advice.
+      </p>
+    </section>
+
+    <section class="screen screen--routine" data-screen="routine" aria-labelledby="routineTitle">
+      <header class="routine-header">
+        <div>
+          <p class="eyebrow" data-mode-label>Full Routine</p>
+          <h1 id="routineTitle" data-step-title>Crown Up Posture Reset</h1>
+        </div>
+        <div class="header-actions">
+          <label class="compact-toggle">
+            <span>Motion</span>
+            <input type="checkbox" data-pref="reduceMotion">
+          </label>
+          <label class="compact-toggle">
+            <span>Silent</span>
+            <input type="checkbox" data-pref="silentMode">
+          </label>
+        </div>
+      </header>
+
+      <div class="routine-layout">
+        <section class="visual-stage" aria-labelledby="visualTitle">
+          <h2 id="visualTitle" class="sr-only">Posture visual guide</h2>
+          <div class="three-stage" data-three-stage>
+            <canvas data-three-canvas aria-label="Simple 3D seated posture guide"></canvas>
+            <div class="visual-fallback" data-visual-fallback hidden>
+              <div class="fallback-figure" aria-hidden="true">
+                <span class="fallback-chair-back"></span>
+                <span class="fallback-seat"></span>
+                <span class="fallback-spine"></span>
+                <span class="fallback-head"></span>
+                <span class="fallback-shoulders"></span>
+                <span class="fallback-arm fallback-arm--left"></span>
+                <span class="fallback-arm fallback-arm--right"></span>
+                <span class="fallback-leg fallback-leg--left"></span>
+                <span class="fallback-leg fallback-leg--right"></span>
+                <span class="fallback-cue fallback-cue--up"></span>
+                <span class="fallback-cue fallback-cue--side"></span>
+                <span class="fallback-cue fallback-cue--ring"></span>
+                <span class="fallback-cue fallback-cue--hip"></span>
+              </div>
+              <span class="fallback-label" data-fallback-symbol>UP</span>
+            </div>
+          </div>
+          <div class="visual-caption" aria-live="polite" data-visual-caption>
+            Crown lifts while feet settle into the floor.
+          </div>
+        </section>
+
+        <section class="guidance-panel" aria-live="polite">
+          <div class="progress-line">
+            <span data-step-count>Step 1 of 9</span>
+            <span data-total-time>About 4 minutes</span>
+          </div>
+          <div class="routine-progress" aria-hidden="true">
+            <span data-routine-progress></span>
+          </div>
+
+          <p class="instruction" data-step-instruction>
+            Sit toward the front of the chair. Feet flat. Imagine the crown of your head floating upward.
+          </p>
+
+          <div
+            class="timer-ring"
+            role="progressbar"
+            aria-label="Step timer"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="100"
+            data-timer-ring
+          >
+            <div>
+              <strong data-timer-primary>3 breaths</strong>
+              <span data-timer-secondary>Slow and easy</span>
+            </div>
+          </div>
+
+          <p class="closing-message" data-closing-message hidden>You are upright, calm, and available.</p>
+
+          <div class="control-grid" aria-label="Routine controls">
+            <button class="button button--ghost" type="button" data-action="back">Back</button>
+            <button class="button button--primary" type="button" data-action="pause">Pause</button>
+            <button class="button button--ghost" type="button" data-action="next">Next</button>
+            <button class="button button--secondary" type="button" data-action="restart">Restart</button>
+          </div>
+
+          <p class="safety-note safety-note--compact">
+            Move gently. Stop if you feel sharp pain, dizziness, numbness, tingling, or symptoms down the arm. This is not medical advice.
+          </p>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <div class="install-banner is-hidden" data-install-banner hidden>
+    <div class="install-banner__text">
+      <p class="install-banner__title">Install Seated Spine Reset</p>
+      <p class="install-banner__meta">Open the chair reset quickly during setup, rehearsal, or long seated work.</p>
+    </div>
+    <button type="button" class="install-banner__action" data-install-button>Install app</button>
+  </div>
+</body>
+</html>

--- a/seated-spine-reset/manifest.webmanifest
+++ b/seated-spine-reset/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "id": "/seated-spine-reset/",
+  "name": "Seated Spine Reset",
+  "short_name": "Spine Reset",
+  "description": "A quiet seated posture and stretch reset for AV techs, laptop work, and long seated sessions.",
+  "start_url": "/seated-spine-reset/?source=pwa",
+  "scope": "/seated-spine-reset/",
+  "display": "standalone",
+  "background_color": "#11110f",
+  "theme_color": "#11110f",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/seated-spine-reset/styles.css
+++ b/seated-spine-reset/styles.css
@@ -1,0 +1,892 @@
+:root {
+  color-scheme: dark;
+  --bg: #11110f;
+  --surface: #191815;
+  --surface-strong: #211f1a;
+  --line: rgba(239, 218, 184, 0.18);
+  --line-strong: rgba(246, 177, 106, 0.38);
+  --text: #f7efe3;
+  --muted: rgba(247, 239, 227, 0.72);
+  --faint: rgba(247, 239, 227, 0.52);
+  --amber: #f0b56d;
+  --sage: #9eb89a;
+  --clay: #ce7a5b;
+  --teal: #8dc8bd;
+  --ink: #0d0c0a;
+  --shadow: rgba(0, 0, 0, 0.36);
+  --radius: 8px;
+  --tap: 52px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+  background: var(--bg);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0) 34%),
+    linear-gradient(145deg, #11110f 0%, #171612 48%, #0d1110 100%);
+  color: var(--text);
+}
+
+body[data-reduce-motion="true"] *,
+body[data-reduce-motion="true"] *::before,
+body[data-reduce-motion="true"] *::after {
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  scroll-behavior: auto !important;
+  transition-duration: 0.001ms !important;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  min-height: var(--tap);
+}
+
+.skip-link {
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  z-index: 20;
+  transform: translate(-50%, -140%);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-strong);
+  color: var(--text);
+  padding: 12px 16px;
+  text-decoration: none;
+  transition: transform 160ms ease;
+}
+
+.skip-link:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--amber);
+  outline-offset: 3px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.app-shell {
+  width: min(1180px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: clamp(18px, 5vw, 48px);
+  display: grid;
+}
+
+.screen {
+  display: none;
+  width: 100%;
+}
+
+.screen.is-active {
+  display: grid;
+}
+
+.screen--landing {
+  align-content: center;
+  gap: 24px;
+  min-height: calc(100vh - clamp(36px, 10vw, 96px));
+}
+
+.landing-grid {
+  display: grid;
+  gap: clamp(20px, 4vw, 36px);
+  align-items: stretch;
+}
+
+.landing-copy,
+.quiet-panel,
+.guidance-panel,
+.visual-stage {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(25, 24, 21, 0.84);
+  box-shadow: 0 24px 60px var(--shadow);
+}
+
+.landing-copy {
+  padding: clamp(24px, 6vw, 56px);
+  display: grid;
+  align-content: center;
+  gap: 18px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--teal);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 2.7rem;
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 12px;
+  font-size: 1.25rem;
+  letter-spacing: 0;
+}
+
+.subtitle {
+  max-width: 780px;
+  margin-bottom: 0;
+  color: var(--text);
+  font-size: 1.4rem;
+  line-height: 1.28;
+}
+
+.context-line {
+  max-width: 680px;
+  margin-bottom: 4px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.55;
+}
+
+.landing-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  padding: 14px 18px;
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 800;
+  line-height: 1.1;
+  text-align: center;
+  text-decoration: none;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.button:focus-visible,
+.switch-row input:focus-visible,
+.compact-toggle input:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 3px;
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.button--primary {
+  background: var(--amber);
+  color: var(--ink);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  background: #ffc37c;
+}
+
+.button--secondary {
+  border-color: var(--line-strong);
+  background: rgba(158, 184, 154, 0.16);
+}
+
+.button--secondary:hover,
+.button--secondary:focus-visible,
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  border-color: rgba(240, 181, 109, 0.7);
+  background: rgba(240, 181, 109, 0.13);
+}
+
+.button--ghost {
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.quiet-panel {
+  padding: clamp(20px, 5vw, 30px);
+  display: grid;
+  align-content: center;
+  gap: 16px;
+}
+
+.toggle-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.switch-row,
+.compact-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.switch-row {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.switch-row strong,
+.switch-row small {
+  display: block;
+}
+
+.switch-row small {
+  margin-top: 4px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+input[type="checkbox"] {
+  width: 54px;
+  height: 30px;
+  flex: 0 0 auto;
+  appearance: none;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  position: relative;
+}
+
+input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  top: 3px;
+  left: 4px;
+  border-radius: 50%;
+  background: var(--muted);
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+input[type="checkbox"]:checked {
+  background: rgba(240, 181, 109, 0.28);
+}
+
+input[type="checkbox"]:checked::after {
+  transform: translateX(22px);
+  background: var(--amber);
+}
+
+.last-done {
+  margin: 0;
+  color: var(--faint);
+  font-size: 0.95rem;
+}
+
+.safety-note {
+  width: min(900px, 100%);
+  margin: 0 auto;
+  border-left: 3px solid var(--clay);
+  padding: 10px 14px;
+  color: var(--muted);
+  background: rgba(206, 122, 91, 0.08);
+  line-height: 1.5;
+}
+
+.screen--routine {
+  gap: 18px;
+  min-height: calc(100vh - clamp(36px, 10vw, 96px));
+}
+
+.routine-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.routine-header h1 {
+  margin-top: 6px;
+  font-size: 2.25rem;
+}
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+  gap: 10px;
+}
+
+.compact-toggle {
+  min-height: 46px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.compact-toggle input {
+  width: 44px;
+  height: 26px;
+}
+
+.compact-toggle input::after {
+  width: 18px;
+  height: 18px;
+}
+
+.compact-toggle input:checked::after {
+  transform: translateX(18px);
+}
+
+.routine-layout {
+  display: grid;
+  gap: 18px;
+}
+
+.visual-stage {
+  min-height: clamp(300px, 58vh, 620px);
+  overflow: hidden;
+  position: relative;
+  display: grid;
+  grid-template-rows: 1fr auto;
+}
+
+.three-stage {
+  position: relative;
+  min-height: 300px;
+  isolation: isolate;
+}
+
+.three-stage canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 300px;
+  touch-action: none;
+}
+
+.visual-fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  align-content: center;
+  place-items: center;
+  gap: 18px;
+  color: var(--amber);
+  background:
+    radial-gradient(circle at 50% 38%, rgba(240, 181, 109, 0.1), transparent 44%),
+    rgba(17, 17, 15, 0.5);
+}
+
+.visual-fallback[hidden] {
+  display: none;
+}
+
+.fallback-figure {
+  position: relative;
+  width: 250px;
+  max-width: 78%;
+  aspect-ratio: 1;
+}
+
+.fallback-figure span {
+  position: absolute;
+  display: block;
+  transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.fallback-chair-back,
+.fallback-seat {
+  border: 2px solid rgba(247, 239, 227, 0.35);
+  border-radius: var(--radius);
+}
+
+.fallback-chair-back {
+  width: 92px;
+  height: 128px;
+  left: 79px;
+  top: 70px;
+}
+
+.fallback-seat {
+  width: 138px;
+  height: 18px;
+  left: 56px;
+  top: 178px;
+}
+
+.fallback-spine {
+  width: 8px;
+  height: 96px;
+  left: 121px;
+  top: 80px;
+  border-radius: 999px;
+  background: var(--amber);
+  transform-origin: bottom center;
+}
+
+.fallback-head {
+  width: 42px;
+  height: 42px;
+  left: 104px;
+  top: 34px;
+  border: 3px solid var(--sage);
+  border-radius: 50%;
+}
+
+.fallback-shoulders {
+  width: 104px;
+  height: 8px;
+  left: 73px;
+  top: 92px;
+  border-radius: 999px;
+  background: var(--clay);
+}
+
+.fallback-arm {
+  width: 7px;
+  height: 76px;
+  top: 98px;
+  border-radius: 999px;
+  background: var(--sage);
+}
+
+.fallback-arm--left {
+  left: 78px;
+  transform: rotate(10deg);
+}
+
+.fallback-arm--right {
+  right: 78px;
+  transform: rotate(-10deg);
+}
+
+.fallback-leg {
+  width: 8px;
+  height: 74px;
+  top: 182px;
+  border-radius: 999px;
+  background: var(--sage);
+  transform-origin: top center;
+}
+
+.fallback-leg--left {
+  left: 93px;
+  transform: rotate(-10deg);
+}
+
+.fallback-leg--right {
+  right: 93px;
+  transform: rotate(10deg);
+}
+
+.fallback-cue {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.fallback-cue--up,
+.fallback-cue--side,
+.fallback-cue--hip {
+  width: 3px;
+  height: 56px;
+  border-radius: 999px;
+  background: var(--teal);
+}
+
+.fallback-cue--up {
+  left: 124px;
+  top: 0;
+}
+
+.fallback-cue--up::after,
+.fallback-cue--side::after,
+.fallback-cue--hip::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -2px;
+  width: 14px;
+  height: 14px;
+  border-left: 3px solid var(--teal);
+  border-top: 3px solid var(--teal);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.fallback-cue--side {
+  left: 56px;
+  top: 42px;
+  transform: rotate(-42deg);
+}
+
+.fallback-cue--hip {
+  left: 176px;
+  top: 170px;
+  transform: rotate(132deg);
+}
+
+.fallback-cue--ring {
+  width: 76px;
+  height: 76px;
+  left: 87px;
+  top: 18px;
+  border: 3px solid var(--teal);
+  border-radius: 50%;
+}
+
+.fallback-label {
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  background: rgba(240, 181, 109, 0.12);
+  color: var(--text);
+  font-size: 1.2rem;
+  font-weight: 900;
+  letter-spacing: 0;
+}
+
+.three-stage[data-visual="crown"] .fallback-cue--up,
+.three-stage[data-visual="breath"] .fallback-cue--up {
+  opacity: 1;
+}
+
+.three-stage[data-visual="chin"] .fallback-head {
+  transform: translateX(-12px);
+}
+
+.three-stage[data-visual="chin"] .fallback-cue--side,
+.three-stage[data-visual="side-stretch"] .fallback-cue--side {
+  opacity: 1;
+}
+
+.three-stage[data-visual="shoulders"] .fallback-shoulders {
+  transform: translateY(8px) scaleX(0.82);
+}
+
+.three-stage[data-visual="shoulders"] .fallback-arm--left,
+.three-stage[data-visual="shoulders"] .fallback-arm--right {
+  transform: rotate(0deg) translateY(6px);
+}
+
+.three-stage[data-visual="side-stretch"] .fallback-spine,
+.three-stage[data-visual="side-stretch"] .fallback-head {
+  transform: rotate(-10deg) translateX(-6px);
+}
+
+.three-stage[data-visual="rotation"] .fallback-cue--ring,
+.three-stage[data-visual="wave"] .fallback-cue--ring,
+.three-stage[data-visual="breath"] .fallback-cue--ring {
+  opacity: 1;
+}
+
+.three-stage[data-visual="chest"] .fallback-arm--left {
+  transform: rotate(-30deg) translate(-10px, 10px);
+}
+
+.three-stage[data-visual="chest"] .fallback-arm--right {
+  transform: rotate(30deg) translate(10px, 10px);
+}
+
+.three-stage[data-visual="wave"] .fallback-spine {
+  transform: rotate(7deg) translateY(4px);
+}
+
+.three-stage[data-visual="figure-four"] .fallback-leg--right {
+  transform: rotate(82deg) translate(8px, -20px);
+}
+
+.three-stage[data-visual="figure-four"] .fallback-cue--hip {
+  opacity: 1;
+}
+
+.visual-caption {
+  min-height: 50px;
+  border-top: 1px solid var(--line);
+  padding: 14px 16px;
+  color: var(--muted);
+  line-height: 1.45;
+  background: rgba(0, 0, 0, 0.16);
+}
+
+.guidance-panel {
+  padding: clamp(18px, 4vw, 28px);
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+
+.progress-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--faint);
+  font-weight: 800;
+  font-size: 0.95rem;
+}
+
+.routine-progress {
+  height: 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.24);
+}
+
+.routine-progress span {
+  display: block;
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--sage), var(--amber), var(--clay));
+  transition: width 220ms ease;
+}
+
+.instruction {
+  margin: 0;
+  color: var(--text);
+  font-size: 1.35rem;
+  line-height: 1.32;
+}
+
+.timer-ring {
+  width: min(260px, 74vw);
+  aspect-ratio: 1;
+  justify-self: center;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: conic-gradient(var(--amber) calc(var(--timer-progress, 1) * 1turn), rgba(255, 255, 255, 0.08) 0);
+  box-shadow: inset 0 0 0 1px var(--line), 0 18px 42px rgba(0, 0, 0, 0.25);
+}
+
+.timer-ring > div {
+  width: calc(100% - 28px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 8px;
+  background: var(--surface);
+  text-align: center;
+  padding: 18px;
+}
+
+.timer-ring strong {
+  font-size: 2.4rem;
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.timer-ring span {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.closing-message {
+  margin: 0;
+  border: 1px solid rgba(141, 200, 189, 0.42);
+  border-radius: var(--radius);
+  padding: 14px;
+  background: rgba(141, 200, 189, 0.12);
+  color: var(--text);
+  font-size: 1.2rem;
+  line-height: 1.35;
+}
+
+.control-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.safety-note--compact {
+  width: 100%;
+  font-size: 0.92rem;
+}
+
+.install-banner {
+  position: fixed;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 12;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: rgba(25, 24, 21, 0.96);
+  box-shadow: 0 22px 50px var(--shadow);
+  padding: 12px;
+}
+
+.install-banner.is-hidden {
+  display: none;
+}
+
+.install-banner p {
+  margin: 0;
+}
+
+.install-banner__title {
+  font-weight: 900;
+}
+
+.install-banner__meta {
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+.install-banner__action {
+  border: 0;
+  border-radius: var(--radius);
+  background: var(--amber);
+  color: var(--ink);
+  padding: 12px 14px;
+  font-weight: 900;
+}
+
+@media (min-width: 760px) {
+  h1 {
+    font-size: 4.8rem;
+  }
+
+  h2 {
+    font-size: 1.38rem;
+  }
+
+  .subtitle {
+    font-size: 1.8rem;
+  }
+
+  .context-line {
+    font-size: 1.15rem;
+  }
+
+  .routine-header h1 {
+    font-size: 3.25rem;
+  }
+
+  .instruction {
+    font-size: 1.7rem;
+  }
+
+  .timer-ring strong {
+    font-size: 3.2rem;
+  }
+
+  .closing-message {
+    font-size: 1.45rem;
+  }
+
+  .landing-grid {
+    grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.8fr);
+  }
+
+  .routine-layout {
+    grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
+    align-items: stretch;
+  }
+
+  .control-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1040px) {
+  h1 {
+    font-size: 5.6rem;
+  }
+
+  .routine-header h1 {
+    font-size: 3.8rem;
+  }
+
+  .instruction {
+    font-size: 1.9rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 14px;
+  }
+
+  .screen--landing,
+  .screen--routine {
+    min-height: calc(100vh - 28px);
+  }
+
+  .routine-header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .compact-toggle {
+    flex: 1 1 140px;
+  }
+
+  .landing-actions .button {
+    flex: 1 1 100%;
+  }
+
+  .visual-stage {
+    min-height: 300px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,7 +3,7 @@
 importScripts('/chat/notification-routing.js');
 
 // Increment this to bust old caches when you deploy
-const CACHE_VERSION = 'v14';
+const CACHE_VERSION = 'v15';
 const STATIC_CACHE = `3dvr-static-${CACHE_VERSION}`;
 const HTML_CACHE = `3dvr-html-${CACHE_VERSION}`;
 const chatNotificationRouting = self.ChatNotificationRouting || null;
@@ -22,6 +22,11 @@ const STATIC_ASSETS = [
   '/chat/notification-routing.js',
   '/styles/install-banner.css',
   '/manifest.webmanifest',
+  '/seated-spine-reset/',
+  '/seated-spine-reset/index.html',
+  '/seated-spine-reset/styles.css',
+  '/seated-spine-reset/app.js',
+  '/seated-spine-reset/manifest.webmanifest',
   '/brand/portal-logo.svg',
   '/app-manifests/chat.webmanifest',
   '/app-manifests/tasks.webmanifest',

--- a/tests/seated-spine-reset.test.js
+++ b/tests/seated-spine-reset.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('seated spine reset ships as a standalone wellness app', async () => {
+  const html = await readFile(new URL('../seated-spine-reset/index.html', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../seated-spine-reset/styles.css', import.meta.url), 'utf8');
+  const js = await readFile(new URL('../seated-spine-reset/app.js', import.meta.url), 'utf8');
+  const manifest = await readFile(new URL('../seated-spine-reset/manifest.webmanifest', import.meta.url), 'utf8');
+  const portalIndex = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const wellness = await readFile(new URL('../wellness.html', import.meta.url), 'utf8');
+
+  assert.match(html, /Seated Spine Reset/);
+  assert.match(html, /A quiet 3&ndash;5 minute reset for neck, shoulders, spine, hips, and breath\./);
+  assert.match(html, /data-start-mode="full"/);
+  assert.match(html, /data-start-mode="quick"/);
+  assert.match(html, /data-pref="reduceMotion"/);
+  assert.match(html, /data-pref="silentMode"/);
+  assert.match(html, /data-three-canvas/);
+  assert.match(html, /class="fallback-figure"/);
+  assert.match(html, /cdnjs\.cloudflare\.com\/ajax\/libs\/three\.js\/r128\/three\.min\.js/);
+  assert.match(html, /Move gently\. Stop if you feel sharp pain/);
+
+  assert.match(css, /dark/);
+  assert.match(css, /--amber/);
+  assert.match(css, /prefers-reduced-motion: reduce/);
+  assert.match(css, /min-height: var\(--tap\)/);
+
+  assert.match(js, /const fullRoutine = \[/);
+  assert.match(js, /Crown Up Posture Reset/);
+  assert.match(js, /Invisible Show-Cue Reset/);
+  assert.match(js, /const quickRoutine = \[/);
+  assert.match(js, /localStorage\.setItem\(STORAGE_KEY/);
+  assert.match(js, /window\.SeatedSpineReset/);
+  assert.match(js, /webGLAvailable/);
+  assert.match(js, /new THREE\.WebGLRenderer/);
+  assert.match(js, /navigator\.vibrate/);
+  assert.match(js, /silentMode: true/);
+
+  assert.match(manifest, /"start_url": "\/seated-spine-reset\/\?source=pwa"/);
+  assert.match(portalIndex, /href="seated-spine-reset\/"/);
+  assert.match(portalIndex, /<span class="app-card__title">Seated Spine Reset<\/span>/);
+  assert.match(wellness, /href="seated-spine-reset\/"/);
+});

--- a/wellness.html
+++ b/wellness.html
@@ -157,6 +157,7 @@
     <nav class="directory-nav" aria-label="Wellness quick links">
       <a href="#mindfulness">Mindfulness</a>
       <a href="meditation/">Breathing Room</a>
+      <a href="seated-spine-reset/">Seated Spine Reset</a>
       <a href="#meditation">Meditation</a>
       <a href="#nutrition">Food &amp; Nutrition</a>
       <a href="#mental-health">Mental Health</a>
@@ -176,6 +177,7 @@
         </ul>
         <div class="resource-links">
           <a href="meditation/">3DVR breathing room →</a>
+          <a href="seated-spine-reset/">Seated spine reset →</a>
           <a href="https://www.mindful.org/category/mindfulness-practice/" target="_blank" rel="noopener">Guided practices →</a>
           <a href="https://www.headspace.com/mindfulness" target="_blank" rel="noopener">Headspace tips →</a>
         </div>
@@ -241,6 +243,7 @@
           <li>Choose breathable, stretch-friendly fabrics for VR sessions and deep work.</li>
         </ul>
         <div class="resource-links">
+          <a href="seated-spine-reset/">Chair reset →</a>
           <a href="https://www.osha.gov/ergonomics" target="_blank" rel="noopener">OSHA ergonomics →</a>
           <a href="https://www.wellandgood.com/athleisure-brands/" target="_blank" rel="noopener">Ergonomic apparel →</a>
         </div>


### PR DESCRIPTION
## Summary
- Add a standalone `seated-spine-reset/` wellness app for full and quick seated posture resets.
- Include Three.js posture visuals with a CSS line-art fallback for browsers without WebGL.
- Register the app in the portal dock, wellness directory, README install list, and service worker cache.

## Validation
- `node --check seated-spine-reset/app.js`
- `node --test tests/seated-spine-reset.test.js tests/logic-lab.test.js tests/webrtc-lab.test.js tests/customer-journey-pages.test.js`
- Termux Node: `/data/data/com.termux/files/usr/bin/node --test tests/seated-spine-reset.test.js`
- Browser flow via Playwright: desktop full routine and mobile quick reset with service workers blocked; proot WebGL is unavailable, CSS fallback verified at 250x250.
- Android Termux: URL intent delivered to the current browser instance; screenshot/UI dump/tap are blocked by Android permissions from this shell.

## Notes
- Silent mode defaults on and preferences are localStorage-backed for v1.
- `window.SeatedSpineReset.setPortalBridge(...)` is available for a future portal/Gun integration.