### PR TITLE
Add Inner Alignment wellness app

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Life](https://3dvr-portal.vercel.app/life/)
 - [Alive System](https://3dvr-portal.vercel.app/alive-system/)
 - [Body Mode](https://3dvr-portal.vercel.app/body-mode/)
+- [Inner Alignment](https://3dvr-portal.vercel.app/inner-alignment/)
 - [Education Suite](https://3dvr-portal.vercel.app/education-suite/)
 - [Attention Visualized](https://3dvr-portal.vercel.app/attention-visualized/)
 - [Logic Lab](https://3dvr-portal.vercel.app/logic-lab/)

--- a/app-manifests/inner-alignment.webmanifest
+++ b/app-manifests/inner-alignment.webmanifest
@@ -1,0 +1,16 @@
+{
+  "id": "/inner-alignment/",
+  "name": "3DVR Inner Alignment",
+  "short_name": "Inner Alignment",
+  "description": "Body, breath, attention, and action training with gentle visual guidance.",
+  "start_url": "/inner-alignment/?source=pwa",
+  "scope": "/inner-alignment/",
+  "display": "standalone",
+  "background_color": "#100d0a",
+  "theme_color": "#100d0a",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -579,6 +579,17 @@
               Open sensory-friendly breath, posture, reflection, and action tools for screen-heavy days.
             </span>
           </a>
+          <a
+            href="inner-alignment/"
+            class="app-card"
+            data-app-keywords="inner alignment wellness consciousness training breath posture attention action threejs"
+          >
+            <span class="app-card__icon" aria-hidden="true">IA</span>
+            <span class="app-card__title">Inner Alignment</span>
+            <span class="app-card__meta">
+              Practice seated resets, breathwork, attention, visualization, and one grounded action.
+            </span>
+          </a>
           <a href="herbal-nervous-system/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌿</span>
             <span class="app-card__title">Herbal Toolkit</span>

--- a/inner-alignment/app.js
+++ b/inner-alignment/app.js
@@ -1,0 +1,385 @@
+import {
+  INNER_ALIGNMENT_CATEGORIES,
+  INNER_ALIGNMENT_KEYS,
+  INNER_ALIGNMENT_PRACTICES,
+  buildPracticeSession,
+  formatPracticeDuration,
+  getInnerAlignmentPractice,
+  readInnerAlignmentList,
+  readInnerAlignmentPreferences,
+  savePracticeSession,
+  writeInnerAlignmentPreferences,
+} from './practices.js';
+
+const appState = {
+  practice: INNER_ALIGNMENT_PRACTICES[0],
+  currentStepIndex: 0,
+  remainingSeconds: INNER_ALIGNMENT_PRACTICES[0].duration,
+  timerId: 0,
+  isRunning: false,
+  isComplete: false,
+  reduceMotion: false,
+  scene: null,
+  syncBridge: null,
+};
+
+function getRefs() {
+  return {
+    body: document.body,
+    practiceGrid: document.getElementById('practiceGrid'),
+    categoryFilters: document.getElementById('categoryFilters'),
+    canvas: document.getElementById('alignmentCanvas'),
+    sceneFallback: document.getElementById('sceneFallback'),
+    activeCategory: document.getElementById('activeCategory'),
+    activeTitle: document.getElementById('activeTitle'),
+    activeIntention: document.getElementById('activeIntention'),
+    activeDuration: document.getElementById('activeDuration'),
+    activeBreath: document.getElementById('activeBreath'),
+    timerDisplay: document.getElementById('timerDisplay'),
+    progressBar: document.getElementById('progressBar'),
+    stepCounter: document.getElementById('stepCounter'),
+    instructionList: document.getElementById('instructionList'),
+    reflectionPrompt: document.getElementById('reflectionPrompt'),
+    reflectionInput: document.getElementById('reflectionInput'),
+    actionInput: document.getElementById('actionInput'),
+    startPauseButton: document.getElementById('startPauseButton'),
+    nextStepButton: document.getElementById('nextStepButton'),
+    resetButton: document.getElementById('resetButton'),
+    saveSessionButton: document.getElementById('saveSessionButton'),
+    saveStatus: document.getElementById('saveStatus'),
+    reduceMotionToggle: document.getElementById('reduceMotionToggle'),
+    sessionList: document.getElementById('sessionList'),
+    sessionCount: document.getElementById('sessionCount'),
+  };
+}
+
+function initInnerAlignment() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const refs = getRefs();
+  const preferences = readInnerAlignmentPreferences();
+  appState.reduceMotion = preferences.reduceMotion;
+  appState.practice = getInnerAlignmentPractice(readActivePracticeId())
+    || getInnerAlignmentPractice(preferences.lastPracticeId);
+  appState.practice = appState.practice || INNER_ALIGNMENT_PRACTICES[0];
+  appState.remainingSeconds = appState.practice.duration;
+
+  refs.reduceMotionToggle.checked = appState.reduceMotion;
+  applyReduceMotion(refs, appState.reduceMotion);
+  renderCategoryFilters(refs);
+  renderPracticeCards(refs);
+  renderActivePractice(refs);
+  renderSessions(refs);
+  bindEvents(refs);
+  loadScene(refs);
+
+  window.InnerAlignment = {
+    setSyncBridge(bridge) {
+      appState.syncBridge = bridge;
+    },
+    getActivePractice() {
+      return appState.practice;
+    },
+  };
+}
+
+function bindEvents(refs) {
+  refs.practiceGrid.addEventListener('click', event => {
+    const button = event.target.closest('[data-practice-id]');
+    if (!button) return;
+    selectPractice(button.getAttribute('data-practice-id'), refs);
+  });
+
+  refs.categoryFilters.addEventListener('click', event => {
+    const button = event.target.closest('[data-category-filter]');
+    if (!button) return;
+    const category = button.getAttribute('data-category-filter') || 'all';
+    renderPracticeCards(refs, category);
+    refs.categoryFilters.querySelectorAll('[data-category-filter]').forEach(filter => {
+      const selected = filter === button;
+      filter.classList.toggle('is-active', selected);
+      filter.setAttribute('aria-pressed', selected ? 'true' : 'false');
+    });
+  });
+
+  refs.startPauseButton.addEventListener('click', () => {
+    if (appState.isRunning) {
+      pausePractice(refs);
+    } else {
+      startPractice(refs);
+    }
+  });
+  refs.nextStepButton.addEventListener('click', () => nextStep(refs));
+  refs.resetButton.addEventListener('click', () => resetPractice(refs));
+  refs.saveSessionButton.addEventListener('click', () => saveCurrentSession(refs));
+  refs.reduceMotionToggle.addEventListener('change', event => {
+    appState.reduceMotion = Boolean(event.target.checked);
+    writeInnerAlignmentPreferences({
+      reduceMotion: appState.reduceMotion,
+      lastPracticeId: appState.practice.id,
+    });
+    applyReduceMotion(refs, appState.reduceMotion);
+    if (appState.scene) appState.scene.setReduceMotion(appState.reduceMotion);
+  });
+}
+
+async function loadScene(refs) {
+  try {
+    const module = await import('./three-scene.js');
+    appState.scene = module.createInnerAlignmentScene(refs.canvas, {
+      visualMode: appState.practice.visual,
+      reduceMotion: appState.reduceMotion,
+    });
+    appState.scene.setPaused(false);
+    refs.sceneFallback.hidden = true;
+  } catch (error) {
+    console.warn('Inner Alignment Three.js scene unavailable', error);
+    refs.sceneFallback.hidden = false;
+    refs.sceneFallback.textContent = 'Visual guide unavailable. The practice timer still works.';
+  }
+}
+
+function renderCategoryFilters(refs) {
+  refs.categoryFilters.replaceChildren();
+  const filters = ['all', ...INNER_ALIGNMENT_CATEGORIES];
+  filters.forEach((category, index) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = index === 0 ? 'filter-button is-active' : 'filter-button';
+    button.dataset.categoryFilter = category;
+    button.setAttribute('aria-pressed', index === 0 ? 'true' : 'false');
+    button.textContent = category === 'all' ? 'All' : category;
+    refs.categoryFilters.append(button);
+  });
+}
+
+function renderPracticeCards(refs, category = 'all') {
+  const practices = category === 'all'
+    ? INNER_ALIGNMENT_PRACTICES
+    : INNER_ALIGNMENT_PRACTICES.filter(practice => practice.category === category);
+
+  refs.practiceGrid.replaceChildren();
+  practices.forEach(practice => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = practice.id === appState.practice.id ? 'practice-card is-active' : 'practice-card';
+    button.dataset.practiceId = practice.id;
+    button.innerHTML = `
+      <span class="practice-card__category">${escapeHtml(practice.category)}</span>
+      <strong>${escapeHtml(practice.title)}</strong>
+      <span>${escapeHtml(practice.intention)}</span>
+      <small>${formatPracticeDuration(practice.duration)} · ${escapeHtml(practice.visual)}</small>
+    `;
+    refs.practiceGrid.append(button);
+  });
+}
+
+function renderActivePractice(refs) {
+  const practice = appState.practice;
+  const progress = 1 - (appState.remainingSeconds / practice.duration);
+  refs.activeCategory.textContent = practice.category;
+  refs.activeTitle.textContent = practice.title;
+  refs.activeIntention.textContent = practice.intention;
+  refs.activeDuration.textContent = formatPracticeDuration(practice.duration);
+  refs.activeBreath.textContent = practice.breathPattern;
+  refs.timerDisplay.textContent = formatPracticeDuration(appState.remainingSeconds);
+  refs.progressBar.value = Math.max(0, Math.min(1, progress));
+  refs.stepCounter.textContent = `Step ${appState.currentStepIndex + 1} of ${practice.instructions.length}`;
+  refs.reflectionPrompt.textContent = practice.reflectionPrompt;
+  refs.instructionList.replaceChildren();
+
+  practice.instructions.forEach((instruction, index) => {
+    const item = document.createElement('li');
+    item.className = index === appState.currentStepIndex ? 'is-active' : '';
+    item.textContent = instruction;
+    refs.instructionList.append(item);
+  });
+
+  refs.startPauseButton.textContent = appState.isRunning ? 'Pause' : 'Start';
+  refs.saveSessionButton.disabled = !appState.isComplete;
+  renderPracticeCards(refs, getActiveCategoryFilter(refs));
+}
+
+function renderSessions(refs) {
+  const sessions = readInnerAlignmentList('sessions');
+  refs.sessionCount.textContent = String(sessions.length);
+  refs.sessionList.replaceChildren();
+  if (!sessions.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'No completed practices saved yet.';
+    refs.sessionList.append(empty);
+    return;
+  }
+
+  sessions.slice(0, 6).forEach(session => {
+    const item = document.createElement('article');
+    item.className = 'session-item';
+    item.innerHTML = `
+      <strong>${escapeHtml(session.practiceTitle)}</strong>
+      <small>${escapeHtml(formatSessionDate(session.createdAt))}</small>
+      <span>${escapeHtml(session.action || 'No action logged')}</span>
+    `;
+    refs.sessionList.append(item);
+  });
+}
+
+function selectPractice(practiceId, refs) {
+  const practice = getInnerAlignmentPractice(practiceId);
+  if (!practice) return;
+  pausePractice(refs);
+  appState.practice = practice;
+  appState.currentStepIndex = 0;
+  appState.remainingSeconds = practice.duration;
+  appState.isComplete = false;
+  refs.reflectionInput.value = '';
+  refs.actionInput.value = '';
+  setSaveStatus(refs, '');
+  saveActivePracticeId(practice.id);
+  writeInnerAlignmentPreferences({ lastPracticeId: practice.id });
+  if (appState.scene) appState.scene.setVisualMode(practice.visual);
+  renderActivePractice(refs);
+}
+
+function startPractice(refs) {
+  if (appState.isComplete) {
+    resetPractice(refs);
+  }
+  appState.isRunning = true;
+  if (appState.scene) appState.scene.setPaused(false);
+  clearInterval(appState.timerId);
+  appState.timerId = window.setInterval(() => {
+    appState.remainingSeconds = Math.max(0, appState.remainingSeconds - 1);
+    updateStepFromTime();
+    if (appState.remainingSeconds === 0) {
+      completePractice(refs);
+      return;
+    }
+    renderActivePractice(refs);
+  }, 1000);
+  renderActivePractice(refs);
+}
+
+function pausePractice(refs) {
+  appState.isRunning = false;
+  clearInterval(appState.timerId);
+  appState.timerId = 0;
+  renderActivePractice(refs);
+}
+
+function resetPractice(refs) {
+  pausePractice(refs);
+  appState.currentStepIndex = 0;
+  appState.remainingSeconds = appState.practice.duration;
+  appState.isComplete = false;
+  setSaveStatus(refs, '');
+  renderActivePractice(refs);
+}
+
+function nextStep(refs) {
+  const maxStep = appState.practice.instructions.length - 1;
+  appState.currentStepIndex = Math.min(maxStep, appState.currentStepIndex + 1);
+  const stepDuration = appState.practice.duration / appState.practice.instructions.length;
+  appState.remainingSeconds = Math.max(
+    0,
+    Math.ceil(appState.practice.duration - (appState.currentStepIndex * stepDuration))
+  );
+  renderActivePractice(refs);
+}
+
+function completePractice(refs) {
+  pausePractice(refs);
+  appState.remainingSeconds = 0;
+  appState.currentStepIndex = appState.practice.instructions.length - 1;
+  appState.isComplete = true;
+  setSaveStatus(refs, 'Practice complete. Add a reflection and one real-world action.');
+  renderActivePractice(refs);
+}
+
+function saveCurrentSession(refs) {
+  const session = savePracticeSession({
+    practiceId: appState.practice.id,
+    reflection: refs.reflectionInput.value,
+    action: refs.actionInput.value,
+  });
+  setSaveStatus(refs, 'Saved locally.');
+  refs.reflectionInput.value = '';
+  refs.actionInput.value = '';
+  appState.isComplete = false;
+  renderSessions(refs);
+  renderActivePractice(refs);
+
+  if (appState.syncBridge && typeof appState.syncBridge.onSessionSaved === 'function') {
+    appState.syncBridge.onSessionSaved(session);
+  }
+}
+
+function updateStepFromTime() {
+  const elapsed = appState.practice.duration - appState.remainingSeconds;
+  const stepDuration = appState.practice.duration / appState.practice.instructions.length;
+  appState.currentStepIndex = Math.min(
+    appState.practice.instructions.length - 1,
+    Math.floor(elapsed / stepDuration)
+  );
+}
+
+function applyReduceMotion(refs, reduceMotion) {
+  refs.body.dataset.reduceMotion = reduceMotion ? 'true' : 'false';
+}
+
+function setSaveStatus(refs, message) {
+  refs.saveStatus.textContent = message;
+}
+
+function getActiveCategoryFilter(refs) {
+  const active = refs.categoryFilters.querySelector('[data-category-filter].is-active');
+  return active ? active.getAttribute('data-category-filter') || 'all' : 'all';
+}
+
+function readActivePracticeId() {
+  try {
+    return window.localStorage.getItem(INNER_ALIGNMENT_KEYS.activePractice) || '';
+  } catch (_error) {
+    return '';
+  }
+}
+
+function saveActivePracticeId(practiceId) {
+  try {
+    window.localStorage.setItem(INNER_ALIGNMENT_KEYS.activePractice, practiceId);
+  } catch (_error) {
+    // Storage can be unavailable in private contexts. The app remains usable for the current session.
+  }
+}
+
+function formatSessionDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initInnerAlignment, { once: true });
+  } else {
+    initInnerAlignment();
+  }
+}

--- a/inner-alignment/index.html
+++ b/inner-alignment/index.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Inner Alignment | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="Body, breath, attention, and action training with gentle Three.js visual guidance."
+  >
+  <meta name="analytics" content="disabled">
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="./style.css">
+  <link rel="manifest" href="/app-manifests/inner-alignment.webmanifest">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
+  <meta name="theme-color" content="#100d0a">
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+      }
+    }
+  </script>
+  <script type="module" src="./app.js"></script>
+</head>
+<body class="inner-page">
+  <a class="skip-link" href="#innerMain">Skip to Inner Alignment</a>
+
+  <header class="inner-top">
+    <nav class="inner-nav" aria-label="Inner Alignment navigation">
+      <a class="inner-brand" href="/">
+        <span class="inner-brand__mark" aria-hidden="true">IA</span>
+        <span>
+          <strong>Inner Alignment</strong>
+          <small>Wellness / consciousness training</small>
+        </span>
+      </a>
+      <div class="inner-nav__links">
+        <a href="/">Portal</a>
+        <a href="/body-mode/">Body Mode</a>
+        <a href="/portal-lab/">Portal Lab</a>
+        <a href="/meditation/">Breathing Room</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="innerMain" class="inner-shell">
+    <section class="hero" aria-labelledby="inner-title">
+      <div class="hero__copy">
+        <p class="kicker">Body as interface</p>
+        <h1 id="inner-title">Inner Alignment</h1>
+        <p class="hero__subtitle">Body, breath, attention, and action.</p>
+        <p class="hero__text">
+          Use the body as the interface for consciousness. Start with posture and breath, train attention,
+          let imagination become insight, then choose one grounded action.
+        </p>
+        <div class="chain" aria-label="Practice sequence">
+          <span>Body</span>
+          <span>Breath</span>
+          <span>Attention</span>
+          <span>Imagination</span>
+          <span>Insight</span>
+          <span>Action</span>
+        </div>
+      </div>
+      <div class="hero__actions">
+        <a class="inner-button inner-button--primary" href="#practiceRunner">Start practice</a>
+        <a class="inner-button" href="#practiceLibrary">Browse practices</a>
+      </div>
+    </section>
+
+    <section class="visual-stage" aria-labelledby="visual-title">
+      <div class="visual-stage__copy">
+        <p class="kicker">3D guidance</p>
+        <h2 id="visual-title">Watch the cue, then return to the body.</h2>
+        <p>
+          The visual is a quiet focus object: a spine wave, breath orb, heart light, attention point,
+          particles, or calm mandala depending on the practice.
+        </p>
+      </div>
+      <div class="canvas-wrap" aria-label="Three.js guided visual">
+        <canvas id="alignmentCanvas"></canvas>
+        <p id="sceneFallback" class="scene-fallback" hidden></p>
+      </div>
+    </section>
+
+    <section class="settings-panel" aria-labelledby="settings-title">
+      <div>
+        <p class="kicker">Sensory settings</p>
+        <h2 id="settings-title">Gentle by default.</h2>
+      </div>
+      <label class="switch-field" for="reduceMotionToggle">
+        <input id="reduceMotionToggle" type="checkbox">
+        <span>Reduce Motion</span>
+      </label>
+    </section>
+
+    <section id="practiceLibrary" class="panel" aria-labelledby="library-title">
+      <div class="section-heading">
+        <p class="kicker">Practice library</p>
+        <h2 id="library-title">Choose the doorway for this moment.</h2>
+        <p>
+          These micro-practices are framed as wellness, self-awareness, relaxation, posture, breath,
+          and intention training. No hard claims, no pressure.
+        </p>
+      </div>
+      <div id="categoryFilters" class="filter-row" aria-label="Practice categories"></div>
+      <div id="practiceGrid" class="practice-grid" aria-label="Inner Alignment practices"></div>
+    </section>
+
+    <section id="practiceRunner" class="runner-layout" aria-labelledby="runner-title">
+      <div class="runner-main">
+        <div class="section-heading">
+          <p id="activeCategory" class="kicker">Seated Body Reset</p>
+          <h2 id="runner-title"><span id="activeTitle">Seated Spinal Wave</span></h2>
+          <p id="activeIntention">Loosen the spine and restore flow.</p>
+        </div>
+
+        <div class="timer-strip" aria-label="Practice timer">
+          <div>
+            <span class="timer-label">Remaining</span>
+            <strong id="timerDisplay">01:30</strong>
+          </div>
+          <div>
+            <span class="timer-label">Duration</span>
+            <strong id="activeDuration">01:30</strong>
+          </div>
+          <div>
+            <span class="timer-label">Breath cue</span>
+            <strong id="activeBreath">inhale-exhale</strong>
+          </div>
+        </div>
+
+        <progress id="progressBar" value="0" max="1">0%</progress>
+
+        <div class="button-row" aria-label="Practice controls">
+          <button id="startPauseButton" class="inner-button inner-button--primary" type="button">Start</button>
+          <button id="nextStepButton" class="inner-button" type="button">Next step</button>
+          <button id="resetButton" class="inner-button" type="button">Reset</button>
+        </div>
+
+        <div class="instruction-panel" aria-live="polite">
+          <p id="stepCounter" class="step-counter">Step 1 of 4</p>
+          <ol id="instructionList"></ol>
+        </div>
+      </div>
+
+      <aside class="runner-side" aria-labelledby="reflection-title">
+        <div>
+          <p class="kicker">Integration</p>
+          <h2 id="reflection-title">Insight becomes action.</h2>
+          <p id="reflectionPrompt" class="prompt">Where do I feel blocked or tense?</p>
+        </div>
+        <label class="text-field" for="reflectionInput">
+          <span>Reflection</span>
+          <textarea id="reflectionInput" rows="4" placeholder="What changed in body, breath, or attention?"></textarea>
+        </label>
+        <label class="text-field" for="actionInput">
+          <span>One real-world action</span>
+          <input id="actionInput" type="text" placeholder="Send the message, stand up, drink water, take the walk">
+        </label>
+        <button id="saveSessionButton" class="inner-button inner-button--primary" type="button" disabled>
+          Save completed practice
+        </button>
+        <p id="saveStatus" class="status-text" aria-live="polite"></p>
+      </aside>
+    </section>
+
+    <section class="panel" aria-labelledby="history-title">
+      <div class="section-heading">
+        <p class="kicker">Local progress</p>
+        <h2 id="history-title">Saved practices: <span id="sessionCount">0</span></h2>
+        <p>
+          Sessions are saved locally in this browser for now. A clean sync hook is available for future
+          Gun-backed storage.
+        </p>
+      </div>
+      <div id="sessionList" class="session-list" aria-live="polite"></div>
+    </section>
+
+    <section class="disclaimer" aria-label="Wellness disclaimer">
+      This app is for general wellness and reflection. It is not medical advice. Move gently and stop if anything hurts.
+    </section>
+  </main>
+
+  <footer class="inner-footer">
+    <a href="/">Portal</a>
+    <a href="/wellness.html">Wellness Directory</a>
+    <a href="/body-mode/">Body Mode</a>
+    <a href="/portal-lab/">Portal Lab</a>
+    <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>
+  </footer>
+</body>
+</html>

