### PR TITLE
[codex] Add simple site launcher

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -53,11 +53,84 @@ function validateGithubRequest(body) {
   return null;
 }
 
-function validateVercelRequest(body) {
-  const { token, projectName, html } = body || {};
+const RESERVED_SUBDOMAINS = new Set([
+  'admin',
+  'api',
+  'app',
+  'apps',
+  'billing',
+  'cdn',
+  'dashboard',
+  'deploy',
+  'email',
+  'help',
+  'launch',
+  'mail',
+  'portal',
+  'staging',
+  'static',
+  'support',
+  'vercel',
+  'www'
+]);
 
-  if (!token || typeof token !== 'string') {
-    return 'A Vercel token is required.';
+function sanitizeProjectName(value, fallback = 'site-launch') {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+
+  return normalized || fallback;
+}
+
+export function sanitizeLaunchSubdomain(value) {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-')
+    .slice(0, 48);
+
+  if (!normalized || normalized.length < 3) {
+    return '';
+  }
+
+  if (RESERVED_SUBDOMAINS.has(normalized)) {
+    return '';
+  }
+
+  return normalized;
+}
+
+export function resolveLaunchDomain(body = {}, options = {}) {
+  const baseDomain = String(options.baseDomain || process.env.SITE_LAUNCH_BASE_DOMAIN || '3dvr.tech')
+    .trim()
+    .toLowerCase()
+    .replace(/^\.+|\.+$/g, '');
+
+  const requestedSubdomain = body.subdomain || body.siteSlug || body.slug || body.alias;
+  const subdomain = sanitizeLaunchSubdomain(requestedSubdomain);
+
+  if (!subdomain || !baseDomain) {
+    return null;
+  }
+
+  return {
+    subdomain,
+    domain: `${subdomain}.${baseDomain}`,
+    baseDomain
+  };
+}
+
+function validateVercelRequest(body, options = {}) {
+  const { token, projectName, html } = body || {};
+  const effectiveToken = token || options.defaultToken;
+
+  if (!effectiveToken || typeof effectiveToken !== 'string') {
+    return 'A Vercel token is required. Configure VERCEL_TOKEN or provide a token.';
   }
 
   if (!projectName || typeof projectName !== 'string') {
@@ -131,7 +204,42 @@ async function commitToGithub({ token, repo, path, branch, content, message, fet
   };
 }
 
-async function createVercelDeployment({ token, projectName, html, fetchImpl = globalThis.fetch }) {
+async function assignVercelAlias({ token, deploymentId, domain, teamId, fetchImpl = globalThis.fetch }) {
+  if (!domain) {
+    return null;
+  }
+
+  const query = teamId ? `?teamId=${encodeURIComponent(teamId)}` : '';
+  const response = await fetchImpl(`https://api.vercel.com/v2/deployments/${deploymentId}/aliases${query}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ alias: domain })
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Vercel alias error ${response.status}: ${errorText || 'Unknown error'}`);
+  }
+
+  const data = await response.json();
+  return {
+    alias: data.alias || domain,
+    aliasUrl: `https://${data.alias || domain}`,
+    aliasAssigned: true
+  };
+}
+
+async function createVercelDeployment({
+  token,
+  projectName,
+  html,
+  launchDomain,
+  teamId,
+  fetchImpl = globalThis.fetch
+}) {
   const files = [
     { file: 'index.html', data: html },
     {
@@ -143,7 +251,7 @@ async function createVercelDeployment({ token, projectName, html, fetchImpl = gl
   ];
 
   const payload = {
-    name: projectName.trim().toLowerCase().replace(/[^a-z0-9-]/gi, '-'),
+    name: sanitizeProjectName(projectName),
     files,
     projectSettings: {
       framework: null
@@ -167,15 +275,39 @@ async function createVercelDeployment({ token, projectName, html, fetchImpl = gl
   }
 
   const data = await response.json();
-  return {
+  const result = {
     id: data.id,
     url: data.url ? `https://${data.url}` : undefined,
     inspectUrl: data.inspectUrl
   };
+
+  if (launchDomain?.domain && data.id) {
+    const aliasResult = await assignVercelAlias({
+      token,
+      deploymentId: data.id,
+      domain: launchDomain.domain,
+      teamId,
+      fetchImpl
+    });
+
+    return {
+      ...result,
+      ...aliasResult,
+      subdomain: launchDomain.subdomain,
+      baseDomain: launchDomain.baseDomain
+    };
+  }
+
+  return result;
 }
 
 export function createGithubPublishHandler(options = {}) {
-  const { fetchImpl = globalThis.fetch } = options;
+  const {
+    fetchImpl = globalThis.fetch,
+    vercelToken = process.env.VERCEL_TOKEN,
+    vercelTeamId = process.env.VERCEL_TEAM_ID,
+    siteLaunchBaseDomain = process.env.SITE_LAUNCH_BASE_DOMAIN
+  } = options;
 
   return async function handler(req, res) {
     setCorsHeaders(res);
@@ -192,16 +324,27 @@ export function createGithubPublishHandler(options = {}) {
     const provider = parseProvider(req);
 
     if (provider === 'vercel') {
-      const validationError = validateVercelRequest(body);
+      const validationError = validateVercelRequest(body, { defaultToken: vercelToken });
       if (validationError) {
         return res.status(400).json({ error: validationError });
       }
 
       try {
+        const token = body.token || vercelToken;
+        const launchDomain = body.subdomain || body.siteSlug || body.slug || body.alias
+          ? resolveLaunchDomain(body, { baseDomain: siteLaunchBaseDomain })
+          : null;
+
+        if ((body.subdomain || body.siteSlug || body.slug || body.alias) && !launchDomain) {
+          return res.status(400).json({ error: 'Choose a valid, available 3dvr.tech subdomain.' });
+        }
+
         const result = await createVercelDeployment({
-          token: body.token,
+          token,
           projectName: body.projectName,
           html: body.html,
+          launchDomain,
+          teamId: body.teamId || vercelTeamId,
           fetchImpl
         });
 

--- a/index.html
+++ b/index.html
@@ -173,6 +173,11 @@
             <span class="app-card__title">Lead Capture</span>
             <span class="app-card__meta">Collect inbound leads and sync with CRM instantly.</span>
           </a>
+          <a href="launch-site/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">🌐</span>
+            <span class="app-card__title">Launch Site</span>
+            <span class="app-card__meta">Generate, revise, and publish a simple website on a 3dvr.tech subdomain.</span>
+          </a>
           <a href="education.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🎓</span>
             <span class="app-card__title">Learn</span>

--- a/launch-site/app.js
+++ b/launch-site/app.js
@@ -1,0 +1,318 @@
+import { readDefaultSecret } from '../web-builder-app/defaults.js';
+
+const gun = window.Gun ? Gun({ peers: window.__GUN_PEERS__ || undefined }) : null;
+const defaultsNode = gun?.get('3dvr-portal')?.get('ai-workbench')?.get('defaults');
+
+const form = document.getElementById('site-form');
+const businessNameInput = document.getElementById('business-name');
+const purposeInput = document.getElementById('site-purpose');
+const audienceInput = document.getElementById('site-audience');
+const actionInput = document.getElementById('site-action');
+const styleInput = document.getElementById('site-style');
+const slugInput = document.getElementById('site-slug');
+const notesInput = document.getElementById('site-notes');
+const revisionInput = document.getElementById('revision-request');
+const generateButton = document.getElementById('generate-site');
+const reviseButton = document.getElementById('revise-site');
+const publishButton = document.getElementById('publish-site');
+const statusBox = document.getElementById('launcher-status');
+const previewFrame = document.getElementById('site-preview');
+const previewTitle = document.getElementById('preview-title');
+const publishResult = document.getElementById('publish-result');
+
+const statusClasses = ['status--info', 'status--success', 'status--warning', 'status--error'];
+const draftStorageKey = 'site-launcher-current-draft';
+
+let currentHtml = '';
+let currentTitle = '';
+let lastPrompt = '';
+let sharedSecrets = {
+  openai: '',
+  vercel: ''
+};
+
+renderEmptyPreview();
+hydrateStoredDraft();
+subscribeToSharedDefaults();
+wireEvents();
+
+function wireEvents() {
+  businessNameInput.addEventListener('input', () => {
+    if (!slugInput.value.trim()) {
+      slugInput.value = sanitizeSlug(businessNameInput.value);
+    }
+  });
+
+  slugInput.addEventListener('input', () => {
+    const start = slugInput.selectionStart;
+    slugInput.value = sanitizeSlug(slugInput.value);
+    slugInput.setSelectionRange(start, start);
+  });
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    generateSite();
+  });
+
+  reviseButton.addEventListener('click', reviseSite);
+  publishButton.addEventListener('click', publishSite);
+}
+
+function collectFormState() {
+  return {
+    businessName: businessNameInput.value.trim(),
+    purpose: purposeInput.value.trim(),
+    audience: audienceInput.value.trim(),
+    action: actionInput.value.trim(),
+    style: styleInput.value,
+    slug: sanitizeSlug(slugInput.value),
+    notes: notesInput.value.trim()
+  };
+}
+
+function sanitizeSlug(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-')
+    .slice(0, 48);
+}
+
+function subscribeToSharedDefaults() {
+  if (!defaultsNode) {
+    return;
+  }
+
+  defaultsNode.on(data => {
+    sharedSecrets = {
+      openai: readDefaultSecret(data, 'openai'),
+      vercel: readDefaultSecret(data, 'vercel')
+    };
+  });
+}
+
+function buildPrompt(state) {
+  return [
+    `Create a polished one-page website for "${state.businessName}".`,
+    `The site address will be ${state.slug}.3dvr.tech.`,
+    `Offer: ${state.purpose}.`,
+    state.audience ? `Audience: ${state.audience}.` : '',
+    state.action ? `Primary action: ${state.action}.` : 'Primary action: contact the business.',
+    `Visual direction: ${state.style}.`,
+    state.notes ? `Important details: ${state.notes}.` : '',
+    'Include a hero, clear offer section, trust section, contact/action section, and footer.',
+    'Use realistic public-facing copy based only on details provided. Do not invent phone numbers, addresses, prices, certifications, or reviews.',
+    'Return json with title, summary, and html keys. The html must be a complete standalone HTML document with inline CSS only.'
+  ].filter(Boolean).join('\n');
+}
+
+function buildRevisionPrompt(revisionRequest) {
+  return [
+    'Revise this website draft.',
+    `Revision request: ${revisionRequest}`,
+    'Return json with title, summary, and html keys. The html must be the complete updated document.',
+    'Current HTML:',
+    currentHtml
+  ].join('\n\n');
+}
+
+async function generateSite() {
+  const state = collectFormState();
+  slugInput.value = state.slug;
+
+  if (!state.businessName || !state.purpose || !state.slug) {
+    setStatus('Name, offer, and address are required.', 'warning');
+    return;
+  }
+
+  lastPrompt = buildPrompt(state);
+  await requestSiteDraft(lastPrompt, 'Generating site...');
+}
+
+async function reviseSite() {
+  const revisionRequest = revisionInput.value.trim();
+  if (!currentHtml) {
+    setStatus('Generate a draft first.', 'warning');
+    return;
+  }
+  if (!revisionRequest) {
+    setStatus('Add a revision request.', 'warning');
+    revisionInput.focus();
+    return;
+  }
+
+  await requestSiteDraft(buildRevisionPrompt(revisionRequest), 'Revising draft...');
+  revisionInput.value = '';
+}
+
+async function requestSiteDraft(prompt, message) {
+  setBusy(true);
+  setStatus(message, 'info');
+  publishResult.innerHTML = '';
+
+  try {
+    const response = await fetch('/api/openai-site', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt,
+        model: 'gpt-4.1-mini',
+        ...(sharedSecrets.openai ? { apiKey: sharedSecrets.openai } : {})
+      })
+    });
+
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result?.error || 'The site generator is not available.');
+    }
+
+    currentHtml = result.html || '';
+    currentTitle = result.title || collectFormState().businessName || 'Website draft';
+    previewTitle.textContent = currentTitle;
+    previewFrame.srcdoc = currentHtml;
+    setStatus(result.summary || 'Draft ready.', 'success');
+    setDraftControlsEnabled(true);
+    storeDraft();
+  } catch (error) {
+    setStatus(error.message || 'Unable to generate the site.', 'error');
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function publishSite() {
+  const state = collectFormState();
+  slugInput.value = state.slug;
+
+  if (!currentHtml) {
+    setStatus('Generate a draft first.', 'warning');
+    return;
+  }
+  if (!state.slug) {
+    setStatus('Choose an address before publishing.', 'warning');
+    slugInput.focus();
+    return;
+  }
+
+  publishButton.disabled = true;
+  setStatus(`Publishing ${state.slug}.3dvr.tech...`, 'info');
+  publishResult.innerHTML = '';
+
+  try {
+    const response = await fetch('/api/vercel-deploy', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        projectName: `3dvr-${state.slug}`,
+        subdomain: state.slug,
+        html: currentHtml,
+        title: currentTitle,
+        ...(sharedSecrets.vercel ? { token: sharedSecrets.vercel } : {})
+      })
+    });
+
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result?.error || 'Publishing failed.');
+    }
+
+    const liveUrl = result.aliasUrl || result.url || result.inspectUrl;
+    if (liveUrl) {
+      publishResult.innerHTML = `Live: <a href="${escapeAttribute(liveUrl)}" target="_blank" rel="noopener">${escapeHtml(liveUrl)}</a>`;
+      setStatus('Published.', 'success');
+    } else {
+      setStatus('Published, but no live URL was returned.', 'warning');
+    }
+  } catch (error) {
+    setStatus(error.message || 'Unable to publish the site.', 'error');
+  } finally {
+    publishButton.disabled = !currentHtml;
+  }
+}
+
+function setBusy(isBusy) {
+  generateButton.disabled = isBusy;
+  reviseButton.disabled = isBusy || !currentHtml;
+  publishButton.disabled = isBusy || !currentHtml;
+}
+
+function setDraftControlsEnabled(enabled) {
+  revisionInput.disabled = !enabled;
+  reviseButton.disabled = !enabled;
+  publishButton.disabled = !enabled;
+}
+
+function setStatus(message, tone = 'info') {
+  statusBox.textContent = message;
+  statusBox.classList.remove(...statusClasses);
+  statusBox.classList.add(`status--${tone}`);
+}
+
+function renderEmptyPreview() {
+  previewFrame.srcdoc = [
+    '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    '<style>body{margin:0;min-height:100vh;display:grid;place-items:center;padding:24px;',
+    'font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#f4f7f5;color:#17231d;}',
+    '.empty{max-width:520px;text-align:center}.empty p{line-height:1.6;color:#52645b}</style></head>',
+    '<body><main class="empty"><h1>Website preview</h1><p>Your generated draft will appear here.</p></main></body></html>'
+  ].join('');
+}
+
+function storeDraft() {
+  try {
+    localStorage.setItem(draftStorageKey, JSON.stringify({
+      html: currentHtml,
+      title: currentTitle,
+      prompt: lastPrompt,
+      form: collectFormState(),
+      updatedAt: Date.now()
+    }));
+  } catch (error) {
+    // Local draft history is optional.
+  }
+}
+
+function hydrateStoredDraft() {
+  try {
+    const raw = localStorage.getItem(draftStorageKey);
+    if (!raw) return;
+    const draft = JSON.parse(raw);
+    if (!draft?.html) return;
+
+    currentHtml = draft.html;
+    currentTitle = draft.title || 'Website draft';
+    lastPrompt = draft.prompt || '';
+
+    const formState = draft.form || {};
+    businessNameInput.value = formState.businessName || '';
+    purposeInput.value = formState.purpose || '';
+    audienceInput.value = formState.audience || '';
+    actionInput.value = formState.action || '';
+    styleInput.value = formState.style || styleInput.value;
+    slugInput.value = formState.slug || '';
+    notesInput.value = formState.notes || '';
+
+    previewTitle.textContent = currentTitle;
+    previewFrame.srcdoc = currentHtml;
+    setDraftControlsEnabled(true);
+    setStatus('Draft restored.', 'info');
+  } catch (error) {
+    renderEmptyPreview();
+  }
+}
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value);
+}

--- a/launch-site/index.html
+++ b/launch-site/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Launch Site | 3DVR Portal</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <header class="topbar">
+    <a href="../index.html" class="brand">3DVR Portal</a>
+    <nav aria-label="Site launcher links">
+      <a href="../web-builder-app/">Advanced builder</a>
+      <a href="../profile.html#profile">Profile</a>
+    </nav>
+  </header>
+
+  <main class="launcher-shell">
+    <section class="launcher-brief" aria-labelledby="launcher-title">
+      <p class="eyebrow">Site launcher</p>
+      <h1 id="launcher-title">Launch a website on 3dvr.tech</h1>
+
+      <form id="site-form" class="brief-form">
+        <label for="business-name">Name</label>
+        <input id="business-name" name="businessName" type="text" autocomplete="organization"
+          placeholder="River City Wellness" required>
+
+        <label for="site-purpose">Offer</label>
+        <textarea id="site-purpose" name="purpose" rows="5"
+          placeholder="Massage therapy, booking requests, gift cards, and a calming first impression." required></textarea>
+
+        <div class="field-grid">
+          <label for="site-audience">Audience
+            <input id="site-audience" name="audience" type="text" placeholder="Busy parents and local workers">
+          </label>
+          <label for="site-action">Action
+            <input id="site-action" name="action" type="text" placeholder="Book a session">
+          </label>
+        </div>
+
+        <div class="field-grid">
+          <label for="site-style">Style
+            <select id="site-style" name="style">
+              <option value="clean, warm, and trustworthy">Warm</option>
+              <option value="bright, energetic, and sales-focused">Bold</option>
+              <option value="minimal, editorial, and premium">Minimal</option>
+              <option value="playful, friendly, and colorful">Playful</option>
+            </select>
+          </label>
+          <label for="site-slug">Address
+            <span class="address-field">
+              <input id="site-slug" name="slug" type="text" inputmode="url" autocomplete="off"
+                placeholder="river-city-wellness" required>
+              <span>.3dvr.tech</span>
+            </span>
+          </label>
+        </div>
+
+        <label for="site-notes">Details</label>
+        <textarea id="site-notes" name="notes" rows="3"
+          placeholder="Hours, location, services, prices, phone, email, testimonials, or anything important."></textarea>
+
+        <div class="actions">
+          <button id="generate-site" class="primary" type="submit">Generate Site</button>
+          <button id="revise-site" class="secondary" type="button" disabled>Revise Draft</button>
+        </div>
+
+        <label for="revision-request" class="revision-label">Revision</label>
+        <input id="revision-request" type="text"
+          placeholder="Make it more direct, add pricing, or change the tone." disabled>
+
+        <p id="launcher-status" class="status status--info" aria-live="polite">Ready.</p>
+      </form>
+    </section>
+
+    <section class="preview-panel" aria-labelledby="preview-title">
+      <div class="preview-header">
+        <div>
+          <p class="eyebrow">Preview</p>
+          <h2 id="preview-title">Draft</h2>
+        </div>
+        <button id="publish-site" class="primary" type="button" disabled>Publish</button>
+      </div>
+      <iframe id="site-preview" title="Website preview"></iframe>
+      <div id="publish-result" class="publish-result" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/launch-site/styles.css
+++ b/launch-site/styles.css
@@ -1,0 +1,274 @@
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 15% 10%, rgba(77, 183, 136, 0.2), transparent 28%),
+    radial-gradient(circle at 85% 0%, rgba(82, 143, 209, 0.2), transparent 26%),
+    linear-gradient(180deg, #09111c 0%, #0c141f 52%, #080c12 100%);
+  color: #eef5f0;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 18px 24px;
+}
+
+.brand {
+  color: #ffffff;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.topbar nav {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.topbar nav a {
+  color: #c7d9e8;
+  text-decoration: none;
+  border: 1px solid rgba(135, 170, 198, 0.24);
+  border-radius: 8px;
+  padding: 9px 11px;
+  background: rgba(8, 15, 24, 0.74);
+}
+
+.launcher-shell {
+  display: grid;
+  grid-template-columns: minmax(320px, 440px) minmax(0, 1fr);
+  gap: 18px;
+  max-width: 1180px;
+  margin: 0 auto 48px;
+  padding: 0 24px 24px;
+}
+
+.launcher-brief,
+.preview-panel {
+  border: 1px solid rgba(87, 119, 150, 0.34);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(14, 24, 36, 0.96), rgba(9, 16, 25, 0.98));
+  box-shadow: 0 22px 54px rgba(0, 0, 0, 0.28);
+}
+
+.launcher-brief {
+  padding: 22px;
+}
+
+.launcher-brief h1 {
+  margin: 4px 0 18px;
+  color: #ffffff;
+  font-size: 2rem;
+  line-height: 1.08;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #8fcdb0;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.brief-form {
+  display: grid;
+  gap: 12px;
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: #d7e8e0;
+  font-weight: 700;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(123, 154, 185, 0.34);
+  border-radius: 8px;
+  background: #09111d;
+  color: #f2f8f4;
+  font: inherit;
+  padding: 11px 12px;
+}
+
+textarea {
+  min-height: 92px;
+  resize: vertical;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: #7fd6a2;
+  outline: 3px solid rgba(127, 214, 162, 0.18);
+}
+
+.address-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  border: 1px solid rgba(123, 154, 185, 0.34);
+  border-radius: 8px;
+  background: #09111d;
+  overflow: hidden;
+}
+
+.address-field input {
+  border: 0;
+  border-radius: 0;
+}
+
+.address-field span {
+  padding: 0 12px;
+  color: #9db8ca;
+  white-space: nowrap;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+button {
+  border-radius: 8px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  min-height: 44px;
+  padding: 11px 14px;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.primary {
+  border: 0;
+  background: linear-gradient(135deg, #7fd6a2, #7cb7e8);
+  color: #071018;
+}
+
+.secondary {
+  border: 1px solid rgba(124, 183, 232, 0.42);
+  background: rgba(24, 42, 61, 0.9);
+  color: #e8f3ff;
+}
+
+.revision-label {
+  margin-top: 2px;
+}
+
+.status,
+.publish-result {
+  margin: 0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  line-height: 1.45;
+}
+
+.status--info {
+  border: 1px solid rgba(124, 183, 232, 0.38);
+  background: rgba(18, 39, 59, 0.58);
+  color: #cfe6ff;
+}
+
+.status--success {
+  border: 1px solid rgba(127, 214, 162, 0.42);
+  background: rgba(20, 62, 42, 0.5);
+  color: #aef0c7;
+}
+
+.status--warning {
+  border: 1px solid rgba(235, 192, 109, 0.45);
+  background: rgba(65, 48, 18, 0.55);
+  color: #ffe0a3;
+}
+
+.status--error {
+  border: 1px solid rgba(224, 105, 105, 0.5);
+  background: rgba(70, 24, 31, 0.58);
+  color: #ffc0c0;
+}
+
+.preview-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 720px;
+  overflow: hidden;
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid rgba(87, 119, 150, 0.28);
+}
+
+.preview-header h2 {
+  margin: 3px 0 0;
+  color: #ffffff;
+}
+
+#site-preview {
+  width: 100%;
+  flex: 1;
+  min-height: 560px;
+  border: 0;
+  background: #ffffff;
+}
+
+.publish-result {
+  border-top: 1px solid rgba(87, 119, 150, 0.28);
+  color: #c7d9e8;
+}
+
+.publish-result:empty {
+  display: none;
+}
+
+.publish-result a {
+  color: #9ee6ba;
+  font-weight: 800;
+}
+
+@media (max-width: 860px) {
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 16px;
+  }
+
+  .launcher-shell {
+    grid-template-columns: 1fr;
+    padding: 0 16px 20px;
+  }
+
+  .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-panel {
+    min-height: 620px;
+  }
+}

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { createGithubPublishHandler } from '../api/github-publish.js';
+import {
+  createGithubPublishHandler,
+  resolveLaunchDomain,
+  sanitizeLaunchSubdomain
+} from '../api/github-publish.js';
 
 function createMockRes() {
   return {
@@ -145,3 +149,109 @@ test('github publish handler supports vercel deploy provider mode', async () => 
   assert.equal(requestPayload.name, 'project-demo');
 });
 
+test('sanitizeLaunchSubdomain normalizes customer site addresses', () => {
+  assert.equal(sanitizeLaunchSubdomain(' River City Wellness! '), 'river-city-wellness');
+  assert.equal(sanitizeLaunchSubdomain('ab'), '');
+  assert.equal(sanitizeLaunchSubdomain('portal'), '');
+});
+
+test('resolveLaunchDomain limits aliases to the configured launch domain', () => {
+  assert.deepEqual(
+    resolveLaunchDomain({ subdomain: 'River City Wellness' }, { baseDomain: '3dvr.tech' }),
+    {
+      subdomain: 'river-city-wellness',
+      domain: 'river-city-wellness.3dvr.tech',
+      baseDomain: '3dvr.tech'
+    }
+  );
+});
+
+test('vercel deploy provider can use server token and assign a 3dvr subdomain', async () => {
+  const calls = [];
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    siteLaunchBaseDomain: '3dvr.tech',
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
+
+      if (String(url).includes('/v13/deployments')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_launch_123',
+              url: '3dvr-river-city-wellness.vercel.app',
+              inspectUrl: 'https://vercel.com/example/launch/dpl_launch_123'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v2/deployments/dpl_launch_123/aliases')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              alias: 'river-city-wellness.3dvr.tech'
+            };
+          }
+        };
+      }
+
+      throw new Error(`Unexpected url ${url}`);
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-river-city-wellness',
+      subdomain: 'River City Wellness',
+      html: '<html><body>deployment test content</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.aliasAssigned, true);
+  assert.equal(res.body.aliasUrl, 'https://river-city-wellness.3dvr.tech');
+  assert.equal(res.body.url, 'https://3dvr-river-city-wellness.vercel.app');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].options.headers.Authorization, 'Bearer server_vercel_token');
+  assert.equal(calls[1].options.headers.Authorization, 'Bearer server_vercel_token');
+  assert.deepEqual(JSON.parse(calls[1].options.body), {
+    alias: 'river-city-wellness.3dvr.tech'
+  });
+});
+
+test('vercel deploy provider rejects reserved launch subdomains', async () => {
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    fetchImpl: async () => {
+      throw new Error('fetch should not run for invalid aliases');
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-portal',
+      subdomain: 'portal',
+      html: '<html><body>deployment test content</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.error, /valid, available/);
+});

--- a/tests/site-launcher-page.test.js
+++ b/tests/site-launcher-page.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('site launcher exposes the simple customer publishing flow', async () => {
+  const html = await readFile(new URL('../launch-site/index.html', import.meta.url), 'utf8');
+  const app = await readFile(new URL('../launch-site/app.js', import.meta.url), 'utf8');
+  const portalHome = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /Launch a website on 3dvr\.tech/);
+  assert.match(html, /id="business-name"/);
+  assert.match(html, /id="site-purpose"/);
+  assert.match(html, /id="site-slug"/);
+  assert.match(html, /id="publish-site"/);
+  assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+  assert.match(html, /src="\/gun-init\.js"/);
+
+  assert.doesNotMatch(html, /GitHub repo/i);
+  assert.doesNotMatch(html, /GitHub branch/i);
+  assert.doesNotMatch(html, /Vercel token/i);
+  assert.doesNotMatch(html, /OpenAI key/i);
+
+  assert.match(app, /fetch\('\/api\/openai-site'/);
+  assert.match(app, /fetch\('\/api\/vercel-deploy'/);
+  assert.match(app, /subdomain: state\.slug/);
+  assert.match(app, /readDefaultSecret\(data, 'openai'\)/);
+  assert.match(app, /readDefaultSecret\(data, 'vercel'\)/);
+
+  assert.match(portalHome, /href="launch-site\/"/);
+  assert.match(portalHome, />Launch Site</);
+});


### PR DESCRIPTION
## What changed

- Adds a new `/launch-site/` customer-facing site launcher with a simple brief, preview, revision, and publish flow.
- Keeps the existing advanced web builder intact while adding a core homepage app card for the simpler launcher.
- Extends the existing Vercel deploy handler so deployments can use server-side `VERCEL_TOKEN`, sanitize reserved `3dvr.tech` subdomains, and assign aliases.
- Adds hidden fallback support for existing shared OpenAI/Vercel defaults via Gun so the launcher can work with the current portal setup without showing key/token fields to users.

## Why

The existing builder is useful for technical/admin users, but it exposes models, Vercel/GitHub fields, branches, paths, and tokens. This adds a lower-friction path for nontechnical users to generate and publish a site on a `3dvr.tech` subdomain.

## Validation

- `node --test tests/github-publish-api.test.js tests/site-launcher-page.test.js tests/finance.test.js`
- `npm test` passed once after installing dependencies in the clean worktree: 210 passed, 1 skipped.
- A second full run hit one Contacts E2E timeout, and rerunning `node --test tests/contacts-identity.e2e.test.js` passed.
- Browser smoke tested `/launch-site/` at 390x844 and 1440x900: no horizontal overflow, publish starts disabled, and no token/GitHub/branch wording is visible.
- Browser smoke tested `/`: the Launch Site app card links to `launch-site/`.

## Deployment notes

The linked Vercel project did not list `OPENAI_API_KEY`, `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, or `SITE_LAUNCH_BASE_DOMAIN` when checked with `vercel env ls`. The launcher therefore supports the existing shared-defaults path as a fallback. Server-side env remains the preferred production setup when those values are added.