### PR TITLE
Add problem validation doc

### DIFF
--- a/docs/problem-validation.md
+++ b/docs/problem-validation.md
@@ -1,0 +1,77 @@
+# 3DVR Problem Validation
+
+## Current Hypothesis
+
+Small businesses, independent builders, and early founders need affordable help turning messy ideas into working websites, apps, workflows, and digital systems.
+
+3DVR provides human-guided, AI-assisted builder support with simple pricing: free starter help, $5/month light support, $20/month website/support, and custom project help.
+
+## Who Might Have This Problem?
+
+- Small businesses without a proper website
+- Friends/coworkers with business ideas
+- Independent creators
+- Local service providers
+- Nontechnical founders
+- Builders with scattered projects
+- People who tried Wix/Squarespace/Shopify but got stuck
+
+## Pain We Are Testing
+
+- "I do not know where to start."
+- "I need a website but cannot afford an agency."
+- "I started building something but got stuck."
+- "My tools are scattered."
+- "I want AI help, but I do not trust it to run everything."
+- "I need someone technical I can actually talk to."
+
+## What We Need To Learn
+
+1. Do people recognize this as a real problem?
+2. What are they doing now instead?
+3. Have they paid anyone before?
+4. Would they pay $5/month, $20/month, or more?
+5. What outcome would make them happy?
+6. What would make them trust 3DVR?
+7. What is the smallest useful thing we can deliver?
+
+## Validation Goal
+
+Talk to 10 people.
+
+Get at least:
+- 3 people with a real project need
+- 2 people willing to pay or start a trial
+- 1 person willing to become an active 3DVR member/client
+
+## Interview Questions
+
+1. What are you trying to build or improve online right now?
+2. What have you already tried?
+3. Where did you get stuck?
+4. Have you paid for help before?
+5. What would make this feel solved?
+6. Would you rather have a website, an app, a workflow, or ongoing support?
+7. Would $5/month, $20/month, or project pricing make sense for you?
+8. What would make you trust someone to help with this?
+9. How often would you want support?
+10. What would you want done first?
+
+## Stop / Continue Criteria
+
+### Continue if:
+- People describe the pain before we pitch it.
+- People have already tried to solve it.
+- People are willing to pay or introduce us to someone.
+- We hear repeated needs across multiple people.
+
+### Narrow if:
+- One audience responds much stronger than others.
+- One offer gets clearer yes/no reactions.
+- One price point feels obvious.
+
+### Pause or Pivot if:
+- People only say "cool idea" but do not act.
+- Nobody has urgency.
+- Nobody would pay.
+- The problem only matters to us internally.


### PR DESCRIPTION
## Summary
- add a 3DVR problem validation doc under `docs/`
- capture target audiences, pains, learning goals, interview questions, and continue/pivot criteria

## Testing
- not run; documentation-only change