### PR TITLE
[codex] Use project stage questions on start router

### DIFF
--- a/docs/start-page-review.md
+++ b/docs/start-page-review.md
@@ -100,7 +100,7 @@ This can work for a personal portal, but for the marketing CTA `Start a project`
 oriented:
 
 - What are you trying to start?
-- What state is it in?
+- What stage is it in?
 - How much help do you want?
 
 ### 6. There Is Some Duplicate Ending Content
@@ -178,7 +178,7 @@ Replace the current questions with project-oriented prompts:
    - offer/business system
    - personal portal/reset
 
-2. What state is it in?
+2. What stage is it in?
    - just an idea
    - partly built
    - already live but messy
@@ -240,7 +240,7 @@ Verify:
 
 ### 4. Rework The Router Questions
 
-Make the router about the visitor's project state, not only emotional state.
+Make the router about the visitor's project stage, not only emotional state.
 
 Verify:
 

--- a/docs/start-page-validation-critique.md
+++ b/docs/start-page-validation-critique.md
@@ -96,7 +96,7 @@ Better router questions:
    - workflow, CRM, or automation
    - personal reset / operating system
 
-2. What state is it in?
+2. What stage is it in?
    - just an idea
    - partly built
    - already live but messy
@@ -153,7 +153,7 @@ The start page routes people, but it does not capture much evidence about what p
 If we are serious about validation, the page should eventually capture:
 
 - what the visitor is trying to build
-- what state it is in
+- what stage it is in
 - what blocked them
 - whether they want done-with-you help, done-for-you help, or tools
 - what price band feels reasonable
@@ -194,7 +194,7 @@ Validation check:
 
 ### Step 3: Rework The Router Into Project Questions
 
-Replace emotional/personal-state questions with project-state questions.
+Replace emotional/personal-state questions with project-stage questions.
 
 Validation check:
 

--- a/start/index.html
+++ b/start/index.html
@@ -216,92 +216,92 @@
           <span class="tag tag--dark">Need help choosing?</span>
           <h2 id="router-title">Answer three quick questions</h2>
           <p>
-            Keep this short on purpose. Pick the pain, the outcome you want, and the level of
-            support you are ready for.
+            Keep this short on purpose. Tell us what you are starting, what stage it is in,
+            and the kind of help you want.
           </p>
         </div>
 
         <div class="router-grid">
           <form class="router-form" id="startRouter">
             <fieldset class="question-card">
-              <legend>1. What hurts most right now?</legend>
-              <p>Pick the pain that is slowing you down the most.</p>
+              <legend>1. What are you trying to start?</legend>
+              <p>Pick the project type closest to what you need.</p>
               <div class="choice-grid">
                 <label class="choice">
-                  <input type="radio" name="pain" value="scattered" checked />
+                  <input type="radio" name="project" value="personal" checked />
                   <span class="choice__body">
-                    <strong>I feel scattered</strong>
-                    <span>I need a reset and one clear next step.</span>
+                    <strong>Personal reset</strong>
+                    <span>I need direction, organization, or a calmer operating system.</span>
                   </span>
                 </label>
                 <label class="choice">
-                  <input type="radio" name="pain" value="alone" />
+                  <input type="radio" name="project" value="website" />
                   <span class="choice__body">
-                    <strong>I feel alone</strong>
-                    <span>I do better when people are around me.</span>
+                    <strong>Website or page</strong>
+                    <span>I need a public page, landing page, or web presence.</span>
                   </span>
                 </label>
                 <label class="choice">
-                  <input type="radio" name="pain" value="income" />
+                  <input type="radio" name="project" value="workflow" />
                   <span class="choice__body">
-                    <strong>I need income</strong>
-                    <span>I want help launching something that can make money.</span>
+                    <strong>Workflow or app</strong>
+                    <span>I need a CRM, automation, checkout, tool, or small app.</span>
                   </span>
                 </label>
               </div>
             </fieldset>
 
             <fieldset class="question-card">
