### PR TITLE
[codex] Add AI-native startup playbook notes

### DIFF
--- a/docs/founders-playbook-ai-native-startups-summary.md
+++ b/docs/founders-playbook-ai-native-startups-summary.md
@@ -1,0 +1,320 @@
+# The Founder's Playbook: AI-Native Startup Notes
+
+Source: `The Founder's Playbook: Building an AI-Native Startup`, PDF dated May 6, 2026.
+
+Original PDF:
+https://cdn.prod.website-files.com/6889473510b50328dbb70ae6/69fe2a55b93bb0732b1fe33c_The-Founders-Playbook-05062026_v3%20(1).pdf
+
+Created for 3DVR review on June 7, 2026.
+
+## Short Version
+
+The playbook argues that AI changes the startup operating model more than the founder's core job. The job is still to find a real problem, build something that solves it, and turn it into a durable company. What changes is the amount of leverage a small team or solo founder can apply at each stage.
+
+The main warning is also clear: because AI makes building much easier, founders can now build the wrong thing faster, scale confusion faster, and create technical or operational debt faster. The scarce resource is not code production. It is judgment, validation, taste, sequencing, and orchestration.
+
+For 3DVR, the useful framing is:
+
+- Use AI to compress execution, not to skip customer evidence.
+- Treat agents as infrastructure, not magic.
+- Keep written context files, scope docs, architecture notes, and review loops current.
+- Build small, validate early, and make every workflow easier to repeat.
+- Let AI handle research, code, and recurring operations while humans own judgment, trust, relationships, and final responsibility.
+
+## Core Thesis
+
+AI-native startups can operate with far less headcount than traditional startups because AI can now help with:
+
+- Research and strategic analysis.
+- Agentic coding and debugging.
+- Document drafting and synthesis.
+- Workflow automation.
+- Customer discovery operations.
+- Metrics reporting and feedback loops.
+- Security, architecture, and compliance review support.
+- Go-to-market planning and execution support.
+
+This does not remove the founder. It changes the founder from a single overloaded worker into an orchestrator of tools, agents, systems, and eventually people.
+
+## The Four Startup Stages
+
+### 1. Idea Stage
+
+Main question:
+
+> Is this worth building?
+
+The playbook treats the Idea stage as a validation phase, not a prototype phase. AI can make prototypes feel cheap, but a working prototype is not proof that the problem matters.
+
+Useful exit criteria:
+
+- The problem is real, specific, frequent, and painful.
+- The target user is clearly named.
+- Customer conversations show the problem exists outside the founder's imagination.
+- The proposed solution matches the problem discovered through validation, not just the founder's original assumption.
+- There is enough qualitative evidence to justify an MVP.
+
+Main risks:
+
+- Mistaking building for validating.
+- Asking AI to confirm a belief instead of pressure-testing it.
+- Prematurely scaling execution before understanding the problem.
+- Creating a polished artifact that makes a weak idea feel more real than it is.
+
+3DVR application:
+
+- Before building a new portal app, write the target user, problem, current workaround, and validation evidence.
+- Use AI to argue against the idea before using AI to build it.
+- Treat prototypes as props for conversations, not as proof.
+- For personal tools, still ask: who else might need this, how often, and what would make it useful enough to return?
+
+### 2. MVP Stage
+
+Main question:
+
+> What exactly should we build first?
+
+The MVP is still an evidence-gathering tool. The goal is to test whether a real group uses, returns to, pays for, or recommends the product.
+
+Useful exit criteria:
+
+- Real users return.
+- Some users pay or clearly intend to pay.
+- Usage continues after initial launch energy fades.
+- Feedback cycles show a pattern, not just scattered enthusiasm.
+- The product is narrow enough to understand what is working.
+
+Main risks:
+
+- Agentic technical debt from repeated AI sessions without durable context.
+- False product-market fit from early launch spikes.
+- Scope creep because adding features feels almost free.
+- Shipping insecure code because the app appears to work.
+
+3DVR application:
+
+- Create or update `AGENTS.md`, architecture notes, and scope notes before major app work.
+- Keep MVPs narrow: one core workflow, one user, one measurable result.
+- Define what counts as signal before launch.
+- Add basic security review before any app handles real user data, payment data, private notes, or auth state.
+- Use tests to lock down the intended behavior so agentic edits do not drift.
+
+### 3. Launch Stage
+
+Main question:
+
+> Can this become a repeatable business or operating system?
+
+Launch begins once the MVP has evidence. The work shifts from proving the product deserves to exist to proving the business or system deserves to grow.
+
+Useful exit criteria:
+
+- Growth comes from identifiable channels, not only founder effort.
+- The product can handle real production usage.
+- Security, reliability, and compliance are no longer informal.
+- Recurring operations run without the founder personally remembering every task.
+- Support, triage, reporting, and product planning have lightweight systems.
+
+Main risks:
+
+- Technical debt from MVP work becomes expensive.
+- The founder stays in every loop and becomes the bottleneck.
+- Security and compliance lag behind real usage.
+- Expansion into new markets creates too many variables before the first market is stable.
+
+3DVR application:
+
+- Audit old portal apps before pushing them harder: routes, auth, data storage, Gun usage, Stripe flows, and mobile usability.
+- Identify which recurring tasks still depend on Thomas remembering them.
+- Build simple operations loops: weekly metrics, issue triage, backup status, revenue review, and customer follow-up.
+- Keep experiments behind clear sections until they are ready for public navigation.
+- Refactor only where there is real usage or clear business value.
+
+### 4. Scale Stage
+
+Main question:
+
+> Can the company operate without the founder personally holding it together?
+
+Scale is about turning the product and organization into something durable, auditable, and defensible. The founder's role shifts toward public-facing leadership, partnerships, enterprise trust, finance, narrative, and strategy.
+
+Useful exit criteria:
+
+- Growth is systematic and explainable.
+- Operations continue when the founder is unavailable.
+- Enterprise or institutional reviewers can understand the company's controls, documentation, reliability, and support.
+- The product has a moat beyond being first: domain depth, workflow integration, proprietary data, and user-specific learning.
+
+Main risks:
+
+- Delegating too quickly without context.
+- Delegating too slowly and blocking the company.
+- Lacking documentation, support posture, or reliability guarantees.
+- Treating go-to-market as founder hustle instead of a system.
+
+3DVR application:
+
+- Convert founder knowledge into reusable docs, prompts, skills, and workflows.
+- Treat Gun data, portal usage, Stripe data, sales notes, support notes, and app behavior as sources for product direction.
+- Build workflow lock-in ethically by making the portal useful in daily operations.
+- Create reliable backups, support paths, and operating docs before expanding usage.
+- Make 3DVR easier to trust: clearer docs, clearer pricing, clearer contact/support paths, and fewer half-exposed experiments.
+
+## Tooling Model
+
+The playbook distinguishes three kinds of AI work:
+
+- Chat: quick thinking, rewrites, analysis, brainstorming, and small questions.
+- Cowork-style agents: longer-running knowledge work across files, systems, calendars, docs, and recurring operations.
+- Code agents: codebase-aware implementation, testing, debugging, refactoring, and deployment work.
+
+For 3DVR, this maps to:
+
+- Chat for strategy, critique, copy, and decision support.
+- Portal/ops agents for recurring business workflows, research, follow-ups, reports, and backups.
+- Codex/Claude Code-style agents for repo changes, tests, PRs, CI, and deployment.
+
+The important rule is to pick the right surface for the job. Do not ask a coding agent to invent product strategy in a vacuum, and do not ask a chat thread to be the source of truth for codebase architecture.
+
+## Practical Operating Principles
+
+### Keep Sense-Making Ahead Of Building
+
+AI makes it easy to build before understanding. That is useful only after the problem is clear.
+
+Before building:
+
+- State the user.
+- State the problem.
+- State what currently happens without the product.
+- State what evidence supports the need.
+- State what would disprove the idea.
+
+### Make AI Argue Against The Idea
+
+Confirmation bias is stronger when AI can produce polished evidence for almost anything. Every project should include an adversarial review:
+
+- Why might this fail?
+- Who already solves this?
+- Why would users ignore it?
+- What would make this a distraction?
+- What evidence would cause us to stop?
+
+### Write Context Down
+
+The playbook strongly emphasizes persistent context. For code projects, that means files like:
+
+- `AGENTS.md`
+- architecture notes
+- scope docs
+- test plans
+- decision logs
+- runbooks
+
+For 3DVR, this is especially important because many apps are small, experimental, and agent-built. Without written constraints, every new session can drift.
+
+### Define Scope Before Letting The Agent Build
+
+A useful MVP scope doc should say:
+
+- What this app does.
+- What it deliberately does not do.
+- Who it is for.
+- What data it handles.
+- What counts as done for v1.
+- What evidence would justify adding more.
+
+### Measure Evidence, Not Polish
+
+Polish can make a weak idea feel strong. Better evidence includes:
+
+- Return usage.
+- Payment or serious purchase intent.
+- Referrals.
+- Repeated requests from the same user segment.
+- Users completing the intended workflow without handholding.
+- Reduced founder effort over time.
+
+### Security Is Not Optional
+
+Working code is not automatically safe code. For 3DVR, any app touching auth, payments, private notes, customer records, contact data, or synced Gun state should get at least a first-pass security review.
+
+Minimum review questions:
+
+- Are secrets exposed?
+- Is auth required where it should be?
+- Are API responses leaking data?
+- Is user input validated?
+- Are Stripe flows tied to the right account/session?
+- Is Gun data scoped intentionally?
+- Can one user's state overwrite another's?
+
+### Operations Should Run Without Memory
+
+If something matters, it should not depend on a person remembering it.
+
+Candidates for automation or recurring checklists:
+
+- Gun database backups.
+- Stripe/account reconciliation.
+- Vercel deployment checks.
+- Broken route checks.
+- Support inbox review.
+- Sales follow-ups.
+- Weekly revenue and usage summary.
+- App inventory and experiment cleanup.
+
+## 3DVR Project Checklist
+
+Use this before starting or expanding a portal/web/tmsteph project.
+
+### Idea
+
+- [ ] Who is this for?
+- [ ] What problem does it solve?
+- [ ] What evidence says the problem is real?
+- [ ] What would disprove the idea?
+- [ ] What existing app/tool already competes with it?
+- [ ] What is the smallest testable version?
+
+### MVP
+
+- [ ] What is the single core workflow?
+- [ ] What is explicitly out of scope?
+- [ ] Where does data live?
+- [ ] Does it need auth, Gun, Stripe, or only localStorage?
+- [ ] What tests protect the core workflow?
+- [ ] What security/privacy review is needed before demo or launch?
+
+### Launch
+
+- [ ] What proves users are returning or paying?
+- [ ] What recurring operations does this create?
+- [ ] What can be automated?
+- [ ] What could break if usage doubles?
+- [ ] What support path exists?
+- [ ] What docs/runbooks need to exist?
+
+### Scale
+
+- [ ] Can this run if Thomas is unavailable for a week?
+- [ ] Is there a backup and recovery path?
+- [ ] Is the data model documented?
+- [ ] Is the public offer/pricing/support path clear?
+- [ ] What makes this hard to copy?
+- [ ] What integrations would make it part of the user's daily workflow?
+
+## Specific Ideas For 3DVR
+
+- Treat the portal as the operating surface for AI-native work: apps, docs, agents, customer data, billing, and experiments in one place.
+- Use `docs/` more aggressively for decision logs and project review notes.
+- Create a reusable `new app checklist` based on the stages above.
+- Build a recurring Gun backup workflow before more cross-device apps depend on it.
+- Add a project registry that labels each app as Idea, MVP, Launch, or Scale.
+- Keep experimental/spiritual/playful work visible but contained, so public business entry paths stay clear.
+- Make Builder or direct help the default paid project lane, while keeping free and supporter paths available.
+- Convert founder-specific knowledge into durable instructions: sales process, app design conventions, Stripe/Gun patterns, and deployment rules.
+
+## Main Takeaway
+
+AI compresses execution, but it does not replace judgment. The founder's leverage comes from using agents to move faster while preserving discipline: validate before building, document before scaling, test before trusting, and automate the work that should not depend on memory.


### PR DESCRIPTION
## Summary
- Add a Markdown summary of the May 6, 2026 Founder's Playbook PDF
- Adapt the main ideas into practical 3DVR project guidance
- Include a reusable stage checklist for Idea, MVP, Launch, and Scale work

## Validation
- git diff --cached --check before commit
- checked generated Markdown for non-ASCII characters