### PR TITLE
Redesign Zero-G Ski Range as FPS trainer

### DIFF
--- a/games.html
+++ b/games.html
@@ -184,7 +184,7 @@ h1 {
       </svg>
     </span>
     <span class="game-title">Zero-G Ski Range</span>
-    <p class="game-blurb">Carve fast lines through a floaty sci-fi training range.</p>
+    <p class="game-blurb">First-person ski-shooter drills with jetpack momentum and target drones.</p>
   </a>
   <a class="game-card stellar" href="stellar-flight.html">
     <span class="game-icon" aria-hidden="true">

--- a/tests/zero-g-ski-range.test.js
+++ b/tests/zero-g-ski-range.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('zero-g ski range exposes first-person ski-shooter mechanics', async () => {
+  const html = await readFile(new URL('../tribes-flight.html', import.meta.url), 'utf8');
+
+  assert.match(html, /<title>3DVR - Zero-G Ski Range<\/title>/);
+  assert.match(html, /First-person ski-shooter range\./);
+  assert.match(html, /requestPointerLock/);
+  assert.match(html, /const SKI_ACCEL = 90;/);
+  assert.match(html, /const JETPACK_FORCE = 62;/);
+  assert.match(html, /Disc Launcher/);
+  assert.match(html, /Trace Repeater/);
+  assert.match(html, /data-action="ski"/);
+  assert.match(html, /data-action="jet"/);
+  assert.match(html, /function drawWeaponView\(\)/);
+  assert.match(html, /function drawTargets\(\)/);
+});
+

--- a/tribes-flight.html
+++ b/tribes-flight.html
@@ -4,27 +4,45 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="portal:issue-launcher" content="off">
-  <title>3DVR - Jetpack Ski Prototype</title>
+  <title>3DVR - Zero-G Ski Range</title>
   <link rel="stylesheet" href="styles/global.css">
   <style>
+  :root {
+    color-scheme: dark;
+    --safe-top: calc(env(safe-area-inset-top, 0px) + 0.9rem);
+    --safe-bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem);
+    --safe-left: calc(env(safe-area-inset-left, 0px) + 1rem);
+    --safe-right: calc(env(safe-area-inset-right, 0px) + 1rem);
+    --glass: rgba(7, 13, 28, 0.72);
+    --glass-strong: rgba(7, 13, 28, 0.86);
+    --line: rgba(132, 204, 255, 0.26);
+    --text: #eff6ff;
+    --muted: #a8bad3;
+    --cyan: #67e8f9;
+    --gold: #f8d47a;
+    --rose: #fb7185;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    height: 100%;
+  }
+
   body {
     margin: 0;
     overflow: hidden;
-    font-family: 'Poppins', sans-serif;
-    background: radial-gradient(circle at 18% -12%, #182848 0%, #090a0f 55%, #030712 100%);
-    color: #f1f5f9;
-  }
-
-  :root {
-    --safe-top: calc(env(safe-area-inset-top, 0px) + 1rem);
-    --safe-bottom: calc(env(safe-area-inset-bottom, 0px) + 1.4rem);
-    --safe-left: calc(env(safe-area-inset-left, 0px) + 1.5rem);
-    --safe-right: calc(env(safe-area-inset-right, 0px) + 1.5rem);
-    --control-safe-zone: 0px;
-  }
-
-  body.touch-enabled {
-    --control-safe-zone: 12rem;
+    background:
+      radial-gradient(circle at 18% 8%, rgba(103, 232, 249, 0.22), transparent 26rem),
+      radial-gradient(circle at 84% 12%, rgba(96, 165, 250, 0.18), transparent 30rem),
+      linear-gradient(180deg, #050816 0%, #08101f 58%, #020617 100%);
+    color: var(--text);
+    font-family: "Poppins", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    touch-action: none;
+    user-select: none;
   }
 
   canvas {
@@ -33,465 +51,485 @@
     display: block;
     width: 100vw;
     height: 100vh;
+    background: #020617;
+    cursor: crosshair;
     touch-action: none;
-    user-select: none;
     z-index: 1;
   }
 
-  .overlay {
+  button,
+  a {
+    font: inherit;
+  }
+
+  .topbar {
     position: fixed;
-    top: calc(6.2rem + env(safe-area-inset-top, 0px));
-    left: 50%;
-    transform: translateX(-50%);
-    width: min(420px, calc(100% - 2rem));
-    background: rgba(15, 23, 42, 0.72);
-    border-radius: 18px;
-    border: 1px solid rgba(148, 163, 184, 0.45);
-    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.55);
-    padding: 1.5rem 1.5rem 1.25rem;
-    color: rgba(226, 232, 240, 0.9);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    z-index: 10;
-    transition: opacity 0.35s ease, transform 0.35s ease;
-  }
-
-  .overlay h1 {
-    margin: 0;
-    font-size: 1.75rem;
-    letter-spacing: 0.04em;
-    color: #f8fafc;
-  }
-
-  .overlay p {
-    margin: 0.75rem 0 0;
-    font-size: 0.95rem;
-    line-height: 1.6;
-  }
-
-  .overlay .hint {
-    margin-top: 1rem;
-    padding: 0.75rem 0.9rem;
-    background: rgba(56, 189, 248, 0.12);
-    border-radius: 12px;
-    border: 1px solid rgba(96, 165, 250, 0.35);
-    color: rgba(224, 242, 254, 0.88);
-    font-size: 0.9rem;
-  }
-
-  .control-list {
-    margin: 1.1rem 0 0;
-    padding-left: 1.1rem;
-    color: rgba(226, 232, 240, 0.82);
-    display: grid;
-    gap: 0.35rem;
-    font-size: 0.92rem;
-  }
-
-  .overlay-links {
-    margin-top: 1.25rem;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .overlay-links a {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.4rem 0.85rem;
-    border-radius: 999px;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    background: rgba(30, 41, 59, 0.7);
-    color: rgba(226, 232, 240, 0.92);
-    text-decoration: none;
-    font-size: 0.85rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-  }
-
-  .overlay-links a:hover,
-  .overlay-links a:focus-visible {
-    border-color: rgba(96, 165, 250, 0.6);
-    background: rgba(59, 130, 246, 0.25);
-    color: #e0f2fe;
-    outline: none;
-  }
-
-  .overlay-close {
-    position: absolute;
-    top: 0.8rem;
-    right: 0.9rem;
-    background: rgba(30, 41, 59, 0.65);
-    border: 1px solid rgba(148, 163, 184, 0.45);
-    color: rgba(226, 232, 240, 0.9);
-    border-radius: 999px;
-    padding: 0.25rem 0.75rem;
-    font-size: 0.8rem;
-    letter-spacing: 0.12em;
-    cursor: pointer;
-    text-transform: uppercase;
-    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-  }
-
-  .overlay-close:focus-visible,
-  .overlay-close:hover {
-    background: rgba(59, 130, 246, 0.25);
-    border-color: rgba(96, 165, 250, 0.55);
-    color: #e0f2fe;
-    outline: none;
-  }
-
-  .overlay-hidden {
-    opacity: 0;
-    transform: translate(-50%, -18px);
-    pointer-events: none;
-  }
-
-  .overlay-hidden .hint,
-  .overlay-hidden p,
-  .overlay-hidden h1 {
-    pointer-events: none;
-  }
-
-  .overlay-toggle {
-    position: fixed;
-    top: calc(6rem + env(safe-area-inset-top, 0px));
-    left: 50%;
-    transform: translateX(-50%);
-    padding: 0.55rem 1.15rem;
-    border-radius: 999px;
-    border: 1px solid rgba(96, 165, 250, 0.5);
-    background: rgba(15, 23, 42, 0.72);
-    color: rgba(191, 219, 254, 0.95);
-    font-size: 0.82rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.5);
-    cursor: pointer;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.3s ease, transform 0.3s ease;
-    z-index: 9;
-  }
-
-  .overlay-toggle:focus-visible,
-  .overlay-toggle:hover {
-    background: rgba(30, 41, 59, 0.8);
-    color: #e0f2fe;
-    border-color: rgba(96, 165, 250, 0.75);
-    outline: none;
-  }
-
-  .overlay-toggle-visible {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateX(-50%) translateY(0);
-  }
-
-  .status {
-    position: fixed;
-    top: calc(var(--safe-top) + 0.5rem);
+    top: var(--safe-top);
+    left: var(--safe-left);
     right: var(--safe-right);
-    padding: 0.85rem 1.2rem;
-    background: rgba(8, 25, 44, 0.7);
-    border-radius: 14px;
-    border: 1px solid rgba(94, 234, 212, 0.35);
-    font-size: 0.85rem;
-    letter-spacing: 0.08em;
-    color: rgba(165, 243, 252, 0.92);
-    box-shadow: 0 18px 40px rgba(8, 145, 178, 0.35);
-    text-transform: uppercase;
-    display: inline-flex;
-    flex-direction: column;
-    gap: 0.35rem;
-    z-index: 11;
-  }
-
-  .status span:last-child {
-    font-weight: 600;
-    font-size: 1rem;
-    letter-spacing: 0.02em;
-    color: #f0fdfc;
-  }
-
-  .score-panel {
-    position: fixed;
-    top: calc(var(--safe-top) + 4.3rem);
-    right: var(--safe-right);
+    z-index: 12;
     display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-    padding: 0.95rem 1.15rem;
-    background: rgba(8, 25, 44, 0.74);
-    border-radius: 16px;
-    border: 1px solid rgba(94, 234, 212, 0.38);
-    box-shadow: 0 18px 42px rgba(8, 145, 178, 0.38);
-    color: rgba(191, 219, 254, 0.92);
-    z-index: 11;
-    min-width: 206px;
-  }
-
-  .score-panel-title {
-    font-size: 0.72rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: rgba(165, 243, 252, 0.88);
-  }
-
-  .score-panel-row {
-    display: flex;
+    align-items: flex-start;
     justify-content: space-between;
-    align-items: baseline;
-    gap: 1rem;
+    gap: 0.75rem;
+    pointer-events: none;
   }
 
-  .score-row-label {
-    font-size: 0.72rem;
+  .hud-card,
+  .range-panel,
+  .guide,
+  .touch-controls,
+  .objective-toast {
+    border: 1px solid var(--line);
+    background: var(--glass);
+    box-shadow: 0 18px 46px rgba(0, 0, 0, 0.34);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+  }
+
+  .hud-card {
+    width: min(260px, 42vw);
+    border-radius: 18px;
+    padding: 0.85rem;
+    pointer-events: auto;
+  }
+
+  .hud-label {
+    display: block;
+    color: rgba(199, 210, 254, 0.84);
+    font-size: 0.66rem;
+    font-weight: 800;
     letter-spacing: 0.16em;
     text-transform: uppercase;
-    color: rgba(148, 163, 184, 0.78);
   }
 
-  .score-row-value {
-    font-size: 0.95rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    color: rgba(224, 242, 254, 0.95);
+  .hud-title {
+    margin-top: 0.22rem;
+    color: #ffffff;
+    font-size: clamp(1rem, 2.7vw, 1.35rem);
+    font-weight: 850;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
   }
 
-  .bar {
-    height: 10px;
-    border-radius: 999px;
-    background: rgba(148, 163, 184, 0.25);
+  .hud-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.55rem;
+    margin-top: 0.8rem;
+  }
+
+  .metric {
+    min-width: 0;
+  }
+
+  .metric span:first-child {
+    display: block;
+    color: var(--muted);
+    font-size: 0.65rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .metric span:last-child {
+    display: block;
+    margin-top: 0.1rem;
+    color: #f8fbff;
+    font-size: 1rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+  }
+
+  .meter {
+    height: 0.48rem;
     overflow: hidden;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.22);
   }
 
-  .bar span {
+  .meter span {
     display: block;
     height: 100%;
     border-radius: inherit;
-    transition: width 0.2s ease;
+    background: linear-gradient(90deg, #22d3ee, #60a5fa, #f8d47a);
+    transition: width 0.16s ease;
+  }
+
+  .range-panel {
+    width: min(230px, 36vw);
+    border-radius: 18px;
+    padding: 0.85rem;
+    pointer-events: auto;
+  }
+
+  .range-panel h2 {
+    margin: 0;
+    color: #ffffff;
+    font-size: 0.84rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .range-panel p {
+    margin: 0.45rem 0 0;
+    color: var(--muted);
+    font-size: 0.76rem;
+    line-height: 1.45;
+  }
+
+  .weapon-strip {
+    display: flex;
+    gap: 0.4rem;
+    margin-top: 0.75rem;
+  }
+
+  .weapon-pill {
+    flex: 1;
+    min-width: 0;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 999px;
+    padding: 0.32rem 0.45rem;
+    color: rgba(226, 232, 240, 0.78);
+    font-size: 0.62rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  .weapon-pill.is-active {
+    border-color: rgba(103, 232, 249, 0.7);
+    background: rgba(34, 211, 238, 0.16);
+    color: #e0faff;
+  }
+
+  .reticle {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    z-index: 8;
+    width: 58px;
+    height: 58px;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+  }
+
+  .reticle::before,
+  .reticle::after {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    content: "";
+    transform: translate(-50%, -50%);
+  }
+
+  .reticle::before {
+    width: 34px;
+    height: 34px;
+    border: 1px solid rgba(239, 246, 255, 0.92);
+    border-radius: 50%;
+    box-shadow: 0 0 18px rgba(103, 232, 249, 0.38);
+  }
+
+  .reticle::after {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: #f8fafc;
+  }
+
+  .reticle-line {
+    position: absolute;
+    background: rgba(239, 246, 255, 0.78);
+    box-shadow: 0 0 10px rgba(103, 232, 249, 0.45);
+  }
+
+  .reticle-line.h-left,
+  .reticle-line.h-right {
+    top: 50%;
+    width: 13px;
+    height: 1px;
+  }
+
+  .reticle-line.h-left {
+    left: 0;
+  }
+
+  .reticle-line.h-right {
+    right: 0;
+  }
+
+  .reticle-line.v-top,
+  .reticle-line.v-bottom {
+    left: 50%;
+    width: 1px;
+    height: 13px;
+  }
+
+  .reticle-line.v-top {
+    top: 0;
+  }
+
+  .reticle-line.v-bottom {
+    bottom: 0;
+  }
+
+  .guide {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    z-index: 20;
+    width: min(560px, calc(100vw - 1.5rem));
+    max-height: min(720px, calc(100vh - 2rem));
+    overflow: auto;
+    padding: clamp(1rem, 4vw, 1.45rem);
+    border-radius: 24px;
+    color: rgba(226, 232, 240, 0.9);
+    transform: translate(-50%, -50%);
+    transition: opacity 0.24s ease, transform 0.24s ease;
+  }
+
+  .guide.is-hidden {
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, calc(-50% - 14px));
+  }
+
+  .guide h1 {
+    margin: 0;
+    color: #ffffff;
+    font-size: clamp(1.8rem, 7vw, 3.4rem);
+    line-height: 0.96;
+    letter-spacing: -0.05em;
+  }
+
+  .guide p {
+    margin: 0.8rem 0 0;
+    color: var(--muted);
+    line-height: 1.55;
+  }
+
+  .guide strong {
+    color: #f8fbff;
+  }
+
+  .guide-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-top: 1rem;
+  }
+
+  .guide-actions a,
+  .guide-actions button,
+  .guide-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 42px;
+    border: 1px solid rgba(148, 163, 184, 0.32);
+    border-radius: 999px;
+    padding: 0 0.9rem;
+    background: rgba(15, 23, 42, 0.8);
+    color: #eff6ff;
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  .guide-actions button.primary {
+    border-color: transparent;
+    background: linear-gradient(135deg, #67e8f9, #f8d47a);
+    color: #05101f;
+  }
+
+  .guide-actions a:focus-visible,
+  .guide-actions button:focus-visible,
+  .guide-toggle:focus-visible {
+    outline: 2px solid rgba(103, 232, 249, 0.82);
+    outline-offset: 3px;
+  }
+
+  .control-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.55rem;
+    margin: 1rem 0 0;
+  }
+
+  .control-item {
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 14px;
+    padding: 0.65rem;
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--muted);
+    font-size: 0.78rem;
+    line-height: 1.4;
+  }
+
+  .control-item b {
+    display: block;
+    margin-bottom: 0.2rem;
+    color: #ffffff;
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .guide-toggle {
+    position: fixed;
+    right: var(--safe-right);
+    bottom: var(--safe-bottom);
+    z-index: 13;
+    background: var(--glass-strong);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+
+  .guide-toggle.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .objective-toast {
+    position: fixed;
+    left: 50%;
+    bottom: calc(var(--safe-bottom) + 4rem);
+    z-index: 11;
+    width: min(460px, calc(100vw - 1.5rem));
+    border-radius: 18px;
+    padding: 0.85rem 1rem;
+    color: var(--muted);
+    font-size: 0.82rem;
+    line-height: 1.45;
+    text-align: center;
+    transform: translateX(-50%);
+  }
+
+  .objective-toast strong {
+    color: #ffffff;
   }
 
   .touch-controls {
     position: fixed;
-    left: 50%;
-    bottom: calc(var(--safe-bottom) + 0.9rem);
-    transform: translateX(-50%);
-    display: flex;
-    flex-wrap: wrap;
-    width: min(520px, calc(100% - 1.5rem));
-    padding: 0.65rem 0.85rem;
-    background: rgba(15, 23, 42, 0.82);
-    border-radius: 999px;
-    border: 1px solid rgba(94, 234, 212, 0.35);
-    box-shadow: 0 24px 60px rgba(8, 145, 178, 0.35);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    column-gap: 0.75rem;
-    row-gap: 0.5rem;
-    align-items: center;
-    justify-content: center;
-    z-index: 10;
-  }
-
-  .touch-controls.is-hidden {
+    left: var(--safe-left);
+    right: var(--safe-right);
+    bottom: var(--safe-bottom);
+    z-index: 12;
     display: none;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 0.45rem;
+    padding: 0.5rem;
+    border-radius: 18px;
   }
 
-  .touch-controls .control-cluster {
-    display: flex;
-    gap: 0.5rem;
-  }
-
-  .touch-controls .control-cluster.primary-cluster {
-    flex-basis: 100%;
-    justify-content: center;
+  .touch-controls.is-visible {
+    display: grid;
   }
 
   .touch-controls button {
-    appearance: none;
-    border: 1px solid rgba(148, 163, 184, 0.45);
-    background: rgba(30, 41, 59, 0.75);
-    color: #f8fafc;
-    border-radius: 999px;
-    padding: 0.55rem 0.85rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    min-width: 54px;
-    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    min-height: 44px;
+    border: 1px solid rgba(148, 163, 184, 0.32);
+    border-radius: 13px;
+    background: rgba(15, 23, 42, 0.74);
+    color: #eff6ff;
+    font-size: 0.72rem;
+    font-weight: 850;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
     touch-action: none;
-    user-select: none;
+  }
+
+  .touch-controls button.is-active {
+    border-color: rgba(103, 232, 249, 0.76);
+    background: rgba(34, 211, 238, 0.22);
   }
 
   .touch-controls button.primary {
-    background: linear-gradient(135deg, #60a5fa, #22d3ee);
-    border-color: rgba(34, 211, 238, 0.9);
-    color: #020617;
+    grid-column: span 2;
+    border-color: rgba(248, 212, 122, 0.72);
+    background: linear-gradient(135deg, rgba(248, 212, 122, 0.88), rgba(103, 232, 249, 0.82));
+    color: #05101f;
   }
 
-  .touch-controls button.active {
-    border-color: rgba(94, 234, 212, 0.75);
-    background: rgba(45, 212, 191, 0.25);
-  }
-
-  .touch-controls button:active {
-    transform: scale(0.96);
-  }
-
-  @media (max-width: 720px) {
-    .overlay {
-      top: calc(5.2rem + env(safe-area-inset-top, 0px));
-      max-height: 44vh;
-      overflow: auto;
+  @media (max-width: 760px) {
+    .topbar {
+      align-items: stretch;
     }
 
-    .status {
-      right: calc(var(--safe-right) - 0.5rem);
+    .hud-card,
+    .range-panel {
+      width: min(50vw - 0.6rem, 230px);
+      padding: 0.68rem;
+      border-radius: 15px;
     }
 
-    .score-panel {
-      right: calc(var(--safe-right) - 0.5rem);
-      top: calc(var(--safe-top) + 4rem);
+    .range-panel p,
+    .weapon-strip {
+      display: none;
+    }
+
+    .hud-grid {
+      gap: 0.4rem;
+      margin-top: 0.55rem;
+    }
+
+    .metric span:first-child {
+      font-size: 0.54rem;
+    }
+
+    .metric span:last-child {
+      font-size: 0.78rem;
+    }
+
+    .control-list {
+      grid-template-columns: 1fr;
+    }
+
+    .objective-toast {
+      bottom: calc(var(--safe-bottom) + 4.5rem);
+      font-size: 0.72rem;
     }
   }
 
   @media (max-width: 520px) {
-    body.touch-enabled {
-      --control-safe-zone: 8rem;
+    .guide {
+      top: 44%;
+      max-height: 70vh;
     }
 
-    .overlay {
-      width: calc(100% - 1.4rem);
-      top: calc(4.4rem + env(safe-area-inset-top, 0px));
-      padding: 0.9rem;
-      max-height: 36vh;
-    }
-
-    .overlay h1 {
-      font-size: 1.25rem;
-    }
-
-    .overlay p,
-    .overlay .hint,
+    .guide p,
     .control-list {
-      font-size: 0.78rem;
-      line-height: 1.45;
+      font-size: 0.76rem;
     }
 
-    .overlay .hint,
-    .control-list {
-      display: none;
+    .topbar {
+      gap: 0.45rem;
     }
 
-    .overlay-links {
-      margin-top: 0.8rem;
-      gap: 0.4rem;
+    .hud-label,
+    .range-panel h2 {
+      font-size: 0.55rem;
     }
 
-    .overlay-links a {
-      padding: 0.34rem 0.58rem;
-      font-size: 0.66rem;
-      letter-spacing: 0.04em;
+    .hud-title {
+      font-size: 0.86rem;
     }
 
-    .overlay-toggle {
-      top: auto;
-      bottom: calc(var(--safe-bottom) + var(--control-safe-zone) + 0.7rem);
-      width: min(190px, calc(100% - 1.4rem));
-      padding: 0.52rem 0.95rem;
-      font-size: 0.72rem;
-      letter-spacing: 0.08em;
-    }
-
-    .status {
-      top: calc(env(safe-area-inset-top, 0px) + 0.65rem);
-      right: calc(env(safe-area-inset-right, 0px) + 0.65rem);
-      padding: 0.48rem 0.62rem;
-      border-radius: 12px;
-      gap: 0.1rem;
-      font-size: 0.58rem;
-      letter-spacing: 0.1em;
-      box-shadow: 0 10px 24px rgba(8, 145, 178, 0.25);
-    }
-
-    .status span:last-child {
-      font-size: 0.78rem;
-    }
-
-    .score-panel {
-      top: calc(env(safe-area-inset-top, 0px) + 0.65rem);
-      left: calc(env(safe-area-inset-left, 0px) + 0.65rem);
-      right: auto;
-      min-width: auto;
-      width: min(170px, calc(58vw - 0.75rem));
-      padding: 0.55rem 0.65rem;
-      gap: 0.3rem;
-      border-radius: 12px;
-      box-shadow: 0 10px 24px rgba(8, 145, 178, 0.25);
-    }
-
-    .score-panel-title,
-    .score-row-label {
-      font-size: 0.56rem;
-      letter-spacing: 0.1em;
-    }
-
-    .score-row-value {
-      font-size: 0.74rem;
-    }
-
-    .bar {
-      height: 6px;
-    }
-
-    .score-panel-target-row {
-      display: none;
-    }
-  }
-
-  @media (max-width: 420px) {
     .touch-controls {
-      display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      width: calc(100% - 4.9rem);
-      left: calc(env(safe-area-inset-left, 0px) + 0.75rem);
-      right: auto;
-      bottom: calc(env(safe-area-inset-bottom, 0px) + 0.75rem);
-      transform: none;
-      padding: 0;
-      background: transparent;
-      border: 0;
-      box-shadow: none;
-      backdrop-filter: none;
-      -webkit-backdrop-filter: none;
-      column-gap: 0.4rem;
-      row-gap: 0.4rem;
-    }
-
-    .touch-controls .control-cluster {
-      display: contents;
-    }
-
-    .touch-controls .control-cluster.primary-cluster {
-      display: contents;
-    }
-
-    .touch-controls button {
-      min-width: 0;
-      min-height: 38px;
-      padding: 0.45rem 0.32rem;
-      border-radius: 11px;
-      font-size: 0.66rem;
-      letter-spacing: 0.02em;
-      background: rgba(15, 23, 42, 0.72);
-      box-shadow: 0 10px 18px rgba(13, 148, 136, 0.22);
     }
 
     .touch-controls button.primary {
-      grid-column: span 2;
+      grid-column: span 1;
+    }
+
+    .objective-toast {
+      display: none;
     }
   }
   </style>
@@ -499,858 +537,1016 @@
   <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="theme-dark">
-  <canvas id="game" width="960" height="540" role="img" aria-label="Jetpack skiing playground"></canvas>
-  <div class="overlay" id="infoOverlay" aria-labelledby="rangeTitle" aria-hidden="false">
-    <button class="overlay-close" type="button" id="overlayClose">Close</button>
-    <h1 id="rangeTitle">Zero-G Ski Range</h1>
+  <canvas id="game" role="img" aria-label="First-person zero-g ski shooter training range"></canvas>
+
+  <div class="topbar" aria-hidden="false">
+    <section class="hud-card" role="status" aria-live="polite" aria-atomic="true">
+      <span class="hud-label">Zero-G Ski Range</span>
+      <div class="hud-title" id="weaponName">Disc Launcher</div>
+      <div class="hud-grid">
+        <div class="metric">
+          <span>Speed</span>
+          <span><span id="speedValue">0</span> m/s</span>
+        </div>
+        <div class="metric">
+          <span>Altitude</span>
+          <span><span id="altitudeValue">0</span> m</span>
+        </div>
+        <div class="metric">
+          <span>Score</span>
+          <span id="scoreValue">0</span>
+        </div>
+        <div class="metric">
+          <span>Combo</span>
+          <span id="comboValue">x1</span>
+        </div>
+      </div>
+      <div class="meter" aria-label="Jetpack energy">
+        <span id="energyBar" style="width: 100%;"></span>
+      </div>
+    </section>
+
+    <aside class="range-panel" aria-label="Range objective">
+      <h2>Training Run</h2>
+      <p id="objectiveText">Hold Shift to ski, use slope speed, then pop the drones before the gate timer expires.</p>
+      <div class="weapon-strip" aria-label="Weapon status">
+        <span class="weapon-pill is-active" id="weaponPill0">1 Disc</span>
+        <span class="weapon-pill" id="weaponPill1">2 Trace</span>
+      </div>
+    </aside>
+  </div>
+
+  <div class="reticle" aria-hidden="true">
+    <span class="reticle-line h-left"></span>
+    <span class="reticle-line h-right"></span>
+    <span class="reticle-line v-top"></span>
+    <span class="reticle-line v-bottom"></span>
+  </div>
+
+  <section class="guide" id="guidePanel" aria-labelledby="guideTitle">
+    <h1 id="guideTitle">First-person ski-shooter range.</h1>
     <p>
-      Carve the holographic bowl, feather the jetpack, and chase drifting targets with the spinfusor or chaingun.
-      Build speed on the slope, then boost into the next line.
+      This redesign makes Zero-G Ski Range feel like a high-speed aerial assault drill:
+      ski the terrain for momentum, feather the jetpack for altitude, and lead moving targets
+      with projectile weapons.
     </p>
-    <div class="hint">
-      Toggle loadouts with <strong>1</strong> and <strong>2</strong>, then use <strong>Shift</strong> to feather your
-      jetpack bursts. Right-click for air brakes when you need to stick a landing.
+    <p>
+      Click <strong>Begin Run</strong> or click the canvas to lock pointer aim. This is an original
+      portal prototype inspired by the feel of momentum shooters, not a copy of any game's assets.
+    </p>
+    <div class="control-list">
+      <div class="control-item"><b>Mouse / Drag</b>Look. Pointer lock works on desktop.</div>
+      <div class="control-item"><b>WASD</b>Move and strafe. Arrow keys also look.</div>
+      <div class="control-item"><b>Shift</b>Hold ski mode to keep speed on terrain.</div>
+      <div class="control-item"><b>Space</b>Jetpack. Manage the energy meter.</div>
+      <div class="control-item"><b>Click / F</b>Fire. Right click or E air-brakes.</div>
+      <div class="control-item"><b>1 / 2 / R</b>Switch weapons or reset the run.</div>
     </div>
-    <ul class="control-list">
-      <li><strong>A / D</strong> lean into the slope</li>
-      <li><strong>Shift</strong> engage jetpack</li>
-      <li><strong>Left click</strong> fire | <strong>Right click</strong> air-brake</li>
-      <li><strong>Drag</strong> on the arena to aim</li>
-      <li><strong>Touch</strong> use the on-screen controls</li>
-    </ul>
-    <nav class="overlay-links" aria-label="Portal links">
-      <a href="index.html">🏠 Portal</a>
-      <a href="games.html">🎮 Game Hub</a>
-      <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">⭐ Subscribe</a>
-      <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">🚀 GitHub</a>
-    </nav>
+    <div class="guide-actions">
+      <button class="primary" type="button" id="beginRun">Begin Run</button>
+      <a href="games.html">Game Hub</a>
+      <a href="index.html">Portal</a>
+    </div>
+  </section>
+
+  <button class="guide-toggle" type="button" id="guideToggle" aria-controls="guidePanel" aria-expanded="true">
+    Guide
+  </button>
+
+  <div class="objective-toast" id="objectiveToast">
+    <strong>Route:</strong> ski through cyan gates for speed, then snap to the rose target drones.
   </div>
-  <button
-    class="overlay-toggle"
-    type="button"
-    id="overlayToggle"
-    aria-controls="infoOverlay"
-    aria-expanded="true"
-  >Guide</button>
-  <div class="status" id="weaponStatus" role="status" aria-live="polite">
-    <span>Loadout</span>
-    <span id="weapon-name">Spinfusor</span>
+
+  <div class="touch-controls" id="touchControls" role="group" aria-label="Touch controls">
+    <button type="button" data-action="left" aria-label="Strafe left">Left</button>
+    <button type="button" data-action="forward" aria-label="Move forward">Forward</button>
+    <button type="button" data-action="right" aria-label="Strafe right">Right</button>
+    <button type="button" data-action="ski" aria-label="Hold ski mode">Ski</button>
+    <button type="button" data-action="jet" aria-label="Use jetpack">Jet</button>
+    <button type="button" class="primary" data-action="fire" aria-label="Fire weapon">Fire</button>
   </div>
-  <div class="score-panel" role="status" aria-live="polite" aria-atomic="true">
-    <span class="score-panel-title">Range Metrics</span>
-    <div class="score-panel-row">
-      <span class="score-row-label">Energy</span>
-      <span class="score-row-value"><span id="energy-value">100</span>%</span>
-    </div>
-    <div class="bar" aria-hidden="true">
-      <span id="energy-bar" style="background: linear-gradient(90deg, #22d3ee, #60a5fa); width: 100%;"></span>
-    </div>
-    <div class="score-panel-row">
-      <span class="score-row-label">Velocity</span>
-      <span class="score-row-value"><span id="velocity-value">0</span> m/s</span>
-    </div>
-    <div class="score-panel-row">
-      <span class="score-row-label">Hits</span>
-      <span class="score-row-value" id="hit-count">0</span>
-    </div>
-    <div class="score-panel-row score-panel-target-row">
-      <span class="score-row-label">Target</span>
-      <span class="score-row-value"><span id="target-health">100</span>%</span>
-    </div>
-  </div>
-  <div class="touch-controls is-hidden" role="group" aria-label="Touch controls">
-    <div class="control-cluster">
-      <button type="button" class="control-btn" data-action="left" aria-label="Lean left">◀</button>
-      <button type="button" class="control-btn" data-action="right" aria-label="Lean right">▶</button>
-    </div>
-    <div class="control-cluster">
-      <button type="button" class="control-btn" data-action="jetpack" aria-label="Engage jetpack">Jet</button>
-      <button type="button" class="control-btn" data-action="brake" aria-label="Air brake">Brake</button>
-    </div>
-    <div class="control-cluster primary-cluster">
-      <button type="button" class="control-btn primary" data-action="fire" aria-label="Fire current weapon">Fire</button>
-    </div>
-  </div>
-  <script>
-    if (window.matchMedia('(max-width: 520px)').matches) {
-      document.getElementById('infoOverlay')?.classList.add('overlay-hidden');
-      const compactOverlayToggle = document.getElementById('overlayToggle');
-      if (compactOverlayToggle) {
-        compactOverlayToggle.classList.add('overlay-toggle-visible');
-        compactOverlayToggle.setAttribute('aria-expanded', 'false');
-      }
-    }
-  </script>
+
   <script>
   const canvas = document.getElementById('game');
-  const ctx = canvas.getContext('2d');
-  const energyBar = document.getElementById('energy-bar');
-  const energyValue = document.getElementById('energy-value');
-  const velocityValue = document.getElementById('velocity-value');
-  const weaponName = document.getElementById('weapon-name');
-  const hitCountEl = document.getElementById('hit-count');
-  const targetHealthEl = document.getElementById('target-health');
+  const ctx = canvas.getContext('2d', { alpha: false });
+  const guidePanel = document.getElementById('guidePanel');
+  const guideToggle = document.getElementById('guideToggle');
+  const beginRun = document.getElementById('beginRun');
+  const touchControls = document.getElementById('touchControls');
+  const weaponName = document.getElementById('weaponName');
+  const speedValue = document.getElementById('speedValue');
+  const altitudeValue = document.getElementById('altitudeValue');
+  const scoreValue = document.getElementById('scoreValue');
+  const comboValue = document.getElementById('comboValue');
+  const energyBar = document.getElementById('energyBar');
+  const objectiveText = document.getElementById('objectiveText');
+  const objectiveToast = document.getElementById('objectiveToast');
+  const weaponPills = [
+    document.getElementById('weaponPill0'),
+    document.getElementById('weaponPill1')
+  ];
 
-  const overlay = document.getElementById('infoOverlay');
-  const overlayClose = document.getElementById('overlayClose');
-  const overlayToggle = document.getElementById('overlayToggle');
-  const touchControls = document.querySelector('.touch-controls');
-  const controlButtons = touchControls ? touchControls.querySelectorAll('button') : [];
-  const coarsePointerQuery = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
-    ? window.matchMedia('(pointer: coarse)')
-    : null;
-
-  function hideOverlay() {
-    if (!overlay) {
-      return;
-    }
-    overlay.classList.add('overlay-hidden');
-    overlay.setAttribute('aria-hidden', 'true');
-    if (overlayToggle) {
-      overlayToggle.classList.add('overlay-toggle-visible');
-      overlayToggle.setAttribute('aria-expanded', 'false');
-    }
-  }
-
-  function showOverlay() {
-    if (!overlay) {
-      return;
-    }
-    overlay.classList.remove('overlay-hidden');
-    overlay.removeAttribute('aria-hidden');
-    if (overlayToggle) {
-      overlayToggle.classList.remove('overlay-toggle-visible');
-      overlayToggle.setAttribute('aria-expanded', 'true');
-    }
-  }
-
-  if (overlayClose) {
-    overlayClose.addEventListener('click', () => {
-      hideOverlay();
-      if (overlayToggle) {
-        overlayToggle.focus();
-      }
-    });
-  }
-
-  if (overlayToggle) {
-    overlayToggle.addEventListener('click', () => {
-      if (!overlay) {
-        return;
-      }
-      const isHidden = overlay.classList.contains('overlay-hidden');
-      if (isHidden) {
-        showOverlay();
-      } else {
-        hideOverlay();
-      }
-    });
-  }
-
-  if (window.matchMedia('(max-width: 520px)').matches) {
-    hideOverlay();
-  }
-
-  const ASPECT_RATIO = 16 / 9;
-  const compactViewportQuery = window.matchMedia('(max-width: 520px)');
-
-  const input = {
-    left: false,
-    right: false,
-    jetpack: false,
-    brake: false,
-    fire: false,
-    mouseX: 480,
-    mouseY: 270
+  const keys = new Set();
+  const projectiles = [];
+  const targets = [];
+  const particles = [];
+  const gates = [];
+  const stars = [];
+  const touchLook = {
+    pointerId: null,
+    x: 0,
+    y: 0
   };
 
-  const GRAVITY = -36;
-  const JETPACK_FORCE = 64;
-  const JETPACK_DRAIN = 22;
-  const GROUND_RECHARGE = 28;
-  const AIR_RECHARGE = 10;
-  const BASE_FORWARD_SPEED = 22;
-  const SLOPE_ACCEL = 18;
-  const LATERAL_SLOPE_PUSH = 14;
-  const GROUND_CONTROL_ACCEL = 36;
-  const AIR_CONTROL_ACCEL = 18;
-  const GROUND_LATERAL_DRAG = 0.86;
-  const AIR_LATERAL_DRAG = 0.94;
-  const BRAKE_DRAG = 0.75;
-  const FORWARD_RESPONSIVENESS_GROUND = 3.2;
-  const FORWARD_RESPONSIVENESS_AIR = 1.4;
-  const LATERAL_LIMIT = 180;
+  const input = {
+    forward: false,
+    back: false,
+    left: false,
+    right: false,
+    ski: false,
+    jet: false,
+    brake: false,
+    fire: false,
+    pointerActive: false
+  };
 
-  function groundHeight(x, z) {
-    const ridge = Math.sin((z + 90) * 0.04) * 6;
-    const cross = Math.cos((x + z * 0.4) * 0.03) * 4;
-    const basin = Math.sin((z * 0.02) + Math.cos(x * 0.015)) * 5;
-    return -18 + ridge + cross + basin;
-  }
+  const touchInput = {
+    forward: false,
+    left: false,
+    right: false,
+    ski: false,
+    jet: false
+  };
 
-  function groundSlopeX(x, z) {
-    const ridge = 0;
-    const cross = -Math.sin((x + z * 0.4) * 0.03) * 0.03 * 4;
-    const basin = Math.cos((z * 0.02) + Math.cos(x * 0.015)) * (-Math.sin(x * 0.015) * 0.015) * 5;
-    return ridge + cross + basin;
-  }
-
-  function groundSlopeZ(x, z) {
-    const ridge = Math.cos((z + 90) * 0.04) * 0.04 * 6;
-    const cross = -Math.sin((x + z * 0.4) * 0.03) * 0.03 * 0.4 * 4;
-    const basin = Math.cos((z * 0.02) + Math.cos(x * 0.015)) * 0.02 * 5;
-    return ridge + cross + basin;
-  }
+  const GRAVITY = 38;
+  const SKI_ACCEL = 90;
+  const WALK_ACCEL = 42;
+  const AIR_ACCEL = 28;
+  const JETPACK_FORCE = 62;
+  const JETPACK_DRAIN = 26;
+  const ENERGY_RECHARGE_GROUND = 32;
+  const ENERGY_RECHARGE_AIR = 12;
+  const MAX_SPEED = 230;
+  const EYE_HEIGHT = 5.4;
+  const GROUND_CLEARANCE = 3.4;
+  const POINTER_SENSITIVITY = 0.0022;
+  const TOUCH_LOOK_SENSITIVITY = 0.004;
+  const KEY_LOOK_SPEED = 1.05;
 
   const player = {
     x: 0,
-    y: groundHeight(0, 0) + 6,
+    y: 0,
     z: 0,
     vx: 0,
     vy: 0,
-    vz: BASE_FORWARD_SPEED,
-    radius: 3.6,
+    vz: 24,
+    yaw: 0,
+    pitch: -0.06,
     energy: 100,
-    maxEnergy: 100,
-    onGround: false,
+    score: 0,
+    combo: 1,
+    comboTime: 0,
     weaponIndex: 0,
-    fireCooldown: 0
+    cooldown: 0,
+    onGround: false,
+    gateStreak: 0
   };
 
   const camera = {
-    x: player.x,
-    y: player.y + 18,
-    z: player.z - 120,
-    yaw: 0,
-    pitch: -0.28,
-    fov: 58,
-    focalLength: 1,
-    near: 0.6
+    fov: 72,
+    focal: 1,
+    near: 0.8
   };
 
   const weapons = [
     {
-      name: 'Spinfusor',
+      name: 'Disc Launcher',
+      shortName: 'Disc',
       cooldown: 0.55,
-      muzzleSpeed: 62,
-      energyCost: 12,
-      spread: 0.012,
-      color: '#60a5fa',
-      radius: 1.9,
-      drag: 0.985,
-      gravityScale: 0.6,
-      impactDamage: 40
+      speed: 112,
+      radius: 2.8,
+      damage: 62,
+      splash: 15,
+      gravity: 0.22,
+      color: '#67e8f9',
+      energyCost: 0,
+      particleCount: 8
     },
     {
-      name: 'Chaingun',
-      cooldown: 0.08,
-      muzzleSpeed: 96,
-      energyCost: 0,
-      spread: 0.035,
-      color: '#facc15',
+      name: 'Trace Repeater',
+      shortName: 'Trace',
+      cooldown: 0.075,
+      speed: 190,
       radius: 1.1,
-      drag: 0.98,
-      gravityScale: 0.1,
-      impactDamage: 6
+      damage: 10,
+      splash: 0,
+      gravity: 0.03,
+      color: '#f8d47a',
+      energyCost: 1.2,
+      particleCount: 2
     }
   ];
 
-  const projectiles = [];
-  const stars = Array.from({ length: 160 }, () => ({
-    x: (Math.random() - 0.5) * 260,
-    y: Math.random() * 200 - 60,
-    z: Math.random() * 600 + 60
-  }));
-
-  const target = {
-    x: 0,
-    y: 0,
-    z: 220,
-    width: 18,
-    height: 38,
-    depth: 18,
-    health: 100,
-    regenDelay: 0,
-    sway: 0
-  };
-
-  let hitsLanded = 0;
-
   function resizeCanvas() {
-    const viewportWidth = window.innerWidth || 960;
-    const viewportHeight = window.innerHeight || 540;
-    const useFullViewport = compactViewportQuery.matches;
-    const desiredWidth = useFullViewport
-      ? viewportWidth
-      : Math.min(1080, Math.max(320, viewportWidth - 24));
-    const width = Math.round(desiredWidth);
-    const height = useFullViewport
-      ? Math.round(viewportHeight)
-      : Math.round(width / ASPECT_RATIO);
-
-    canvas.style.width = useFullViewport ? '100vw' : `${width}px`;
-    canvas.style.height = useFullViewport ? '100vh' : `${height}px`;
-    canvas.width = width;
-    canvas.height = height;
-
-    camera.focalLength = (canvas.height * 0.5) / Math.tan((camera.fov * Math.PI) / 360);
-    input.mouseX = Math.min(canvas.width - 10, Math.max(10, input.mouseX));
-    input.mouseY = Math.min(canvas.height - 10, Math.max(10, input.mouseY));
+    const ratio = Math.min(2, window.devicePixelRatio || 1);
+    const width = Math.max(320, window.innerWidth || 960);
+    const height = Math.max(320, window.innerHeight || 540);
+    canvas.width = Math.round(width * ratio);
+    canvas.height = Math.round(height * ratio);
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+    camera.focal = (height * 0.5) / Math.tan((camera.fov * Math.PI) / 360);
   }
 
-  resizeCanvas();
-  window.addEventListener('resize', resizeCanvas);
+  function viewWidth() {
+    return canvas.width / Math.min(2, window.devicePixelRatio || 1);
+  }
 
-  if (touchControls) {
-    const updateTouchControlsVisibility = () => {
-      const touchPoints = typeof navigator !== 'undefined' && 'maxTouchPoints' in navigator
-        ? navigator.maxTouchPoints
-        : 0;
-      const hasCoarsePointer = coarsePointerQuery ? coarsePointerQuery.matches : false;
-      const showControls = hasCoarsePointer || touchPoints > 0;
-      touchControls.classList.toggle('is-hidden', !showControls);
-      if (showControls) {
-        document.body.classList.add('touch-enabled');
-      } else {
-        document.body.classList.remove('touch-enabled');
-      }
+  function viewHeight() {
+    return canvas.height / Math.min(2, window.devicePixelRatio || 1);
+  }
+
+  function terrainHeight(x, z) {
+    const run = Math.sin(z * 0.012) * 17;
+    const cross = Math.cos((x + z * 0.35) * 0.018) * 11;
+    const channel = -Math.cos((x * 0.012) + Math.sin(z * 0.01)) * 7;
+    const grade = -z * 0.018;
+    return run + cross + channel + grade - 8;
+  }
+
+  function terrainSlope(x, z) {
+    const sample = 2.5;
+    const left = terrainHeight(x - sample, z);
+    const right = terrainHeight(x + sample, z);
+    const back = terrainHeight(x, z - sample);
+    const forward = terrainHeight(x, z + sample);
+    return {
+      x: (right - left) / (sample * 2),
+      z: (forward - back) / (sample * 2)
     };
+  }
 
-    const handlePointerPreferenceChange = () => updateTouchControlsVisibility();
+  function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+  }
 
-    updateTouchControlsVisibility();
-    window.addEventListener('resize', updateTouchControlsVisibility);
-    window.addEventListener('orientationchange', updateTouchControlsVisibility);
+  function horizontalSpeed() {
+    return Math.hypot(player.vx, player.vz);
+  }
 
-    if (coarsePointerQuery) {
-      if (typeof coarsePointerQuery.addEventListener === 'function') {
-        coarsePointerQuery.addEventListener('change', handlePointerPreferenceChange);
-      } else if (typeof coarsePointerQuery.addListener === 'function') {
-        coarsePointerQuery.addListener(handlePointerPreferenceChange);
-      }
+  function forwardVector() {
+    const cp = Math.cos(player.pitch);
+    return {
+      x: Math.sin(player.yaw) * cp,
+      y: Math.sin(player.pitch),
+      z: Math.cos(player.yaw) * cp
+    };
+  }
+
+  function rightVector() {
+    return {
+      x: Math.cos(player.yaw),
+      y: 0,
+      z: -Math.sin(player.yaw)
+    };
+  }
+
+  function addScaledVelocity(vector, scale) {
+    player.vx += vector.x * scale;
+    player.vz += vector.z * scale;
+  }
+
+  function resetRun() {
+    player.x = 0;
+    player.z = 0;
+    player.y = terrainHeight(0, 0) + GROUND_CLEARANCE;
+    player.vx = 0;
+    player.vy = 0;
+    player.vz = 30;
+    player.yaw = 0;
+    player.pitch = -0.06;
+    player.energy = 100;
+    player.score = 0;
+    player.combo = 1;
+    player.comboTime = 0;
+    player.cooldown = 0;
+    player.gateStreak = 0;
+    projectiles.length = 0;
+    particles.length = 0;
+    seedTargets();
+    seedGates();
+    updateHud();
+    objectiveText.textContent = 'Hold Shift to ski, use slope speed, then pop the drones before the gate timer expires.';
+    objectiveToast.innerHTML = '<strong>Route:</strong> ski through cyan gates for speed, then snap to the rose target drones.';
+  }
+
+  function seedStars() {
+    stars.length = 0;
+    for (let i = 0; i < 180; i += 1) {
+      stars.push({
+        x: (Math.random() - 0.5) * 900,
+        y: Math.random() * 420 + 60,
+        z: Math.random() * 1000 + 80,
+        size: Math.random() * 1.5 + 0.5
+      });
     }
   }
 
-  function setInputState(action, active) {
-    switch (action) {
-      case 'left':
-        input.left = active;
-        break;
-      case 'right':
-        input.right = active;
-        break;
-      case 'jetpack':
-        input.jetpack = active;
-        break;
-      case 'brake':
-        input.brake = active;
-        break;
-      case 'fire':
-        input.fire = active;
-        break;
-      default:
-        break;
+  function seedTargets() {
+    targets.length = 0;
+    for (let i = 0; i < 6; i += 1) {
+      spawnTarget(i, player.z + 160 + i * 110);
     }
   }
 
-  function handleInputDown(event) {
+  function spawnTarget(index, z) {
+    const x = player.x + (Math.random() - 0.5) * 170;
+    const y = terrainHeight(x, z) + 34 + Math.random() * 28;
+    targets[index] = {
+      x,
+      y,
+      z,
+      baseX: x,
+      baseY: y,
+      radius: 8 + Math.random() * 4,
+      health: 100,
+      phase: Math.random() * Math.PI * 2,
+      destroyed: false,
+      respawnDelay: 0
+    };
+  }
+
+  function seedGates() {
+    gates.length = 0;
+    for (let i = 0; i < 9; i += 1) {
+      spawnGate(i, player.z + 110 + i * 95);
+    }
+  }
+
+  function spawnGate(index, z) {
+    const x = Math.sin(z * 0.015) * 70 + (Math.random() - 0.5) * 42;
+    gates[index] = {
+      x,
+      z,
+      y: terrainHeight(x, z) + 13,
+      radius: 16,
+      passed: false
+    };
+  }
+
+  function setGuideVisible(visible) {
+    guidePanel.classList.toggle('is-hidden', !visible);
+    guidePanel.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    guideToggle.classList.toggle('is-visible', !visible);
+    guideToggle.setAttribute('aria-expanded', visible ? 'true' : 'false');
+  }
+
+  function beginPointerRun() {
+    setGuideVisible(false);
+    if (canvas.requestPointerLock && !matchMedia('(pointer: coarse)').matches) {
+      canvas.requestPointerLock();
+    }
+    canvas.focus?.();
+  }
+
+  function updateHud() {
+    const groundY = terrainHeight(player.x, player.z) + GROUND_CLEARANCE;
+    const altitude = Math.max(0, player.y - groundY);
+    speedValue.textContent = Math.round(horizontalSpeed());
+    altitudeValue.textContent = altitude.toFixed(1);
+    scoreValue.textContent = String(player.score);
+    comboValue.textContent = `x${player.combo}`;
+    energyBar.style.width = `${clamp(player.energy, 0, 100)}%`;
+    weaponName.textContent = weapons[player.weaponIndex].name;
+    weaponPills.forEach((pill, index) => {
+      pill.classList.toggle('is-active', index === player.weaponIndex);
+    });
+  }
+
+  function handleKeyDown(event) {
     if (event.repeat) {
       return;
     }
-    if (event.code === 'KeyA') {
-      input.left = true;
-    }
-    if (event.code === 'KeyD') {
-      input.right = true;
-    }
-    if (event.code === 'ShiftLeft' || event.code === 'ShiftRight') {
-      input.jetpack = true;
-    }
+    keys.add(event.code);
     if (event.code === 'Digit1') {
       player.weaponIndex = 0;
-      weaponName.textContent = weapons[0].name;
     }
     if (event.code === 'Digit2') {
       player.weaponIndex = 1;
-      weaponName.textContent = weapons[1].name;
+    }
+    if (event.code === 'KeyR') {
+      resetRun();
+    }
+    if (event.code === 'KeyF' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+      input.fire = true;
+    }
+    if (event.code === 'Escape') {
+      setGuideVisible(true);
     }
   }
 
-  function handleInputUp(event) {
-    if (event.code === 'KeyA') {
-      input.left = false;
+  function handleKeyUp(event) {
+    keys.delete(event.code);
+    if (event.code === 'KeyF' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+      input.fire = false;
     }
-    if (event.code === 'KeyD') {
-      input.right = false;
+  }
+
+  function updateKeyboardInput() {
+    input.forward = keys.has('KeyW') || touchInput.forward;
+    input.back = keys.has('KeyS');
+    input.left = keys.has('KeyA') || touchInput.left;
+    input.right = keys.has('KeyD') || touchInput.right;
+    input.ski = keys.has('ShiftLeft') || keys.has('ShiftRight') || touchInput.ski;
+    input.jet = keys.has('Space') || touchInput.jet;
+    input.brake = keys.has('KeyE') || input.brake;
+  }
+
+  function resetHoldInputs() {
+    input.fire = false;
+    input.brake = false;
+    input.jet = false;
+    input.ski = false;
+    input.forward = false;
+    input.back = false;
+    input.left = false;
+    input.right = false;
+    touchInput.forward = false;
+    touchInput.left = false;
+    touchInput.right = false;
+    touchInput.ski = false;
+    touchInput.jet = false;
+    keys.clear();
+  }
+
+  function lookBy(dx, dy, sensitivity) {
+    player.yaw += dx * sensitivity;
+    player.pitch = clamp(player.pitch - dy * sensitivity, -1.15, 0.82);
+  }
+
+  function handlePointerMove(event) {
+    if (document.pointerLockElement === canvas) {
+      lookBy(event.movementX, event.movementY, POINTER_SENSITIVITY);
+      return;
     }
-    if (event.code === 'ShiftLeft' || event.code === 'ShiftRight') {
-      input.jetpack = false;
+    if (touchLook.pointerId === event.pointerId) {
+      const dx = event.clientX - touchLook.x;
+      const dy = event.clientY - touchLook.y;
+      touchLook.x = event.clientX;
+      touchLook.y = event.clientY;
+      lookBy(dx, dy, TOUCH_LOOK_SENSITIVITY);
     }
   }
 
   function handlePointerDown(event) {
-    const isTouch = event.pointerType === 'touch';
-    if (overlay && !overlay.classList.contains('overlay-hidden')) {
-      hideOverlay();
+    if (!guidePanel.classList.contains('is-hidden')) {
+      setGuideVisible(false);
     }
-    if (isTouch) {
-      event.preventDefault();
-    }
-    if (!isTouch && event.button === 0) {
+    if (event.pointerType === 'mouse' && event.button === 0) {
       input.fire = true;
+      beginPointerRun();
     }
-    if (!isTouch && event.button === 2) {
+    if (event.pointerType === 'mouse' && event.button === 2) {
       input.brake = true;
     }
-    updatePointerPosition(event);
-    if (!isTouch && typeof canvas.setPointerCapture === 'function' && event.pointerId != null) {
-      try {
-        canvas.setPointerCapture(event.pointerId);
-      } catch (error) {
-        /* Capture may fail on unsupported platforms. */
-      }
+    if (event.pointerType !== 'mouse') {
+      touchLook.pointerId = event.pointerId;
+      touchLook.x = event.clientX;
+      touchLook.y = event.clientY;
+      input.pointerActive = true;
+      event.preventDefault();
     }
   }
 
   function handlePointerUp(event) {
-    const isTouch = event.pointerType === 'touch';
-    if (!isTouch && event.button === 0) {
+    if (event.pointerType === 'mouse' && event.button === 0) {
       input.fire = false;
     }
-    if (!isTouch && event.button === 2) {
+    if (event.pointerType === 'mouse' && event.button === 2) {
       input.brake = false;
     }
-    if (!isTouch && typeof canvas.releasePointerCapture === 'function' && event.pointerId != null) {
-      try {
-        canvas.releasePointerCapture(event.pointerId);
-      } catch (error) {
-        /* Ignore release failures. */
-      }
+    if (touchLook.pointerId === event.pointerId) {
+      touchLook.pointerId = null;
+      input.pointerActive = false;
     }
   }
 
-  function handlePointerLeave() {
-    resetPointerInputs();
+  function setTouchAction(action, active, button) {
+    button.classList.toggle('is-active', active);
+    if (action === 'forward') {
+      touchInput.forward = active;
+    }
+    if (action === 'left') {
+      touchInput.left = active;
+    }
+    if (action === 'right') {
+      touchInput.right = active;
+    }
+    if (action === 'ski') {
+      touchInput.ski = active;
+    }
+    if (action === 'jet') {
+      touchInput.jet = active;
+    }
+    if (action === 'fire') {
+      input.fire = active;
+    }
   }
 
-  function updatePointerPosition(event) {
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    input.mouseX = (event.clientX - rect.left) * scaleX;
-    input.mouseY = (event.clientY - rect.top) * scaleY;
-  }
-
-  function resetPointerInputs() {
-    input.fire = false;
-    input.brake = false;
-  }
-
-  function resetAllInputs() {
-    input.left = false;
-    input.right = false;
-    input.jetpack = false;
-    resetPointerInputs();
-  }
-
-  document.addEventListener('keydown', handleInputDown);
-  document.addEventListener('keyup', handleInputUp);
-  window.addEventListener('blur', resetAllInputs);
-  canvas.addEventListener('pointerdown', handlePointerDown);
-  canvas.addEventListener('pointerup', handlePointerUp);
-  canvas.addEventListener('pointercancel', handlePointerUp);
-  canvas.addEventListener('pointerleave', handlePointerLeave);
-  canvas.addEventListener('pointermove', updatePointerPosition);
-  canvas.addEventListener('contextmenu', event => event.preventDefault());
-
-  if (controlButtons.length) {
-    controlButtons.forEach(button => {
+  function setupTouchControls() {
+    const hasTouch = matchMedia('(pointer: coarse)').matches || navigator.maxTouchPoints > 0;
+    touchControls.classList.toggle('is-visible', hasTouch);
+    touchControls.querySelectorAll('button').forEach(button => {
       const action = button.dataset.action;
-      if (!action) {
-        return;
-      }
-      const handleButtonDown = event => {
-        if (event.pointerType === 'touch') {
-          event.preventDefault();
-        }
-        button.classList.add('active');
-        setInputState(action, true);
-      };
-      const handleButtonUp = event => {
-        if (event.pointerType === 'touch') {
-          event.preventDefault();
-        }
-        button.classList.remove('active');
-        setInputState(action, false);
-      };
-      button.addEventListener('pointerdown', handleButtonDown);
-      button.addEventListener('pointerup', handleButtonUp);
-      button.addEventListener('pointerleave', handleButtonUp);
-      button.addEventListener('pointercancel', handleButtonUp);
-      button.addEventListener('contextmenu', event => event.preventDefault());
+      button.addEventListener('pointerdown', event => {
+        event.preventDefault();
+        setTouchAction(action, true, button);
+      });
+      button.addEventListener('pointerup', event => {
+        event.preventDefault();
+        setTouchAction(action, false, button);
+      });
+      button.addEventListener('pointercancel', () => setTouchAction(action, false, button));
+      button.addEventListener('pointerleave', () => setTouchAction(action, false, button));
     });
   }
 
-  function worldToCamera(point) {
-    const dx = point.x - camera.x;
-    const dy = point.y - camera.y;
-    const dz = point.z - camera.z;
-
-    const cosYaw = Math.cos(camera.yaw);
-    const sinYaw = Math.sin(camera.yaw);
-    const yawX = cosYaw * dx - sinYaw * dz;
-    const yawZ = sinYaw * dx + cosYaw * dz;
-
-    const cosPitch = Math.cos(camera.pitch);
-    const sinPitch = Math.sin(camera.pitch);
-    const pitchY = cosPitch * dy - sinPitch * yawZ;
-    const pitchZ = sinPitch * dy + cosPitch * yawZ;
-
-    return { x: yawX, y: pitchY, z: pitchZ };
-  }
-
-  function projectPoint(point) {
-    const cameraPoint = worldToCamera(point);
-    if (cameraPoint.z <= camera.near) {
-      return null;
-    }
-    const scale = camera.focalLength / cameraPoint.z;
-    return {
-      x: canvas.width * 0.5 + cameraPoint.x * scale,
-      y: canvas.height * 0.5 - cameraPoint.y * scale,
-      depth: cameraPoint.z
-    };
-  }
-
-  function cameraToWorldDirection(dir) {
-    const cosPitch = Math.cos(camera.pitch);
-    const sinPitch = Math.sin(camera.pitch);
-    const pitchY = cosPitch * dir.y + sinPitch * dir.z;
-    const pitchZ = -sinPitch * dir.y + cosPitch * dir.z;
-
-    const cosYaw = Math.cos(camera.yaw);
-    const sinYaw = Math.sin(camera.yaw);
-    const worldX = cosYaw * dir.x + sinYaw * pitchZ;
-    const worldZ = -sinYaw * dir.x + cosYaw * pitchZ;
-
-    return { x: worldX, y: pitchY, z: worldZ };
-  }
-
-  function screenToWorldDirection(screenX, screenY) {
-    const x = (screenX - canvas.width * 0.5) / camera.focalLength;
-    const y = (canvas.height * 0.5 - screenY) / camera.focalLength;
-    const length = Math.sqrt(x * x + y * y + 1);
-    const dir = { x: x / length, y: y / length, z: 1 / length };
-    return cameraToWorldDirection(dir);
-  }
-
-  function updateCamera(delta) {
-    const desiredX = player.x + player.vx * 0.6;
-    const desiredY = player.y + 18;
-    const desiredZ = player.z - 120;
-    const smoothing = Math.min(1, delta * 4);
-    camera.x += (desiredX - camera.x) * smoothing;
-    camera.y += (desiredY - camera.y) * smoothing;
-    camera.z += (desiredZ - camera.z) * Math.min(1, delta * 2.5);
-
-    const desiredYaw = Math.atan2(player.vx, player.vz);
-    camera.yaw += (desiredYaw * 0.45 - camera.yaw) * Math.min(1, delta * 2.2);
-
-    const altitude = Math.max(0, player.y - groundHeight(player.x, player.z) - player.radius);
-    const desiredPitch = -0.22 - Math.min(0.32, altitude * 0.008);
-    camera.pitch += (desiredPitch - camera.pitch) * Math.min(1, delta * 2.6);
+  function updateLookFromKeys(delta) {
+    const yawInput = (keys.has('ArrowLeft') ? -1 : 0) + (keys.has('ArrowRight') ? 1 : 0);
+    const pitchInput = (keys.has('ArrowUp') ? 1 : 0) + (keys.has('ArrowDown') ? -1 : 0);
+    player.yaw += yawInput * KEY_LOOK_SPEED * delta;
+    player.pitch = clamp(player.pitch + pitchInput * KEY_LOOK_SPEED * delta, -1.15, 0.82);
   }
 
   function updatePlayer(delta) {
-    const slopeX = groundSlopeX(player.x, player.z);
-    const slopeZ = groundSlopeZ(player.x, player.z);
-    const groundY = groundHeight(player.x, player.z) + player.radius;
+    updateKeyboardInput();
+    updateLookFromKeys(Math.min(delta, 1 / 30));
 
-    const lateralAccel = player.onGround ? GROUND_CONTROL_ACCEL : AIR_CONTROL_ACCEL;
-    const accelDirection = (input.right ? 1 : 0) - (input.left ? 1 : 0);
-    player.vx += accelDirection * lateralAccel * delta;
+    const groundY = terrainHeight(player.x, player.z) + GROUND_CLEARANCE;
+    const slope = terrainSlope(player.x, player.z);
+    const forward = forwardVector();
+    const right = rightVector();
+    const forwardFlat = { x: forward.x, z: forward.z };
+    const flatLength = Math.hypot(forwardFlat.x, forwardFlat.z) || 1;
+    forwardFlat.x /= flatLength;
+    forwardFlat.z /= flatLength;
 
-    const targetForward = BASE_FORWARD_SPEED + Math.max(0, -slopeZ) * SLOPE_ACCEL;
-    const forwardResponsiveness = player.onGround ? FORWARD_RESPONSIVENESS_GROUND : FORWARD_RESPONSIVENESS_AIR;
-    player.vz += (targetForward - player.vz) * Math.min(1, forwardResponsiveness * delta);
-
-    player.vx += -slopeX * LATERAL_SLOPE_PUSH * delta;
-    player.vy += slopeZ * 8 * delta;
-    player.vy += GRAVITY * delta;
-
-    if (input.jetpack && player.energy > 0) {
-      player.vy += JETPACK_FORCE * delta;
-      player.energy = Math.max(0, player.energy - JETPACK_DRAIN * delta);
+    const moveAccel = player.onGround ? WALK_ACCEL : AIR_ACCEL;
+    if (input.forward) {
+      player.vx += forwardFlat.x * moveAccel * delta;
+      player.vz += forwardFlat.z * moveAccel * delta;
+    }
+    if (input.back) {
+      player.vx -= forwardFlat.x * moveAccel * 0.55 * delta;
+      player.vz -= forwardFlat.z * moveAccel * 0.55 * delta;
+    }
+    if (input.left) {
+      addScaledVelocity(right, -moveAccel * 0.75 * delta);
+    }
+    if (input.right) {
+      addScaledVelocity(right, moveAccel * 0.75 * delta);
     }
 
-    const lateralDrag = player.onGround ? GROUND_LATERAL_DRAG : AIR_LATERAL_DRAG;
-    const dragPower = delta * 60;
-    player.vx *= Math.pow(lateralDrag, dragPower);
-    player.vz *= Math.pow(player.onGround ? 0.98 : 0.992, dragPower);
+    if (player.onGround && input.ski) {
+      player.vx += -slope.x * SKI_ACCEL * delta;
+      player.vz += -slope.z * SKI_ACCEL * delta;
+      player.vx += forwardFlat.x * 7 * delta;
+      player.vz += forwardFlat.z * 7 * delta;
+    }
+
+    if (input.jet && player.energy > 0) {
+      player.vy += JETPACK_FORCE * delta;
+      player.vx += forward.x * 10 * delta;
+      player.vz += forward.z * 10 * delta;
+      player.energy = Math.max(0, player.energy - JETPACK_DRAIN * delta);
+      emitJetParticles(2);
+    }
+
+    player.vy -= GRAVITY * delta;
+
+    const groundDrag = input.ski ? 0.993 : 0.86;
+    const drag = player.onGround ? groundDrag : 0.996;
+    const dragFactor = Math.pow(drag, delta * 60);
+    player.vx *= dragFactor;
+    player.vz *= dragFactor;
 
     if (input.brake) {
-      const brakePower = Math.pow(BRAKE_DRAG, dragPower);
-      player.vx *= brakePower;
-      player.vz *= brakePower;
+      const brake = Math.pow(0.73, delta * 60);
+      player.vx *= brake;
+      player.vz *= brake;
+      player.vy *= Math.pow(0.9, delta * 60);
+    }
+
+    const speed = horizontalSpeed();
+    if (speed > MAX_SPEED) {
+      const ratio = MAX_SPEED / speed;
+      player.vx *= ratio;
+      player.vz *= ratio;
     }
 
     player.x += player.vx * delta;
     player.y += player.vy * delta;
     player.z += player.vz * delta;
 
-    if (player.x < -LATERAL_LIMIT) {
-      player.x = -LATERAL_LIMIT;
-      player.vx *= -0.4;
-    }
-    if (player.x > LATERAL_LIMIT) {
-      player.x = LATERAL_LIMIT;
-      player.vx *= -0.4;
-    }
-
     if (player.y <= groundY) {
       player.y = groundY;
       if (player.vy < 0) {
         player.vy = 0;
       }
-      if (!player.onGround) {
-        player.onGround = true;
-      }
+      player.onGround = true;
+      player.energy = Math.min(100, player.energy + ENERGY_RECHARGE_GROUND * delta);
     } else {
-      if (player.onGround) {
-        player.onGround = false;
+      player.onGround = false;
+      if (!input.jet) {
+        player.energy = Math.min(100, player.energy + ENERGY_RECHARGE_AIR * delta);
       }
     }
 
-    if (player.onGround) {
-      player.energy = Math.min(player.maxEnergy, player.energy + GROUND_RECHARGE * delta);
-    } else if (!input.jetpack) {
-      player.energy = Math.min(player.maxEnergy, player.energy + AIR_RECHARGE * delta);
+    player.cooldown = Math.max(0, player.cooldown - delta);
+    player.comboTime = Math.max(0, player.comboTime - delta);
+    if (player.comboTime <= 0) {
+      player.combo = 1;
     }
-
-    energyBar.style.width = `${(player.energy / player.maxEnergy) * 100}%`;
-    energyValue.textContent = Math.round(player.energy);
-    const horizontalSpeed = Math.sqrt(player.vx * player.vx + player.vz * player.vz);
-    velocityValue.textContent = horizontalSpeed.toFixed(1);
   }
 
-  function fireWeapon(delta) {
+  function fireWeapon() {
     const weapon = weapons[player.weaponIndex];
-    player.fireCooldown = Math.max(0, player.fireCooldown - delta);
-    if (!input.fire || player.fireCooldown > 0) {
+    if (!input.fire || player.cooldown > 0 || player.energy < weapon.energyCost) {
       return;
     }
-    if (player.energy < weapon.energyCost) {
-      return;
-    }
-
-    const aimDirection = screenToWorldDirection(input.mouseX, input.mouseY);
-    if (!aimDirection) {
-      return;
-    }
-
-    const spreadYaw = (Math.random() - 0.5) * weapon.spread;
-    const spreadPitch = (Math.random() - 0.5) * weapon.spread;
-    const cosSpread = Math.cos(spreadYaw);
-    const sinSpread = Math.sin(spreadYaw);
-    const dirX = aimDirection.x * cosSpread - aimDirection.z * sinSpread;
-    const dirZ = aimDirection.x * sinSpread + aimDirection.z * cosSpread;
-    const dirY = aimDirection.y + spreadPitch;
-    const magnitude = Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ) || 1;
-    const direction = {
-      x: dirX / magnitude,
-      y: dirY / magnitude,
-      z: dirZ / magnitude
+    const direction = forwardVector();
+    const muzzleRight = rightVector();
+    const muzzle = {
+      x: player.x + direction.x * 4 + muzzleRight.x * 1.8,
+      y: player.y + EYE_HEIGHT - 1.2,
+      z: player.z + direction.z * 4 + muzzleRight.z * 1.8
     };
-
     projectiles.push({
-      x: player.x,
-      y: player.y + player.radius * 0.2,
-      z: player.z,
-      vx: direction.x * weapon.muzzleSpeed + player.vx * 0.3,
-      vy: direction.y * weapon.muzzleSpeed + player.vy * 0.3,
-      vz: direction.z * weapon.muzzleSpeed + player.vz * 0.3,
+      x: muzzle.x,
+      y: muzzle.y,
+      z: muzzle.z,
+      vx: direction.x * weapon.speed + player.vx * 0.35,
+      vy: direction.y * weapon.speed + player.vy * 0.18,
+      vz: direction.z * weapon.speed + player.vz * 0.35,
       radius: weapon.radius,
+      damage: weapon.damage,
+      splash: weapon.splash,
+      gravity: weapon.gravity,
       color: weapon.color,
-      drag: weapon.drag,
-      gravityScale: weapon.gravityScale,
-      damage: weapon.impactDamage,
-      age: 0
+      age: 0,
+      weapon: weapon.shortName
     });
-
+    player.cooldown = weapon.cooldown;
     player.energy = Math.max(0, player.energy - weapon.energyCost);
-    player.fireCooldown = weapon.cooldown;
-    weaponName.textContent = weapon.name;
+    emitMuzzleParticles(muzzle, direction, weapon);
   }
 
   function updateProjectiles(delta) {
     for (let i = projectiles.length - 1; i >= 0; i -= 1) {
       const projectile = projectiles[i];
       projectile.age += delta;
-      const dragFactor = Math.pow(projectile.drag, delta * 60);
-      projectile.vx *= dragFactor;
-      projectile.vz *= dragFactor;
-      projectile.vy = (projectile.vy + GRAVITY * projectile.gravityScale * delta) * dragFactor;
-
+      projectile.vy -= GRAVITY * projectile.gravity * delta;
       projectile.x += projectile.vx * delta;
       projectile.y += projectile.vy * delta;
       projectile.z += projectile.vz * delta;
 
-      if (projectile.age > 6 || projectile.z < player.z - 40 || projectile.z > player.z + 620) {
-        projectiles.splice(i, 1);
-        continue;
+      let remove = projectile.age > 5 || projectile.z < player.z - 140 || projectile.z > player.z + 900;
+      if (projectile.y <= terrainHeight(projectile.x, projectile.z) + 1) {
+        remove = true;
+        emitImpact(projectile.x, projectile.y, projectile.z, projectile.color, 8);
       }
 
-      if (projectile.y <= groundHeight(projectile.x, projectile.z) + 0.5) {
-        projectiles.splice(i, 1);
-        continue;
-      }
-
-      const dx = projectile.x - target.x;
-      const dz = projectile.z - target.z;
-      const dy = projectile.y - (target.y + target.height * 0.5);
-      if (
-        Math.abs(dx) <= target.width * 0.6 &&
-        Math.abs(dz) <= target.depth * 0.6 &&
-        dy >= -target.height * 0.5 &&
-        dy <= target.height * 0.5 &&
-        target.health > 0
-      ) {
-        projectiles.splice(i, 1);
-        target.health = Math.max(0, target.health - projectile.damage);
-        if (target.health <= 0) {
-          target.regenDelay = 2.4;
+      targets.forEach(target => {
+        if (remove || target.destroyed) {
+          return;
         }
-        hitsLanded += 1;
-        hitCountEl.textContent = hitsLanded;
-        targetHealthEl.textContent = Math.round(target.health);
+        const distance = Math.hypot(projectile.x - target.x, projectile.y - target.y, projectile.z - target.z);
+        const hitRadius = target.radius + projectile.radius + projectile.splash;
+        if (distance <= hitRadius) {
+          remove = true;
+          damageTarget(target, projectile.damage, projectile.color);
+          emitImpact(projectile.x, projectile.y, projectile.z, projectile.color, 14);
+        }
+      });
+
+      if (remove) {
+        projectiles.splice(i, 1);
       }
     }
   }
 
-  function updateTarget(delta) {
-    target.sway += delta;
-    const swing = Math.sin(target.sway * 0.8);
-    const drift = Math.cos(target.sway * 0.6);
-    target.x = player.x + swing * 42;
-    target.z = player.z + 220 + drift * 28;
-    const groundY = groundHeight(target.x, target.z);
-    target.y = groundY + 26 + Math.sin(target.sway * 1.2) * 6;
-
-    if (target.regenDelay > 0) {
-      target.regenDelay = Math.max(0, target.regenDelay - delta);
-    } else if (target.health < 100) {
-      target.health = Math.min(100, target.health + 18 * delta);
+  function damageTarget(target, amount, color) {
+    target.health -= amount;
+    if (target.health <= 0 && !target.destroyed) {
+      target.destroyed = true;
+      target.respawnDelay = 1.8;
+      player.score += 100 * player.combo;
+      player.combo = Math.min(9, player.combo + 1);
+      player.comboTime = 4.5;
+      objectiveToast.innerHTML = `<strong>Drone down.</strong> Combo x${player.combo}. Keep skiing for the next lane.`;
+      emitImpact(target.x, target.y, target.z, color, 34);
     }
-
-    targetHealthEl.textContent = Math.round(target.health);
   }
 
-  function updateStarfield(delta) {
-    const forward = player.vz * delta;
-    stars.forEach(star => {
-      star.z -= forward;
-      if (star.z < 40) {
-        star.z += 600;
-        star.x = (Math.random() - 0.5) * 260;
-        star.y = Math.random() * 200 - 60;
+  function updateTargets(delta) {
+    targets.forEach((target, index) => {
+      if (target.destroyed) {
+        target.respawnDelay -= delta;
+        if (target.respawnDelay <= 0) {
+          spawnTarget(index, player.z + 360 + index * 70 + Math.random() * 160);
+        }
+        return;
+      }
+      target.phase += delta;
+      target.x = target.baseX + Math.sin(target.phase * 1.3) * 24;
+      target.y = target.baseY + Math.sin(target.phase * 1.9) * 9;
+      if (target.z < player.z - 100) {
+        spawnTarget(index, player.z + 520 + Math.random() * 260);
       }
     });
   }
 
+  function updateGates() {
+    gates.forEach((gate, index) => {
+      if (gate.z < player.z - 90) {
+        spawnGate(index, player.z + 720 + Math.random() * 170);
+        return;
+      }
+      if (!gate.passed) {
+        const distance = Math.hypot(player.x - gate.x, player.y - gate.y, player.z - gate.z);
+        if (distance <= gate.radius + 6) {
+          gate.passed = true;
+          player.gateStreak += 1;
+          player.score += 35 * player.gateStreak;
+          player.energy = Math.min(100, player.energy + 18);
+          objectiveToast.innerHTML = `<strong>Gate clean.</strong> Energy restored. Gate streak ${player.gateStreak}.`;
+        }
+      }
+    });
+  }
+
+  function emitJetParticles(count) {
+    const forward = forwardVector();
+    for (let i = 0; i < count; i += 1) {
+      particles.push({
+        x: player.x - forward.x * 2 + (Math.random() - 0.5) * 1.2,
+        y: player.y + EYE_HEIGHT - 3 + (Math.random() - 0.5) * 0.8,
+        z: player.z - forward.z * 2 + (Math.random() - 0.5) * 1.2,
+        vx: -forward.x * 16 + (Math.random() - 0.5) * 8,
+        vy: -10 - Math.random() * 8,
+        vz: -forward.z * 16 + (Math.random() - 0.5) * 8,
+        color: '#67e8f9',
+        age: 0,
+        life: 0.45 + Math.random() * 0.24,
+        size: 2 + Math.random() * 3
+      });
+    }
+  }
+
+  function emitMuzzleParticles(origin, direction, weapon) {
+    for (let i = 0; i < weapon.particleCount; i += 1) {
+      particles.push({
+        x: origin.x,
+        y: origin.y,
+        z: origin.z,
+        vx: direction.x * (30 + Math.random() * 18) + (Math.random() - 0.5) * 8,
+        vy: direction.y * 18 + (Math.random() - 0.5) * 8,
+        vz: direction.z * (30 + Math.random() * 18) + (Math.random() - 0.5) * 8,
+        color: weapon.color,
+        age: 0,
+        life: 0.28 + Math.random() * 0.2,
+        size: 2 + Math.random() * 3
+      });
+    }
+  }
+
+  function emitImpact(x, y, z, color, count) {
+    for (let i = 0; i < count; i += 1) {
+      particles.push({
+        x,
+        y,
+        z,
+        vx: (Math.random() - 0.5) * 46,
+        vy: (Math.random() - 0.2) * 32,
+        vz: (Math.random() - 0.5) * 46,
+        color,
+        age: 0,
+        life: 0.55 + Math.random() * 0.5,
+        size: 2 + Math.random() * 5
+      });
+    }
+  }
+
+  function updateParticles(delta) {
+    for (let i = particles.length - 1; i >= 0; i -= 1) {
+      const particle = particles[i];
+      particle.age += delta;
+      particle.x += particle.vx * delta;
+      particle.y += particle.vy * delta;
+      particle.z += particle.vz * delta;
+      particle.vy -= GRAVITY * 0.18 * delta;
+      if (particle.age >= particle.life) {
+        particles.splice(i, 1);
+      }
+    }
+  }
+
+  function cameraPoint(point) {
+    const eyeY = player.y + EYE_HEIGHT;
+    const dx = point.x - player.x;
+    const dy = point.y - eyeY;
+    const dz = point.z - player.z;
+    const cosYaw = Math.cos(player.yaw);
+    const sinYaw = Math.sin(player.yaw);
+    const yawX = cosYaw * dx - sinYaw * dz;
+    const yawZ = sinYaw * dx + cosYaw * dz;
+    const cosPitch = Math.cos(player.pitch);
+    const sinPitch = Math.sin(player.pitch);
+    return {
+      x: yawX,
+      y: cosPitch * dy - sinPitch * yawZ,
+      z: sinPitch * dy + cosPitch * yawZ
+    };
+  }
+
+  function project(point) {
+    const cam = cameraPoint(point);
+    if (cam.z <= camera.near) {
+      return null;
+    }
+    const width = viewWidth();
+    const height = viewHeight();
+    const scale = camera.focal / cam.z;
+    return {
+      x: width * 0.5 + cam.x * scale,
+      y: height * 0.5 - cam.y * scale,
+      depth: cam.z,
+      scale
+    };
+  }
+
   function drawSky() {
-    const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
-    gradient.addColorStop(0, '#020617');
-    gradient.addColorStop(0.35, '#0b1530');
-    gradient.addColorStop(1, '#030712');
+    const width = viewWidth();
+    const height = viewHeight();
+    const horizon = height * (0.55 + player.pitch * 0.26);
+    const gradient = ctx.createLinearGradient(0, 0, 0, height);
+    gradient.addColorStop(0, '#06102a');
+    gradient.addColorStop(0.44, '#0b1c35');
+    gradient.addColorStop(1, '#06111d');
     ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillRect(0, 0, width, height);
 
     ctx.save();
     ctx.globalCompositeOperation = 'screen';
-    ctx.fillStyle = 'rgba(59, 130, 246, 0.12)';
-    for (let i = 0; i < 5; i += 1) {
-      const waveY = (i + 1) * 60 + Math.sin((performance.now() * 0.0006) + i) * 18;
+    ctx.strokeStyle = 'rgba(103, 232, 249, 0.08)';
+    ctx.lineWidth = 1;
+    for (let i = 0; i < 9; i += 1) {
+      const y = horizon + i * 28;
       ctx.beginPath();
-      ctx.ellipse(canvas.width * (i % 2 === 0 ? 0.3 : 0.7), waveY, canvas.width * 0.32, 48, 0, 0, Math.PI * 2);
-      ctx.fill();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y + Math.sin(player.z * 0.004 + i) * 14);
+      ctx.stroke();
     }
     ctx.restore();
   }
 
-  function drawStarfield() {
+  function drawStars() {
     ctx.save();
     ctx.globalCompositeOperation = 'screen';
     stars.forEach(star => {
-      const worldPoint = {
+      const wrappedZ = ((star.z - player.z) % 1100 + 1100) % 1100 + player.z + 80;
+      const point = project({
         x: player.x + star.x,
-        y: camera.y + star.y,
-        z: player.z + star.z
-      };
-      const projected = projectPoint(worldPoint);
-      if (!projected) {
+        y: star.y,
+        z: wrappedZ
+      });
+      if (!point) {
         return;
       }
-      const size = Math.max(1, 2.4 - projected.depth * 0.003);
-      const alpha = 0.25 + Math.min(0.6, 260 / (projected.depth + 60));
-      ctx.fillStyle = `rgba(148, 197, 255, ${alpha.toFixed(3)})`;
+      const alpha = clamp(1 - point.depth / 1200, 0.14, 0.78);
+      ctx.fillStyle = `rgba(200, 236, 255, ${alpha.toFixed(3)})`;
       ctx.beginPath();
-      ctx.arc(projected.x, projected.y, size, 0, Math.PI * 2);
+      ctx.arc(point.x, point.y, star.size, 0, Math.PI * 2);
       ctx.fill();
     });
     ctx.restore();
   }
 
   function drawTerrain() {
-    const stepZ = 14;
-    const stepX = 16;
-    const forwardRange = 360;
-    const lateralRange = 180;
+    const step = 26;
+    const lateral = 360;
+    const forward = 760;
+    const back = 52;
     const quads = [];
+    const startZ = Math.floor((player.z - back) / step) * step;
+    const endZ = player.z + forward;
+    const startX = Math.floor((player.x - lateral) / step) * step;
+    const endX = player.x + lateral;
 
-    const startZ = Math.floor(player.z / stepZ) * stepZ - stepZ;
-    const endZ = player.z + forwardRange;
-    const xStart = Math.floor((player.x - lateralRange) / stepX) * stepX;
-    const xEnd = Math.floor((player.x + lateralRange) / stepX) * stepX + stepX;
-
-    for (let z = startZ; z < endZ; z += stepZ) {
-      const nextZ = z + stepZ;
-      for (let x = xStart; x < xEnd; x += stepX) {
-        const nextX = x + stepX;
-        const p0 = projectPoint({ x, y: groundHeight(x, z), z });
-        const p1 = projectPoint({ x: nextX, y: groundHeight(nextX, z), z });
-        const p2 = projectPoint({ x: nextX, y: groundHeight(nextX, nextZ), z: nextZ });
-        const p3 = projectPoint({ x, y: groundHeight(x, nextZ), z: nextZ });
-
+    for (let z = startZ; z < endZ; z += step) {
+      for (let x = startX; x < endX; x += step) {
+        const p0w = { x, y: terrainHeight(x, z), z };
+        const p1w = { x: x + step, y: terrainHeight(x + step, z), z };
+        const p2w = { x: x + step, y: terrainHeight(x + step, z + step), z: z + step };
+        const p3w = { x, y: terrainHeight(x, z + step), z: z + step };
+        const p0 = project(p0w);
+        const p1 = project(p1w);
+        const p2 = project(p2w);
+        const p3 = project(p3w);
         if (!p0 || !p1 || !p2 || !p3) {
           continue;
         }
-
-        const avgDepth = (p0.depth + p1.depth + p2.depth + p3.depth) / 4;
-        const avgHeight = (groundHeight(x, z) + groundHeight(nextX, z) + groundHeight(nextX, nextZ) + groundHeight(x, nextZ)) / 4;
-        quads.push({ points: [p0, p1, p2, p3], depth: avgDepth, height: avgHeight });
+        const averageDepth = (p0.depth + p1.depth + p2.depth + p3.depth) / 4;
+        const averageHeight = (p0w.y + p1w.y + p2w.y + p3w.y) / 4;
+        quads.push({ points: [p0, p1, p2, p3], depth: averageDepth, height: averageHeight, x, z });
       }
     }
 
     quads.sort((a, b) => b.depth - a.depth);
-
     quads.forEach(quad => {
-      const { points, height } = quad;
-      const tone = Math.max(-1, Math.min(1, (height + 18) / 24));
-      const blue = 180 + tone * 25;
-      const green = 110 + tone * 40;
-      const red = 30 + tone * 25;
-      ctx.fillStyle = `rgba(${red.toFixed(0)}, ${green.toFixed(0)}, ${blue.toFixed(0)}, 0.72)`;
+      const shade = clamp((quad.height + 36) / 72, 0, 1);
+      const lane = Math.abs(Math.sin(quad.x * 0.017 + quad.z * 0.01));
+      const r = 8 + shade * 20;
+      const g = 42 + shade * 48 + lane * 12;
+      const b = 68 + shade * 92 + lane * 16;
+      ctx.fillStyle = `rgba(${r.toFixed(0)}, ${g.toFixed(0)}, ${b.toFixed(0)}, 0.92)`;
       ctx.beginPath();
-      ctx.moveTo(points[0].x, points[0].y);
-      for (let i = 1; i < points.length; i += 1) {
-        ctx.lineTo(points[i].x, points[i].y);
-      }
+      ctx.moveTo(quad.points[0].x, quad.points[0].y);
+      quad.points.slice(1).forEach(point => ctx.lineTo(point.x, point.y));
       ctx.closePath();
       ctx.fill();
-
-      ctx.strokeStyle = `rgba(94, 234, 212, ${0.08 + (1 - tone) * 0.12})`;
-      ctx.lineWidth = 0.6;
+      ctx.strokeStyle = `rgba(103, 232, 249, ${clamp(0.035 + (1 - quad.depth / 800) * 0.12, 0.02, 0.16)})`;
+      ctx.lineWidth = 0.75;
       ctx.stroke();
+    });
+  }
+
+  function drawGates() {
+    ctx.save();
+    ctx.globalCompositeOperation = 'screen';
+    gates.forEach(gate => {
+      const point = project({ x: gate.x, y: gate.y, z: gate.z });
+      if (!point) {
+        return;
+      }
+      const radius = clamp(gate.radius * point.scale, 8, 140);
+      ctx.strokeStyle = gate.passed ? 'rgba(103, 232, 249, 0.18)' : 'rgba(103, 232, 249, 0.78)';
+      ctx.lineWidth = gate.passed ? 1 : 3;
+      ctx.beginPath();
+      ctx.ellipse(point.x, point.y, radius * 1.25, radius, 0, 0, Math.PI * 2);
+      ctx.stroke();
+      if (!gate.passed) {
+        ctx.strokeStyle = 'rgba(248, 212, 122, 0.32)';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.ellipse(point.x, point.y, radius * 1.55, radius * 1.18, 0, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    });
+    ctx.restore();
+  }
+
+  function drawTargets() {
+    targets.forEach(target => {
+      if (target.destroyed) {
+        return;
+      }
+      const point = project({ x: target.x, y: target.y, z: target.z });
+      if (!point) {
+        return;
+      }
+      const radius = clamp(target.radius * point.scale, 5, 64);
+      ctx.save();
+      ctx.globalCompositeOperation = 'screen';
+      const gradient = ctx.createRadialGradient(point.x, point.y, 1, point.x, point.y, radius * 1.7);
+      gradient.addColorStop(0, 'rgba(255, 255, 255, 0.95)');
+      gradient.addColorStop(0.24, 'rgba(251, 113, 133, 0.78)');
+      gradient.addColorStop(1, 'rgba(251, 113, 133, 0)');
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, radius * 1.7, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255, 228, 230, 0.92)';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.strokeStyle = 'rgba(251, 113, 133, 0.78)';
+      ctx.beginPath();
+      ctx.moveTo(point.x - radius * 1.6, point.y);
+      ctx.lineTo(point.x + radius * 1.6, point.y);
+      ctx.moveTo(point.x, point.y - radius * 1.6);
+      ctx.lineTo(point.x, point.y + radius * 1.6);
+      ctx.stroke();
+      ctx.restore();
+
+      ctx.save();
+      ctx.fillStyle = 'rgba(2, 6, 23, 0.72)';
+      ctx.fillRect(point.x - radius, point.y - radius * 2 - 7, radius * 2, 5);
+      ctx.fillStyle = '#fb7185';
+      ctx.fillRect(point.x - radius, point.y - radius * 2 - 7, radius * 2 * clamp(target.health / 100, 0, 1), 5);
+      ctx.restore();
     });
   }
 
@@ -1358,246 +1554,177 @@
     ctx.save();
     ctx.globalCompositeOperation = 'screen';
     projectiles.forEach(projectile => {
-      const projected = projectPoint({ x: projectile.x, y: projectile.y, z: projectile.z });
-      if (!projected) {
+      const point = project(projectile);
+      if (!point) {
         return;
       }
-      const size = Math.max(2, projectile.radius * (camera.focalLength / projected.depth));
-      const gradient = ctx.createRadialGradient(projected.x, projected.y, size * 0.2, projected.x, projected.y, size);
-      gradient.addColorStop(0, `${projectile.color}dd`);
+      const radius = clamp(projectile.radius * point.scale, 2, 28);
+      const gradient = ctx.createRadialGradient(point.x, point.y, 1, point.x, point.y, radius * 2.5);
+      gradient.addColorStop(0, `${projectile.color}ff`);
       gradient.addColorStop(1, `${projectile.color}00`);
       ctx.fillStyle = gradient;
       ctx.beginPath();
-      ctx.arc(projected.x, projected.y, size, 0, Math.PI * 2);
+      ctx.arc(point.x, point.y, radius * 2.5, 0, Math.PI * 2);
       ctx.fill();
     });
     ctx.restore();
   }
 
-  function drawPlayer() {
-    const nose = projectPoint({ x: player.x, y: player.y + player.radius * 0.6, z: player.z + 6 });
-    const left = projectPoint({ x: player.x - player.radius, y: player.y - player.radius * 0.4, z: player.z - 2 });
-    const right = projectPoint({ x: player.x + player.radius, y: player.y - player.radius * 0.4, z: player.z - 2 });
-    const plumeAnchor = projectPoint({ x: player.x, y: player.y - player.radius * 0.6, z: player.z - 8 });
-
-    if (!nose || !left || !right) {
-      return;
-    }
-
+  function drawParticles() {
     ctx.save();
-    ctx.fillStyle = 'rgba(94, 234, 212, 0.75)';
-    ctx.beginPath();
-    ctx.moveTo(nose.x, nose.y);
-    ctx.lineTo(right.x, right.y);
-    ctx.lineTo(left.x, left.y);
-    ctx.closePath();
-    ctx.fill();
-
-    ctx.strokeStyle = 'rgba(125, 211, 252, 0.9)';
-    ctx.lineWidth = 1.2;
-    ctx.beginPath();
-    ctx.moveTo(nose.x, nose.y);
-    ctx.lineTo(right.x, right.y);
-    ctx.lineTo(left.x, left.y);
-    ctx.closePath();
-    ctx.stroke();
-
-    if (plumeAnchor && !player.onGround) {
-      const plumeEnd = projectPoint({ x: player.x, y: player.y - player.radius * 0.6, z: player.z - 14 });
-      if (plumeEnd) {
-        ctx.globalCompositeOperation = 'screen';
-        const plumeRadius = Math.max(3, (camera.focalLength / plumeEnd.depth) * 6);
-        const gradient = ctx.createRadialGradient(plumeEnd.x, plumeEnd.y, plumeRadius * 0.1, plumeEnd.x, plumeEnd.y, plumeRadius);
-        gradient.addColorStop(0, 'rgba(59, 130, 246, 0.65)');
-        gradient.addColorStop(1, 'rgba(14, 116, 144, 0)');
-        ctx.fillStyle = gradient;
-        ctx.beginPath();
-        ctx.arc(plumeEnd.x, plumeEnd.y, plumeRadius, 0, Math.PI * 2);
-        ctx.fill();
+    ctx.globalCompositeOperation = 'screen';
+    particles.forEach(particle => {
+      const point = project(particle);
+      if (!point) {
+        return;
       }
-    }
-
+      const alpha = clamp(1 - particle.age / particle.life, 0, 1);
+      const size = clamp(particle.size * point.scale, 1, 18);
+      ctx.fillStyle = `${particle.color}${Math.round(alpha * 220).toString(16).padStart(2, '0')}`;
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, size, 0, Math.PI * 2);
+      ctx.fill();
+    });
     ctx.restore();
   }
 
-  function drawTarget() {
-    const halfW = target.width * 0.5;
-    const halfD = target.depth * 0.5;
-    const baseY = target.y;
-    const topY = target.y + target.height;
-
-    const fl = projectPoint({ x: target.x - halfW, y: baseY, z: target.z - halfD });
-    const fr = projectPoint({ x: target.x + halfW, y: baseY, z: target.z - halfD });
-    const bl = projectPoint({ x: target.x - halfW, y: baseY, z: target.z + halfD });
-    const br = projectPoint({ x: target.x + halfW, y: baseY, z: target.z + halfD });
-    const tfl = projectPoint({ x: target.x - halfW, y: topY, z: target.z - halfD });
-    const tfr = projectPoint({ x: target.x + halfW, y: topY, z: target.z - halfD });
-    const tbl = projectPoint({ x: target.x - halfW, y: topY, z: target.z + halfD });
-    const tbr = projectPoint({ x: target.x + halfW, y: topY, z: target.z + halfD });
-
-    if (!fl || !fr || !bl || !br || !tfl || !tfr || !tbl || !tbr) {
-      return;
-    }
-
+  function drawVelocityLines() {
+    const width = viewWidth();
+    const height = viewHeight();
+    const speed = horizontalSpeed();
+    const count = clamp(Math.floor(speed / 9), 4, 24);
     ctx.save();
-    ctx.globalAlpha = 0.9;
-
-    ctx.fillStyle = 'rgba(236, 72, 153, 0.35)';
-    ctx.beginPath();
-    ctx.moveTo(tbl.x, tbl.y);
-    ctx.lineTo(tbr.x, tbr.y);
-    ctx.lineTo(tfr.x, tfr.y);
-    ctx.lineTo(tfl.x, tfl.y);
-    ctx.closePath();
-    ctx.fill();
-
-    ctx.fillStyle = 'rgba(190, 24, 93, 0.45)';
-    ctx.beginPath();
-    ctx.moveTo(fr.x, fr.y);
-    ctx.lineTo(br.x, br.y);
-    ctx.lineTo(tbr.x, tbr.y);
-    ctx.lineTo(tfr.x, tfr.y);
-    ctx.closePath();
-    ctx.fill();
-
-    ctx.fillStyle = 'rgba(244, 114, 182, 0.72)';
-    ctx.beginPath();
-    ctx.moveTo(fl.x, fl.y);
-    ctx.lineTo(fr.x, fr.y);
-    ctx.lineTo(tfr.x, tfr.y);
-    ctx.lineTo(tfl.x, tfl.y);
-    ctx.closePath();
-    ctx.fill();
-
-    ctx.strokeStyle = 'rgba(236, 72, 153, 0.8)';
-    ctx.lineWidth = 1.2;
-    ctx.beginPath();
-    ctx.moveTo(fl.x, fl.y);
-    ctx.lineTo(fr.x, fr.y);
-    ctx.lineTo(tfr.x, tfr.y);
-    ctx.lineTo(tfl.x, tfl.y);
-    ctx.closePath();
-    ctx.stroke();
-
-    ctx.restore();
-
-    const indicator = projectPoint({ x: target.x, y: topY + 5, z: target.z - halfD });
-    if (indicator) {
-      const width = Math.max(28, (camera.focalLength / indicator.depth) * 24);
-      ctx.save();
-      ctx.globalAlpha = 0.86;
-      ctx.fillStyle = 'rgba(15, 23, 42, 0.7)';
-      ctx.fillRect(indicator.x - width * 0.5 - 2, indicator.y - 6, width + 4, 10);
-      ctx.strokeStyle = 'rgba(236, 72, 153, 0.65)';
-      ctx.lineWidth = 1;
-      ctx.strokeRect(indicator.x - width * 0.5 - 2, indicator.y - 6, width + 4, 10);
-      const ratio = target.health / 100;
-      ctx.fillStyle = 'rgba(192, 132, 252, 0.9)';
-      ctx.fillRect(indicator.x - width * 0.5, indicator.y - 4, width * ratio, 6);
-      ctx.restore();
+    ctx.strokeStyle = `rgba(103, 232, 249, ${clamp(speed / 260, 0.12, 0.46)})`;
+    ctx.lineWidth = 1;
+    for (let i = 0; i < count; i += 1) {
+      const lane = (i / count) * Math.PI * 2 + player.z * 0.005;
+      const x = width * 0.5 + Math.cos(lane) * width * (0.18 + (i % 5) * 0.06);
+      const y = height * 0.5 + Math.sin(lane) * height * (0.12 + (i % 4) * 0.05);
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(x - Math.cos(lane) * speed * 0.24, y - Math.sin(lane) * speed * 0.16);
+      ctx.stroke();
     }
-  }
-
-  function drawCrosshair() {
-    ctx.save();
-    ctx.strokeStyle = 'rgba(248, 250, 252, 0.85)';
-    ctx.lineWidth = 1.4;
-    ctx.beginPath();
-    ctx.arc(input.mouseX, input.mouseY, 12, 0, Math.PI * 2);
-    ctx.moveTo(input.mouseX - 18, input.mouseY);
-    ctx.lineTo(input.mouseX - 6, input.mouseY);
-    ctx.moveTo(input.mouseX + 6, input.mouseY);
-    ctx.lineTo(input.mouseX + 18, input.mouseY);
-    ctx.moveTo(input.mouseX, input.mouseY - 18);
-    ctx.lineTo(input.mouseX, input.mouseY - 6);
-    ctx.moveTo(input.mouseX, input.mouseY + 6);
-    ctx.lineTo(input.mouseX, input.mouseY + 18);
-    ctx.stroke();
     ctx.restore();
   }
 
-  function drawUIOverlay() {
-    if (compactViewportQuery.matches) {
-      return;
-    }
-
-    const altitude = Math.max(0, player.y - groundHeight(player.x, player.z) - player.radius);
-    const horizontalSpeed = Math.sqrt(player.vx * player.vx + player.vz * player.vz);
-    const rangeDepth = Math.max(0, target.z - player.z);
-
+  function drawWeaponView() {
+    const width = viewWidth();
+    const height = viewHeight();
+    const bob = Math.sin(performance.now() * 0.009) * clamp(horizontalSpeed() / 90, 0, 1) * 4;
+    const x = width * 0.68;
+    const y = height - 56 + bob;
+    const weapon = weapons[player.weaponIndex];
     ctx.save();
-    ctx.globalAlpha = 0.94;
-    ctx.fillStyle = 'rgba(15, 23, 42, 0.62)';
-    ctx.strokeStyle = 'rgba(94, 234, 212, 0.35)';
-    ctx.lineWidth = 1.4;
-    const panelWidth = 226;
-    const panelHeight = 96;
-    const x = 24;
-    const y = 24;
-    const r = 14;
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.fillStyle = 'rgba(5, 10, 24, 0.9)';
+    ctx.strokeStyle = 'rgba(148, 163, 184, 0.28)';
+    ctx.lineWidth = 2;
     ctx.beginPath();
-    ctx.moveTo(x + r, y);
-    ctx.lineTo(x + panelWidth - r, y);
-    ctx.quadraticCurveTo(x + panelWidth, y, x + panelWidth, y + r);
-    ctx.lineTo(x + panelWidth, y + panelHeight - r);
-    ctx.quadraticCurveTo(x + panelWidth, y + panelHeight, x + panelWidth - r, y + panelHeight);
-    ctx.lineTo(x + r, y + panelHeight);
-    ctx.quadraticCurveTo(x, y + panelHeight, x, y + panelHeight - r);
-    ctx.lineTo(x, y + r);
-    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.moveTo(x - 26, y + 34);
+    ctx.lineTo(x + 122, y + 52);
+    ctx.lineTo(x + 166, y + 12);
+    ctx.lineTo(x + 54, y - 24);
     ctx.closePath();
     ctx.fill();
     ctx.stroke();
+    ctx.globalCompositeOperation = 'screen';
+    ctx.strokeStyle = weapon.color;
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(x + 30, y - 8);
+    ctx.lineTo(x + 142, y + 14);
+    ctx.stroke();
+    ctx.fillStyle = weapon.color;
+    ctx.beginPath();
+    ctx.arc(x + 150, y + 15, player.cooldown > 0 ? 5 : 8, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
 
-    ctx.strokeStyle = 'rgba(56, 189, 248, 0.35)';
+  function drawStatusRibbon() {
+    const width = viewWidth();
+    const height = viewHeight();
+    const speed = horizontalSpeed();
+    const skiText = input.ski ? 'SKI' : player.onGround ? 'RUN' : 'AIR';
+    const lockText = document.pointerLockElement === canvas ? 'AIM LOCK' : 'CLICK TO AIM';
+    ctx.save();
+    ctx.fillStyle = 'rgba(2, 6, 23, 0.58)';
+    ctx.strokeStyle = 'rgba(103, 232, 249, 0.22)';
     ctx.lineWidth = 1;
     ctx.beginPath();
-    ctx.moveTo(x + 16, y + 40);
-    ctx.lineTo(x + panelWidth - 16, y + 40);
-    ctx.moveTo(x + 16, y + 68);
-    ctx.lineTo(x + panelWidth - 16, y + 68);
+    ctx.roundRect(width * 0.5 - 145, height - 58, 290, 32, 16);
+    ctx.fill();
     ctx.stroke();
-
-    ctx.fillStyle = 'rgba(226, 232, 240, 0.94)';
-    ctx.font = '16px "Poppins", sans-serif';
-    ctx.fillText('Altitude', x + 16, y + 28);
-    ctx.fillText(`${altitude.toFixed(1)} m`, x + 130, y + 28);
-    ctx.fillText('Velocity', x + 16, y + 56);
-    ctx.fillText(`${horizontalSpeed.toFixed(1)} m/s`, x + 130, y + 56);
-    ctx.fillText('Range', x + 16, y + 84);
-    ctx.fillText(`${rangeDepth.toFixed(1)} m`, x + 130, y + 84);
+    ctx.fillStyle = 'rgba(239, 246, 255, 0.88)';
+    ctx.font = '700 12px Poppins, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(`${skiText}  |  ${lockText}  |  ${Math.round(speed)} M/S`, width * 0.5, height - 37);
     ctx.restore();
+  }
+
+  function render() {
+    drawSky();
+    drawStars();
+    drawTerrain();
+    drawGates();
+    drawTargets();
+    drawProjectiles();
+    drawParticles();
+    drawVelocityLines();
+    drawWeaponView();
+    drawStatusRibbon();
+  }
+
+  function update(delta) {
+    input.brake = keys.has('KeyE') || input.brake;
+    updatePlayer(delta);
+    fireWeapon();
+    updateProjectiles(delta);
+    updateTargets(delta);
+    updateGates(delta);
+    updateParticles(delta);
+    updateHud();
   }
 
   let lastTime = performance.now();
-
   function loop(time) {
-    const delta = Math.min(0.05, (time - lastTime) / 1000);
+    const delta = Math.min(0.045, (time - lastTime) / 1000);
     lastTime = time;
-
-    updatePlayer(delta);
-    updateCamera(delta);
-    fireWeapon(delta);
-    updateProjectiles(delta);
-    updateTarget(delta);
-    updateStarfield(delta);
-
-    drawSky();
-    drawStarfield();
-    drawTerrain();
-    drawProjectiles();
-    drawTarget();
-    drawPlayer();
-    drawCrosshair();
-    drawUIOverlay();
-
+    update(delta);
+    render();
     requestAnimationFrame(loop);
   }
 
-  weaponName.textContent = weapons[player.weaponIndex].name;
-  targetHealthEl.textContent = Math.round(target.health);
+  window.addEventListener('resize', resizeCanvas);
+  window.addEventListener('orientationchange', resizeCanvas);
+  window.addEventListener('keydown', handleKeyDown);
+  window.addEventListener('keyup', handleKeyUp);
+  window.addEventListener('blur', resetHoldInputs);
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointercancel', handlePointerUp);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('contextmenu', event => event.preventDefault());
+  beginRun.addEventListener('click', beginPointerRun);
+  guideToggle.addEventListener('click', () => setGuideVisible(true));
+  document.addEventListener('pointerlockchange', () => {
+    if (document.pointerLockElement !== canvas) {
+      input.fire = false;
+    }
+  });
+
+  resizeCanvas();
+  setupTouchControls();
+  seedStars();
+  resetRun();
+
+  if (matchMedia('(max-width: 520px)').matches) {
+    setGuideVisible(false);
+  }
+
   requestAnimationFrame(loop);
-</script>
+  </script>
 
   <script defer src="/issue-launcher.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- rebuild `tribes-flight.html` into a first-person ski-shooter training range
- add pointer-lock aiming, keyboard look, touch look, ski mode, jetpack energy, air brake, two weapons, projectile target drones, gates, speed/altitude/score/combo HUD, and first-person weapon view
- update the Game Hub blurb to match the redesigned experience
- add a focused Node regression test for the first-person ski-shooter mechanics

## Validation
- `node --test tests/zero-g-ski-range.test.js tests/games-page-icons.test.js`
- `git diff --check`
- local Playwright browser smoke against `http://127.0.0.1:3000/tribes-flight.html` verified nonblank canvas render and no page errors; local Vercel analytics 404 ignored as expected
- local Playwright interaction pass verified Begin Run hides the guide, movement increases speed, altitude changes, and jetpack energy drains

## Notes
- No backend, GunJS, Stripe/billing, or analytics changes.
- Keeps the existing `tribes-flight.html` route for the Game Hub.
- Uses original portal canvas art and mechanics; no copied game assets.