### PR TITLE
Add Portal Lab app

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Attention Visualized](https://3dvr-portal.vercel.app/attention-visualized/)
 - [Logic Lab](https://3dvr-portal.vercel.app/logic-lab/)
 - [Intention Lab](https://3dvr-portal.vercel.app/intention-lab/)
+- [Portal Lab](https://3dvr-portal.vercel.app/portal-lab/)
 - [Seated Spine Reset](https://3dvr-portal.vercel.app/seated-spine-reset/)
 
 Open the page you want and use your browser’s **Install** or **Add to Home Screen** option to pin it like a native app.

--- a/app-manifests/portal-lab.webmanifest
+++ b/app-manifests/portal-lab.webmanifest
@@ -1,0 +1,16 @@
+{
+  "id": "/portal-lab/",
+  "name": "3DVR Portal Lab",
+  "short_name": "Portal Lab",
+  "description": "Explore frequency, consciousness, coherence, randomness, ritual, and reality.",
+  "start_url": "/portal-lab/?source=pwa",
+  "scope": "/portal-lab/",
+  "display": "standalone",
+  "background_color": "#120f0d",
+  "theme_color": "#120f0d",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -675,6 +675,19 @@
               Turn attention into state, state into action, and test randomness honestly.
             </span>
           </a>
+          <a
+            href="portal-lab/"
+            class="app-card"
+            data-app-tier="experimental"
+            data-app-keywords="portal frequency consciousness coherence ritual sound breath rng dreams research"
+          >
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">GATE</span>
+            <span class="app-card__title">Portal Lab</span>
+            <span class="app-card__meta">
+              Explore frequency, consciousness, coherence, ritual, and randomness without overclaiming.
+            </span>
+          </a>
           <a href="xr-motion-lab/index.html" class="app-card" data-app-tier="experimental">
             <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">🥽</span>

--- a/portal-lab/index.html
+++ b/portal-lab/index.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Portal Lab | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="Explore frequency, consciousness, coherence, randomness, ritual, and reality."
+  >
+  <meta name="analytics" content="disabled">
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="./portal-lab.css">
+  <link rel="manifest" href="/app-manifests/portal-lab.webmanifest">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
+  <meta name="theme-color" content="#120f0d">
+  <script type="module" src="./portal-lab.js"></script>
+</head>
+<body class="portal-lab-page">
+  <a class="skip-link" href="#portalLabMain">Skip to Portal Lab</a>
+
+  <header class="portal-top">
+    <nav class="portal-nav" aria-label="Portal Lab navigation">
+      <a class="portal-brand" href="/">
+        <span class="portal-brand__mark" aria-hidden="true">LAB</span>
+        <span>
+          <strong>Portal Lab</strong>
+          <small>Frequency + Consciousness Lab</small>
+        </span>
+      </a>
+      <div class="portal-nav__links">
+        <a href="/">Portal</a>
+        <a href="/body-mode/">Body Mode</a>
+        <a href="/intention-lab/">Intention Lab</a>
+        <a href="/science/">Science</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="portalLabMain" class="portal-shell">
+    <section class="hero-gate" aria-labelledby="portal-lab-title">
+      <div class="hero-gate__copy">
+        <p class="kicker">Guided research temple</p>
+        <h1 id="portal-lab-title">Portal Lab</h1>
+        <p class="hero-subtitle">
+          A practice + research space for exploring frequency, consciousness, coherence, randomness,
+          ritual, and reality.
+        </p>
+        <p class="hero-question">
+          Can attention, emotion, sound, rhythm, geometry, magnetism, ritual, or group coherence affect
+          physical reality? Could portals be altered-state thresholds, informational gateways, social rituals,
+          technological interfaces, or speculative physical anomalies?
+        </p>
+      </div>
+      <aside class="temple-card" aria-label="Portal Lab framing">
+        <p>
+          "Mystery is allowed. Fear is optional. Evidence matters. Experience matters.
+          We track which is which."
+        </p>
+      </aside>
+      <div class="hero-actions" aria-label="Portal Lab actions">
+        <a class="portal-button portal-button--primary" href="#session">Begin Session</a>
+        <a class="portal-button" href="#portal-types">Explore Portal Types</a>
+        <a class="portal-button" href="#research-atlas">Research Atlas</a>
+        <a class="portal-button" href="#journal">View Journal</a>
+      </div>
+    </section>
+
+    <section class="safety-note" aria-label="Safety note">
+      This app is for reflection, meditation, journaling, and exploratory experiments. It is not medical advice,
+      scientific proof, or a substitute for professional support. Stop any practice that causes distress.
+    </section>
+
+    <section id="portal-types" class="portal-section" aria-labelledby="levels-title">
+      <div class="section-heading">
+        <p class="kicker">Four levels</p>
+        <h2 id="levels-title">Four Levels of the Portal Question</h2>
+        <p>
+          Start with what is directly useful, then move carefully toward what is testable,
+          interpretive, or speculative.
+        </p>
+      </div>
+
+      <div class="level-stack">
+        <article class="level-card">
+          <div class="level-card__head">
+            <span class="evidence-tag">Documented</span>
+            <h3>Level 1: Frequency definitely affects consciousness</h3>
+          </div>
+          <p>
+            Sound, rhythm, breath, light, chanting, music, meditation, and movement can shift the nervous system.
+            This is the safest doorway into the portal question because the state change can be felt and practiced.
+          </p>
+          <div class="state-grid" aria-label="State-change examples">
+            <span>ordinary mind <strong>to</strong> meditative mind</span>
+            <span>fear body <strong>to</strong> coherent body</span>
+            <span>ego narrative <strong>to</strong> direct perception</span>
+            <span>scattered attention <strong>to</strong> focused intention</span>
+            <span>trauma posture <strong>to</strong> opened spine and breath</span>
+          </div>
+        </article>
+
+        <article class="level-card">
+          <div class="level-card__head">
+            <span class="evidence-tag evidence-tag--controversial">Controversial</span>
+            <h3>Level 2: Consciousness affecting randomness is testable</h3>
+          </div>
+          <p>
+            Random number generators, intention experiments, PEAR-style research,
+            Global Consciousness Project-style questions, and remote-viewing-adjacent tests are not settled proof.
+            They are controversial, but they can be framed as measurable protocols.
+          </p>
+        </article>
+
+        <article class="level-card">
+          <div class="level-card__head">
+            <span class="evidence-tag evidence-tag--mixed">Mixed meanings</span>
+            <h3>Level 3: Portals may have multiple meanings</h3>
+          </div>
+          <div class="portal-type-grid">
+            <article>
+              <h4>Psychological portal</h4>
+              <p>A shift in state, identity, perception, memory, or attention.</p>
+            </article>
+            <article>
+              <h4>Informational portal</h4>
+              <p>Intuition, dreams, synchronicity, and remote perception claims.</p>
+            </article>
+            <article>
+              <h4>Social portal</h4>
+              <p>Ritual, ceremony, circle practice, group coherence, and shared symbols.</p>
+            </article>
+            <article>
+              <h4>Technological portal</h4>
+              <p>VR, AR, sensors, sound, light, biofeedback, and networked interfaces.</p>
+            </article>
+            <article>
+              <h4>Physical portal</h4>
+              <p>Speculative spacetime or anomaly claims. This is the least supported category.</p>
+            </article>
+          </div>
+        </article>
+
+        <article class="level-card">
+          <div class="level-card__head">
+            <span class="evidence-tag evidence-tag--practice">Personal practice</span>
+            <h3>Level 4: Frequency + consciousness may work through coherence</h3>
+          </div>
+          <p>
+            Coherence means alignment of breath, posture, attention, nervous system, emotion, intention, and body.
+            The practical question is not whether every claim is true. The practical question is whether you become
+            clearer, steadier, kinder, and more able to act.
+          </p>
+          <div class="tool-list" aria-label="Traditional tuning tools">
+            <span>chanting</span>
+            <span>breath</span>
+            <span>drumming</span>
+            <span>bells</span>
+            <span>mantra</span>
+            <span>fasting</span>
+            <span>sacred geometry</span>
+            <span>darkness</span>
+            <span>sunrise</span>
+            <span>fire</span>
+            <span>circle formations</span>
+            <span>group prayer</span>
+            <span>silence</span>
+            <span>repetition</span>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="session" class="portal-section" aria-labelledby="modes-title">
+      <div class="section-heading">
+        <p class="kicker">Portal Lab v0.1</p>
+        <h2 id="modes-title">Choose a gate, run it gently, and record what happened.</h2>
+      </div>
+
+      <div class="mode-grid">
+        <article class="mode-card mode-card--wide" aria-labelledby="breath-title">
+          <div class="mode-card__head">
+            <span class="evidence-tag evidence-tag--practice">Personal practice</span>
+            <h3 id="breath-title">Breath Gate</h3>
+          </div>
+          <div class="breath-layout">
+            <div class="breath-orb" id="breathOrb" aria-hidden="true">
+              <span></span>
+            </div>
+            <div>
+              <p>
+                Slow visual breathing at 5 to 6 breaths per minute. No flashing, no intensity,
+                just a quiet pace for downshifting.
+              </p>
+              <label class="field-control" for="breathRate">
+                <span>Breath rate</span>
+                <select id="breathRate">
+                  <option value="5">5 breaths/min</option>
+                  <option value="6" selected>6 breaths/min</option>
+                </select>
+              </label>
+              <div class="button-row">
+                <button class="portal-button portal-button--primary" id="startBreath" type="button">
+                  Start breath
+                </button>
+                <button class="portal-button" id="stopBreath" type="button">Stop</button>
+              </div>
+              <p class="status-text" id="breathStatus" aria-live="polite">Breath gate idle.</p>
+            </div>
+          </div>
+        </article>
+
+        <article class="mode-card" aria-labelledby="tone-title">
+          <div class="mode-card__head">
+            <span class="evidence-tag evidence-tag--practice">Sound practice</span>
+            <h3 id="tone-title">Tone Gate</h3>
+          </div>
+          <p>Use a low-volume drone tone. Keep volume comfortable and stop immediately if it feels unpleasant.</p>
+          <label class="field-control" for="toneSelect">
+            <span>Tone</span>
+            <select id="toneSelect">
+              <option value="low">Low tone</option>
+              <option value="medium" selected>Medium tone</option>
+              <option value="high">High tone</option>
+            </select>
+          </label>
+          <label class="field-control" for="toneVolume">
+            <span>Volume <output id="toneVolumeValue" for="toneVolume">8%</output></span>
+            <input id="toneVolume" type="range" min="0" max="30" value="8">
+          </label>
+          <label class="check-control" for="binauralMode">
+            <input id="binauralMode" type="checkbox">
+            <span>Gentle binaural-style split</span>
+          </label>
+          <div class="button-row">
+            <button class="portal-button portal-button--primary" id="startTone" type="button">Start tone</button>
+            <button class="portal-button" id="stopTone" type="button">Stop tone</button>
+          </div>
+          <p class="status-text" id="toneStatus" aria-live="polite">Tone gate idle.</p>
+        </article>
+
+        <article class="mode-card" aria-labelledby="spine-title">
+          <div class="mode-card__head">
+            <span class="evidence-tag evidence-tag--practice">Body coherence</span>
+            <h3 id="spine-title">Spine Gate</h3>
+          </div>
+          <ul class="practice-list">
+            <li>Crown up.</li>
+            <li>Jaw soft.</li>
+            <li>Shoulders down.</li>
+            <li>Pelvis rooted.</li>
+            <li>Breath into ribs, back, and body.</li>
+          </ul>
+          <a class="portal-button" href="/body-mode/seated-spine-reset/">Open guided reset</a>
+        </article>
+
+        <article class="mode-card mode-card--wide" aria-labelledby="intention-title">
+          <div class="mode-card__head">
+            <span class="evidence-tag evidence-tag--practice">Attention practice</span>
+            <h3 id="intention-title">Intention Gate</h3>
+          </div>
+          <label class="text-control" for="intentionInput">
+            <span>One clear intention</span>
+            <textarea
+              id="intentionInput"
+              rows="4"
+              placeholder="Example: I will listen carefully, regulate my body, and take one honest action."
+            ></textarea>
+          </label>
+          <div class="button-row">
+            <button class="portal-button portal-button--primary" id="saveIntention" type="button">
+              Save intention
+            </button>
+          </div>
+          <div class="focus-display" id="activeIntention" aria-live="polite">No intention saved yet.</div>
+        </article>
+
+        <article class="mode-card mode-card--wide" aria-labelledby="randomness-title">
+          <div class="mode-card__head">
+            <span class="evidence-tag evidence-tag--controversial">Exploratory</span>
+            <h3 id="randomness-title">Randomness Gate</h3>
+          </div>
+          <p>
+            Generate 100 browser-random 0/1 values. Choose a direction first, then read the result honestly.
+          </p>
+          <label class="field-control" for="randomIntent">
+            <span>Selected intention</span>
+            <select id="randomIntent">
+              <option value="more-ones">More 1s</option>
+              <option value="more-zeros">More 0s</option>
+            </select>
+          </label>
+          <button class="portal-button portal-button--primary" id="runRandomness" type="button">
+            Run 100-bit trial
+          </button>
+          <div class="rng-output" id="randomnessResult" aria-live="polite">
+            No trial run yet.
+          </div>
+          <div class="bit-strip" id="bitStrip" aria-label="Random bit visualization"></div>
+          <p class="fine-print">This is exploratory and not proof of paranormal ability.</p>
+        </article>
+
+        <article class="mode-card mode-card--wide" aria-labelledby="dream-title">
+          <div class="mode-card__head">
+            <span class="evidence-tag evidence-tag--personal">Personal practice</span>
+            <h3 id="dream-title">Dream Gate</h3>
+          </div>
+          <div class="entry-grid">
+            <label class="field-control" for="entryType">
+              <span>Log type</span>
+              <select id="entryType">
+                <option value="dream">Dream log</option>
+                <option value="symbol">Symbol log</option>
+                <option value="synchronicity">Synchronicity log</option>
+              </select>
+            </label>
+            <label class="text-control" for="entryTitle">
+              <span>Title</span>
+              <input id="entryTitle" type="text" placeholder="Moon room, repeating number, doorway image">
+            </label>
+          </div>
+          <label class="text-control" for="entryBody">
+            <span>Observation</span>
+            <textarea
+              id="entryBody"
+              rows="4"
+              placeholder="What happened? What was felt? What pattern repeats?"
+            ></textarea>
+          </label>
+          <button class="portal-button portal-button--primary" id="saveEntry" type="button">Save entry</button>
+        </article>
+
+        <article class="mode-card" aria-labelledby="group-title">
+          <div class="mode-card__head">
+            <span class="evidence-tag evidence-tag--future">Future mode</span>
+            <h3 id="group-title">Group Gate</h3>
+          </div>
+          <p>
+            Future shared sessions can invite multiple people to focus on the same image, word, or random target.
+            For now, this stays local-only.
+          </p>
+          <label class="check-control" for="communityShare">
+            <input id="communityShare" type="checkbox">
+            <span>Share selected note with community</span>
+          </label>
+          <p class="status-text" id="shareStatus">Community sharing is a placeholder and is off by default.</p>
+        </article>
+
+        <article class="mode-card mode-card--wide" aria-labelledby="reality-title">
+          <div class="mode-card__head">
+            <span class="evidence-tag evidence-tag--documented">Reality Check</span>
+            <h3 id="reality-title">Separate the layers</h3>
+          </div>
+          <div class="reality-grid">
+            <label class="text-control" for="feltExperience">
+              <span>Felt experience</span>
+              <textarea id="feltExperience" rows="3"></textarea>
+            </label>
+            <label class="text-control" for="measuredData">
+              <span>Measured data</span>
+              <textarea id="measuredData" rows="3"></textarea>
+            </label>
+            <label class="text-control" for="interpretation">
+              <span>Interpretation</span>
+              <textarea id="interpretation" rows="3"></textarea>
+            </label>
+            <label class="text-control" for="openQuestion">
+              <span>Open question</span>
+              <textarea id="openQuestion" rows="3"></textarea>
+            </label>
+          </div>
+          <button class="portal-button portal-button--primary" id="saveRealityCheck" type="button">
+            Save reality check
+          </button>
+          <p class="status-text" id="realityStatus" aria-live="polite">No reality check saved yet.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="research-atlas" class="portal-section" aria-labelledby="atlas-title">
+      <div class="section-heading">
+        <p class="kicker">Research Atlas</p>
+        <h2 id="atlas-title">Starter topics for careful exploration.</h2>
+        <p>
+          Each card separates documented facts, speculative interpretations, myth warnings, practical relevance,
+          and a safe reflection or experiment.
+        </p>
+      </div>
+      <div class="atlas-grid" id="atlasGrid"></div>
+    </section>
+
+    <section id="journal" class="portal-section" aria-labelledby="journal-title">
+      <div class="section-heading">
+        <p class="kicker">Local journal</p>
+        <h2 id="journal-title">What this browser remembers.</h2>
+        <p>
+          Intentions, dreams, synchronicities, notes, favorites, and randomness sessions stay in localStorage
+          unless a future sync layer is deliberately enabled.
+        </p>
+      </div>
+      <div class="journal-grid">
+        <article class="journal-panel">
+          <h3>Intentions</h3>
+          <div id="intentionList" class="entry-list" aria-live="polite"></div>
+        </article>
+        <article class="journal-panel">
+          <h3>Dreams + symbols</h3>
+          <div id="dreamList" class="entry-list" aria-live="polite"></div>
+        </article>
+        <article class="journal-panel">
+          <h3>Synchronicities</h3>
+          <div id="synchList" class="entry-list" aria-live="polite"></div>
+        </article>
+        <article class="journal-panel">
+          <h3>Research notes</h3>
+          <div id="noteList" class="entry-list" aria-live="polite"></div>
+        </article>
+        <article class="journal-panel">
+          <h3>Randomness sessions</h3>
+          <div id="sessionList" class="entry-list" aria-live="polite"></div>
+        </article>
+        <article class="journal-panel">
+          <h3>Favorite topics</h3>
+          <div id="favoriteList" class="entry-list" aria-live="polite"></div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="portal-footer">
+    <a href="/">Portal</a>
+    <a href="/body-mode/">Body Mode</a>
+    <a href="/intention-lab/">Intention Lab</a>
+    <a href="/science/">Science</a>
+    <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>
+  </footer>
+</body>
+</html>

--- a/portal-lab/portal-lab.css
+++ b/portal-lab/portal-lab.css
@@ -1,0 +1,779 @@
+:root {
+  color-scheme: dark;
+  --portal-bg: #0d0a08;
+  --portal-bg-soft: #14100d;
+  --portal-panel: rgba(33, 27, 22, 0.88);
+  --portal-panel-soft: rgba(255, 244, 225, 0.055);
+  --portal-panel-strong: rgba(48, 38, 30, 0.94);
+  --portal-border: rgba(246, 216, 168, 0.18);
+  --portal-text: #f7efe1;
+  --portal-muted: #c7b9a5;
+  --portal-dim: #988873;
+  --portal-gold: #e8be67;
+  --portal-rose: #d9957e;
+  --portal-teal: #8fd3c6;
+  --portal-violet: #b9a6e8;
+  --portal-red: #e3a09a;
+  --portal-green: #9fd2a4;
+  --portal-shadow: 0 24px 70px rgba(0, 0, 0, 0.36);
+  --portal-radius: 8px;
+  --portal-max: 1180px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--portal-bg);
+}
+
+body.portal-lab-page {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(232, 190, 103, 0.08), transparent 360px),
+    linear-gradient(135deg, #0d0a08 0%, #14100d 55%, #100d12 100%);
+  color: var(--portal-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+body.portal-lab-page a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--portal-teal);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 20;
+  transform: translateY(-150%);
+  padding: 10px 14px;
+  border-radius: var(--portal-radius);
+  background: var(--portal-teal);
+  color: #07110f;
+  font-weight: 800;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.portal-top {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--portal-border);
+  background: rgba(13, 10, 8, 0.9);
+  backdrop-filter: blur(14px);
+}
+
+.portal-nav,
+.portal-shell,
+.portal-footer {
+  width: min(100% - 28px, var(--portal-max));
+  margin: 0 auto;
+}
+
+.portal-nav {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.portal-brand,
+.portal-nav__links,
+.hero-actions,
+.button-row,
+.portal-footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.portal-brand {
+  text-decoration: none;
+}
+
+.portal-brand__mark {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid rgba(232, 190, 103, 0.42);
+  border-radius: var(--portal-radius);
+  background:
+    linear-gradient(145deg, rgba(232, 190, 103, 0.18), rgba(143, 211, 198, 0.08)),
+    rgba(255, 255, 255, 0.04);
+  color: var(--portal-gold);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+}
+
+.portal-brand strong,
+.portal-brand small {
+  display: block;
+}
+
+.portal-brand small {
+  color: var(--portal-muted);
+  font-size: 0.78rem;
+}
+
+.portal-nav__links a,
+.portal-footer a {
+  padding: 8px 10px;
+  border: 1px solid var(--portal-border);
+  border-radius: var(--portal-radius);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--portal-muted);
+  text-decoration: none;
+}
+
+.portal-nav__links a:hover,
+.portal-footer a:hover {
+  border-color: rgba(143, 211, 198, 0.42);
+  color: var(--portal-text);
+}
+
+.portal-shell {
+  padding: 24px 0 42px;
+  display: grid;
+  gap: 22px;
+}
+
+.hero-gate,
+.portal-section,
+.safety-note {
+  border: 1px solid var(--portal-border);
+  border-radius: var(--portal-radius);
+  background: var(--portal-panel);
+  box-shadow: var(--portal-shadow);
+}
+
+.hero-gate {
+  min-height: 68vh;
+  display: grid;
+  align-content: center;
+  gap: 18px;
+  padding: clamp(22px, 5vw, 46px);
+}
+
+.hero-gate__copy {
+  display: grid;
+  gap: 14px;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--portal-gold);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+h4,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: clamp(3rem, 12vw, 6.7rem);
+  line-height: 0.9;
+  letter-spacing: -0.06em;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: clamp(1.8rem, 4.5vw, 3.45rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+h3 {
+  margin-bottom: 0;
+  font-size: 1.22rem;
+  line-height: 1.18;
+}
+
+h4 {
+  margin-bottom: 8px;
+  font-size: 1rem;
+}
+
+.hero-subtitle {
+  max-width: 820px;
+  margin-bottom: 0;
+  color: #f1dfc0;
+  font-size: clamp(1.12rem, 2vw, 1.36rem);
+}
+
+.hero-question,
+.section-heading p,
+.level-card p,
+.mode-card p,
+.journal-panel,
+.fine-print,
+.status-text,
+.safety-note {
+  color: var(--portal-muted);
+}
+
+.hero-question {
+  max-width: 900px;
+  margin-bottom: 0;
+}
+
+.temple-card {
+  max-width: 760px;
+  padding: 20px;
+  border: 1px solid rgba(232, 190, 103, 0.24);
+  border-radius: var(--portal-radius);
+  background:
+    linear-gradient(135deg, rgba(232, 190, 103, 0.12), rgba(143, 211, 198, 0.07)),
+    rgba(0, 0, 0, 0.18);
+}
+
+.temple-card p {
+  margin: 0;
+  color: var(--portal-text);
+  font-size: clamp(1.12rem, 2.2vw, 1.55rem);
+  line-height: 1.35;
+}
+
+.portal-button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 13px;
+  border: 1px solid var(--portal-border);
+  border-radius: var(--portal-radius);
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--portal-text);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.portal-button:hover:not(:disabled) {
+  border-color: rgba(143, 211, 198, 0.5);
+  background: rgba(143, 211, 198, 0.1);
+}
+
+.portal-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.portal-button--primary {
+  border-color: rgba(232, 190, 103, 0.62);
+  background: #e8be67;
+  color: #130d06;
+  font-weight: 850;
+}
+
+.safety-note {
+  padding: 16px;
+  background:
+    linear-gradient(135deg, rgba(217, 149, 126, 0.12), rgba(255, 255, 255, 0.04)),
+    rgba(33, 27, 22, 0.9);
+}
+
+.portal-section {
+  padding: clamp(18px, 4vw, 30px);
+}
+
+.section-heading {
+  display: grid;
+  gap: 10px;
+  max-width: 870px;
+  margin-bottom: 20px;
+}
+
+.section-heading p {
+  margin-bottom: 0;
+}
+
+.level-stack,
+.mode-grid,
+.journal-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.level-card,
+.mode-card,
+.journal-panel,
+.atlas-card,
+.state-grid span,
+.portal-type-grid article,
+.tool-list span,
+.entry-item,
+.rng-output {
+  border: 1px solid var(--portal-border);
+  border-radius: var(--portal-radius);
+  background: var(--portal-panel-soft);
+}
+
+.level-card,
+.mode-card,
+.journal-panel,
+.atlas-card {
+  padding: 18px;
+}
+
+.level-card__head,
+.mode-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.evidence-tag {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  min-height: 27px;
+  padding: 4px 8px;
+  border: 1px solid rgba(143, 211, 198, 0.28);
+  border-radius: var(--portal-radius);
+  background: rgba(143, 211, 198, 0.08);
+  color: var(--portal-teal);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.evidence-tag--controversial {
+  border-color: rgba(217, 149, 126, 0.34);
+  background: rgba(217, 149, 126, 0.09);
+  color: var(--portal-rose);
+}
+
+.evidence-tag--mixed,
+.evidence-tag--future {
+  border-color: rgba(185, 166, 232, 0.34);
+  background: rgba(185, 166, 232, 0.08);
+  color: var(--portal-violet);
+}
+
+.evidence-tag--practice,
+.evidence-tag--personal {
+  border-color: rgba(232, 190, 103, 0.34);
+  background: rgba(232, 190, 103, 0.08);
+  color: var(--portal-gold);
+}
+
+.evidence-tag--documented {
+  border-color: rgba(159, 210, 164, 0.34);
+  background: rgba(159, 210, 164, 0.08);
+  color: var(--portal-green);
+}
+
+.state-grid,
+.portal-type-grid,
+.tool-list,
+.entry-grid,
+.reality-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.state-grid span,
+.tool-list span {
+  padding: 10px 12px;
+}
+
+.state-grid strong {
+  color: var(--portal-gold);
+}
+
+.portal-type-grid article {
+  padding: 14px;
+}
+
+.portal-type-grid p,
+.atlas-card p,
+.entry-item p {
+  margin-bottom: 0;
+}
+
+.tool-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.tool-list span {
+  text-align: center;
+}
+
+.mode-grid {
+  grid-template-columns: 1fr;
+}
+
+.mode-card {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.breath-layout {
+  display: grid;
+  gap: 16px;
+  align-items: center;
+}
+
+.breath-orb {
+  width: min(56vw, 220px);
+  aspect-ratio: 1 / 1;
+  justify-self: center;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(232, 190, 103, 0.28);
+  background:
+    radial-gradient(circle at center, rgba(143, 211, 198, 0.22), rgba(232, 190, 103, 0.08) 48%, transparent 70%),
+    rgba(0, 0, 0, 0.18);
+}
+
+.breath-orb span {
+  width: 44%;
+  aspect-ratio: 1 / 1;
+  border-radius: 999px;
+  background: rgba(232, 190, 103, 0.54);
+  box-shadow: 0 0 42px rgba(232, 190, 103, 0.2);
+}
+
+.breath-orb.is-breathing span {
+  animation: breatheGate var(--breath-cycle, 10s) ease-in-out infinite;
+}
+
+@keyframes breatheGate {
+  0%,
+  100% {
+    transform: scale(0.72);
+    opacity: 0.65;
+  }
+
+  48%,
+  52% {
+    transform: scale(1.75);
+    opacity: 1;
+  }
+}
+
+.field-control,
+.text-control,
+.check-control {
+  display: grid;
+  gap: 8px;
+  color: var(--portal-text);
+  font-weight: 750;
+}
+
+.check-control {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  font-weight: 650;
+}
+
+.field-control input,
+.field-control select,
+.text-control input,
+.text-control textarea,
+.text-control select {
+  width: 100%;
+  border: 1px solid var(--portal-border);
+  border-radius: var(--portal-radius);
+  background: rgba(8, 6, 5, 0.72);
+  color: var(--portal-text);
+}
+
+.field-control input,
+.field-control select,
+.text-control input {
+  min-height: 44px;
+  padding: 9px 11px;
+}
+
+.text-control textarea {
+  resize: vertical;
+  min-height: 96px;
+  padding: 10px 11px;
+}
+
+input[type="range"] {
+  accent-color: var(--portal-gold);
+}
+
+.status-text,
+.fine-print {
+  margin-bottom: 0;
+  font-size: 0.94rem;
+}
+
+.practice-list {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--portal-muted);
+}
+
+.practice-list li + li {
+  margin-top: 8px;
+}
+
+.focus-display {
+  min-height: 72px;
+  padding: 14px;
+  border: 1px solid rgba(232, 190, 103, 0.22);
+  border-radius: var(--portal-radius);
+  background: rgba(232, 190, 103, 0.08);
+  color: #f5e8cf;
+}
+
+.rng-output {
+  padding: 14px;
+}
+
+.rng-stats {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.rng-stats span {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--portal-muted);
+}
+
+.rng-stats strong {
+  color: var(--portal-text);
+}
+
+.bit-strip {
+  display: grid;
+  grid-template-columns: repeat(20, minmax(0, 1fr));
+  gap: 3px;
+  min-height: 60px;
+}
+
+.bit-cell {
+  aspect-ratio: 1 / 1;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.bit-cell[data-bit="1"] {
+  background: rgba(232, 190, 103, 0.64);
+}
+
+.atlas-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.atlas-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.atlas-card summary {
+  display: grid;
+  gap: 8px;
+  cursor: pointer;
+  padding: 16px;
+  list-style: none;
+}
+
+.atlas-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.atlas-card summary h3 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.atlas-card__labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.atlas-card__body {
+  display: grid;
+  gap: 12px;
+  padding: 0 16px 16px;
+}
+
+.atlas-block {
+  padding: 13px;
+  border: 1px solid var(--portal-border);
+  border-radius: var(--portal-radius);
+  background: rgba(0, 0, 0, 0.14);
+}
+
+.atlas-block h4 {
+  color: var(--portal-gold);
+}
+
+.favorite-button {
+  width: fit-content;
+}
+
+.journal-grid {
+  grid-template-columns: 1fr;
+}
+
+.journal-panel {
+  min-height: 190px;
+}
+
+.entry-list {
+  display: grid;
+  gap: 10px;
+}
+
+.entry-item {
+  padding: 12px;
+}
+
+.entry-item strong,
+.entry-item small {
+  display: block;
+}
+
+.entry-item small {
+  color: var(--portal-dim);
+}
+
+.entry-item strong {
+  color: var(--portal-text);
+}
+
+.empty-state {
+  margin-bottom: 0;
+  color: var(--portal-dim);
+}
+
+.portal-footer {
+  padding: 0 0 44px;
+}
+
+@media (min-width: 720px) {
+  .hero-gate {
+    grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  }
+
+  .hero-actions {
+    grid-column: 1 / -1;
+  }
+
+  .state-grid,
+  .portal-type-grid,
+  .entry-grid,
+  .reality-grid,
+  .journal-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tool-list {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .mode-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mode-card--wide {
+    grid-column: span 2;
+  }
+
+  .breath-layout {
+    grid-template-columns: minmax(190px, 0.5fr) minmax(0, 1fr);
+  }
+}
+
+@media (min-width: 1040px) {
+  .journal-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .portal-type-grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .portal-nav {
+    align-items: flex-start;
+  }
+
+  .portal-nav__links {
+    justify-content: flex-start;
+  }
+
+  .portal-button {
+    width: 100%;
+  }
+
+  .hero-actions .portal-button,
+  .button-row .portal-button {
+    width: auto;
+  }
+
+  .level-card__head,
+  .mode-card__head {
+    display: grid;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+
+  .breath-orb.is-breathing span {
+    transform: scale(1.1);
+  }
+}

--- a/portal-lab/portal-lab.js
+++ b/portal-lab/portal-lab.js
@@ -1,0 +1,861 @@
+export const PORTAL_LAB_KEYS = Object.freeze({
+  intentions: 'portalLab.intentions',
+  dreams: 'portalLab.dreams',
+  synchs: 'portalLab.synchs',
+  notes: 'portalLab.notes',
+  sessions: 'portalLab.sessions',
+  favorites: 'portalLab.favorites',
+});
+
+export const PORTAL_LAB_TOPICS = Object.freeze([
+  {
+    id: 'tesla-resonance',
+    title: 'Nikola Tesla: resonance, electricity, wireless power, myth vs. record',
+    labels: ['Historical', 'Documented', 'Myth / unverified'],
+    summary: joinText(
+      'Tesla is a real doorway into resonance, alternating current,',
+      'high-voltage experiments, and wireless power dreams.'
+    ),
+    facts: [
+      joinText(
+        'Tesla held many patents and worked on alternating current systems,',
+        'radio-adjacent communication, lighting, and resonance.'
+      ),
+      joinText(
+        'Wardenclyffe was an unfinished wireless communication and power project,',
+        'not proof that unlimited free energy was deployed.'
+      ),
+    ],
+    speculation: joinText(
+      'Speculative readings often turn Tesla into a symbol of suppressed ether technology',
+      'or hidden energy systems.'
+    ),
+    warning: joinText(
+      'Separate documented electrical engineering from internet myth, quote fragments,',
+      'and claims without primary records.'
+    ),
+    matters: joinText(
+      'Tesla gives Portal Lab a grounded way to ask how resonance moves energy',
+      'without making every legend factual.'
+    ),
+    experiment: 'Safely compare how different drone tones affect attention, posture, and mood. Do not use high volume.',
+    sourceNotes: joinText(
+      'Source notes placeholder: Tesla patents, biographies, Wardenclyffe records,',
+      'and engineering histories.'
+    ),
+  },
+  {
+    id: 'jack-parsons-jpl',
+    title: 'Jack Parsons & JPL: rocketry, Aerojet, Thelema, myth of "NASA founder"',
+    labels: ['Historical', 'Documented', 'Myth / unverified'],
+    summary: joinText(
+      'Parsons was part of early Caltech rocketry and Aerojet history,',
+      'while his occult life feeds later mythology.'
+    ),
+    facts: [
+      joinText(
+        'JPL history names Jack Parsons among the early rocketry group',
+        'working with Frank Malina, Edward Forman, and others.'
+      ),
+      'Aerojet and JPL emerged from specific Caltech and Army-backed rocket work, not from a single founder story.',
+    ],
+    speculation: joinText(
+      'Some interpretations read Parsons as a ritual-technological bridge',
+      'between occult practice and spaceflight.'
+    ),
+    warning: 'Avoid the oversimplified claim that Parsons founded NASA. NASA was created later as a federal agency.',
+    matters: 'This topic shows how real technical history, personality, ritual, and myth can become fused.',
+    experiment: 'Map one historical claim into documented fact, speculation, myth warning, and open question.',
+    sourceNotes: 'Source notes placeholder: NASA/JPL history, Aerojet history, biographies, and Caltech archives.',
+  },
+  {
+    id: 'project-gateway',
+    title: 'Project Gateway: altered states and consciousness training',
+    labels: ['Declassified', 'Controversial', 'Personal practice'],
+    summary: joinText(
+      'Gateway material is useful as a case study in state training,',
+      'audio guidance, and official interest in consciousness.'
+    ),
+    facts: [
+      'CIA Reading Room materials include Gateway-related analysis and altered-state training documents.',
+      'The documents are records of interest and analysis, not confirmation that every metaphysical claim is correct.',
+    ],
+    speculation: 'Speculative readings treat Gateway as a proof text for out-of-body travel or nonlocal perception.',
+    warning: 'Declassified does not mean proven. It means the record exists and can be studied.',
+    matters: joinText(
+      'Gateway helps Portal Lab practice disciplined curiosity around breath, audio,',
+      'attention, and state change.'
+    ),
+    experiment: joinText(
+      'Run a ten-minute audio-free relaxation protocol and log felt experience,',
+      'measured data, and interpretation separately.'
+    ),
+    sourceNotes: 'Source notes placeholder: CIA Reading Room Gateway files and independent critiques.',
+  },
+  {
+    id: 'project-scanate',
+    title: 'Project SCANATE: remote viewing and Cold War intelligence research',
+    labels: ['Declassified', 'Controversial', 'Historical'],
+    summary: joinText(
+      'SCANATE and later remote-viewing programs are examples of intelligence agencies',
+      'testing unusual perception claims.'
+    ),
+    facts: [
+      'CIA Reading Room records include SCANATE, GRILL FLAME, SUN STREAK, CENTER LANE, and STAR GATE material.',
+      'The records include protocols, sessions, reviews, and program history rather than a simple verdict of proof.',
+    ],
+    speculation: joinText(
+      'Supporters interpret some sessions as anomalous information access;',
+      'critics dispute methods and conclusions.'
+    ),
+    warning: 'Remote-viewing-adjacent tests need strict blinding, preregistration, target pools, and sober scoring.',
+    matters: 'This topic teaches how to design tests that reduce story-making after the result is known.',
+    experiment: joinText(
+      'Have a friend choose one image from a hidden set, write impressions before viewing,',
+      'then score against all options.'
+    ),
+    sourceNotes: 'Source notes placeholder: CIA Reading Room STAR GATE and SCANATE documents.',
+  },
+  {
+    id: 'dugway',
+    title: 'Dugway Proving Ground: secrecy, chemical/biological testing history',
+    labels: ['Documented', 'Historical', 'Speculative'],
+    summary: 'Dugway is a real U.S. Army test site whose mission and history create an understandable aura of secrecy.',
+    facts: [
+      'Army sources describe Dugway as a Utah proving ground established in 1942 for chemical warfare testing.',
+      joinText(
+        'Official materials describe chemical, biological, radiological,',
+        'and nuclear defense testing and training missions.'
+      ),
+    ],
+    speculation: joinText(
+      'Internet lore can expand real secrecy into unsupported claims about portals,',
+      'entities, or hidden physics.'
+    ),
+    warning: 'A secretive site is not automatically evidence for every claim attached to it.',
+    matters: 'Dugway is a good practice case for separating documented military testing from anomaly mythology.',
+    experiment: joinText(
+      'Create a claim table: what is documented, what is plausible,',
+      'what is unverified, and what would count as evidence.'
+    ),
+    sourceNotes: 'Source notes placeholder: U.S. Army Dugway Proving Ground history and environmental records.',
+  },
+  {
+    id: 'cern-ritual-myth',
+    title: 'CERN Ritual Myth: Shiva symbolism, particle physics, prank video, internet lore',
+    labels: ['Documented', 'Myth / unverified', 'Science'],
+    summary: 'CERN combines advanced physics, symbolic art, and internet rumor in a way that demands careful sorting.',
+    facts: [
+      joinText(
+        'CERN says the Shiva statue was a gift from India recognizing collaboration',
+        'and symbolizing cosmic dance imagery.'
+      ),
+      'CERN has addressed a strange ritual video as an unauthorized prank, not an official ceremony.',
+    ],
+    speculation: joinText(
+      'Portal language around CERN usually comes from metaphor, internet lore,',
+      'and fear around powerful machines.'
+    ),
+    warning: 'Particle physics is not the same as ritual magic. Symbolic art is not proof of hidden ceremony.',
+    matters: 'This topic trains non-paranoid thinking around science, symbolism, and viral video culture.',
+    experiment: joinText(
+      'Read one scientific explanation and one mythic interpretation,',
+      'then write what each explains and what each ignores.'
+    ),
+    sourceNotes: 'Source notes placeholder: CERN FAQ pages, physics outreach pages, and media statements.',
+  },
+  {
+    id: 'random-generators',
+    title: 'Random Number Generators: intention and randomness',
+    labels: ['Controversial', 'Testable', 'Statistics'],
+    summary: joinText(
+      'RNG experiments ask whether intention or group attention correlates',
+      'with deviations from expected randomness.'
+    ),
+    facts: [
+      joinText(
+        'PEAR operated at Princeton from 1979 to 2007 and studied random event generators',
+        'among other anomalies questions.'
+      ),
+      joinText(
+        'The Global Consciousness Project describes a network of physical RNGs',
+        'used to look for correlations with global events.'
+      ),
+    ],
+    speculation: joinText(
+      'Some researchers interpret small statistical effects as consciousness-linked;',
+      'critics question methods and theory.'
+    ),
+    warning: joinText(
+      'A single run is not a conclusion. Look for preregistered protocols, controls,',
+      'replication, and effect size.'
+    ),
+    matters: joinText(
+      'Randomness is one of the few portal-adjacent questions that can be made measurable',
+      'in a browser-first lab.'
+    ),
+    experiment: joinText(
+      'Run the 100-bit gate repeatedly, record the direction before each run,',
+      'and analyze many sessions later.'
+    ),
+    sourceNotes: joinText(
+      'Source notes placeholder: PEAR archive, GCP papers, statistics critiques,',
+      'and replication discussions.'
+    ),
+  },
+  {
+    id: 'dmt-altered-states',
+    title: 'DMT / altered states: subjective portals and body-state transformation',
+    labels: ['Documented', 'Personal practice', 'Controversial'],
+    summary: joinText(
+      'DMT research is relevant to Portal Lab as a study of intense subjective portal-like experience,',
+      'not as a claim engine.'
+    ),
+    facts: [
+      joinText(
+        'Peer-reviewed studies describe DMT as producing intense altered states',
+        'with measurable brain and subjective reports.'
+      ),
+      'The fact that an experience is powerful does not settle what it means metaphysically.',
+    ],
+    speculation: joinText(
+      'Some people interpret these states as contact, realms, or gateways;',
+      'others interpret them as brain-generated experience.'
+    ),
+    warning: joinText(
+      'This app does not advise substance use. Use sober practices like breath,',
+      'sound, sleep logging, and reflection.'
+    ),
+    matters: 'Altered-state reports show why felt experience matters while still needing careful interpretation.',
+    experiment: joinText(
+      'Log dreams, meditation, music-induced imagery, or breath practice',
+      'as subjective portal data without overclaiming.'
+    ),
+    sourceNotes: 'Source notes placeholder: NIH/PubMed studies, harm-reduction sources, and phenomenology papers.',
+  },
+]);
+
+let fallbackIdCounter = 0;
+
+function joinText(...parts) {
+  return parts.join(' ');
+}
+
+export function readPortalLabList(keyName, storage = globalThis.localStorage) {
+  const key = PORTAL_LAB_KEYS[keyName] || keyName;
+  if (!storage || typeof storage.getItem !== 'function') {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(storage.getItem(key) || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+export function writePortalLabList(keyName, entries, storage = globalThis.localStorage) {
+  const key = PORTAL_LAB_KEYS[keyName] || keyName;
+  if (!storage || typeof storage.setItem !== 'function') {
+    return [];
+  }
+  const safeEntries = Array.isArray(entries) ? entries : [];
+  storage.setItem(key, JSON.stringify(safeEntries));
+  return safeEntries;
+}
+
+export function appendPortalLabEntry(keyName, entry, storage = globalThis.localStorage) {
+  const entries = readPortalLabList(keyName, storage);
+  const nextEntry = {
+    id: normalizeText(entry?.id) || makePortalLabId(keyName),
+    createdAt: normalizeText(entry?.createdAt) || new Date().toISOString(),
+    ...entry,
+  };
+  entries.unshift(nextEntry);
+  writePortalLabList(keyName, entries.slice(0, 80), storage);
+  return nextEntry;
+}
+
+export function generateBinaryValues(count = 100, cryptoProvider = globalThis.crypto) {
+  const requestedCount = Number(count);
+  if (!Number.isInteger(requestedCount) || requestedCount <= 0 || requestedCount > 10000) {
+    throw new RangeError('count must be an integer between 1 and 10000');
+  }
+  if (!cryptoProvider || typeof cryptoProvider.getRandomValues !== 'function') {
+    throw new Error('crypto.getRandomValues is required for Portal Lab randomness trials');
+  }
+  const bytes = new Uint8Array(requestedCount);
+  cryptoProvider.getRandomValues(bytes);
+  return Array.from(bytes, byte => byte & 1);
+}
+
+export function analyzeRandomnessGate(values, intention = 'more-ones') {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new TypeError('values must be a non-empty array');
+  }
+  const normalizedValues = values.map(value => {
+    const number = Number(value);
+    if (number !== 0 && number !== 1) {
+      throw new RangeError('values must contain only 0 or 1');
+    }
+    return number;
+  });
+  const selectedIntention = intention === 'more-zeros' ? 'more-zeros' : 'more-ones';
+  const ones = normalizedValues.reduce((total, value) => total + value, 0);
+  const zeros = normalizedValues.length - ones;
+  const expected = normalizedValues.length / 2;
+  const targetCount = selectedIntention === 'more-ones' ? ones : zeros;
+  const targetDifference = targetCount - expected;
+  const differenceFromExpected = ones - expected;
+  const classification = classifyRandomnessResult(targetDifference, normalizedValues.length);
+
+  return {
+    source: 'browser-crypto-getRandomValues',
+    count: normalizedValues.length,
+    intention: selectedIntention,
+    ones,
+    zeros,
+    expected,
+    differenceFromExpected,
+    targetDifference,
+    classification,
+    interpretation: buildRandomnessInterpretation(classification),
+  };
+}
+
+export function buildRandomnessSession(input = {}) {
+  const values = Array.isArray(input.values) ? input.values : [];
+  const analysis = input.analysis || analyzeRandomnessGate(values, input.intention);
+  return {
+    id: normalizeText(input.id) || makePortalLabId('session'),
+    app: 'portal-lab',
+    type: 'randomness-gate',
+    version: 1,
+    createdAt: normalizeText(input.createdAt) || new Date().toISOString(),
+    values,
+    result: analysis,
+  };
+}
+
+export function getResearchTopic(topicId) {
+  return PORTAL_LAB_TOPICS.find(topic => topic.id === topicId) || null;
+}
+
+export function toggleFavoriteTopic(topicId, storage = globalThis.localStorage) {
+  const topic = getResearchTopic(topicId);
+  if (!topic) {
+    throw new Error(`Unknown Portal Lab topic: ${topicId}`);
+  }
+  const favorites = readPortalLabList('favorites', storage);
+  const exists = favorites.includes(topicId);
+  const next = exists ? favorites.filter(id => id !== topicId) : [topicId, ...favorites];
+  writePortalLabList('favorites', next, storage);
+  return next;
+}
+
+function classifyRandomnessResult(targetDifference, sampleCount) {
+  const nearThreshold = Math.max(3, Math.round(sampleCount * 0.06));
+  if (Math.abs(targetDifference) <= nearThreshold) {
+    return 'near chance';
+  }
+  return targetDifference > 0 ? 'above chance' : 'below chance';
+}
+
+function buildRandomnessInterpretation(classification) {
+  if (classification === 'above chance') {
+    return 'This run landed above the selected direction. Treat it as one exploratory data point.';
+  }
+  if (classification === 'below chance') {
+    return 'This run landed below the selected direction. Treat it as one exploratory data point.';
+  }
+  return 'This run stayed near chance. That is a valid result, not a failure.';
+}
+
+function makePortalLabId(prefix) {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    return `${prefix}-${cryptoApi.randomUUID()}`;
+  }
+  fallbackIdCounter += 1;
+  return `${prefix}-${Date.now()}-${fallbackIdCounter}`;
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function formatDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function setText(element, value) {
+  if (element) {
+    element.textContent = value;
+  }
+}
+
+function createEntryItem(title, body, meta = '') {
+  const item = document.createElement('article');
+  item.className = 'entry-item';
+  const strong = document.createElement('strong');
+  strong.textContent = title || 'Untitled';
+  item.append(strong);
+  if (meta) {
+    const small = document.createElement('small');
+    small.textContent = meta;
+    item.append(small);
+  }
+  if (body) {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = body;
+    item.append(paragraph);
+  }
+  return item;
+}
+
+function renderEntryList(element, entries, emptyText, formatEntry) {
+  if (!element) {
+    return;
+  }
+  element.replaceChildren();
+  if (!entries.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = emptyText;
+    element.append(empty);
+    return;
+  }
+  entries.slice(0, 8).forEach(entry => {
+    element.append(formatEntry(entry));
+  });
+}
+
+function renderAtlas(refs) {
+  if (!refs.atlasGrid) {
+    return;
+  }
+  refs.atlasGrid.replaceChildren();
+  const favorites = new Set(readPortalLabList('favorites'));
+  PORTAL_LAB_TOPICS.forEach(topic => {
+    const details = document.createElement('details');
+    details.className = 'atlas-card';
+    details.dataset.topic = topic.id;
+
+    const summary = document.createElement('summary');
+    const title = document.createElement('h3');
+    const titleText = document.createElement('span');
+    titleText.textContent = topic.title;
+    const marker = document.createElement('span');
+    marker.className = 'evidence-tag';
+    marker.textContent = favorites.has(topic.id) ? 'Favorite' : 'Open';
+    title.append(titleText, marker);
+
+    const labels = document.createElement('div');
+    labels.className = 'atlas-card__labels';
+    topic.labels.forEach(label => {
+      const tag = document.createElement('span');
+      tag.className = 'evidence-tag';
+      tag.textContent = label;
+      labels.append(tag);
+    });
+    const summaryText = document.createElement('p');
+    summaryText.textContent = topic.summary;
+    summary.append(title, labels, summaryText);
+
+    const body = document.createElement('div');
+    body.className = 'atlas-card__body';
+    body.append(
+      createAtlasBlock('Documented facts', topic.facts.join(' ')),
+      createAtlasBlock('Speculative interpretations', topic.speculation),
+      createAtlasBlock('Myth warnings', topic.warning),
+      createAtlasBlock('Why it matters', topic.matters),
+      createAtlasBlock('Safe experiment or reflection', topic.experiment),
+      createAtlasBlock('Source notes placeholder', topic.sourceNotes)
+    );
+
+    const favoriteButton = document.createElement('button');
+    favoriteButton.className = 'portal-button favorite-button';
+    favoriteButton.type = 'button';
+    favoriteButton.dataset.favoriteTopic = topic.id;
+    favoriteButton.textContent = favorites.has(topic.id) ? 'Remove favorite' : 'Favorite topic';
+    body.append(favoriteButton);
+
+    details.append(summary, body);
+    refs.atlasGrid.append(details);
+  });
+}
+
+function createAtlasBlock(title, body) {
+  const block = document.createElement('div');
+  block.className = 'atlas-block';
+  const heading = document.createElement('h4');
+  heading.textContent = title;
+  const paragraph = document.createElement('p');
+  paragraph.textContent = body;
+  block.append(heading, paragraph);
+  return block;
+}
+
+function renderJournal(refs) {
+  const intentions = readPortalLabList('intentions');
+  const dreams = readPortalLabList('dreams');
+  const synchs = readPortalLabList('synchs');
+  const notes = readPortalLabList('notes');
+  const sessions = readPortalLabList('sessions');
+  const favorites = readPortalLabList('favorites');
+
+  renderEntryList(refs.intentionList, intentions, 'No intentions saved yet.', entry => (
+    createEntryItem('Intention', entry.text, formatDate(entry.createdAt))
+  ));
+  renderEntryList(refs.dreamList, dreams, 'No dreams or symbols saved yet.', entry => (
+    createEntryItem(entry.title || entry.type, entry.body, `${entry.type || 'dream'} - ${formatDate(entry.createdAt)}`)
+  ));
+  renderEntryList(refs.synchList, synchs, 'No synchronicities saved yet.', entry => (
+    createEntryItem(entry.title || 'Synchronicity', entry.body, formatDate(entry.createdAt))
+  ));
+  renderEntryList(refs.noteList, notes, 'No research notes saved yet.', entry => (
+    createEntryItem(entry.title || 'Reality check', summarizeRealityNote(entry), formatDate(entry.createdAt))
+  ));
+  renderEntryList(refs.sessionList, sessions, 'No randomness sessions saved yet.', entry => (
+    createEntryItem(
+      entry.result?.classification || 'Randomness session',
+      `${entry.result?.ones ?? 0} ones, ${entry.result?.zeros ?? 0} zeros, intention: ${entry.result?.intention || ''}`,
+      formatDate(entry.createdAt)
+    )
+  ));
+  renderEntryList(refs.favoriteList, favorites, 'No favorite topics yet.', topicId => {
+    const topic = getResearchTopic(topicId);
+    return createEntryItem(topic?.title || topicId, topic?.summary || '', 'Research Atlas');
+  });
+}
+
+function summarizeRealityNote(entry) {
+  if (entry.body) {
+    return entry.body;
+  }
+  return [
+    entry.feltExperience ? `Felt: ${entry.feltExperience}` : '',
+    entry.measuredData ? `Measured: ${entry.measuredData}` : '',
+    entry.interpretation ? `Interpretation: ${entry.interpretation}` : '',
+    entry.openQuestion ? `Question: ${entry.openQuestion}` : '',
+  ].filter(Boolean).join(' ');
+}
+
+function initBreathGate(refs) {
+  if (!refs.startBreath || !refs.stopBreath || !refs.breathOrb) {
+    return;
+  }
+  const reducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  refs.startBreath.addEventListener('click', () => {
+    const bpm = Number(refs.breathRate?.value || 6);
+    const cycle = 60 / (bpm || 6);
+    refs.breathOrb.style.setProperty('--breath-cycle', `${cycle}s`);
+    refs.breathOrb.classList.add('is-breathing');
+    setText(
+      refs.breathStatus,
+      reducedMotion
+        ? `Reduced motion is active. Use a ${Math.round(cycle)} second inhale/exhale rhythm.`
+        : `Breathing at ${bpm} breaths per minute. Let the visual cue stay gentle.`
+    );
+  });
+  refs.stopBreath.addEventListener('click', () => {
+    refs.breathOrb.classList.remove('is-breathing');
+    setText(refs.breathStatus, 'Breath gate stopped.');
+  });
+}
+
+function initToneGate(refs) {
+  const toneState = {
+    context: null,
+    nodes: [],
+  };
+
+  const stopTone = () => {
+    toneState.nodes.forEach(node => {
+      try {
+        if (typeof node.stop === 'function') {
+          node.stop();
+        }
+        if (typeof node.disconnect === 'function') {
+          node.disconnect();
+        }
+      } catch (_error) {
+        // Already stopped.
+      }
+    });
+    toneState.nodes = [];
+    setText(refs.toneStatus, 'Tone gate stopped.');
+  };
+
+  refs.stopTone?.addEventListener('click', stopTone);
+  refs.toneVolume?.addEventListener('input', () => {
+    setText(refs.toneVolumeValue, `${refs.toneVolume.value}%`);
+  });
+  refs.startTone?.addEventListener('click', async () => {
+    const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextCtor) {
+      setText(refs.toneStatus, 'Web Audio API is not available in this browser.');
+      return;
+    }
+
+    stopTone();
+    toneState.context = toneState.context || new AudioContextCtor();
+    if (toneState.context.state === 'suspended') {
+      await toneState.context.resume();
+    }
+
+    const baseFrequency = getToneFrequency(refs.toneSelect?.value);
+    const gain = toneState.context.createGain();
+    gain.gain.value = Number(refs.toneVolume?.value || 8) / 100;
+    gain.connect(toneState.context.destination);
+    toneState.nodes.push(gain);
+
+    const useSplit = Boolean(refs.binauralMode?.checked);
+    const leftFrequency = baseFrequency;
+    const rightFrequency = useSplit ? baseFrequency + 4 : baseFrequency;
+    const oscillators = [
+      createOscillator(toneState.context, leftFrequency, useSplit ? -1 : 0, gain),
+      createOscillator(toneState.context, rightFrequency, useSplit ? 1 : 0, gain),
+    ];
+    oscillators.forEach(oscillator => toneState.nodes.push(oscillator));
+    setText(refs.toneStatus, `Playing a ${refs.toneSelect?.value || 'medium'} tone at low volume.`);
+  });
+}
+
+function createOscillator(context, frequency, pan, destination) {
+  const oscillator = context.createOscillator();
+  oscillator.type = 'sine';
+  oscillator.frequency.value = frequency;
+
+  if (typeof context.createStereoPanner === 'function') {
+    const panner = context.createStereoPanner();
+    panner.pan.value = pan;
+    oscillator.connect(panner);
+    panner.connect(destination);
+  } else {
+    oscillator.connect(destination);
+  }
+
+  oscillator.start();
+  return oscillator;
+}
+
+function getToneFrequency(value) {
+  if (value === 'low') return 110;
+  if (value === 'high') return 432;
+  return 220;
+}
+
+function initIntentionGate(refs) {
+  refs.saveIntention?.addEventListener('click', () => {
+    const text = normalizeText(refs.intentionInput?.value);
+    if (!text) {
+      setText(refs.activeIntention, 'Write one clear intention before saving.');
+      return;
+    }
+    const entry = appendPortalLabEntry('intentions', { text });
+    refs.intentionInput.value = '';
+    setText(refs.activeIntention, entry.text);
+    renderJournal(refs);
+  });
+
+  const latest = readPortalLabList('intentions')[0];
+  if (latest) {
+    setText(refs.activeIntention, latest.text);
+  }
+}
+
+function initRandomnessGate(refs) {
+  refs.runRandomness?.addEventListener('click', () => {
+    try {
+      const values = generateBinaryValues(100);
+      const analysis = analyzeRandomnessGate(values, refs.randomIntent?.value);
+      const session = buildRandomnessSession({ values, analysis });
+      appendPortalLabEntry('sessions', session);
+      renderRandomness(refs, session);
+      renderJournal(refs);
+    } catch (error) {
+      setText(refs.randomnessResult, error.message || 'Randomness trial failed.');
+    }
+  });
+
+  if (!(window.crypto && typeof window.crypto.getRandomValues === 'function') && refs.runRandomness) {
+    refs.runRandomness.disabled = true;
+    setText(refs.randomnessResult, 'Browser crypto is unavailable here, so the randomness gate is disabled.');
+  }
+}
+
+function renderRandomness(refs, session) {
+  const result = session.result;
+  refs.randomnessResult.replaceChildren();
+  const stats = document.createElement('div');
+  stats.className = 'rng-stats';
+  [
+    ['Selected direction', result.intention === 'more-ones' ? 'more 1s' : 'more 0s'],
+    ['Ones', result.ones],
+    ['Zeros', result.zeros],
+    ['Expected', result.expected],
+    ['Difference from expected ones', result.differenceFromExpected],
+    ['Result', result.classification],
+  ].forEach(([label, value]) => {
+    const row = document.createElement('span');
+    const rowLabel = document.createElement('span');
+    rowLabel.textContent = label;
+    const rowValue = document.createElement('strong');
+    rowValue.textContent = String(value);
+    row.append(rowLabel, rowValue);
+    stats.append(row);
+  });
+  const interpretation = document.createElement('p');
+  interpretation.textContent = `${result.interpretation} This is exploratory and not proof of paranormal ability.`;
+  refs.randomnessResult.append(stats, interpretation);
+
+  refs.bitStrip.replaceChildren();
+  session.values.forEach(value => {
+    const cell = document.createElement('span');
+    cell.className = 'bit-cell';
+    cell.dataset.bit = String(value);
+    cell.title = String(value);
+    refs.bitStrip.append(cell);
+  });
+}
+
+function initDreamGate(refs) {
+  refs.saveEntry?.addEventListener('click', () => {
+    const type = refs.entryType?.value || 'dream';
+    const title = normalizeText(refs.entryTitle?.value);
+    const body = normalizeText(refs.entryBody?.value);
+    if (!title && !body) {
+      return;
+    }
+
+    const entry = { type, title, body };
+    appendPortalLabEntry(type === 'synchronicity' ? 'synchs' : 'dreams', entry);
+    refs.entryTitle.value = '';
+    refs.entryBody.value = '';
+    renderJournal(refs);
+  });
+}
+
+function initRealityCheck(refs) {
+  refs.communityShare?.addEventListener('change', () => {
+    setText(
+      refs.shareStatus,
+      refs.communityShare.checked
+        ? 'Placeholder only: this note will still stay local in v0.1.'
+        : 'Community sharing is a placeholder and is off by default.'
+    );
+  });
+
+  refs.saveRealityCheck?.addEventListener('click', () => {
+    const note = {
+      title: 'Reality check',
+      feltExperience: normalizeText(refs.feltExperience?.value),
+      measuredData: normalizeText(refs.measuredData?.value),
+      interpretation: normalizeText(refs.interpretation?.value),
+      openQuestion: normalizeText(refs.openQuestion?.value),
+      shareRequested: Boolean(refs.communityShare?.checked),
+    };
+    if (!note.feltExperience && !note.measuredData && !note.interpretation && !note.openQuestion) {
+      setText(refs.realityStatus, 'Add at least one layer before saving.');
+      return;
+    }
+    appendPortalLabEntry('notes', note);
+    ['feltExperience', 'measuredData', 'interpretation', 'openQuestion'].forEach(name => {
+      if (refs[name]) refs[name].value = '';
+    });
+    setText(
+      refs.realityStatus,
+      note.shareRequested
+        ? 'Saved locally. Community sharing is a future option and did not publish this note.'
+        : 'Reality check saved locally.'
+    );
+    renderJournal(refs);
+  });
+}
+
+function initAtlas(refs) {
+  renderAtlas(refs);
+  refs.atlasGrid?.addEventListener('click', event => {
+    const button = event.target.closest('[data-favorite-topic]');
+    if (!button) {
+      return;
+    }
+    toggleFavoriteTopic(button.getAttribute('data-favorite-topic'));
+    renderAtlas(refs);
+    renderJournal(refs);
+  });
+}
+
+function initBrowserApp() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  const refs = {
+    breathOrb: document.getElementById('breathOrb'),
+    breathRate: document.getElementById('breathRate'),
+    startBreath: document.getElementById('startBreath'),
+    stopBreath: document.getElementById('stopBreath'),
+    breathStatus: document.getElementById('breathStatus'),
+    toneSelect: document.getElementById('toneSelect'),
+    toneVolume: document.getElementById('toneVolume'),
+    toneVolumeValue: document.getElementById('toneVolumeValue'),
+    binauralMode: document.getElementById('binauralMode'),
+    startTone: document.getElementById('startTone'),
+    stopTone: document.getElementById('stopTone'),
+    toneStatus: document.getElementById('toneStatus'),
+    intentionInput: document.getElementById('intentionInput'),
+    saveIntention: document.getElementById('saveIntention'),
+    activeIntention: document.getElementById('activeIntention'),
+    randomIntent: document.getElementById('randomIntent'),
+    runRandomness: document.getElementById('runRandomness'),
+    randomnessResult: document.getElementById('randomnessResult'),
+    bitStrip: document.getElementById('bitStrip'),
+    entryType: document.getElementById('entryType'),
+    entryTitle: document.getElementById('entryTitle'),
+    entryBody: document.getElementById('entryBody'),
+    saveEntry: document.getElementById('saveEntry'),
+    communityShare: document.getElementById('communityShare'),
+    shareStatus: document.getElementById('shareStatus'),
+    feltExperience: document.getElementById('feltExperience'),
+    measuredData: document.getElementById('measuredData'),
+    interpretation: document.getElementById('interpretation'),
+    openQuestion: document.getElementById('openQuestion'),
+    saveRealityCheck: document.getElementById('saveRealityCheck'),
+    realityStatus: document.getElementById('realityStatus'),
+    atlasGrid: document.getElementById('atlasGrid'),
+    intentionList: document.getElementById('intentionList'),
+    dreamList: document.getElementById('dreamList'),
+    synchList: document.getElementById('synchList'),
+    noteList: document.getElementById('noteList'),
+    sessionList: document.getElementById('sessionList'),
+    favoriteList: document.getElementById('favoriteList'),
+  };
+
+  initBreathGate(refs);
+  initToneGate(refs);
+  initIntentionGate(refs);
+  initRandomnessGate(refs);
+  initDreamGate(refs);
+  initRealityCheck(refs);
+  initAtlas(refs);
+  renderJournal(refs);
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initBrowserApp, { once: true });
+  } else {
+    initBrowserApp();
+  }
+}

--- a/science/index.html
+++ b/science/index.html
@@ -132,6 +132,13 @@
             </div>
             <span aria-hidden="true">↗</span>
           </a>
+          <a class="resource" href="/portal-lab/">
+            <div class="resource__title">
+              <span>Portal Lab</span>
+              <span>Explore frequency, coherence, ritual, and randomness with grounded labels</span>
+            </div>
+            <span aria-hidden="true">↗</span>
+          </a>
           <a class="resource" href="/notes/">
             <div class="resource__title">
               <span>Notes</span>

--- a/tests/portal-lab.test.js
+++ b/tests/portal-lab.test.js
@@ -1,0 +1,195 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import {
+  PORTAL_LAB_KEYS,
+  PORTAL_LAB_TOPICS,
+  analyzeRandomnessGate,
+  appendPortalLabEntry,
+  buildRandomnessSession,
+  generateBinaryValues,
+  getResearchTopic,
+  readPortalLabList,
+  toggleFavoriteTopic,
+} from '../portal-lab/portal-lab.js';
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function createMemoryStorage(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+  };
+}
+
+test('Portal Lab ships the requested standalone app and manifest', async () => {
+  const appDir = new URL('../portal-lab/', import.meta.url);
+  assert.equal(await fileExists(new URL('index.html', appDir)), true);
+  assert.equal(await fileExists(new URL('portal-lab.css', appDir)), true);
+  assert.equal(await fileExists(new URL('portal-lab.js', appDir)), true);
+  assert.equal(await fileExists(new URL('../app-manifests/portal-lab.webmanifest', import.meta.url)), true);
+
+  const html = await readFile(new URL('index.html', appDir), 'utf8');
+  const css = await readFile(new URL('portal-lab.css', appDir), 'utf8');
+  const manifest = await readFile(new URL('../app-manifests/portal-lab.webmanifest', import.meta.url), 'utf8');
+
+  assert.match(html, /<title>Portal Lab \| 3DVR Portal<\/title>/);
+  assert.match(html, /A practice \+ research space for exploring frequency, consciousness, coherence/);
+  assert.match(html, /Mystery is allowed\. Fear is optional\. Evidence matters\. Experience matters/);
+  assert.match(html, /Four Levels of the Portal Question/);
+  assert.match(html, /Level 1: Frequency definitely affects consciousness/);
+  assert.match(html, /Consciousness affecting randomness is testable/);
+  assert.match(html, /Physical portal/);
+  assert.match(html, /Portal Lab v0\.1/);
+  assert.match(html, /Breath Gate/);
+  assert.match(html, /Tone Gate/);
+  assert.match(html, /Spine Gate/);
+  assert.match(html, /Intention Gate/);
+  assert.match(html, /Randomness Gate/);
+  assert.match(html, /Dream Gate/);
+  assert.match(html, /Group Gate/);
+  assert.match(html, /Reality Check/);
+  assert.match(html, /Research Atlas/);
+  assert.match(html, /This is exploratory and not proof of paranormal ability/);
+  assert.match(html, /Stop any practice that causes distress/);
+  assert.match(html, /<meta name="analytics" content="disabled">/);
+  assert.doesNotMatch(html, /Your thoughts control random numbers/i);
+  assert.doesNotMatch(html, /Guaranteed manifestation/i);
+  assert.doesNotMatch(html, /can heal disease/i);
+
+  assert.match(css, /--portal-bg: #0d0a08/);
+  assert.match(css, /prefers-reduced-motion: reduce/);
+  assert.match(css, /@keyframes breatheGate/);
+
+  assert.match(manifest, /3DVR Portal Lab/);
+  assert.match(manifest, /"start_url": "\/portal-lab\/\?source=pwa"/);
+  assert.match(manifest, /"scope": "\/portal-lab\/"/);
+});
+
+test('Portal Lab uses the requested localStorage keys', () => {
+  assert.deepEqual(PORTAL_LAB_KEYS, {
+    intentions: 'portalLab.intentions',
+    dreams: 'portalLab.dreams',
+    synchs: 'portalLab.synchs',
+    notes: 'portalLab.notes',
+    sessions: 'portalLab.sessions',
+    favorites: 'portalLab.favorites',
+  });
+
+  const storage = createMemoryStorage();
+  assert.deepEqual(readPortalLabList('intentions', storage), []);
+  const entry = appendPortalLabEntry('intentions', { id: 'intent-test', text: 'Breathe and act' }, storage);
+  assert.equal(entry.id, 'intent-test');
+  assert.equal(readPortalLabList('intentions', storage)[0].text, 'Breathe and act');
+  assert.match(storage.getItem(PORTAL_LAB_KEYS.intentions), /Breathe and act/);
+});
+
+test('generateBinaryValues uses crypto.getRandomValues and returns exact binary samples', () => {
+  const cryptoProvider = {
+    getRandomValues(values) {
+      values.forEach((_, index) => {
+        values[index] = index;
+      });
+      return values;
+    },
+  };
+
+  const values = generateBinaryValues(100, cryptoProvider);
+  assert.equal(values.length, 100);
+  assert.deepEqual(values.slice(0, 6), [0, 1, 0, 1, 0, 1]);
+  assert.throws(() => generateBinaryValues(0, cryptoProvider), /between 1 and 10000/);
+  assert.throws(() => generateBinaryValues(100, {}), /crypto\.getRandomValues is required/);
+});
+
+test('analyzeRandomnessGate reports above, below, and near chance honestly', () => {
+  const above = analyzeRandomnessGate([
+    ...Array(61).fill(1),
+    ...Array(39).fill(0),
+  ], 'more-ones');
+  assert.equal(above.ones, 61);
+  assert.equal(above.zeros, 39);
+  assert.equal(above.classification, 'above chance');
+  assert.match(above.interpretation, /exploratory data point/);
+
+  const below = analyzeRandomnessGate([
+    ...Array(61).fill(1),
+    ...Array(39).fill(0),
+  ], 'more-zeros');
+  assert.equal(below.classification, 'below chance');
+
+  const near = analyzeRandomnessGate([
+    ...Array(53).fill(1),
+    ...Array(47).fill(0),
+  ], 'more-ones');
+  assert.equal(near.classification, 'near chance');
+});
+
+test('buildRandomnessSession stores browser randomness source and neutral analysis', () => {
+  const values = [
+    ...Array(50).fill(1),
+    ...Array(50).fill(0),
+  ];
+  const session = buildRandomnessSession({ id: 'session-test', values, intention: 'more-ones' });
+
+  assert.equal(session.id, 'session-test');
+  assert.equal(session.app, 'portal-lab');
+  assert.equal(session.type, 'randomness-gate');
+  assert.equal(session.version, 1);
+  assert.equal(session.result.source, 'browser-crypto-getRandomValues');
+  assert.equal(session.result.classification, 'near chance');
+});
+
+test('Research Atlas includes all requested starter topics and labels', () => {
+  const titles = PORTAL_LAB_TOPICS.map(topic => topic.title);
+  assert.equal(PORTAL_LAB_TOPICS.length, 8);
+  assert.ok(titles.some(title => title.includes('Nikola Tesla')));
+  assert.ok(titles.some(title => title.includes('Jack Parsons')));
+  assert.ok(titles.some(title => title.includes('Project Gateway')));
+  assert.ok(titles.some(title => title.includes('Project SCANATE')));
+  assert.ok(titles.some(title => title.includes('Dugway Proving Ground')));
+  assert.ok(titles.some(title => title.includes('CERN Ritual Myth')));
+  assert.ok(titles.some(title => title.includes('Random Number Generators')));
+  assert.ok(titles.some(title => title.includes('DMT / altered states')));
+
+  const cern = getResearchTopic('cern-ritual-myth');
+  assert.ok(cern.labels.includes('Myth / unverified'));
+  assert.match(cern.warning, /Symbolic art is not proof/);
+});
+
+test('favorite topics are local-only and toggle through portalLab.favorites', () => {
+  const storage = createMemoryStorage();
+  let favorites = toggleFavoriteTopic('random-generators', storage);
+  assert.deepEqual(favorites, ['random-generators']);
+  assert.match(storage.getItem(PORTAL_LAB_KEYS.favorites), /random-generators/);
+
+  favorites = toggleFavoriteTopic('random-generators', storage);
+  assert.deepEqual(favorites, []);
+  assert.throws(() => toggleFavoriteTopic('unknown-topic', storage), /Unknown Portal Lab topic/);
+});
+
+test('Portal homepage, Science Lab, and README link to Portal Lab', async () => {
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const science = await readFile(new URL('../science/index.html', import.meta.url), 'utf8');
+  const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+
+  assert.match(portal, /href="portal-lab\/"/);
+  assert.match(portal, />Portal Lab</);
+  assert.match(portal, /data-app-tier="experimental"/);
+  assert.match(portal, /Explore frequency, consciousness, coherence, ritual, and randomness/);
+  assert.match(science, /href="\/portal-lab\/"/);
+  assert.match(science, /Explore frequency, coherence, ritual, and randomness/);
+  assert.match(readme, /\[Portal Lab\]\(https:\/\/3dvr-portal\.vercel\.app\/portal-lab\/\)/);
+});


### PR DESCRIPTION
## Summary
- Add /portal-lab/ as a local-first Frequency + Consciousness Lab with guided four-level framing, session gates, Research Atlas, and journal dashboard.
- Add a 100-bit browser crypto randomness gate with neutral above/below/near-chance output and local session persistence.
- Wire Portal Lab into the homepage experimental app dock, Science Lab shared resources, README, and installable manifest.

## Storage
- Local-only v0.1 keys: portalLab.intentions, portalLab.dreams, portalLab.synchs, portalLab.notes, portalLab.sessions, portalLab.favorites.
- Community sharing is present only as a disabled future placeholder; no Gun writes or backend changes were added.

## Safety framing
- The app labels documented, declassified, controversial, speculative, myth/unverified, and personal-practice material separately.
- Copy avoids medical claims and supernatural certainty claims; RNG output is explicitly exploratory and not proof of paranormal ability.

## Verification
- npm test -- tests/portal-lab.test.js
- git diff --check
- Manual Playwright smoke on http://127.0.0.1:3000/portal-lab/ with mobile viewport: page load, breath animation, tone start/stop, intention save, dream/synchronicity save and reload, randomness run and storage, research card favorite, and no console errors.

## Notes
- No Stripe, billing, backend, paid API, or analytics changes.