### PR TITLE
[codex] Dock Stellar Drift instructions

### DIFF
--- a/stellar-flight.html
+++ b/stellar-flight.html
@@ -43,10 +43,9 @@
 
   .overlay {
     position: fixed;
-    top: calc(6.5rem + env(safe-area-inset-top, 0px));
-    left: 50%;
-    transform: translateX(-50%);
-    width: min(440px, calc(100% - 2rem));
+    right: var(--safe-right);
+    bottom: calc(var(--safe-bottom) + var(--control-safe-zone));
+    width: min(420px, calc(100vw - 2rem));
     background: rgba(15, 23, 42, 0.72);
     backdrop-filter: blur(12px);
     border-radius: 18px;
@@ -95,7 +94,7 @@
 
   .overlay-hidden {
     opacity: 0;
-    transform: translate(-50%, -18px);
+    transform: translate3d(0, 18px, 0);
     pointer-events: none;
   }
 
@@ -107,9 +106,8 @@
 
   .overlay-toggle {
     position: fixed;
-    top: calc(6rem + env(safe-area-inset-top, 0px));
-    left: 50%;
-    transform: translateX(-50%);
+    right: var(--safe-right);
+    bottom: calc(var(--safe-bottom) + var(--control-safe-zone));
     padding: 0.55rem 1.15rem;
     border-radius: 999px;
     border: 1px solid rgba(96, 165, 250, 0.5);
@@ -136,7 +134,7 @@
   .overlay-toggle-visible {
     opacity: 1;
     pointer-events: auto;
-    transform: translateX(-50%) translateY(0);
+    transform: translate3d(0, 0, 0);
   }
 
   .status {
@@ -792,12 +790,15 @@
 
   @media (max-width: 720px) {
     .overlay {
-      top: 7.5rem;
+      right: calc(env(safe-area-inset-right, 0px) + 1rem);
+      bottom: calc(var(--safe-bottom) + var(--control-safe-zone) + 1rem);
+      width: min(380px, calc(100vw - 2rem));
       padding: 1rem;
     }
 
     .overlay-toggle {
-      top: 7rem;
+      right: calc(env(safe-area-inset-right, 0px) + 1rem);
+      bottom: calc(var(--safe-bottom) + var(--control-safe-zone) + 1rem);
     }
 
     .overlay h1 {
@@ -862,8 +863,9 @@
 
   @media (max-width: 540px) {
     .overlay {
-      top: calc(4.6rem + env(safe-area-inset-top, 0px));
-      width: min(360px, calc(100% - 1.25rem));
+      right: calc(env(safe-area-inset-right, 0px) + 0.65rem);
+      bottom: calc(var(--safe-bottom) + var(--control-safe-zone) + 1.25rem);
+      width: min(320px, calc(100vw - 1.3rem));
       padding: 0.85rem 0.9rem 0.85rem;
       max-height: 34vh;
       overflow: auto;
@@ -885,9 +887,8 @@
     }
 
     .overlay-toggle {
-      top: auto;
-      bottom: calc(var(--safe-bottom) + var(--control-safe-zone) + 0.75rem);
-      transform: translate(-50%, 0);
+      right: calc(env(safe-area-inset-right, 0px) + 0.65rem);
+      bottom: calc(var(--safe-bottom) + var(--control-safe-zone) + 1rem);
     }
 
     .status {
@@ -1064,7 +1065,7 @@
     Touch: Off
   </button>
 
-  <button class="overlay-toggle" id="overlayToggle" type="button" aria-hidden="true">Show Flight Controls</button>
+  <button class="overlay-toggle" id="overlayToggle" type="button" aria-label="Show flight controls" aria-hidden="true">Show Controls</button>
 
   <div class="overlay" aria-live="polite" aria-hidden="false">
     <button class="overlay-close" id="overlayClose" type="button">Hide</button>

--- a/tests/stellar-flight-layout.test.js
+++ b/tests/stellar-flight-layout.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+function cssRule(css, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escaped}\\s*\\{(?<body>[^}]+)\\}`));
+  assert.ok(match?.groups?.body, `Expected CSS rule for ${selector}`);
+  return match.groups.body;
+}
+
+test('stellar drift keeps flight instructions out of the cockpit sightline', async () => {
+  const html = await readFile(new URL('../stellar-flight.html', import.meta.url), 'utf8');
+  const overlay = cssRule(html, '.overlay');
+  const overlayHidden = cssRule(html, '.overlay-hidden');
+  const overlayToggle = cssRule(html, '.overlay-toggle');
+
+  assert.match(html, /<title>Stellar Drift - Endless Flight<\/title>/);
+  assert.match(html, /id="overlayToggle"/);
+  assert.match(html, /aria-label="Show flight controls"[^>]*>Show Controls<\/button>/);
+  assert.match(html, /id="primaryInstructions"/);
+
+  assert.match(overlay, /right:\s*var\(--safe-right\)/);
+  assert.match(overlay, /bottom:\s*calc\(var\(--safe-bottom\) \+ var\(--control-safe-zone\)\)/);
+  assert.match(overlay, /width:\s*min\(420px,\s*calc\(100vw - 2rem\)\)/);
+  assert.doesNotMatch(overlay, /left:\s*50%/);
+  assert.doesNotMatch(overlay, /top:\s*calc\(6\.5rem/);
+
+  assert.match(overlayHidden, /transform:\s*translate3d\(0,\s*18px,\s*0\)/);
+  assert.match(overlayToggle, /right:\s*var\(--safe-right\)/);
+  assert.match(overlayToggle, /bottom:\s*calc\(var\(--safe-bottom\) \+ var\(--control-safe-zone\)\)/);
+
+  assert.match(
+    html,
+    /@media \(max-width: 540px\)[\s\S]+?\.overlay\s*\{[\s\S]+?bottom:\s*calc\(var\(--safe-bottom\) \+ var\(--control-safe-zone\) \+ 1\.25rem\)/
+  );
+  assert.match(html, /@media \(max-width: 540px\)[\s\S]+?width:\s*min\(320px,\s*calc\(100vw - 1\.3rem\)\)/);
+  assert.match(html, /@media \(max-width: 540px\)[\s\S]+?\.hint\s*\{[\s\S]+?display:\s*none/);
+});


### PR DESCRIPTION
## Summary
- Move the Stellar Drift instruction panel and hidden controls toggle from the top-center sightline to the lower-right dock.
- Keep mobile instructions collapsed by default, compact the reopen button, and keep the opened tray above touch controls.
- Add a focused regression test for the overlay positioning rules.

## Validation
- node --test tests/stellar-flight-layout.test.js
- WebKit Playwright smoke at 1440x900 and 390x844 with no page/console errors, no WebGL fallback, mobile touch controls enabled, opened instructions clear of action/throttle controls, and screenshot pixel checks confirming the Three.js scene renders.