### PR TITLE
[codex] Add 3DVR home backlinks to portal start pages

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -101,6 +101,39 @@ body.landing {
   padding: 6rem 1.5rem 4rem;
 }
 
+.site-backlink {
+  position: absolute;
+  top: 1.35rem;
+  left: 1.5rem;
+  z-index: 11;
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.5rem;
+  padding: 0 1rem;
+  border: 1px solid rgba(186, 230, 253, 0.24);
+  border-radius: 999px;
+  background: rgba(8, 15, 31, 0.74);
+  color: rgba(226, 232, 240, 0.9);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 800;
+  box-shadow: 0 18px 50px rgba(4, 9, 20, 0.28);
+  backdrop-filter: blur(14px);
+  transition: transform var(--transition-base),
+    background var(--transition-base),
+    border-color var(--transition-base),
+    color var(--transition-base);
+}
+
+.site-backlink:hover,
+.site-backlink:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(14, 165, 233, 0.2);
+  border-color: rgba(125, 211, 252, 0.6);
+  color: var(--color-text);
+  outline: none;
+}
+
 .skip-link {
   position: absolute;
   top: 1.5rem;
@@ -1379,6 +1412,14 @@ footer a {
 @media (max-width: 640px) {
   .landing-shell {
     padding: 4.5rem 1rem 3rem;
+  }
+
+  .site-backlink {
+    top: 0.9rem;
+    left: 1rem;
+    min-height: 2.25rem;
+    padding: 0 0.85rem;
+    font-size: 0.84rem;
   }
 
   .portal-swirl-brand {

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
     <div class="app-boot__bar"><span></span></div>
   </div>
   <div class="landing-shell">
+    <a class="site-backlink" href="https://3dvr.tech/" aria-label="Back to 3dvr.tech home">3dvr.tech home</a>
     <div class="top-nav top-nav--collapsed">
       <div class="top-nav__primary">
         <button

--- a/start/index.html
+++ b/start/index.html
@@ -16,7 +16,7 @@
   <body>
     <header class="hero">
       <nav class="top-nav" aria-label="Main navigation">
-        <a class="brand" href="../index.html">3dvr.tech</a>
+        <a class="brand" href="https://3dvr.tech/" aria-label="Back to 3dvr.tech home">3dvr.tech home</a>
         <div class="nav-links">
           <a href="#paths">Paths</a>
           <a href="#paid-lanes">Paid lanes</a>

--- a/start/style.css
+++ b/start/style.css
@@ -66,9 +66,16 @@ a {
 .brand {
   font-size: 1rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
   text-transform: uppercase;
   text-decoration: none;
+  color: var(--text);
+}
+
+.brand:hover,
+.brand:focus-visible {
+  color: var(--accent-strong);
+  outline: none;
 }
 
 .nav-links {


### PR DESCRIPTION
## What changed

- Added a visible top-left `3dvr.tech home` backlink to the portal home page.
- Updated the `/start/` top-left brand link to point directly back to `https://3dvr.tech/`.
- Added responsive styling so the portal backlink stays visible on mobile.

## Why

Users should be able to get back to the main 3dvr.tech site quickly from both the portal and start page.

## Validation

- Ran `git diff --check`.
- Confirmed both pages include `https://3dvr.tech/` backlinks in the expected top-left elements.
