### PR TITLE
[codex] Add problem validation and start page critique

### DIFF
--- a/docs/problem-validation.md
+++ b/docs/problem-validation.md
@@ -1,20 +1,70 @@
 # 3DVR Problem Validation
 
-## Current Hypothesis
+Created June 7, 2026.
 
-Small businesses, independent builders, and early founders need affordable help turning messy ideas into working websites, apps, workflows, and digital systems.
+## Current Concern
 
-3DVR provides human-guided, AI-assisted builder support with simple pricing: free starter help, $5/month light support, $20/month website/support, and custom project help.
+We have built a lot of useful pieces, but the core 3DVR problem is still not fully validated.
+
+Right now 3DVR contains several overlapping bets:
+
+- personal operating system / portal
+- AI agent workspace
+- web and app builder
+- CRM and sales tooling
+- wellness and life tools
+- Gun-powered local-first apps
+- small business support / Builder lane
+
+Those may connect later, but we should not assume they validate the same problem. The next useful work is to identify one sharp problem, one audience, and one testable offer.
+
+## Current Best Hypothesis
+
+Small businesses, independent builders, and early founders need affordable direct help turning messy ideas into working websites, apps, workflows, and digital systems.
+
+3DVR provides human-guided, AI-assisted builder support. The portal is the workspace and support layer behind that service, not necessarily the first product customers understand or buy.
+
+## Alternate Hypotheses
+
+### Personal Portal First
+
+Thomas needs a personal operating system first. 3DVR becomes public only after repeated personal workflows prove useful enough for other people.
+
+Risk:
+
+- This may stay personally valuable but commercially unclear.
+
+### AI Agent Workspace
+
+Builders and small teams need one place to run agents, save work, manage contacts, handle billing, and coordinate projects.
+
+Risk:
+
+- This is abstract and may require a lot of product maturity before a buyer understands it.
+
+### Direct Project Help
+
+People with an idea, business, website, or workflow need an affordable technical partner who can help them make progress without hiring an agency.
+
+Risk:
+
+- This may validate more like a service business than a software product.
+
+Current strongest angle:
+
+- Direct project help is probably easiest to validate because people can say yes or no with a concrete project and money.
+- The portal can then become the delivery layer, client workspace, and operational system.
 
 ## Who Might Have This Problem?
 
 - Small businesses without a proper website
-- Friends/coworkers with business ideas
+- Friends or coworkers with business ideas
 - Independent creators
 - Local service providers
 - Nontechnical founders
 - Builders with scattered projects
-- People who tried Wix/Squarespace/Shopify but got stuck
+- People who tried Wix, Squarespace, Shopify, or AI site builders but got stuck
+- People who need a simple CRM, sales page, form, checkout, or project workflow
 
 ## Pain We Are Testing
 
@@ -24,54 +74,118 @@ Small businesses, independent builders, and early founders need affordable help 
 - "My tools are scattered."
 - "I want AI help, but I do not trust it to run everything."
 - "I need someone technical I can actually talk to."
+- "I need progress this week, not a giant platform."
 
 ## What We Need To Learn
 
-1. Do people recognize this as a real problem?
+1. Do people describe this pain before we pitch it?
 2. What are they doing now instead?
-3. Have they paid anyone before?
-4. Would they pay $5/month, $20/month, or more?
-5. What outcome would make them happy?
+3. Have they paid for help before?
+4. Would they pay $5/month, $20/month, $50/month, or project pricing?
+5. What outcome would make them feel helped?
 6. What would make them trust 3DVR?
