### PR TITLE
Inline release app links in summaries

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -102,18 +102,15 @@
       <a class="release-link" href="v0.0.48.html">v0.0.48</a>
       <span class="release-meta">Week of June 1, 2026</span>
       <p class="release-summary">
-        Wellness and consciousness apps, Focus Flow planning, partner policy, GunJS backup tooling, new experimental
-        rooms, and Games access.
-      </p>
-      <p class="release-summary">
-        <strong>Open:</strong>
-        <a href="../intention-lab/">Intention Lab</a>,
+        Wellness and consciousness apps like <a href="../intention-lab/">Intention Lab</a>,
         <a href="../body-mode/">Body Mode</a>,
         <a href="../portal-lab/">Portal Lab</a>,
-        <a href="../inner-alignment/">Inner Alignment</a>,
+        and <a href="../inner-alignment/">Inner Alignment</a>, plus
+        <a href="../docs/focus-flow-os-plan.md">Focus Flow planning</a>,
+        <a href="../reseller-policy/">partner policy</a>, GunJS backup tooling,
         <a href="../life-force-room/">Life Force Room</a>,
         <a href="../master-key-room/">Master Key Room</a>,
-        <a href="../games.html">Games</a>.
+        and <a href="../games.html">Games</a> access.
       </p>
     </article>
   </div>
@@ -124,15 +121,19 @@
         <a class="release-link" href="v0.0.48.html">v0.0.48</a>
         <span class="release-meta">Week of June 1, 2026</span>
         <p class="release-summary">
-          Wellness and consciousness apps, Focus Flow planning, partner policy, GunJS backup tooling, new experimental
-          rooms, and Games access.
+          Wellness and consciousness apps, <a href="../docs/focus-flow-os-plan.md">Focus Flow planning</a>,
+          <a href="../reseller-policy/">partner policy</a>, GunJS backup tooling, new experimental rooms, and
+          <a href="../games.html">Games</a> access.
         </p>
       </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.47.html">v0.0.47</a>
         <span class="release-meta">Week of May 25, 2026</span>
         <p class="release-summary">
-          Revenue Desk, Market Lab, Growth Operator, WebRTC reliability, memory capture, CRM flow, and portal logo polish.
+          <a href="../revenue-desk/">Revenue Desk</a>, <a href="../market-lab/">Market Lab</a>,
+          <a href="../growth-operator/">Growth Operator</a>, <a href="../webrtc-lab/">WebRTC reliability</a>,
+          <a href="../memory-capture/">memory capture</a>, <a href="../crm/flow.html">CRM flow</a>, and portal logo
+          polish.
         </p>
       </li>
       <li class="release-card">

--- a/releases/v0.0.47.html
+++ b/releases/v0.0.47.html
@@ -33,25 +33,29 @@
       connected to revenue, market research, WebRTC reliability, and customer follow-through.
     </p>
     <ul class="release-summary-list">
