### PR TITLE
[codex] Add spatial VR portal prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -756,6 +756,17 @@
             <span class="app-card__title">XR Motion Lab</span>
             <span class="app-card__meta">Use device sensors and camera passthrough for a mobile AR/VR prototype.</span>
           </a>
+          <a
+            href="vr-portal/"
+            class="app-card"
+            data-app-tier="experimental"
+            data-app-keywords="vr ar xr spatial interface desktop crm notes calendar tasks finance portal"
+          >
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">🥽</span>
+            <span class="app-card__title">Spatial Portal</span>
+            <span class="app-card__meta">Open, view, and edit core portal data inside a 3D workspace.</span>
+          </a>
           <a href="website-builder.html" class="app-card" data-app-tier="experimental">
             <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">🛠️</span>

--- a/tests/vr-portal.test.js
+++ b/tests/vr-portal.test.js
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+  createInitialPortalState,
+  deletePortalRecord,
+  filterPortalRecords,
+  flattenRecordForGun,
+  getAppById,
+  getAppSummary,
+  normalizePortalState,
+  upsertPortalRecord
+} from '../vr-portal/data.js';
+
+test('spatial portal page ships a Three.js scene and editable core app workspace', async () => {
+  const html = await readFile(new URL('../vr-portal/index.html', import.meta.url), 'utf8');
+  const app = await readFile(new URL('../vr-portal/app.js', import.meta.url), 'utf8');
+
+  assert.match(html, /Spatial workspace/);
+  assert.match(html, /id="spatial-canvas"/);
+  assert.match(html, /id="record-form"/);
+  assert.match(html, /id="app-frame"/);
+  assert.match(app, /three@0\.165\.0\/build\/three\.module\.js/);
+  assert.match(app, /gun\.get\('3dvr-portal'\)\.get\('spatialPortal'\)\.get\('apps'\)/);
+});
+
+test('spatial portal data supports app selection, filtering, editing, and deletion', () => {
+  const state = createInitialPortalState();
+  const crm = getAppById(state, 'crm');
+
+  assert.equal(state.apps.length >= 5, true);
+  assert.equal(filterPortalRecords(crm, 'nova').length, 1);
+
+  upsertPortalRecord(state, 'crm', {
+    id: 'crm-test',
+    title: 'Test Studio',
+    stage: 'Lead',
+    owner: 'Casey',
+    due: '2026-06-30',
+    body: 'Needs a headset-ready CRM walkthrough.'
+  });
+
+  assert.equal(state.selectedRecordId, 'crm-test');
+  assert.equal(filterPortalRecords(crm, 'headset crm').length, 1);
+  assert.equal(getAppSummary(crm).total, 3);
+
+  deletePortalRecord(state, 'crm', 'crm-test');
+  assert.equal(filterPortalRecords(crm, 'Test Studio').length, 0);
+});
+
+test('spatial portal normalizes cached state and flattens records for Gun', () => {
+  const state = normalizePortalState({
+    selectedAppId: 'notes',
+    selectedRecordId: 'notes-new',
+    apps: [
+      {
+        id: 'notes',
+        records: [
+          {
+            id: 'notes-new',
+            title: 'Cached page',
+            space: 'Research',
+            owner: 'Alex',
+            body: 'Recovered from local cache.'
+          }
+        ]
+      }
+    ]
+  });
+
+  assert.equal(state.selectedAppId, 'notes');
+  assert.equal(state.selectedRecordId, 'notes-new');
+  assert.equal(filterPortalRecords(getAppById(state, 'notes'), 'cached').length, 1);
+
+  assert.deepEqual(flattenRecordForGun({ id: 'x', title: 'Record', meta: { nested: true } }), {
+    id: 'x',
+    title: 'Record',
+    meta: '{"nested":true}'
+  });
+});
+
+test('background sync can update records without stealing app selection', () => {
+  const state = createInitialPortalState();
+  state.selectedAppId = 'crm';
+  state.selectedRecordId = 'crm-nova';
+
+  upsertPortalRecord(state, 'finance', {
+    id: 'finance-sync',
+    title: 'Synced budget',
+    stage: 'Forecast'
+  }, { select: false });
+
+  assert.equal(state.selectedAppId, 'crm');
+  assert.equal(state.selectedRecordId, 'crm-nova');
+  assert.equal(filterPortalRecords(getAppById(state, 'finance'), 'Synced budget').length, 1);
+});

--- a/tests/vr-portal.test.js
+++ b/tests/vr-portal.test.js
@@ -24,6 +24,14 @@ test('spatial portal page ships a Three.js scene and editable core app workspace
   assert.match(app, /gun\.get\('3dvr-portal'\)\.get\('spatialPortal'\)\.get\('apps'\)/);
 });
 