-7. What is the smallest useful thing we can deliver?
+7. What is the smallest useful deliverable?
+8. Would they use a portal workspace if it came with direct help?
+9. Which part do they value more: the finished asset, the ongoing help, or the operating system?
+10. What would they want done first?
+
+## Evidence We Already Have
+
+Fill this section with concrete examples only.
+
+- Real conversations:
+- People who asked for help:
+- People who paid:
+- Repeated requests:
+- Apps/tools someone actually used:
+- Problems Thomas personally experiences repeatedly:
+- Workflows that keep reappearing across projects:
+
+## Evidence We Do Not Have Yet
+
+- Which audience has the strongest urgency.
+- Whether people understand "portal" as a product.
+- Whether Builder-style support is priced correctly.
+- Whether people want subscription support or one-time project help.
+- Whether customers will return weekly/monthly.
+- Whether Gun/local-first tooling matters to customers or is mostly an implementation preference.
+- Whether 3DVR's public site explains the offer clearly enough.
 
 ## Validation Goal
 
 Talk to 10 people.
 
 Get at least:
+
 - 3 people with a real project need
 - 2 people willing to pay or start a trial
 - 1 person willing to become an active 3DVR member/client
+- 1 repeated pain pattern strong enough to narrow the offer
+
+## Interview Targets
+
+Start with people who can discuss a real recent project, not hypothetical interest.
+
+- Local business owner
+- Friend/coworker with a business idea
+- Creator who needs a landing page or store
+- Service provider with messy intake/scheduling
+- Person who tried to build a site and stopped
+- Person who needs a simple customer/contact workflow
+- Person already paying for web/software help
+- Person using AI tools but not shipping
+- Person with a paid event, class, service, or product idea
+- Existing 3DVR/contact who has asked for help before
 
 ## Interview Questions
+
+Use past behavior questions before pitching 3DVR.
 
 1. What are you trying to build or improve online right now?
 2. What have you already tried?
 3. Where did you get stuck?
-4. Have you paid for help before?
+4. Have you paid for help before? What happened?
 5. What would make this feel solved?
 6. Would you rather have a website, an app, a workflow, or ongoing support?
-7. Would $5/month, $20/month, or project pricing make sense for you?
-8. What would make you trust someone to help with this?
-9. How often would you want support?
-10. What would you want done first?
+7. What would you want done first?
+8. How soon does this matter?
+9. What would make you trust someone to help with this?
+10. Would $5/month, $20/month, $50/month, or project pricing make sense?
+11. Would a shared portal/workspace help, or would you rather just receive the finished result?
+12. If this existed, what would make you come back next week?
 
 ## Stop / Continue Criteria
 
-### Continue if:
+### Continue If
+
 - People describe the pain before we pitch it.
 - People have already tried to solve it.
 - People are willing to pay or introduce us to someone.
 - We hear repeated needs across multiple people.
+- The same first deliverable appears in multiple conversations.
 
-### Narrow if:
+### Narrow If
+
 - One audience responds much stronger than others.
 - One offer gets clearer yes/no reactions.
 - One price point feels obvious.
+- Customers value direct help more than the portal itself.
+- Customers value one specific workflow more than the whole ecosystem.
 
-### Pause or Pivot if:
+### Pause Or Pivot If
+
 - People only say "cool idea" but do not act.
 - Nobody has urgency.
 - Nobody would pay.
 - The problem only matters to us internally.
+- People need custom agency work but do not want a recurring relationship.
+- The portal adds confusion instead of trust.
+
+## Current Working Decision
+
+Until validation says otherwise:
+
+- Lead with direct AI-enabled project help.
+- Treat the portal as the delivery workspace.
+- Keep the public start page oriented around concrete projects and help, not the full operating-system vision.
+- Build fewer new apps until we know which customer problem they support.

