### PR TITLE
[codex] Shorten portal home backlink label

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
     <div class="app-boot__bar"><span></span></div>
   </div>
   <div class="landing-shell">
-    <a class="site-backlink" href="https://3dvr.tech/" aria-label="Back to 3dvr.tech home">3dvr.tech home</a>
+    <a class="site-backlink" href="https://3dvr.tech/" aria-label="Back to 3dvr.tech home">3dvr.tech</a>
     <div class="top-nav top-nav--collapsed">
       <div class="top-nav__primary">
         <button

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -41,6 +41,8 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Sign in or create account/);
     assert.match(html, /Use one account to save your progress and sync your points across devices\./);
     assert.doesNotMatch(html, /Sign in to save your progress/);
+    assert.match(html, /class="site-backlink" href="https:\/\/3dvr\.tech\/" aria-label="Back to 3dvr\.tech home">3dvr\.tech<\/a>/);
+    assert.doesNotMatch(html, />3dvr\.tech home<\/a>/);
     assert.match(html, /App dock/);
     assert.match(html, /Command center/);
     assert.match(html, /Same account, same apps, deeper levels of control\./);


### PR DESCRIPTION
## Summary
- Shorten the portal homepage top-left backlink from `3dvr.tech home` to `3dvr.tech`
- Add a regression assertion so the homepage link text does not drift back

## Validation
- `node --test tests/customer-journey-pages.test.js`
- `git diff --check`
- `npm test` after `npm install` still has unrelated existing-main failures: auth-entrypoints sign-in assertion, Playwright runtime alias expectations, and Vercel insights tag coverage for existing HTML files.
