### PR TITLE
[codex] Fix spatial portal visibility and desktop layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,6 +381,15 @@
             <span class="app-card__title">Home</span>
             <span class="app-card__meta">Launch the desktop workspace for portal navigation.</span>
           </a>
+          <a
+            href="vr-portal/"
+            class="app-card"
+            data-app-keywords="vr ar xr spatial interface desktop crm notes calendar tasks finance portal"
+          >
+            <span class="app-card__icon" aria-hidden="true">🥽</span>
+            <span class="app-card__title">Spatial Portal</span>
+            <span class="app-card__meta">Open, view, and edit core portal data inside a 3D workspace.</span>
+          </a>
           <a href="human-scale-economics/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🌱</span>
             <span class="app-card__title">Human Economics</span>
@@ -755,17 +764,6 @@
             <span class="app-card__icon" aria-hidden="true">🥽</span>
             <span class="app-card__title">XR Motion Lab</span>
             <span class="app-card__meta">Use device sensors and camera passthrough for a mobile AR/VR prototype.</span>
-          </a>
-          <a
-            href="vr-portal/"
-            class="app-card"
-            data-app-tier="experimental"
-            data-app-keywords="vr ar xr spatial interface desktop crm notes calendar tasks finance portal"
-          >
-            <span class="app-card__badge">Experimental</span>
-            <span class="app-card__icon" aria-hidden="true">🥽</span>
-            <span class="app-card__title">Spatial Portal</span>
-            <span class="app-card__meta">Open, view, and edit core portal data inside a 3D workspace.</span>
           </a>
           <a href="website-builder.html" class="app-card" data-app-tier="experimental">
             <span class="app-card__badge">Experimental</span>