--- a/docs/start-page-validation-critique.md
+++ b/docs/start-page-validation-critique.md
@@ -1,0 +1,258 @@
+# 3DVR Start Page Validation Critique
+
+Created June 7, 2026.
+
+Reviewed source:
+
+- `start/index.html`
+- `start/router.js`
+- `start/style.css`
+- `docs/problem-validation.md`
+
+## Short Version
+
+The latest start page is better than the previous version because the hero now starts from a project-oriented frame:
+
+> Start your next 3dvr project.
+
+That is closer to what the public site promises. But the page still has a core validation problem: it tries to route people into the 3DVR ecosystem before we have validated which problem they actually care about.
+
+The page currently mixes:
+
+- free personal organization
+- paid project help
+- existing billing management
+- community/light support
+- daily direction
+- project tools
+- contacts, messenger, and finance
+
+Those are real 3DVR capabilities, but they make the start page feel like a portal map rather than a sharp offer.
+
+## What Is Working
+
+- The hero now sounds public-facing instead of like an internal routing memo.
+- The three main actions are understandable:
+  - Start free
+  - Get direct help
+  - Manage billing
+- Existing customers have a direct billing route.
+- Paid checkout still stays attached to sign-in, which protects Stripe/account continuity.
+- The router is simple and testable.
+- The page avoids forcing every visitor into a single path.
+
+## Main Issue
+
+The page still assumes the answer is "choose a 3DVR path" before proving that the visitor recognizes the problem.
+
+For a new visitor, the first question is probably not:
+
+> Which portal lane do I belong in?
+
+It is closer to:
+
+> Can 3DVR help me get my thing unstuck?
+
+The start page should make the problem feel concrete before it asks the visitor to understand free, paid, billing, portal accounts, daily direction, support lanes, and internal apps.
+
+## Problem 1: The Offer Is Still Too Broad
+
+Current visible paths include:
+
+- getting organized
+- launching something
+- managing billing
+- daily direction
+- paid plans
+- community support
+- projects
+- contacts
+- messenger
+- finance
+
+This is too much for an unvalidated public offer. It may be accurate to the portal, but it does not force a decision about what problem 3DVR is solving first.
+
+Recommended direction:
+
+- Make the primary offer: direct AI-enabled project help.
+- Make the portal the workspace behind the help.
+- Keep free and billing paths available but visually secondary.
+
+## Problem 2: The Router Still Asks Personal-State Questions
+
+Current router questions:
+
+- What hurts most right now?
+- What do you want next?
+- How much help do you want?
+
+These can work for a personal portal, but they do not validate the public "Start a project" promise. A visitor with a business or project likely expects questions about the thing they want to build.
+
+Better router questions:
+
+1. What are you trying to start?
+   - website or landing page
+   - offer, store, or checkout
+   - workflow, CRM, or automation
+   - personal reset / operating system
+
+2. What state is it in?
+   - just an idea
+   - partly built
+   - already live but messy
+   - blocked and needs rescue
+
+3. What kind of help do you want?
+   - show me the next step
+   - help me build it
+   - help me clean up what exists
+   - help me operate it monthly
+
+This would generate more useful validation data and better match the page headline.
+
+## Problem 3: Paid Lanes Are Still Plan-First
+
+The paid lane section asks the visitor to understand $5, $20, $50, and $200 plans before the problem has been sharpened.
+
+That may work for existing customers, but new visitors likely need outcome labels first.
+
+Better framing:
+
+- "I need a quick page or cleanup" -> Founder / $20
+- "I need direct build help for an active project" -> Builder / $50
+- "I need ongoing team support" -> Embedded / $200
+- "I just want to support or stay connected" -> Family & Friends / $5
+
+The Builder lane should probably become the default business/project recommendation unless validation says otherwise.
+
+## Problem 4: The Bottom Sections Send Users Into Too Many Internal Apps
+
+The page currently links to internal destinations like:
+
+- Daily Direction
+- Projects
+- Contacts
+- Messenger
+- Finance
+- Browse apps
+
+These may be useful after sign-in, but on the public start page they weaken the offer. They make the visitor think the next step is exploring tools, not solving a project problem.
+
+Recommended direction:
+
+- Collapse the bottom into three final actions:
+  - Start free
+  - Get Builder help
+  - Open billing
+- Move app exploration after account creation or into the portal home.
+
+## Problem 5: We Are Not Collecting Validation Signal Here
+
+The start page routes people, but it does not capture much evidence about what people need.
+
+If we are serious about validation, the page should eventually capture:
+
+- what the visitor is trying to build
+- what state it is in
+- what blocked them
+- whether they want done-with-you help, done-for-you help, or tools
+- what price band feels reasonable
+- whether they want a follow-up
+
+This does not need to be a heavy form. It could be a tiny "Tell us what you are starting" box before or after the router.
+
+## Suggested Small Fix Sequence
+
+### Step 1: Rewrite Path Cards Around Visitor Problems
+
+Keep three cards, but rename them:
+
+- "I need to get organized"
+- "I need help building something"
+- "I already pay for 3DVR"
+
+Remove remaining copy that explains routing mechanics more than user outcomes.
+
+Validation check:
+
+- A visitor can identify themselves without understanding the portal.
+
+### Step 2: Make Builder The Default Project Lane
+
+Reorder paid lanes:
+
+1. Builder
+2. Founder
+3. Embedded
+4. Family & Friends
+
+Make Builder visually recommended for active projects.
+
+Validation check:
+
+- Business/project visitors see one obvious paid path.
+
+### Step 3: Rework The Router Into Project Questions
+
+Replace emotional/personal-state questions with project-state questions.
+
+Validation check:
+
+- Router recommendations teach us what kind of project the visitor has.
+- Tests cover Builder for active website/workflow/business needs.
+
+### Step 4: Reduce Bottom App Links
+
+Replace the internal app grid with a shorter final action band.
+
+Validation check:
+
+- Public start page no longer sends new visitors into many internal apps before they understand the offer.
+
+### Step 5: Add A Lightweight Lead Capture Prompt
+
+Add one optional field:
+
+> What are you trying to start?
+
+Potential actions:
+
+- Save locally for now.
+- Later: send to CRM/Gun/contact workflow.
+- Later: connect to email or support flow.
+
+Validation check:
+
+- We start collecting real language from visitors instead of only routing clicks.
+
+## Copy Direction
+
+Prefer:
+
+- "Tell us what you are trying to build."
+- "Get a working first version."
+- "Clean up a stuck project."
+- "Use 3DVR as the workspace for the help."
+- "Start free if you only need direction."
+- "Choose Builder if you want direct help shipping."
+
+Avoid:
+
+- "portal identity"
+- "customer journey"
+- "routing"
+- "plan education"
+- "entry path"
+- "workspace first" before the value is clear
+
+## Validation Lens For Future Edits
+
+Before editing the start page, ask:
+
+1. Does this make the customer problem sharper?
+2. Does this help us learn what visitors actually need?
+3. Does this reduce or increase the number of choices?
+4. Does this explain outcomes before internal tools?
+5. Does this support the direct project-help hypothesis?
+
+If not, defer it.

