### PR TITLE
[codex] Update projects app as Seed Deck

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,12 +521,12 @@
           <a
             href="projects/index.html"
             class="app-card"
-            data-app-keywords="projects launchpad project nodes social commons updates needs offers supporters"
+            data-app-keywords="projects seed deck launchpad project nodes social commons updates needs offers supporters"
           >
             <span class="app-card__icon" aria-hidden="true">📂</span>
             <span class="app-card__title">Projects</span>
             <span class="app-card__meta">
-              Start project nodes with profiles, updates, needs, offers, and support links.
+              Open Seed Deck to plant ideas with pages, updates, needs, offers, and support links.
             </span>
           </a>
           <a href="releases/" class="app-card">

--- a/projects/index.html
+++ b/projects/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Projects · 3DVR Project Launchpad</title>
+  <title>Projects · 3DVR Seed Deck</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="../gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
@@ -13,10 +13,10 @@
   <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="projects theme-dark">
-  <a class="skip-link" href="#projectsMain">Skip to project launchpad</a>
+  <a class="skip-link" href="#projectsMain">Skip to Seed Deck</a>
   <div class="projects-shell">
     <header class="projects-hero" aria-labelledby="projectsTitle">
-      <nav class="projects-nav" aria-label="Project launchpad navigation">
+      <nav class="projects-nav" aria-label="Seed Deck navigation">
         <a href="../index.html">Portal</a>
         <a href="../community/">Community</a>
         <a href="../crm/">CRM</a>
@@ -24,38 +24,38 @@
       </nav>
       <div class="projects-hero__grid">
         <div>
-          <p class="projects-hero__eyebrow">3DVR project launchpad</p>
-          <h1 id="projectsTitle" class="projects-hero__title">Where fledgling projects become real.</h1>
+          <p class="projects-hero__eyebrow">3DVR Seed Deck</p>
+          <h1 id="projectsTitle" class="projects-hero__title">Start before you're ready.</h1>
           <p class="projects-hero__lede">
-            A home for projects before they are companies: public profile, mission, updates, needs, offers,
-            contact paths, support links, followers, and human-approved AI help.
+            3DVR gives your project a place to grow: a living page, simple intake, trust-building
+            updates, support links, and human-approved AI help before the idea is ready to be a business.
           </p>
           <div class="projects-hero__actions">
-            <a class="cta primary" href="#projectForm">Start a project node</a>
-            <a class="cta ghost" href="#projectBoard">Browse project nodes</a>
+            <a class="cta primary" href="#projectForm">Plant a seed</a>
+            <a class="cta ghost" href="#projectBoard">Browse the seed bed</a>
             <a class="cta ghost" href="../start/">Choose a 3DVR plan</a>
           </div>
         </div>
-        <aside class="projects-meta" aria-label="Launchpad positioning">
+        <aside class="projects-meta" aria-label="Seed Deck positioning">
           <p class="projects-meta__label">Positioning</p>
           <p>
-            The social network for people building the future: a project nursery where seeds can
-            gather people, explain themselves, collect support, and grow into real work.
+            Not a social network. Not a website builder. Not a CRM. A seed bed where unfinished
+            ideas can gather people, explain themselves, collect support, and become real.
           </p>
           <ul>
             <li><code>3dvr.tech/project-name</code> for a simple project home.</li>
             <li><code>project.3dvr.tech</code> when the project is ready for a custom subdomain.</li>
-            <li>Use independent websites later, after the project has momentum.</li>
+            <li>Use independent websites later, after the project has roots.</li>
           </ul>
         </aside>
       </div>
     </header>
 
-    <main id="projectsMain" class="projects-main" aria-label="3DVR project launchpad">
-      <section class="metrics-grid" id="launchpadStats" aria-label="Launchpad stats">
+    <main id="projectsMain" class="projects-main" aria-label="3DVR Seed Deck">
+      <section class="metrics-grid" id="launchpadStats" aria-label="Seed Deck stats">
         <article>
           <span id="nodeCount">0</span>
-          <strong>Project nodes</strong>
+          <strong>Seeds planted</strong>
         </article>
         <article>
           <span id="updateCount">0</span>
@@ -71,11 +71,11 @@
         </article>
       </section>
 
-      <section class="workspace-grid" aria-label="Project launchpad workspace">
+      <section class="workspace-grid" aria-label="Seed Deck workspace">
         <form id="projectForm" class="projects-section form-panel" aria-labelledby="createProjectTitle">
           <div class="section-header">
