### PR TITLE
[codex] Relax agent line length guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,9 @@ Keep this portal human-readable and maintainable. Favor clear intent over AI cha
 
 ## Formatting
 - Use two spaces for indentation in HTML, CSS, JavaScript, and JSON.
-- Keep lines under 120 characters where practical and end files with a trailing newline.
+- Preserve trailing newlines and readable formatting.
+- Do not reflow code or prose only to satisfy a line-length target; wrap lines when it improves readability or when
+  project tooling requires it.
 
 ## JavaScript
 - Prefer `const` and `let`; avoid unused variables and keep functions focused.


### PR DESCRIPTION
## Summary
- Replace the portal AGENTS.md 120-character line preference with guidance to preserve readable formatting.
- Explicitly tell agents not to reflow code or prose solely to satisfy a line-length target.

## Notes
- I checked the primary repos under /root: 3dvr-portal, 3dvr-web, 3dvr-agent, 3dvr-ops, and tmsteph. The explicit top-level line-length rule was only present in the portal AGENTS.md.
- The main /root/3dvr-portal checkout is dirty with unrelated work, so this was made from the clean portal worktree.

## Validation
- git diff --check