### PR TITLE
[codex] Wait for shared builder defaults

### DIFF
--- a/launch-site/app.js
+++ b/launch-site/app.js
@@ -22,6 +22,7 @@ const publishResult = document.getElementById('publish-result');
 
 const statusClasses = ['status--info', 'status--success', 'status--warning', 'status--error'];
 const draftStorageKey = 'site-launcher-current-draft';
+const sharedDefaultsWaitMs = 6000;
 
 let currentHtml = '';
 let currentTitle = '';
@@ -29,6 +30,10 @@ let lastPrompt = '';
 let sharedSecrets = {
   openai: '',
   vercel: ''
+};
+const sharedSecretResolvers = {
+  openai: [],
+  vercel: []
 };
 
 renderEmptyPreview();
@@ -82,15 +87,68 @@ function sanitizeSlug(value) {
 
 function subscribeToSharedDefaults() {
   if (!defaultsNode) {
+    resolveSharedSecretWaiters('openai');
+    resolveSharedSecretWaiters('vercel');
     return;
   }
 
   defaultsNode.on(data => {
+    if (!hasDefaultRecord(data)) {
+      return;
+    }
+
     sharedSecrets = {
       openai: readDefaultSecret(data, 'openai'),
       vercel: readDefaultSecret(data, 'vercel')
     };
+    if (sharedSecrets.openai) {
+      resolveSharedSecretWaiters('openai');
+    }
+    if (sharedSecrets.vercel) {
+      resolveSharedSecretWaiters('vercel');
+    }
   });
+}
+
+function hasDefaultRecord(data) {
+  return Boolean(
+    data &&
+    typeof data === 'object' &&
+    Object.keys(data).some(key => key !== '_')
+  );
+}
+
+function resolveSharedSecretWaiters(targetKey) {
+  const waiters = sharedSecretResolvers[targetKey] || [];
+  while (waiters.length) {
+    waiters.shift()?.();
+  }
+}
+
+function wait(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForSharedSecret(targetKey, message) {
+  if (sharedSecrets[targetKey]) {
+    return true;
+  }
+
+  if (!defaultsNode) {
+    return false;
+  }
+
+  setStatus(message, 'info');
+  await Promise.race([
+    new Promise(resolve => {
+      sharedSecretResolvers[targetKey]?.push(resolve);
+    }),
+    wait(sharedDefaultsWaitMs)
+  ]);
+
+  return Boolean(sharedSecrets[targetKey]);
 }
 
 function buildPrompt(state) {
@@ -153,6 +211,7 @@ async function requestSiteDraft(prompt, message) {
   publishResult.innerHTML = '';
 
   try {
+    await waitForSharedSecret('openai', 'Loading shared site generator key...');
     const response = await fetch('/api/openai-site', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -201,6 +260,7 @@ async function publishSite() {
   publishResult.innerHTML = '';
 
   try {
+    await waitForSharedSecret('vercel', 'Loading shared publishing key...');
     const response = await fetch('/api/vercel-deploy', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/tests/site-launcher-page.test.js
+++ b/tests/site-launcher-page.test.js
@@ -25,6 +25,9 @@ test('site launcher exposes the simple customer publishing flow', async () => {
   assert.match(app, /subdomain: state\.slug/);
   assert.match(app, /readDefaultSecret\(data, 'openai'\)/);
   assert.match(app, /readDefaultSecret\(data, 'vercel'\)/);
+  assert.match(app, /waitForSharedSecret\('openai'/);
+  assert.match(app, /waitForSharedSecret\('vercel'/);
+  assert.match(app, /hasDefaultRecord\(data\)/);
 
   assert.match(portalHome, /href="launch-site\/"/);
   assert.match(portalHome, />Launch Site</);

--- a/tests/web-builder-defaults.test.js
+++ b/tests/web-builder-defaults.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
   hasEncryptedDefault,
@@ -51,4 +52,13 @@ test('listAvailableDefaultTargets supports cipher-only mode', () => {
     listAvailableDefaultTargets(record, { includePlain: false, includeCipher: true }),
     ['vercel']
   );
+});
+
+test('web builder waits for shared defaults before missing-key warning', async () => {
+  const app = await readFile(new URL('../web-builder-app/app.js', import.meta.url), 'utf8');
+
+  assert.match(app, /DEFAULTS_LOAD_TIMEOUT_MS/);
+  assert.match(app, /readDefaultsConfig\(timeoutMs\)/);
+  assert.match(app, /hasDefaultRecord\(data\)/);
+  assert.match(app, /await loadDefaultsWithOptions\(\{ force: false, silent: true, timeoutMs: DEFAULTS_LOAD_TIMEOUT_MS \}\)/);
 });

--- a/web-builder-app/app.js
+++ b/web-builder-app/app.js
@@ -55,6 +55,15 @@ let currentSources = [];
 let currentSearchUsage = null;
 let generateStatusAnimationTimer = null;
 let billingStatusSyncPromise = null;
+let resolveDefaultsFirstRecord = null;
+const defaultsFirstRecordPromise = new Promise(resolve => {
+  resolveDefaultsFirstRecord = resolve;
+});
+const defaultSecretResolvers = {
+  openai: [],
+  vercel: [],
+  github: []
+};
 
 const identityStorageKey = 'web-builder-identity';
 const sharedBillingTierStorageKey = 'portal-usage-tier';
@@ -70,6 +79,7 @@ const modelStorageKey = 'web-builder-model';
 
 const STATUS_TONE_CLASSES = ['status--info', 'status--success', 'status--warning', 'status--error'];
 const LOAD_DEFAULTS_LABEL = 'Reload shared defaults';
+const DEFAULTS_LOAD_TIMEOUT_MS = 6000;
 
 const menuToggle = document.getElementById('menu-toggle');
 const builderNav = document.getElementById('builder-nav');
@@ -787,7 +797,17 @@ function hydrateStoredKeys() {
 
 function subscribeToDefaults() {
   defaultsNode.on(data => {
+    if (!hasDefaultRecord(data)) {
+      return;
+    }
+
     currentDefaultConfig = data || {};
+    resolveDefaultsFirstRecord?.(currentDefaultConfig);
+    ['openai', 'vercel', 'github'].forEach(targetKey => {
+      if (readDefaultSecret(currentDefaultConfig, targetKey)) {
+        resolveDefaultSecretWaiters(targetKey);
+      }
+    });
 
     const plainAvailable = describeTargets(
       listAvailableDefaultTargets(currentDefaultConfig, { includePlain: true, includeCipher: false })
@@ -815,6 +835,38 @@ function subscribeToDefaults() {
       'warning'
     );
   });
+}
+
+function hasDefaultRecord(data) {
+  return Boolean(
+    data &&
+    typeof data === 'object' &&
+    Object.keys(data).some(key => key !== '_')
+  );
+}
+
+function resolveDefaultSecretWaiters(targetKey) {
+  const waiters = defaultSecretResolvers[targetKey] || [];
+  while (waiters.length) {
+    waiters.shift()?.();
+  }
+}
+
+async function waitForDefaultSecret(targetKey, timeoutMs = DEFAULTS_LOAD_TIMEOUT_MS) {
+  if (readDefaultSecret(currentDefaultConfig, targetKey)) {
+    return true;
+  }
+
+  await Promise.race([
+    new Promise(resolve => {
+      defaultSecretResolvers[targetKey]?.push(resolve);
+    }),
+    new Promise(resolve => {
+      setTimeout(resolve, timeoutMs);
+    })
+  ]);
+
+  return Boolean(readDefaultSecret(currentDefaultConfig, targetKey));
 }
 
 function describeTargets(targets) {
@@ -973,9 +1025,11 @@ function usingAnySharedKey() {
 }
 
 async function loadDefaultsWithOptions(options = {}) {
-  const { force = true, silent = false } = options;
+  const { force = true, silent = false, timeoutMs = DEFAULTS_LOAD_TIMEOUT_MS } = options;
   const hasCachedConfig = Object.keys(currentDefaultConfig || {}).length > 0;
-  const config = hasCachedConfig ? currentDefaultConfig : await new Promise(resolve => defaultsNode.once(resolve));
+  const config = hasCachedConfig
+    ? currentDefaultConfig
+    : await readDefaultsConfig(timeoutMs);
   const targets = [
     {
       key: 'openai',
@@ -1059,6 +1113,20 @@ async function loadDefaultsWithOptions(options = {}) {
   if (!silent) {
     setDefaultStatus('No shared defaults are configured yet.', 'warning');
   }
+}
+
+function readDefaultsConfig(timeoutMs = DEFAULTS_LOAD_TIMEOUT_MS) {
+  const hasCachedConfig = Object.keys(currentDefaultConfig || {}).length > 0;
+  if (hasCachedConfig) {
+    return Promise.resolve(currentDefaultConfig);
+  }
+
+  return Promise.race([
+    defaultsFirstRecordPromise,
+    new Promise(resolve => {
+      setTimeout(() => resolve({}), timeoutMs);
+    })
+  ]);
 }
 
 function saveLocalKeys() {
@@ -1392,7 +1460,17 @@ async function readGenerationStream(response, { onStatus } = {}) {
 }
 
 async function requestGeneration(prompt, mode) {
-  const apiKey = getActiveKey(openaiInput, defaultSecrets.openai, 'openai');
+  let apiKey = getActiveKey(openaiInput, defaultSecrets.openai, 'openai');
+  if (!apiKey) {
+    setGenerateStatus('Loading shared defaults...', 'info');
+    await loadDefaultsWithOptions({ force: false, silent: true, timeoutMs: DEFAULTS_LOAD_TIMEOUT_MS });
+    if (!readDefaultSecret(currentDefaultConfig, 'openai')) {
+      await waitForDefaultSecret('openai', DEFAULTS_LOAD_TIMEOUT_MS);
+      await loadDefaultsWithOptions({ force: false, silent: true, timeoutMs: 0 });
+    }
+    apiKey = getActiveKey(openaiInput, defaultSecrets.openai, 'openai');
+  }
+
   if (!apiKey) {
     setGenerateStatus('No OpenAI key available. Open Config and load shared defaults or add a personal key. Portal billing tiers do not include OpenAI API billing.', 'warning');
     revealConfig();


### PR DESCRIPTION
## What changed

- Makes `/launch-site/` wait for the specific shared OpenAI or Vercel default before sending generate or publish requests.
- Makes the advanced web builder hydrate shared defaults before showing the missing OpenAI key warning.
- Ignores empty and partial Gun emissions so an encrypted-only partial update does not race ahead of the plaintext `apiKey` field.

## Root cause

`portal.3dvr.tech` is serving the launcher correctly, and Gun still has the shared defaults. The relay can emit partial records first, such as only `vercelTokenCipher`, before the plaintext `apiKey` arrives. The launcher could send `/api/openai-site` before that plaintext key had loaded, and because Vercel has no server-side `OPENAI_API_KEY`, the API returned `OpenAI API key is not configured.`

## Validation

- `node --test tests/site-launcher-page.test.js tests/web-builder-defaults.test.js tests/openai-site.test.js`
- Local browser smoke with `/api/openai-site` intercepted: generate request included an `apiKey` after waiting for Gun defaults, without making a real OpenAI call.