### PR TITLE
[codex] Add manifestation practice app card

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,6 +435,11 @@
             <span class="app-card__title">Master Key Room</span>
             <span class="app-card__meta">Practice a grounded 24-step attention, reflection, and action course.</span>
           </a>
+          <a href="meditation/affirmations.html#manifestationHeading" class="app-card" data-app-keywords="manifestation woop mental contrasting affirmation vision wish outcome obstacle if then plan intention practice">
+            <span class="app-card__icon" aria-hidden="true">WOOP</span>
+            <span class="app-card__title">Manifestation Practice</span>
+            <span class="app-card__meta">Turn a vision into a wish, outcome, obstacle, and if/then plan you can act on.</span>
+          </a>
           <a href="meditation/#meditationFlow" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🧘</span>
             <span class="app-card__title">Meditation</span>

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -32,6 +32,17 @@ test('homepage app search can find CRM by CRM keywords', async () => {
   assert.match(html, /keywordIncludesQuery/);
 });
 
+test('homepage app search can find the manifestation practice', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(
+    html,
+    /href="meditation\/affirmations\.html#manifestationHeading" class="app-card" data-app-keywords="[^"]*\bmanifestation\b[^"]*"/
+  );
+  assert.match(html, /<span class="app-card__title">Manifestation Practice<\/span>/);
+  assert.match(html, /wish, outcome, obstacle, and if\/then plan/);
+});
+
 test('homepage top navigation keeps Games one click away', async () => {
   const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
 


### PR DESCRIPTION
## Summary
- Adds a dedicated Manifestation Practice card to the portal home app dock.
- Links directly to `meditation/affirmations.html#manifestationHeading` so users land on the grounded manifestation exercise.
- Adds manifestation/WOOP/search keywords so searching the home page for `manifestation` finds the card.
- Extends homepage search regression coverage for this card.

## Validation
- `node --test tests/homepage-search-ux.test.js`
- `git diff --check`