### PR TITLE
Add worker power planning docs

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -12,3 +12,9 @@ Design documents:
 - [Civic Operating System Plan](./civic-operating-system-plan.md) - open-source
   civic infrastructure for source-backed issue pages, local action, public
   knowledge, privacy-safe participation, and transparent community tooling.
+- [Rank-And-File Power Plan](./rank-and-file-power-plan.md) - a privacy-aware
+  worker organizing strategy for listening, agreement questions, issue patterns,
+  and one-issue workplace improvements.
+- [Worker Listening CRM Template](./worker-listening-crm-template.md) - a
+  practical private template for respectful coworker conversations, follow-ups,
+  privacy levels, and recurring workplace concerns.

--- a/roadmap/rank-and-file-power-plan.md
+++ b/roadmap/rank-and-file-power-plan.md
@@ -1,0 +1,566 @@
+# Rank-And-File Power Plan
+
+## Purpose
+
+This document turns the workplace organizing idea into a practical 3DVR planning
+artifact.
+
+The goal is not to "start a union" where representation already exists. The
+goal is to build rank-and-file power inside the existing union and across the
+workplace:
+
+```text
+listen
+map
+learn the agreement
+document patterns
+coordinate with stewards and reps
+bring coworkers together around one concrete improvement
+```
+
+This is a worker education and planning document. It is not legal advice,
+official union guidance, or a substitute for the collective bargaining
+agreement, union representatives, stewards, or qualified professionals.
+
+## Working Principle
+
+The deeper mission is the same as the civic operating system plan:
+
+```text
+systems where everyday people distribute power
+```
+
+A union is already one of those systems.
+
+The work is to help make that system more alive:
+
+- More informed
+- More connected
+- More participatory
+- More transparent
+- More worker-led
+- More disciplined
+
+The first product is not an app. The first product is trust.
+
+## Source Notes
+
+These sources should be rechecked before any public-facing tool is shipped:
+
+- [IATSE Local 122](https://www.iatse122.org/) - official Local 122 site for San
+  Diego and Coachella Valley stage and entertainment workers.
+- [IATSE Local 122 About Us](https://www.iatse122.org/about-us/) - official Local
+  122 membership-facing page.
+- [NLRB Concerted Activity](https://www.nlrb.gov/about-nlrb/rights-we-protect/the-law/employees/concerted-activity)
+  - federal overview of employee rights around acting with coworkers on wages,
+  benefits, and working conditions.
+
+The product should link to official sources instead of paraphrasing legal or
+contractual rules as if 3DVR is the authority.
+
+## Product Thesis
+
+3DVR can eventually provide a privacy-aware worker power toolkit:
+
+```text
+Worker Listening CRM
+Contract Question Log
+Issue Pattern Tracker
+New Worker Guide
+Meeting Reminder System
+Training Resource Library
+One-Issue Campaign Planner
+```
+
+But the first version should remain simple, private, and careful.
+
+The practical first tool:
+
+```text
+Worker Listening CRM
+```
+
+Not a sales CRM. Not a complaint feed. An organizing memory system.
+
+## Organizing Model
+
+### 1. Start With Listening
+
+The first job is not leading with a big plan. The first job is understanding
+what workers already care about.
+
+Useful questions:
+
+- How has work been for you lately?
+- What is one thing you wish was better?
+- Do you feel like people know the agreement?
+- Do people know who to talk to when something goes wrong?
+- Would you want more communication between coworkers?
+- What would make new workers feel more supported?
+
+Do not recruit people into a vision before understanding the real workplace
+pain points.
+
+### 2. Map The Workplace
+
+Build a private map of the workplace:
+
+- Venue
+- Department
+- Crew type
+- Who people trust
+- Who trains new people
+- Who knows the agreement
+- Who complains but never acts
+- Who is respected by management
+- Who is respected by workers
+- Who is isolated
+- Who is new and needs support
+
+Power is not only titles. In a workplace, power is often the person everyone
+asks:
+
+```text
+How do we actually do this?
+```
+
+### 3. Learn The Agreement And Pathways
+
+The agreement is the core tool.
+
+Track recurring questions around:
+
+- Calls and scheduling
+- Turnaround and rest periods
+- Safety
+- Overtime
+- Meal breaks
+- Classification and pay rate
+- Rigging, audio, video, lighting, and department expectations
+- Training
+- Favoritism
+- Retaliation concerns
+- Dispatch or referral fairness
+- Communication from management
+
+Do not turn every issue into drama. Turn it into documentation and questions
+that can be checked against the agreement or raised with the right union contact.
+
+### 4. Become Useful To The Local
+
+The strongest early role is calm usefulness:
+
+```text
+Let's check the agreement.
+Let's write down what happened.
+Let's ask the steward or business rep.
+Let's make sure everyone affected is included.
+```
+
+That is organizing.
+
+### 5. Build A Communication Layer
+
+The communication layer should not be public, reckless, or employer-facing.
+
+Possible private sections:
+
+- Contract questions
+- Safety concerns
+- Recurring issues
+- New worker guide
+- Who to contact
+- Meeting reminders
+- Anonymous pattern tracking
+- Training resources
+- What happened
+- Who saw
+- What agreement section might apply
+
+Keep sensitive details private and coordinated with the union. Avoid creating a
+system that exposes workers to retaliation.
+
+### 6. Stay Disciplined
+
+Smart organizing is calm, documented, and collective.
+
+Avoid:
+
+- Threats
+- Harassment
+- Public accusations without sources
+- Sharing private personnel information
+- Leaking sensitive client or event information
+- Naming coworkers without consent
+- Venting in employer-monitored channels
+
+The power move:
+
+```text
+calm
+documented
+collective
+contract-aware
+privacy-aware
+```
+
+## Product Guardrails
+
+### Hard Boundaries
+
+- Do not use 3DVR branding to imply official union authority.
+- Do not store sensitive coworker notes in public nodes.
+- Do not publish coworker names, private stories, or personnel details.
+- Do not create a retaliation target list.
+- Do not create a public grievance feed.
+- Do not provide legal advice.
+- Do not tell workers to ignore their steward, rep, or agreement.
+- Do not collect more personal information than needed.
+- Do not sync sensitive records without an explicit encryption and consent plan.
+
+### Safer Defaults
+
+- Private by default
+- Minimal notes
+- Consent-based names
+- Aggregate patterns over personal stories
+- Contract questions over accusations
+- Follow-up reminders over hot takes
+- Exportable notes for union conversations
+- Clear disclaimers and official-source links
+
+## First Project: Worker Listening CRM
+
+The Worker Listening CRM should help one worker remember conversations,
+follow-ups, and recurring concerns without turning people into data objects.
+
+Core fields:
+
+```text
+coworker name or nickname
+venue or department
+relationship strength
+main concern
+agreement knowledge level
+willing to attend meeting
+willing to help others
+follow-up date
+notes
+privacy level
+```
+
+Use the companion document:
+
+```text
+roadmap/worker-listening-crm-template.md
+```
+
+## 30-Day Plan
+
+### Week 1: Listen To Five Workers
+
+Goal:
+
+- Five low-pressure conversations.
+- No big pitch.
+- Write down only what is necessary.
+
+Prompt:
+
+```text
+How has work been for you lately?
+```
+
+Output:
+
+- Five private listening records.
+- Initial pattern notes.
+
+### Week 2: Identify Top Three Recurring Issues
+
+Goal:
+
+- Convert individual frustration into patterns.
+
+Output:
+
+```text
+Issue 1
+Issue 2
+Issue 3
+Who is affected
+What agreement questions exist
+What facts still need checking
+```
+
+### Week 3: Ask A Steward, Rep, Or Experienced Member
+
+Goal:
+
+- Learn how the issues fit the agreement and existing union process.
+
+Output:
+
+- Contract section notes.
+- Recommended next steps.
+- What not to do.
+
+### Week 4: Bring Two Or Three Workers Together
+
+Goal:
+
+- One issue.
+- One crew.
+- One improvement.
+
+Possible outcomes:
+
+- A shared question for a steward or rep.
+- A respectful meeting request.
+- A new worker guide draft.
+- A training request.
+- A better communication channel.
+- A documented pattern with dates and source notes.
+
+## Product Modules
+
+### 1. Worker Listening CRM
+
+Purpose:
+
+Help a worker remember private conversations and follow up responsibly.
+
+Default storage:
+
+- Local private notes.
+- Future encrypted sync only if needed.
+
+### 2. Contract Question Log
+
+Purpose:
+
+Turn uncertainty into questions that can be checked.
+
+Fields:
+
+```text
+question
+venue
+crew type
+agreement section if known
+source or observation
+who to ask
+status
+answer
+follow-up
+```
+
+### 3. Issue Pattern Tracker
+
+Purpose:
+
+Track recurring patterns without naming people publicly.
+
+Examples:
+
+- Late calls
+- Missed meal break questions
+- Training gaps
+- Safety concerns
+- Dispatch confusion
+- Pay classification questions
+
+### 4. New Worker Guide
+
+Purpose:
+
+Help newer workers learn practical basics:
+
+- Who to ask
+- What to bring
+- How calls work
+- Common venue expectations
+- Agreement basics
+- Safety basics
+- How to raise a question
+
+This should be reviewed with experienced members before sharing broadly.
+
+### 5. Meeting Reminder System
+
+Purpose:
+
+Make participation easier.
+
+Features:
+
+- Meeting date
+- Agenda link
+- Reminder
+- Questions to bring
+- Who plans to attend
+
+### 6. One-Issue Campaign Planner
+
+Purpose:
+
+Avoid vague frustration.
+
+Structure:
+
+```text
+issue
+who is affected
+what is documented
+agreement question
+who has authority
+what workers want
+next collective step
+timeline
+result
+```
+
+## Future App Route Ideas
+
+Possible routes:
+
+```text
+/worker-power/
+/worker-listening/
+/rank-and-file/
+```
+
+Recommended first public-facing route:
+
+```text
+/worker-power/
+```
+
+Public page content:
+
+- Worker power principles
+- Listening-first organizing
+- Privacy and source discipline
+- Link to official union and labor-rights sources
+- Contact 3DVR for a private toolkit discussion
+
+Avoid using Local 122 branding as if the app is official.
+
+## Data And Privacy Model
+
+If this becomes a portal app, do not put sensitive records under a public shared
+Gun path.
+
+Safer options:
+
+### Local Draft Mode
+
+Use browser storage only for private notes when the user understands the device
+risk.
+
+### Encrypted Personal Sync
+
+Use SEA-backed encryption under the user's personal namespace.
+
+Example conceptual path:
+
+```text
+~{userPub}/worker-power/v1/listeningRecords/{recordId}
+```
+
+### Shared Campaign Data
+
+Only share aggregate, non-sensitive records with explicit consent.
+
+Example:
+
+```text
+3dvr-portal/worker-power/publicResources/{resourceId}
+3dvr-portal/worker-power/templates/{templateId}
+```
+
+Sensitive worker records should not be written to:
+
+```text
+3dvr-portal/worker-power/listeningRecords
+```
+
+unless encrypted, consented, and intentionally shared.
+
+## Relationship To Existing Portal Work
+
+This plan connects to:
+
+- Civic Operating System Plan: workplace democracy is civic infrastructure.
+- Cybernetic Portal Design: worker power is a feedback loop.
+- CRM Conversation Capture: the same UX pattern can support worker listening.
+- Tasks: turn issues into concrete next actions.
+- Notes: private reflection and meeting prep.
+- Body Mode: keep workers regulated before hard conversations.
+- Releases: publish public-facing improvements when appropriate.
+
+## First Implementation Prompt
+
+Use this when ready to build the first static page:
+
+```text
+Create a new static portal section at /worker-power/.
+
+Purpose:
+A privacy-aware worker organizing toolkit for listening, contract questions,
+issue patterns, new worker support, and one-issue campaigns.
+
+Tone:
+Calm, disciplined, pro-worker, contract-aware, source-backed, and non-reckless.
+
+Required sections:
+- Listen First
+- Map The Workplace
+- Learn The Agreement
+- Document Patterns
+- Coordinate With The Union
+- One Issue, One Improvement
+
+Safety:
+This is not legal advice, official union guidance, or a public complaint board.
+Do not encourage doxxing, harassment, threats, public accusations without
+documentation, or sharing sensitive coworker details. Link users to official
+union and NLRB resources.
+
+Storage:
+Do not store sensitive worker records in public Gun paths. Default to local
+drafts or encrypted personal sync if a storage layer is added later.
+
+CTA:
+- Start a Worker Listening Log
+- Read the Worker Listening CRM Template
+- Contact 3DVR: 3dvr.tech@gmail.com
+```
+
+## Open Questions
+
+- Should this live under 3DVR, tmsteph, or remain private for now?
+- Should the first tool be a personal Markdown template before any app exists?
+- What data should never be stored digitally?
+- What should be reviewed by a steward or rep before use?
+- How can the system help without creating fear or surveillance?
+- Is the first public audience stagehands, broader workers, or community
+  organizers?
+
+## Design North Star
+
+The final system should help workers:
+
+```text
+listen with respect
+remember what matters
+learn the agreement
+protect each other
+coordinate calmly
+act collectively
+build durable power
+```
+
+The goal is not to become "the union guy."
+
+The goal is to become useful, disciplined, and trusted.

--- a/roadmap/worker-listening-crm-template.md
+++ b/roadmap/worker-listening-crm-template.md
@@ -1,0 +1,500 @@
+# Worker Listening CRM Template
+
+## Purpose
+
+This is a practical template for a private worker listening system.
+
+It is inspired by the CRM pattern, but it is not a sales tool. It is a memory
+tool for respectful rank-and-file conversations.
+
+The purpose:
+
+```text
+listen
+remember
+follow up
+find patterns
+coordinate safely
+```
+
+This template is not legal advice, official union guidance, or a public
+complaint system. Coordinate sensitive issues with the appropriate steward,
+business representative, union officer, or qualified professional.
+
+## Core Rule
+
+Do not make people type while talking. Make the system easy to fill out after a
+conversation in under two minutes.
+
+Write less than you think.
+
+Store only what is useful.
+
+## Privacy Levels
+
+Every record should have a privacy level.
+
+### Private
+
+Personal note only. Do not share.
+
+Use for:
+
+- Relationship notes
+- Follow-up reminders
+- Private uncertainty
+- Context that could identify or expose someone
+
+### Share With Union Contact
+
+Can be summarized for a steward, rep, or trusted union contact.
+
+Use for:
+
+- Agreement questions
+- Recurring workplace patterns
+- Safety questions
+- Specific incidents where the affected worker wants support
+
+### Aggregate Only
+
+Do not name people. Use only as a pattern.
+
+Use for:
+
+- "Several newer workers are confused about call times."
+- "Multiple crew members asked about meal break expectations."
+- "People want clearer training for audio networking."
+
+### Public Resource
+
+Safe to share publicly because it does not expose workers.
+
+Use for:
+
+- General training resources
+- Meeting reminders
+- Official links
+- Public event information
+- Contract education prompts that do not disclose issues
+
+## Minimal Record
+
+Use this when time is short:
+
+```text
+Name or nickname:
+Venue / department:
+Main concern:
+What they want:
+Follow-up date:
+Privacy level:
+```
+
+If that is all you capture, it is enough.
+
+## Full Record
+
+```text
+id:
+createdAt:
+updatedAt:
+
+person:
+  nameOrNickname:
+  venue:
+  department:
+  crewType:
+  relationshipStrength: new / familiar / trusted / close
+  contactMethod: in person / phone / text / email / social / unknown
+
+conversation:
+  date:
+  context: call / break / after work / meeting / phone / other
+  mainConcern:
+  exactWords:
+  whatTheyWant:
+  agreementQuestion:
+  affectedGroup:
+
+organizing:
+  agreementKnowledge: low / medium / high / unknown
+  willingToAttendMeeting: yes / no / maybe / unknown
+  willingToHelpOthers: yes / no / maybe / unknown
+  trustedByWorkers: yes / no / maybe / unknown
+  trustedForTraining: yes / no / maybe / unknown
+  needsSupport: yes / no / maybe / unknown
+
+followUp:
+  nextAction:
+  followUpDate:
+  whoToAsk:
+  status: open / waiting / done / paused
+
+privacy:
+  level: private / share-with-union-contact / aggregate-only / public-resource
+  consentToName: yes / no / unknown
+  sensitive: yes / no
+
+notes:
+  privateNotes:
+  patternNotes:
+```
+
+## Suggested Chips
+
+### Relationship Strength
+
+- New
+- Familiar
+- Trusted
+- Close
+
+### Venue / Department
+
+- Audio
+- Video
+- Lighting
+- Rigging
+- Carpentry
+- Projection
+- General stagehand
+- Convention
+- Theater
+- Arena
+- Hotel
+- Other
+
+### Main Concern
+
+- Scheduling
+- Turnaround
+- Safety
+- Pay classification
+- Meal breaks
+- Training
+- Dispatch or referral
+- Communication
+- Favoritism
+- New worker support
+- Equipment
+- Contract question
+- Other
+
+### Agreement Knowledge
+
+- Low
+- Medium
+- High
+- Unknown
+
+### Willingness
+
+- Yes
+- No
+- Maybe
+- Unknown
+
+### Next Action
+
+- Listen again
+- Check agreement
+- Ask steward
+- Ask business rep
+- Talk to experienced member
+- Invite to meeting
+- Send official link
+- Summarize pattern
+- No action
+
+### Follow-Up Date
+
+- Tomorrow
+- 3 days
+- 1 week
+- 2 weeks
+- 1 month
+- Before next call
+- Custom
+
+## Conversation Prompts
+
+Use one question at a time.
+
+### Opening
+
+```text
+How has work been for you lately?
+```
+
+### Issue Discovery
+
+```text
+What is one thing you wish was better?
+```
+
+### Contract Awareness
+
+```text
+Do people know what the agreement says about that?
+```
+
+### Support
+
+```text
+Do people know who to talk to when something goes wrong?
+```
+
+### Communication
+
+```text
+Would better worker-to-worker communication help?
+```
+
+### Action
+
+```text
+What would be one realistic improvement?
+```
+
+## After-Conversation Summary
+
+After talking, write this:
+
+```text
+What I heard:
+What they want:
+What I should check:
+Who else might be affected:
+Next respectful follow-up:
+```
+
+Keep it short.
+
+## Pattern Tracker
+
+Every week, summarize records without naming people:
+
+```text
+Top recurring issue:
+Who seems affected:
+What facts are confirmed:
+What is still unclear:
+What agreement section might apply:
+Who should be asked:
+One next step:
+```
+
+Example:
+
+```text
+Top recurring issue:
+Newer audio workers feel underprepared for Dante/networking expectations.
+
+Who seems affected:
+Newer A/V workers and people crossing from general stagehand work into audio.
+
+What facts are confirmed:
+At least three workers asked for more training or clearer expectations.
+
+What is still unclear:
+Whether the current training path already covers this and people do not know
+where to find it.
+
+What agreement section might apply:
+Unknown. Ask experienced member or rep.
+
+Who should be asked:
+Experienced audio lead, steward, or training contact.
+
+One next step:
+Draft a simple Dante/networking learning resource list.
+```
+
+## 30-Day Listening Log
+
+### Week 1
+
+Goal:
+
+- Talk to five coworkers.
+- Do not pitch.
+- Capture only minimal records.
+
+Checklist:
+
+- Conversation 1
+- Conversation 2
+- Conversation 3
+- Conversation 4
+- Conversation 5
+
+### Week 2
+
+Goal:
+
+- Identify top three recurring issues.
+
+Output:
+
+```text
+Issue 1:
+Issue 2:
+Issue 3:
+```
+
+### Week 3
+
+Goal:
+
+- Ask a steward, rep, or experienced member how these issues fit the agreement
+  or existing process.
+
+Output:
+
+```text
+Question asked:
+Who answered:
+What I learned:
+What not to assume:
+Next step:
+```
+
+### Week 4
+
+Goal:
+
+- Bring two or three coworkers together around one concrete improvement.
+
+Output:
+
+```text
+Issue:
+Who is affected:
+What improvement is realistic:
+Who should be included:
+What is the next collective step:
+```
+
+## Future App Data Model
+
+If this becomes a portal app, records should be private by default.
+
+### Local Draft Record
+
+```js
+{
+  id: 'worker_listening_...',
+  app: 'worker-listening-crm',
+  version: 1,
+  createdAt: '2026-06-05T00:00:00.000Z',
+  updatedAt: '2026-06-05T00:00:00.000Z',
+  person: {
+    nameOrNickname: '',
+    venue: '',
+    department: '',
+    crewType: '',
+    relationshipStrength: 'new',
+    contactMethod: 'in-person'
+  },
+  conversation: {
+    date: '2026-06-05',
+    context: 'call',
+    mainConcern: '',
+    exactWords: '',
+    whatTheyWant: '',
+    agreementQuestion: '',
+    affectedGroup: ''
+  },
+  organizing: {
+    agreementKnowledge: 'unknown',
+    willingToAttendMeeting: 'unknown',
+    willingToHelpOthers: 'unknown',
+    trustedByWorkers: 'unknown',
+    trustedForTraining: 'unknown',
+    needsSupport: 'unknown'
+  },
+  followUp: {
+    nextAction: 'listen-again',
+    followUpDate: '',
+    whoToAsk: '',
+    status: 'open'
+  },
+  privacy: {
+    level: 'private',
+    consentToName: 'unknown',
+    sensitive: false
+  },
+  notes: {
+    privateNotes: '',
+    patternNotes: ''
+  }
+}
+```
+
+### Storage Recommendation
+
+Do not write this record to a public Gun path.
+
+Private encrypted sync concept:
+
+```text
+~{userPub}/worker-power/v1/listeningRecords/{recordId}
+```
+
+Safe public template/resource concept:
+
+```text
+3dvr-portal/worker-power/templates/{templateId}
+3dvr-portal/worker-power/publicResources/{resourceId}
+```
+
+## What Not To Store
+
+Avoid storing:
+
+- Social Security numbers
+- Home addresses
+- Private medical information
+- Immigration status
+- Private personnel details
+- Rumors stated as facts
+- Coworker names without consent
+- Client-sensitive or event-sensitive information
+- Anything that would create unnecessary retaliation risk
+
+If a detail is not needed for a next respectful action, do not store it.
+
+## Export Template
+
+Use this when bringing a question to a steward, rep, or experienced member:
+
+```text
+Issue pattern:
+Who is affected, without unnecessary names:
+Dates or examples:
+Agreement section if known:
+What workers want clarified:
+What has already been tried:
+What I am asking for:
+```
+
+## Design North Star
+
+The Worker Listening CRM should make it easier to be:
+
+```text
+calm
+useful
+trusted
+organized
+contract-aware
+privacy-aware
+collective
+```
+
+The highest-status behavior is not being the loudest person.
+
+It is being the coworker who remembers, follows up, checks facts, and brings
+people together safely.
+


### PR DESCRIPTION
## Summary
- add a Rank-And-File Power planning document for privacy-aware worker organizing systems
- add a Worker Listening CRM template for respectful coworker conversations, follow-ups, privacy levels, and issue patterns
- link both documents from the roadmap README

## Safety and scope
- documentation-only change
- not legal advice or official union guidance
- avoids public complaint-board framing, doxxing, harassment, sensitive disclosures, and public Gun paths for worker records
- recommends official union/NLRB source links and steward/rep coordination

## Validation
- `git diff --check`
- line-length scan for changed Markdown files
- ASCII-only scan for changed Markdown files

## Notes
- No runtime app, backend, Stripe/billing, analytics, or data-storage changes.