--- a/inner-alignment/practices.js
+++ b/inner-alignment/practices.js
@@ -1,0 +1,292 @@
+export const INNER_ALIGNMENT_KEYS = Object.freeze({
+  preferences: 'innerAlignment.preferences',
+  sessions: 'innerAlignment.sessions',
+  activePractice: 'innerAlignment.activePractice',
+  reflections: 'innerAlignment.reflections',
+});
+
+export const INNER_ALIGNMENT_CATEGORIES = Object.freeze([
+  'Seated Body Reset',
+  'Breath & Nervous System',
+  'Focus & Awareness',
+  'Light / Energy Visualization',
+  'Intention Into Action',
+]);
+
+export const INNER_ALIGNMENT_PRACTICES = Object.freeze([
+  {
+    id: 'seated-spinal-wave',
+    title: 'Seated Spinal Wave',
+    category: 'Seated Body Reset',
+    duration: 90,
+    intention: 'Loosen the spine and restore flow.',
+    instructions: [
+      'Sit tall with both feet on the ground.',
+      'Inhale and gently arch the chest forward.',
+      'Exhale and round the spine back.',
+      'Move slowly like a wave through the spine.',
+    ],
+    visual: 'spine-wave',
+    breathPattern: 'inhale-exhale',
+    reflectionPrompt: 'Where do I feel blocked or tense?',
+  },
+  {
+    id: 'neck-shoulder-release',
+    title: 'Neck & Shoulder Release',
+    category: 'Seated Body Reset',
+    duration: 120,
+    intention: 'Release screen posture and soften the upper body.',
+    instructions: [
+      'Let the jaw soften and drop the shoulders away from the ears.',
+      'Slowly turn the head right, center, then left without forcing range.',
+      'Roll the shoulders forward three times, then backward three times.',
+      'Pause with the chest open and breathe into the back of the ribs.',
+    ],
+    visual: 'spine-wave',
+    breathPattern: 'slow-nasal',
+    reflectionPrompt: 'What changes when I stop bracing my shoulders?',
+  },
+  {
+    id: 'chest-opener',
+    title: 'Chest Opener',
+    category: 'Seated Body Reset',
+    duration: 75,
+    intention: 'Open the front body and make more room for breath.',
+    instructions: [
+      'Interlace fingers behind the back or hold the sides of the chair.',
+      'Inhale and gently lift the sternum without compressing the low back.',
+      'Keep the neck long and the jaw easy.',
+      'Exhale slowly and keep the front body spacious.',
+    ],
+    visual: 'heart-light',
+    breathPattern: 'inhale-expand',
+    reflectionPrompt: 'What feels easier to receive when the chest has space?',
+  },
+  {
+    id: 'wrist-forearm-reset',
+    title: 'Wrist & Forearm Reset',
+    category: 'Seated Body Reset',
+    duration: 80,
+    intention: 'Give keyboard and controller muscles a clean reset.',
+    instructions: [
+      'Extend one arm forward with palm facing down.',
+      'Use the other hand to gently draw the fingers back for one breath.',
+      'Turn the palm up and repeat with the wrist soft.',
+      'Switch sides, then shake out both hands lightly.',
+    ],
+    visual: 'rising-particles',
+    breathPattern: 'easy-breath',
+    reflectionPrompt: 'Where can I grip less today?',
+  },
+  {
+    id: 'box-breathing',
+    title: 'Box Breathing',
+    category: 'Breath & Nervous System',
+    duration: 120,
+    intention: 'Create a steady rhythm for calm focus.',
+    instructions: [
+      'Inhale for four counts.',
+      'Hold gently for four counts.',
+      'Exhale for four counts.',
+      'Hold gently for four counts, then repeat.',
+    ],
+    visual: 'breathing-orb',
+    breathPattern: '4-4-4-4',
+    reflectionPrompt: 'What becomes clearer when the breath has a shape?',
+  },
+  {
+    id: 'long-exhale-calm',
+    title: 'Long Exhale Calm',
+    category: 'Breath & Nervous System',
+    duration: 150,
+    intention: 'Downshift through a longer, softer exhale.',
+    instructions: [
+      'Inhale through the nose for four counts.',
+      'Exhale slowly for six to eight counts.',
+      'Let the ribs soften down without collapsing.',
+      'Repeat gently and keep the face relaxed.',
+    ],
+    visual: 'breathing-orb',
+    breathPattern: '4-8',
+    reflectionPrompt: 'What am I ready to release without forcing it?',
+  },
+  {
+    id: 'third-eye-focus',
+    title: 'Third-Eye Focus',
+    category: 'Focus & Awareness',
+    duration: 180,
+    intention: 'Train attention on one quiet point.',
+    instructions: [
+      'Let the gaze rest softly near the center point.',
+      'Feel the space between the eyebrows without strain.',
+      'When thought pulls attention away, notice it and return.',
+      'Keep the body grounded while the mind becomes simple.',
+    ],
+    visual: 'third-eye-focus',
+    breathPattern: 'natural',
+    reflectionPrompt: 'What did I notice about attention when it wandered?',
+  },
+  {
+    id: 'heart-light-gratitude',
+    title: 'Heart Light Gratitude',
+    category: 'Light / Energy Visualization',
+    duration: 150,
+    intention: 'Practice warmth, appreciation, and steadiness.',
+    instructions: [
+      'Rest one hand on the center of the chest if comfortable.',
+      'Imagine a warm light expanding from the heart area.',
+      'Name one person, place, or moment you appreciate.',
+      'Let gratitude be felt in the body, not only thought.',
+    ],
+    visual: 'heart-light',
+    breathPattern: 'coherent',
+    reflectionPrompt: 'What did gratitude change in my body?',
+  },
+  {
+    id: 'observe-the-observer',
+    title: 'Observe the Observer',
+    category: 'Focus & Awareness',
+    duration: 180,
+    intention: 'Notice awareness without chasing every thought.',
+    instructions: [
+      'Sit upright and let the breath happen naturally.',
+      'Notice thoughts as events passing through awareness.',
+      'Ask softly: who is aware of this thought?',
+      'Rest as the noticing, without needing an answer.',
+    ],
+    visual: 'mandala-calm',
+    breathPattern: 'natural',
+    reflectionPrompt: 'What remains when I do not follow the thought?',
+  },
+  {
+    id: 'intention-into-action',
+    title: 'Intention Into Action',
+    category: 'Intention Into Action',
+    duration: 120,
+    intention: 'Turn insight into one physical step.',
+    instructions: [
+      'Write the intention in plain language.',
+      'Feel the desired state in the body for three breaths.',
+      'Name the smallest action that would make it real today.',
+      'Commit to the first visible step, not the whole mountain.',
+    ],
+    visual: 'rising-particles',
+    breathPattern: 'three-breaths',
+    reflectionPrompt: 'What one action will prove this intention in the real world?',
+  },
+]);
+
+export function getInnerAlignmentPractice(practiceId) {
+  return INNER_ALIGNMENT_PRACTICES.find(practice => practice.id === practiceId) || null;
+}
+
+export function getPracticesByCategory(category) {
+  return INNER_ALIGNMENT_PRACTICES.filter(practice => practice.category === category);
+}
+
+export function formatPracticeDuration(seconds) {
+  const value = Math.max(0, Math.floor(Number(seconds) || 0));
+  const minutes = Math.floor(value / 60);
+  const remainingSeconds = value % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
+}
+
+export function buildPracticeSession(input = {}) {
+  const practice = getInnerAlignmentPractice(input.practiceId) || INNER_ALIGNMENT_PRACTICES[0];
+  const now = new Date().toISOString();
+  return {
+    id: normalizeText(input.id) || makeSessionId(),
+    app: 'inner-alignment',
+    version: 1,
+    practiceId: practice.id,
+    practiceTitle: practice.title,
+    category: practice.category,
+    createdAt: normalizeText(input.createdAt) || now,
+    completedAt: normalizeText(input.completedAt) || now,
+    reflection: normalizeText(input.reflection),
+    action: normalizeText(input.action),
+  };
+}
+
+export function readInnerAlignmentList(keyName, storage = globalThis.localStorage) {
+  const key = INNER_ALIGNMENT_KEYS[keyName] || keyName;
+  if (!storage || typeof storage.getItem !== 'function') {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(storage.getItem(key) || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+export function writeInnerAlignmentList(keyName, entries, storage = globalThis.localStorage) {
+  const key = INNER_ALIGNMENT_KEYS[keyName] || keyName;
+  if (!storage || typeof storage.setItem !== 'function') {
+    return [];
+  }
+  const safeEntries = Array.isArray(entries) ? entries : [];
+  storage.setItem(key, JSON.stringify(safeEntries));
+  return safeEntries;
+}
+
+export function savePracticeSession(sessionInput, storage = globalThis.localStorage) {
+  const session = buildPracticeSession(sessionInput);
+  const sessions = readInnerAlignmentList('sessions', storage);
+  writeInnerAlignmentList('sessions', [session, ...sessions].slice(0, 80), storage);
+
+  const reflections = readInnerAlignmentList('reflections', storage);
+  writeInnerAlignmentList('reflections', [{
+    id: session.id,
+    practiceId: session.practiceId,
+    reflection: session.reflection,
+    action: session.action,
+    createdAt: session.createdAt,
+  }, ...reflections].slice(0, 80), storage);
+
+  return session;
+}
+
+export function readInnerAlignmentPreferences(storage = globalThis.localStorage) {
+  if (!storage || typeof storage.getItem !== 'function') {
+    return { reduceMotion: false, lastPracticeId: INNER_ALIGNMENT_PRACTICES[0].id };
+  }
+  try {
+    const parsed = JSON.parse(storage.getItem(INNER_ALIGNMENT_KEYS.preferences) || '{}');
+    return {
+      reduceMotion: Boolean(parsed.reduceMotion),
+      lastPracticeId: getInnerAlignmentPractice(parsed.lastPracticeId)
+        ? parsed.lastPracticeId
+        : INNER_ALIGNMENT_PRACTICES[0].id,
+    };
+  } catch (_error) {
+    return { reduceMotion: false, lastPracticeId: INNER_ALIGNMENT_PRACTICES[0].id };
+  }
+}
+
+export function writeInnerAlignmentPreferences(preferences, storage = globalThis.localStorage) {
+  const next = {
+    ...readInnerAlignmentPreferences(storage),
+    ...preferences,
+  };
+  if (storage && typeof storage.setItem === 'function') {
+    storage.setItem(INNER_ALIGNMENT_KEYS.preferences, JSON.stringify(next));
+  }
+  return next;
+}
+
+let fallbackSessionCounter = 0;
+
+function makeSessionId() {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    return `inner-${cryptoApi.randomUUID()}`;
+  }
+  fallbackSessionCounter += 1;
+  return `inner-${Date.now()}-${fallbackSessionCounter}`;
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}

--- a/inner-alignment/style.css
+++ b/inner-alignment/style.css
@@ -1,0 +1,629 @@
+:root {
+  color-scheme: dark;
+  --inner-bg: #0f0c09;
+  --inner-bg-soft: #17120e;
+  --inner-panel: rgba(34, 27, 21, 0.88);
+  --inner-panel-soft: rgba(255, 244, 226, 0.055);
+  --inner-border: rgba(232, 190, 118, 0.18);
+  --inner-text: #f7efe3;
+  --inner-muted: #cbbda8;
+  --inner-dim: #9a8a76;
+  --inner-gold: #e1b56a;
+  --inner-teal: #91d7ca;
+  --inner-rose: #e7a38b;
+  --inner-violet: #b9a5f0;
+  --inner-green: #a6d2a3;
+  --inner-shadow: 0 26px 70px rgba(0, 0, 0, 0.38);
+  --inner-radius: 8px;
+  --inner-max: 1180px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--inner-bg);
+}
+
+body.inner-page {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(145, 215, 202, 0.12), transparent 30rem),
+    linear-gradient(145deg, #0f0c09 0%, #17120e 54%, #111018 100%);
+  color: var(--inner-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.58;
+}
+
+body.inner-page a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--inner-teal);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 20;
+  transform: translateY(-150%);
+  padding: 10px 14px;
+  border-radius: var(--inner-radius);
+  background: var(--inner-teal);
+  color: #07110f;
+  font-weight: 850;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.inner-top {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--inner-border);
+  background: rgba(15, 12, 9, 0.9);
+  backdrop-filter: blur(14px);
+}
+
+.inner-nav,
+.inner-shell,
+.inner-footer {
+  width: min(100% - 28px, var(--inner-max));
+  margin: 0 auto;
+}
+
+.inner-nav {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.inner-brand,
+.inner-nav__links,
+.hero__actions,
+.chain,
+.button-row,
+.filter-row,
+.inner-footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.inner-brand {
+  text-decoration: none;
+}
+
+.inner-brand__mark {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid rgba(225, 181, 106, 0.4);
+  border-radius: var(--inner-radius);
+  background:
+    linear-gradient(145deg, rgba(225, 181, 106, 0.18), rgba(145, 215, 202, 0.08)),
+    rgba(255, 255, 255, 0.04);
+  color: var(--inner-gold);
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.inner-brand strong,
+.inner-brand small {
+  display: block;
+}
+
+.inner-brand small {
+  color: var(--inner-muted);
+  font-size: 0.78rem;
+}
+
+.inner-nav__links a,
+.inner-footer a {
+  padding: 8px 10px;
+  border: 1px solid var(--inner-border);
+  border-radius: var(--inner-radius);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--inner-muted);
+  text-decoration: none;
+}
+
+.inner-nav__links a:hover,
+.inner-footer a:hover {
+  border-color: rgba(145, 215, 202, 0.45);
+  color: var(--inner-text);
+}
+
+.inner-shell {
+  padding: 24px 0 42px;
+  display: grid;
+  gap: 22px;
+}
+
+.hero,
+.panel,
+.runner-main,
+.runner-side,
+.settings-panel,
+.disclaimer {
+  border: 1px solid var(--inner-border);
+  border-radius: var(--inner-radius);
+  background: var(--inner-panel);
+  box-shadow: var(--inner-shadow);
+}
+
+.hero {
+  display: grid;
+  gap: 18px;
+  padding: clamp(22px, 5vw, 44px);
+}
+
+.hero__copy,
+.section-heading,
+.runner-main,
+.runner-side {
+  display: grid;
+  gap: 14px;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--inner-gold);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: clamp(3rem, 11vw, 6.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.055em;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: clamp(1.55rem, 4vw, 3rem);
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+}
+
+.hero__subtitle {
+  max-width: 780px;
+  margin-bottom: 0;
+  color: #f1dfc4;
+  font-size: clamp(1.15rem, 2vw, 1.35rem);
+}
+
+.hero__text,
+.section-heading p,
+.visual-stage__copy p,
+.runner-main p,
+.runner-side p,
+.status-text,
+.disclaimer {
+  color: var(--inner-muted);
+}
+
+.hero__text {
+  max-width: 850px;
+  margin-bottom: 0;
+}
+
+.chain span {
+  padding: 8px 10px;
+  border: 1px solid rgba(145, 215, 202, 0.2);
+  border-radius: var(--inner-radius);
+  background: rgba(145, 215, 202, 0.06);
+  color: var(--inner-teal);
+  font-weight: 750;
+}
+
+.inner-button,
+.filter-button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 13px;
+  border: 1px solid var(--inner-border);
+  border-radius: var(--inner-radius);
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--inner-text);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.inner-button:hover:not(:disabled),
+.filter-button:hover {
+  border-color: rgba(145, 215, 202, 0.45);
+  background: rgba(145, 215, 202, 0.1);
+}
+
+.inner-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.inner-button--primary,
+.filter-button.is-active {
+  border-color: rgba(225, 181, 106, 0.65);
+  background: var(--inner-gold);
+  color: #130d06;
+  font-weight: 850;
+}
+
+.visual-stage {
+  min-height: 520px;
+  display: grid;
+  gap: 18px;
+  align-items: center;
+}
+
+.visual-stage__copy {
+  display: grid;
+  gap: 10px;
+}
+
+.canvas-wrap {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+}
+
+#alignmentCanvas {
+  width: 100%;
+  height: min(68vh, 560px);
+  min-height: 340px;
+  display: block;
+}
+
+.scene-fallback {
+  position: absolute;
+  inset: auto 18px 18px;
+  padding: 12px;
+  border: 1px solid var(--inner-border);
+  border-radius: var(--inner-radius);
+  background: rgba(15, 12, 9, 0.86);
+  color: var(--inner-muted);
+}
+
+.settings-panel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 18px;
+}
+
+.switch-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+}
+
+.switch-field input {
+  width: 22px;
+  height: 22px;
+  accent-color: var(--inner-gold);
+}
+
+.panel,
+.runner-main,
+.runner-side {
+  padding: clamp(18px, 4vw, 28px);
+}
+
+.practice-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.practice-card {
+  min-height: 172px;
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--inner-border);
+  border-radius: var(--inner-radius);
+  background: var(--inner-panel-soft);
+  color: var(--inner-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.practice-card:hover,
+.practice-card.is-active {
+  border-color: rgba(225, 181, 106, 0.5);
+  background: rgba(225, 181, 106, 0.09);
+}
+
+.practice-card strong,
+.practice-card span,
+.practice-card small {
+  display: block;
+}
+
+.practice-card__category {
+  color: var(--inner-teal);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.practice-card small {
+  color: var(--inner-dim);
+}
+
+.runner-layout {
+  display: grid;
+  gap: 18px;
+}
+
+.timer-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.timer-strip div {
+  min-height: 84px;
+  display: grid;
+  gap: 4px;
+  align-content: center;
+  padding: 14px;
+  border: 1px solid var(--inner-border);
+  border-radius: var(--inner-radius);
+  background: rgba(0, 0, 0, 0.14);
+}
+
+.timer-label {
+  color: var(--inner-dim);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.timer-strip strong {
+  color: var(--inner-text);
+  font-size: clamp(1.12rem, 3vw, 1.7rem);
+  line-height: 1;
+}
+
+progress {
+  width: 100%;
+  height: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(225, 181, 106, 0.26);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.18);
+}
+
+progress::-webkit-progress-bar {
+  background: rgba(0, 0, 0, 0.18);
+}
+
+progress::-webkit-progress-value {
+  background: linear-gradient(90deg, var(--inner-gold), var(--inner-teal));
+}
+
+progress::-moz-progress-bar {
+  background: linear-gradient(90deg, var(--inner-gold), var(--inner-teal));
+}
+
+.instruction-panel,
+.session-item {
+  padding: 16px;
+  border: 1px solid var(--inner-border);
+  border-radius: var(--inner-radius);
+  background: rgba(0, 0, 0, 0.14);
+}
+
+.step-counter {
+  margin-bottom: 10px;
+  color: var(--inner-gold);
+  font-weight: 850;
+}
+
+#instructionList {
+  margin: 0;
+  padding-left: 22px;
+  color: var(--inner-muted);
+}
+
+#instructionList li {
+  padding: 6px 0;
+}
+
+#instructionList li.is-active {
+  color: var(--inner-text);
+  font-weight: 800;
+}
+
+.prompt {
+  padding: 13px;
+  border: 1px solid rgba(145, 215, 202, 0.24);
+  border-radius: var(--inner-radius);
+  background: rgba(145, 215, 202, 0.07);
+}
+
+.text-field {
+  display: grid;
+  gap: 8px;
+  color: var(--inner-text);
+  font-weight: 800;
+}
+
+.text-field input,
+.text-field textarea {
+  width: 100%;
+  border: 1px solid var(--inner-border);
+  border-radius: var(--inner-radius);
+  background: rgba(8, 6, 5, 0.72);
+  color: var(--inner-text);
+}
+
+.text-field input {
+  min-height: 44px;
+  padding: 9px 11px;
+}
+
+.text-field textarea {
+  min-height: 112px;
+  padding: 10px 11px;
+  resize: vertical;
+}
+
+.status-text {
+  min-height: 1.4em;
+  margin-bottom: 0;
+}
+
+.session-list {
+  display: grid;
+  gap: 10px;
+}
+
+.session-item {
+  display: grid;
+  gap: 4px;
+}
+
+.session-item strong,
+.session-item small,
+.session-item span {
+  display: block;
+}
+
+.session-item small,
+.empty-state {
+  color: var(--inner-dim);
+}
+
+.empty-state {
+  margin-bottom: 0;
+}
+
+.disclaimer {
+  padding: 16px;
+  background:
+    linear-gradient(135deg, rgba(231, 163, 139, 0.12), rgba(255, 255, 255, 0.04)),
+    var(--inner-panel);
+}
+
+.inner-footer {
+  padding: 0 0 44px;
+}
+
+body[data-reduce-motion="true"] *,
+body[data-reduce-motion="true"] *::before,
+body[data-reduce-motion="true"] *::after {
+  scroll-behavior: auto !important;
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.001ms !important;
+}
+
+@media (min-width: 760px) {
+  .hero {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+  }
+
+  .hero__actions {
+    justify-content: flex-end;
+  }
+
+  .visual-stage {
+    grid-template-columns: minmax(260px, 0.55fr) minmax(0, 1fr);
+  }
+
+  .practice-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .runner-layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  }
+}
+
+@media (min-width: 1080px) {
+  .practice-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .inner-nav {
+    align-items: flex-start;
+  }
+
+  .inner-nav__links {
+    justify-content: flex-start;
+  }
+
+  .settings-panel,
+  .timer-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-panel {
+    display: grid;
+  }
+
+  .inner-button {
+    width: 100%;
+  }
+
+  .hero__actions .inner-button,
+  .button-row .inner-button {
+    width: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/inner-alignment/three-scene.js
+++ b/inner-alignment/three-scene.js
@@ -1,0 +1,227 @@
+import * as THREE from 'three';
+
+const VISUAL_COLORS = Object.freeze({
+  'breathing-orb': 0xd9b26d,
+  'spine-wave': 0x91d7ca,
+  'heart-light': 0xe7a38b,
+  'third-eye-focus': 0xb9a5f0,
+  'rising-particles': 0xd9b26d,
+  'mandala-calm': 0x91d7ca,
+});
+
+export function createInnerAlignmentScene(canvas, options = {}) {
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0d0a08);
+
+  const camera = new THREE.PerspectiveCamera(42, 1, 0.1, 100);
+  camera.position.set(0, 0.1, 6);
+
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: false,
+    powerPreference: 'low-power',
+  });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.75));
+
+  const root = new THREE.Group();
+  scene.add(root);
+
+  const ambient = new THREE.AmbientLight(0xf7efe2, 1.3);
+  scene.add(ambient);
+
+  const glow = new THREE.PointLight(0xe8be67, 1.5, 12);
+  glow.position.set(0, 1.2, 3);
+  scene.add(glow);
+
+  const state = {
+    visualMode: options.visualMode || 'breathing-orb',
+    reduceMotion: Boolean(options.reduceMotion),
+    paused: false,
+    disposed: false,
+    frameId: 0,
+    startTime: performance.now(),
+    root,
+    meshes: [],
+  };
+
+  function resize() {
+    const rect = canvas.getBoundingClientRect();
+    const width = Math.max(1, Math.floor(rect.width));
+    const height = Math.max(1, Math.floor(rect.height));
+    renderer.setSize(width, height, false);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  }
+
+  function clearVisual() {
+    state.meshes.forEach(mesh => {
+      state.root.remove(mesh);
+      if (mesh.geometry) mesh.geometry.dispose();
+      if (mesh.material) {
+        if (Array.isArray(mesh.material)) {
+          mesh.material.forEach(material => material.dispose());
+        } else {
+          mesh.material.dispose();
+        }
+      }
+    });
+    state.meshes = [];
+  }
+
+  function addMesh(mesh) {
+    state.meshes.push(mesh);
+    state.root.add(mesh);
+    return mesh;
+  }
+
+  function buildVisual(mode) {
+    clearVisual();
+    const color = VISUAL_COLORS[mode] || VISUAL_COLORS['breathing-orb'];
+
+    if (mode === 'spine-wave') {
+      const points = [];
+      for (let index = 0; index < 28; index += 1) {
+        const y = -1.9 + index * 0.14;
+        points.push(new THREE.Vector3(0, y, 0));
+      }
+      const curve = new THREE.CatmullRomCurve3(points);
+      const geometry = new THREE.TubeGeometry(curve, 64, 0.025, 10, false);
+      const material = new THREE.MeshBasicMaterial({ color });
+      addMesh(new THREE.Mesh(geometry, material));
+      addSeatedGuide(color);
+      return;
+    }
+
+    if (mode === 'heart-light') {
+      addMesh(new THREE.Mesh(
+        new THREE.SphereGeometry(0.45, 48, 32),
+        new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.78 })
+      ));
+      addRing(0.9, color, 0.22);
+      addRing(1.35, color, 0.12);
+      return;
+    }
+
+    if (mode === 'third-eye-focus') {
+      addMesh(new THREE.Mesh(
+        new THREE.SphereGeometry(0.16, 32, 24),
+        new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.95 })
+      ));
+      addRing(0.62, color, 0.18);
+      addRing(1.05, color, 0.11);
+      return;
+    }
+
+    if (mode === 'rising-particles') {
+      for (let index = 0; index < 42; index += 1) {
+        const particle = addMesh(new THREE.Mesh(
+          new THREE.SphereGeometry(0.025 + (index % 4) * 0.006, 12, 8),
+          new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.62 })
+        ));
+        const angle = index * 0.61;
+        particle.position.set(Math.cos(angle) * (0.25 + (index % 7) * 0.08), -2 + (index % 14) * 0.28, 0);
+        particle.userData.seed = index * 0.37;
+      }
+      return;
+    }
+
+    if (mode === 'mandala-calm') {
+      addRing(0.62, color, 0.28);
+      addRing(1.05, 0xd9b26d, 0.2);
+      addRing(1.48, color, 0.14);
+      addRing(1.9, 0xe7a38b, 0.1);
+      for (let index = 0; index < 12; index += 1) {
+        const bead = addMesh(new THREE.Mesh(
+          new THREE.SphereGeometry(0.055, 16, 12),
+          new THREE.MeshBasicMaterial({ color: index % 2 ? color : 0xd9b26d, transparent: true, opacity: 0.72 })
+        ));
+        const angle = (Math.PI * 2 * index) / 12;
+        bead.position.set(Math.cos(angle) * 1.18, Math.sin(angle) * 1.18, 0);
+      }
+      return;
+    }
+
+    addMesh(new THREE.Mesh(
+      new THREE.SphereGeometry(0.72, 48, 32),
+      new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.62 })
+    ));
+    addRing(1.18, color, 0.18);
+  }
+
+  function addRing(radius, color, opacity) {
+    return addMesh(new THREE.Mesh(
+      new THREE.TorusGeometry(radius, 0.012, 10, 96),
+      new THREE.MeshBasicMaterial({ color, transparent: true, opacity })
+    ));
+  }
+
+  function addSeatedGuide(color) {
+    const material = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.32 });
+    const geometry = new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(-0.9, -1.85, 0),
+      new THREE.Vector3(0, -1.45, 0),
+      new THREE.Vector3(0.9, -1.85, 0),
+      new THREE.Vector3(-0.65, -0.4, 0),
+      new THREE.Vector3(0.65, -0.4, 0),
+    ]);
+    addMesh(new THREE.LineSegments(geometry, material));
+  }
+
+  function animate(now) {
+    if (state.disposed) return;
+    resize();
+
+    if (!state.paused) {
+      const elapsed = (now - state.startTime) / 1000;
+      const slow = state.reduceMotion ? 0.18 : 1;
+      state.meshes.forEach((mesh, index) => {
+        if (state.visualMode === 'breathing-orb') {
+          const scale = state.reduceMotion ? 1.02 : 0.85 + Math.sin(elapsed * 0.75) * 0.16;
+          mesh.scale.setScalar(scale);
+          mesh.rotation.z = elapsed * 0.08 * slow;
+        } else if (state.visualMode === 'spine-wave') {
+          mesh.rotation.z = Math.sin(elapsed * 0.45 + index) * 0.04 * slow;
+          mesh.position.x = Math.sin(elapsed * 0.8 + index * 0.5) * 0.08 * slow;
+        } else if (state.visualMode === 'heart-light') {
+          const scale = state.reduceMotion ? 1.03 : 0.92 + Math.sin(elapsed * 1.1 + index) * 0.1;
+          mesh.scale.setScalar(scale);
+        } else if (state.visualMode === 'third-eye-focus') {
+          mesh.scale.setScalar(state.reduceMotion ? 1 : 0.96 + Math.sin(elapsed * 0.9 + index) * 0.05);
+        } else if (state.visualMode === 'rising-particles') {
+          mesh.position.y += 0.004 * slow;
+          if (mesh.position.y > 2.1) mesh.position.y = -2.05;
+          mesh.position.x += Math.sin(elapsed + mesh.userData.seed) * 0.0008 * slow;
+        } else if (state.visualMode === 'mandala-calm') {
+          mesh.rotation.z = elapsed * 0.04 * (index % 2 ? -1 : 1) * slow;
+        }
+      });
+    }
+
+    renderer.render(scene, camera);
+    state.frameId = requestAnimationFrame(animate);
+  }
+
+  buildVisual(state.visualMode);
+  state.frameId = requestAnimationFrame(animate);
+
+  return {
+    setVisualMode(mode) {
+      state.visualMode = VISUAL_COLORS[mode] ? mode : 'breathing-orb';
+      state.startTime = performance.now();
+      buildVisual(state.visualMode);
+    },
+    setReduceMotion(value) {
+      state.reduceMotion = Boolean(value);
+    },
+    setPaused(value) {
+      state.paused = Boolean(value);
+    },
+    dispose() {
+      state.disposed = true;
+      cancelAnimationFrame(state.frameId);
+      clearVisual();
+      renderer.dispose();
+    },
+  };
+}