-            <p class="section-eyebrow">Create a node</p>
-            <h2 id="createProjectTitle">Put the seed somewhere visible.</h2>
+            <p class="section-eyebrow">Plant a seed</p>
+            <h2 id="createProjectTitle">Give the idea digital soil.</h2>
             <p class="section-lede">
               A rough project is enough. Capture the mission, needs, offers, and where supporters should go next.
             </p>
@@ -148,7 +148,7 @@
               <input id="projectSupport" type="url" placeholder="Stripe, donation, subscription, or signup URL" />
             </label>
           </div>
-          <button class="cta primary" type="submit">Save project node</button>
+          <button class="cta primary" type="submit">Save seed page</button>
           <p id="syncStatus" class="sync-status" role="status" aria-live="polite">Connecting to project graph...</p>
         </form>
 
@@ -160,38 +160,59 @@
           <div class="plan-ladder">
             <article>
               <strong>Free</strong>
-              <span>Profile, posts, needs, offers, contact form direction.</span>
+              <span>Public seed page with mission, updates, needs, offers, and contact direction.</span>
             </article>
             <article>
               <strong>$5/mo</strong>
-              <span>Custom subdomain, basic intake, support button.</span>
+              <span>Custom subdomain, contact form, basic updates, and support button.</span>
             </article>
             <article>
               <strong>$20/mo</strong>
-              <span>Booking, payments, lead dashboard, AI drafts.</span>
+              <span>Booking, email forwarding, project dashboard, and lead overview.</span>
             </article>
             <article>
               <strong>$50/mo</strong>
-              <span>Managed project desk, email, forms, automation.</span>
+              <span>AI-assisted replies, lead tracking, payments, and managed forms.</span>
             </article>
             <article>
               <strong>$200/mo</strong>
-              <span>Full digital operating system and white-glove launch support.</span>
+              <span>Full project operator: pages, campaigns, support, and automations.</span>
             </article>
           </div>
         </aside>
       </section>
 
+      <section class="projects-section" aria-labelledby="gardenTitle">
+        <div class="section-header">
+          <p class="section-eyebrow">Community garden</p>
+          <h2 id="gardenTitle">Browse fledgling projects by theme.</h2>
+          <p class="section-lede">
+            Seed Deck is for community-scale things that are useful, beautiful, local, strange, practical, or alive.
+          </p>
+        </div>
+        <div class="theme-grid" aria-label="Seed Deck themes">
+          <span>Regenerative living</span>
+          <span>Open-source tools</span>
+          <span>Music and healing</span>
+          <span>Local services</span>
+          <span>Events</span>
+          <span>Education</span>
+          <span>Weird tech</span>
+          <span>Spiritual technology</span>
+          <span>Family-scale startups</span>
+        </div>
+      </section>
+
       <section id="projectBoard" class="projects-section" aria-labelledby="boardTitle">
         <div class="board-head">
           <div class="section-header">
-            <p class="section-eyebrow">Live commons</p>
-            <h2 id="boardTitle">Project nodes</h2>
+            <p class="section-eyebrow">Live seed bed</p>
+            <h2 id="boardTitle">Project seeds</h2>
             <p class="section-lede">
-              The point is not polish. The point is identity, community, momentum, and tools.
+              The point is not polish. The point is courage, identity, community, momentum, and tools.
             </p>
           </div>
-          <div class="filters" aria-label="Filter project nodes">
+          <div class="filters" aria-label="Filter project seeds">
             <button type="button" class="filter active" data-filter="all">All</button>
             <button type="button" class="filter" data-filter="seed">Seeds</button>
             <button type="button" class="filter" data-filter="building">Building</button>
@@ -208,7 +229,7 @@
             <p class="section-eyebrow">Project journal</p>
             <h2 id="updateTitle">Post an update.</h2>
             <p class="section-lede">
-              Updates make unfinished work visible. Share what changed, what is blocked, or what help is needed.
+              Updates, milestones, public notes, screenshots, and demos make unfinished work trustworthy.
             </p>
           </div>
           <label>
@@ -231,8 +252,8 @@
             <p class="section-eyebrow">Human-approved AI help</p>
             <h2 id="aiHelpTitle">AI prepares. People steer.</h2>
             <p class="section-lede">
-              Future agents can draft posts, replies, proposals, project plans, and outreach, but publishing,
-              sending, billing, and commitments stay human-gated.
+              Future agents can draft replies, summarize interest, suggest next steps, build tiny pages,
+              and organize leads, but publishing, sending, billing, and commitments stay human-gated.
             </p>
           </div>
           <div class="ai-queue" aria-label="Future AI approval queue">
