### PR TITLE
Map Stellar Drift spacebar to fire

### DIFF
--- a/stellar-flight.html
+++ b/stellar-flight.html
@@ -1072,8 +1072,8 @@
     <h1>Stellar Drift</h1>
     <p id="primaryInstructions">
       Fly through stars and luminous worlds. Use <strong>WASD</strong> to steer, <strong>Arrow Keys</strong> or mouse to
-      look, <strong>Space/Ctrl</strong> to climb or drop, and fire with <strong>Enter</strong>, <strong>F</strong>, or
-      left-click.
+      look, <strong>E/Ctrl</strong> to climb or drop, and fire with <strong>Space</strong>, <strong>Enter</strong>,
+      <strong>F</strong>, or left-click.
     </p>
     <div class="hint" id="secondaryInstructions">
       Press <strong>R</strong> if you ever want to re-center your ship. Click for pointer-lock mouse look, then press
@@ -2225,8 +2225,8 @@
       primaryInstructions.innerHTML =
         [
           'Glide through procedurally scattered stars and luminous worlds. Use <strong>WASD</strong> to steer,',
-          '<strong>Arrow Keys</strong> or mouse to look, <strong>Space/Ctrl</strong> to climb or drop, and <strong>Shift</strong> to boost.',
-          'Fire a laser burst with <strong>Enter</strong>, <strong>F</strong>, or left-click.'
+          '<strong>Arrow Keys</strong> or mouse to look, <strong>E/Ctrl</strong> to climb or drop, <strong>Space</strong> to fire, and <strong>Shift</strong> to boost.',
+          'Fire a laser burst with <strong>Space</strong>, <strong>Enter</strong>, <strong>F</strong>, or left-click.'
         ].join(' ');
       secondaryInstructions.innerHTML =
         [
@@ -2487,6 +2487,7 @@
     'Enter',
     'KeyA',
     'KeyD',
+    'KeyE',
     'KeyF',
     'KeyR',
     'KeyS',
@@ -2670,7 +2671,7 @@
     if (event.code === 'KeyR') {
       recenterShip();
     }
-    if (event.code === 'KeyF' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+    if (event.code === 'Space' || event.code === 'KeyF' || event.code === 'Enter' || event.code === 'NumpadEnter') {
       triggerLaserBurst();
     }
   });
@@ -2817,7 +2818,7 @@
     if (keys.has('KeyD')) {
       velocity.addScaledVector(right, acceleration * delta);
     }
-    if (keys.has('Space')) {
+    if (keys.has('KeyE')) {
       velocity.addScaledVector(vertical, acceleration * delta);
     }
     if (keys.has('ControlLeft') || keys.has('ControlRight')) {

--- a/tests/stellar-flight-keyboard-controls.test.js
+++ b/tests/stellar-flight-keyboard-controls.test.js
@@ -6,8 +6,8 @@ test('stellar drift supports keyboard-only flight controls', async () => {
   const html = await readFile(new URL('../stellar-flight.html', import.meta.url), 'utf8');
 
   assert.match(html, /<strong>Arrow Keys<\/strong> or mouse to\s+look/);
-  assert.match(html, /<strong>Space\/Ctrl<\/strong> to climb or drop/);
-  assert.match(html, /fire with <strong>Enter<\/strong>, <strong>F<\/strong>, or\s+left-click/);
+  assert.match(html, /<strong>E\/Ctrl<\/strong> to climb or drop/);
+  assert.match(html, /fire with <strong>Space<\/strong>, <strong>Enter<\/strong>,\s+<strong>F<\/strong>, or left-click/);
 
   assert.match(html, /const keyboardLookSpeed = 1\.35;/);
   assert.match(html, /const keyboardPitchSpeed = 1\.05;/);
@@ -16,6 +16,7 @@ test('stellar drift supports keyboard-only flight controls', async () => {
   assert.match(html, /'ArrowLeft'/);
   assert.match(html, /'ArrowRight'/);
   assert.match(html, /'Enter'/);
+  assert.match(html, /'KeyE'/);
   assert.match(html, /'NumpadEnter'/);
 
   assert.match(
@@ -29,11 +30,14 @@ test('stellar drift supports keyboard-only flight controls', async () => {
   assert.match(html, /const keyboardLookDelta = Math\.min\(delta, 1 \/ 30\);/);
   assert.match(html, /yaw \+= lookYaw \* keyboardLookSpeed \* keyboardLookDelta;/);
   assert.match(html, /pitch \+= lookPitch \* keyboardPitchSpeed \* keyboardLookDelta;/);
-  assert.match(html, /event\.code === 'KeyF' \|\| event\.code === 'Enter' \|\| event\.code === 'NumpadEnter'/);
+  assert.match(
+    html,
+    /event\.code === 'Space' \|\| event\.code === 'KeyF' \|\| event\.code === 'Enter' \|\| event\.code === 'NumpadEnter'/
+  );
 
   assert.match(
     html,
-    /if \(keys\.has\('Space'\)\) \{\s+velocity\.addScaledVector\(vertical, acceleration \* delta\);\s+\}/
+    /if \(keys\.has\('KeyE'\)\) \{\s+velocity\.addScaledVector\(vertical, acceleration \* delta\);\s+\}/
   );
-  assert.doesNotMatch(html, /event\.code === 'Space'[\s\S]{0,120}triggerLaserBurst/);
+  assert.match(html, /event\.code === 'Space'[\s\S]{0,160}triggerLaserBurst/);
 });


### PR DESCRIPTION
## Summary
- maps Stellar Drift keyboard firing to Space, while keeping Enter, F, and left-click fire controls
- moves keyboard climb from Space to E so Ctrl can continue to descend
- updates in-app flight instructions and keyboard-control tests

## Root Cause
Space was already assigned to vertical climb, and the keyboard test explicitly asserted that Space must not fire.

## Validation
- `node --test tests/stellar-flight-keyboard-controls.test.js tests/stellar-flight-layout.test.js`
- `git diff --check`

## Notes
- No backend, billing, or data-model changes.