### PR TITLE
[codex] Add portal GunJS backup tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 .env.local
 .env.*.local
+backups/

--- a/ops/control-plane/home/RUNBOOKS/README.md
+++ b/ops/control-plane/home/RUNBOOKS/README.md
@@ -11,3 +11,4 @@ This folder holds repeatable procedures Codex can use to operate the workspace.
 - `3dvr-next-build-plan.md`: 30-90 day agent-ready build plan for the portal, API, DO hub, notifications, device layer, and 3dvr-agent
 - `digitalocean-agent-host.md`: live droplet host details, service commands, and recovery flow for `3dvr-agent`
 - `self-hosted-supabase-on-digitalocean.md`: cost, resource, and deployment tradeoffs for running Postgres or Supabase on DigitalOcean
+- `portal-gunjs-backups.md`: two-layer backup procedure for the portal Gun relay RAD directory and known-root JSON snapshots

--- a/ops/control-plane/home/RUNBOOKS/portal-gunjs-backups.md
+++ b/ops/control-plane/home/RUNBOOKS/portal-gunjs-backups.md
@@ -1,0 +1,117 @@
+# Portal GunJS Backups
+
+The portal currently treats GunJS as the source of truth for shared app state, CRM records, guest profiles,
+billing mirrors, agent ops, notes, chat, and lab data. Backups need two layers:
+
+1. Archive the relay's RAD data directory. This is the authoritative backup.
+2. Capture known root snapshots as JSON. This is useful for inspection, restore drills, and quick sanity checks, but it
+   cannot prove every Gun soul was discovered.
+
+## What To Back Up
+
+- Relay peer: `wss://gun-relay-3dvr.fly.dev/gun`
+- Default Gun RAD directory when not overridden: `radata`
+- Portal root manifest: `ops/gun/portal-gun-roots.json`
+- Local snapshot output: `backups/gun-snapshots/`
+
+Treat every backup artifact as sensitive. Even encrypted SEA records, billing mirrors, guest profiles, and key-vault
+ciphertexts should not be committed or shared casually.
+
+## Daily Host Archive
+
+Run this on the host or container that owns the relay data volume:
+
+```sh
+GUN_RAD_DIR=/path/to/radata \
+GUN_BACKUP_DIR=/var/backups/3dvr/gun-rad \
+GUN_BACKUP_RETENTION_DAYS=14 \
+ops/gun/archive-rad.sh
+```
+
+If the relay is managed by systemd and you want a more consistent archive, stop the service during the tar:
+
+```sh
+GUN_RAD_DIR=/path/to/radata \
+GUN_BACKUP_STOP_SERVICE=1 \
+GUN_RELAY_SERVICE=gun-relay.service \
+ops/gun/archive-rad.sh
+```
+
+Off-host copy is required. A local archive on the same VM or Fly volume is only a short-term safety net.
+Use `GUN_BACKUP_RCLONE_REMOTE` once rclone is configured for DigitalOcean Spaces, S3, Backblaze, or another store:
+
+```sh
+GUN_RAD_DIR=/path/to/radata \
+GUN_BACKUP_RCLONE_REMOTE=do-spaces:3dvr-backups/gun-rad \
+ops/gun/archive-rad.sh
+```
+
+## Daily Known-Roots Snapshot
+
+Run this from a repo checkout with dependencies installed:
+
+```sh
+npm run gun:backup
+```
+
+Useful overrides:
+
+```sh
+GUN_BACKUP_OUT_DIR=/var/backups/3dvr/gun-snapshots \
+GUN_BACKUP_PEERS='wss://gun-relay-3dvr.fly.dev/gun https://gun-relay-3dvr.fly.dev/gun' \
+npm run gun:backup
+```
+
+Dry-run the manifest without connecting:
+
+```sh
+npm run gun:backup -- --dry-run
+```
+
+Snapshot one root for a quick health check:
+
+```sh
+npm run gun:backup -- --root portal --depth 0
+```
+
+The command writes:
+
+- `portal-gun-known-roots-<timestamp>.json`
+- `portal-gun-known-roots-<timestamp>.json.sha256`
+
+## Cron Example
+
+Run both layers nightly and keep stdout/stderr in system logs:
+
+```cron
+15 7 * * * cd /opt/3dvr-portal && GUN_RAD_DIR=/path/to/radata ops/gun/archive-rad.sh
+30 7 * * * cd /opt/3dvr-portal && npm run gun:backup
+```
+
+## Restore Notes
+
+Do not restore over a running relay without a deliberate maintenance window.
+
+For a RAD archive restore:
+
+1. Stop the relay.
+2. Move the existing RAD directory aside; do not delete it first.
+3. Verify the archive checksum.
+4. Extract the tarball into the expected parent directory.
+5. Start the relay.
+6. Use `gun-explorer/`, `test-gun.html`, and a few app pages to verify critical paths such as:
+   - `3dvr-portal/billing`
+   - `3dvr-portal/agentOps`
+   - `3dvr-crm`
+   - `3dvr-guests`
+   - `3dvr-chat`
+
+Known-root JSON snapshots are not a full restore source unless the missing data is known to live under one of the
+manifest paths. Use them first for inspection and emergency record recovery, not as the only backup.
+
+## Immediate Standard
+
+- Nightly RAD archive.
+- Nightly known-root JSON snapshot.
+- Off-host copy before considering the system backed up.
+- Weekly restore drill into a disposable relay.

