### PR TITLE
[codex] Add portal vision card

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,6 +379,17 @@
             <span class="app-card__title">Human-Scale Tech</span>
             <span class="app-card__meta">Plan the trusted, open, healthy technology ecosystem behind 3DVR.</span>
           </a>
+          <a
+            href="https://3dvr.tech/vision/"
+            class="app-card"
+            target="_blank"
+            rel="noopener"
+            data-app-keywords="vision roadmap open hardware backpack car laptop phone e-bike tent yurt nomad ecosystem"
+          >
+            <span class="app-card__icon" aria-hidden="true">3D</span>
+            <span class="app-card__title">Vision</span>
+            <span class="app-card__meta">Read the 3dvr.tech open hardware and nomad ecosystem roadmap.</span>
+          </a>
           <a href="open-source/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">{ }</span>
             <span class="app-card__title">Open Source</span>

--- a/tests/vision-card.test.js
+++ b/tests/vision-card.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('portal homepage links to the public 3dvr.tech vision page', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /href="https:\/\/3dvr\.tech\/vision\/"/);
+  assert.match(html, /target="_blank"/);
+  assert.match(html, /rel="noopener"/);
+  assert.match(html, /<span class="app-card__title">Vision<\/span>/);
+  assert.match(html, /open hardware and nomad ecosystem roadmap/);
+  assert.match(html, /data-app-keywords="vision roadmap open hardware backpack car laptop phone e-bike tent yurt nomad ecosystem"/);
+});


### PR DESCRIPTION
## Summary
- Add a Portal homepage card linking to https://3dvr.tech/vision/
- Include search keywords for the open hardware and nomad ecosystem roadmap
- Add a targeted Node test for the portal card link

## Validation
- node --test tests/vision-card.test.js
- git diff --check