--- a/start/index.html
+++ b/start/index.html
@@ -77,26 +77,26 @@
     <main class="dashboard-shell">
       <section class="journey-shell" id="paths" aria-labelledby="paths-title">
         <div class="section-heading section-heading--left">
-          <span class="tag tag--dark">3 clear paths</span>
+          <span class="tag tag--dark">3 clear needs</span>
           <h2 id="paths-title">Start where you actually are</h2>
           <p>
-            Free, paid, and existing billing each get their own first step. That keeps the entry
-            path short and reduces decision drag before someone even gets into the portal.
+            Pick the sentence that sounds most like your situation. The portal can stay in the
+            background until the next step is obvious.
           </p>
         </div>
 
         <div class="path-grid">
           <article class="path-card">
-            <span class="panel-label">Free path</span>
-            <h3>Get moving without a card</h3>
+            <span class="panel-label">I need to get organized</span>
+            <h3>Find one next step without a card</h3>
             <p>
-              Start with your email, create one portal account, and use daily direction as the first
-              workspace.
+              Use the free path when the project still feels scattered and you need a small,
+              concrete place to begin.
             </p>
             <ul class="path-list">
-              <li>Email first</li>
+              <li>One clear starting point</li>
               <li>No credit card required</li>
-              <li>Clean upgrade path later</li>
+              <li>Upgrade only when direct help makes sense</li>
             </ul>
             <div class="path-card__actions">
               <a class="button primary" href="../free-trial.html">Start free</a>
