### PR TITLE
[codex] Simplify conversation capture

### DIFF
--- a/sales/research.html
+++ b/sales/research.html
@@ -380,15 +380,16 @@
             <option value="professional-services">Professional services</option>
             <option value="local-service">Construction and local service</option>
             <option value="support-team">Health, support, and local teams</option>
+            <option value="not-sure">Not sure yet</option>
           </select>
         </label>
         <label class="space-y-2">
           <span class="text-xs uppercase tracking-[0.24em] text-slate-400">Company or team</span>
-          <input id="interviewCompany" type="text" placeholder="Studio, contractor, or organization name" class="w-full rounded-xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-slate-100" />
+          <input id="interviewCompany" list="interviewUnknownOptions" type="text" placeholder="Studio, contractor, organization, N/A, or not sure" class="w-full rounded-xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-slate-100" />
         </label>
         <label class="space-y-2">
           <span class="text-xs uppercase tracking-[0.24em] text-slate-400">Contact</span>
-          <input id="interviewContact" type="text" placeholder="Owner or team lead" class="w-full rounded-xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-slate-100" />
+          <input id="interviewContact" list="interviewUnknownOptions" type="text" placeholder="Owner, team lead, N/A, or not sure" class="w-full rounded-xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-slate-100" />
         </label>
         <label class="space-y-2">
           <span class="text-xs uppercase tracking-[0.24em] text-slate-400">Status</span>
@@ -398,19 +399,33 @@
             <option value="Interviewed">Interviewed</option>
             <option value="Qualified">Qualified</option>
             <option value="Not a fit">Not a fit</option>
+            <option value="Not sure">Not sure</option>
+            <option value="N/A">N/A</option>
           </select>
         </label>
         <label class="space-y-2 xl:col-span-2">
           <span class="text-xs uppercase tracking-[0.24em] text-slate-400">What pain did you hear?</span>
-          <textarea id="interviewNotes" placeholder="Lead flow, scheduling, follow-up, payments, coordination..." class="min-h-[120px] w-full rounded-xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-slate-100"></textarea>
+          <textarea id="interviewNotes" placeholder="Lead flow, scheduling, follow-up, payments, coordination, N/A, or not sure..." class="min-h-[120px] w-full rounded-xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-slate-100"></textarea>
         </label>
         <label class="space-y-2 xl:col-span-2">
           <span class="text-xs uppercase tracking-[0.24em] text-slate-400">Next step</span>
-          <input id="interviewNextStep" type="text" placeholder="Book the follow-up call, send Builder overview, or mark not a fit" class="w-full rounded-xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-slate-100" />
+          <input id="interviewNextStep" list="interviewUnknownOptions" type="text" placeholder="Book follow-up, send Builder overview, N/A, or not sure" class="w-full rounded-xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-slate-100" />
         </label>
+        <datalist id="interviewUnknownOptions">
+          <option value="N/A"></option>
+          <option value="Not sure"></option>
+        </datalist>
+        <div class="xl:col-span-2 rounded-xl border border-white/5 bg-slate-950/60 p-3">
+          <p class="text-xs uppercase tracking-[0.24em] text-slate-400">Quick capture</p>
+          <div class="mt-2 flex flex-wrap gap-2">
+            <button type="button" data-interview-quick="follow-up" class="inline-flex items-center justify-center rounded-lg border border-emerald-300/20 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-100 hover:bg-emerald-500/20">Needs follow-up</button>
+            <button type="button" data-interview-quick="not-sure" class="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold text-slate-100 hover:bg-white/10">Not sure yet</button>
+            <button type="button" data-interview-quick="not-fit" class="inline-flex items-center justify-center rounded-lg border border-rose-300/20 bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-100 hover:bg-rose-500/20">Probably not a fit</button>
+          </div>
+        </div>
         <div class="xl:col-span-2 flex flex-wrap items-center gap-3">
