### PR TITLE
[codex] Update reseller payout and Stripe access policy

### DIFF
--- a/reseller-policy/index.html
+++ b/reseller-policy/index.html
@@ -35,8 +35,8 @@
       </article>
       <article>
         <span>3</span>
-        <h2>Payout follows delivery</h2>
-        <p>Partner payout is held until delivery is confirmed and no refund, dispute, or product issue is pending.</p>
+        <h2>Payout follows the return window</h2>
+        <p>Partner payout is held until delivery is confirmed, the return window closes, and no customer issue is pending.</p>
       </article>
     </section>
 
@@ -92,6 +92,11 @@
           If volume or complexity increases, the preferred next step is the partner's own
           Stripe account or a Stripe Connect setup.
         </p>
+        <p>
+          Direct access to 3DVR's Stripe account is only considered for someone who officially
+          joins 3DVR in an approved operator, contractor, employee, or similar internal role.
+          Any access must be named, permission-limited, and removable.
+        </p>
       </article>
 
       <article>
@@ -113,8 +118,14 @@
         <h2>Payouts</h2>
         <p>
           Partner payout is not earned when the order is placed. It is earned after payment
-          succeeds, the product ships, tracking is provided, delivery is confirmed, and no
-          unresolved refund, dispute, fraud, supplier, or customer issue remains.
+          succeeds, the product ships, tracking is provided, delivery is confirmed, the stated
+          return or refund window has closed, and no unresolved refund, dispute, fraud, supplier,
+          or customer issue remains.
+        </p>
+        <p>
+          If a product has a longer return period, replacement period, supplier claim period,
+          or customer-support window, 3DVR may hold payout until that window is closed or a
+          reasonable reserve is set.
         </p>
         <p>
           Unless a pilot-specific agreement says otherwise, payout is calculated from the
@@ -166,6 +177,10 @@
           <div>
             <strong>Formalize the role</strong>
             <p>Create a contractor, employee, operator, or vendor agreement with clear access rules.</p>
+          </div>
+          <div>
+            <strong>Join 3DVR officially</strong>
+            <p>Consider direct Stripe access only for approved team members with named, limited permissions.</p>
           </div>
         </div>
       </article>

--- a/reseller-policy/styles.css
+++ b/reseller-policy/styles.css
@@ -198,7 +198,7 @@ li + li {
 
 .path-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 14px;
 }
 

--- a/tests/reseller-policy-page.test.js
+++ b/tests/reseller-policy-page.test.js
@@ -13,10 +13,14 @@ describe('reseller partner policy page', () => {
     assert.match(html, /3DVR does not operate an open marketplace/);
     assert.match(html, /When a customer pays through 3DVR's Stripe account, 3DVR is the merchant of/);
     assert.match(html, /Partner payout is not earned when the order is placed/);
+    assert.match(html, /the stated\s+return or refund window has closed/);
+    assert.match(html, /Direct access to 3DVR's Stripe account is only considered for someone who officially\s+joins 3DVR/);
+    assert.match(html, /named, permission-limited, and removable/);
     assert.match(html, /No counterfeit, unauthorized branded, or trademark-risk products/);
     assert.match(html, /No regulated, age-restricted, hazardous, medical, supplement, weapon/);
     assert.match(html, /3DVR may refund a customer/);
     assert.match(html, /Stripe Connect setup/);
+    assert.match(html, /Join 3DVR officially/);
     assert.match(html, /Customer data may only be used for fulfillment/);
     assert.match(html, /not legal, tax, medical, or financial advice/);
   });


### PR DESCRIPTION
## Summary
- change reseller partner payout timing to wait until confirmed delivery and the stated return/refund window has closed
- clarify that longer return, replacement, supplier claim, or support windows can extend payout holds or require a reserve
- add an official 3DVR role path for anyone who needs direct access to 3DVR's Stripe account, with named and limited permissions
- adjust the growth-path grid for the added option

## Validation
- `node --test tests/reseller-policy-page.test.js`
- Playwright WebKit smoke at `/reseller-policy/` for desktop and mobile: HTTP 200, no console errors, no horizontal overflow, updated copy present

## References
- Stripe Connect: https://docs.stripe.com/connect
- Stripe team access: https://docs.stripe.com/dashboard/teams