### PR TITLE
Tune Stellar Drift arrow aim speed

### DIFF
--- a/stellar-flight.html
+++ b/stellar-flight.html
@@ -2475,8 +2475,8 @@
   let pitch = 0;
   let pointerLocked = false;
   const pitchLimit = Math.PI / 2 - 0.08;
-  const keyboardLookSpeed = 1.35;
-  const keyboardPitchSpeed = 1.05;
+  const keyboardLookSpeed = 0.9;
+  const keyboardPitchSpeed = 0.72;
   const keyboardFlightCodes = new Set([
     'ArrowUp',
     'ArrowDown',

--- a/tests/stellar-flight-keyboard-controls.test.js
+++ b/tests/stellar-flight-keyboard-controls.test.js
@@ -9,8 +9,8 @@ test('stellar drift supports keyboard-only flight controls', async () => {
   assert.match(html, /<strong>E\/Ctrl<\/strong> to climb or drop/);
   assert.match(html, /fire with <strong>Space<\/strong>, <strong>Enter<\/strong>,\s+<strong>F<\/strong>, or left-click/);
 
-  assert.match(html, /const keyboardLookSpeed = 1\.35;/);
-  assert.match(html, /const keyboardPitchSpeed = 1\.05;/);
+  assert.match(html, /const keyboardLookSpeed = 0\.9;/);
+  assert.match(html, /const keyboardPitchSpeed = 0\.72;/);
   assert.match(html, /'ArrowUp'/);
   assert.match(html, /'ArrowDown'/);
   assert.match(html, /'ArrowLeft'/);


### PR DESCRIPTION
## Summary
- lowers Stellar Drift arrow-key yaw speed from `1.35` to `0.9`
- lowers arrow-key pitch speed from `1.05` to `0.72`
- updates the keyboard controls test so the gentler aim rate stays intentional

## User Impact
Arrow-key aiming should feel less twitchy and easier to line up after Space was mapped to fire.

## Validation
- `node --test tests/stellar-flight-keyboard-controls.test.js tests/stellar-flight-layout.test.js`
- `git diff --check`

## Billing / Stripe
No billing, Stripe, backend, or data changes.