### PR TITLE
[codex] Add Sober Spark stimulation app

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,11 @@
             <span class="app-card__title">Alive System</span>
             <span class="app-card__meta">Track energy, urges, social reps, and dopamine redirects through the portal Gun relay.</span>
           </a>
+          <a href="sober-spark/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">SPARK</span>
+            <span class="app-card__title">Sober Spark</span>
+            <span class="app-card__meta">Open an interactive light and sound room for redirecting coffee or weed cravings.</span>
+          </a>
           <a href="attention-shield/" class="app-card" data-app-tier="experimental">
             <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">🛡️</span>

--- a/sober-spark/index.html
+++ b/sober-spark/index.html
@@ -1,0 +1,731 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sober Spark | 3DVR Portal</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #090909;
+      --ink: #f8f0da;
+      --muted: #b7ad94;
+      --hot: #ff4d2e;
+      --pulse: #ffe66d;
+      --blue: #2fe6ff;
+      --green: #55ff84;
+      --panel: rgba(10, 10, 10, 0.64);
+      --line: rgba(248, 240, 218, 0.18);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      min-height: 100%;
+    }
+
+    body {
+      margin: 0;
+      background:
+        linear-gradient(120deg, rgba(255, 77, 46, 0.2), transparent 28%),
+        radial-gradient(circle at 82% 12%, rgba(47, 230, 255, 0.22), transparent 26rem),
+        radial-gradient(circle at 12% 82%, rgba(85, 255, 132, 0.16), transparent 24rem),
+        var(--bg);
+      color: var(--ink);
+      font-family: "Trebuchet MS", "Avenir Next", Verdana, sans-serif;
+      overflow: hidden;
+      touch-action: none;
+    }
+
+    canvas {
+      position: fixed;
+      inset: 0;
+      width: 100vw;
+      height: 100vh;
+      display: block;
+    }
+
+    .shell {
+      position: relative;
+      z-index: 2;
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      pointer-events: none;
+    }
+
+    header,
+    .controls,
+    .bottom-bar {
+      pointer-events: auto;
+    }
+
+    header {
+      width: min(1120px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 22px 0 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 16px;
+    }
+
+    .brand {
+      display: grid;
+      gap: 6px;
+    }
+
+    .brand a {
+      color: var(--muted);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0;
+      text-transform: uppercase;
+      font-size: 0.78rem;
+    }
+
+    h1 {
+      margin: 0;
+      max-width: 720px;
+      color: var(--ink);
+      font-size: 5.8rem;
+      line-height: 0.82;
+      letter-spacing: 0;
+      text-transform: uppercase;
+      text-shadow:
+        0 0 28px rgba(255, 230, 109, 0.36),
+        0 0 56px rgba(255, 77, 46, 0.28);
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 9px;
+      padding: 10px 13px;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      color: var(--muted);
+      box-shadow: 0 16px 50px rgba(0, 0, 0, 0.3);
+      backdrop-filter: blur(18px);
+      font-size: 0.95rem;
+      white-space: nowrap;
+    }
+
+    .status::before {
+      content: "";
+      width: 10px;
+      height: 10px;
+      background: var(--green);
+      box-shadow: 0 0 18px var(--green);
+    }
+
+    .stage-label {
+      align-self: center;
+      justify-self: center;
+      text-align: center;
+      max-width: 720px;
+      padding: 24px;
+      pointer-events: none;
+      text-transform: uppercase;
+    }
+
+    .stage-label strong {
+      display: block;
+      font-size: 4.8rem;
+      line-height: 0.88;
+      letter-spacing: 0;
+      text-shadow: 0 0 36px rgba(47, 230, 255, 0.38);
+    }
+
+    .stage-label span {
+      display: block;
+      margin-top: 14px;
+      color: rgba(248, 240, 218, 0.7);
+      font-size: 1.15rem;
+      letter-spacing: 0;
+    }
+
+    .bottom-bar {
+      width: min(1120px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 0 0 20px;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      align-items: end;
+      gap: 16px;
+    }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      padding: 12px;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      box-shadow: 0 20px 70px rgba(0, 0, 0, 0.36);
+      backdrop-filter: blur(18px);
+    }
+
+    button,
+    .select-wrap {
+      min-height: 46px;
+      border: 1px solid rgba(248, 240, 218, 0.18);
+      background: rgba(248, 240, 218, 0.08);
+      color: var(--ink);
+      font: inherit;
+      font-weight: 900;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    button {
+      cursor: pointer;
+      padding: 0 14px;
+    }
+
+    button:hover,
+    button:focus-visible {
+      outline: 2px solid var(--pulse);
+      outline-offset: 2px;
+      background: rgba(255, 230, 109, 0.18);
+    }
+
+    button[data-active="true"] {
+      background: linear-gradient(135deg, var(--pulse), var(--hot));
+      color: #140800;
+      border-color: transparent;
+    }
+
+    .select-wrap {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 10px;
+      color: var(--muted);
+    }
+
+    select {
+      border: 0;
+      background: transparent;
+      color: var(--ink);
+      font: inherit;
+      font-weight: 900;
+      text-transform: uppercase;
+      outline: none;
+    }
+
+    option {
+      background: #111;
+      color: var(--ink);
+    }
+
+    .meter {
+      display: grid;
+      gap: 8px;
+      min-width: min(100%, 260px);
+      padding: 14px;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      box-shadow: 0 20px 70px rgba(0, 0, 0, 0.36);
+      backdrop-filter: blur(18px);
+    }
+
+    .meter span {
+      color: var(--muted);
+      font-size: 0.8rem;
+      font-weight: 900;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    .bar {
+      height: 12px;
+      background: rgba(248, 240, 218, 0.12);
+      overflow: hidden;
+    }
+
+    .bar i {
+      display: block;
+      height: 100%;
+      width: 62%;
+      background: linear-gradient(90deg, var(--green), var(--blue), var(--pulse), var(--hot));
+      box-shadow: 0 0 24px rgba(255, 230, 109, 0.45);
+      transform-origin: left center;
+    }
+
+    .hint {
+      color: rgba(248, 240, 218, 0.68);
+      font-size: 0.9rem;
+      line-height: 1.35;
+    }
+
+    .spark {
+      position: fixed;
+      z-index: 3;
+      width: 18px;
+      height: 18px;
+      border: 2px solid var(--pulse);
+      pointer-events: none;
+      transform: translate(-50%, -50%) rotate(45deg);
+      animation: pop 520ms ease-out forwards;
+      box-shadow: 0 0 26px var(--pulse);
+    }
+
+    @keyframes pop {
+      from {
+        opacity: 1;
+        transform: translate(-50%, -50%) rotate(45deg) scale(0.2);
+      }
+
+      to {
+        opacity: 0;
+        transform: translate(-50%, -50%) rotate(225deg) scale(3.4);
+      }
+    }
+
+    @media (max-width: 720px) {
+      header {
+        display: grid;
+      }
+
+      h1 {
+        font-size: 3.25rem;
+      }
+
+      .stage-label strong {
+        font-size: 2.65rem;
+      }
+
+      .stage-label span {
+        font-size: 0.98rem;
+      }
+
+      .status {
+        width: fit-content;
+      }
+
+      .bottom-bar {
+        grid-template-columns: 1fr;
+      }
+
+      .controls {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      button,
+      .select-wrap {
+        width: 100%;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .spark {
+        animation-duration: 1ms;
+      }
+    }
+  </style>
+</head>
+<body>
+  <canvas id="stage" aria-label="Interactive stimulation field"></canvas>
+  <div class="shell">
+    <header>
+      <div class="brand">
+        <a href="../index.html">3DVR Portal</a>
+        <h1>Sober Spark</h1>
+      </div>
+      <div class="status" id="soundStatus">Sound muted</div>
+    </header>
+
+    <div class="stage-label" aria-live="polite">
+      <strong id="modeTitle">Ride the urge</strong>
+      <span id="modeLine">Move, tap, hold, breathe, repeat</span>
+    </div>
+
+    <div class="bottom-bar">
+      <div class="controls" aria-label="Sober Spark controls">
+        <button type="button" id="soundButton">Unmute sound</button>
+        <button type="button" id="burstButton">Burst</button>
+        <button type="button" id="strobeButton" data-active="false">Strobe</button>
+        <button type="button" id="resetButton">Reset</button>
+        <label class="select-wrap">
+          Mode
+          <select id="modeSelect">
+            <option value="urge">Urge surf</option>
+            <option value="coffee">Coffee edge</option>
+            <option value="weed">Weed redirect</option>
+            <option value="focus">Focus tunnel</option>
+          </select>
+        </label>
+      </div>
+
+      <div class="meter" aria-label="Intensity meter">
+        <span>Stimulation level</span>
+        <div class="bar"><i id="meterBar"></i></div>
+        <div class="hint">Pointer controls the field. Press and hold for pressure release. Space triggers a burst.</div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+    const soundButton = document.getElementById("soundButton");
+    const soundStatus = document.getElementById("soundStatus");
+    const burstButton = document.getElementById("burstButton");
+    const strobeButton = document.getElementById("strobeButton");
+    const resetButton = document.getElementById("resetButton");
+    const modeSelect = document.getElementById("modeSelect");
+    const modeTitle = document.getElementById("modeTitle");
+    const modeLine = document.getElementById("modeLine");
+    const meterBar = document.getElementById("meterBar");
+
+    const modes = {
+      urge: {
+        title: "Ride the urge",
+        line: "Move, tap, hold, breathe, repeat",
+        colors: ["#ff4d2e", "#ffe66d", "#2fe6ff", "#55ff84"],
+        tempo: 0.76,
+        tone: 130.81
+      },
+      coffee: {
+        title: "Wake without coffee",
+        line: "Fast eyes, clean hands, no crash",
+        colors: ["#ffe66d", "#ff8a2a", "#2fe6ff", "#ffffff"],
+        tempo: 1.12,
+        tone: 164.81
+      },
+      weed: {
+        title: "Redirect the want",
+        line: "Let the craving become color",
+        colors: ["#55ff84", "#2fe6ff", "#b7ff3c", "#ff4d2e"],
+        tempo: 0.64,
+        tone: 98
+      },
+      focus: {
+        title: "Lock the tunnel",
+        line: "Narrow the noise into one beam",
+        colors: ["#2fe6ff", "#f8f0da", "#55ff84", "#ffe66d"],
+        tempo: 0.92,
+        tone: 196
+      }
+    };
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+    let particles = [];
+    let rings = [];
+    let stars = [];
+    let pointer = { x: 0.5, y: 0.5, down: false, active: false };
+    let intensity = 0.58;
+    let strobe = false;
+    let audio = null;
+    let soundOn = false;
+    let beatTimer = 0;
+    let lastTime = performance.now();
+
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      seed();
+    }
+
+    function seed() {
+      const count = Math.floor(Math.min(260, Math.max(120, (width * height) / 8200)));
+      particles = Array.from({ length: count }, (_, index) => {
+        const angle = Math.random() * Math.PI * 2;
+        const speed = 0.25 + Math.random() * 1.8;
+        return {
+          x: Math.random() * width,
+          y: Math.random() * height,
+          vx: Math.cos(angle) * speed,
+          vy: Math.sin(angle) * speed,
+          size: 1 + Math.random() * 5,
+          hue: index % 4,
+          spin: Math.random() * Math.PI * 2
+        };
+      });
+      stars = Array.from({ length: 80 }, () => ({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        size: 0.5 + Math.random() * 1.8,
+        phase: Math.random() * Math.PI * 2
+      }));
+    }
+
+    function activeMode() {
+      return modes[modeSelect.value] || modes.urge;
+    }
+
+    function setPointer(event) {
+      const point = event.touches ? event.touches[0] : event;
+      pointer.x = point.clientX / width;
+      pointer.y = point.clientY / height;
+      pointer.active = true;
+      intensity = Math.min(1, intensity + 0.03);
+    }
+
+    function addRing(x = pointer.x * width, y = pointer.y * height, force = 1) {
+      rings.push({ x, y, r: 8, force, life: 1 });
+      const spark = document.createElement("span");
+      spark.className = "spark";
+      spark.style.left = `${x}px`;
+      spark.style.top = `${y}px`;
+      document.body.appendChild(spark);
+      spark.addEventListener("animationend", () => spark.remove(), { once: true });
+      if (soundOn) playPing(force);
+    }
+
+    function initAudio() {
+      if (audio) return;
+      const AudioContext = window.AudioContext || window.webkitAudioContext;
+      const context = new AudioContext();
+      const master = context.createGain();
+      const filter = context.createBiquadFilter();
+      const delay = context.createDelay();
+      const feedback = context.createGain();
+      const pad = context.createOscillator();
+      const padGain = context.createGain();
+
+      master.gain.value = 0.0001;
+      filter.type = "lowpass";
+      filter.frequency.value = 900;
+      delay.delayTime.value = 0.18;
+      feedback.gain.value = 0.22;
+      pad.type = "sine";
+      pad.frequency.value = activeMode().tone / 2;
+      padGain.gain.value = 0.025;
+
+      pad.connect(padGain);
+      padGain.connect(filter);
+      filter.connect(delay);
+      filter.connect(master);
+      delay.connect(feedback);
+      feedback.connect(delay);
+      delay.connect(master);
+      master.connect(context.destination);
+      pad.start();
+      audio = { context, master, filter, delay, pad, padGain };
+    }
+
+    function setSound(enabled) {
+      initAudio();
+      soundOn = enabled;
+      audio.context.resume();
+      const now = audio.context.currentTime;
+      audio.master.gain.cancelScheduledValues(now);
+      audio.master.gain.setTargetAtTime(enabled ? 0.36 : 0.0001, now, 0.05);
+      soundButton.textContent = enabled ? "Mute sound" : "Unmute sound";
+      soundButton.dataset.active = String(enabled);
+      soundStatus.textContent = enabled ? "Sound live" : "Sound muted";
+    }
+
+    function playPing(force = 1) {
+      if (!audio) return;
+      const mode = activeMode();
+      const now = audio.context.currentTime;
+      const osc = audio.context.createOscillator();
+      const gain = audio.context.createGain();
+      const pick = [1, 1.25, 1.5, 2][Math.floor(Math.random() * 4)];
+      osc.type = Math.random() > 0.4 ? "triangle" : "square";
+      osc.frequency.setValueAtTime(mode.tone * pick, now);
+      osc.frequency.exponentialRampToValueAtTime(mode.tone * pick * (0.5 + Math.random()), now + 0.14);
+      gain.gain.setValueAtTime(0.001, now);
+      gain.gain.exponentialRampToValueAtTime(0.12 * force, now + 0.015);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.22);
+      osc.connect(gain);
+      gain.connect(audio.filter);
+      osc.start(now);
+      osc.stop(now + 0.24);
+    }
+
+    function playNoise(force = 1) {
+      if (!audio) return;
+      const now = audio.context.currentTime;
+      const length = Math.floor(audio.context.sampleRate * 0.12);
+      const buffer = audio.context.createBuffer(1, length, audio.context.sampleRate);
+      const data = buffer.getChannelData(0);
+      for (let i = 0; i < length; i += 1) {
+        data[i] = (Math.random() * 2 - 1) * (1 - i / length);
+      }
+      const source = audio.context.createBufferSource();
+      const gain = audio.context.createGain();
+      source.buffer = buffer;
+      gain.gain.value = 0.08 * force;
+      source.connect(gain);
+      gain.connect(audio.filter);
+      source.start(now);
+    }
+
+    function burst(force = 1.2) {
+      for (let i = 0; i < 7; i += 1) {
+        addRing(
+          width * (0.2 + Math.random() * 0.6),
+          height * (0.18 + Math.random() * 0.64),
+          force * (0.6 + Math.random() * 0.8)
+        );
+      }
+      intensity = 1;
+      if (soundOn) playNoise(force);
+    }
+
+    function updateAudio(dt) {
+      if (!audio || !soundOn) return;
+      const mode = activeMode();
+      const now = audio.context.currentTime;
+      const px = pointer.x || 0.5;
+      const py = pointer.y || 0.5;
+      audio.filter.frequency.setTargetAtTime(420 + px * 4200, now, 0.04);
+      audio.delay.delayTime.setTargetAtTime(0.08 + py * 0.26, now, 0.06);
+      audio.pad.frequency.setTargetAtTime(mode.tone * (0.45 + px * 0.42), now, 0.05);
+      audio.padGain.gain.setTargetAtTime(0.018 + intensity * 0.036, now, 0.08);
+      beatTimer += dt * mode.tempo * (0.7 + intensity);
+      if (beatTimer > 0.28) {
+        beatTimer = 0;
+        playPing(0.35 + intensity * 0.45);
+      }
+    }
+
+    function draw(now) {
+      const dt = Math.min(0.04, (now - lastTime) / 1000);
+      lastTime = now;
+      const mode = activeMode();
+      const px = pointer.x * width;
+      const py = pointer.y * height;
+      intensity += (pointer.down ? 0.9 : 0.42 - intensity) * dt * 0.9;
+      intensity = Math.max(0.25, Math.min(1, intensity));
+      meterBar.style.transform = `scaleX(${intensity})`;
+      updateAudio(dt);
+
+      const flash = strobe && Math.floor(now / 85) % 2 === 0;
+      ctx.fillStyle = flash ? "rgba(248, 240, 218, 0.42)" : "rgba(5, 5, 5, 0.22)";
+      ctx.fillRect(0, 0, width, height);
+
+      const sweep = ctx.createRadialGradient(px, py, 20, px, py, Math.max(width, height) * 0.78);
+      sweep.addColorStop(0, `${mode.colors[1]}66`);
+      sweep.addColorStop(0.26, `${mode.colors[2]}22`);
+      sweep.addColorStop(1, "rgba(0,0,0,0)");
+      ctx.fillStyle = sweep;
+      ctx.fillRect(0, 0, width, height);
+
+      stars.forEach((star) => {
+        const alpha = 0.25 + Math.sin(now * 0.004 + star.phase) * 0.2;
+        ctx.fillStyle = `rgba(248,240,218,${alpha})`;
+        ctx.fillRect(star.x, star.y, star.size, star.size);
+      });
+
+      particles.forEach((particle) => {
+        const dx = px - particle.x;
+        const dy = py - particle.y;
+        const dist = Math.hypot(dx, dy) || 1;
+        const pull = pointer.active ? (pointer.down ? -220 : 110) / (dist + 80) : 0;
+        particle.vx += (dx / dist) * pull * dt;
+        particle.vy += (dy / dist) * pull * dt;
+        particle.vx += Math.sin(now * 0.0015 + particle.spin) * 0.03;
+        particle.vy += Math.cos(now * 0.0013 + particle.spin) * 0.03;
+        particle.vx *= 0.992;
+        particle.vy *= 0.992;
+        particle.x += particle.vx * (0.8 + intensity * 1.8);
+        particle.y += particle.vy * (0.8 + intensity * 1.8);
+        if (particle.x < -40) particle.x = width + 40;
+        if (particle.x > width + 40) particle.x = -40;
+        if (particle.y < -40) particle.y = height + 40;
+        if (particle.y > height + 40) particle.y = -40;
+
+        const color = mode.colors[particle.hue % mode.colors.length];
+        const size = particle.size * (1 + intensity * 1.8);
+        ctx.save();
+        ctx.translate(particle.x, particle.y);
+        ctx.rotate(particle.spin + now * 0.002);
+        ctx.fillStyle = color;
+        ctx.shadowColor = color;
+        ctx.shadowBlur = 22 + intensity * 42;
+        ctx.fillRect(-size / 2, -size / 2, size, size);
+        ctx.restore();
+      });
+
+      rings = rings.filter((ring) => ring.life > 0);
+      rings.forEach((ring) => {
+        ring.r += (260 + ring.force * 160) * dt;
+        ring.life -= dt * 0.72;
+        ctx.beginPath();
+        ctx.arc(ring.x, ring.y, ring.r, 0, Math.PI * 2);
+        ctx.strokeStyle = `rgba(255,230,109,${ring.life})`;
+        ctx.lineWidth = 5 + ring.force * 6;
+        ctx.shadowColor = mode.colors[2];
+        ctx.shadowBlur = 26;
+        ctx.stroke();
+        particles.forEach((particle) => {
+          const dx = particle.x - ring.x;
+          const dy = particle.y - ring.y;
+          const dist = Math.hypot(dx, dy) || 1;
+          if (Math.abs(dist - ring.r) < 42) {
+            particle.vx += (dx / dist) * ring.force * 1.8;
+            particle.vy += (dy / dist) * ring.force * 1.8;
+          }
+        });
+      });
+
+      requestAnimationFrame(draw);
+    }
+
+    soundButton.addEventListener("click", () => setSound(!soundOn));
+    burstButton.addEventListener("click", () => burst(1.25));
+    strobeButton.addEventListener("click", () => {
+      strobe = !strobe;
+      strobeButton.dataset.active = String(strobe);
+    });
+    resetButton.addEventListener("click", () => {
+      rings = [];
+      intensity = 0.45;
+      seed();
+    });
+    modeSelect.addEventListener("change", () => {
+      const mode = activeMode();
+      modeTitle.textContent = mode.title;
+      modeLine.textContent = mode.line;
+      burst(0.75);
+    });
+
+    window.addEventListener("pointermove", setPointer);
+    window.addEventListener("pointerdown", (event) => {
+      setPointer(event);
+      pointer.down = true;
+      addRing(event.clientX, event.clientY, 1.15);
+    });
+    window.addEventListener("pointerup", () => {
+      pointer.down = false;
+    });
+    window.addEventListener("touchmove", (event) => {
+      setPointer(event);
+      event.preventDefault();
+    }, { passive: false });
+    window.addEventListener("keydown", (event) => {
+      if (event.code === "Space") {
+        event.preventDefault();
+        burst(1.35);
+      }
+      if (event.key.toLowerCase() === "m") {
+        setSound(!soundOn);
+      }
+    });
+    window.addEventListener("resize", resize);
+
+    resize();
+    burst(0.6);
+    requestAnimationFrame(draw);
+  </script>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What changed

- Added `sober-spark/`, a full-screen interactive stimulation app for redirecting coffee or weed cravings while staying sober.
- Added a Sober Spark app card to the portal home app grid.
- Kept sound muted by default; Web Audio starts only after the user presses Unmute.

## App behavior

- Canvas light field reacts to pointer movement, taps, press-and-hold, keyboard space bursts, and mode changes.
- Includes Urge Surf, Coffee Edge, Weed Redirect, and Focus Tunnel modes.
- Provides optional sound with oscillator pings, filtered delay, and burst noise after explicit opt-in.

## Validation

- Ran `git diff --check`.
- Served locally at `http://127.0.0.1:4179/`.
- Used headless Chrome to verify the app DOM, default muted state, portal home card, and a 1366x768 screenshot.
