### PR TITLE
[codex] Add public reseller partner policy

### DIFF
--- a/reseller-policy/index.html
+++ b/reseller-policy/index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reseller &amp; Fulfillment Partner Policy | 3DVR</title>
+  <meta
+    name="description"
+    content="3DVR's public policy for small reseller and fulfillment partner pilots that use 3DVR-hosted storefronts and checkout."
+  />
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <main class="policy-shell">
+    <section class="policy-hero" aria-labelledby="policyTitle">
+      <p class="eyebrow">3DVR partner policy</p>
+      <h1 id="policyTitle">Reseller &amp; Fulfillment Partner Policy</h1>
+      <p class="lede">
+        A simple operating policy for small product pilots where 3DVR hosts the page,
+        runs checkout, and a partner sources or fulfills the product.
+      </p>
+      <p class="updated">Last updated June 3, 2026</p>
+    </section>
+
+    <section class="summary-band" aria-label="Policy summary">
+      <article>
+        <span>1</span>
+        <h2>Approved pilots only</h2>
+        <p>3DVR does not operate an open marketplace. Every partner, product, and storefront must be approved first.</p>
+      </article>
+      <article>
+        <span>2</span>
+        <h2>Customers come first</h2>
+        <p>If an order cannot be fulfilled cleanly, 3DVR may update the customer, cancel the order, or refund the payment.</p>
+      </article>
+      <article>
+        <span>3</span>
+        <h2>Payout follows delivery</h2>
+        <p>Partner payout is held until delivery is confirmed and no refund, dispute, or product issue is pending.</p>
+      </article>
+    </section>
+
+    <section class="policy-content" aria-label="Policy details">
+      <article>
+        <h2>Purpose</h2>
+        <p>
+          This policy covers small reseller, sourcing, and fulfillment pilots connected
+          to 3DVR-hosted pages or checkout flows. It is meant to keep customer payments,
+          product quality, fulfillment, and refund decisions clear before a pilot grows.
+        </p>
+        <p>
+          This page is a public operating policy, not a full contract. A separate written
+          agreement, invoice, message thread, or statement of work may add pilot-specific
+          pricing, duties, limits, or approval requirements.
+        </p>
+      </article>
+
+      <article>
+        <h2>Who Does What</h2>
+        <div class="split-list">
+          <div>
+            <h3>3DVR handles</h3>
+            <ul>
+              <li>Hosted page or storefront setup.</li>
+              <li>Checkout and payment processing when 3DVR's Stripe is used.</li>
+              <li>Refund, dispute, and payment-risk decisions.</li>
+              <li>Final approval over products, claims, content, and launch timing.</li>
+            </ul>
+          </div>
+          <div>
+            <h3>Partners handle</h3>
+            <ul>
+              <li>Accurate product details, supplier details, pricing inputs, and shipping estimates.</li>
+              <li>Ordering, fulfillment, tracking, delivery updates, returns, and replacements.</li>
+              <li>Customer support for product, shipping, quality, and delivery questions.</li>
+              <li>Making sure products are lawful, authentic, safe, and not misleadingly advertised.</li>
+            </ul>
+          </div>
+        </div>
+      </article>
+
+      <article>
+        <h2>Merchant of Record</h2>
+        <p>
+          When a customer pays through 3DVR's Stripe account, 3DVR is the merchant of
+          record for that transaction unless another written arrangement says otherwise.
+          This means 3DVR controls refunds, chargeback handling, customer payment records,
+          and payment-risk decisions.
+        </p>
+        <p>
+          A partner does not receive direct access to 3DVR's Stripe account by default.
+          If volume or complexity increases, the preferred next step is the partner's own
+          Stripe account or a Stripe Connect setup.
+        </p>
+      </article>
+
+      <article>
+        <h2>Product Limits</h2>
+        <p>
+          We only approve low-risk products for pilot storefronts. 3DVR may reject or
+          remove any product at any time.
+        </p>
+        <ul class="check-list">
+          <li>No counterfeit, unauthorized branded, or trademark-risk products.</li>
+          <li>No regulated, age-restricted, hazardous, medical, supplement, weapon, adult, gambling, or financial products.</li>
+          <li>No high-ticket products, batteries, dangerous goods, or items with unusual shipping risk unless approved in writing.</li>
+          <li>No unsupported health, safety, earnings, affiliation, warranty, or performance claims.</li>
+          <li>No product that violates Stripe rules, card-network rules, supplier terms, platform terms, or applicable law.</li>
+        </ul>
+      </article>
+
+      <article>
+        <h2>Payouts</h2>
+        <p>
+          Partner payout is not earned when the order is placed. It is earned after payment
+          succeeds, the product ships, tracking is provided, delivery is confirmed, and no
+          unresolved refund, dispute, fraud, supplier, or customer issue remains.
+        </p>
+        <p>
+          Unless a pilot-specific agreement says otherwise, payout is calculated from the
+          customer amount actually received minus payment fees, taxes, refunds, disputes,
+          chargebacks, shipping adjustments, reserves, and 3DVR's agreed platform fee or margin.
+        </p>
+        <p>
+          If an order is refunded before payout, the partner is not paid for that order. If
+          payout already happened, 3DVR may request reimbursement or offset the amount from
+          future payouts.
+        </p>
+      </article>
+
+      <article>
+        <h2>Refunds, Shipping, and Support</h2>
+        <p>
+          3DVR may refund a customer if an item is not shipped, not delivered, materially
+          different from the listing, defective, unsafe, delayed without a reasonable update,
+          or likely to create a payment or customer-protection issue.
+        </p>
+        <p>
+          Partners must provide realistic shipping estimates and prompt tracking updates.
+          If a promised shipping timeline cannot be met, the partner must notify 3DVR quickly
+          so the customer can be updated or refunded when appropriate.
+        </p>
+        <p>
+          Customer data may only be used for fulfillment, delivery, support, returns,
+          replacements, and required recordkeeping. It may not be reused, sold, exported,
+          or added to a marketing list without written approval.
+        </p>
+      </article>
+
+      <article>
+        <h2>When a Pilot Grows</h2>
+        <p>
+          A small pilot can stay simple. If order volume, product risk, customer support,
+          advertising, tax handling, or payout complexity increases, 3DVR may require a
+          more formal setup before continuing.
+        </p>
+        <div class="path-grid">
+          <div>
+            <strong>Keep it small</strong>
+            <p>Use written pilot limits, approved products, payout holds, and manual review.</p>
+          </div>
+          <div>
+            <strong>Use separate payments</strong>
+            <p>Move the partner to their own Stripe account or a Stripe Connect structure.</p>
+          </div>
+          <div>
+            <strong>Formalize the role</strong>
+            <p>Create a contractor, employee, operator, or vendor agreement with clear access rules.</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="resources">
+        <h2>Reference Rules</h2>
+        <p>
+          We review partner pilots against payment-platform rules, product-risk rules, and
+          customer-protection rules. These resources are useful starting points:
+        </p>
+        <ul>
+          <li><a href="https://stripe.com/legal/restricted-businesses">Stripe Prohibited and Restricted Businesses</a></li>
+          <li><a href="https://docs.stripe.com/connect">Stripe Connect documentation</a></li>
+          <li><a href="https://www.ftc.gov/business-guidance/resources/business-guide-ftcs-mail-internet-or-telephone-order-merchandise-rule">FTC Mail, Internet, or Telephone Order Merchandise Rule guide</a></li>
+        </ul>
+      </article>
+
+      <aside class="note" aria-label="Policy note">
+        <strong>Plain-language note:</strong>
+        this policy is not legal, tax, medical, or financial advice. It is 3DVR's public
+        operating standard for small partner storefront pilots. 3DVR can pause, reject,
+        remove, or refund any pilot, product, order, or storefront when needed.
+      </aside>
+    </section>
+  </main>
+
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/reseller-policy/styles.css
+++ b/reseller-policy/styles.css
@@ -1,0 +1,288 @@
+:root {
+  color-scheme: light;
+  --ink: #171b1f;
+  --muted: #58616b;
+  --paper: #fbfaf6;
+  --panel: #ffffff;
+  --soft: #f1ece3;
+  --line: #ddd5c8;
+  --accent: #41695a;
+  --accent-strong: #24473b;
+  --warm: #9f6530;
+  --shadow: 0 18px 50px rgba(23, 27, 31, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    linear-gradient(180deg, rgba(241, 236, 227, 0.9), rgba(251, 250, 246, 0.95) 360px),
+    var(--paper);
+  color: var(--ink);
+}
+
+a {
+  color: var(--accent-strong);
+  font-weight: 750;
+  text-underline-offset: 3px;
+}
+
+.policy-shell {
+  min-height: 100vh;
+}
+
+.policy-hero {
+  width: min(1120px, calc(100% - 36px));
+  margin: 0 auto;
+  padding: 74px 0 44px;
+}
+
+.eyebrow {
+  margin: 0 0 18px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 900px;
+  margin-bottom: 18px;
+  font-size: clamp(2.55rem, 8vw, 5.7rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.lede {
+  max-width: 760px;
+  margin-bottom: 18px;
+  color: var(--muted);
+  font-size: clamp(1.08rem, 2.2vw, 1.32rem);
+  line-height: 1.58;
+}
+
+.updated {
+  margin: 0;
+  color: #6f6559;
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.summary-band {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+  border-block: 1px solid var(--line);
+}
+
+.summary-band article {
+  min-height: 210px;
+  padding: 32px;
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.summary-band span {
+  display: inline-grid;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 20px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 850;
+}
+
+.summary-band h2,
+.policy-content h2 {
+  margin-bottom: 12px;
+  font-size: clamp(1.35rem, 2.4vw, 2rem);
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.summary-band p,
+.policy-content p,
+.policy-content li {
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.68;
+}
+
+.policy-content {
+  width: min(960px, calc(100% - 36px));
+  margin: 0 auto;
+  padding: 56px 0 72px;
+}
+
+.policy-content > article,
+.note {
+  padding: 32px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.policy-content > article:first-child {
+  padding-top: 0;
+}
+
+.split-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.split-list > div,
+.path-grid > div {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+h3 {
+  margin-bottom: 12px;
+  color: var(--accent-strong);
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+
+ul {
+  margin: 0;
+  padding-left: 1.15rem;
+}
+
+li + li {
+  margin-top: 10px;
+}
+
+.check-list {
+  padding-left: 0;
+  list-style: none;
+}
+
+.check-list li {
+  position: relative;
+  padding-left: 26px;
+}
+
+.check-list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.76em;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--warm);
+}
+
+.path-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.path-grid strong {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--accent-strong);
+  font-size: 1rem;
+}
+
+.path-grid p {
+  margin: 0;
+  font-size: 0.94rem;
+}
+
+.resources ul {
+  display: grid;
+  gap: 10px;
+  padding-left: 0;
+  list-style: none;
+}
+
+.resources li {
+  margin: 0;
+}
+
+.note {
+  margin-top: 18px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--soft);
+  color: #403831;
+  line-height: 1.65;
+}
+
+.note strong {
+  color: var(--ink);
+}
+
+@media (max-width: 780px) {
+  .policy-hero {
+    width: min(100% - 28px, 620px);
+    padding: 48px 0 34px;
+  }
+
+  h1 {
+    font-size: clamp(2.45rem, 13vw, 4.2rem);
+  }
+
+  .summary-band,
+  .split-list,
+  .path-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-band article {
+    min-height: 0;
+    padding: 24px 18px;
+  }
+
+  .policy-content {
+    width: min(100% - 28px, 620px);
+    padding: 40px 0 56px;
+  }
+
+  .policy-content > article,
+  .note {
+    padding-block: 26px;
+  }
+
+  .split-list > div,
+  .path-grid > div {
+    padding: 18px;
+  }
+}
+
+@media (max-width: 390px) {
+  .policy-hero,
+  .policy-content {
+    width: calc(100% - 22px);
+  }
+
+  h1 {
+    font-size: 2.35rem;
+  }
+}

--- a/tests/reseller-policy-page.test.js
+++ b/tests/reseller-policy-page.test.js
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const pageDir = new URL('../reseller-policy/', import.meta.url);
+
+describe('reseller partner policy page', () => {
+  it('publishes a general public partner policy', async () => {
+    const html = await readFile(new URL('index.html', pageDir), 'utf8');
+
+    assert.match(html, /Reseller &amp; Fulfillment Partner Policy \| 3DVR/);
+    assert.match(html, /Approved pilots only/);
+    assert.match(html, /3DVR does not operate an open marketplace/);
+    assert.match(html, /When a customer pays through 3DVR's Stripe account, 3DVR is the merchant of/);
+    assert.match(html, /Partner payout is not earned when the order is placed/);
+    assert.match(html, /No counterfeit, unauthorized branded, or trademark-risk products/);
+    assert.match(html, /No regulated, age-restricted, hazardous, medical, supplement, weapon/);
+    assert.match(html, /3DVR may refund a customer/);
+    assert.match(html, /Stripe Connect setup/);
+    assert.match(html, /Customer data may only be used for fulfillment/);
+    assert.match(html, /not legal, tax, medical, or financial advice/);
+  });
+
+  it('links to official payment and customer-protection resources', async () => {
+    const html = await readFile(new URL('index.html', pageDir), 'utf8');
+
+    assert.match(html, /https:\/\/stripe\.com\/legal\/restricted-businesses/);
+    assert.match(html, /https:\/\/docs\.stripe\.com\/connect/);
+    assert.match(html, /https:\/\/www\.ftc\.gov\/business-guidance\/resources\/business-guide-ftcs-mail-internet-or-telephone-order-merchandise-rule/);
+  });
+
+  it('keeps the policy responsive without external assets', async () => {
+    const html = await readFile(new URL('index.html', pageDir), 'utf8');
+    const css = await readFile(new URL('styles.css', pageDir), 'utf8');
+
+    assert.match(html, /<link rel="stylesheet" href="\.\/styles\.css" \/>/);
+    assert.doesNotMatch(html, /<img\b/);
+    assert.doesNotMatch(html, /cdn\./);
+    assert.match(css, /@media \(max-width: 780px\)/);
+    assert.match(css, /grid-template-columns: 1fr/);
+    assert.match(css, /text-size-adjust:\s*100%/);
+  });
+
+  it('links the sample storefront back to the public policy', async () => {
+    const html = await readFile(new URL('../victor-dropship/index.html', import.meta.url), 'utf8');
+
+    assert.match(html, /href="\/reseller-policy\/"/);
+    assert.match(html, /Reseller &amp; fulfillment partner policy/);
+  });
+});

--- a/victor-dropship/index.html
+++ b/victor-dropship/index.html
@@ -84,6 +84,10 @@
         <p>Orders are reviewed and sent to the best available fulfillment partner.</p>
       </article>
     </section>
+
+    <footer class="storefront-policy">
+      <a href="/reseller-policy/">Reseller &amp; fulfillment partner policy</a>
+    </footer>
   </main>
 
   <script src="./app.js"></script>

--- a/victor-dropship/styles.css
+++ b/victor-dropship/styles.css
@@ -223,6 +223,20 @@ button:disabled {
   line-height: 1.6;
 }
 
+.storefront-policy {
+  padding: 22px 28px;
+  border-top: 1px solid var(--line);
+  background: var(--paper);
+  text-align: center;
+}
+
+.storefront-policy a {
+  color: var(--accent-strong);
+  font-size: 0.92rem;
+  font-weight: 750;
+  text-underline-offset: 3px;
+}
+
 @media (max-width: 820px) {
   .product-hero {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add a public `/reseller-policy/` page for general reseller and fulfillment partner pilots
- cover merchant-of-record handling, approved-product limits, payout holds, refunds, customer data, and Stripe Connect escalation
- link the sample storefront footer to the public policy

## Validation
- `node --test tests/reseller-policy-page.test.js tests/storefront-checkout-api.test.js`
- Playwright WebKit smoke at `/reseller-policy/` for desktop and mobile: HTTP 200, no console errors, no horizontal overflow

## Notes
- This is public operating-policy copy, not a full contract.
- `npm ci` reported existing dependency audit findings: 2 moderate, 1 high; no package changes were made.