### PR TITLE
Fix Pong controls and mouse lock

### DIFF
--- a/pong.html
+++ b/pong.html
@@ -401,7 +401,7 @@
     <h1>Pong Arena</h1>
     <p>
       A neon 3DVR paddle duel. Use Up/Down or Left/Right to move, track the ball trail,
-      and score against a less-perfect training AI.
+      click the arena to lock mouse control, and score against a less-perfect training AI.
     </p>
     <div class="hud" aria-label="Pong score and status">
       <div class="hud-card">
@@ -491,6 +491,7 @@ const BALL_RADIUS = 0.46;
 const BASE_BALL_SPEED = 12.8;
 const MAX_BALL_SPEED = 20;
 const PLAYER_SPEED = 17.5;
+const MOUSE_LOCK_SENSITIVITY = 0.038;
 const AI_MAX_SPEED = 9.6;
 const AI_REACTION_SECONDS = 0.34;
 const AI_AIM_ERROR = 1.85;
@@ -514,6 +515,8 @@ let rallyCount = 0;
 let aiThinkTimer = 0;
 let aiTargetY = 0;
 let pointerControlActive = false;
+let pointerLocked = false;
+let pointerLockHintShown = false;
 let touchMoveDirection = 0;
 let statusTimer = 0;
 
@@ -773,8 +776,8 @@ function resizeRenderer() {
 function syncKeyboardVelocity() {
   const upward = keysDown.has('ArrowUp') || keysDown.has('ArrowLeft');
   const downward = keysDown.has('ArrowDown') || keysDown.has('ArrowRight');
-  if (upward && !downward) return -1;
-  if (downward && !upward) return 1;
+  if (upward && !downward) return 1;
+  if (downward && !upward) return -1;
   return 0;
 }
 
@@ -783,6 +786,36 @@ function movePlayerByPointer(clientY) {
   const normalized = clamp((clientY - rect.top) / rect.height, 0, 1);
   const courtY = (0.5 - normalized) * FIELD_HEIGHT;
   player.y = clamp(courtY, -WALL_LIMIT + PADDLE_HEIGHT / 2, WALL_LIMIT - PADDLE_HEIGHT / 2);
+}
+
+function movePlayerByPointerDelta(deltaY) {
+  player.y = clamp(
+    player.y - deltaY * MOUSE_LOCK_SENSITIVITY,
+    -WALL_LIMIT + PADDLE_HEIGHT / 2,
+    WALL_LIMIT - PADDLE_HEIGHT / 2
+  );
+}
+
+function requestMouseLock() {
+  if (!arena.requestPointerLock || document.pointerLockElement === arena) {
+    return;
+  }
+  pointerLockHintShown = true;
+  try {
+    arena.requestPointerLock();
+  } catch (err) {
+    console.warn('Pointer lock request failed', err);
+  }
+}
+
+function syncPointerLockState() {
+  pointerLocked = document.pointerLockElement === arena;
+  pointerControlActive = pointerLocked;
+  if (pointerLocked) {
+    setMessage('Mouse locked. Move up/down to steer; press Esc to release.', 2600);
+  } else if (pointerLockHintShown) {
+    setMessage('Mouse released. Click the arena to lock again.', 1800);
+  }
 }
 
 function updatePlayer(deltaSeconds) {
@@ -951,7 +984,7 @@ function startGame() {
   }
   initScene();
   updateHud();
-  setMessage('Ready. Up/Down or Left/Right controls the player paddle.', 3000);
+  setMessage('Ready. Up/Down or Left/Right controls the paddle. Click the arena to lock the mouse.', 3600);
   animationFrameId = requestAnimationFrame(tick);
 }
 
@@ -973,17 +1006,32 @@ window.addEventListener('keyup', event => {
 });
 
 arena.addEventListener('pointermove', event => {
-  if (event.pointerType === 'mouse' || event.pointerType === 'pen') {
+  if (!pointerLocked && (event.pointerType === 'mouse' || event.pointerType === 'pen')) {
     pointerControlActive = true;
     movePlayerByPointer(event.clientY);
   }
 });
 
 arena.addEventListener('pointerleave', event => {
-  if (event.pointerType === 'mouse' || event.pointerType === 'pen') {
+  if (!pointerLocked && (event.pointerType === 'mouse' || event.pointerType === 'pen')) {
     pointerControlActive = false;
   }
 });
+
+arena.addEventListener('pointerdown', event => {
+  if (event.pointerType === 'mouse') {
+    requestMouseLock();
+  }
+});
+
+document.addEventListener('mousemove', event => {
+  if (pointerLocked) {
+    pointerControlActive = true;
+    movePlayerByPointerDelta(event.movementY);
+  }
+});
+
+document.addEventListener('pointerlockchange', syncPointerLockState);
 
 arena.addEventListener('touchstart', event => {
   event.preventDefault();
@@ -1001,7 +1049,7 @@ arena.addEventListener('touchend', () => {
 });
 
 document.querySelectorAll('.touch-controls button').forEach(button => {
-  const direction = button.dataset.move === 'up' ? -1 : 1;
+  const direction = button.dataset.move === 'up' ? 1 : -1;
   const setMoving = active => {
     touchMoveDirection = active ? direction : 0;
     pointerControlActive = false;

--- a/tests/pong-three-redesign.test.js
+++ b/tests/pong-three-redesign.test.js
@@ -20,7 +20,9 @@ describe('Pong Three.js redesign', () => {
     assert.match(html, /'ArrowRight'/);
     assert.match(html, /keysDown\.has\('ArrowLeft'\)/);
     assert.match(html, /keysDown\.has\('ArrowRight'\)/);
-    assert.match(html, /Left\/Right controls the player paddle/);
+    assert.match(html, /Left\/Right controls the paddle/);
+    assert.match(html, /if \(upward && !downward\) return 1;/);
+    assert.match(html, /if \(downward && !upward\) return -1;/);
   });
 
   it('keeps the AI intentionally beatable', async () => {
@@ -31,5 +33,15 @@ describe('Pong Three.js redesign', () => {
     assert.match(html, /const AI_AIM_ERROR = 1\.85;/);
     assert.match(html, /aimNoise/);
     assert.match(html, /aiThinkTimer/);
+  });
+
+  it('locks mouse control after clicking the arena', async () => {
+    const html = await readFile(new URL('../pong.html', import.meta.url), 'utf8');
+
+    assert.match(html, /requestMouseLock\(\)/);
+    assert.match(html, /arena\.requestPointerLock\(\)/);
+    assert.match(html, /document\.pointerLockElement === arena/);
+    assert.match(html, /movePlayerByPointerDelta\(event\.movementY\)/);
+    assert.match(html, /press Esc to release/);
   });
 });


### PR DESCRIPTION
## Summary
- Fix Pong keyboard direction so Up/Left move the player paddle up and Down/Right move it down in the Three.js court.
- Fix touch button direction to match the corrected court coordinates.
- Add click-to-lock mouse control with Pointer Lock; Escape releases the cursor.
- Update Pong regression coverage for direction signs and pointer lock behavior.

## Validation
- `node --test tests/pong-three-redesign.test.js tests/games-page-icons.test.js`
- `git diff --check`
- Local browser check at `http://127.0.0.1:3000/pong.html` verified the WebGL canvas loads, fallback is hidden, new mouse-lock copy appears, and the page has no app startup errors.

## Notes
- No Stripe, billing, API, or backend changes.
