### PR TITLE
Add project launchpad MVP

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,10 +518,16 @@
             <span class="app-card__title">Profile</span>
             <span class="app-card__meta">Track your progress and manage your rewards.</span>
           </a>
-          <a href="projects/index.html" class="app-card">
+          <a
+            href="projects/index.html"
+            class="app-card"
+            data-app-keywords="projects launchpad project nodes social commons updates needs offers supporters"
+          >
             <span class="app-card__icon" aria-hidden="true">📂</span>
             <span class="app-card__title">Projects</span>
-            <span class="app-card__meta">Review active explorations and the next steps to ship them.</span>
+            <span class="app-card__meta">
+              Start project nodes with profiles, updates, needs, offers, and support links.
+            </span>
           </a>
           <a href="releases/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🚀</span>

--- a/projects/app.js
+++ b/projects/app.js
@@ -1,0 +1,442 @@
+const PROJECT_LAUNCHPAD_ROOT = 'projectLaunchpad';
+const LOCAL_KEY = '3dvr-project-launchpad';
+
+const seedProjects = [
+  {
+    id: 'seed_regenerative_farm',
+    slug: 'regenerative-farm',
+    name: 'Regenerative Farm',
+    stage: 'seed',
+    category: 'farm / retreat / education',
+    mission:
+      'A family-led plan for land, soil, food, retreats, music-led wellness, nature education, and community renewal.',
+    needs: ['land access', 'farm mentors', 'volunteers', 'funding path'],
+    offers: ['music circles', 'nature education', 'farm days', 'community meals'],
+    contact: 'mailto:3dvr.tech@gmail.com?subject=Regenerative%20Farm',
+    support: '../projects/#regenerative-farm',
+    createdAt: 1719000000000,
+  },
+  {
+    id: 'seed_sd_day_traders',
+    slug: 'sd-day-traders',
+    name: 'SD Day Traders',
+    stage: 'live',
+    category: 'trading education',
+    mission: 'A small trading group that helps people tighten their trading process and request consultation time.',
+    needs: ['warm leads', 'booking requests', 'member trust', 'clear offer copy'],
+    offers: ['trading process review', 'consultation requests', 'group education'],
+    contact: 'mailto:gamboaesai@gmail.com?subject=SD%20Day%20Traders%20consultation',
+    support: 'https://sd-day-traders.3dvr.tech/',
+    createdAt: 1719100000000,
+  },
+  {
+    id: 'seed_open_future',
+    slug: 'open-future-computing',
+    name: 'Open Future Computing',
+    stage: 'building',
+    category: 'open source / tools',
+    mission:
+      'A practical path toward local-first, open, human-controlled computing for regular people and small teams.',
+    needs: ['coders', 'docs', 'device testers', 'small business pilots'],
+    offers: ['portal tools', 'agent workflows', 'local-first patterns', 'implementation help'],
+    contact: 'mailto:3dvr.tech@gmail.com?subject=Open%20Future%20Computing',
+    support: '../open-source/',
+    createdAt: 1719200000000,
+  },
+];
+
+const seedUpdates = [
+  {
+    id: 'update_regenerative_farm_start',
+    projectId: 'seed_regenerative_farm',
+    title: 'Land access research is ready',
+    body: 'The next move is a land-seeker profile, FarmLink/RCD outreach, and visits to local farm models.',
+    createdAt: 1719300000000,
+  },
+  {
+    id: 'update_sd_day_traders_booking',
+    projectId: 'seed_sd_day_traders',
+    title: 'Booking request simplified',
+    body: 'The consultation flow now starts with a professional email request instead of a heavy calendar embed.',
+    createdAt: 1719400000000,
+  },
+];
+
+const state = {
+  nodes: new Map(),
+  updates: new Map(),
+  followers: new Map(),
+  filter: 'all',
+};
+
+const els = {
+  form: document.getElementById('projectForm'),
+  name: document.getElementById('projectName'),
+  stage: document.getElementById('projectStage'),
+  slug: document.getElementById('projectSlug'),
+  category: document.getElementById('projectCategory'),
+  mission: document.getElementById('projectMission'),
+  needs: document.getElementById('projectNeeds'),
+  offers: document.getElementById('projectOffers'),
+  contact: document.getElementById('projectContact'),
+  support: document.getElementById('projectSupport'),
+  status: document.getElementById('syncStatus'),
+  list: document.getElementById('projectList'),
+  filters: Array.from(document.querySelectorAll('[data-filter]')),
+  updateForm: document.getElementById('updateForm'),
+  updateProject: document.getElementById('updateProject'),
+  updateHeading: document.getElementById('updateHeading'),
+  updateBody: document.getElementById('updateBody'),
+  nodeCount: document.getElementById('nodeCount'),
+  updateCount: document.getElementById('updateCount'),
+  needCount: document.getElementById('needCount'),
+  offerCount: document.getElementById('offerCount'),
+};
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function slugify(value) {
+  return clean(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
+
+function createId(prefix) {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function splitList(value) {
+  return clean(value)
+    .split(/[\n,;]+/)
+    .map(item => item.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
+function stageLabel(stage) {
+  const labels = {
+    seed: 'Seed',
+    building: 'Building',
+    live: 'Live',
+    seeking: 'Seeking support',
+  };
+  return labels[stage] || 'Seed';
+}
+
+function getGunRoot() {
+  if (typeof window.Gun !== 'function') {
+    els.status.textContent = 'Gun is unavailable. Saving project nodes in this browser.';
+    return null;
+  }
+
+  const gun = window.gun || window.Gun(window.__GUN_PEERS__ || ['https://gun-relay-3dvr.fly.dev/gun']);
+  window.gun = gun;
+  els.status.textContent = 'Connected to the 3DVR project graph.';
+
+  // Node shape:
+  // gun.get('3dvr-portal').get('projectLaunchpad').get('nodes').get(slug)
+  // gun.get('3dvr-portal').get('projectLaunchpad').get('updates').get(updateId)
+  // gun.get('3dvr-portal').get('projectLaunchpad').get('followers').get(slug)
+  return gun.get('3dvr-portal').get(PROJECT_LAUNCHPAD_ROOT);
+}
+
+const root = getGunRoot();
+
+function normalizeNode(node) {
+  const name = clean(node?.name);
+  const slug = slugify(node?.slug || name);
+  if (!name || !slug) return null;
+  return {
+    id: clean(node.id) || `project_${slug}`,
+    slug,
+    name,
+    stage: clean(node.stage) || 'seed',
+    category: clean(node.category) || 'project',
+    mission: clean(node.mission),
+    needs: Array.isArray(node.needs) ? node.needs.map(clean).filter(Boolean) : splitList(node.needs),
+    offers: Array.isArray(node.offers) ? node.offers.map(clean).filter(Boolean) : splitList(node.offers),
+    contact: clean(node.contact) || 'mailto:3dvr.tech@gmail.com',
+    support: clean(node.support),
+    createdAt: Number(node.createdAt || Date.now()),
+    updatedAt: Number(node.updatedAt || Date.now()),
+  };
+}
+
+function saveLocalBackup() {
+  try {
+    const payload = {
+      nodes: Array.from(state.nodes.values()).filter(node => !node.seedOnly),
+      updates: Array.from(state.updates.values()).filter(update => !update.seedOnly),
+      followers: Array.from(state.followers.entries()),
+    };
+    localStorage.setItem(LOCAL_KEY, JSON.stringify(payload));
+  } catch (_error) {
+    // Gun is the shared source of truth when available.
+  }
+}
+
+function loadLocalBackup() {
+  try {
+    const payload = JSON.parse(localStorage.getItem(LOCAL_KEY) || '{}');
+    if (Array.isArray(payload.nodes)) {
+      payload.nodes.forEach(node => {
+        const normalized = normalizeNode(node);
+        if (normalized) state.nodes.set(normalized.slug, normalized);
+      });
+    }
+    if (Array.isArray(payload.updates)) {
+      payload.updates.forEach(update => {
+        if (update && update.id && update.projectId && update.title) state.updates.set(update.id, update);
+      });
+    }
+    if (Array.isArray(payload.followers)) {
+      payload.followers.forEach(([slug, count]) => state.followers.set(slug, Number(count || 0)));
+    }
+  } catch (_error) {
+    // Ignore malformed local drafts.
+  }
+}
+
+function loadSeeds() {
+  seedProjects.forEach(project => {
+    const node = normalizeNode(project);
+    if (node && !state.nodes.has(node.slug)) state.nodes.set(node.slug, { ...node, seedOnly: true });
+  });
+  seedUpdates.forEach(update => {
+    if (!state.updates.has(update.id)) state.updates.set(update.id, { ...update, seedOnly: true });
+  });
+}
+
+function latestUpdateFor(project) {
+  return Array.from(state.updates.values())
+    .filter(update => update.projectId === project.id || update.projectSlug === project.slug)
+    .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0))[0];
+}
+
+function renderStats() {
+  const nodes = Array.from(state.nodes.values()).filter(node => node.name);
+  const updates = Array.from(state.updates.values()).filter(update => update.title);
+  els.nodeCount.textContent = String(nodes.length);
+  els.updateCount.textContent = String(updates.length);
+  els.needCount.textContent = String(nodes.reduce((total, node) => total + node.needs.length, 0));
+  els.offerCount.textContent = String(nodes.reduce((total, node) => total + node.offers.length, 0));
+}
+
+function renderProjectOptions() {
+  const current = els.updateProject.value;
+  const projects = Array.from(state.nodes.values()).sort((a, b) => a.name.localeCompare(b.name));
+  els.updateProject.innerHTML = '';
+  projects.forEach(project => {
+    const option = document.createElement('option');
+    option.value = project.slug;
+    option.textContent = project.name;
+    els.updateProject.append(option);
+  });
+  if (current) els.updateProject.value = current;
+}
+
+function createList(items, fallback) {
+  const list = document.createElement('ul');
+  const values = items.length ? items : [fallback];
+  values.forEach(value => {
+    const item = document.createElement('li');
+    item.textContent = value;
+    list.append(item);
+  });
+  return list;
+}
+
+function renderProjects() {
+  const projects = Array.from(state.nodes.values())
+    .filter(project => project.name)
+    .filter(project => state.filter === 'all' || project.stage === state.filter)
+    .sort((a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0));
+
+  els.list.innerHTML = '';
+  if (!projects.length) {
+    els.list.innerHTML = '<div class="empty-state">No project nodes in this lane yet.</div>';
+    renderStats();
+    renderProjectOptions();
+    return;
+  }
+
+  projects.forEach(project => {
+    const card = document.createElement('article');
+    const update = latestUpdateFor(project);
+    const followers = state.followers.get(project.slug) || 0;
+    card.className = 'project-node';
+    card.id = project.slug;
+    card.innerHTML = `
+      <div class="node-top">
+        <div>
+          <span class="node-chip"></span>
+          <h3 class="node-title"></h3>
+        </div>
+        <span class="node-stage"></span>
+      </div>
+      <p class="node-mission"></p>
+      <span class="node-slug"></span>
+      <div class="node-lists">
+        <div class="node-needs"><h4>Needs</h4></div>
+        <div class="node-offers"><h4>Offers</h4></div>
+      </div>
+      <div class="node-update" hidden>
+        <h4>Latest update</h4>
+        <strong></strong>
+        <p></p>
+      </div>
+      <div class="node-actions"></div>
+    `;
+    card.querySelector('.node-chip').textContent = project.category;
+    card.querySelector('.node-title').textContent = project.name;
+    card.querySelector('.node-stage').textContent = stageLabel(project.stage);
+    card.querySelector('.node-mission').textContent = project.mission || 'Mission not written yet.';
+    card.querySelector('.node-slug').textContent = `3dvr.tech/${project.slug} · ${project.slug}.3dvr.tech later`;
+    card.querySelector('.node-needs').append(createList(project.needs, 'Needs not listed yet'));
+    card.querySelector('.node-offers').append(createList(project.offers, 'Offers not listed yet'));
+
+    if (update) {
+      const updateBox = card.querySelector('.node-update');
+      updateBox.hidden = false;
+      updateBox.querySelector('strong').textContent = update.title;
+      updateBox.querySelector('p').textContent = update.body;
+    }
+
+    const actions = card.querySelector('.node-actions');
+    const contact = document.createElement('a');
+    contact.href = project.contact;
+    contact.textContent = 'Contact';
+    actions.append(contact);
+
+    if (project.support) {
+      const support = document.createElement('a');
+      support.href = project.support;
+      support.textContent = 'Support';
+      actions.append(support);
+    }
+
+    const follow = document.createElement('button');
+    follow.type = 'button';
+    follow.dataset.follow = project.slug;
+    follow.textContent = `Follow (${followers})`;
+    actions.append(follow);
+
+    els.list.append(card);
+  });
+
+  renderStats();
+  renderProjectOptions();
+}
+
+function saveNode(event) {
+  event.preventDefault();
+  const name = clean(els.name.value);
+  const node = normalizeNode({
+    id: createId('project'),
+    name,
+    stage: els.stage.value,
+    slug: els.slug.value || slugify(name),
+    category: els.category.value,
+    mission: els.mission.value,
+    needs: splitList(els.needs.value),
+    offers: splitList(els.offers.value),
+    contact: els.contact.value,
+    support: els.support.value,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  if (!node) return;
+  state.nodes.set(node.slug, node);
+  saveLocalBackup();
+  renderProjects();
+  root?.get('nodes').get(node.slug).put(node);
+  els.form.reset();
+  els.status.textContent = root ? 'Project node saved to the shared graph.' : 'Project node saved locally.';
+}
+
+function saveUpdate(event) {
+  event.preventDefault();
+  const projectSlug = clean(els.updateProject.value);
+  const project = state.nodes.get(projectSlug);
+  const update = {
+    id: createId('update'),
+    projectId: project?.id || projectSlug,
+    projectSlug,
+    title: clean(els.updateHeading.value),
+    body: clean(els.updateBody.value),
+    createdAt: Date.now(),
+  };
+  if (!update.projectSlug || !update.title || !update.body) return;
+  state.updates.set(update.id, update);
+  if (project) {
+    project.updatedAt = Date.now();
+    state.nodes.set(project.slug, project);
+  }
+  saveLocalBackup();
+  renderProjects();
+  root?.get('updates').get(update.id).put(update);
+  if (project) root?.get('nodes').get(project.slug).put(project);
+  els.updateForm.reset();
+  els.status.textContent = root ? 'Project update posted to the shared graph.' : 'Project update saved locally.';
+}
+
+function followProject(slug) {
+  const count = (state.followers.get(slug) || 0) + 1;
+  state.followers.set(slug, count);
+  saveLocalBackup();
+  renderProjects();
+  root?.get('followers').get(slug).put({ slug, count, updatedAt: Date.now() });
+  els.status.textContent = 'Follow saved.';
+}
+
+function bindFilters() {
+  els.filters.forEach(button => {
+    button.addEventListener('click', () => {
+      state.filter = button.dataset.filter || 'all';
+      els.filters.forEach(item => item.classList.toggle('active', item === button));
+      renderProjects();
+    });
+  });
+}
+
+function bindGun() {
+  if (!root) return;
+  root.get('nodes').map().on((node, slug) => {
+    const normalized = normalizeNode({ ...node, slug: node?.slug || slug });
+    if (!normalized) return;
+    state.nodes.set(normalized.slug, normalized);
+    saveLocalBackup();
+    renderProjects();
+  });
+  root.get('updates').map().on((update, id) => {
+    if (!update || !update.title) return;
+    state.updates.set(update.id || id, { ...update, id: update.id || id });
+    saveLocalBackup();
+    renderProjects();
+  });
+  root.get('followers').map().on((follow, slug) => {
+    if (!follow) return;
+    state.followers.set(follow.slug || slug, Number(follow.count || 0));
+    saveLocalBackup();
+    renderProjects();
+  });
+}
+
+els.form.addEventListener('submit', saveNode);
+els.updateForm.addEventListener('submit', saveUpdate);
+els.list.addEventListener('click', event => {
+  const button = event.target.closest('[data-follow]');
+  if (!button) return;
+  followProject(button.dataset.follow);
+});
+
+loadSeeds();
+loadLocalBackup();
+bindFilters();
+renderProjects();
+bindGun();

--- a/projects/index.html
+++ b/projects/index.html
@@ -3,151 +3,277 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Projects · 3DVR Portal</title>
+  <title>Projects · 3DVR Project Launchpad</title>
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <link rel="stylesheet" href="../styles/global.css">
   <link rel="stylesheet" href="./projects.css">
-
+  <script defer src="./app.js"></script>
   <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="projects theme-dark">
-  <a class="skip-link" href="#projectsMain">Skip to project directory</a>
+  <a class="skip-link" href="#projectsMain">Skip to project launchpad</a>
   <div class="projects-shell">
     <header class="projects-hero" aria-labelledby="projectsTitle">
-      <div>
-        <p class="projects-hero__eyebrow">Project directory</p>
-        <h1 id="projectsTitle" class="projects-hero__title">Keep explorations visible and ready to ship</h1>
-        <p class="projects-hero__lede">
-          Capture active concepts, link them to notes and tasks, and spell out what success looks like before we build.
-          Everything here stays portable across VR, desktop, and mobile flows.
-        </p>
-        <div class="projects-hero__actions">
-          <a class="cta primary" href="../index.html">⬅️ Back to portal</a>
-          <a class="cta ghost" href="../notes/">📝 Open shared notes</a>
-          <a class="cta ghost" href="../tasks.html">✅ Plan next tasks</a>
+      <nav class="projects-nav" aria-label="Project launchpad navigation">
+        <a href="../index.html">Portal</a>
+        <a href="../community/">Community</a>
+        <a href="../crm/">CRM</a>
+        <a href="../billing/">Billing</a>
+      </nav>
+      <div class="projects-hero__grid">
+        <div>
+          <p class="projects-hero__eyebrow">3DVR project launchpad</p>
+          <h1 id="projectsTitle" class="projects-hero__title">Where fledgling projects become real.</h1>
+          <p class="projects-hero__lede">
+            A home for projects before they are companies: public profile, mission, updates, needs, offers,
+            contact paths, support links, followers, and human-approved AI help.
+          </p>
+          <div class="projects-hero__actions">
+            <a class="cta primary" href="#projectForm">Start a project node</a>
+            <a class="cta ghost" href="#projectBoard">Browse project nodes</a>
+            <a class="cta ghost" href="../start/">Choose a 3DVR plan</a>
+          </div>
         </div>
-      </div>
-      <div class="projects-meta" aria-label="Project data guidance">
-        <p class="projects-meta__label">Shared data paths</p>
-        <ul>
-          <li><code>gun.get('projects').get('ideas')</code> for concepts and owners.</li>
-          <li><code>gun.get('projects').get('artifacts')</code> for sketches, diagrams, and attachments.</li>
-          <li><code>gun.get('projects').get('handoff')</code> for build-ready checklists.</li>
-        </ul>
+        <aside class="projects-meta" aria-label="Launchpad positioning">
+          <p class="projects-meta__label">Positioning</p>
+          <p>
+            The social network for people building the future: a project nursery where seeds can
+            gather people, explain themselves, collect support, and grow into real work.
+          </p>
+          <ul>
+            <li><code>3dvr.tech/project-name</code> for a simple project home.</li>
+            <li><code>project.3dvr.tech</code> when the project is ready for a custom subdomain.</li>
+            <li>Use independent websites later, after the project has momentum.</li>
+          </ul>
+        </aside>
       </div>
     </header>
 
-    <main id="projectsMain" class="projects-main" aria-label="3DVR project directory">
-      <section class="projects-section" aria-labelledby="wearableTitle">
-        <div class="section-header">
-          <p class="section-eyebrow">Active exploration</p>
-          <h2 id="wearableTitle">Wearable input kit for travel and AR</h2>
-          <p class="section-lede">
-            A portable keyboard and pointing system that clips to your legs for standing or seated
-            work, keeps phones usable while pocketed, and mirrors desktop control inside VR or AR
-            glasses.
-          </p>
-        </div>
-        <div class="project-grid" role="list">
-          <article class="project-card" role="listitem" aria-labelledby="cardDesignTitle">
-            <div class="project-card__icon" aria-hidden="true">⌨️</div>
-            <div class="project-card__body">
-              <div class="project-card__header">
-                <h3 id="cardDesignTitle">Form factor</h3>
-                <span class="status-pill">Status: Designing</span>
-              </div>
-              <p>
-                Split keyboard halves strap to each thigh so posture stays comfortable when walking,
-                standing at a counter, or seated on a flight. A low-profile fold keeps the kit in a
-                backpack and deploys in seconds.
-              </p>
-              <ul>
-                <li>Leg-mounted plates keep wrists aligned and elbows relaxed.</li>
-                <li>Compact columns mirror standard layouts for fast onboarding.</li>
-                <li>Detachable straps support both casual and athletic wear.</li>
-              </ul>
-            </div>
-          </article>
-
-          <article class="project-card" role="listitem" aria-labelledby="cardControlTitle">
-            <div class="project-card__icon" aria-hidden="true">🖱️</div>
-            <div class="project-card__body">
-              <div class="project-card__header">
-                <h3 id="cardControlTitle">Input + pointing</h3>
-                <span class="status-pill status-pill--focus">Focus: Ergonomics</span>
-              </div>
-              <p>
-                Capacitive trackpads on both sides keep mousing symmetrical and shoulder-friendly. Thumb clusters handle
-                modifiers, quick toggles, and media so typing stays uninterrupted.
-              </p>
-              <ul>
-                <li>Dual trackpads that map to desktop, mobile, and VR cursors.</li>
-                <li>Haptics confirm gestures without needing to look down.</li>
-                <li>Low-latency Bluetooth first, with a wired fallback for labs.</li>
-              </ul>
-            </div>
-          </article>
-
-          <article class="project-card" role="listitem" aria-labelledby="cardXRTitle">
-            <div class="project-card__icon" aria-hidden="true">🕶️</div>
-            <div class="project-card__body">
-              <div class="project-card__header">
-                <h3 id="cardXRTitle">AR + phone pairing</h3>
-                <span class="status-pill status-pill--planning">Planning: Prototyping</span>
-              </div>
-              <p>
-                The kit mirrors phone UI inside AR glasses so you can keep the phone in your pocket, navigate apps, and
-                respond quickly while staying heads-up. Inputs also pass through to desktop and VR sessions.
-              </p>
-              <ul>
-                <li>Overlay notifications and text fields in-headset for glanceable control.</li>
-                <li>Bridge sessions through <code>gun.get('projects').get('io-link')</code> for shared state.</li>
-                <li>USB-C passthrough keeps phones powered during long days.</li>
-              </ul>
-            </div>
-          </article>
-        </div>
+    <main id="projectsMain" class="projects-main" aria-label="3DVR project launchpad">
+      <section class="metrics-grid" id="launchpadStats" aria-label="Launchpad stats">
+        <article>
+          <span id="nodeCount">0</span>
+          <strong>Project nodes</strong>
+        </article>
+        <article>
+          <span id="updateCount">0</span>
+          <strong>Updates</strong>
+        </article>
+        <article>
+          <span id="needCount">0</span>
+          <strong>Needs listed</strong>
+        </article>
+        <article>
+          <span id="offerCount">0</span>
+          <strong>Offers listed</strong>
+        </article>
       </section>
 
-      <section class="projects-section" aria-labelledby="nextStepsTitle">
+      <section class="workspace-grid" aria-label="Project launchpad workspace">
+        <form id="projectForm" class="projects-section form-panel" aria-labelledby="createProjectTitle">
+          <div class="section-header">
+            <p class="section-eyebrow">Create a node</p>
+            <h2 id="createProjectTitle">Put the seed somewhere visible.</h2>
+            <p class="section-lede">
+              A rough project is enough. Capture the mission, needs, offers, and where supporters should go next.
+            </p>
+          </div>
+          <div class="field-row">
+            <label>
+              Name
+              <input
+                id="projectName"
+                required
+                maxlength="80"
+                placeholder="Regenerative Farm, repair circle, music retreat..."
+              />
+            </label>
+            <label>
+              Stage
+              <select id="projectStage">
+                <option value="seed">Seed</option>
+                <option value="building">Building</option>
+                <option value="live">Live</option>
+                <option value="seeking">Seeking support</option>
+              </select>
+            </label>
+          </div>
+          <div class="field-row">
+            <label>
+              Slug
+              <input id="projectSlug" maxlength="64" placeholder="project-name" />
+            </label>
+            <label>
+              Category
+              <input id="projectCategory" maxlength="64" placeholder="farm, software, music, co-op..." />
+            </label>
+          </div>
+          <label>
+            Mission
+            <textarea
+              id="projectMission"
+              required
+              rows="3"
+              maxlength="360"
+              placeholder="What are you building, who is it for, and why should people care?"
+            ></textarea>
+          </label>
+          <div class="field-row">
+            <label>
+              Needs
+              <textarea
+                id="projectNeeds"
+                rows="3"
+                placeholder="land, funding, coders, volunteers, artists..."
+              ></textarea>
+            </label>
+            <label>
+              Offers
+              <textarea
+                id="projectOffers"
+                rows="3"
+                placeholder="classes, repairs, websites, retreats, music..."
+              ></textarea>
+            </label>
+          </div>
+          <div class="field-row">
+            <label>
+              Contact link
+              <input id="projectContact" type="url" placeholder="mailto:3dvr.tech@gmail.com" />
+            </label>
+            <label>
+              Support link
+              <input id="projectSupport" type="url" placeholder="Stripe, donation, subscription, or signup URL" />
+            </label>
+          </div>
+          <button class="cta primary" type="submit">Save project node</button>
+          <p id="syncStatus" class="sync-status" role="status" aria-live="polite">Connecting to project graph...</p>
+        </form>
+
+        <aside class="projects-section" aria-labelledby="ladderTitle">
+          <div class="section-header">
+            <p class="section-eyebrow">Plan ladder</p>
+            <h2 id="ladderTitle">Let the node grow with the project.</h2>
+          </div>
+          <div class="plan-ladder">
+            <article>
+              <strong>Free</strong>
+              <span>Profile, posts, needs, offers, contact form direction.</span>
+            </article>
+            <article>
+              <strong>$5/mo</strong>
+              <span>Custom subdomain, basic intake, support button.</span>
+            </article>
+            <article>
+              <strong>$20/mo</strong>
+              <span>Booking, payments, lead dashboard, AI drafts.</span>
+            </article>
+            <article>
+              <strong>$50/mo</strong>
+              <span>Managed project desk, email, forms, automation.</span>
+            </article>
+            <article>
+              <strong>$200/mo</strong>
+              <span>Full digital operating system and white-glove launch support.</span>
+            </article>
+          </div>
+        </aside>
+      </section>
+
+      <section id="projectBoard" class="projects-section" aria-labelledby="boardTitle">
+        <div class="board-head">
+          <div class="section-header">
+            <p class="section-eyebrow">Live commons</p>
+            <h2 id="boardTitle">Project nodes</h2>
+            <p class="section-lede">
+              The point is not polish. The point is identity, community, momentum, and tools.
+            </p>
+          </div>
+          <div class="filters" aria-label="Filter project nodes">
+            <button type="button" class="filter active" data-filter="all">All</button>
+            <button type="button" class="filter" data-filter="seed">Seeds</button>
+            <button type="button" class="filter" data-filter="building">Building</button>
+            <button type="button" class="filter" data-filter="live">Live</button>
+            <button type="button" class="filter" data-filter="seeking">Seeking</button>
+          </div>
+        </div>
+        <div id="projectList" class="project-grid" aria-live="polite"></div>
+      </section>
+
+      <section class="workspace-grid" aria-label="Project updates and operating model">
+        <form id="updateForm" class="projects-section form-panel" aria-labelledby="updateTitle">
+          <div class="section-header">
+            <p class="section-eyebrow">Project journal</p>
+            <h2 id="updateTitle">Post an update.</h2>
+            <p class="section-lede">
+              Updates make unfinished work visible. Share what changed, what is blocked, or what help is needed.
+            </p>
+          </div>
+          <label>
+            Project
+            <select id="updateProject" required></select>
+          </label>
+          <label>
+            Update title
+            <input id="updateHeading" required maxlength="100" placeholder="What moved forward?" />
+          </label>
+          <label>
+            Update
+            <textarea id="updateBody" required rows="4" placeholder="Short project journal entry..."></textarea>
+          </label>
+          <button class="cta primary" type="submit">Post update</button>
+        </form>
+
+        <aside class="projects-section" aria-labelledby="aiHelpTitle">
+          <div class="section-header">
+            <p class="section-eyebrow">Human-approved AI help</p>
+            <h2 id="aiHelpTitle">AI prepares. People steer.</h2>
+            <p class="section-lede">
+              Future agents can draft posts, replies, proposals, project plans, and outreach, but publishing,
+              sending, billing, and commitments stay human-gated.
+            </p>
+          </div>
+          <div class="ai-queue" aria-label="Future AI approval queue">
+            <article>
+              <strong>Draft update</strong>
+              <span>Turn rough notes into a public project post.</span>
+            </article>
+            <article>
+              <strong>Draft outreach</strong>
+              <span>Ask a supporter, volunteer, customer, or partner for the next move.</span>
+            </article>
+            <article>
+              <strong>Plan next step</strong>
+              <span>Convert a messy idea into tasks, offers, and support requests.</span>
+            </article>
+          </div>
+        </aside>
+      </section>
+
+      <section class="projects-section" aria-labelledby="operatingRulesTitle">
         <div class="section-header">
-          <p class="section-eyebrow">Next steps</p>
-          <h2 id="nextStepsTitle">Make the concept testable</h2>
+          <p class="section-eyebrow">Operating idea</p>
+          <h2 id="operatingRulesTitle">A commons for living projects.</h2>
           <p class="section-lede">
-            Pair the exploration with concrete experiments so we can validate comfort, latency, and
-            cross-device routing.
+            Independent websites still matter, but they are often the finished artifact. Project Launchpad is the
+            early home: a sketch, a prototype, a garden, a group, a tool, a movement, or a family trying to begin.
           </p>
         </div>
-        <div class="step-list" role="list">
-          <div class="step" role="listitem">
-            <div class="step__icon" aria-hidden="true">🧩</div>
-            <div>
-              <h3>Prototype layout and straps</h3>
-              <p>
-                Rough-print keyboard plates, map keys to travel-friendly columns, and record fit
-                notes in shared notes.
-              </p>
-            </div>
-          </div>
-          <div class="step" role="listitem">
-            <div class="step__icon" aria-hidden="true">🔗</div>
-            <div>
-              <h3>Sync controls across devices</h3>
-              <p>
-                Route inputs through <code>gun.get('projects').get('io-link')</code> to keep phone,
-                desktop, and VR views aligned.
-              </p>
-            </div>
-          </div>
-          <div class="step" role="listitem">
-            <div class="step__icon" aria-hidden="true">🧪</div>
-            <div>
-              <h3>Test in travel and standing scenarios</h3>
-              <p>
-                Measure comfort while walking, at a standing desk, and on flights. Capture clips and
-                feedback before the next iteration.
-              </p>
-            </div>
-          </div>
+        <div class="principle-grid">
+          <article>
+            <strong>Not an attention trap</strong>
+            <span>People follow projects because they want to help, learn, fund, join, or collaborate.</span>
+          </article>
+          <article>
+            <strong>Seed before company</strong>
+            <span>A node can become a website, business, nonprofit, software project, retreat, co-op, or band.</span>
+          </article>
+          <article>
+            <strong>Network effects that serve</strong>
+            <span>Projects can discover builders, donors, coders, artists, land, customers, and volunteers.</span>
+          </article>
         </div>
       </section>
     </main>

--- a/projects/projects.css
+++ b/projects/projects.css
@@ -1,261 +1,422 @@
 :root {
-  --projects-surface: rgba(17, 24, 39, 0.8);
-  --projects-surface-alt: rgba(30, 41, 59, 0.85);
-  --projects-border: rgba(148, 163, 184, 0.28);
-  --projects-text: #e2e8f0;
-  --projects-muted: #cbd5e1;
-  --projects-cta: #60a5fa;
-  --projects-cta-strong: #3b82f6;
+  --projects-surface: rgba(16, 22, 33, 0.9);
+  --projects-surface-alt: rgba(26, 36, 52, 0.88);
+  --projects-border: rgba(148, 163, 184, 0.26);
+  --projects-text: #e5eef8;
+  --projects-muted: #b8c6d6;
+  --projects-soft: rgba(96, 165, 250, 0.12);
+  --projects-cta: #7dd3fc;
+  --projects-cta-strong: #38bdf8;
+  --projects-good: #a7f3d0;
+  --projects-warn: #fde68a;
 }
 
 .projects {
   color: var(--projects-text);
-  background: var(--page-background);
-  padding: 2rem 1.25rem 3rem;
+  background:
+    radial-gradient(circle at 15% 0%, rgba(45, 212, 191, 0.14), transparent 34rem),
+    radial-gradient(circle at 85% 12%, rgba(125, 211, 252, 0.12), transparent 30rem),
+    var(--page-background);
+  padding: 1.5rem 1rem 3rem;
 }
 
 .projects-shell {
-  max-width: 1100px;
+  max-width: 1180px;
   margin: 0 auto;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.projects-nav {
   display: flex;
-  flex-direction: column;
-  gap: 2rem;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-bottom: 1rem;
+}
+
+.projects-nav a,
+.filter,
+.cta {
+  border: 1px solid var(--projects-border);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.62);
+  color: var(--projects-text);
+  text-decoration: none;
+  font: inherit;
+}
+
+.projects-nav a {
+  padding: 0.45rem 0.75rem;
+}
+
+.projects-hero,
+.projects-section,
+.metrics-grid article {
+  border: 1px solid var(--projects-border);
+  background: linear-gradient(145deg, var(--projects-surface), var(--projects-surface-alt));
+  box-shadow: 0 28px 56px rgba(0, 0, 0, 0.18);
 }
 
 .projects-hero {
+  border-radius: 18px;
+  padding: 1.35rem;
+}
+
+.projects-hero__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
-  padding: 1.75rem;
-  border: 1px solid var(--projects-border);
-  border-radius: 20px;
-  background: linear-gradient(135deg, var(--projects-surface), var(--projects-surface-alt));
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.18);
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+  gap: 1.25rem;
+  align-items: stretch;
 }
 
-.projects-hero__eyebrow {
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--projects-muted);
-  font-size: 0.85rem;
-  margin: 0 0 0.25rem;
-}
-
-.projects-hero__title {
-  margin: 0 0 0.5rem;
-  font-size: clamp(1.8rem, 3vw, 2.2rem);
-}
-
-.projects-hero__lede {
-  margin: 0 0 0.9rem;
-  color: var(--projects-muted);
-  font-size: 1.02rem;
-}
-
-.projects-hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 0.75rem;
-}
-
-.projects-meta {
-  padding: 1rem;
-  border-radius: 16px;
-  border: 1px dashed var(--projects-border);
-  background: rgba(15, 23, 42, 0.6);
-}
-
-.projects-meta__label {
-  margin: 0 0 0.35rem;
-  color: var(--projects-muted);
-  font-weight: 600;
-}
-
-.projects-meta ul {
-  margin: 0;
-  padding-left: 1.2rem;
-  color: var(--projects-text);
-  line-height: 1.5;
-}
-
-.projects-main {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
-.projects-section {
-  border: 1px solid var(--projects-border);
-  border-radius: 20px;
-  padding: 1.5rem;
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.55));
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.14);
-}
-
-.section-header {
-  display: grid;
-  gap: 0.35rem;
-  margin-bottom: 1.25rem;
-}
-
+.projects-hero__eyebrow,
 .section-eyebrow {
   margin: 0;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--projects-muted);