-          <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-400">Save interview log</button>
-          <p id="interviewLogSaveStatus" class="text-sm text-slate-400" role="status" aria-live="polite">Use the CRM draft links above, then log the conversation outcome here.</p>
+          <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-400">Save capture</button>
+          <p id="interviewLogSaveStatus" class="text-sm text-slate-400" role="status" aria-live="polite">Save whatever you know now. N/A and not sure are valid.</p>
         </div>
       </form>
       <div id="interviewLogList" class="space-y-3"></div>

--- a/sales/research.js
+++ b/sales/research.js
@@ -15,6 +15,8 @@ const INTERVIEW_STATUS_VALUES = Object.freeze([
   'Interviewed',
   'Qualified',
   'Not a fit',
+  'Not sure',
+  'N/A',
 ]);
 
 const SEGMENTS = Object.freeze({
@@ -41,6 +43,14 @@ const SEGMENTS = Object.freeze({
     nextStep: 'Send first Embedded note today',
     opener: 'Teams usually do not need more apps first. They need one clearer operating loop for intake, scheduling, and shared follow-up.',
     full: 'Open with: Teams usually do not need more apps first. They need one clearer operating loop for intake, scheduling, and shared follow-up.\nAsk: Where does coordination break down most often right now: intake, scheduling, handoff, or client follow-up?\nClose: If the pain is shared across a real team, Embedded is the cleaner fit because it gives you a tighter monthly execution lane.',
+  }),
+  'not-sure': Object.freeze({
+    label: 'Not sure yet',
+    marketSegment: 'Not sure yet',
+    queueLead: 'Unsorted conversation capture',
+    nextStep: 'Clarify fit when there is more signal',
+    opener: 'Capture the real words first. Sort the segment later.',
+    full: 'Capture the real words first. Sort the segment later.',
   }),
 });
 
@@ -1013,6 +1023,46 @@ function hydrateInterviewsFromGun() {
   interviewsNode.on(applyRemoteInterviews);
 }
 