--- a/tests/inner-alignment.test.js
+++ b/tests/inner-alignment.test.js
@@ -1,0 +1,176 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import {
+  INNER_ALIGNMENT_CATEGORIES,
+  INNER_ALIGNMENT_KEYS,
+  INNER_ALIGNMENT_PRACTICES,
+  buildPracticeSession,
+  formatPracticeDuration,
+  getInnerAlignmentPractice,
+  getPracticesByCategory,
+  readInnerAlignmentList,
+  readInnerAlignmentPreferences,
+  savePracticeSession,
+  writeInnerAlignmentPreferences,
+} from '../inner-alignment/practices.js';
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function createMemoryStorage(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+  };
+}
+
+test('Inner Alignment ships a standalone Three.js wellness app route', async () => {
+  const appDir = new URL('../inner-alignment/', import.meta.url);
+  assert.equal(await fileExists(new URL('index.html', appDir)), true);
+  assert.equal(await fileExists(new URL('style.css', appDir)), true);
+  assert.equal(await fileExists(new URL('app.js', appDir)), true);
+  assert.equal(await fileExists(new URL('three-scene.js', appDir)), true);
+  assert.equal(await fileExists(new URL('practices.js', appDir)), true);
+
+  const html = await readFile(new URL('index.html', appDir), 'utf8');
+  const css = await readFile(new URL('style.css', appDir), 'utf8');
+  const app = await readFile(new URL('app.js', appDir), 'utf8');
+  const scene = await readFile(new URL('three-scene.js', appDir), 'utf8');
+  const manifest = await readFile(new URL('../app-manifests/inner-alignment.webmanifest', import.meta.url), 'utf8');
+
+  assert.match(html, /<title>Inner Alignment \| 3DVR Portal<\/title>/);
+  assert.match(html, /Body, breath, attention, and action\./);
+  assert.match(html, /Use the body as the interface for consciousness/);
+  assert.match(html, /Practice library/);
+  assert.match(html, /id="categoryFilters"/);
+  assert.match(html, /id="practiceGrid"/);
+  assert.match(html, /three@0\.160\.0\/build\/three\.module\.js/);
+  assert.match(html, /This app is for general wellness and reflection/);
+  assert.match(html, /not medical advice/);
+  assert.match(html, /<meta name="analytics" content="disabled">/);
+  assert.doesNotMatch(html, /promise enlightenment|cure|treat disease|medical treatment/i);
+
+  assert.match(css, /--inner-bg: #0f0c09/);
+  assert.match(css, /prefers-reduced-motion: reduce/);
+  assert.match(css, /\.visual-stage/);
+
+  assert.match(app, /window\.InnerAlignment/);
+  assert.match(app, /setSyncBridge/);
+  assert.match(app, /INNER_ALIGNMENT_KEYS\.activePractice/);
+  assert.match(scene, /from 'three'/);
+  assert.match(scene, /breathing-orb/);
+  assert.match(scene, /spine-wave/);
+  assert.match(scene, /heart-light/);
+  assert.match(scene, /third-eye-focus/);
+  assert.match(scene, /rising-particles/);
+  assert.match(scene, /mandala-calm/);
+
+  assert.match(manifest, /3DVR Inner Alignment/);
+  assert.match(manifest, /"start_url": "\/inner-alignment\/\?source=pwa"/);
+  assert.match(manifest, /"scope": "\/inner-alignment\/"/);
+});
+
+test('Inner Alignment practice library includes requested starter practices and categories', () => {
+  const titles = INNER_ALIGNMENT_PRACTICES.map(practice => practice.title);
+  assert.equal(INNER_ALIGNMENT_PRACTICES.length, 10);
+  assert.deepEqual(INNER_ALIGNMENT_CATEGORIES, [
+    'Seated Body Reset',
+    'Breath & Nervous System',
+    'Focus & Awareness',
+    'Light / Energy Visualization',
+    'Intention Into Action',
+  ]);
+  [
+    'Seated Spinal Wave',
+    'Neck & Shoulder Release',
+    'Chest Opener',
+    'Wrist & Forearm Reset',
+    'Box Breathing',
+    'Long Exhale Calm',
+    'Third-Eye Focus',
+    'Heart Light Gratitude',
+    'Observe the Observer',
+    'Intention Into Action',
+  ].forEach(title => assert.ok(titles.includes(title), title));
+
+  const spinalWave = getInnerAlignmentPractice('seated-spinal-wave');
+  assert.equal(spinalWave.visual, 'spine-wave');
+  assert.equal(spinalWave.breathPattern, 'inhale-exhale');
+  assert.ok(spinalWave.instructions.length >= 4);
+  assert.equal(getPracticesByCategory('Breath & Nervous System').length, 2);
+});
+
+test('Inner Alignment localStorage helpers use clear local keys', () => {
+  assert.deepEqual(INNER_ALIGNMENT_KEYS, {
+    preferences: 'innerAlignment.preferences',
+    sessions: 'innerAlignment.sessions',
+    activePractice: 'innerAlignment.activePractice',
+    reflections: 'innerAlignment.reflections',
+  });
+
+  const storage = createMemoryStorage();
+  assert.deepEqual(readInnerAlignmentList('sessions', storage), []);
+  let preferences = readInnerAlignmentPreferences(storage);
+  assert.equal(preferences.reduceMotion, false);
+  assert.equal(preferences.lastPracticeId, 'seated-spinal-wave');
+
+  preferences = writeInnerAlignmentPreferences({
+    reduceMotion: true,
+    lastPracticeId: 'third-eye-focus',
+  }, storage);
+  assert.equal(preferences.reduceMotion, true);
+  assert.equal(preferences.lastPracticeId, 'third-eye-focus');
+  assert.match(storage.getItem(INNER_ALIGNMENT_KEYS.preferences), /third-eye-focus/);
+});
+
+test('Inner Alignment sessions save reflection and one real-world action locally', () => {
+  const storage = createMemoryStorage();
+  const session = savePracticeSession({
+    id: 'inner-test',
+    practiceId: 'long-exhale-calm',
+    reflection: 'My shoulders dropped.',
+    action: 'Take a walk after this.',
+  }, storage);
+
+  assert.equal(session.id, 'inner-test');
+  assert.equal(session.app, 'inner-alignment');
+  assert.equal(session.practiceTitle, 'Long Exhale Calm');
+  assert.equal(session.category, 'Breath & Nervous System');
+  assert.equal(readInnerAlignmentList('sessions', storage).length, 1);
+  assert.equal(readInnerAlignmentList('reflections', storage).length, 1);
+  assert.match(storage.getItem(INNER_ALIGNMENT_KEYS.sessions), /Take a walk after this/);
+
+  const fallback = buildPracticeSession({ practiceId: 'unknown-practice' });
+  assert.equal(fallback.practiceId, 'seated-spinal-wave');
+});
+
+test('Inner Alignment formats practice durations for timers', () => {
+  assert.equal(formatPracticeDuration(0), '00:00');
+  assert.equal(formatPracticeDuration(75), '01:15');
+  assert.equal(formatPracticeDuration(180), '03:00');
+});
+
+test('Portal homepage, wellness directory, and README link to Inner Alignment', async () => {
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const wellness = await readFile(new URL('../wellness.html', import.meta.url), 'utf8');
+  const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+
+  assert.match(portal, /href="inner-alignment\/"/);
+  assert.match(portal, />Inner Alignment</);
+  assert.match(portal, /seated resets, breathwork, attention, visualization, and one grounded action/);
+  assert.match(wellness, /href="inner-alignment\/"/);
+  assert.match(readme, /\[Inner Alignment\]\(https:\/\/3dvr-portal\.vercel\.app\/inner-alignment\/\)/);
+});

--- a/wellness.html
+++ b/wellness.html
@@ -156,6 +156,7 @@
   <main id="wellnessDirectory" class="directory" aria-label="Wellness directory sections">
     <nav class="directory-nav" aria-label="Wellness quick links">
       <a href="#mindfulness">Mindfulness</a>
+      <a href="inner-alignment/">Inner Alignment</a>
       <a href="body-mode/">Body Mode</a>
       <a href="meditation/">Breathing Room</a>
       <a href="seated-spine-reset/">Seated Spine Reset</a>
@@ -177,6 +178,7 @@
           <li>Keep a gratitude log that highlights team wins and personal growth.</li>
         </ul>
         <div class="resource-links">
+          <a href="inner-alignment/">Inner Alignment →</a>
           <a href="body-mode/">Body Mode resets →</a>
           <a href="meditation/">3DVR breathing room →</a>
           <a href="seated-spine-reset/">Seated spine reset →</a>
@@ -193,6 +195,7 @@
           <li>Experiment with movement-based meditation: mindful walking or stretching.</li>
         </ul>
         <div class="resource-links">
+          <a href="inner-alignment/">Inner Alignment →</a>
           <a href="https://insighttimer.com/meditation-app" target="_blank" rel="noopener">Insight Timer →</a>
           <a href="https://www.calm.com/meditate" target="_blank" rel="noopener">Calm collections →</a>
         </div>


### PR DESCRIPTION
## Summary
- Add /inner-alignment/ as a static Wellness / Consciousness Training app with Three.js visual guidance.
- Add modular practice data for seated body resets, breathwork, focus, light/energy visualization, and intention-into-action practices.
- Add a guided practice runner with start/pause, next step, countdown, reflection prompt, one real-world action field, local progress, and reduce-motion preference.
- Wire Inner Alignment into the portal homepage dock, Wellness Directory, README, and installable app manifest.

## Storage
- Local-first v1 keys: innerAlignment.preferences, innerAlignment.sessions, innerAlignment.activePractice, innerAlignment.reflections.
- Added window.InnerAlignment.setSyncBridge(...) as a future sync hook. No Gun writes or backend changes were added.

## Safety framing
- Copy frames practices as wellness, self-awareness, relaxation, posture, breath, and intention training.
- Includes the requested disclaimer: not medical advice, move gently, stop if anything hurts.
- No claims about curing illness, releasing DMT, treating trauma, or guaranteeing enlightenment.

## Verification
- npm test -- tests/inner-alignment.test.js
- git diff --check
- Local Playwright smoke on http://127.0.0.1:3000/inner-alignment/ across mobile and desktop: route loads, practice cards render, reduce motion persists, timer start/pause/next works, completed session saves/reloads locally, and no console errors.
- Three.js canvas pixel checks passed on mobile and desktop, including nonblank render and motion delta. Screenshots checked for framing.

## Notes
- Uses a pinned Three.js module import map from jsDelivr to keep the portal static and avoid a build step.
- No Stripe, billing, backend, paid API, or analytics changes.