### PR TITLE
Add CRM conversation capture flow

### DIFF
--- a/crm/app.js
+++ b/crm/app.js
@@ -7,6 +7,8 @@ import {
   CRM_FIT_OPTIONS,
   CRM_URGENCY_OPTIONS,
   CRM_RECORD_TYPE_OPTIONS,
+  buildConversationCaptureRecord,
+  sanitizeConversationCaptureRecord,
   normalizeCrmRecordType,
   normalizeCrmWarmth,
   parseCrmList,
@@ -41,6 +43,8 @@ const ORG_CONTACTS_NODE_KEY = 'org-3dvr-demo';
 const contactsWorkspaceOrg = gun.get(ORG_CONTACTS_NODE_KEY);
 const touchLogRoot = portalRoot.get('crm-touch-log');
 const crmDraftsRoot = portalRoot.get('crm-outreach-drafts');
+// Mobile discovery captures live under 3dvr-portal/crm/conversationCaptures.
+const conversationCapturesRoot = portalRoot.get('crm').get('conversationCaptures');
 const scoreManager = window.ScoreSystem && typeof window.ScoreSystem.getManager === 'function'
   ? window.ScoreSystem.getManager({ gun, user, portalRoot })
   : null;
@@ -64,6 +68,7 @@ const contactWorkspacePersonalIndex = Object.create(null);
 const crmIndex = Object.create(null);
 const draftIndex = new Map();
 const touchLogIndex = new Map();
+const conversationCaptureIndex = new Map();
 const duplicateSummaryById = new Map();
 const WEEKLY_CHALLENGE_GOAL = 3;
 const SALES_STALE_DAYS = 7;
@@ -168,6 +173,22 @@ const elements = {
   quickConversationChannel: document.getElementById('quickConversationChannel'),
   quickConversationNextStep: document.getElementById('quickConversationNextStep'),
   quickConversationStatus: document.getElementById('quickConversationStatus'),
+  openConversationCapture: document.getElementById('openConversationCapture'),
+  conversationCapturePanel: document.getElementById('conversationCapturePanel'),
+  conversationCaptureForm: document.getElementById('conversationCaptureForm'),
+  conversationCaptureName: document.getElementById('conversationCaptureName'),
+  conversationCaptureContactDetail: document.getElementById('conversationCaptureContactDetail'),
+  conversationProjectDescription: document.getElementById('conversationProjectDescription'),
+  conversationExactWords: document.getElementById('conversationExactWords'),
+  conversationSignupTrigger: document.getElementById('conversationSignupTrigger'),
+  conversationFollowUpCustom: document.getElementById('conversationFollowUpCustom'),
+  conversationCaptureStatus: document.getElementById('conversationCaptureStatus'),
+  conversationCaptureSummary: document.getElementById('conversationCaptureSummary'),
+  resetConversationCapture: document.getElementById('resetConversationCapture'),
+  conversationCapturesList: document.getElementById('conversationCapturesList'),
+  conversationCapturePlanFilter: document.getElementById('conversationCapturePlanFilter'),
+  conversationCaptureActionFilter: document.getElementById('conversationCaptureActionFilter'),
+  conversationCaptureInterestFilter: document.getElementById('conversationCaptureInterestFilter'),
   quickLeadForm: document.getElementById('quickLeadForm'),
   quickLeadName: document.getElementById('quickLeadName'),
   quickLeadEmail: document.getElementById('quickLeadEmail'),
@@ -518,6 +539,143 @@ function deriveQuickConversationName(note = '') {
   return fallback || `Quick note ${new Date().toLocaleString()}`;
 }
 
+function getCheckedValue(name = '') {
+  return String(document.querySelector(`input[name="${escapeSelectorValue(name)}"]:checked`)?.value || '').trim();
+}
+
+function getCheckedValues(name = '') {
+  return Array.from(document.querySelectorAll(`input[name="${escapeSelectorValue(name)}"]:checked`))
+    .map(input => String(input.value || '').trim())
+    .filter(Boolean);
+}
+
+function dateDaysFromNow(days) {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function getConversationFollowUpDate() {
+  const custom = String(elements.conversationFollowUpCustom?.value || '').trim();
+  const quick = getCheckedValue('conversationFollowUpQuick');
+  if (quick === 'custom') {
+    return custom;
+  }
+  if (custom) {
+    return custom;
+  }
+  if (quick === 'tomorrow') return dateDaysFromNow(1);
+  if (quick === '3-days') return dateDaysFromNow(3);
+  if (quick === '1-week') return dateDaysFromNow(7);
+  if (quick === '2-weeks') return dateDaysFromNow(14);
+  if (quick === '1-month') return dateDaysFromNow(30);
+  return '';
+}
+
+function getConversationCaptureInput(personId = '') {
+  return {
+    personId,
+    name: elements.conversationCaptureName?.value,
+    relationship: getCheckedValue('conversationRelationship'),
+    contactMethod: getCheckedValue('conversationContactMethod'),
+    contactDetail: elements.conversationCaptureContactDetail?.value,
+    projectType: getCheckedValue('conversationProjectType'),
+    projectDescription: elements.conversationProjectDescription?.value,
+    painPoints: getCheckedValues('conversationPainPoints'),
+    exactWords: elements.conversationExactWords?.value,
+    interestedPlan: getCheckedValue('conversationInterestedPlan'),
+    signupTrigger: elements.conversationSignupTrigger?.value,
+    interestLevel: getCheckedValue('conversationInterestLevel'),
+    nextAction: getCheckedValue('conversationNextAction'),
+    followUpDate: getConversationFollowUpDate(),
+  };
+}
+
+function getConversationCaptureIdentity() {
+  return {
+    id: getParticipantId(),
+    alias,
+    label: getParticipantLabel(),
+  };
+}
+
+function getCaptureWarmth(capture = {}) {
+  if (capture.interestLevel === 'Ready now') return 'hot';
+  if (capture.interestLevel === 'Interested' || capture.interestLevel === 'Maybe later') return 'warm';
+  if (capture.interestLevel === 'Polite only' || capture.interestLevel === 'Not a fit') return 'cold';
+  return 'warm';
+}
+
+function getCaptureStatus(capture = {}) {
+  if (capture.interestLevel === 'Ready now') return 'Warm - Discovery';
+  if (capture.interestLevel === 'Interested') return 'Warm - Awareness';
+  if (capture.interestLevel === 'Maybe later') return 'Warm - Follow-up';
+  if (capture.interestLevel === 'Not a fit') return 'Lost';
+  return DEFAULT_PERSON_STATUS;
+}
+
+function getCaptureFit(capture = {}) {
+  const projectType = String(capture.projectType || '').toLowerCase();
+  if (projectType.includes('website') || projectType === 'business' || projectType === 'service') return 'website';
+  if (projectType.includes('brand') || projectType.includes('art') || projectType.includes('music')) return 'branding';
+  if (projectType === 'product' || projectType === 'community' || projectType === 'event') return 'app';
+  return '';
+}
+
+function getCaptureContactFields(capture = {}, existing = {}) {
+  const detail = String(capture.contactDetail || '').trim();
+  const method = String(capture.contactMethod || '').toLowerCase();
+  const email = detail.includes('@') || method === 'email' ? detail : String(existing.email || '').trim();
+  const phone = method === 'phone' && !detail.includes('@') ? detail : String(existing.phone || '').trim();
+  return { email, phone };
+}
+
+function buildCaptureTags(capture = {}) {
+  const tags = ['conversation-capture', 'source/mobile-conversation'];
+  if (capture.interestedPlan) {
+    tags.push(`offer/${String(capture.interestedPlan).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`);
+  }
+  if (capture.projectType) {
+    tags.push(`project/${String(capture.projectType).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`);
+  }
+  return tags.join(', ');
+}
+
+function buildCaptureNote(capture = {}) {
+  const lines = [
+    capture.projectType ? `Wants online: ${capture.projectType}` : '',
+    capture.projectDescription ? `What it is: ${capture.projectDescription}` : '',
+    capture.painPoints?.length ? `Pain: ${capture.painPoints.join(', ')}` : '',
+    capture.exactWords ? `Exact words: ${capture.exactWords}` : '',
+    capture.interestedPlan ? `Plan interest: ${capture.interestedPlan}` : '',
+    capture.signupTrigger ? `Signup trigger: ${capture.signupTrigger}` : '',
+    capture.interestLevel ? `Interest: ${capture.interestLevel}` : '',
+    capture.nextAction ? `Next action: ${capture.nextAction}` : '',
+    capture.followUpDate ? `Follow-up: ${capture.followUpDate}` : '',
+  ].filter(Boolean);
+  return lines.join('\n');
+}
+
+function resetConversationCaptureForm({ keepOpen = true } = {}) {
+  elements.conversationCaptureForm?.reset();
+  showConversationCaptureStatus('');
+  if (elements.conversationCaptureSummary) {
+    elements.conversationCaptureSummary.classList.add('hidden');
+    elements.conversationCaptureSummary.innerHTML = '';
+  }
+  if (keepOpen) {
+    elements.conversationCaptureName?.focus();
+  }
+}
+
+function openConversationCapturePanel() {
+  elements.conversationCapturePanel?.classList.remove('hidden');
+  window.requestAnimationFrame(() => {
+    elements.conversationCaptureName?.focus();
+  });
+}
+
 function findQuickConversationRecord(personValue = '', note = '') {
   const people = getQuickConversationPeople();
   const explicit = String(personValue || '').trim().toLowerCase();
@@ -559,6 +717,24 @@ function showQuickConversationStatus(message = '', tone = 'info') {
   };
   elements.quickConversationStatus.className = `rounded-xl border px-3 py-2 text-sm ${palettes[tone] || palettes.info}`;
   elements.quickConversationStatus.textContent = copy;
+}
+
+function showConversationCaptureStatus(message = '', tone = 'info') {
+  if (!elements.conversationCaptureStatus) return;
+  const copy = String(message || '').trim();
+  if (!copy) {
+    elements.conversationCaptureStatus.className = 'hidden rounded-xl border px-3 py-2 text-sm';
+    elements.conversationCaptureStatus.textContent = '';
+    return;
+  }
+  const palettes = {
+    info: 'border-sky-500/30 bg-sky-950/40 text-sky-100',
+    success: 'border-emerald-500/30 bg-emerald-950/40 text-emerald-100',
+    warn: 'border-amber-500/30 bg-amber-950/40 text-amber-100',
+    error: 'border-rose-500/30 bg-rose-950/40 text-rose-100',
+  };
+  elements.conversationCaptureStatus.className = `rounded-xl border px-3 py-2 text-sm ${palettes[tone] || palettes.info}`;
+  elements.conversationCaptureStatus.textContent = copy;
 }
 
 function showImportStatus(message = '', tone = 'info') {
@@ -1704,6 +1880,67 @@ function renderList() {
   renderSalesMoves();
 }
 
+function conversationCaptureMatchesFilters(capture = {}) {
+  const plan = String(elements.conversationCapturePlanFilter?.value || '').trim();
+  const action = String(elements.conversationCaptureActionFilter?.value || '').trim();
+  const interest = String(elements.conversationCaptureInterestFilter?.value || '').trim();
+  return (!plan || capture.interestedPlan === plan)
+    && (!action || capture.nextAction === action)
+    && (!interest || capture.interestLevel === interest);
+}
+
+function renderConversationCaptureCard(capture = {}) {
+  const personButton = capture.personId
+    ? `<button type="button" data-action="open-detail" data-record-id="${safeAttr(capture.personId)}" class="rounded-lg bg-white/10 px-3 py-2 text-xs font-semibold text-white hover:bg-white/15">Open person</button>`
+    : '';
+  return `
+    <article class="rounded-2xl border border-white/10 bg-gray-900/65 p-4" data-conversation-capture-id="${safeAttr(capture.id)}">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div class="min-w-0 space-y-2">
+          <div class="flex flex-wrap items-center gap-2">
+            <h3 class="text-lg font-semibold text-white">${safe(capture.name || 'Unnamed conversation')}</h3>
+            ${capture.interestLevel ? `<span class="rounded-full border border-teal-300/20 bg-teal-950/45 px-2 py-1 text-xs text-teal-100">${safe(capture.interestLevel)}</span>` : ''}
+          </div>
+          ${renderBadgeRow([
+            capture.relationship,
+            capture.projectType,
+            capture.interestedPlan ? `Plan ${capture.interestedPlan}` : '',
+            capture.nextAction ? `Next ${capture.nextAction}` : '',
+            capture.followUpDate ? `Follow-up ${capture.followUpDate}` : '',
+          ])}
+          ${capture.projectDescription ? `<p class="text-sm text-gray-300">${safe(capture.projectDescription)}</p>` : ''}
+          ${capture.painPoints?.length ? `<p class="text-xs text-amber-100/90 rounded-lg border border-amber-400/15 bg-amber-950/35 p-3">Pain: ${safe(capture.painPoints.join(', '))}</p>` : ''}
+          ${capture.exactWords ? `<p class="text-xs text-sky-100/90 rounded-lg border border-sky-400/15 bg-sky-950/35 p-3">"${safe(capture.exactWords)}"</p>` : ''}
+          <p class="text-xs text-gray-500">Saved ${safe(formatUpdated(capture.updatedAt || capture.createdAt))}</p>
+        </div>
+        <div class="shrink-0">${personButton}</div>
+      </div>
+    </article>
+  `;
+}
+
+function renderConversationCaptures() {
+  if (!elements.conversationCapturesList) return;
+  const captures = Array.from(conversationCaptureIndex.values())
+    .map(sanitizeConversationCaptureRecord)
+    .filter(capture => String(capture.id || '').trim())
+    .sort((a, b) => String(b.updatedAt || b.createdAt || '').localeCompare(String(a.updatedAt || a.createdAt || '')));
+  const filtered = captures.filter(conversationCaptureMatchesFilters);
+
+  if (!captures.length) {
+    elements.conversationCapturesList.innerHTML = '<p class="rounded-xl border border-dashed border-white/10 bg-white/5 p-4 text-sm text-gray-400">No structured conversation captures yet.</p>';
+    return;
+  }
+  if (!filtered.length) {
+    elements.conversationCapturesList.innerHTML = '<p class="rounded-xl border border-dashed border-white/10 bg-white/5 p-4 text-sm text-gray-400">No captures match those filters.</p>';
+    return;
+  }
+  elements.conversationCapturesList.innerHTML = filtered
+    .slice(0, 12)
+    .map(renderConversationCaptureCard)
+    .join('');
+}
+
 function renderSalesMoveRows(target, records, formatter) {
   if (!target) return;
   if (!records.length) {
@@ -1814,6 +2051,21 @@ function putCrmRecord(record) {
       crmIndex[record.id] = { ...(crmIndex[record.id] || {}), ...sanitizeCrmRecord(record), id: record.id };
       scheduleRender();
       resolve(record);
+    });
+  });
+}
+
+function putConversationCapture(capture) {
+  return new Promise((resolve, reject) => {
+    const sanitized = sanitizeConversationCaptureRecord(capture);
+    conversationCapturesRoot.get(sanitized.id).put(sanitized, ack => {
+      if (ack && ack.err) {
+        reject(new Error(String(ack.err)));
+        return;
+      }
+      conversationCaptureIndex.set(sanitized.id, sanitized);
+      renderConversationCaptures();
+      resolve(sanitized);
     });
   });
 }
@@ -2788,6 +3040,98 @@ async function handleCreateSubmit(event) {
   }
 }
 
+async function handleConversationCaptureSubmit(event) {
+  event.preventDefault();
+  const name = String(elements.conversationCaptureName?.value || '').trim();
+  if (!name) {
+    showConversationCaptureStatus('Add a name or nickname first. Everything else can stay incomplete.', 'warn');
+    elements.conversationCaptureName?.focus();
+    return;
+  }
+
+  const existing = findQuickConversationRecord(name, [
+    elements.conversationProjectDescription?.value,
+    elements.conversationExactWords?.value,
+    elements.conversationSignupTrigger?.value,
+  ].join(' '));
+  const captureDraft = buildConversationCaptureRecord(
+    getConversationCaptureInput(existing?.id || ''),
+    getConversationCaptureIdentity(),
+    { idFactory: generateId }
+  );
+  const contactFields = getCaptureContactFields(captureDraft, existing || {});
+  const now = captureDraft.createdAt || new Date().toISOString();
+  const captureNote = buildCaptureNote(captureDraft);
+  const nextAction = captureDraft.nextAction || existing?.nextBestAction || '';
+  const savedRecord = pruneRecordForType({
+    ...(existing || {}),
+    id: existing?.id || generateId(),
+    recordType: 'person',
+    name: existing?.name || captureDraft.name,
+    email: contactFields.email,
+    phone: contactFields.phone,
+    tags: mergeCommaSeparatedValues(existing?.tags, buildCaptureTags(captureDraft)),
+    status: existing?.status || getCaptureStatus(captureDraft),
+    warmth: existing?.warmth || getCaptureWarmth(captureDraft),
+    fit: existing?.fit || getCaptureFit(captureDraft),
+    primaryPain: existing?.primaryPain || captureDraft.painPoints?.[0] || captureDraft.exactWords || '',
+    currentWorkaround: existing?.currentWorkaround || captureDraft.exactWords || '',
+    offerAmount: existing?.offerAmount || captureDraft.interestedPlan || '',
+    lastSignal: 'Conversation capture',
+    nextExperiment: existing?.nextExperiment || captureDraft.signupTrigger || '',
+    nextBestAction: nextAction,
+    nextFollowUp: captureDraft.followUpDate || existing?.nextFollowUp || '',
+    notes: appendConversationNote(existing?.notes, {
+      timestamp: now,
+      channelLabel: 'Conversation Capture',
+      note: captureNote || `Captured a founder-discovery conversation with ${captureDraft.name}.`,
+      nextStep: nextAction,
+    }),
+    source: existing?.source || 'Conversation capture',
+    created: existing?.created || now,
+    updated: now,
+    lastContacted: now,
+    activityCount: toActivityCount(existing?.activityCount) + 1,
+    contactId: existing?.contactId || '',
+  });
+  const capture = sanitizeConversationCaptureRecord({
+    ...captureDraft,
+    personId: savedRecord.id,
+    updatedAt: now,
+  });
+
+  try {
+    await putCrmRecord(savedRecord);
+    await putConversationCapture(capture);
+    appendTouchLogEntry(savedRecord, {
+      touchType: 'conversation',
+      note: captureNote || `Captured ${capture.name}.`,
+      followUp: capture.followUpDate,
+      source: 'Conversation capture',
+      statusAfter: savedRecord.status || DEFAULT_PERSON_STATUS,
+      timestamp: now,
+    });
+    state.focusId = savedRecord.id;
+    state.focusApplied = false;
+    showConversationCaptureStatus(`Saved conversation for ${capture.name}.`, 'success');
+    if (elements.conversationCaptureSummary) {
+      elements.conversationCaptureSummary.classList.remove('hidden');
+      elements.conversationCaptureSummary.innerHTML = `
+        <p class="text-xs font-semibold uppercase tracking-[0.28em] text-emerald-200">Saved</p>
+        <h3 class="mt-1 text-lg font-semibold text-white">${safe(capture.name)}</h3>
+        <p class="mt-2 text-sm text-emerald-100/90">${safe(capture.nextAction || 'No next action selected yet.')}</p>
+        ${capture.followUpDate ? `<p class="mt-1 text-xs text-emerald-100/70">Follow up ${safe(capture.followUpDate)}</p>` : ''}
+      `;
+    }
+    elements.conversationCaptureForm?.reset();
+    elements.conversationCaptureName?.focus();
+    if (scoreManager) scoreManager.increment(existing ? 3 : 8);
+  } catch (err) {
+    console.error('Unable to save structured conversation capture', err);
+    showConversationCaptureStatus('Could not save this conversation right now.', 'error');
+  }
+}
+
 async function handleQuickConversationSubmit(event) {
   event.preventDefault();
   const note = String(elements.quickConversationNote?.value || '').trim();
@@ -3086,6 +3430,12 @@ async function handleAction(action, recordId) {
 
 function attachEvents() {
   elements.form?.addEventListener('submit', handleCreateSubmit);
+  elements.openConversationCapture?.addEventListener('click', openConversationCapturePanel);
+  elements.conversationCaptureForm?.addEventListener('submit', handleConversationCaptureSubmit);
+  elements.resetConversationCapture?.addEventListener('click', () => resetConversationCaptureForm());
+  elements.conversationCapturePlanFilter?.addEventListener('change', renderConversationCaptures);
+  elements.conversationCaptureActionFilter?.addEventListener('change', renderConversationCaptures);
+  elements.conversationCaptureInterestFilter?.addEventListener('change', renderConversationCaptures);
   elements.quickConversationForm?.addEventListener('submit', handleQuickConversationSubmit);
   elements.quickLeadForm?.addEventListener('submit', handleQuickLeadSubmit);
   elements.filterInput?.addEventListener('input', applyFilter);
@@ -3152,6 +3502,13 @@ function attachEvents() {
     const card = event.target.closest('.crm-card[data-record-id]');
     if (!card || event.target.closest('button, a, input, select, textarea, form')) return;
     openDetail(card.dataset.recordId || '');
+  });
+
+  elements.conversationCapturesList?.addEventListener('click', async event => {
+    const actionTarget = event.target.closest('[data-action]');
+    if (!actionTarget) return;
+    event.preventDefault();
+    await handleAction(actionTarget.dataset.action || '', actionTarget.dataset.recordId || '');
   });
 
   const handleDetailActionClick = async event => {
@@ -3253,6 +3610,16 @@ function startSync() {
     }
   });
 
+  conversationCapturesRoot.map().on((data, id) => {
+    if (!id) return;
+    if (!data) {
+      conversationCaptureIndex.delete(id);
+    } else {
+      conversationCaptureIndex.set(id, sanitizeConversationCaptureRecord({ ...data, id }));
+    }
+    renderConversationCaptures();
+  });
+
   crmRecords.map().on((data, id) => {
     if (!id) return;
     if (!data) {
@@ -3280,6 +3647,7 @@ function init() {
   startSync();
   renderWeeklyChallenge();
   renderList();
+  renderConversationCaptures();
   applyUrlDraftIfNeeded();
 }
 

--- a/crm/crm-editing.js
+++ b/crm/crm-editing.js
@@ -71,6 +71,79 @@ const DEFAULT_RECORD_TYPE_OPTIONS = Object.freeze([
   Object.freeze({ value: 'problem', label: 'Problem / pain' }),
 ]);
 
+const DEFAULT_CONVERSATION_RELATIONSHIP_OPTIONS = Object.freeze([
+  'Friend',
+  'Coworker',
+  'Client',
+  'Family',
+  'Stranger',
+  'Business Owner',
+  'Other',
+]);
+
+const DEFAULT_CONVERSATION_CONTACT_METHOD_OPTIONS = Object.freeze([
+  'Phone',
+  'Email',
+  'Instagram',
+  'Facebook',
+  'In person only',
+]);
+
+const DEFAULT_CONVERSATION_PROJECT_TYPE_OPTIONS = Object.freeze([
+  'Business',
+  'Personal brand',
+  'Product',
+  'Event',
+  'Service',
+  'Art/music',
+  'Community',
+  'Existing website',
+  'Just curious',
+  'Nothing yet',
+]);
+
+const DEFAULT_CONVERSATION_PAIN_POINT_OPTIONS = Object.freeze([
+  'No website',
+  'Website outdated',
+  'Too expensive',
+  'Too confusing',
+  'No time',
+  'Needs design',
+  'Needs hosting',
+  'Needs marketing',
+  'Needs online payments',
+  'Needs booking/forms',
+  'Not sure yet',
+]);
+
+const DEFAULT_CONVERSATION_PLAN_OPTIONS = Object.freeze([
+  'Free',
+  '$5/mo',
+  '$20/mo',
+  '$50/mo',
+  'Custom',
+  'Not interested yet',
+]);
+
+const DEFAULT_CONVERSATION_INTEREST_LEVEL_OPTIONS = Object.freeze([
+  'Ready now',
+  'Interested',
+  'Maybe later',
+  'Polite only',
+  'Not a fit',
+]);
+
+const DEFAULT_CONVERSATION_NEXT_ACTION_OPTIONS = Object.freeze([
+  'Send link',
+  'Send pricing',
+  'Send example site',
+  'Make free homepage',
+  'Schedule call',
+  'Ask again later',
+  'Introduce to team',
+  'No action',
+]);
+
 export const CRM_STATUS_OPTIONS = DEFAULT_STATUS_OPTIONS;
 export const CRM_MARKET_SEGMENT_OPTIONS = DEFAULT_MARKET_SEGMENT_OPTIONS;
 export const CRM_PAIN_SEVERITY_OPTIONS = DEFAULT_PAIN_SEVERITY_OPTIONS;
@@ -79,6 +152,13 @@ export const CRM_WARMTH_OPTIONS = DEFAULT_WARMTH_OPTIONS;
 export const CRM_FIT_OPTIONS = DEFAULT_FIT_OPTIONS;
 export const CRM_URGENCY_OPTIONS = DEFAULT_URGENCY_OPTIONS;
 export const CRM_RECORD_TYPE_OPTIONS = DEFAULT_RECORD_TYPE_OPTIONS;
+export const CRM_CONVERSATION_RELATIONSHIP_OPTIONS = DEFAULT_CONVERSATION_RELATIONSHIP_OPTIONS;
+export const CRM_CONVERSATION_CONTACT_METHOD_OPTIONS = DEFAULT_CONVERSATION_CONTACT_METHOD_OPTIONS;
+export const CRM_CONVERSATION_PROJECT_TYPE_OPTIONS = DEFAULT_CONVERSATION_PROJECT_TYPE_OPTIONS;
+export const CRM_CONVERSATION_PAIN_POINT_OPTIONS = DEFAULT_CONVERSATION_PAIN_POINT_OPTIONS;
+export const CRM_CONVERSATION_PLAN_OPTIONS = DEFAULT_CONVERSATION_PLAN_OPTIONS;
+export const CRM_CONVERSATION_INTEREST_LEVEL_OPTIONS = DEFAULT_CONVERSATION_INTEREST_LEVEL_OPTIONS;
+export const CRM_CONVERSATION_NEXT_ACTION_OPTIONS = DEFAULT_CONVERSATION_NEXT_ACTION_OPTIONS;
 
 export function createCrmEditingManager(initialIds = []) {
   const editing = new Set();
@@ -192,6 +272,116 @@ export function parseCrmList(value) {
 
 export function serializeCrmList(value) {
   return parseCrmList(value).join(', ');
+}
+
+function normalizeConversationOption(value = '', options = []) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  const match = (Array.isArray(options) ? options : []).find(option => (
+    String(option || '').trim().toLowerCase() === raw.toLowerCase()
+  ));
+  return match || raw;
+}
+
+export function normalizeConversationCaptureList(value = [], options = []) {
+  const parts = Array.isArray(value)
+    ? value
+    : value && typeof value === 'object'
+    ? Object.keys(value)
+      .filter(key => key !== '_')
+      .sort((a, b) => Number(a) - Number(b))
+      .map(key => value[key])
+    : String(value || '').split(/[\n,]/);
+  const output = [];
+  const seen = new Set();
+
+  parts.forEach(entry => {
+    const normalized = normalizeConversationOption(entry, options);
+    const key = normalized.toLowerCase();
+    if (!normalized || seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    output.push(normalized);
+  });
+
+  return output;
+}
+
+function normalizeIsoDate(value = '') {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return raw;
+  return parsed.toISOString();
+}
+
+function createConversationCaptureId(now, idFactory) {
+  if (typeof idFactory === 'function') {
+    return String(idFactory() || '').trim();
+  }
+  const timestamp = now instanceof Date && !Number.isNaN(now.getTime())
+    ? now.getTime()
+    : Date.now();
+  return `conversation-${timestamp}`;
+}
+
+export function sanitizeConversationCaptureRecord(data = {}) {
+  const clean = {};
+  Object.entries(data || {}).forEach(([key, value]) => {
+    if (key === '_' || typeof value === 'function') return;
+    clean[key] = value;
+  });
+
+  clean.id = String(clean.id || '').trim();
+  clean.personId = String(clean.personId || '').trim();
+  clean.name = String(clean.name || '').trim();
+  clean.relationship = normalizeConversationOption(clean.relationship, CRM_CONVERSATION_RELATIONSHIP_OPTIONS);
+  clean.contactMethod = normalizeConversationOption(clean.contactMethod, CRM_CONVERSATION_CONTACT_METHOD_OPTIONS);
+  clean.contactDetail = String(clean.contactDetail || '').trim();
+  clean.projectType = normalizeConversationOption(clean.projectType, CRM_CONVERSATION_PROJECT_TYPE_OPTIONS);
+  clean.projectDescription = String(clean.projectDescription || '').trim();
+  clean.painPoints = normalizeConversationCaptureList(clean.painPoints, CRM_CONVERSATION_PAIN_POINT_OPTIONS);
+  clean.exactWords = String(clean.exactWords || '').trim();
+  clean.interestedPlan = normalizeConversationOption(clean.interestedPlan, CRM_CONVERSATION_PLAN_OPTIONS);
+  clean.signupTrigger = String(clean.signupTrigger || '').trim();
+  clean.interestLevel = normalizeConversationOption(clean.interestLevel, CRM_CONVERSATION_INTEREST_LEVEL_OPTIONS);
+  clean.nextAction = normalizeConversationOption(clean.nextAction, CRM_CONVERSATION_NEXT_ACTION_OPTIONS);
+  clean.followUpDate = String(clean.followUpDate || '').trim();
+  clean.createdAt = normalizeIsoDate(clean.createdAt);
+  clean.updatedAt = normalizeIsoDate(clean.updatedAt);
+  clean.source = String(clean.source || 'mobile-conversation').trim();
+
+  return clean;
+}
+
+export function buildConversationCaptureRecord(input = {}, identity = {}, options = {}) {
+  const now = options.now instanceof Date ? options.now : new Date(options.now || Date.now());
+  const timestamp = Number.isNaN(now.getTime()) ? new Date().toISOString() : now.toISOString();
+  const id = String(input.id || createConversationCaptureId(now, options.idFactory)).trim();
+
+  return sanitizeConversationCaptureRecord({
+    id,
+    personId: input.personId,
+    name: input.name,
+    relationship: input.relationship,
+    contactMethod: input.contactMethod,
+    contactDetail: input.contactDetail,
+    projectType: input.projectType,
+    projectDescription: input.projectDescription,
+    painPoints: input.painPoints,
+    exactWords: input.exactWords,
+    interestedPlan: input.interestedPlan,
+    signupTrigger: input.signupTrigger,
+    interestLevel: input.interestLevel,
+    nextAction: input.nextAction,
+    followUpDate: input.followUpDate,
+    createdAt: input.createdAt || timestamp,
+    updatedAt: timestamp,
+    source: 'mobile-conversation',
+    capturedBy: String(identity.id || identity.alias || '').trim(),
+    capturedByLabel: String(identity.label || identity.alias || '').trim(),
+  });
 }
 
 export function sanitizeCrmRecord(data) {
@@ -341,8 +531,18 @@ if (typeof window !== 'undefined') {
     CRM_PAIN_SEVERITY_OPTIONS,
     CRM_PILOT_STATUS_OPTIONS,
     CRM_RECORD_TYPE_OPTIONS,
+    CRM_CONVERSATION_RELATIONSHIP_OPTIONS,
+    CRM_CONVERSATION_CONTACT_METHOD_OPTIONS,
+    CRM_CONVERSATION_PROJECT_TYPE_OPTIONS,
+    CRM_CONVERSATION_PAIN_POINT_OPTIONS,
+    CRM_CONVERSATION_PLAN_OPTIONS,
+    CRM_CONVERSATION_INTEREST_LEVEL_OPTIONS,
+    CRM_CONVERSATION_NEXT_ACTION_OPTIONS,
     createCrmEditingManager,
     normalizeCrmRecordType,
+    normalizeConversationCaptureList,
+    sanitizeConversationCaptureRecord,
+    buildConversationCaptureRecord,
     parseCrmList,
     serializeCrmList,
     sanitizeCrmRecord,

--- a/crm/index.html
+++ b/crm/index.html
@@ -37,6 +37,9 @@
     #contactList,
     #crmDuplicateSummary,
     #crmDetailCard,
+    #conversationCapturePanel,
+    #conversationCaptureSummary,
+    #conversationCapturesList,
     #crmCreateOverlay > div,
     .crm-card {
       max-width: 100%;
@@ -152,44 +155,281 @@
       <div class="grid gap-5 lg:grid-cols-[0.75fr,1.25fr] lg:items-start">
         <div class="space-y-2">
           <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Quick capture</p>
-          <h2 class="text-2xl font-semibold">Drop the note. Keep moving.</h2>
+          <h2 class="text-2xl font-semibold">Ask, tap, save.</h2>
           <p class="text-sm text-gray-300">
-            Use this after a work chat, text, call, or random idea. Add the person if you remember. Add one next step if there is one.
+            Pull this up during a real conversation. Tap the useful signal, dictate tiny notes, and save the next step.
           </p>
+          <button
+            id="openConversationCapture"
+            type="button"
+            class="mt-3 inline-flex w-full items-center justify-center rounded-2xl bg-teal-400 px-5 py-4 text-base font-bold text-gray-950 shadow-lg shadow-teal-950/30 hover:bg-teal-300 sm:w-auto"
+          >
+            + Capture Conversation
+          </button>
         </div>
-        <form id="quickConversationForm" class="grid gap-3">
-          <label for="quickConversationNote" class="sr-only">Conversation note</label>
-          <textarea
-            id="quickConversationNote"
-            rows="4"
-            class="w-full rounded-2xl border border-white/10 bg-white text-gray-950 p-4 text-base leading-relaxed"
-            placeholder="Example: Talked to Victor. He still wants the Alibaba store. Ask him to send one product link tomorrow."
-          ></textarea>
-          <div class="grid gap-3 md:grid-cols-[1fr,0.7fr]">
-            <div>
-              <label for="quickConversationPerson" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Who</label>
-              <input id="quickConversationPerson" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional name" autocomplete="name" />
-            </div>
-            <div>
-              <label for="quickConversationChannel" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Kind</label>
-              <select id="quickConversationChannel" class="w-full p-3 rounded-xl text-black">
-                <option value="conversation">Conversation</option>
-                <option value="message">Text / DM</option>
-                <option value="call">Call</option>
-                <option value="email">Email</option>
-                <option value="group-chat">Group chat</option>
-              </select>
-            </div>
+        <div class="space-y-5">
+          <div
+            id="conversationCapturePanel"
+            class="hidden rounded-3xl border border-teal-300/20 bg-gray-950/45 p-4 sm:p-5"
+          >
+            <form id="conversationCaptureForm" class="grid gap-5">
+              <section class="space-y-3">
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-200">1 · Person</p>
+                  <label for="conversationCaptureName" class="mt-2 block text-lg font-semibold">Name or nickname</label>
+                  <input
+                    id="conversationCaptureName"
+                    type="text"
+                    class="mt-2 w-full rounded-2xl border border-white/10 bg-white p-4 text-lg text-gray-950"
+                    placeholder="Max, Sean, the coffee shop owner..."
+                    autocomplete="name"
+                  />
+                </div>
+                <fieldset class="space-y-2">
+                  <legend class="text-sm font-semibold text-gray-300">Relationship</legend>
+                  <div class="flex flex-wrap gap-2">
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationRelationship" value="Friend">Friend</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationRelationship" value="Coworker">Coworker</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationRelationship" value="Client">Client</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationRelationship" value="Family">Family</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationRelationship" value="Stranger">Stranger</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationRelationship" value="Business Owner">Business owner</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationRelationship" value="Other">Other</label>
+                  </div>
+                </fieldset>
+                <fieldset class="space-y-2">
+                  <legend class="text-sm font-semibold text-gray-300">Contact method</legend>
+                  <div class="flex flex-wrap gap-2">
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationContactMethod" value="Phone">Phone</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationContactMethod" value="Email">Email</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationContactMethod" value="Instagram">Instagram</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationContactMethod" value="Facebook">Facebook</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationContactMethod" value="In person only">In person only</label>
+                  </div>
+                  <label for="conversationCaptureContactDetail" class="sr-only">Contact detail</label>
+                  <input
+                    id="conversationCaptureContactDetail"
+                    type="text"
+                    class="w-full rounded-xl border border-white/10 bg-white p-3 text-gray-950"
+                    placeholder="Optional phone, email, handle, or where you met"
+                  />
+                </fieldset>
+              </section>
+
+              <section class="space-y-3">
+                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-200">2 · Project / need</p>
+                <fieldset class="space-y-2">
+                  <legend class="text-lg font-semibold">Do they have something they want online?</legend>
+                  <div class="flex flex-wrap gap-2">
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Business">Business</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Personal brand">Personal brand</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Product">Product</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Event">Event</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Service">Service</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Art/music">Art/music</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Community">Community</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Existing website">Existing website</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Just curious">Just curious</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationProjectType" value="Nothing yet">Nothing yet</label>
+                  </div>
+                </fieldset>
+                <label for="conversationProjectDescription" class="block text-sm font-semibold text-gray-300">What is it?</label>
+                <textarea
+                  id="conversationProjectDescription"
+                  rows="2"
+                  class="w-full rounded-2xl border border-white/10 bg-white p-4 text-base text-gray-950"
+                  placeholder="Voice note friendly: aspiring audio engineer, local AV work, needs Dante/networking..."
+                ></textarea>
+              </section>
+
+              <section class="space-y-3">
+                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-200">3 · Pain</p>
+                <fieldset class="space-y-2">
+                  <legend class="text-lg font-semibold">What is stopping them?</legend>
+                  <div class="flex flex-wrap gap-2">
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="No website">No website</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Website outdated">Website outdated</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Too expensive">Too expensive</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Too confusing">Too confusing</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="No time">No time</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Needs design">Needs design</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Needs hosting">Needs hosting</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Needs marketing">Needs marketing</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Needs online payments">Needs online payments</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Needs booking/forms">Needs booking/forms</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="checkbox" name="conversationPainPoints" value="Not sure yet">Not sure yet</label>
+                  </div>
+                </fieldset>
+                <label for="conversationExactWords" class="block text-sm font-semibold text-gray-300">Exact words they used</label>
+                <textarea
+                  id="conversationExactWords"
+                  rows="2"
+                  class="w-full rounded-2xl border border-white/10 bg-white p-4 text-base text-gray-950"
+                  placeholder="Quote their words if you can. This becomes better follow-up copy later."
+                ></textarea>
+              </section>
+
+              <section class="space-y-3">
+                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-200">4 · Plan interest</p>
+                <fieldset class="space-y-2">
+                  <legend class="text-lg font-semibold">Which plan felt interesting?</legend>
+                  <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    <label class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center text-sm font-semibold"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestedPlan" value="Free">Free</label>
+                    <label class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center text-sm font-semibold"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestedPlan" value="$5/mo">$5/mo</label>
+                    <label class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center text-sm font-semibold"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestedPlan" value="$20/mo">$20/mo</label>
+                    <label class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center text-sm font-semibold"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestedPlan" value="$50/mo">$50/mo</label>
+                    <label class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center text-sm font-semibold"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestedPlan" value="Custom">Custom</label>
+                    <label class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center text-sm font-semibold"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestedPlan" value="Not interested yet">Not yet</label>
+                  </div>
+                </fieldset>
+                <label for="conversationSignupTrigger" class="block text-sm font-semibold text-gray-300">What would make them happy to sign up?</label>
+                <textarea id="conversationSignupTrigger" rows="2" class="w-full rounded-2xl border border-white/10 bg-white p-4 text-base text-gray-950"></textarea>
+              </section>
+
+              <section class="space-y-3">
+                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-200">5 · Mood</p>
+                <fieldset class="space-y-2">
+                  <legend class="text-lg font-semibold">How interested were they?</legend>
+                  <div class="flex flex-wrap gap-2">
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestLevel" value="Ready now">Ready now</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestLevel" value="Interested">Interested</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestLevel" value="Maybe later">Maybe later</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestLevel" value="Polite only">Polite only</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationInterestLevel" value="Not a fit">Not a fit</label>
+                  </div>
+                </fieldset>
+              </section>
+
+              <section class="space-y-3">
+                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-200">6 · Next step</p>
+                <fieldset class="space-y-2">
+                  <legend class="text-lg font-semibold">What should I do next?</legend>
+                  <div class="flex flex-wrap gap-2">
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationNextAction" value="Send link">Send link</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationNextAction" value="Send pricing">Send pricing</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationNextAction" value="Send example site">Send example site</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationNextAction" value="Make free homepage">Make free homepage</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationNextAction" value="Schedule call">Schedule call</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationNextAction" value="Ask again later">Ask again later</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationNextAction" value="Introduce to team">Introduce to team</label>
+                    <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationNextAction" value="No action">No action</label>
+                  </div>
+                </fieldset>
+                <div class="grid gap-3 sm:grid-cols-[1fr,180px]">
+                  <fieldset class="space-y-2">
+                    <legend class="text-sm font-semibold text-gray-300">Follow-up date</legend>
+                    <div class="flex flex-wrap gap-2">
+                      <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationFollowUpQuick" value="tomorrow">Tomorrow</label>
+                      <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationFollowUpQuick" value="3-days">3 days</label>
+                      <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationFollowUpQuick" value="1-week">1 week</label>
+                      <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationFollowUpQuick" value="2-weeks">2 weeks</label>
+                      <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationFollowUpQuick" value="1-month">1 month</label>
+                      <label class="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm"><input class="mr-2 accent-teal-400" type="radio" name="conversationFollowUpQuick" value="custom">Custom</label>
+                    </div>
+                  </fieldset>
+                  <div>
+                    <label for="conversationFollowUpCustom" class="block text-sm font-semibold text-gray-300">Custom</label>
+                    <input id="conversationFollowUpCustom" type="date" class="mt-2 w-full rounded-xl border border-white/10 bg-white p-3 text-gray-950" />
+                  </div>
+                </div>
+              </section>
+
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <button type="submit" class="rounded-2xl bg-teal-400 px-5 py-4 font-bold text-gray-950 hover:bg-teal-300">Save Conversation</button>
+                <button id="resetConversationCapture" type="button" class="rounded-2xl border border-white/10 bg-white/10 px-5 py-4 font-semibold text-white hover:bg-white/15">Clear</button>
+              </div>
+              <p id="conversationCaptureStatus" class="hidden rounded-xl border px-3 py-2 text-sm" role="status" aria-live="polite"></p>
+            </form>
           </div>
-          <div class="grid gap-3 md:grid-cols-[1fr,auto] md:items-end">
-            <div>
-              <label for="quickConversationNextStep" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Next step</label>
-              <input id="quickConversationNextStep" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional: ask for product link, send examples, follow up Friday..." />
+
+          <div id="conversationCaptureSummary" class="hidden rounded-2xl border border-emerald-400/25 bg-emerald-950/35 p-4"></div>
+
+          <details class="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <summary class="cursor-pointer text-sm font-semibold text-gray-200">Fast fallback note</summary>
+            <form id="quickConversationForm" class="mt-4 grid gap-3">
+              <label for="quickConversationNote" class="sr-only">Conversation note</label>
+              <textarea
+                id="quickConversationNote"
+                rows="4"
+                class="w-full rounded-2xl border border-white/10 bg-white text-gray-950 p-4 text-base leading-relaxed"
+                placeholder="Example: Talked to Victor. He still wants the Alibaba store. Ask him to send one product link tomorrow."
+              ></textarea>
+              <div class="grid gap-3 md:grid-cols-[1fr,0.7fr]">
+                <div>
+                  <label for="quickConversationPerson" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Who</label>
+                  <input id="quickConversationPerson" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional name" autocomplete="name" />
+                </div>
+                <div>
+                  <label for="quickConversationChannel" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Kind</label>
+                  <select id="quickConversationChannel" class="w-full p-3 rounded-xl text-black">
+                    <option value="conversation">Conversation</option>
+                    <option value="message">Text / DM</option>
+                    <option value="call">Call</option>
+                    <option value="email">Email</option>
+                    <option value="group-chat">Group chat</option>
+                  </select>
+                </div>
+              </div>
+              <div class="grid gap-3 md:grid-cols-[1fr,auto] md:items-end">
+                <div>
+                  <label for="quickConversationNextStep" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Next step</label>
+                  <input id="quickConversationNextStep" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional: ask for product link, send examples, follow up Friday..." />
+                </div>
+                <button type="submit" class="rounded-xl bg-teal-500 px-5 py-3 font-semibold text-gray-950 hover:bg-teal-400">Save note</button>
+              </div>
+              <p id="quickConversationStatus" class="hidden rounded-xl border px-3 py-2 text-sm" role="status" aria-live="polite"></p>
+            </form>
+          </details>
+
+          <section class="rounded-2xl border border-white/10 bg-gray-950/35 p-4">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-sky-300">Recent Conversations</p>
+                <p class="text-sm text-gray-300">Filter the capture research without digging through dense CRM rows.</p>
+              </div>
+              <div class="grid gap-2 sm:grid-cols-3">
+                <label class="text-xs text-gray-400">
+                  Plan
+                  <select id="conversationCapturePlanFilter" class="mt-1 w-full rounded-lg bg-white p-2 text-gray-950">
+                    <option value="">All plans</option>
+                    <option value="Free">Free</option>
+                    <option value="$5/mo">$5/mo</option>
+                    <option value="$20/mo">$20/mo</option>
+                    <option value="$50/mo">$50/mo</option>
+                    <option value="Custom">Custom</option>
+                    <option value="Not interested yet">Not interested yet</option>
+                  </select>
+                </label>
+                <label class="text-xs text-gray-400">
+                  Next
+                  <select id="conversationCaptureActionFilter" class="mt-1 w-full rounded-lg bg-white p-2 text-gray-950">
+                    <option value="">All actions</option>
+                    <option value="Send link">Send link</option>
+                    <option value="Send pricing">Send pricing</option>
+                    <option value="Send example site">Send example site</option>
+                    <option value="Make free homepage">Make free homepage</option>
+                    <option value="Schedule call">Schedule call</option>
+                    <option value="Ask again later">Ask again later</option>
+                    <option value="Introduce to team">Introduce to team</option>
+                    <option value="No action">No action</option>
+                  </select>
+                </label>
+                <label class="text-xs text-gray-400">
+                  Interest
+                  <select id="conversationCaptureInterestFilter" class="mt-1 w-full rounded-lg bg-white p-2 text-gray-950">
+                    <option value="">All interest</option>
+                    <option value="Ready now">Ready now</option>
+                    <option value="Interested">Interested</option>
+                    <option value="Maybe later">Maybe later</option>
+                    <option value="Polite only">Polite only</option>
+                    <option value="Not a fit">Not a fit</option>
+                  </select>
+                </label>
+              </div>
             </div>
-            <button type="submit" class="rounded-xl bg-teal-500 px-5 py-3 font-semibold text-gray-950 hover:bg-teal-400">Save note</button>
-          </div>
-          <p id="quickConversationStatus" class="hidden rounded-xl border px-3 py-2 text-sm" role="status" aria-live="polite"></p>
-        </form>
+            <div id="conversationCapturesList" class="mt-4 space-y-3"></div>
+          </section>
+        </div>
       </div>
     </section>
 

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -12,12 +12,31 @@ async function read(relativePath) {
 test('CRM page exposes workflow filters and import controls for fast lead retrieval', async () => {
   const html = await read('crm/index.html');
   assert.match(html, /id="quickConversationCapture"/);
+  assert.match(html, /id="openConversationCapture"/);
+  assert.match(html, /\+ Capture Conversation/);
+  assert.match(html, /id="conversationCapturePanel"/);
+  assert.match(html, /id="conversationCaptureForm"/);
+  assert.match(html, /id="conversationCaptureName"/);
+  assert.match(html, /name="conversationRelationship"/);
+  assert.match(html, /name="conversationProjectType"/);
+  assert.match(html, /name="conversationPainPoints"/);
+  assert.match(html, /name="conversationInterestedPlan"/);
+  assert.match(html, /name="conversationInterestLevel"/);
+  assert.match(html, /name="conversationNextAction"/);
+  assert.match(html, /id="conversationFollowUpCustom"/);
+  assert.match(html, /id="conversationCaptureSummary"/);
+  assert.match(html, /id="conversationCapturesList"/);
+  assert.match(html, /id="conversationCapturePlanFilter"/);
+  assert.match(html, /id="conversationCaptureActionFilter"/);
+  assert.match(html, /id="conversationCaptureInterestFilter"/);
+  assert.match(html, /Ask, tap, save\./);
+  assert.match(html, /Save Conversation/);
   assert.match(html, /id="quickConversationForm"/);
   assert.match(html, /id="quickConversationNote"/);
   assert.match(html, /id="quickConversationPerson"/);
   assert.match(html, /id="quickConversationChannel"/);
   assert.match(html, /id="quickConversationNextStep"/);
-  assert.match(html, /Drop the note\. Keep moving\./);
+  assert.match(html, /Ask, tap, save\./);
   assert.match(html, /overflow-x: hidden/);
   assert.match(html, /overflow-wrap: anywhere/);
   assert.match(html, /#crmFloatingIdentity/);
@@ -73,6 +92,15 @@ test('CRM page exposes workflow filters and import controls for fast lead retrie
 
 test('CRM app includes keyboard search shortcut, workflow filters, and import wiring', async () => {
   const js = await read('crm/app.js');
+  assert.match(js, /portalRoot\.get\('crm'\)\.get\('conversationCaptures'\)/);
+  assert.match(js, /function handleConversationCaptureSubmit\(event\)/);
+  assert.match(js, /buildConversationCaptureRecord/);
+  assert.match(js, /source\/mobile-conversation/);
+  assert.match(js, /putConversationCapture\(capture\)/);
+  assert.match(js, /conversationCapturesRoot\.map\(\)\.on/);
+  assert.match(js, /conversationCaptureForm\?\.addEventListener\('submit', handleConversationCaptureSubmit\)/);
+  assert.match(js, /openConversationCapture\?\.addEventListener\('click', openConversationCapturePanel\)/);
+  assert.match(js, /conversationCapturePlanFilter\?\.addEventListener\('change', renderConversationCaptures\)/);
   assert.match(js, /handleQuickConversationSubmit/);
   assert.match(js, /findQuickConversationRecord/);
   assert.match(js, /appendConversationNote/);

--- a/tests/crm-editing.test.js
+++ b/tests/crm-editing.test.js
@@ -10,9 +10,13 @@ import {
   CRM_FIT_OPTIONS,
   CRM_URGENCY_OPTIONS,
   CRM_RECORD_TYPE_OPTIONS,
+  CRM_CONVERSATION_PLAN_OPTIONS,
+  buildConversationCaptureRecord,
   normalizeCrmRecordType,
   normalizeCrmWarmth,
+  normalizeConversationCaptureList,
   parseCrmList,
+  sanitizeConversationCaptureRecord,
   sanitizeCrmRecord,
   buildCrmRelationshipBoard,
 } from '../crm/crm-editing.js';
@@ -99,6 +103,96 @@ describe('crm option sets', () => {
       { value: 'group', label: 'Group / account' },
       { value: 'problem', label: 'Problem / pain' },
     ]);
+  });
+});
+
+describe('crm conversation capture helpers', () => {
+  it('normalizes structured mobile discovery captures', () => {
+    assert.deepEqual(Array.from(CRM_CONVERSATION_PLAN_OPTIONS), [
+      'Free',
+      '$5/mo',
+      '$20/mo',
+      '$50/mo',
+      'Custom',
+      'Not interested yet',
+    ]);
+    assert.deepEqual(normalizeConversationCaptureList({
+      1: 'Needs design',
+      0: 'No website',
+      _: 'gun metadata',
+    }), ['No website', 'Needs design']);
+
+    const record = buildConversationCaptureRecord({
+      personId: 'person-1',
+      name: 'Max',
+      relationship: 'coworker',
+      contactMethod: 'in person only',
+      projectType: 'art/music',
+      projectDescription: 'Aspiring audio engineer learning Dante and networking.',
+      painPoints: ['No website', 'No website', 'Needs design'],
+      exactWords: 'I want to learn more general computer knowledge.',
+      interestedPlan: '$20/mo',
+      signupTrigger: 'A clear AV learning path.',
+      interestLevel: 'Interested',
+      nextAction: 'Send example site',
+      followUpDate: '2026-06-08',
+    }, { id: 'guest-1', label: 'Thomas' }, {
+      idFactory: () => 'capture-1',
+      now: new Date('2026-06-04T20:00:00.000Z'),
+    });
+
+    assert.deepEqual(record, {
+      id: 'capture-1',
+      personId: 'person-1',
+      name: 'Max',
+      relationship: 'Coworker',
+      contactMethod: 'In person only',
+      contactDetail: '',
+      projectType: 'Art/music',
+      projectDescription: 'Aspiring audio engineer learning Dante and networking.',
+      painPoints: ['No website', 'Needs design'],
+      exactWords: 'I want to learn more general computer knowledge.',
+      interestedPlan: '$20/mo',
+      signupTrigger: 'A clear AV learning path.',
+      interestLevel: 'Interested',
+      nextAction: 'Send example site',
+      followUpDate: '2026-06-08',
+      createdAt: '2026-06-04T20:00:00.000Z',
+      updatedAt: '2026-06-04T20:00:00.000Z',
+      source: 'mobile-conversation',
+      capturedBy: 'guest-1',
+      capturedByLabel: 'Thomas',
+    });
+  });
+
+  it('sanitizes captures without losing optional incomplete fields', () => {
+    assert.deepEqual(sanitizeConversationCaptureRecord({
+      id: 'capture-2',
+      name: 'Sean',
+      painPoints: 'No website, Needs booking/forms',
+      interestedPlan: 'custom',
+      nextAction: 'send pricing',
+      source: '',
+    }), {
+      id: 'capture-2',
+      personId: '',
+      name: 'Sean',
+      relationship: '',
+      contactMethod: '',
+      contactDetail: '',
+      projectType: '',
+      projectDescription: '',
+      painPoints: ['No website', 'Needs booking/forms'],
+      exactWords: '',
+      interestedPlan: 'Custom',
+      signupTrigger: '',
+      interestLevel: '',
+      nextAction: 'Send pricing',
+      followUpDate: '',
+      createdAt: '',
+      updatedAt: '',
+      source: 'mobile-conversation',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- adds a mobile-first `+ Capture Conversation` flow to the CRM for founder-discovery conversations
- stores structured captures under `gun.get('3dvr-portal').get('crm').get('conversationCaptures')`
- links each capture to an existing same-name CRM person or creates a lightweight CRM person record for follow-up
- adds recent conversation filters for plan interest, next action, and interest level

## User Impact
This makes in-person 3DVR sales and discovery conversations tappable instead of requiring dense CRM typing. Captures keep the person, project need, pain, exact words, plan interest, mood, and next step in one place.

## Validation
- `node --test tests/crm-editing.test.js tests/crm-contacts-workflow.test.js`
- `node --check crm/app.js`
- `node --check crm/crm-editing.js`
- `git diff --check`
- local Chromium sanity check at `/crm/`: opened `+ Capture Conversation`, filled name, verified panel visibility and no page exceptions

## Full Suite Note
After running `npm install`, `npm test` still fails on pre-existing broad repo checks unrelated to this CRM change:
- `tests/auth-entrypoints.test.js` expects an older homepage sign-in redirect snippet
- `tests/vercel-insights-tag.test.js` reports missing Insights tags across existing app pages

## Billing / Stripe
No billing, Stripe, or subscription flow changes.