-  font-size: 0.9rem;
+  font-size: 0.86rem;
 }
 
-.section-lede {
+.projects-hero__title,
+.section-header h2 {
   margin: 0;
+  letter-spacing: 0;
+}
+
+.projects-hero__title {
+  max-width: 760px;
+  font-size: clamp(2.25rem, 2.8rem, 3.2rem);
+  line-height: 1.02;
+}
+
+.projects-hero__lede,
+.section-lede,
+.projects-meta,
+.project-node p,
+.sync-status {
   color: var(--projects-muted);
+}
+
+.projects-hero__lede {
+  max-width: 780px;
+  margin: 0.8rem 0 0;
+  font-size: 1.05rem;
+}
+
+.projects-hero__actions,
+.filters,
+.node-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.projects-hero__actions {
+  margin-top: 1rem;
+}
+
+.cta,
+.filter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.58rem 0.9rem;
+  cursor: pointer;
+}
+
+.cta.primary {
+  color: #07111f;
+  background: var(--projects-cta);
+  border-color: transparent;
+  font-weight: 800;
+}
+
+.cta.ghost,
+.filter {
+  background: rgba(96, 165, 250, 0.08);
+}
+
+.filter.active {
+  color: #07111f;
+  background: var(--projects-good);
+  border-color: transparent;
+  font-weight: 800;
+}
+
+.projects-meta {
+  border: 1px dashed var(--projects-border);
+  border-radius: 16px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.68);
+}
+
+.projects-meta__label {
+  margin: 0 0 0.4rem;
+  color: var(--projects-text);
+  font-weight: 800;
+}
+
+.projects-meta p {
+  margin: 0 0 0.75rem;
+}
+
+.projects-meta ul,
+.project-node ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  line-height: 1.55;
+}
+
+.projects-main {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.metrics-grid article {
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.metrics-grid span {
+  display: block;
+  color: var(--projects-cta);
+  font-size: 1.8rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.metrics-grid strong {
+  display: block;
+  margin-top: 0.3rem;
+  color: var(--projects-muted);
+}
+
+.workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.projects-section {
+  border-radius: 18px;
+  padding: 1.25rem;
+}
+
+.section-header {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.section-header h2 {
+  font-size: clamp(1.35rem, 1.8rem, 2.1rem);
+}
+
+.form-panel,
+.project-node {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.field-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--projects-text);
+  font-weight: 700;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--projects-border);
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--projects-text);
+  padding: 0.68rem 0.75rem;
+  font: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.sync-status {
+  min-height: 1.2rem;
+  margin: 0;
+}
+
+.plan-ladder,
+.ai-queue,
+.principle-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.plan-ladder article,
+.ai-queue article,
+.principle-grid article {
+  border: 1px solid var(--projects-border);
+  border-radius: 12px;
+  padding: 0.8rem;
+  background: rgba(15, 23, 42, 0.56);
+}
+
+.plan-ladder strong,
+.ai-queue strong,
+.principle-grid strong {
+  display: block;
+  color: var(--projects-text);
+  margin-bottom: 0.25rem;
+}
+
+.plan-ladder span,
+.ai-queue span,
+.principle-grid span {
+  color: var(--projects-muted);
+}
+
+.board-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
 }
 
 .project-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
 }
 
