### PR TITLE
Add cybernetic portal design document

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -3,3 +3,9 @@
 This directory contains the March 2026 to February 2027 profitability roadmap for 3dvr.tech.
 
 Open [/roadmap/index.html](./index.html) for the full plan, revenue milestones, and execution phases.
+
+Design documents:
+
+- [Cybernetic Portal Design](./cybernetic-portal-design.md) - 1970s
+  cybernetics as a product lens for 3DVR feedback loops, CRM memory, wellness
+  regulation, learning, and community coordination.

--- a/roadmap/cybernetic-portal-design.md
+++ b/roadmap/cybernetic-portal-design.md
@@ -1,0 +1,712 @@
+# Cybernetic Portal Design
+
+## Purpose
+
+This document captures a design direction for 3DVR inspired by 1970s cybernetics:
+second-order cybernetics, management cybernetics, Project Cybersyn, Gregory
+Bateson's ecology of mind, autopoiesis, counterculture systems thinking, and
+the early dream of computers as tools for coordination and consciousness.
+
+The goal is not to make 3DVR feel academic. The goal is to use cybernetics as a
+clear product lens:
+
+> Who or what is steering the system, and by what feedback?
+
+For 3DVR, the answer should be:
+
+> People are steered by clearer awareness, better memory, honest feedback,
+> small actions, and tools that help them coordinate without becoming dependent.
+
+## Design Thesis
+
+3DVR should not only be a collection of apps. It should become a living
+interface for personal, creative, business, and community feedback loops.
+
+The portal should help a person move through this loop:
+
+```text
+notice state or opportunity
+-> capture signal
+-> interpret context
+-> choose next action
+-> act in the world
+-> collect feedback
+-> adjust the system
+```
+
+A dashboard is not the system. The feedback loop is the system.
+
+Every important 3DVR app should answer:
+
+- What signal does this app capture?
+- What memory does it preserve?
+- What decision does it clarify?
+- What action does it make easier?
+- What feedback comes back into the system?
+- What identity, policy, or purpose is steering the loop?
+
+## Historical Lens
+
+### First-Order Cybernetics
+
+First-order cybernetics studied observed systems:
+
+```text
+system -> feedback -> correction
+```
+
+Examples:
+
+- thermostat regulates temperature
+- missile guidance tracks a target
+- machine adjusts based on sensor data
+- communication system reduces noise
+
+This is useful, but incomplete for human systems.
+
+### Second-Order Cybernetics
+
+Second-order cybernetics asks what happens when the observer is part of the
+system:
+
+```text
+observer <-> observed
+self <-> environment
+mind <-> world
+```
+
+For product design, this matters because a person using the portal is not just
+recording reality. They are shaping what they notice, what they name, what they
+believe is possible, and what they do next.
+
+Design implication:
+
+- Do not pretend interfaces are neutral.
+- Show the user how their framing affects the system.
+- Let users rename goals, reinterpret signals, and revise their own model.
+- Support reflection without trapping people in endless self-analysis.
+
+### Stafford Beer and Management Cybernetics
+
+Stafford Beer applied cybernetic thinking to organizations. His Viable System
+Model describes a healthy organization as a living nervous system with:
+
+```text
+operations
+coordination
+control
+intelligence
+policy / identity
+```
+
+For 3DVR, this maps directly to company building:
+
+```text
+customer conversations
+-> CRM notes
+-> offer refinement
+-> delivery
+-> feedback
+-> next action
+```
+
+And:
+
+```text
+vision
+-> projects
+-> weekly actions
+-> results
+-> reflection
+-> adjusted vision
+```
+
+A small company fails when its loops break:
+
+- interested people are forgotten
+- offers stay vague
+- follow-up does not happen
+- projects do not close
+- user feedback never reaches product design
+- identity gets replaced by urgency
+
+Design implication:
+
+The CRM is not just a database. It is the memory and attention system of the
+company. The Conversation Capture feature should be treated as a cybernetic
+sensor: it turns live human signals into follow-up, offer design, and learning.
+
+### Project Cybersyn
+
+Project Cybersyn used factories, telex machines, statistical models, and an
+operations room to coordinate economic information in Chile.
+
+The simplified loop:
+
+```text
+factories
+-> telex network
+-> data analysis
+-> operations room
+-> policy / action
+-> factories
+```
+
+The lesson for 3DVR is not "centralize everything." The lesson is:
+
+> A system becomes powerful when real signals travel quickly enough to change
+> real decisions.
+
+Design implication:
+
+- The portal should privilege live signals over vanity dashboards.
+- A CRM note should change a next action.
+- A release note should link directly to the shipped app.
+- A task should connect to the person, revenue, user, or project it serves.
+- A dashboard should make the next move easier, not just display history.
+
+### Bateson: Mind as Loop
+
+Gregory Bateson treated mind as something that exists in patterns and loops, not
+only inside the skull.
+
+Example:
+
+```text
+person
+-> cane
+-> ground
+-> feedback
+-> nervous system
+-> movement
+```
+
+The whole circuit is mind-in-action.
+
+For 3DVR, the same applies to:
+
+- phone plus user
+- browser plus user
+- AI plus user
+- VR headset plus user
+- CRM plus founder
+- community plus builder
+
+Design implication:
+
+Ask:
+
+> How do our tools extend the mind without enslaving it?
+
+The portal should make users more aware, capable, and coordinated. It should not
+make them more reactive, fragmented, or dependent.
+
+### Autopoiesis
+
+Maturana and Varela described living systems as self-producing. A living system
+does not merely respond to the world. It continuously produces and maintains
+itself.
+
+Applied to 3DVR:
+
+```text
+who we talk to
+what we offer
+what we write down
+what we follow up on
+what we ship
+what we ignore
+```
+
+Those loops are the company.
+
+Design implication:
+
+- Repeated practices matter more than declarations.
+- Apps should support recurring rhythms, not isolated bursts.
+- The portal should make the desired loop easy to repeat.
+- Identity should emerge from what the system actually does every week.
+
+### Cybernetics and Counterculture
+
+The 1970s overlap between cybernetics, communes, ecology, education, computing,
+psychedelics, and whole-earth systems thinking matters for 3DVR because it
+points to a humane version of technology:
+
+```text
+decentralized communities
+open-source learning
+personal transformation
+ecological balance
+collective intelligence
+computer networks
+alternative education
+```
+
+Design implication:
+
+3DVR should feel like open-source computing for real life: a place where people
+can learn, coordinate, build, recover attention, and launch practical work.
+
+## Product Principles
+
+### 1. Feedback Loops Over Static Pages
+
+Every important surface should support a loop:
+
+```text
+input -> interpretation -> action -> feedback -> memory
+```
+
+Bad pattern:
+
+```text
+read page -> feel inspired -> leave -> forget
+```
+
+Better pattern:
+
+```text
+read prompt
+-> capture thought
+-> choose next action
+-> schedule or do action
+-> return with result
+```
+
+### 2. The Observer Is Part of the App
+
+The app should help the user notice their own state, framing, and intent.
+
+Examples:
+
+- "What are you trying to steer?"
+- "What feedback are you using?"
+- "What would prove this is working?"
+- "What is one action in the physical world?"
+- "What changed after you acted?"
+
+### 3. Memory Is a Strategic Asset
+
+3DVR should remember things people naturally forget:
+
+- who showed interest
+- what exact words they used
+- what plan felt interesting
+- what next step was promised
+- which shipped app solves which problem
+- which release note links to which result
+- which practice helped state regulation
+
+### 4. Autonomy Plus Coordination
+
+Healthy systems balance local autonomy and shared coordination.
+
+In product terms:
+
+- let people work locally
+- sync important records through GunJS
+- make shared context visible
+- avoid forced centralization
+- preserve user agency
+
+### 5. Dashboards Must Change Behavior
+
+If a dashboard does not change the next action, it is decoration.
+
+Useful dashboards should answer:
+
+- What needs attention now?
+- What did we learn?
+- What is stale?
+- What is the next small action?
+- Who needs a follow-up?
+- What loop is broken?
+
+### 6. Steering Toward Life
+
+Cybernetics can become controlling if used badly. 3DVR should use feedback to
+increase freedom, creativity, and coordination.
+
+Design boundaries:
+
+- no manipulative habit loops
+- no hidden social scoring
+- no shame-based productivity
+- no surveillance framing
+- no pretending dashboards are truth
+- no replacing human judgment with automation
+
+Good cybernetics:
+
+```text
+awareness -> choice -> action -> feedback -> learning
+```
+
+Bad cybernetics:
+
+```text
+measurement -> pressure -> compliance -> dependency
+```
+
+## Core 3DVR Feedback Loops
+
+### Business Loop
+
+```text
+person has a need
+-> conversation is captured
+-> CRM preserves exact signal
+-> offer is refined
+-> example or pricing is sent
+-> person responds
+-> delivery or follow-up happens
+-> offer improves
+```
+
+Current implementation anchors:
+
+- CRM
+- Conversation Capture
+- Contacts
+- Sales
+- Email Operator
+- Revenue Desk
+- Releases
+
+Product direction:
+
+- make "next promised action" impossible to lose
+- link CRM captures to example apps, pricing, and follow-up drafts
+- summarize repeated pain points into offer design
+- show which release shipped a real solution
+
+### Product Shipping Loop
+
+```text
+idea
+-> design doc
+-> small app or feature
+-> pull request
+-> merged release
+-> release note with direct app link
+-> user feedback
+-> next iteration
+```
+
+Product direction:
+
+- make every release note link to the actual app or route
+- connect design docs to shipped routes
+- show which shipped items are active, stale, or experimental
+- keep PRs as the memory of intent and tradeoffs
+
+### Personal Regulation Loop
+
+```text
+user feels tension or scattered attention
+-> portal guides breath / stretch / attention
+-> user notices state shift
+-> user writes one reflection
+-> user chooses one next action
+-> user returns after acting
+```
+
+Current implementation anchors:
+
+- Body Mode
+- Seated Spine Reset
+- Breathing Room
+- Inner Alignment
+- Intention Lab
+- Portal Lab
+
+Product direction:
+
+- support phone, laptop, desktop, and headset
+- preserve flow when the user leaves to send email or log into another tool
+- provide a return state: "You were about to do X"
+- track the smallest useful self-regulation loops, not medical claims
+
+### Learning Loop
+
+```text
+curiosity
+-> interactive lesson
+-> browser-based experiment
+-> reflection
+-> tiny build
+-> saved artifact
+-> next lesson
+```
+
+Current implementation anchors:
+
+- Education Suite
+- Attention Visualized
+- Logic Lab
+- Science Lab
+- Intention Lab
+
+Product direction:
+
+- make lessons interactive by default
+- show the data behind concepts
+- let users export experiments
+- connect learning to actual building
+
+### Community Loop
+
+```text
+member joins
+-> states goal
+-> system suggests next project or room
+-> community gives feedback
+-> member contributes
+-> system remembers reputation and needs
+-> member gets more relevant opportunities
+```
+
+Current implementation anchors:
+
+- Community
+- Cell
+- Chat
+- Tasks
+- Contacts
+- Notes
+
+Product direction:
+
+- avoid opaque ranking systems
+- make contributions visible and portable
+- connect people to concrete next steps
+- keep small groups coherent before scaling
+
+## Interface Patterns
+
+### Capture First, Organize Later
+
+For field use, typing should be minimal.
+
+Pattern:
+
+```text
+big button
+-> chips / toggles / short fields
+-> voice-friendly notes
+-> save incomplete
+-> clean later
+```
+
+Use this for:
+
+- CRM Conversation Capture
+- idea capture
+- body state check-ins
+- release notes
+- customer feedback
+
+### One Next Action
+
+Every loop should point to one real action.
+
+Examples:
+
+- send link
+- send pricing
+- create example page
+- schedule call
+- breathe for 60 seconds
+- write the offer
+- publish the release
+- message the person
+
+### Return Without Losing Flow
+
+The portal should support context switching.
+
+Example:
+
+```text
+portal says: send email to Max
+-> user leaves to Gmail
+-> user returns
+-> portal asks: did you send it?
+-> if yes, log touch
+-> if no, resume draft
+```
+
+Design requirement:
+
+- keep current intention, next action, and open loop visible
+- support "I did it", "still planned", and "changed plan"
+- never punish the user for leaving the app
+
+### Cybernetic Cards
+
+Cards should not only display information. They should represent live loops.
+
+Useful card anatomy:
+
+```text
+signal
+context
+next action
+feedback status
+last updated
+link to source
+```
+
+### Operations Room, Not Control Room
+
+The portal can borrow the "operations room" feeling from Cybersyn without
+becoming authoritarian.
+
+Design tone:
+
+- calm
+- readable
+- sensory-friendly
+- action-oriented
+- clear hierarchy
+- low-glare dark mode
+- no conspiracy-board aesthetic
+- no fake certainty
+
+## Data Principles
+
+### GunJS as Shared Memory
+
+Collaborative or cross-device data should sync through GunJS.
+
+Examples:
+
+```text
+3dvr-portal/crm/conversationCaptures
+3dvr-portal/crm-touch-log
+3dvr-portal/intention-lab/runs
+3dvr-portal/tasks
+3dvr-portal/notes
+```
+
+Design implication:
+
+- local state is acceptable for preferences and drafts
+- important commitments and shared records should sync
+- node paths should be explicit in code comments and docs
+- records should include enough context to survive UI changes
+
+### Records Should Preserve Feedback
+
+A record should not only say what happened. It should say what the system should
+do with it.
+
+Example CRM capture:
+
+```text
+name
+relationship
+project type
+pain points
+exact words
+plan interest
+interest level
+next action
+follow-up date
+source
+created / updated
+```
+
+This supports:
+
+- follow-up
+- offer design
+- research
+- sales copy
+- product prioritization
+
+## Metrics That Matter
+
+Avoid vanity metrics unless they are tied to action.
+
+Useful metrics:
+
+- conversations captured this week
+- follow-ups due today
+- repeated pain points
+- offer plans mentioned
+- releases shipped with direct app links
+- next actions completed
+- state practices completed before work
+- users who returned after leaving to do external work
+
+Bad metrics:
+
+- page views without action
+- abstract engagement
+- points without purpose
+- dashboards no one uses
+- complexity that does not steer anything
+
+## Open Questions
+
+- How should the portal show the user's current open loop across apps?
+- Should there be a persistent "Now steering" panel?
+- How should CRM pain signals become offer experiments?
+- How should release notes connect to user feedback?
+- What belongs in GunJS versus local-only preferences?
+- How can VR mode support operations-room awareness without overwhelm?
+- What is the smallest "cybernetic cockpit" worth building first?
+
+## First Implementation Direction
+
+Build a Cybernetic Cockpit as a lightweight portal layer, not a new giant app.
+
+First version:
+
+```text
+current intention
+active next action
+recent signal
+follow-up due
+state check
+last shipped thing
+return-to-work prompt
+```
+
+It should pull from existing apps:
+
+- CRM Conversation Capture
+- Tasks
+- Notes
+- Releases
+- Body Mode / Breathing Room
+- Intention Lab
+
+Primary question:
+
+> What is steering me right now?
+
+Secondary question:
+
+> What feedback should change my next action?
+
+## Design North Star
+
+The good version of cybernetics is not control over people.
+
+It is control with awareness:
+
+```text
+observe honestly
+remember clearly
+coordinate gently
+act concretely
+learn recursively
+steer toward life
+```
+
+3DVR should build living interfaces where people become more free, more
+creative, more aware, and more able to coordinate.
+


### PR DESCRIPTION
## Summary
- adds `roadmap/cybernetic-portal-design.md` as a permanent design document
- frames 1970s cybernetics as a practical product lens for 3DVR
- maps second-order cybernetics, Stafford Beer, Cybersyn, Bateson, autopoiesis, and counterculture systems thinking into concrete portal loops
- links the document from `roadmap/README.md`

## Design Focus
The document centers the question: who or what is steering the system, and by what feedback? It translates that into CRM memory, release loops, wellness regulation, learning loops, community coordination, and a future Cybernetic Cockpit direction.

## Validation
- `git diff --check`
- line-length scan for the new markdown files
- ASCII-only scan for the new markdown files

## Billing / Stripe
No billing, Stripe, app runtime, backend, or data changes.