-              <legend>2. What do you want next?</legend>
-              <p>Choose the outcome that would help most this week.</p>
+              <legend>2. What stage is it in?</legend>
+              <p>Choose the stage that best describes the project today.</p>
               <div class="choice-grid">
                 <label class="choice">
-                  <input type="radio" name="goal" value="clarity" checked />
+                  <input type="radio" name="stage" value="idea" checked />
                   <span class="choice__body">
-                    <strong>A clear next step</strong>
-                    <span>I need clarity more than more tools.</span>
+                    <strong>Just an idea</strong>
+                    <span>I need a first pass and one clear next step.</span>
                   </span>
                 </label>
                 <label class="choice">
-                  <input type="radio" name="goal" value="community" />
+                  <input type="radio" name="stage" value="partly-built" />
                   <span class="choice__body">
-                    <strong>A small group</strong>
-                    <span>I want accountability and support.</span>
+                    <strong>Partly built</strong>
+                    <span>Something exists, but it needs structure or momentum.</span>
                   </span>
                 </label>
                 <label class="choice">
-                  <input type="radio" name="goal" value="launch" />
+                  <input type="radio" name="stage" value="stuck" />
                   <span class="choice__body">
-                    <strong>A launch plan</strong>
-                    <span>I want to ship an offer, page, or project.</span>
+                    <strong>Stuck and needs rescue</strong>
+                    <span>It is blocked, messy, or live but not working cleanly.</span>
                   </span>
                 </label>
               </div>
             </fieldset>
 
             <fieldset class="question-card">
-              <legend>3. How much help do you want?</legend>
+              <legend>3. What kind of help do you want?</legend>
               <p>Pick the support level that feels realistic right now.</p>
               <div class="choice-grid">
                 <label class="choice">
                   <input type="radio" name="support" value="free" checked />
                   <span class="choice__body">
-                    <strong>Free</strong>
+                    <strong>Show me the next step</strong>
                     <span>I want to get moving before I pay.</span>
                   </span>
                 </label>
                 <label class="choice">
                   <input type="radio" name="support" value="community" />
                   <span class="choice__body">
-                    <strong>Community</strong>
-                    <span>I want people and light support around me.</span>
+                    <strong>Light support</strong>
+                    <span>I want accountability and a gentle support lane.</span>
                   </span>
                 </label>
                 <label class="choice">
                   <input type="radio" name="support" value="direct" />
                   <span class="choice__body">
-                    <strong>Direct help</strong>
-                    <span>I want paid support that moves faster.</span>
+                    <strong>Help me build it</strong>
+                    <span>I want direct paid support that moves faster.</span>
                   </span>
                 </label>
               </div>

