### PR TITLE
Add direct app links to release notes

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -102,7 +102,18 @@
       <a class="release-link" href="v0.0.48.html">v0.0.48</a>
       <span class="release-meta">Week of June 1, 2026</span>
       <p class="release-summary">
-        Wellness and consciousness apps, Focus Flow planning, partner policy, GunJS backup tooling, and new experimental rooms.
+        Wellness and consciousness apps, Focus Flow planning, partner policy, GunJS backup tooling, new experimental
+        rooms, and Games access.
+      </p>
+      <p class="release-summary">
+        <strong>Open:</strong>
+        <a href="../intention-lab/">Intention Lab</a>,
+        <a href="../body-mode/">Body Mode</a>,
+        <a href="../portal-lab/">Portal Lab</a>,
+        <a href="../inner-alignment/">Inner Alignment</a>,
+        <a href="../life-force-room/">Life Force Room</a>,
+        <a href="../master-key-room/">Master Key Room</a>,
+        <a href="../games.html">Games</a>.
       </p>
     </article>
   </div>
@@ -113,7 +124,8 @@
         <a class="release-link" href="v0.0.48.html">v0.0.48</a>
         <span class="release-meta">Week of June 1, 2026</span>
         <p class="release-summary">
-          Wellness and consciousness apps, Focus Flow planning, partner policy, GunJS backup tooling, and new experimental rooms.
+          Wellness and consciousness apps, Focus Flow planning, partner policy, GunJS backup tooling, new experimental
+          rooms, and Games access.
         </p>
       </li>
       <li class="release-card">

--- a/releases/v0.0.47.html
+++ b/releases/v0.0.47.html
@@ -41,6 +41,21 @@
   </div>
 
   <div class="section">
+    <h2>Open the Work</h2>
+    <ul class="link-list">
+      <li><a href="../revenue-desk/">Revenue Desk</a> for the new operating surface and money actions.</li>
+      <li><a href="../market-lab/">Market Lab</a> for Gun-backed landing-page tests and CTA tracking.</li>
+      <li><a href="../growth-operator/">Growth Operator</a> for market and outreach operating cycles.</li>
+      <li><a href="../memory-capture/">Memory Capture</a> for turning raw thoughts into proposals and follow-up.</li>
+      <li><a href="../community-farming-network/">Community Farming Network</a> for the new community project page.</li>
+      <li><a href="../crm/">CRM</a> for the flow interface and mobile overflow fixes.</li>
+      <li><a href="../webrtc-lab/">WebRTC Lab</a> for relay diagnostics and peer discovery work.</li>
+      <li><a href="../gun-live-room/">Gun Live Room</a> for live-room media experiments.</li>
+      <li><a href="../docs/path-to-profitability.md">Path to Profitability</a> and <a href="../docs/market-research-2026.md">Market Research 2026</a> for the written strategy docs.</li>
+    </ul>
+  </div>
+
+  <div class="section">
     <h2>Merged PRs</h2>
     <ul class="link-list">
       <li><a href="https://github.com/tmsteph/3dvr-portal/pull/604">#604 Add weekly release notes through v0.0.46</a></li>

--- a/releases/v0.0.48.html
+++ b/releases/v0.0.48.html
@@ -38,6 +38,22 @@
       <li><strong>Focus Flow direction:</strong> the Focus Flow OS plan captured the next layer: preserve momentum while leaving the portal to do real external work.</li>
       <li><strong>Partner and revenue policy:</strong> reseller partner language, payout expectations, and Stripe access boundaries became explicit.</li>
       <li><strong>Infrastructure and rooms:</strong> Supabase-on-DigitalOcean notes, GunJS backup tooling, Life Force Room, and Master Key Room expanded the operating base.</li>
+      <li><strong>Games access:</strong> Games moved into the top nav and Stellar Drift gained clearer keyboard-flight instructions.</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Open the Work</h2>
+    <ul class="link-list">
+      <li><a href="../intention-lab/">Intention Lab</a> for state checks, grounding, honest RNG experiments, and action logging.</li>
+      <li><a href="../body-mode/">Body Mode</a> for the sensory-friendly body reset collection.</li>
+      <li><a href="../body-mode/seated-spine-reset/">Seated Spine Reset</a> for the first fully working Body Mode app.</li>
+      <li><a href="../portal-lab/">Portal Lab</a> for frequency, consciousness, coherence, ritual, and research practice.</li>
+      <li><a href="../inner-alignment/">Inner Alignment</a> for the Three.js body, breath, attention, and action runner.</li>
+      <li><a href="../docs/focus-flow-os-plan.md">Focus Flow OS Plan</a> for the next work-gate direction.</li>
+      <li><a href="../reseller-policy/">Reseller Policy</a> for partner expectations and Stripe access boundaries.</li>
+      <li><a href="../life-force-room/">Life Force Room</a> and <a href="../master-key-room/">Master Key Room</a> for the new experimental rooms.</li>
+      <li><a href="../games.html">Games</a> and <a href="../stellar-flight.html">Stellar Drift</a> for the game work.</li>
     </ul>
   </div>
 
