### PR TITLE
[codex] Move 3DVR Girl to experimental apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,7 +365,8 @@
             <span class="app-card__title">Games</span>
             <span class="app-card__meta">Compete, sharpen skills, and earn bonus points.</span>
           </a>
-          <a href="3dvr-girl/" class="app-card">
+          <a href="3dvr-girl/" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">◎</span>
             <span class="app-card__title">3DVR Girl</span>
             <span class="app-card__meta">Open the visual companion portal for motion, beauty, and next-level immersion.</span>


### PR DESCRIPTION
## What changed

- Marked the `3DVR Girl` app card as experimental with `data-app-tier="experimental"`.
- Added the standard `Experimental` badge to the card.

## Why

This moves 3DVR Girl under the portal experimental apps toggle instead of showing it with the default core app list.

## Validation

- Ran `git diff --check`.
- Confirmed the 3DVR Girl card now uses the same experimental markup as neighboring experimental app cards.