+function appendInterviewNote(note) {
+  if (!interviewNotes || !note) {
+    return;
+  }
+  const existing = String(interviewNotes.value || '').trim();
+  interviewNotes.value = existing ? `${existing}\n${note}` : note;
+}
+
+function applyQuickInterviewCapture(type) {
+  if (type === 'follow-up') {
+    if (interviewStatus) interviewStatus.value = 'Interviewed';
+    appendInterviewNote('Needs follow-up. Capture details when there is more time.');
+    if (interviewNextStep && !interviewNextStep.value.trim()) {
+      interviewNextStep.value = 'Follow up';
+    }
+  }
+
+  if (type === 'not-sure') {
+    if (interviewSegment) interviewSegment.value = 'not-sure';
+    if (interviewStatus) interviewStatus.value = 'Not sure';
+    appendInterviewNote('Not sure yet. Save the raw signal and sort it later.');
+    if (interviewNextStep && !interviewNextStep.value.trim()) {
+      interviewNextStep.value = 'Not sure';
+    }
+  }
+
+  if (type === 'not-fit') {
+    if (interviewStatus) interviewStatus.value = 'Not a fit';
+    appendInterviewNote('Probably not a fit.');
+    if (interviewNextStep && !interviewNextStep.value.trim()) {
+      interviewNextStep.value = 'N/A';
+    }
+  }
+
+  if (interviewLogSaveStatus) {
+    interviewLogSaveStatus.textContent = 'Quick capture added. Save now or add more detail first.';
+  }
+  interviewNotes?.focus();
+}
+
 function handleInterviewSubmit(event) {
   event.preventDefault();
   const segmentId = SEGMENTS[String(interviewSegment?.value || '').trim()]
@@ -1027,15 +1077,8 @@ function handleInterviewSubmit(event) {
     : 'Queued';
   const scheduledId = String(interviewScheduledId?.value || '').trim();
 
-  if (!company && !contact) {
-    if (interviewLogSaveStatus) {
-      interviewLogSaveStatus.textContent = 'Add at least a company or contact before saving.';
-    }
-    interviewCompany?.focus();
-    return;
-  }
-
   const now = new Date().toISOString();
+  const captureNotes = notes || 'Incomplete capture. Details are N/A or not sure yet.';
   setInterviews([
     {
       id: generateId(),
@@ -1043,8 +1086,8 @@ function handleInterviewSubmit(event) {
       company,
       contact,
       status,
-      notes,
-      nextStep,
+      notes: captureNotes,
+      nextStep: nextStep || 'Not sure',
       createdAt: now,
       updatedAt: now,
       source: 'Market research desk',
@@ -1071,7 +1114,7 @@ function handleInterviewSubmit(event) {
   if (interviewLogSaveStatus) {
     interviewLogSaveStatus.textContent = scheduledId
       ? 'Saved the interview log and cleared the scheduled slot.'
-      : 'Saved the interview log. Keep the next step concrete.';
+      : 'Saved the capture. You can refine it later.';
   }
 }
 
@@ -1256,8 +1299,17 @@ function bindPlaybookActions() {
   });
 }
 
+function bindInterviewQuickCapture() {
+  document.querySelectorAll('[data-interview-quick]').forEach(button => {
+    button.addEventListener('click', () => {
+      applyQuickInterviewCapture(button.getAttribute('data-interview-quick') || '');
+    });
+  });
+}
+
 function init() {
   bindPlaybookActions();
+  bindInterviewQuickCapture();
   hydrateQueueFromLocal();
   hydrateInterviewsFromLocal();
   hydrateScheduledInterviewsFromLocal();

--- a/tests/sales-research.test.js
+++ b/tests/sales-research.test.js
@@ -29,6 +29,11 @@ test('sales research desk keeps current market signals tied to action', async ()
   assert.match(html, /Open calendar draft/);
   assert.match(html, /id="interviewLogForm"/);
   assert.match(html, /id="interviewScheduledId"/);
+  assert.match(html, /Not sure yet/);
+  assert.match(html, /data-interview-quick="follow-up"/);
+  assert.match(html, /data-interview-quick="not-sure"/);
+  assert.match(html, /Save capture/);
+  assert.match(html, /N\/A and not sure are valid/);
   assert.match(html, /id="interviewSprintStatus"/);
   assert.match(html, /First 3 today/);
   assert.match(html, /One real conversation per segment/);
@@ -37,4 +42,9 @@ test('sales research desk keeps current market signals tied to action', async ()
   assert.match(html, /https:\/\/www\.census\.gov\/econ\/bfs\/pdf\/historic\/bfs_2025m12\.pdf/);
   assert.match(html, /https:\/\/advocacy\.sba\.gov\/wp-content\/uploads\/2025\/06\/United_States_2025-State-Profile\.pdf/);
   assert.match(html, /https:\/\/www\.fedsmallbusiness\.org\/2026-report-on-employer-firms/);
+
+  const js = await readFile(new URL('../sales/research.js', import.meta.url), 'utf8');
+  assert.match(js, /function applyQuickInterviewCapture/);
+  assert.match(js, /Incomplete capture\. Details are N\/A or not sure yet\./);
+  assert.doesNotMatch(js, /Add at least a company or contact before saving/);
 });


### PR DESCRIPTION
## Summary
- Make Sales Research conversation capture less strict and more SPA-like
- Add Not sure / N/A affordances to segment, status, and short text fields
- Add quick capture chips for follow-up, not-sure, and not-a-fit notes
- Allow incomplete captures to save without requiring company/contact first

## Local validation
- node --test tests/sales-research.test.js tests/sales-research-scoreboard.test.js tests/sales-research-playbooks.test.js
- node --check sales/research.js
- git diff --check

## Note
The Playwright calendar E2E could not run in this fresh worktree because the local Playwright package is not installed here; CI should cover the browser path.