-.project-card {
+.project-node {
   border: 1px solid var(--projects-border);
   border-radius: 16px;
   padding: 1rem;
-  background: rgba(30, 41, 59, 0.8);
-  display: grid;
-  grid-template-columns: auto 1fr;
+  background:
+    linear-gradient(160deg, rgba(15, 23, 42, 0.72), rgba(30, 41, 59, 0.82)),
+    var(--projects-soft);
+}
+
+.node-top {
+  display: flex;
+  justify-content: space-between;
   gap: 0.75rem;
   align-items: start;
 }
 
-.project-card__icon {
-  font-size: 1.8rem;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
-  padding: 0.6rem;
-  border: 1px solid var(--projects-border);
+.node-title {
+  margin: 0;
+  font-size: 1.18rem;
 }
 
-.project-card__body {
-  display: grid;
-  gap: 0.4rem;
-}
-
-.project-card__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
+.node-slug,
+.node-stage,
+.node-chip {
+  display: inline-flex;
+  width: fit-content;
   align-items: center;
-  flex-wrap: wrap;
-}
-
-.project-card__header h3 {
-  margin: 0;
-}
-
-.project-card p {
-  margin: 0;
-  color: var(--projects-muted);
-}
-
-.project-card ul {
-  margin: 0;
-  padding-left: 1.1rem;
-  color: var(--projects-text);
-  line-height: 1.5;
-}
-
-.status-pill {
-  padding: 0.2rem 0.65rem;
   border-radius: 999px;
+  padding: 0.25rem 0.55rem;
   border: 1px solid var(--projects-border);
-  background: rgba(96, 165, 250, 0.1);
-  color: var(--projects-text);
-  font-size: 0.85rem;
-  font-weight: 600;
+  color: var(--projects-muted);
+  background: rgba(15, 23, 42, 0.7);
+  font-size: 0.84rem;
 }
 
-.status-pill--focus {
-  background: rgba(244, 114, 182, 0.12);
-  border-color: rgba(244, 114, 182, 0.35);
+.node-stage {
+  color: #07111f;
+  background: var(--projects-warn);
+  border-color: transparent;
+  font-weight: 800;
 }
 
-.status-pill--planning {
-  background: rgba(125, 211, 252, 0.12);
-  border-color: rgba(125, 211, 252, 0.35);
-}
-
-.step-list {
+.node-lists {
   display: grid;
-  gap: 0.8rem;
-}
-
-.step {
-  display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.75rem;
-  align-items: center;
-  padding: 0.9rem;
+}
+
+.node-lists h4,
+.node-update h4 {
+  margin: 0 0 0.35rem;
+}
+
+.node-update {
+  border-left: 3px solid var(--projects-cta-strong);
+  padding-left: 0.75rem;
+}
+
+.node-actions a,
+.node-actions button {
+  border: 1px solid var(--projects-border);
+  border-radius: 999px;
+  color: var(--projects-text);
+  background: rgba(96, 165, 250, 0.1);
+  padding: 0.45rem 0.7rem;
+  text-decoration: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  border: 1px dashed var(--projects-border);
   border-radius: 14px;
-  border: 1px solid var(--projects-border);
-  background: rgba(30, 41, 59, 0.7);
-}
-
-.step__icon {
-  font-size: 1.5rem;
-  height: 42px;
-  width: 42px;
-  display: grid;
-  place-items: center;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid var(--projects-border);
-}
-
-.step h3 {
-  margin: 0 0 0.15rem;
-}
-
-.step p {
-  margin: 0;
+  padding: 1rem;
   color: var(--projects-muted);
 }
 
-.cta.primary {
-  background: var(--projects-cta);
-  color: #0b1220;
-  border: 1px solid transparent;
+.principle-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.cta.primary:hover,
-.cta.ghost:hover {
-  transform: translateY(-2px);
+@media (max-width: 820px) {
+  .projects-hero__grid,
+  .workspace-grid,
+  .field-row,
+  .node-lists,
+  .principle-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .board-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
 }
 
-.cta.ghost {
-  background: rgba(96, 165, 250, 0.08);
-  border: 1px solid var(--projects-border);
-  color: var(--projects-text);
-}
-
-@media (max-width: 640px) {
+@media (max-width: 480px) {
   .projects {
-    padding: 1.5rem 1rem 2rem;
+    padding-inline: 0.75rem;
   }
 
   .projects-hero,
   .projects-section {
-    padding: 1.25rem;
+    padding: 1rem;
   }
 
-  .project-card,
-  .step {
+  .metrics-grid {
     grid-template-columns: 1fr;
-  }
-
-  .project-card__icon,
-  .step__icon {
-    width: fit-content;
   }
 }

--- a/tests/projects-launchpad.test.js
+++ b/tests/projects-launchpad.test.js
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const baseDir = new URL('../projects/', import.meta.url);
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+describe('3DVR Project Launchpad', () => {
+  it('ships a project nursery route with public node surfaces', async () => {
+    const html = await readFile(new URL('index.html', baseDir), 'utf8');
+
+    assert.equal(await fileExists(new URL('index.html', baseDir)), true);
+    assert.equal(await fileExists(new URL('projects.css', baseDir)), true);
+    assert.equal(await fileExists(new URL('app.js', baseDir)), true);
+    assert.match(html, /3DVR Project Launchpad/);
+    assert.match(html, /Where fledgling projects become real/);
+    assert.match(html, /A home for projects before they are companies/);
+    assert.match(html, /The social network for people building the future/);
+    assert.match(html, /id="projectForm"/);
+    assert.match(html, /id="projectBoard"/);
+    assert.match(html, /id="projectList"/);
+    assert.match(html, /id="updateForm"/);
+    assert.match(html, /id="launchpadStats"/);
+    assert.match(html, /Human-approved AI help/);
+    assert.match(html, /project\.3dvr\.tech/);
+    assert.match(html, /<script[^>]+src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"/);
+    assert.match(html, /<script[^>]+src="\.{2}\/gun-init\.js"/);
+    assert.match(html, /<script defer src="\.\/app\.js"><\/script>/);
+  });
+
+  it('backs project nodes, updates, and followers with Gun plus a local backup', async () => {
+    const js = await readFile(new URL('app.js', baseDir), 'utf8');
+
+    assert.match(js, /PROJECT_LAUNCHPAD_ROOT = 'projectLaunchpad'/);
+    assert.match(js, /LOCAL_KEY = '3dvr-project-launchpad'/);
+    assert.match(js, /gun\.get\('3dvr-portal'\)\.get\(PROJECT_LAUNCHPAD_ROOT\)/);
+    assert.match(js, /root\?\.get\('nodes'\)\.get\(node\.slug\)\.put\(node\)/);
+    assert.match(js, /root\?\.get\('updates'\)\.get\(update\.id\)\.put\(update\)/);
+    assert.match(js, /root\?\.get\('followers'\)\.get\(slug\)\.put/);
+    assert.match(js, /localStorage\.setItem\(LOCAL_KEY/);
+    assert.match(js, /Regenerative Farm/);
+    assert.match(js, /SD Day Traders/);
+  });
+
+  it('keeps Projects registered in the portal dock as the launchpad entry', async () => {
+    const html = await readFile(new URL('../index.html', baseDir), 'utf8');
+
+    assert.match(html, /href="projects\/index\.html"/);
+    assert.match(html, /<span class="app-card__title">Projects<\/span>/);
+    assert.match(html, /project nodes with profiles, updates, needs, offers, and support links/);
+    assert.match(html, /data-app-keywords="[^"]*\blaunchpad\b[^"]*"/);
+  });
+});


### PR DESCRIPTION
## Summary
- Turn `projects/` into the first 3DVR Project Launchpad MVP for living project nodes
- Add Gun + localStorage-backed project nodes, updates, needs, offers, support/contact links, and follower counts
- Seed initial nodes for Regenerative Farm, SD Day Traders, and Open Future Computing
- Update the portal dock Projects card with launchpad search keywords and positioning
- Add regression coverage for the route, Gun node shape, and homepage registration

## Validation
- `node --test tests/projects-launchpad.test.js tests/homepage-search-ux.test.js tests/pocket-workstation.test.js tests/customer-journey-pages.test.js`
- `node --check projects/app.js`
- `git diff --check`
- Local HTTP smoke checks against `http://127.0.0.1:3000/projects/`, `/projects/app.js`, and `/`

## Full suite note
- Ran `npm ci` and then `npm test`.
- The new Project Launchpad tests pass inside the full run.
- The full suite still has unrelated existing failures:
  - `tests/auth-entrypoints.test.js` expects `window.location.href='/sign-in.html'` in homepage auth copy/runtime
  - `tests/contacts-score.e2e.test.js` times out navigating to `contacts/index.html`
  - `tests/vercel-insights-tag.test.js` reports many pre-existing pages missing Insights tags
- `npm ci` reports existing audit warnings: 2 moderate, 1 high.