@@ -56,6 +72,8 @@
       <li><a href="https://github.com/tmsteph/3dvr-portal/pull/668">#668 Add Life Force Room experimental app</a></li>
       <li><a href="https://github.com/tmsteph/3dvr-portal/pull/669">#669 Add portal GunJS backup tooling</a></li>
       <li><a href="https://github.com/tmsteph/3dvr-portal/pull/670">#670 Add Master Key Room portal app</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/671">#671 Add Games nav link and update releases</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/672">#672 Dock Stellar Drift instructions</a></li>
     </ul>
   </div>
 
@@ -63,7 +81,7 @@
     <h2>Release Cadence</h2>
     <p>
       v0.0.48 is the current Monday release for the week of June 1. The next planned release should continue from
-      PRs merged after #670 unless a hotfix needs to be called out separately.
+      PRs merged after #672 unless a hotfix needs to be called out separately.
     </p>
   </div>
 

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -25,6 +25,8 @@ describe('release hub backfill', () => {
     assert.match(html, /Week of June 1, 2026/);
     assert.match(html, /Wellness and consciousness apps/);
     assert.match(html, /GunJS backup tooling/);
+    assert.match(html, /href="\.\.\/intention-lab\/">Intention Lab</);
+    assert.match(html, /href="\.\.\/games\.html">Games</);
     assert.match(html, /href="v0\.0\.47\.html">v0\.0\.47</);
     assert.match(html, /Week of May 25, 2026/);
     assert.match(html, /Revenue Desk/);
@@ -88,5 +90,27 @@ describe('release hub backfill', () => {
       assert.match(html, topicPattern);
       assert.match(html, navPattern);
     }
+  });
+
+  it('rewards release readers with direct links to the shipped apps and docs', async () => {
+    const release47 = await readFile(new URL('v0.0.47.html', baseDir), 'utf8');
+    const release48 = await readFile(new URL('v0.0.48.html', baseDir), 'utf8');
+
+    assert.match(release47, /<h2>Open the Work<\/h2>/);
+    assert.match(release47, /href="\.\.\/revenue-desk\/">Revenue Desk</);
+    assert.match(release47, /href="\.\.\/market-lab\/">Market Lab</);
+    assert.match(release47, /href="\.\.\/webrtc-lab\/">WebRTC Lab</);
+    assert.match(release47, /href="\.\.\/docs\/path-to-profitability\.md">Path to Profitability</);
+
+    assert.match(release48, /<h2>Open the Work<\/h2>/);
+    assert.match(release48, /href="\.\.\/intention-lab\/">Intention Lab</);
+    assert.match(release48, /href="\.\.\/body-mode\/">Body Mode</);
+    assert.match(release48, /href="\.\.\/portal-lab\/">Portal Lab</);
+    assert.match(release48, /href="\.\.\/inner-alignment\/">Inner Alignment</);
+    assert.match(release48, /href="\.\.\/life-force-room\/">Life Force Room</);
+    assert.match(release48, /href="\.\.\/master-key-room\/">Master Key Room</);
+    assert.match(release48, /href="\.\.\/games\.html">Games</);
+    assert.match(release48, /href="\.\.\/stellar-flight\.html">Stellar Drift</);
+    assert.match(release48, /pull\/672/);
   });
 });


### PR DESCRIPTION
## Summary
- Add direct `Open the Work` sections to `v0.0.47` and `v0.0.48` so readers can jump into the shipped apps/docs from the release page.
- Add quick links to the latest release card on `/releases/` for the current wellness/consciousness apps, rooms, and Games.
- Include the current week’s Games/Stellar Drift work in `v0.0.48` now that PR #672 has landed.
- Extend release tests so app/doc links stay present.

## Verification
- `git diff --check`
- `node --test tests/releases-hub.test.js`
- Local existence check for every linked app/doc target.

## Billing / Stripe
- No Stripe or billing behavior changes.