--- a/ops/gun/archive-rad.sh
+++ b/ops/gun/archive-rad.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+  cat <<'USAGE'
+Usage: GUN_RAD_DIR=/path/to/radata ops/gun/archive-rad.sh
+
+Creates a timestamped tar.gz archive and sha256 file for the Gun relay RAD data
+directory. Run this on the machine/container that owns the relay data volume.
+
+Environment:
+  GUN_RAD_DIR                 Required unless one common path exists.
+  GUN_BACKUP_DIR              Default: /var/backups/3dvr/gun-rad
+  GUN_BACKUP_RETENTION_DAYS   Default: 14
+  GUN_BACKUP_RCLONE_REMOTE    Optional rclone destination, e.g. do-spaces:3dvr-backups/gun-rad
+  GUN_BACKUP_STOP_SERVICE     Set to 1 to stop/start a systemd service around the archive.
+  GUN_RELAY_SERVICE           systemd service name when GUN_BACKUP_STOP_SERVICE=1.
+USAGE
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+find_default_rad_dir() {
+  for candidate in \
+    /data/radata \
+    /data/gun/radata \
+    /opt/gun-relay/radata \
+    /opt/3dvr-gun-relay/radata \
+    ./radata
+  do
+    if [ -d "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+rad_dir="${GUN_RAD_DIR:-}"
+if [ -z "$rad_dir" ]; then
+  rad_dir="$(find_default_rad_dir || true)"
+fi
+
+if [ -z "$rad_dir" ] || [ ! -d "$rad_dir" ]; then
+  echo "GUN_RAD_DIR must point to the relay RAD data directory." >&2
+  usage >&2
+  exit 1
+fi
+
+backup_dir="${GUN_BACKUP_DIR:-/var/backups/3dvr/gun-rad}"
+retention_days="${GUN_BACKUP_RETENTION_DAYS:-14}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+host="$(hostname | tr -c 'A-Za-z0-9_.-' '-')"
+base="$(basename "$rad_dir")"
+parent="$(cd "$(dirname "$rad_dir")" && pwd)"
+archive="${backup_dir}/portal-gun-rad-${host}-${timestamp}.tar.gz"
+tmp="${archive}.tmp"
+
+mkdir -p "$backup_dir"
+chmod 700 "$backup_dir"
+
+restart_service=0
+if [ "${GUN_BACKUP_STOP_SERVICE:-0}" = "1" ]; then
+  if [ -z "${GUN_RELAY_SERVICE:-}" ]; then
+    echo "GUN_RELAY_SERVICE is required when GUN_BACKUP_STOP_SERVICE=1." >&2
+    exit 1
+  fi
+  systemctl stop "$GUN_RELAY_SERVICE"
+  restart_service=1
+fi
+
+cleanup() {
+  status=$?
+  rm -f "$tmp"
+  if [ "$restart_service" = "1" ]; then
+    systemctl start "$GUN_RELAY_SERVICE" || true
+  fi
+  exit "$status"
+}
+trap cleanup INT TERM EXIT
+
+tar -C "$parent" -czf "$tmp" "$base"
+mv "$tmp" "$archive"
+chmod 600 "$archive"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$backup_dir" && sha256sum "$(basename "$archive")" > "$(basename "$archive").sha256")
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$backup_dir" && shasum -a 256 "$(basename "$archive")" > "$(basename "$archive").sha256")
+else
+  echo "No sha256sum or shasum found; archive created without checksum." >&2
+fi
+
+if [ -n "${GUN_BACKUP_RCLONE_REMOTE:-}" ]; then
+  if ! command -v rclone >/dev/null 2>&1; then
+    echo "GUN_BACKUP_RCLONE_REMOTE is set but rclone is not installed." >&2
+    exit 1
+  fi
+  rclone copy "$archive" "$GUN_BACKUP_RCLONE_REMOTE"
+  if [ -f "${archive}.sha256" ]; then
+    rclone copy "${archive}.sha256" "$GUN_BACKUP_RCLONE_REMOTE"
+  fi
+fi
+
+find "$backup_dir" -type f \
+  \( -name 'portal-gun-rad-*.tar.gz' -o -name 'portal-gun-rad-*.tar.gz.sha256' \) \
+  -mtime +"$retention_days" \
+  -delete
+
+trap - INT TERM EXIT
+if [ "$restart_service" = "1" ]; then
+  systemctl start "$GUN_RELAY_SERVICE"
+fi
+
+printf 'Gun RAD backup written: %s\n' "$archive"

--- a/ops/gun/portal-gun-roots.json
+++ b/ops/gun/portal-gun-roots.json
@@ -1,0 +1,166 @@
+{
+  "version": 1,
+  "description": "Known 3DVR portal Gun roots for portable JSON snapshots. This is not a full relay backup; archive the RAD data directory too.",
+  "defaultDepth": 2,
+  "roots": [
+    {
+      "name": "portal",
+      "path": ["3dvr-portal"],
+      "depth": 3,
+      "critical": true,
+      "notes": "Primary portal workspace graph used by billing, app state, agent ops, money-ai, life, and newer apps."
+    },
+    {
+      "name": "crm",
+      "path": ["3dvr-crm"],
+      "depth": 3,
+      "critical": true,
+      "notes": "CRM records shared by contacts, memory capture, sales, and email operator."
+    },
+    {
+      "name": "guests",
+      "path": ["3dvr-guests"],
+      "depth": 3,
+      "critical": true,
+      "sensitive": true,
+      "notes": "Guest account profile and migration data."
+    },
+    {
+      "name": "contacts-public",
+      "path": ["contacts-public"],
+      "depth": 2,
+      "notes": "Shared contacts spaces."
+    },
+    {
+      "name": "org-demo",
+      "path": ["org-3dvr-demo"],
+      "depth": 2,
+      "notes": "Legacy org contacts graph."
+    },
+    {
+      "name": "chat",
+      "path": ["3dvr-chat"],
+      "depth": 2,
+      "notes": "Portal chat rooms and messages."
+    },
+    {
+      "name": "social-media",
+      "path": ["social-media"],
+      "depth": 2,
+      "notes": "Social command center legacy graph."
+    },
+    {
+      "name": "meeting-notes",
+      "path": ["meeting-notes"],
+      "depth": 2,
+      "notes": "Meeting notes app graph."
+    },
+    {
+      "name": "simple-folders",
+      "path": ["simple-folders"],
+      "depth": 2,
+      "notes": "Legacy notes folder graph."
+    },
+    {
+      "name": "simple-notes",
+      "path": ["simple-notes"],
+      "depth": 2,
+      "notes": "Legacy notes graph."
+    },
+    {
+      "name": "money-ai-legacy",
+      "path": ["money-ai"],
+      "depth": 2,
+      "notes": "Legacy Money AI mirror."
+    },
+    {
+      "name": "finance-legacy",
+      "path": ["finance"],
+      "depth": 2,
+      "sensitive": true,
+      "notes": "Legacy finance mirror."
+    },
+    {
+      "name": "ai",
+      "path": ["ai"],
+      "depth": 3,
+      "critical": true,
+      "sensitive": true,
+      "notes": "AI workbench key vault and related encrypted records."
+    },
+    {
+      "name": "stripe",
+      "path": ["stripe"],
+      "depth": 3,
+      "critical": true,
+      "sensitive": true,
+      "notes": "Stripe event/customer mirrors when written through Gun."
+    },
+    {
+      "name": "score",
+      "path": ["score"],
+      "depth": 2,
+      "notes": "Score/rewards ledger and totals."
+    },
+    {
+      "name": "science",
+      "path": ["science"],
+      "depth": 2,
+      "notes": "Science and intention summary mirrors."
+    },
+    {
+      "name": "projects",
+      "path": ["projects"],
+      "depth": 2,
+      "notes": "Project ideas, artifacts, and handoff graph."
+    },
+    {
+      "name": "education",
+      "path": ["education"],
+      "depth": 2,
+      "notes": "Education content graph."
+    },
+    {
+      "name": "job-tracker",
+      "path": ["job-tracker"],
+      "depth": 2,
+      "notes": "Job tracker records."
+    },
+    {
+      "name": "video-labs",
+      "path": ["3dvr-gun-video-lab"],
+      "depth": 2,
+      "notes": "Gun video frame lab room state."
+    },
+    {
+      "name": "clip-lab",
+      "path": ["3dvr-gun-clip-lab"],
+      "depth": 2,
+      "notes": "Gun clip lab room state."
+    },
+    {
+      "name": "live-room",
+      "path": ["3dvr-gun-live-room"],
+      "depth": 2,
+      "notes": "Gun live room state."
+    },
+    {
+      "name": "chunk-stream",
+      "path": ["3dvr-gun-chunk-stream"],
+      "depth": 2,
+      "notes": "Gun chunk stream state."
+    },
+    {
+      "name": "webrtc-lab",
+      "path": ["3dvr-webrtc-lab-v2"],
+      "depth": 2,
+      "notes": "WebRTC lab signaling state."
+    },
+    {
+      "name": "portal-video-control",
+      "path": ["portalVideoControl"],
+      "depth": 2,
+      "notes": "Video smart launcher control state."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "npm run dev",
     "test": "node --test",
     "env:check": "node scripts/env/check.mjs",
+    "gun:backup": "node scripts/gun/backup-known-roots.mjs",
     "money:loop": "node scripts/money/run-loop.mjs",
     "money:autopilot": "node scripts/money/run-autopilot.mjs",
     "market:pulse": "node scripts/growth/run-market-pulse.mjs",

--- a/scripts/gun/backup-known-roots.mjs
+++ b/scripts/gun/backup-known-roots.mjs
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_MANIFEST = 'ops/gun/portal-gun-roots.json';
+const DEFAULT_OUT_DIR = 'backups/gun-snapshots';
+const DEFAULT_PEERS = [
+  'wss://gun-relay-3dvr.fly.dev/gun',
+  'https://gun-relay-3dvr.fly.dev/gun'
+];
+const DEFAULT_TIMEOUT_MS = 1000;
+const DEFAULT_CONNECT_TIMEOUT_MS = 15000;
+const DEFAULT_HARD_TIMEOUT_MS = 600000;
+const DEFAULT_MAX_KEYS_PER_NODE = 150;
+const nativeSetTimeout = globalThis.setTimeout.bind(globalThis);
+const nativeClearTimeout = globalThis.clearTimeout.bind(globalThis);
+
+function usage() {
+  return `Usage: node scripts/gun/backup-known-roots.mjs [options]
+
+Options:
+  --manifest <file>          Root manifest JSON. Default: ${DEFAULT_MANIFEST}
+  --out-dir <dir>            Snapshot output directory. Default: ${DEFAULT_OUT_DIR}
+  --peer <url>               Use a Gun peer. Can be repeated.
+  --root <name-or-path>       Snapshot only roots matching a manifest name or slash path. Can be repeated.
+  --depth <n>                Override all manifest root depths.
+  --timeout-ms <n>           Per-node read timeout. Default: ${DEFAULT_TIMEOUT_MS}
+  --connect-timeout-ms <n>   Peer connection timeout. Default: ${DEFAULT_CONNECT_TIMEOUT_MS}
+  --hard-timeout-ms <n>      Whole-process timeout. Default: ${DEFAULT_HARD_TIMEOUT_MS}
+  --max-keys <n>             Max child keys traversed per node. Default: ${DEFAULT_MAX_KEYS_PER_NODE}
+  --dry-run                  Print planned backup targets without connecting.
+  --help                     Show this help.
+
+Environment:
+  GUN_BACKUP_PEERS           Comma or space separated peers.
+  GUN_BACKUP_ROOTS           Comma or space separated manifest names or slash paths.
+  GUN_BACKUP_MANIFEST        Manifest path.
+  GUN_BACKUP_OUT_DIR         Output directory.
+  GUN_BACKUP_DEPTH           Override depth.
+  GUN_BACKUP_TIMEOUT_MS      Per-node read timeout.
+  GUN_BACKUP_CONNECT_TIMEOUT_MS
+  GUN_BACKUP_HARD_TIMEOUT_MS
+  GUN_BACKUP_MAX_KEYS
+  GUN_BACKUP_DEBUG=1        Print phase logs to stderr.
+`;
+}
+
+function splitList(value) {
+  if (!value) return [];
+  return String(value)
+    .split(/[,\s]+/)
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+function parsePositiveInt(value, fallback, label) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv = process.argv.slice(2), env = process.env) {
+  const options = {
+    manifest: env.GUN_BACKUP_MANIFEST || DEFAULT_MANIFEST,
+    outDir: env.GUN_BACKUP_OUT_DIR || DEFAULT_OUT_DIR,
+    peers: splitList(env.GUN_BACKUP_PEERS),
+    roots: splitList(env.GUN_BACKUP_ROOTS),
+    depth: parsePositiveInt(env.GUN_BACKUP_DEPTH, undefined, 'GUN_BACKUP_DEPTH'),
+    timeoutMs: parsePositiveInt(env.GUN_BACKUP_TIMEOUT_MS, DEFAULT_TIMEOUT_MS, 'GUN_BACKUP_TIMEOUT_MS'),
+    connectTimeoutMs: parsePositiveInt(
+      env.GUN_BACKUP_CONNECT_TIMEOUT_MS,
+      DEFAULT_CONNECT_TIMEOUT_MS,
+      'GUN_BACKUP_CONNECT_TIMEOUT_MS'
+    ),
+    hardTimeoutMs: parsePositiveInt(
+      env.GUN_BACKUP_HARD_TIMEOUT_MS,
+      DEFAULT_HARD_TIMEOUT_MS,
+      'GUN_BACKUP_HARD_TIMEOUT_MS'
+    ),
+    maxKeys: parsePositiveInt(env.GUN_BACKUP_MAX_KEYS, DEFAULT_MAX_KEYS_PER_NODE, 'GUN_BACKUP_MAX_KEYS'),
+    debug: env.GUN_BACKUP_DEBUG === '1',
+    dryRun: false
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--manifest') {
+      options.manifest = argv[++index];
+    } else if (arg === '--out-dir') {
+      options.outDir = argv[++index];
+    } else if (arg === '--peer') {
+      options.peers.push(argv[++index]);
+    } else if (arg === '--root') {
+      options.roots.push(argv[++index]);
+    } else if (arg === '--depth') {
+      options.depth = parsePositiveInt(argv[++index], undefined, '--depth');
+    } else if (arg === '--timeout-ms') {
+      options.timeoutMs = parsePositiveInt(argv[++index], DEFAULT_TIMEOUT_MS, '--timeout-ms');
+    } else if (arg === '--connect-timeout-ms') {
+      options.connectTimeoutMs = parsePositiveInt(
+        argv[++index],
+        DEFAULT_CONNECT_TIMEOUT_MS,
+        '--connect-timeout-ms'
+      );
+    } else if (arg === '--hard-timeout-ms') {
+      options.hardTimeoutMs = parsePositiveInt(argv[++index], DEFAULT_HARD_TIMEOUT_MS, '--hard-timeout-ms');
+    } else if (arg === '--max-keys') {
+      options.maxKeys = parsePositiveInt(argv[++index], DEFAULT_MAX_KEYS_PER_NODE, '--max-keys');
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  options.peers = Array.from(new Set((options.peers.length ? options.peers : DEFAULT_PEERS).filter(Boolean)));
+  options.roots = Array.from(new Set(options.roots.filter(Boolean)));
+  return options;
+}
+
+function debugLog(options, message) {
+  if (options.debug) {
+    console.error(`[gun-backup] ${message}`);
+  }
+}
+
+async function withGunConsoleNoiseFiltered(options, action) {
+  if (options.debug) return action();
+  const originalLog = console.log;
+  console.log = (...args) => {
+    const message = args.map(String).join(' ');
+    if (
+      message.includes('Hello wonderful person') ||
+      message.includes('AXE relay enabled') ||
+      message.startsWith('Multicast on ')
+    ) {
+      return;
+    }
+    originalLog(...args);
+  };
+  try {
+    return await action();
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+function normalizeRoot(root, index, manifestDefaultDepth, overrideDepth) {
+  const pathParts = Array.isArray(root.path)
+    ? root.path.map(String).filter(Boolean)
+    : splitList(String(root.path || '').replaceAll('/', ' '));
+  if (!pathParts.length) {
+    throw new Error(`Manifest root at index ${index} is missing path.`);
+  }
+  return {
+    name: root.name || pathParts.join('/'),
+    path: pathParts,
+    depth: overrideDepth ?? root.depth ?? manifestDefaultDepth ?? 3,
+    critical: Boolean(root.critical),
+    sensitive: Boolean(root.sensitive),
+    notes: root.notes || ''
+  };
+}
+
+function getNodeFromPath(gun, pathParts) {
+  return pathParts.reduce((node, key) => node.get(key), gun);
+}
+
+function omitMetaFields(value, seen = new WeakSet()) {
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+  if (!Array.isArray(value) && Object.keys(value).length === 1 && typeof value['#'] === 'string') {
+    return { '#': value['#'] };
+  }
+  const clone = Array.isArray(value) ? [] : {};
+  for (const [key, child] of Object.entries(value)) {
+    if (key === '_') continue;
+    if (typeof child === 'function') continue;
+    clone[key] = omitMetaFields(child, seen);
+  }
+  return clone;
+}
+
+function onceWithTimeout(node, timeoutMs) {
+  return new Promise(resolve => {
+    let settled = false;
+    const timer = nativeSetTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve({ timedOut: true, value: undefined });
+    }, timeoutMs);
+
+    node.once(value => {
+      if (settled) return;
+      settled = true;
+      nativeClearTimeout(timer);
+      resolve({ timedOut: false, value });
+    });
+  });
+}
+
+async function snapshotNode(node, context, depth, seen, pathParts) {
+  const { timedOut, value } = await onceWithTimeout(node, context.timeoutMs);
+  const pathLabel = pathParts.join('/');
+  if (timedOut) {
+    context.warnings.push(`Timed out reading ${pathLabel}`);
+    return { _backup: { status: 'timeout', path: pathLabel } };
+  }
+  if (value === undefined) {
+    return null;
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const soul = value._?.['#'];
+  if (soul) {
+    if (seen.has(soul)) {
+      return { _link: soul };
+    }
+    seen.add(soul);
+  }
+
+  const cleaned = omitMetaFields(value);
+  if (depth <= 0) {
+    return cleaned;
+  }
+
+  const keys = Object.keys(cleaned).sort();
+  const traversedKeys = keys.slice(0, context.maxKeys);
+  const result = {};
+  if (keys.length > context.maxKeys) {
+    result._backup = {
+      status: 'truncated',
+      traversedKeys: context.maxKeys,
+      totalKeys: keys.length,
+      path: pathLabel
+    };
+    context.warnings.push(`Truncated ${pathLabel}: ${keys.length} keys, traversed ${context.maxKeys}`);
+  }
+
+  for (const key of traversedKeys) {
+    result[key] = await snapshotNode(node.get(key), context, depth - 1, seen, [...pathParts, key]);
+  }
+  return result;
+}
+
+async function waitForPeer(gun, timeoutMs) {
+  return new Promise(resolve => {
+    let settled = false;
+    const eventTarget = gun?._?.root || gun;
+    const done = payload => {
+      if (settled) return;
+      settled = true;
+      nativeClearTimeout(timer);
+      resolve(payload);
+    };
+    const timer = nativeSetTimeout(() => done(null), timeoutMs);
+    eventTarget.on('hi', peer => done(peer));
+  });
+}
+
+function peerLabel(peer) {
+  if (!peer) return null;
+  if (typeof peer === 'string') return peer;
+  return peer.url || peer.id || peer.wire?.url || JSON.stringify(peer);
+}
+
+async function createGun(peers, options = {}) {
+  debugLog(options, 'importing gun/lib/server.js');
+  const { gun } = await withGunConsoleNoiseFiltered(options, async () => {
+    const moduleResult = await import('gun/lib/server.js');
+    const Gun = moduleResult.default || moduleResult;
+    debugLog(options, 'constructing Gun client');
+    const gun = Gun({
+      peers,
+      axe: false,
+      multicast: false,
+      localStorage: false,
+      radisk: false,
+      file: false
+    });
+    return { gun };
+  });
+  debugLog(options, 'Gun client constructed');
+  return { gun };
+}
+
+function timestampForFile(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+function sha256(text) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+async function runBackup(options) {
+  const manifestPath = path.resolve(options.manifest);
+  debugLog(options, `reading manifest ${manifestPath}`);
+  const manifest = await readJson(manifestPath);
+  const roots = (manifest.roots || []).map((root, index) =>
+    normalizeRoot(root, index, manifest.defaultDepth, options.depth)
+  );
+  const rootFilters = new Set(options.roots);
+  const selectedRoots = rootFilters.size
+    ? roots.filter(root => rootFilters.has(root.name) || rootFilters.has(root.path.join('/')))
+    : roots;
+  if (!selectedRoots.length) {
+    throw new Error(`No roots found in ${manifestPath}`);
+  }
+
+  if (options.dryRun) {
+    return {
+      dryRun: true,
+      manifest: manifestPath,
+      peers: options.peers,
+      roots: selectedRoots.map(({ name, path: rootPath, depth, critical, sensitive }) => ({
+        name,
+        path: rootPath,
+        depth,
+        critical,
+        sensitive
+      }))
+    };
+  }
+
+  debugLog(options, `creating Gun client for ${options.peers.join(', ')}`);
+  const { gun } = await createGun(options.peers, options);
+  debugLog(options, 'attaching peer wait');
+  const peerWait = waitForPeer(gun, options.connectTimeoutMs);
+  debugLog(options, `triggering connection read at ${selectedRoots[0].path.join('/')}`);
+  getNodeFromPath(gun, selectedRoots[0].path).once(() => {});
+  const connectedPeer = await peerWait;
+  if (!connectedPeer) {
+    throw new Error(`No Gun peer connected within ${options.connectTimeoutMs}ms.`);
+  }
+  debugLog(options, `connected to ${peerLabel(connectedPeer)}`);
+
+  const warnings = [];
+  const startedAt = new Date();
+  const snapshot = {
+    schema: '3dvr.portal.gun-known-roots.snapshot.v1',
+    capturedAt: startedAt.toISOString(),
+    connectedPeer: peerLabel(connectedPeer),
+    peers: options.peers,
+    manifest: {
+      path: manifestPath,
+      version: manifest.version || null,
+      rootCount: selectedRoots.length
+    },
+    options: {
+      timeoutMs: options.timeoutMs,
+      connectTimeoutMs: options.connectTimeoutMs,
+      hardTimeoutMs: options.hardTimeoutMs,
+      maxKeys: options.maxKeys
+    },
+    roots: [],
+    warnings
+  };
+
+  for (const root of selectedRoots) {
+    debugLog(options, `snapshotting ${root.path.join('/')} at depth ${root.depth}`);
+    const rootStarted = Date.now();
+    const context = { timeoutMs: options.timeoutMs, maxKeys: options.maxKeys, warnings };
+    const seen = new Set();
+    let status = 'ok';
+    let data;
+    try {
+      data = await snapshotNode(getNodeFromPath(gun, root.path), context, root.depth, seen, root.path);
+    } catch (error) {
+      status = 'error';
+      data = { _backup: { status: 'error', message: error.message } };
+      warnings.push(`Error reading ${root.path.join('/')}: ${error.message}`);
+    }
+
+    snapshot.roots.push({
+      name: root.name,
+      path: root.path,
+      depth: root.depth,
+      critical: root.critical,
+      sensitive: root.sensitive,
+      notes: root.notes,
+      status,
+      durationMs: Date.now() - rootStarted,
+      data
+    });
+  }
+
+  snapshot.finishedAt = new Date().toISOString();
+  snapshot.durationMs = new Date(snapshot.finishedAt).getTime() - startedAt.getTime();
+
+  await mkdir(options.outDir, { recursive: true });
+  const fileName = `portal-gun-known-roots-${timestampForFile(startedAt)}.json`;
+  const outputPath = path.resolve(options.outDir, fileName);
+  const serialized = `${JSON.stringify(snapshot, null, 2)}\n`;
+  debugLog(options, `writing ${outputPath}`);
+  await writeFile(outputPath, serialized, { mode: 0o600 });
+
+  const digest = sha256(serialized);
+  await writeFile(`${outputPath}.sha256`, `${digest}  ${fileName}\n`, { mode: 0o600 });
+
+  return {
+    dryRun: false,
+    outputPath,
+    sha256Path: `${outputPath}.sha256`,
+    sha256: digest,
+    connectedPeer: snapshot.connectedPeer,
+    rootCount: snapshot.roots.length,
+    warningCount: warnings.length,
+    durationMs: snapshot.durationMs
+  };
+}
+
+export { parseArgs, runBackup };
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  let exitCode = 0;
+  let hardTimer = null;
+  try {
+    const options = parseArgs();
+    hardTimer = nativeSetTimeout(() => {
+      console.error(`Gun backup exceeded hard timeout of ${options.hardTimeoutMs}ms.`);
+      process.exit(1);
+    }, options.hardTimeoutMs);
+    if (options.help) {
+      console.log(usage());
+    } else {
+      const result = await runBackup(options);
+      console.log(JSON.stringify(result, null, 2));
+    }
+  } catch (error) {
+    exitCode = 1;
+    console.error(error.message);
+  } finally {
+    if (hardTimer) nativeClearTimeout(hardTimer);
+    nativeSetTimeout(() => process.exit(exitCode), 50);
+  }
+}

--- a/tests/gun-backup-ops.test.js
+++ b/tests/gun-backup-ops.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+
+test('Gun backup operations include host archive, known roots, and repo-safe outputs', async () => {
+  const [manifestRaw, packageRaw, gitignore, archiveScript, snapshotScript, runbook, runbookIndex] =
+    await Promise.all([
+      readFile(new URL('../ops/gun/portal-gun-roots.json', import.meta.url), 'utf8'),
+      readFile(new URL('../package.json', import.meta.url), 'utf8'),
+      readFile(new URL('../.gitignore', import.meta.url), 'utf8'),
+      readFile(new URL('../ops/gun/archive-rad.sh', import.meta.url), 'utf8'),
+      readFile(new URL('../scripts/gun/backup-known-roots.mjs', import.meta.url), 'utf8'),
+      readFile(new URL('../ops/control-plane/home/RUNBOOKS/portal-gunjs-backups.md', import.meta.url), 'utf8'),
+      readFile(new URL('../ops/control-plane/home/RUNBOOKS/README.md', import.meta.url), 'utf8')
+    ]);
+
+  const manifest = JSON.parse(manifestRaw);
+  const packageJson = JSON.parse(packageRaw);
+  const rootNames = new Set(manifest.roots.map(root => root.name));
+  const rootPaths = manifest.roots.map(root => root.path.join('/'));
+
+  assert.equal(manifest.version, 1);
+  assert.ok(rootNames.has('portal'));
+  assert.ok(rootNames.has('crm'));
+  assert.ok(rootNames.has('guests'));
+  assert.ok(rootNames.has('ai'));
+  assert.ok(rootPaths.includes('3dvr-portal'));
+  assert.ok(rootPaths.includes('3dvr-crm'));
+  assert.ok(rootPaths.includes('3dvr-guests'));
+  assert.ok(manifest.roots.some(root => root.sensitive), 'manifest should mark sensitive roots');
+
+  assert.equal(packageJson.scripts['gun:backup'], 'node scripts/gun/backup-known-roots.mjs');
+  assert.match(gitignore, /^backups\/$/m);
+
+  assert.match(snapshotScript, /gun\/lib\/server\.js/);
+  assert.match(snapshotScript, /GUN_BACKUP_PEERS/);
+  assert.match(snapshotScript, /GUN_BACKUP_ROOTS/);
+  assert.match(snapshotScript, /--root/);
+  assert.match(snapshotScript, /portal-gun-known-roots-/);
+  assert.match(snapshotScript, /sha256/);
+  assert.match(snapshotScript, /radisk:\s*false/);
+  assert.match(snapshotScript, /localStorage:\s*false/);
+
+  assert.match(archiveScript, /GUN_RAD_DIR/);
+  assert.match(archiveScript, /portal-gun-rad-/);
+  assert.match(archiveScript, /sha256sum|shasum/);
+  assert.match(archiveScript, /GUN_BACKUP_RCLONE_REMOTE/);
+  assert.match(archiveScript, /GUN_BACKUP_STOP_SERVICE/);
+
+  assert.match(runbook, /authoritative backup/i);
+  assert.match(runbook, /known root snapshots/i);
+  assert.match(runbook, /Off-host copy is required/i);
+  assert.match(runbook, /Weekly restore drill/i);
+  assert.match(runbookIndex, /portal-gunjs-backups\.md/);
+});


### PR DESCRIPTION
## Summary
- add a two-layer portal GunJS backup plan: RAD directory archives plus known-root JSON snapshots
- add `npm run gun:backup` for bounded known-root snapshots with checksums, root filters, hard timeouts, and ignored local outputs
- add `ops/gun/archive-rad.sh` for host-side `radata` tarball/checksum archives with optional service stop and rclone upload
- document the daily schedule, off-host copy requirement, and restore guardrails in a runbook

## Notes
- The RAD archive is the authoritative backup because a Gun client cannot discover every soul without known roots.
- JSON snapshots are inspection/recovery aids and are treated as sensitive artifacts.
- Generated backup files are ignored under `backups/`.

## Validation
- `node --test tests/gun-backup-ops.test.js tests/gun-toolkit.test.js tests/gun-peer-config.test.js`
- `node --check scripts/gun/backup-known-roots.mjs`
- `sh -n ops/gun/archive-rad.sh`
- `git diff --check`
- `npm run gun:backup -- --dry-run --root portal --depth 0`
- live bounded snapshot: `npm run gun:backup -- --root portal --depth 0 --timeout-ms 1000 --connect-timeout-ms 5000 --hard-timeout-ms 15000 --max-keys 25`
- temp RAD archive smoke with fake `/tmp/.../radata` produced `.tar.gz` plus `.sha256`