-      <li><strong>Revenue and market systems:</strong> Market Lab, Revenue Desk, Growth Operator, Market Pulse, and path-to-profitability docs turned demand research into clearer money actions.</li>
-      <li><strong>Realtime media reliability:</strong> WebRTC and Gun live-room work added cache busting, lower bandwidth, TURN support, relay diagnostics, HTTPS fallback, and better signaling waits.</li>
-      <li><strong>Portal surface:</strong> homepage search, release hub polish, PWA boot behavior, and the interactive Three.js portal logo made the main entry point feel sharper.</li>
-      <li><strong>Operational capture:</strong> Memory Capture, People Log, CRM flow, and Community Farming Network work gave more places to turn ideas and relationships into action.</li>
-    </ul>
-  </div>
-
-  <div class="section">
-    <h2>Open the Work</h2>
-    <ul class="link-list">
-      <li><a href="../revenue-desk/">Revenue Desk</a> for the new operating surface and money actions.</li>
-      <li><a href="../market-lab/">Market Lab</a> for Gun-backed landing-page tests and CTA tracking.</li>
-      <li><a href="../growth-operator/">Growth Operator</a> for market and outreach operating cycles.</li>
-      <li><a href="../memory-capture/">Memory Capture</a> for turning raw thoughts into proposals and follow-up.</li>
-      <li><a href="../community-farming-network/">Community Farming Network</a> for the new community project page.</li>
-      <li><a href="../crm/">CRM</a> for the flow interface and mobile overflow fixes.</li>
-      <li><a href="../webrtc-lab/">WebRTC Lab</a> for relay diagnostics and peer discovery work.</li>
-      <li><a href="../gun-live-room/">Gun Live Room</a> for live-room media experiments.</li>
-      <li><a href="../docs/path-to-profitability.md">Path to Profitability</a> and <a href="../docs/market-research-2026.md">Market Research 2026</a> for the written strategy docs.</li>
+      <li>
+        <strong>Revenue and market systems:</strong>
+        <a href="../market-lab/">Market Lab</a>, <a href="../revenue-desk/">Revenue Desk</a>,
+        <a href="../growth-operator/">Growth Operator</a>, Market Pulse, and
+        <a href="../docs/path-to-profitability.md">path-to-profitability docs</a> turned demand research into clearer
+        money actions.
+      </li>
+      <li>
+        <strong>Realtime media reliability:</strong>
+        <a href="../webrtc-lab/">WebRTC Lab</a> and <a href="../gun-live-room/">Gun Live Room</a> work added cache
+        busting, lower bandwidth, TURN support, relay diagnostics, HTTPS fallback, and better signaling waits.
+      </li>
+      <li>
+        <strong>Portal surface:</strong>
+        <a href="../index.html">homepage</a> search, release hub polish, PWA boot behavior, and the interactive
+        Three.js portal logo made the main entry point feel sharper.
+      </li>
+      <li>
+        <strong>Operational capture:</strong>
+        <a href="../memory-capture/">Memory Capture</a>, People Log, <a href="../crm/flow.html">CRM flow</a>, and
+        <a href="../community-farming-network/">Community Farming Network</a> work gave more places to turn ideas and
+        relationships into action.
+      </li>
     </ul>
   </div>
 

--- a/releases/v0.0.48.html
+++ b/releases/v0.0.48.html
@@ -34,26 +34,33 @@
       portal direction while tightening partner policy and data durability.
     </p>
     <ul class="release-summary-list">
-      <li><strong>Wellness and consciousness apps:</strong> Intention Lab, Body Mode, Seated Spine Reset, Portal Lab, and Inner Alignment added grounded routes for breath, posture, attention, research, and action.</li>
-      <li><strong>Focus Flow direction:</strong> the Focus Flow OS plan captured the next layer: preserve momentum while leaving the portal to do real external work.</li>
-      <li><strong>Partner and revenue policy:</strong> reseller partner language, payout expectations, and Stripe access boundaries became explicit.</li>
-      <li><strong>Infrastructure and rooms:</strong> Supabase-on-DigitalOcean notes, GunJS backup tooling, Life Force Room, and Master Key Room expanded the operating base.</li>
-      <li><strong>Games access:</strong> Games moved into the top nav and Stellar Drift gained clearer keyboard-flight instructions.</li>
-    </ul>
-  </div>
-
-  <div class="section">
-    <h2>Open the Work</h2>
-    <ul class="link-list">
-      <li><a href="../intention-lab/">Intention Lab</a> for state checks, grounding, honest RNG experiments, and action logging.</li>
-      <li><a href="../body-mode/">Body Mode</a> for the sensory-friendly body reset collection.</li>
-      <li><a href="../body-mode/seated-spine-reset/">Seated Spine Reset</a> for the first fully working Body Mode app.</li>
-      <li><a href="../portal-lab/">Portal Lab</a> for frequency, consciousness, coherence, ritual, and research practice.</li>
-      <li><a href="../inner-alignment/">Inner Alignment</a> for the Three.js body, breath, attention, and action runner.</li>
-      <li><a href="../docs/focus-flow-os-plan.md">Focus Flow OS Plan</a> for the next work-gate direction.</li>
-      <li><a href="../reseller-policy/">Reseller Policy</a> for partner expectations and Stripe access boundaries.</li>
-      <li><a href="../life-force-room/">Life Force Room</a> and <a href="../master-key-room/">Master Key Room</a> for the new experimental rooms.</li>
-      <li><a href="../games.html">Games</a> and <a href="../stellar-flight.html">Stellar Drift</a> for the game work.</li>
+      <li>
+        <strong>Wellness and consciousness apps:</strong>
+        <a href="../intention-lab/">Intention Lab</a>, <a href="../body-mode/">Body Mode</a>,
+        <a href="../body-mode/seated-spine-reset/">Seated Spine Reset</a>,
+        <a href="../portal-lab/">Portal Lab</a>, and <a href="../inner-alignment/">Inner Alignment</a> added grounded
+        routes for breath, posture, attention, research, and action.
+      </li>
+      <li>
+        <strong>Focus Flow direction:</strong>
+        the <a href="../docs/focus-flow-os-plan.md">Focus Flow OS plan</a> captured the next layer: preserve momentum
+        while leaving the portal to do real external work.
+      </li>
+      <li>
+        <strong>Partner and revenue policy:</strong>
+        <a href="../reseller-policy/">reseller partner language</a>, payout expectations, and Stripe access boundaries
+        became explicit.
+      </li>
+      <li>
+        <strong>Infrastructure and rooms:</strong>
+        Supabase-on-DigitalOcean notes, GunJS backup tooling, <a href="../life-force-room/">Life Force Room</a>, and
+        <a href="../master-key-room/">Master Key Room</a> expanded the operating base.
+      </li>
+      <li>
+        <strong>Games access:</strong>
+        <a href="../games.html">Games</a> moved into the top nav and
+        <a href="../stellar-flight.html">Stellar Drift</a> gained clearer keyboard-flight instructions.
+      </li>
     </ul>
   </div>
 

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -92,17 +92,18 @@ describe('release hub backfill', () => {
     }
   });
 