--- a/start/router.js
+++ b/start/router.js
@@ -69,15 +69,23 @@ const ROUTES = {
 };
 
 function getRouteKey(answers) {
-  if (answers.support === 'direct' && answers.goal === 'launch' && answers.pain === 'income') {
+  if (answers.support === 'direct' && answers.project === 'workflow') {
     return 'builder';
   }
 
-  if (answers.support === 'direct' && answers.goal === 'launch') {
+  if (answers.support === 'direct' && answers.stage === 'stuck') {
+    return 'builder';
+  }
+
+  if (answers.support === 'direct' && answers.project === 'website') {
     return 'founder';
   }
 
-  if (answers.goal === 'community' || answers.pain === 'alone' || answers.support === 'community') {
+  if (answers.support === 'direct' && answers.stage === 'partly-built') {
+    return 'founder';
+  }
+
+  if (answers.support === 'community') {
     return 'cell';
   }
 
@@ -120,8 +128,8 @@ function renderRecommendation(root, recommendation) {
 function readAnswers(form) {
   const data = new FormData(form);
   return {
-    pain: data.get('pain') || 'scattered',
-    goal: data.get('goal') || 'clarity',
+    project: data.get('project') || 'personal',
+    stage: data.get('stage') || 'idea',
     support: data.get('support') || 'free',
   };
 }

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -111,9 +111,13 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Continue with \$50/);
     assert.match(html, /Continue with \$200/);
     assert.match(html, /Need help choosing\?/);
-    assert.match(html, /What hurts most right now\?/);
-    assert.match(html, /What do you want next\?/);
-    assert.match(html, /How much help do you want\?/);
+    assert.match(html, /What are you trying to start\?/);
+    assert.match(html, /What stage is it in\?/);
+    assert.match(html, /What kind of help do you want\?/);
+    assert.match(html, /Just an idea/);
+    assert.match(html, /Partly built/);
+    assert.match(html, /Stuck and needs rescue/);
+    assert.doesNotMatch(html, /What state is it in\?/);
     assert.match(html, /Best next move/);
     assert.match(html, /Open sign-in/);
     assert.match(html, /Open billing/);

--- a/tests/start-router.test.js
+++ b/tests/start-router.test.js
@@ -4,47 +4,58 @@ import { getRouteKey, getRecommendation } from '../start/router.js';
 
 test('start router sends clarity-first answers to Life', () => {
   const key = getRouteKey({
-    pain: 'scattered',
-    goal: 'clarity',
+    project: 'personal',
+    stage: 'idea',
     support: 'free',
   });
 
   assert.equal(key, 'life');
   assert.equal(
-    getRecommendation({ pain: 'scattered', goal: 'clarity', support: 'free' }).title,
+    getRecommendation({ project: 'personal', stage: 'idea', support: 'free' }).title,
     'Start free in the portal'
   );
   assert.equal(
-    getRecommendation({ pain: 'scattered', goal: 'clarity', support: 'free' }).primaryLabel,
+    getRecommendation({ project: 'personal', stage: 'idea', support: 'free' }).primaryLabel,
     'Start free'
   );
 });
 
 test('start router sends accountability answers to Cell', () => {
   const key = getRouteKey({
-    pain: 'alone',
-    goal: 'community',
+    project: 'personal',
+    stage: 'idea',
     support: 'community',
   });
 
   assert.equal(key, 'cell');
   assert.match(
-    getRecommendation({ pain: 'alone', goal: 'community', support: 'community' }).plan,
+    getRecommendation({ project: 'personal', stage: 'idea', support: 'community' }).plan,
     /Family & Friends \$5/
   );
   assert.equal(
-    getRecommendation({ pain: 'alone', goal: 'community', support: 'community' }).primaryLabel,
+    getRecommendation({ project: 'personal', stage: 'idea', support: 'community' }).primaryLabel,
     'Continue with $5 plan'
   );
 });
 
-test('start router sends launch answers to Founder or Builder based on income pressure', () => {
+test('start router sends direct website or partly built projects to Founder', () => {
   assert.equal(
-    getRouteKey({ pain: 'scattered', goal: 'launch', support: 'direct' }),
+    getRouteKey({ project: 'website', stage: 'idea', support: 'direct' }),
     'founder'
   );
   assert.equal(
-    getRouteKey({ pain: 'income', goal: 'launch', support: 'direct' }),
+    getRouteKey({ project: 'personal', stage: 'partly-built', support: 'direct' }),
+    'founder'
+  );
+});
+
+test('start router sends direct workflow or rescue projects to Builder', () => {
+  assert.equal(
+    getRouteKey({ project: 'workflow', stage: 'idea', support: 'direct' }),
+    'builder'
+  );
+  assert.equal(
+    getRouteKey({ project: 'website', stage: 'stuck', support: 'direct' }),
     'builder'
   );
 });


### PR DESCRIPTION
## Summary
- Rework the /start router from personal-state questions to project-oriented questions
- Use `stage` wording instead of ambiguous `state` wording
- Route direct workflow/rescue work to Builder and direct website/partly-built work to Founder
- Update start page critique docs and focused tests

## Validation
- node --test tests/customer-journey-pages.test.js tests/start-router.test.js
- git diff --check