@@ -105,16 +105,16 @@
           </article>
 
           <article class="path-card">
-            <span class="panel-label">Paid path</span>
-            <h3>Sign in once, then choose a lane</h3>
+            <span class="panel-label">I need help building something</span>
+            <h3>Get direct help on a real project</h3>
             <p>
-              Paid help starts with one portal account. After sign-in, the matching plan stays tied to
-              the same identity for upgrades, invoices, and support.
+              Use the paid path when you have a website, offer, workflow, or app that needs
+              hands-on help to ship.
             </p>
             <ul class="path-list">
-              <li>Account first</li>
-              <li>Stripe checkout second</li>
-              <li>Safer plan switches later</li>
+              <li>Project first, plan second</li>
+              <li>Sign in once before Stripe</li>
+              <li>Keep support tied to one account</li>
             </ul>
             <div class="path-card__actions">
               <a class="button primary" href="../sign-in.html?redirect=%2Fbilling%2F">Sign in for paid plans</a>
@@ -123,11 +123,11 @@
           </article>
 
           <article class="path-card">
-            <span class="panel-label">Existing billing</span>
-            <h3>Manage what is already active</h3>
+            <span class="panel-label">I already pay for 3DVR</span>
+            <h3>Manage an active subscription</h3>
             <p>
-              Returning subscribers should not have to wade through acquisition copy. Open billing to
-              switch plans, update payment methods, invoices, or cancel renewal.
+              Use billing when the relationship already exists and you need invoices, payment
+              methods, plan changes, or cancellation.
             </p>
             <ul class="path-list">
               <li>Switch tiers safely</li>

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -85,8 +85,9 @@ describe('portal customer journey pages', () => {
     const html = await readFile(new URL('../start/index.html', import.meta.url), 'utf8');
     assert.match(html, /Start your next 3dvr project\./);
     assert.match(html, /getting organized, ready for direct help, or already managing/);
-    assert.match(html, /3 clear paths/);
+    assert.match(html, /3 clear needs/);
     assert.match(html, /Start where you actually are/);
+    assert.match(html, /Pick the sentence that sounds most like your situation/);
     assert.match(html, /Start free/);
     assert.match(html, /Get direct help/);
     assert.match(html, /Manage billing/);
@@ -97,7 +98,13 @@ describe('portal customer journey pages', () => {
     assert.match(html, /I already pay for 3dvr/);
     assert.doesNotMatch(html, /The job of this page is simple/);
     assert.doesNotMatch(html, /Do not make every customer start on the same screen/);
-    assert.match(html, /Manage what is already active/);
+    assert.match(html, /I need to get organized/);
+    assert.match(html, /Find one next step without a card/);
+    assert.match(html, /I need help building something/);
+    assert.match(html, /Get direct help on a real project/);
+    assert.match(html, /I already pay for 3DVR/);
+    assert.match(html, /Manage an active subscription/);
+    assert.doesNotMatch(html, /Free, paid, and existing billing each get their own first step/);
     assert.match(html, /Paid lanes/);
     assert.match(html, /Continue with \$5/);
     assert.match(html, /Continue with \$20/);


### PR DESCRIPTION
## Summary
- Expand the 3DVR problem validation doc around the current concern that the core problem is still fuzzy
- Add a start page critique through the validation lens
- Recommend a small sequence: visitor-problem path cards, Builder as default project lane, project-state router, fewer internal app links, lightweight lead capture

## Validation
- git diff --cached --check