### PR TITLE
[codex] Fix CRM conversation capture saves

### DIFF
--- a/crm/app.js
+++ b/crm/app.js
@@ -8,6 +8,7 @@ import {
   CRM_URGENCY_OPTIONS,
   CRM_RECORD_TYPE_OPTIONS,
   buildConversationCaptureRecord,
+  buildGunConversationCapturePayload,
   sanitizeConversationCaptureRecord,
   normalizeCrmRecordType,
   normalizeCrmWarmth,
@@ -2058,7 +2059,8 @@ function putCrmRecord(record) {
 function putConversationCapture(capture) {
   return new Promise((resolve, reject) => {
     const sanitized = sanitizeConversationCaptureRecord(capture);
-    conversationCapturesRoot.get(sanitized.id).put(sanitized, ack => {
+    const payload = buildGunConversationCapturePayload(sanitized);
+    conversationCapturesRoot.get(sanitized.id).put(payload, ack => {
       if (ack && ack.err) {
         reject(new Error(String(ack.err)));
         return;

--- a/crm/crm-editing.js
+++ b/crm/crm-editing.js
@@ -384,6 +384,15 @@ export function buildConversationCaptureRecord(input = {}, identity = {}, option
   });
 }
 
+export function buildGunConversationCapturePayload(data = {}) {
+  const clean = sanitizeConversationCaptureRecord(data);
+
+  return {
+    ...clean,
+    painPoints: clean.painPoints.join('\n'),
+  };
+}
+
 export function sanitizeCrmRecord(data) {
   if (!data || typeof data !== 'object') return {};
   const clean = {};
@@ -543,6 +552,7 @@ if (typeof window !== 'undefined') {
     normalizeConversationCaptureList,
     sanitizeConversationCaptureRecord,
     buildConversationCaptureRecord,
+    buildGunConversationCapturePayload,
     parseCrmList,
     serializeCrmList,
     sanitizeCrmRecord,

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -95,8 +95,10 @@ test('CRM app includes keyboard search shortcut, workflow filters, and import wi
   assert.match(js, /portalRoot\.get\('crm'\)\.get\('conversationCaptures'\)/);
   assert.match(js, /function handleConversationCaptureSubmit\(event\)/);
   assert.match(js, /buildConversationCaptureRecord/);
+  assert.match(js, /buildGunConversationCapturePayload\(sanitized\)/);
   assert.match(js, /source\/mobile-conversation/);
   assert.match(js, /putConversationCapture\(capture\)/);
+  assert.match(js, /conversationCapturesRoot\.get\(sanitized\.id\)\.put\(payload/);
   assert.match(js, /conversationCapturesRoot\.map\(\)\.on/);
   assert.match(js, /conversationCaptureForm\?\.addEventListener\('submit', handleConversationCaptureSubmit\)/);
   assert.match(js, /openConversationCapture\?\.addEventListener\('click', openConversationCapturePanel\)/);

--- a/tests/crm-editing.test.js
+++ b/tests/crm-editing.test.js
@@ -12,6 +12,7 @@ import {
   CRM_RECORD_TYPE_OPTIONS,
   CRM_CONVERSATION_PLAN_OPTIONS,
   buildConversationCaptureRecord,
+  buildGunConversationCapturePayload,
   normalizeCrmRecordType,
   normalizeCrmWarmth,
   normalizeConversationCaptureList,
@@ -193,6 +194,22 @@ describe('crm conversation capture helpers', () => {
       updatedAt: '',
       source: 'mobile-conversation',
     });
+  });
+
+  it('serializes captures into a Gun-safe payload without losing readable pain points', () => {
+    const payload = buildGunConversationCapturePayload({
+      id: 'capture-3',
+      name: 'Rae',
+      painPoints: ['No website', 'No website', 'Needs booking/forms'],
+      interestedPlan: '$50/mo',
+    });
+
+    assert.equal(Array.isArray(payload.painPoints), false);
+    assert.equal(payload.painPoints, 'No website\nNeeds booking/forms');
+    assert.deepEqual(sanitizeConversationCaptureRecord(payload).painPoints, [
+      'No website',
+      'Needs booking/forms',
+    ]);
   });
 });
 


### PR DESCRIPTION
## What changed
- Serialize conversation capture pain points into a Gun-safe string before writing to Gun.
- Keep the UI and read path using normalized arrays so capture cards and filters still behave the same.
- Added regression coverage for the serializer and the CRM save wiring.

## Why
Gun `.put()` can reject payloads containing array values. The quick conversation capture form stored `painPoints` as an array and wrote it directly, which could surface as `Could not save this conversation right now`.

## Validation
- `node --test tests/crm-editing.test.js tests/crm-contacts-workflow.test.js` passed.
- `git diff --check` passed.
- `npm ci` completed.
- `npm test` rerun after dependencies: 527 passed, 4 failed, 2 skipped. Remaining failures are unrelated existing assertions in `tests/auth-entrypoints.test.js`, `tests/playwright-install-runtime.test.js`, and `tests/vercel-insights-tag.test.js`.