### PR TITLE
[codex] Make start page hero customer-facing

### DIFF
--- a/start/index.html
+++ b/start/index.html
@@ -28,15 +28,15 @@
       <div class="hero-grid">
         <div class="hero-content">
           <span class="tag">Start here</span>
-          <h1>One account. One path. One next move.</h1>
+          <h1>Start your next 3dvr project.</h1>
           <p>
-            Start free if you want to get moving. Start paid if you want direct help. If you already pay
-            through Stripe, go straight to billing management.
+            Tell us where you are: getting organized, ready for direct help, or already managing
+            a subscription. We will route you to the cleanest next step.
           </p>
           <div class="hero-actions">
             <a class="button primary" href="../free-trial.html">Start free</a>
-            <a class="button secondary" href="#paid-lanes">Choose a paid lane</a>
-            <a class="button tertiary" href="../billing/index.html">Already paying?</a>
+            <a class="button secondary" href="#paid-lanes">Get direct help</a>
+            <a class="button tertiary" href="../billing/index.html">Manage billing</a>
           </div>
           <div class="hero-status">
             <span>No card for free</span>
@@ -46,24 +46,24 @@
         </div>
 
         <aside class="hero-panel">
-          <span class="panel-label">What happens next</span>
-          <h2>Keep the journey obvious</h2>
+          <span class="panel-label">Pick your path</span>
+          <h2>Three ways to begin</h2>
           <p>
-            The job of this page is simple: make the first step clear, keep billing attached to one
-            portal identity, and avoid sending existing customers back through acquisition copy.
+            You can start without paying, get help launching something real, or go straight to
+            the billing tools for an active subscription.
           </p>
           <div class="step-list">
             <div class="step-item">
-              <strong>1. Choose free, paid, or existing billing</strong>
-              <span>Do not make every customer start on the same screen.</span>
+              <strong>1. I am getting organized</strong>
+              <span>Start free, create one portal account, and get one next step.</span>
             </div>
             <div class="step-item">
-              <strong>2. Sign in once for paid plans</strong>
-              <span>That keeps checkout, invoices, plan changes, and support on one identity.</span>
+              <strong>2. I want help launching something</strong>
+              <span>Choose direct support, sign in once, and continue to the right plan.</span>
             </div>
             <div class="step-item">
-              <strong>3. Land in the right place immediately</strong>
-              <span>Free goes into the portal. Paid continues to Stripe. Existing customers open billing.</span>
+              <strong>3. I already pay for 3dvr</strong>
+              <span>Open billing history, payment methods, plan changes, or cancellation.</span>
             </div>
           </div>
           <div class="hero-actions hero-actions--stacked">

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -83,12 +83,20 @@ describe('portal customer journey pages', () => {
 
   it('turns the start page into a compact onboarding router with easy plan access', async () => {
     const html = await readFile(new URL('../start/index.html', import.meta.url), 'utf8');
-    assert.match(html, /One account\. One path\. One next move\./);
+    assert.match(html, /Start your next 3dvr project\./);
+    assert.match(html, /getting organized, ready for direct help, or already managing/);
     assert.match(html, /3 clear paths/);
     assert.match(html, /Start where you actually are/);
     assert.match(html, /Start free/);
-    assert.match(html, /Choose a paid lane/);
-    assert.match(html, /Already paying\?/);
+    assert.match(html, /Get direct help/);
+    assert.match(html, /Manage billing/);
+    assert.match(html, /Pick your path/);
+    assert.match(html, /Three ways to begin/);
+    assert.match(html, /I am getting organized/);
+    assert.match(html, /I want help launching something/);
+    assert.match(html, /I already pay for 3dvr/);
+    assert.doesNotMatch(html, /The job of this page is simple/);
+    assert.doesNotMatch(html, /Do not make every customer start on the same screen/);
     assert.match(html, /Manage what is already active/);
     assert.match(html, /Paid lanes/);
     assert.match(html, /Continue with \$5/);


### PR DESCRIPTION
## Summary
- Rewrite the /start hero around starting a 3dvr project instead of internal account-routing language
- Keep the existing free, direct-help, and billing paths intact
- Update the focused customer journey test to protect the new customer-facing copy and reject internal memo phrasing

## Validation
- node --test tests/customer-journey-pages.test.js tests/start-router.test.js
- git diff --check