+test('portal launcher includes the spatial portal app card', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /href="vr-portal\/"/);
+  assert.match(html, /Spatial Portal/);
+  assert.match(html, /data-app-keywords="vr ar xr spatial interface desktop crm notes calendar tasks finance portal"/);
+});
+
 test('spatial portal data supports app selection, filtering, editing, and deletion', () => {
   const state = createInitialPortalState();
   const crm = getAppById(state, 'crm');

--- a/vr-portal/app.js
+++ b/vr-portal/app.js
@@ -1,0 +1,394 @@
+import {
+  STORAGE_KEY,
+  createInitialPortalState,
+  deletePortalRecord,
+  filterPortalRecords,
+  flattenRecordForGun,
+  getAppById,
+  getAppSummary,
+  getRecordById,
+  normalizePortalState,
+  upsertPortalRecord
+} from './data.js';
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+const state = loadState();
+const elements = {
+  canvas: document.getElementById('spatial-canvas'),
+  dock: document.getElementById('app-dock'),
+  appType: document.getElementById('app-type'),
+  appTitle: document.getElementById('app-title'),
+  appDescription: document.getElementById('app-description'),
+  recordTotal: document.getElementById('record-total'),
+  recordNext: document.getElementById('record-next'),
+  recordSearch: document.getElementById('record-search'),
+  recordList: document.getElementById('record-list'),
+  recordForm: document.getElementById('record-form'),
+  editorFields: document.getElementById('editor-fields'),
+  newRecord: document.getElementById('new-record'),
+  deleteRecord: document.getElementById('delete-record'),
+  appFrame: document.getElementById('app-frame'),
+  appFrameLabel: document.getElementById('app-frame-label'),
+  openAppLink: document.getElementById('open-app-link'),
+  xrButton: document.getElementById('xr-button')
+};
+
+let currentTab = 'data';
+let syncReady = false;
+let portalRoot = null;
+let sceneApi = null;
+
+document.body.dataset.deviceMode = 'headset';
+render();
+bootGunSync();
+bootSpatialScene();
+bindEvents();
+
+function bindEvents() {
+  elements.recordSearch.addEventListener('input', renderRecords);
+
+  elements.newRecord.addEventListener('click', () => {
+    const app = getAppById(state, state.selectedAppId);
+    state.selectedRecordId = '';
+    renderEditor(app, null);
+  });
+
+  elements.deleteRecord.addEventListener('click', () => {
+    const app = getAppById(state, state.selectedAppId);
+    const record = getRecordById(app, state.selectedRecordId);
+    if (!app || !record) {
+      return;
+    }
+    deletePortalRecord(state, app.id, record.id);
+    saveState();
+    syncDelete(app.id, record.id);
+    render();
+  });
+
+  elements.recordForm.addEventListener('submit', event => {
+    event.preventDefault();
+    const app = getAppById(state, state.selectedAppId);
+    if (!app) {
+      return;
+    }
+    const formData = new FormData(elements.recordForm);
+    const values = Object.fromEntries(formData.entries());
+    try {
+      upsertPortalRecord(state, app.id, values);
+      const record = getRecordById(app, state.selectedRecordId);
+      saveState();
+      syncRecord(app.id, record);
+      render();
+    } catch (error) {
+      elements.editorFields.querySelector('[name="title"]')?.focus();
+    }
+  });
+
+  document.querySelectorAll('[data-device-mode]').forEach(button => {
+    button.addEventListener('click', () => {
+      const mode = button.dataset.deviceMode;
+      document.body.dataset.deviceMode = mode;
+      document.querySelectorAll('[data-device-mode]').forEach(item => {
+        item.classList.toggle('is-active', item === button);
+      });
+      if (mode === 'flat') {
+        state.viewMode = 'flat';
+      } else {
+        state.viewMode = 'spatial';
+      }
+      saveState();
+      sceneApi?.resize();
+    });
+  });
+
+  document.querySelectorAll('[data-panel-tab]').forEach(button => {
+    button.addEventListener('click', () => {
+      currentTab = button.dataset.panelTab;
+      document.querySelectorAll('[data-panel-tab]').forEach(tab => {
+        const selected = tab === button;
+        tab.classList.toggle('is-active', selected);
+        tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+      });
+      document.querySelectorAll('[data-panel-view]').forEach(view => {
+        view.hidden = view.dataset.panelView !== currentTab;
+      });
+      if (currentTab === 'app') {
+        renderAppFrame();
+      }
+    });
+  });
+
+  elements.xrButton.addEventListener('click', async () => {
+    if (!navigator.xr || typeof navigator.xr.isSessionSupported !== 'function') {
+      elements.xrButton.textContent = 'XR off';
+      return;
+    }
+    const supported = await navigator.xr.isSessionSupported('immersive-vr');
+    elements.xrButton.textContent = supported ? 'XR ready' : 'XR off';
+  });
+}
+
+function render() {
+  renderDock();
+  renderAppPanel();
+  renderRecords();
+  renderAppFrame();
+  sceneApi?.setActiveApp(state.selectedAppId);
+}
+
+function renderDock() {
+  elements.dock.replaceChildren(...state.apps.map((app, index) => {
+    const summary = getAppSummary(app);
+    const button = document.createElement('button');
+    const active = app.id === state.selectedAppId;
+    button.type = 'button';
+    button.className = `app-tile${active ? ' is-active' : ''}`;
+    button.style.setProperty('--tile-accent', app.accent);
+    button.style.setProperty('--tile-x', `${(index - 2) * 6.5}rem`);
+    button.style.setProperty('--tile-y', `${index % 2 === 0 ? -4 : 3.5}rem`);
+    button.style.setProperty('--tile-z', `${-80 - (index % 3) * 48}px`);
+    button.style.setProperty('--tile-rotate', `${index < 2 ? 12 : index > 2 ? -12 : 0}deg`);
+    button.innerHTML = `
+      <span class="app-tile__name">${escapeHtml(app.name)}</span>
+      <span class="app-tile__meta">${escapeHtml(app.type)}</span>
+      <span class="app-tile__count">${summary.total} records</span>
+    `;
+    button.addEventListener('click', () => {
+      state.selectedAppId = app.id;
+      state.selectedRecordId = app.records[0]?.id || '';
+      saveState();
+      render();
+    });
+    return button;
+  }));
+}
+
+function renderAppPanel() {
+  const app = getAppById(state, state.selectedAppId);
+  const record = getRecordById(app, state.selectedRecordId);
+  const summary = getAppSummary(app);
+  elements.appType.textContent = app.type;
+  elements.appTitle.textContent = app.name;
+  elements.appDescription.textContent = app.description;
+  elements.recordTotal.textContent = summary.total;
+  elements.recordNext.textContent = summary.nextDue || 'None';
+  renderEditor(app, record);
+}
+
+function renderRecords() {
+  const app = getAppById(state, state.selectedAppId);
+  const records = filterPortalRecords(app, elements.recordSearch.value);
+  elements.recordList.replaceChildren(...records.map(record => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `record-button${record.id === state.selectedRecordId ? ' is-active' : ''}`;
+    button.style.setProperty('--active-accent', app.accent);
+    button.innerHTML = `
+      <span class="record-button__title">${escapeHtml(record.title)}</span>
+      <span class="record-button__meta">${escapeHtml([record.stage, record.owner, record.due].filter(Boolean).join(' / '))}</span>
+    `;
+    button.addEventListener('click', () => {
+      state.selectedRecordId = record.id;
+      saveState();
+      renderRecords();
+      renderEditor(app, record);
+    });
+    return button;
+  }));
+}
+
+function renderEditor(app, record) {
+  elements.recordForm.reset();
+  elements.recordForm.elements.id.value = record?.id || '';
+  elements.deleteRecord.disabled = !record;
+  elements.editorFields.replaceChildren(...app.fields.map(field => createField(field, record)));
+}
+
+function createField(field, record) {
+  const label = document.createElement('label');
+  label.className = 'field';
+  const text = document.createElement('span');
+  text.textContent = field.label;
+  label.append(text);
+
+  const value = record?.[field.name] || '';
+  let input;
+  if (field.type === 'textarea') {
+    input = document.createElement('textarea');
+    input.rows = 5;
+    input.value = value;
+  } else if (field.type === 'select') {
+    input = document.createElement('select');
+    field.options.forEach(option => {
+      const optionEl = document.createElement('option');
+      optionEl.value = option;
+      optionEl.textContent = option;
+      input.append(optionEl);
+    });
+    input.value = value || field.options[0] || '';
+  } else {
+    input = document.createElement('input');
+    input.type = field.type || 'text';
+    input.value = value;
+  }
+
+  input.name = field.name;
+  input.required = !!field.required;
+  label.append(input);
+  return label;
+}
+
+function renderAppFrame() {
+  const app = getAppById(state, state.selectedAppId);
+  if (!app) {
+    return;
+  }
+  elements.appFrameLabel.textContent = `${app.name} app`;
+  elements.openAppLink.href = app.path;
+  if (currentTab === 'app' && elements.appFrame.getAttribute('src') !== app.path) {
+    elements.appFrame.src = app.path;
+  }
+}
+
+function bootGunSync() {
+  if (typeof Gun !== 'function') {
+    return;
+  }
+  const peers = window.__GUN_PEERS__ || ['wss://relay.3dvr.tech/gun', 'wss://gun-relay-3dvr.fly.dev/gun'];
+  const gun = Gun(peers);
+  portalRoot = gun.get('3dvr-portal').get('spatialPortal').get('apps');
+  syncReady = true;
+  state.apps.forEach(app => {
+    const recordsNode = portalRoot.get(app.id).get('records');
+    recordsNode.map().on((value, key) => {
+      if (!value || key === '_' || !syncReady) {
+        return;
+      }
+      if (value.deleted) {
+        deletePortalRecord(state, app.id, key);
+      } else {
+        upsertPortalRecord(state, app.id, { ...value, id: key }, { select: false });
+      }
+      saveState(false);
+      render();
+    });
+    app.records.forEach(record => syncRecord(app.id, record));
+  });
+}
+
+function syncRecord(appId, record) {
+  if (!portalRoot || !record) {
+    return;
+  }
+  portalRoot.get(appId).get('records').get(record.id).put(flattenRecordForGun(record));
+}
+
+function syncDelete(appId, recordId) {
+  if (!portalRoot || !recordId) {
+    return;
+  }
+  portalRoot.get(appId).get('records').get(recordId).put({
+    id: recordId,
+    deleted: true,
+    updatedAt: new Date().toISOString()
+  });
+}
+
+function bootSpatialScene() {
+  const renderer = new THREE.WebGLRenderer({
+    canvas: elements.canvas,
+    antialias: true,
+    alpha: true,
+    preserveDrawingBuffer: true
+  });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(55, 1, 0.1, 100);
+  camera.position.set(0, 0.4, 6.8);
+
+  const group = new THREE.Group();
+  scene.add(group);
+  scene.add(new THREE.AmbientLight(0xffffff, 0.72));
+  const keyLight = new THREE.PointLight(0x8be9fd, 60, 16);
+  keyLight.position.set(2, 3, 4);
+  scene.add(keyLight);
+
+  const grid = new THREE.GridHelper(18, 18, 0x38bdf8, 0x334155);
+  grid.position.y = -2.1;
+  grid.material.opacity = 0.28;
+  grid.material.transparent = true;
+  scene.add(grid);
+
+  const panels = state.apps.map((app, index) => {
+    const geometry = new THREE.BoxGeometry(1.8, 1.1, 0.08);
+    const material = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(app.accent),
+      metalness: 0.25,
+      roughness: 0.38,
+      emissive: new THREE.Color(app.accent),
+      emissiveIntensity: 0.08
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set((index - 2) * 1.9, index % 2 === 0 ? 0.55 : -0.35, -Math.abs(index - 2) * 0.45);
+    mesh.rotation.y = (index - 2) * -0.12;
+    group.add(mesh);
+    return { appId: app.id, mesh, material };
+  });
+
+  function resize() {
+    const rect = elements.canvas.getBoundingClientRect();
+    renderer.setSize(rect.width, rect.height, false);
+    camera.aspect = rect.width / Math.max(rect.height, 1);
+    camera.updateProjectionMatrix();
+  }
+
+  function animate(time) {
+    const seconds = time * 0.001;
+    group.rotation.y = Math.sin(seconds * 0.32) * 0.08;
+    panels.forEach((panel, index) => {
+      panel.mesh.position.y += Math.sin(seconds * 0.8 + index) * 0.0008;
+    });
+    renderer.render(scene, camera);
+    requestAnimationFrame(animate);
+  }
+
+  function setActiveApp(appId) {
+    panels.forEach(panel => {
+      panel.material.emissiveIntensity = panel.appId === appId ? 0.38 : 0.08;
+      panel.mesh.scale.setScalar(panel.appId === appId ? 1.12 : 1);
+    });
+  }
+
+  resize();
+  setActiveApp(state.selectedAppId);
+  requestAnimationFrame(animate);
+  window.addEventListener('resize', resize);
+  sceneApi = { resize, setActiveApp };
+}
+
+function loadState() {
+  try {
+    const cached = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
+    return normalizePortalState(cached);
+  } catch (error) {
+    return createInitialPortalState();
+  }
+}
+
+function saveState(persist = true) {
+  if (!persist) {
+    return;
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function escapeHtml(value) {
+  return `${value || ''}`.replace(/[&<>"']/g, char => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  })[char]);
+}

--- a/vr-portal/data.js
+++ b/vr-portal/data.js
@@ -1,0 +1,364 @@
+export const STORAGE_KEY = '3dvr.spatialPortal.v1';
+
+export const PORTAL_APPS = [
+  {
+    id: 'crm',
+    name: 'CRM',
+    type: 'Revenue',
+    path: '/crm/',
+    accent: '#36d399',
+    description: 'Pipeline, contacts, deal notes, and follow-up dates.',
+    fields: [
+      { name: 'title', label: 'Account', type: 'text', required: true },
+      { name: 'stage', label: 'Stage', type: 'select', options: ['Lead', 'Qualified', 'Proposal', 'Won'] },
+      { name: 'owner', label: 'Owner', type: 'text' },
+      { name: 'due', label: 'Next touch', type: 'date' },
+      { name: 'body', label: 'Notes', type: 'textarea' }
+    ],
+    records: [
+      {
+        id: 'crm-nova',
+        title: 'Nova Arcade',
+        stage: 'Qualified',
+        owner: 'Taylor',
+        due: '2026-06-18',
+        body: 'Interested in a shared VR arcade operations dashboard with live headset status.'
+      },
+      {
+        id: 'crm-aurora',
+        title: 'Aurora Labs',
+        stage: 'Proposal',
+        owner: 'Morgan',
+        due: '2026-06-20',
+        body: 'Needs mixed-reality onboarding and a portable sales room for investor demos.'
+      }
+    ]
+  },
+  {
+    id: 'notes',
+    name: 'Notes',
+    type: 'Knowledge',
+    path: '/notes/',
+    accent: '#fbbf24',
+    description: 'Shared pages, session notes, briefs, and research fragments.',
+    fields: [
+      { name: 'title', label: 'Page title', type: 'text', required: true },
+      { name: 'space', label: 'Space', type: 'text' },
+      { name: 'owner', label: 'Owner', type: 'text' },
+      { name: 'body', label: 'Content', type: 'textarea' }
+    ],
+    records: [
+      {
+        id: 'notes-interface',
+        title: 'Spatial desktop thesis',
+        space: 'Interface',
+        owner: 'Team',
+        body: '2D tools remain available as floating planes while spatial apps get depth, presence, and context.'
+      },
+      {
+        id: 'notes-devices',
+        title: 'Device reach',
+        space: 'Platform',
+        owner: 'Team',
+        body: 'Phone, laptop, desktop, headset, and future displays share the same portal state.'
+      }
+    ]
+  },
+  {
+    id: 'calendar',
+    name: 'Calendar',
+    type: 'Schedule',
+    path: '/calendar/',
+    accent: '#38bdf8',
+    description: 'Events, planning sessions, launches, and follow-up windows.',
+    fields: [
+      { name: 'title', label: 'Event', type: 'text', required: true },
+      { name: 'stage', label: 'Track', type: 'select', options: ['Planning', 'Build', 'Review', 'Launch'] },
+      { name: 'due', label: 'Date', type: 'date' },
+      { name: 'owner', label: 'Lead', type: 'text' },
+      { name: 'body', label: 'Agenda', type: 'textarea' }
+    ],
+    records: [
+      {
+        id: 'calendar-review',
+        title: 'Spatial portal review',
+        stage: 'Review',
+        due: '2026-06-21',
+        owner: 'Interface team',
+        body: 'Walk through phone, desktop, and headset layouts.'
+      },
+      {
+        id: 'calendar-launch',
+        title: 'Prototype launch window',
+        stage: 'Launch',
+        due: '2026-06-28',
+        owner: 'Ops',
+        body: 'Publish portal app and collect first community feedback.'
+      }
+    ]
+  },
+  {
+    id: 'tasks',
+    name: 'Tasks',
+    type: 'Operations',
+    path: '/tasks/',
+    accent: '#fb7185',
+    description: 'Work queues, blockers, priorities, and release steps.',
+    fields: [
+      { name: 'title', label: 'Task', type: 'text', required: true },
+      { name: 'stage', label: 'Status', type: 'select', options: ['Backlog', 'Doing', 'Blocked', 'Done'] },
+      { name: 'owner', label: 'Owner', type: 'text' },
+      { name: 'due', label: 'Due', type: 'date' },
+      { name: 'body', label: 'Details', type: 'textarea' }
+    ],
+    records: [
+      {
+        id: 'tasks-input',
+        title: 'Map controller gestures',
+        stage: 'Doing',
+        owner: 'XR',
+        due: '2026-06-19',
+        body: 'Prototype gaze, pointer, keyboard, and touch controls against one shared action model.'
+      },
+      {
+        id: 'tasks-sync',
+        title: 'Harden Gun sync',
+        stage: 'Backlog',
+        owner: 'Platform',
+        due: '2026-06-24',
+        body: 'Move from demo records to app-native record adapters.'
+      }
+    ]
+  },
+  {
+    id: 'finance',
+    name: 'Finance',
+    type: 'Ledger',
+    path: '/finance/',
+    accent: '#a3e635',
+    description: 'Budgets, expenses, runway notes, and sponsorship targets.',
+    fields: [
+      { name: 'title', label: 'Line item', type: 'text', required: true },
+      { name: 'stage', label: 'Category', type: 'select', options: ['Revenue', 'Expense', 'Forecast', 'Grant'] },
+      { name: 'owner', label: 'Owner', type: 'text' },
+      { name: 'due', label: 'Review date', type: 'date' },
+      { name: 'body', label: 'Memo', type: 'textarea' }
+    ],
+    records: [
+      {
+        id: 'finance-headsets',
+        title: 'Headset test pool',
+        stage: 'Expense',
+        owner: 'Ops',
+        due: '2026-07-03',
+        body: 'Reserve funds for baseline Quest, Vision Pro, Android phone, and desktop QA devices.'
+      },
+      {
+        id: 'finance-sponsors',
+        title: 'Spatial workspace sponsors',
+        stage: 'Revenue',
+        owner: 'Sales',
+        due: '2026-07-10',
+        body: 'Package the portal demo as a partner walkthrough for local venues and creators.'
+      }
+    ]
+  }
+];
+
+export function createInitialPortalState(apps = PORTAL_APPS) {
+  const now = new Date().toISOString();
+  return {
+    selectedAppId: apps[0]?.id || '',
+    selectedRecordId: apps[0]?.records?.[0]?.id || '',
+    viewMode: 'spatial',
+    updatedAt: now,
+    apps: apps.map((app, index) => ({
+      id: app.id,
+      name: app.name,
+      type: app.type,
+      path: app.path,
+      accent: app.accent,
+      description: app.description,
+      fields: app.fields.map(field => ({ ...field })),
+      orbit: {
+        x: (index - Math.floor(apps.length / 2)) * 2.2,
+        y: index % 2 === 0 ? 0.5 : -0.35,
+        z: -4 - (index % 3) * 0.9
+      },
+      records: app.records.map(record => normalizeRecord(record, app.id, now))
+    }))
+  };
+}
+
+export function normalizePortalState(input, fallbackApps = PORTAL_APPS) {
+  const base = createInitialPortalState(fallbackApps);
+  if (!input || typeof input !== 'object') {
+    return base;
+  }
+
+  const appsById = new Map(base.apps.map(app => [app.id, app]));
+  const incomingApps = Array.isArray(input.apps) ? input.apps : [];
+  incomingApps.forEach(app => {
+    if (!app || typeof app !== 'object' || !appsById.has(app.id)) {
+      return;
+    }
+    const baseApp = appsById.get(app.id);
+    const records = Array.isArray(app.records) ? app.records : [];
+    const normalizedRecords = records
+      .map(record => normalizeRecord(record, baseApp.id, record?.updatedAt || input.updatedAt))
+      .filter(record => record.title);
+    if (normalizedRecords.length > 0) {
+      baseApp.records = mergeRecords(baseApp.records, normalizedRecords);
+    }
+  });
+
+  const selectedAppId = appsById.has(input.selectedAppId) ? input.selectedAppId : base.selectedAppId;
+  const selectedApp = appsById.get(selectedAppId);
+  const selectedRecordId = selectedApp.records.some(record => record.id === input.selectedRecordId)
+    ? input.selectedRecordId
+    : selectedApp.records[0]?.id || '';
+
+  return {
+    ...base,
+    selectedAppId,
+    selectedRecordId,
+    viewMode: input.viewMode === 'flat' ? 'flat' : 'spatial',
+    updatedAt: typeof input.updatedAt === 'string' ? input.updatedAt : base.updatedAt,
+    apps: base.apps
+  };
+}
+
+export function getAppById(state, appId) {
+  return state.apps.find(app => app.id === appId) || state.apps[0] || null;
+}
+
+export function getRecordById(app, recordId) {
+  return app?.records.find(record => record.id === recordId) || app?.records[0] || null;
+}
+
+export function getAppSummary(app) {
+  const records = app?.records || [];
+  const pending = records.filter(record => {
+    const stage = `${record.stage || ''}`.toLowerCase();
+    return stage && !['won', 'done', 'launch'].includes(stage);
+  }).length;
+  return {
+    total: records.length,
+    pending,
+    nextDue: records
+      .map(record => record.due)
+      .filter(Boolean)
+      .sort()[0] || ''
+  };
+}
+
+export function filterPortalRecords(app, query) {
+  const terms = `${query || ''}`.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) {
+    return app?.records || [];
+  }
+  return (app?.records || []).filter(record => {
+    const haystack = [
+      record.title,
+      record.stage,
+      record.owner,
+      record.due,
+      record.body,
+      record.space
+    ].join(' ').toLowerCase();
+    return terms.every(term => haystack.includes(term));
+  });
+}
+
+export function upsertPortalRecord(state, appId, values, options = {}) {
+  const app = getAppById(state, appId);
+  if (!app) {
+    return state;
+  }
+  const shouldSelect = options.select !== false;
+  const now = new Date().toISOString();
+  const record = normalizeRecord(values, app.id, now);
+  if (!record.title) {
+    throw new Error('A title is required.');
+  }
+  const existingIndex = app.records.findIndex(item => item.id === record.id);
+  if (existingIndex >= 0) {
+    app.records.splice(existingIndex, 1, {
+      ...app.records[existingIndex],
+      ...record,
+      updatedAt: now
+    });
+  } else {
+    app.records.unshift(record);
+  }
+  if (shouldSelect) {
+    state.selectedAppId = app.id;
+    state.selectedRecordId = record.id;
+  }
+  state.updatedAt = now;
+  return state;
+}
+
+export function deletePortalRecord(state, appId, recordId) {
+  const app = getAppById(state, appId);
+  if (!app) {
+    return state;
+  }
+  app.records = app.records.filter(record => record.id !== recordId);
+  state.selectedAppId = app.id;
+  state.selectedRecordId = app.records[0]?.id || '';
+  state.updatedAt = new Date().toISOString();
+  return state;
+}
+
+export function flattenRecordForGun(record) {
+  const result = {};
+  Object.entries(record || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      result[key] = '';
+      return;
+    }
+    if (typeof value === 'object') {
+      result[key] = JSON.stringify(value);
+      return;
+    }
+    result[key] = value;
+  });
+  return result;
+}
+
+export function normalizeRecord(input, appId = '', updatedAt = new Date().toISOString()) {
+  const title = `${input?.title || ''}`.trim();
+  const id = slugify(input?.id || `${appId}-${title || Date.now()}`);
+  return {
+    id,
+    appId,
+    title,
+    stage: `${input?.stage || input?.space || ''}`.trim(),
+    space: `${input?.space || input?.stage || ''}`.trim(),
+    owner: `${input?.owner || ''}`.trim(),
+    due: `${input?.due || ''}`.trim(),
+    body: `${input?.body || ''}`.trim(),
+    updatedAt: `${input?.updatedAt || updatedAt}`
+  };
+}
+
+function mergeRecords(baseRecords, incomingRecords) {
+  const recordsById = new Map(baseRecords.map(record => [record.id, record]));
+  incomingRecords.forEach(record => {
+    const current = recordsById.get(record.id);
+    if (!current || `${record.updatedAt}` >= `${current.updatedAt}`) {
+      recordsById.set(record.id, record);
+    }
+  });
+  return Array.from(recordsById.values()).sort((a, b) => `${b.updatedAt}`.localeCompare(`${a.updatedAt}`));
+}
+
+function slugify(value) {
+  return `${value || 'record'}`
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-|-$/g, '') || `record-${Date.now()}`;
+}

--- a/vr-portal/index.html
+++ b/vr-portal/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>3DVR Spatial Portal</title>
+  <meta name="theme-color" content="#111827">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <link rel="stylesheet" href="/styles/global.css">
+  <link rel="stylesheet" href="./styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <script type="module" src="./app.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#workspace">Skip to workspace</a>
+  <main class="portal-shell" id="workspace">
+    <section class="stage" aria-labelledby="portal-title">
+      <canvas id="spatial-canvas" aria-label="Spatial portal scene"></canvas>
+      <div class="stage__overlay">
+        <header class="portal-header">
+          <div>
+            <p class="portal-kicker">3DVR portal prototype</p>
+            <h1 id="portal-title">Spatial workspace</h1>
+          </div>
+          <nav class="portal-actions" aria-label="Portal links">
+            <a href="/" class="portal-link">Home</a>
+            <a href="/home/" class="portal-link">Desktop</a>
+            <button class="portal-link" type="button" id="xr-button">XR</button>
+          </nav>
+        </header>
+
+        <div class="device-bar" aria-label="Viewport modes">
+          <button class="device-chip is-active" type="button" data-device-mode="headset">Headset</button>
+          <button class="device-chip" type="button" data-device-mode="desktop">Desktop</button>
+          <button class="device-chip" type="button" data-device-mode="phone">Phone</button>
+          <button class="device-chip" type="button" data-device-mode="flat">2D</button>
+        </div>
+
+        <div class="orbit-dock" id="app-dock" aria-label="Portal apps"></div>
+      </div>
+    </section>
+
+    <section class="workspace-panel" aria-label="Selected app workspace">
+      <div class="workspace-panel__header">
+        <div>
+          <p class="workspace-panel__type" id="app-type">Core app</p>
+          <h2 id="app-title">Portal app</h2>
+          <p id="app-description"></p>
+        </div>
+        <div class="workspace-panel__stats" aria-label="App summary">
+          <span><strong id="record-total">0</strong> records</span>
+          <span><strong id="record-next">None</strong> next</span>
+        </div>
+      </div>
+
+      <div class="workspace-tabs" role="tablist" aria-label="Workspace views">
+        <button class="workspace-tab is-active" type="button" role="tab" aria-selected="true" data-panel-tab="data">
+          Data
+        </button>
+        <button class="workspace-tab" type="button" role="tab" aria-selected="false" data-panel-tab="app">
+          2D app
+        </button>
+      </div>
+
+      <div class="data-view" data-panel-view="data">
+        <div class="record-toolbar">
+          <label class="search-field">
+            <span>Search</span>
+            <input id="record-search" type="search" autocomplete="off">
+          </label>
+          <button class="primary-action" type="button" id="new-record">New</button>
+        </div>
+
+        <div class="record-layout">
+          <div class="record-list" id="record-list" aria-label="Records"></div>
+          <form class="record-editor" id="record-form">
+            <input type="hidden" name="id">
+            <div class="editor-fields" id="editor-fields"></div>
+            <div class="editor-actions">
+              <button class="primary-action" type="submit">Save</button>
+              <button class="secondary-action" type="button" id="delete-record">Delete</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div class="app-view" data-panel-view="app" hidden>
+        <div class="app-frame-toolbar">
+          <span id="app-frame-label">Embedded app</span>
+          <a id="open-app-link" class="secondary-action" href="/" target="_blank" rel="noopener">Open</a>
+        </div>
+        <iframe id="app-frame" title="Selected 2D portal app"></iframe>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/vr-portal/styles.css
+++ b/vr-portal/styles.css
@@ -1,0 +1,494 @@
+:root {
+  --portal-bg: #10151f;
+  --portal-ink: #f8fafc;
+  --portal-muted: #aeb9c8;
+  --portal-line: rgba(226, 232, 240, 0.16);
+  --portal-panel: rgba(17, 24, 39, 0.84);
+  --portal-panel-strong: rgba(8, 13, 22, 0.92);
+  --portal-field: rgba(255, 255, 255, 0.08);
+  --portal-teal: #2dd4bf;
+  --portal-amber: #fbbf24;
+  --portal-rose: #fb7185;
+  --portal-green: #a3e635;
+  --focus-ring: 0 0 0 3px rgba(45, 212, 191, 0.3);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    linear-gradient(135deg, rgba(16, 21, 31, 0.98), rgba(24, 32, 43, 0.98)),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.04) 0 1px, transparent 1px 82px);
+  color: var(--portal-ink);
+  font-family: Inter, Poppins, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 30;
+  padding: 0.65rem 0.9rem;
+  border-radius: 8px;
+  background: var(--portal-amber);
+  color: #111827;
+  transform: translateY(-150%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.portal-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(420px, 0.8fr);
+  overflow: hidden;
+}
+
+.stage {
+  position: relative;
+  min-height: 100vh;
+  perspective: 1200px;
+  overflow: hidden;
+  border-right: 1px solid var(--portal-line);
+}
+
+#spatial-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.stage__overlay {
+  position: relative;
+  z-index: 2;
+  min-height: 100%;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 1rem;
+  padding: clamp(1rem, 2vw, 2rem);
+  pointer-events: none;
+}
+
+.portal-header,
+.device-bar,
+.orbit-dock {
+  pointer-events: auto;
+}
+
+.portal-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.portal-kicker,
+.workspace-panel__type {
+  margin: 0 0 0.2rem;
+  color: var(--portal-teal);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+}
+
+.portal-header h1,
+.workspace-panel h2 {
+  margin: 0;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.portal-header h1 {
+  font-size: clamp(2rem, 5vw, 4.8rem);
+}
+
+.portal-actions,
+.device-bar,
+.workspace-tabs,
+.editor-actions,
+.app-frame-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.portal-link,
+.device-chip,
+.workspace-tab,
+.secondary-action,
+.primary-action {
+  min-height: 2.5rem;
+  border: 1px solid var(--portal-line);
+  border-radius: 8px;
+  padding: 0.62rem 0.85rem;
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--portal-ink);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.portal-link:hover,
+.device-chip:hover,
+.workspace-tab:hover,
+.secondary-action:hover {
+  color: var(--portal-ink);
+  border-color: rgba(45, 212, 191, 0.5);
+}
+
+.device-chip.is-active,
+.workspace-tab.is-active,
+.primary-action {
+  border-color: rgba(45, 212, 191, 0.65);
+  background: var(--portal-teal);
+  color: #042f2e;
+  font-weight: 800;
+}
+
+.orbit-dock {
+  position: relative;
+  align-self: center;
+  min-height: min(58vh, 560px);
+  transform-style: preserve-3d;
+}
+
+.app-tile {
+  --tile-accent: var(--portal-teal);
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: clamp(10rem, 17vw, 15.5rem);
+  min-height: 8.25rem;
+  display: grid;
+  gap: 0.75rem;
+  align-content: space-between;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--tile-accent) 56%, transparent);
+  border-radius: 8px;
+  background: linear-gradient(145deg, rgba(17, 24, 39, 0.9), rgba(6, 10, 18, 0.88));
+  color: var(--portal-ink);
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.32);
+  cursor: pointer;
+  transform: translate3d(var(--tile-x), var(--tile-y), var(--tile-z)) rotateY(var(--tile-rotate));
+  transition: transform 220ms ease, border-color 220ms ease, background 220ms ease;
+}
+
+.app-tile::before {
+  content: "";
+  width: 2.8rem;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: var(--tile-accent);
+}
+
+.app-tile:hover,
+.app-tile.is-active {
+  border-color: var(--tile-accent);
+  background: linear-gradient(145deg, rgba(31, 41, 55, 0.94), rgba(8, 13, 22, 0.92));
+}
+
+.app-tile.is-active {
+  transform:
+    translate3d(calc(var(--tile-x) - 0.25rem), calc(var(--tile-y) - 0.25rem), calc(var(--tile-z) + 44px))
+    rotateY(var(--tile-rotate));
+}
+
+.app-tile__name {
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.app-tile__meta {
+  color: var(--portal-muted);
+  font-size: 0.86rem;
+}
+
+.app-tile__count {
+  color: var(--tile-accent);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.workspace-panel {
+  position: relative;
+  z-index: 3;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: 1rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  background: var(--portal-panel);
+  backdrop-filter: blur(18px);
+}
+
+.workspace-panel__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: start;
+}
+
+.workspace-panel h2 {
+  font-size: clamp(1.8rem, 3vw, 3rem);
+}
+
+.workspace-panel p {
+  color: var(--portal-muted);
+  margin: 0.45rem 0 0;
+}
+
+.workspace-panel__stats {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 8.5rem;
+  padding: 0.8rem;
+  border: 1px solid var(--portal-line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--portal-muted);
+}
+
+.workspace-panel__stats strong {
+  color: var(--portal-ink);
+}
+
+.data-view,
+.app-view {
+  min-height: 0;
+}
+
+.record-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.search-field,
+.field {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--portal-muted);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.search-field input,
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  border: 1px solid var(--portal-line);
+  border-radius: 8px;
+  padding: 0.72rem 0.8rem;
+  background: var(--portal-field);
+  color: var(--portal-ink);
+  outline: none;
+}
+
+.field textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.search-field input:focus,
+.field input:focus,
+.field select:focus,
+.field textarea:focus,
+.portal-link:focus-visible,
+.device-chip:focus-visible,
+.workspace-tab:focus-visible,
+.secondary-action:focus-visible,
+.primary-action:focus-visible,
+.app-tile:focus-visible {
+  box-shadow: var(--focus-ring);
+  border-color: var(--portal-teal);
+}
+
+.record-layout {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(13rem, 0.75fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.record-list {
+  min-height: 0;
+  max-height: calc(100vh - 17rem);
+  overflow: auto;
+  display: grid;
+  align-content: start;
+  gap: 0.65rem;
+  padding-right: 0.2rem;
+}
+
+.record-button {
+  width: 100%;
+  min-height: 4.3rem;
+  display: grid;
+  gap: 0.15rem;
+  text-align: left;
+  border: 1px solid var(--portal-line);
+  border-radius: 8px;
+  padding: 0.8rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--portal-ink);
+  cursor: pointer;
+}
+
+.record-button.is-active {
+  border-color: var(--active-accent, var(--portal-teal));
+  background: color-mix(in srgb, var(--active-accent, var(--portal-teal)) 16%, rgba(255, 255, 255, 0.06));
+}
+
+.record-button__title {
+  font-weight: 800;
+}
+
+.record-button__meta {
+  color: var(--portal-muted);
+  font-size: 0.82rem;
+}
+
+.record-editor {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--portal-line);
+  border-radius: 8px;
+  background: var(--portal-panel-strong);
+}
+
+.editor-fields {
+  min-height: 0;
+  overflow: auto;
+  display: grid;
+  gap: 0.8rem;
+  align-content: start;
+}
+
+.app-view {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.app-frame-toolbar {
+  justify-content: space-between;
+}
+
+#app-frame {
+  width: 100%;
+  min-height: calc(100vh - 12rem);
+  border: 1px solid var(--portal-line);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+body[data-device-mode="flat"] .stage {
+  min-height: 35vh;
+}
+
+body[data-device-mode="flat"] .orbit-dock {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  gap: 0.75rem;
+  min-height: 15rem;
+  transform: none;
+}
+
+body[data-device-mode="flat"] .app-tile {
+  position: static;
+  transform: none;
+}
+
+@media (max-width: 1020px) {
+  .portal-shell {
+    grid-template-columns: 1fr;
+    overflow: visible;
+  }
+
+  .stage,
+  .workspace-panel {
+    min-height: auto;
+  }
+
+  .stage {
+    min-height: 58vh;
+    border-right: 0;
+    border-bottom: 1px solid var(--portal-line);
+  }
+
+  .workspace-panel {
+    min-height: 42vh;
+  }
+
+  .record-list {
+    max-height: 22rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .stage__overlay {
+    gap: 0.8rem;
+  }
+
+  .portal-header,
+  .workspace-panel__header,
+  .record-toolbar,
+  .record-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-header {
+    display: grid;
+  }
+
+  .portal-actions,
+  .device-bar,
+  .workspace-tabs {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 0.15rem;
+  }
+
+  .orbit-dock {
+    display: flex;
+    gap: 0.75rem;
+    overflow-x: auto;
+    align-self: end;
+    min-height: 10rem;
+    padding-bottom: 0.8rem;
+  }
+
+  .app-tile,
+  .app-tile.is-active {
+    position: static;
+    flex: 0 0 13rem;
+    transform: none;
+  }
+
+  .workspace-panel__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new `/vr-portal/` spatial workspace prototype backed by Three.js.
- Include editable demo data for CRM, Notes, Calendar, Tasks, and Finance with local cache plus explicit Gun sync paths.
- Add a homepage app dock card for Spatial Portal.

## Validation
- `node --test tests/vr-portal.test.js`
- Browser smoke-tested the prototype locally for desktop and mobile: nonblank WebGL canvas, no horizontal overflow, CRM record edit flow, and embedded 2D CRM frame.