@@ -255,10 +276,10 @@
       <section class="projects-section" aria-labelledby="operatingRulesTitle">
         <div class="section-header">
           <p class="section-eyebrow">Operating idea</p>
-          <h2 id="operatingRulesTitle">A commons for living projects.</h2>
+          <h2 id="operatingRulesTitle">A seed bed for useful, beautiful things.</h2>
           <p class="section-lede">
-            Independent websites still matter, but they are often the finished artifact. Project Launchpad is the
-            early home: a sketch, a prototype, a garden, a group, a tool, a movement, or a family trying to begin.
+            The world does not just need more apps. It needs more people with courage to build community-scale
+            things. 3DVR Seed Deck helps unfinished ideas become real.
           </p>
         </div>
         <div class="principle-grid">

--- a/projects/projects.css
+++ b/projects/projects.css
@@ -263,14 +263,16 @@ textarea {
 
 .plan-ladder,
 .ai-queue,
-.principle-grid {
+.principle-grid,
+.theme-grid {
   display: grid;
   gap: 0.75rem;
 }
 
 .plan-ladder article,
 .ai-queue article,
-.principle-grid article {
+.principle-grid article,
+.theme-grid span {
   border: 1px solid var(--projects-border);
   border-radius: 12px;
   padding: 0.8rem;
@@ -385,6 +387,15 @@ textarea {
 
 .principle-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.theme-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.theme-grid span {
+  color: var(--projects-text);
+  font-weight: 800;
 }
 
 @media (max-width: 820px) {

--- a/tests/projects-launchpad.test.js
+++ b/tests/projects-launchpad.test.js
@@ -14,23 +14,28 @@ async function fileExists(path) {
   }
 }
 
-describe('3DVR Project Launchpad', () => {
+describe('3DVR Seed Deck', () => {
   it('ships a project nursery route with public node surfaces', async () => {
     const html = await readFile(new URL('index.html', baseDir), 'utf8');
 
     assert.equal(await fileExists(new URL('index.html', baseDir)), true);
     assert.equal(await fileExists(new URL('projects.css', baseDir)), true);
     assert.equal(await fileExists(new URL('app.js', baseDir)), true);
-    assert.match(html, /3DVR Project Launchpad/);
-    assert.match(html, /Where fledgling projects become real/);
-    assert.match(html, /A home for projects before they are companies/);
-    assert.match(html, /The social network for people building the future/);
+    assert.match(html, /3DVR Seed Deck/);
+    assert.match(html, /Start before you're ready/);
+    assert.match(html, /Not a social network\. Not a website builder\. Not a CRM\. A seed bed/);
+    assert.match(html, /3DVR Seed Deck helps unfinished ideas become real/);
+    assert.match(html, /Community garden/);
+    assert.match(html, /Regenerative living/);
+    assert.match(html, /Open-source tools/);
+    assert.match(html, /Spiritual technology/);
     assert.match(html, /id="projectForm"/);
     assert.match(html, /id="projectBoard"/);
     assert.match(html, /id="projectList"/);
     assert.match(html, /id="updateForm"/);
     assert.match(html, /id="launchpadStats"/);
     assert.match(html, /Human-approved AI help/);
+    assert.match(html, /summarize interest/);
     assert.match(html, /project\.3dvr\.tech/);
     assert.match(html, /<script[^>]+src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"/);
     assert.match(html, /<script[^>]+src="\.{2}\/gun-init\.js"/);
@@ -56,7 +61,8 @@ describe('3DVR Project Launchpad', () => {
 
     assert.match(html, /href="projects\/index\.html"/);
     assert.match(html, /<span class="app-card__title">Projects<\/span>/);
-    assert.match(html, /project nodes with profiles, updates, needs, offers, and support links/);
+    assert.match(html, /Open Seed Deck to plant ideas with pages, updates, needs, offers, and support links/);
+    assert.match(html, /data-app-keywords="[^"]*\bseed deck\b[^"]*"/);
     assert.match(html, /data-app-keywords="[^"]*\blaunchpad\b[^"]*"/);
   });
 });


### PR DESCRIPTION
## Summary
- Reposition the Projects app as 3DVR Seed Deck with the "Start before you're ready" homepage and project-page language.
- Add a community garden theme section for fledgling project discovery.
- Update the portal dock metadata and focused tests for the Seed Deck naming while keeping the underlying Gun/localStorage launchpad keys stable.

## Validation
- `node --test tests/projects-launchpad.test.js tests/homepage-search-ux.test.js tests/pocket-workstation.test.js tests/customer-journey-pages.test.js`
- `node --check projects/app.js`
- `git diff --check`