### PR TITLE
[codex] Add plant border accents to portal

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -4,6 +4,49 @@ body.landing {
   align-items: stretch;
 }
 
+body.landing::before,
+body.landing::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+body.landing::before {
+  inset: 0.9rem;
+  border: 1px solid rgba(134, 239, 172, 0.34);
+  border-radius: 2rem;
+  background:
+    linear-gradient(90deg, rgba(74, 222, 128, 0.16), transparent 18%, transparent 82%, rgba(45, 212, 191, 0.14)),
+    linear-gradient(180deg, rgba(134, 239, 172, 0.12), transparent 16%, transparent 84%, rgba(74, 222, 128, 0.14));
+  box-shadow:
+    inset 0 0 38px rgba(34, 197, 94, 0.12),
+    inset 0 0 2px rgba(187, 247, 208, 0.3),
+    0 0 46px rgba(20, 184, 166, 0.14);
+}
+
+body.landing::after {
+  background:
+    radial-gradient(ellipse 1.6rem 0.75rem at 1.2rem 8%, rgba(134, 239, 172, 0.6), transparent 70%),
+    radial-gradient(ellipse 0.75rem 1.6rem at 2.35rem 14%, rgba(74, 222, 128, 0.42), transparent 70%),
+    radial-gradient(ellipse 1.7rem 0.8rem at 1.15rem 31%, rgba(187, 247, 208, 0.46), transparent 70%),
+    radial-gradient(ellipse 0.8rem 1.7rem at 2.45rem 39%, rgba(45, 212, 191, 0.34), transparent 70%),
+    radial-gradient(ellipse 1.55rem 0.75rem at 1.15rem 62%, rgba(74, 222, 128, 0.48), transparent 70%),
+    radial-gradient(ellipse 0.78rem 1.55rem at 2.2rem 72%, rgba(134, 239, 172, 0.36), transparent 70%),
+    radial-gradient(ellipse 1.6rem 0.75rem at calc(100% - 1.2rem) 11%, rgba(134, 239, 172, 0.56), transparent 70%),
+    radial-gradient(ellipse 0.78rem 1.6rem at calc(100% - 2.25rem) 20%, rgba(45, 212, 191, 0.36), transparent 70%),
+    radial-gradient(ellipse 1.7rem 0.8rem at calc(100% - 1.15rem) 48%, rgba(187, 247, 208, 0.44), transparent 70%),
+    radial-gradient(ellipse 0.8rem 1.7rem at calc(100% - 2.35rem) 58%, rgba(74, 222, 128, 0.38), transparent 70%),
+    radial-gradient(ellipse 1.6rem 0.75rem at calc(100% - 1.25rem) 83%, rgba(134, 239, 172, 0.5), transparent 70%),
+    radial-gradient(ellipse 1.65rem 0.75rem at 20% 1.25rem, rgba(74, 222, 128, 0.34), transparent 70%),
+    radial-gradient(ellipse 1.7rem 0.75rem at 48% calc(100% - 1.15rem), rgba(134, 239, 172, 0.34), transparent 70%),
+    linear-gradient(90deg, transparent, rgba(74, 222, 128, 0.18) 18%, transparent 38%, transparent 62%, rgba(45, 212, 191, 0.14) 82%, transparent),
+    linear-gradient(180deg, transparent, rgba(74, 222, 128, 0.12) 26%, transparent 48%, transparent 66%, rgba(134, 239, 172, 0.1) 88%, transparent);
+  filter: drop-shadow(0 0 0.85rem rgba(74, 222, 128, 0.2));
+  opacity: 0.95;
+}
+
 .app-boot {
   position: fixed;
   inset: 0;
@@ -1412,6 +1455,15 @@ footer a {
 @media (max-width: 640px) {
   .landing-shell {
     padding: 4.5rem 1rem 3rem;
+  }
+
+  body.landing::before {
+    inset: 0.45rem;
+    border-radius: 1.35rem;
+  }
+
+  body.landing::after {
+    opacity: 0.58;
   }
 
   .site-backlink {


### PR DESCRIPTION
## What changed

- Added subtle green plant-like border accents to the portal landing page.
- Used CSS-only decorative layers behind the portal UI.
- Reduced accent intensity on small screens so the top-left home link and controls stay readable.

## Why

The portal needed a little more organic green energy around the edges without disrupting the app grid or navigation.

## Validation

- Ran `git diff --check`.
- Captured desktop and mobile Chrome screenshots.
- Verified guest landing page loads with no horizontal overflow at desktop and 390px mobile widths.