--- a/tests/vr-portal.test.js
+++ b/tests/vr-portal.test.js
@@ -30,6 +30,7 @@ test('portal launcher includes the spatial portal app card', async () => {
   assert.match(html, /href="vr-portal\/"/);
   assert.match(html, /Spatial Portal/);
   assert.match(html, /data-app-keywords="vr ar xr spatial interface desktop crm notes calendar tasks finance portal"/);
+  assert.doesNotMatch(html, /href="vr-portal\/"[\s\S]{0,140}data-app-tier="experimental"/);
 });
 
 test('spatial portal data supports app selection, filtering, editing, and deletion', () => {

--- a/vr-portal/styles.css
+++ b/vr-portal/styles.css
@@ -35,6 +35,10 @@ a {
   -webkit-tap-highlight-color: transparent;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 .skip-link {
   position: fixed;
   top: 0.75rem;
@@ -52,15 +56,16 @@ a {
 }
 
 .portal-shell {
-  min-height: 100vh;
+  height: 100vh;
+  min-height: 44rem;
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(420px, 0.8fr);
+  grid-template-columns: minmax(20rem, 0.36fr) minmax(46rem, 0.64fr);
   overflow: hidden;
 }
 
 .stage {
   position: relative;
-  min-height: 100vh;
+  min-height: 0;
   perspective: 1200px;
   overflow: hidden;
   border-right: 1px solid var(--portal-line);
@@ -77,11 +82,11 @@ a {
 .stage__overlay {
   position: relative;
   z-index: 2;
-  min-height: 100%;
+  height: 100%;
   display: grid;
-  grid-template-rows: auto auto 1fr;
+  grid-template-rows: auto auto minmax(0, 1fr);
   gap: 1rem;
-  padding: clamp(1rem, 2vw, 2rem);
+  padding: clamp(1rem, 1.8vw, 1.5rem);
   pointer-events: none;
 }
 
@@ -92,10 +97,10 @@ a {
 }
 
 .portal-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 1rem;
-  align-items: flex-start;
+  align-items: start;
 }
 
 .portal-kicker,
@@ -116,7 +121,8 @@ a {
 }
 
 .portal-header h1 {
-  font-size: clamp(2rem, 5vw, 4.8rem);
+  max-width: 11ch;
+  font-size: clamp(1.9rem, 3.4vw, 3.2rem);
 }
 
 .portal-actions,
@@ -128,6 +134,10 @@ a {
   flex-wrap: wrap;
   gap: 0.55rem;
   align-items: center;
+}
+
+.portal-actions {
+  justify-content: flex-end;
 }
 
 .portal-link,
@@ -164,29 +174,32 @@ a {
 
 .orbit-dock {
   position: relative;
-  align-self: center;
-  min-height: min(58vh, 560px);
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-content: start;
+  gap: 0.75rem;
+  overflow: auto;
+  padding: 0.15rem 0.2rem 0.25rem 0;
   transform-style: preserve-3d;
 }
 
 .app-tile {
   --tile-accent: var(--portal-teal);
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: clamp(10rem, 17vw, 15.5rem);
-  min-height: 8.25rem;
+  position: relative;
+  width: 100%;
+  min-height: 7rem;
   display: grid;
-  gap: 0.75rem;
+  gap: 0.45rem;
   align-content: space-between;
-  padding: 1rem;
+  padding: 0.9rem;
   border: 1px solid color-mix(in srgb, var(--tile-accent) 56%, transparent);
   border-radius: 8px;
   background: linear-gradient(145deg, rgba(17, 24, 39, 0.9), rgba(6, 10, 18, 0.88));
   color: var(--portal-ink);
   box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.32);
   cursor: pointer;
-  transform: translate3d(var(--tile-x), var(--tile-y), var(--tile-z)) rotateY(var(--tile-rotate));
+  transform: translateZ(0);
   transition: transform 220ms ease, border-color 220ms ease, background 220ms ease;
 }
 
@@ -205,13 +218,11 @@ a {
 }
 
 .app-tile.is-active {
-  transform:
-    translate3d(calc(var(--tile-x) - 0.25rem), calc(var(--tile-y) - 0.25rem), calc(var(--tile-z) + 44px))
-    rotateY(var(--tile-rotate));
+  transform: translateY(-2px);
 }
 
 .app-tile__name {
-  font-size: 1.3rem;
+  font-size: 1.05rem;
   font-weight: 800;
 }
 
@@ -229,7 +240,8 @@ a {
 .workspace-panel {
   position: relative;
   z-index: 3;
-  min-height: 100vh;
+  min-height: 0;
+  height: 100%;
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr);
   gap: 1rem;
@@ -274,6 +286,11 @@ a {
   min-height: 0;
 }
 
+.data-view {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
 .record-toolbar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -304,7 +321,7 @@ a {
 }
 
 .field textarea {
-  min-height: 7rem;
+  min-height: 5.75rem;
   resize: vertical;
 }
 
@@ -325,13 +342,13 @@ a {
 .record-layout {
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(13rem, 0.75fr) minmax(0, 1fr);
+  grid-template-columns: minmax(14rem, 0.42fr) minmax(0, 0.58fr);
   gap: 1rem;
 }
 
 .record-list {
   min-height: 0;
-  max-height: calc(100vh - 17rem);
+  max-height: none;
   overflow: auto;
   display: grid;
   align-content: start;
@@ -369,6 +386,7 @@ a {
 
 .record-editor {
   min-height: 0;
+  height: 100%;
   display: grid;
   grid-template-rows: minmax(0, 1fr) auto;
   gap: 1rem;
@@ -387,6 +405,7 @@ a {
 }
 
 .app-view {
+  min-height: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1rem;
@@ -398,22 +417,22 @@ a {
 
 #app-frame {
   width: 100%;
-  min-height: calc(100vh - 12rem);
+  height: 100%;
+  min-height: 0;
   border: 1px solid var(--portal-line);
   border-radius: 8px;
   background: #ffffff;
 }
 
 body[data-device-mode="flat"] .stage {
-  min-height: 35vh;
+  min-height: 0;
 }
 
 body[data-device-mode="flat"] .orbit-dock {
-  display: flex;
+  display: grid;
   flex-wrap: wrap;
-  align-content: center;
+  align-content: start;
   gap: 0.75rem;
-  min-height: 15rem;
   transform: none;
 }
 
@@ -424,6 +443,8 @@ body[data-device-mode="flat"] .app-tile {
 
 @media (max-width: 1020px) {
   .portal-shell {
+    height: auto;
+    min-height: 100vh;
     grid-template-columns: 1fr;
     overflow: visible;
   }
@@ -441,6 +462,7 @@ body[data-device-mode="flat"] .app-tile {
 
   .workspace-panel {
     min-height: 42vh;
+    height: auto;
   }
 
   .record-list {


### PR DESCRIPTION
## Summary
- Move the Spatial Portal card into the visible app dock near Home instead of hiding it behind the experimental toggle.
- Fix desktop layout so the app dock appears in the first viewport and the workspace stays viewport-bound.
- Restore proper `[hidden]` behavior so the embedded 2D app iframe does not leak into the data view.
- Keep Save/Delete actions reachable in the desktop editor.

## Validation
- `node --test tests/vr-portal.test.js`
- Local Playwright smoke checks for desktop and mobile: visible homepage card, no horizontal overflow, no desktop page overflow, visible app tiles, reachable editor actions, and working 2D CRM iframe tab.