### PR TITLE
[codex] Fix one-click guest entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -942,11 +942,23 @@
 
     function continueAsGuest() {
       const authModal = document.getElementById('auth-modal');
-      ensureGuestId();
+      if (window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
+        window.ScoreSystem.ensureGuestIdentity();
+      } else {
+        ensureGuestId();
+        localStorage.setItem('guest', 'true');
+      }
+      localStorage.removeItem('signedIn');
+      localStorage.removeItem('alias');
+      localStorage.removeItem('username');
+      localStorage.removeItem('password');
       localStorage.setItem('guest', 'true');
       authModal.style.display = 'none';
       authModal.setAttribute('aria-hidden', 'true');
       window.dispatchEvent(new Event('auth-modal:closed'));
+      window.dispatchEvent(new CustomEvent('portal-auth:changed', {
+        detail: { mode: 'guest' }
+      }));
     }
 
     function startAccountFromHere() {

--- a/navbar.js
+++ b/navbar.js
@@ -49,6 +49,9 @@ function ensureHomepageSearchShortcuts() {
 function createNavbar() {
   ensureHomepageSearchShortcuts();
   hideUnreadyHomepageSections();
+  document.querySelectorAll('.floating-identity').forEach(existingNav => {
+    existingNav.remove();
+  });
 
   if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function') {
     window.ScoreSystem.recallUserSession(user);
@@ -237,3 +240,4 @@ function createNavbar() {
 
 ensureHomepageSearchShortcuts();
 window.addEventListener('load', createNavbar);
+window.addEventListener('portal-auth:changed', createNavbar);


### PR DESCRIPTION
## What changed

- Updated `continueAsGuest()` to use the shared `ScoreSystem.ensureGuestIdentity()` helper when available.
- Clear stale signed-in markers before entering guest mode.
- Dispatch a `portal-auth:changed` event after guest entry.
- Rebuild the floating identity widget on auth changes, replacing the stale anonymous widget instead of waiting for reload/second click.

## Why

On a brand-new browser session, the portal could initialize account UI before guest mode was fully established. That made guest entry feel like it required a second click or reload.

## Validation

- Ran `git diff --check`.
- Served the portal locally on `127.0.0.1:4182`.
- Used a clean Chrome profile with storage cleared, clicked `Continue as guest` once, and confirmed the modal hid, `guest=true` was set, stale `signedIn` was cleared, and exactly one floating identity widget remained.