-  it('rewards release readers with direct links to the shipped apps and docs', async () => {
+  it('links shipped apps and docs inline where the release summaries mention them', async () => {
     const release47 = await readFile(new URL('v0.0.47.html', baseDir), 'utf8');
     const release48 = await readFile(new URL('v0.0.48.html', baseDir), 'utf8');
 
-    assert.match(release47, /<h2>Open the Work<\/h2>/);
+    assert.doesNotMatch(release47, /<h2>Open the Work<\/h2>/);
     assert.match(release47, /href="\.\.\/revenue-desk\/">Revenue Desk</);
     assert.match(release47, /href="\.\.\/market-lab\/">Market Lab</);
     assert.match(release47, /href="\.\.\/webrtc-lab\/">WebRTC Lab</);
-    assert.match(release47, /href="\.\.\/docs\/path-to-profitability\.md">Path to Profitability</);
+    assert.match(release47, /href="\.\.\/docs\/path-to-profitability\.md">path-to-profitability docs</);
+    assert.match(release47, /<strong>Revenue and market systems:<\/strong>[\s\S]*href="\.\.\/market-lab\/"/);
 
-    assert.match(release48, /<h2>Open the Work<\/h2>/);
+    assert.doesNotMatch(release48, /<h2>Open the Work<\/h2>/);
     assert.match(release48, /href="\.\.\/intention-lab\/">Intention Lab</);
     assert.match(release48, /href="\.\.\/body-mode\/">Body Mode</);
     assert.match(release48, /href="\.\.\/portal-lab\/">Portal Lab</);
@@ -111,6 +112,7 @@ describe('release hub backfill', () => {
     assert.match(release48, /href="\.\.\/master-key-room\/">Master Key Room</);
     assert.match(release48, /href="\.\.\/games\.html">Games</);
     assert.match(release48, /href="\.\.\/stellar-flight\.html">Stellar Drift</);
+    assert.match(release48, /<strong>Wellness and consciousness apps:<\/strong>[\s\S]*href="\.\.\/intention-lab\/"/);
     assert.match(release48, /pull\/672/);
   });
 });


### PR DESCRIPTION
## Summary
- Link shipped apps/docs directly where they are mentioned in the `v0.0.47` and `v0.0.48` release summaries.
- Remove the separate `Open the Work` sections now that the summaries themselves are actionable.
- Inline key latest-release links on `/releases/` so the first release card is useful without a second link block.
- Update release tests to enforce inline links and keep the duplicate section out.

## Verification
- `git diff --check`
- `node --test tests/releases-hub.test.js`
- Local existence check for every linked app/doc target.

## Billing / Stripe
- No Stripe or billing behavior changes.
