### PR TITLE
[codex] Improve site launcher publish flow

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -4,6 +4,8 @@ const setCorsHeaders = (res) => {
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 };
 
+const DEFAULT_SITE_LAUNCH_VERCEL_TEAM_ID = 'team_KXuVUd00RMnDsjoqwdREcZ7J';
+
 function parseProvider(req) {
   const fromQuery = String(req?.query?.provider || '').trim().toLowerCase();
   if (fromQuery) {
@@ -232,6 +234,16 @@ async function assignVercelAlias({ token, deploymentId, domain, teamId, fetchImp
   };
 }
 
+function withVercelTeamScope(url, teamId) {
+  if (!teamId) {
+    return url;
+  }
+
+  const scopedUrl = new URL(url);
+  scopedUrl.searchParams.set('teamId', teamId);
+  return scopedUrl.toString();
+}
+
 async function createVercelDeployment({
   token,
   projectName,
@@ -259,7 +271,7 @@ async function createVercelDeployment({
     target: 'production'
   };
 
-  const response = await fetchImpl('https://api.vercel.com/v13/deployments', {
+  const response = await fetchImpl(withVercelTeamScope('https://api.vercel.com/v13/deployments', teamId), {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -305,7 +317,7 @@ export function createGithubPublishHandler(options = {}) {
   const {
     fetchImpl = globalThis.fetch,
     vercelToken = process.env.VERCEL_TOKEN,
-    vercelTeamId = process.env.VERCEL_TEAM_ID,
+    vercelTeamId = process.env.SITE_LAUNCH_VERCEL_TEAM_ID || process.env.VERCEL_TEAM_ID || DEFAULT_SITE_LAUNCH_VERCEL_TEAM_ID,
     siteLaunchBaseDomain = process.env.SITE_LAUNCH_BASE_DOMAIN
   } = options;
 

--- a/launch-site/app.js
+++ b/launch-site/app.js
@@ -35,6 +35,11 @@ const sharedSecretResolvers = {
   openai: [],
   vercel: []
 };
+const defaultButtonText = {
+  generate: 'Generate Site',
+  revise: 'Revise Draft',
+  publish: 'Publish'
+};
 
 renderEmptyPreview();
 hydrateStoredDraft();
@@ -186,7 +191,7 @@ async function generateSite() {
   }
 
   lastPrompt = buildPrompt(state);
-  await requestSiteDraft(lastPrompt, 'Generating site...');
+  await requestSiteDraft(lastPrompt, 'Preparing site draft...', 'generate');
 }
 
 async function reviseSite() {
@@ -201,17 +206,20 @@ async function reviseSite() {
     return;
   }
 
-  await requestSiteDraft(buildRevisionPrompt(revisionRequest), 'Revising draft...');
+  await requestSiteDraft(buildRevisionPrompt(revisionRequest), 'Preparing revision...', 'revise');
   revisionInput.value = '';
 }
 
-async function requestSiteDraft(prompt, message) {
-  setBusy(true);
+async function requestSiteDraft(prompt, message, operation = 'generate') {
+  setBusy(true, operation);
   setStatus(message, 'info');
   publishResult.innerHTML = '';
 
   try {
     await waitForSharedSecret('openai', 'Loading shared site generator key...');
+    setStatus(operation === 'revise'
+      ? 'Sending revision request to the site generator...'
+      : 'Sending site request to the generator...', 'info');
     const response = await fetch('/api/openai-site', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -227,6 +235,7 @@ async function requestSiteDraft(prompt, message) {
       throw new Error(result?.error || 'The site generator is not available.');
     }
 
+    setStatus('Rendering the preview...', 'info');
     currentHtml = result.html || '';
     currentTitle = result.title || collectFormState().businessName || 'Website draft';
     previewTitle.textContent = currentTitle;
@@ -255,12 +264,13 @@ async function publishSite() {
     return;
   }
 
-  publishButton.disabled = true;
+  setBusy(true, 'publish');
   setStatus(`Publishing ${state.slug}.3dvr.tech...`, 'info');
   publishResult.innerHTML = '';
 
   try {
     await waitForSharedSecret('vercel', 'Loading shared publishing key...');
+    setStatus('Creating the deployment in the 3dvr workspace and assigning the address...', 'info');
     const response = await fetch('/api/vercel-deploy', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -278,6 +288,7 @@ async function publishSite() {
       throw new Error(result?.error || 'Publishing failed.');
     }
 
+    setStatus('Preparing the live link...', 'info');
     const liveUrl = result.aliasUrl || result.url || result.inspectUrl;
     if (liveUrl) {
       publishResult.innerHTML = `Live: <a href="${escapeAttribute(liveUrl)}" target="_blank" rel="noopener">${escapeHtml(liveUrl)}</a>`;
@@ -288,14 +299,19 @@ async function publishSite() {
   } catch (error) {
     setStatus(error.message || 'Unable to publish the site.', 'error');
   } finally {
-    publishButton.disabled = !currentHtml;
+    setBusy(false);
   }
 }
 
-function setBusy(isBusy) {
+function setBusy(isBusy, operation = '') {
+  form.setAttribute('aria-busy', isBusy ? 'true' : 'false');
   generateButton.disabled = isBusy;
   reviseButton.disabled = isBusy || !currentHtml;
   publishButton.disabled = isBusy || !currentHtml;
+
+  generateButton.textContent = operation === 'generate' && isBusy ? 'Generating...' : defaultButtonText.generate;
+  reviseButton.textContent = operation === 'revise' && isBusy ? 'Revising...' : defaultButtonText.revise;
+  publishButton.textContent = operation === 'publish' && isBusy ? 'Publishing...' : defaultButtonText.publish;
 }
 
 function setDraftControlsEnabled(enabled) {

--- a/launch-site/index.html
+++ b/launch-site/index.html
@@ -66,12 +66,16 @@
 
         <div class="actions">
           <button id="generate-site" class="primary" type="submit">Generate Site</button>
-          <button id="revise-site" class="secondary" type="button" disabled>Revise Draft</button>
         </div>
 
         <label for="revision-request" class="revision-label">Revision</label>
         <input id="revision-request" type="text"
           placeholder="Make it more direct, add pricing, or change the tone." disabled>
+
+        <div class="actions revision-actions">
+          <button id="revise-site" class="secondary" type="button" disabled>Revise Draft</button>
+          <button id="publish-site" class="primary" type="button" disabled>Publish</button>
+        </div>
 
         <p id="launcher-status" class="status status--info" aria-live="polite">Ready.</p>
       </form>
@@ -83,7 +87,6 @@
           <p class="eyebrow">Preview</p>
           <h2 id="preview-title">Draft</h2>
         </div>
-        <button id="publish-site" class="primary" type="button" disabled>Publish</button>
       </div>
       <iframe id="site-preview" title="Website preview"></iframe>
       <div id="publish-result" class="publish-result" aria-live="polite"></div>

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -111,9 +111,11 @@ test('github publish handler supports owner + repo payload shape', async () => {
 });
 
 test('github publish handler supports vercel deploy provider mode', async () => {
+  const calls = [];
   let requestPayload = null;
   const handler = createGithubPublishHandler({
-    fetchImpl: async (_url, options = {}) => {
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
       requestPayload = JSON.parse(options.body);
       return {
         ok: true,
@@ -147,6 +149,7 @@ test('github publish handler supports vercel deploy provider mode', async () => 
   assert.equal(res.body.id, 'dpl_123');
   assert.equal(res.body.url, 'https://project-demo.vercel.app');
   assert.equal(requestPayload.name, 'project-demo');
+  assert.match(calls[0].url, /\/v13\/deployments\?teamId=team_KXuVUd00RMnDsjoqwdREcZ7J$/);
 });
 
 test('sanitizeLaunchSubdomain normalizes customer site addresses', () => {
@@ -170,6 +173,7 @@ test('vercel deploy provider can use server token and assign a 3dvr subdomain', 
   const calls = [];
   const handler = createGithubPublishHandler({
     vercelToken: 'server_vercel_token',
+    vercelTeamId: 'team_3dvr',
     siteLaunchBaseDomain: '3dvr.tech',
     fetchImpl: async (url, options = {}) => {
       calls.push({ url: String(url), options });
@@ -223,6 +227,8 @@ test('vercel deploy provider can use server token and assign a 3dvr subdomain', 
   assert.equal(res.body.aliasUrl, 'https://river-city-wellness.3dvr.tech');
   assert.equal(res.body.url, 'https://3dvr-river-city-wellness.vercel.app');
   assert.equal(calls.length, 2);
+  assert.match(calls[0].url, /\/v13\/deployments\?teamId=team_3dvr$/);
+  assert.match(calls[1].url, /\/v2\/deployments\/dpl_launch_123\/aliases\?teamId=team_3dvr$/);
   assert.equal(calls[0].options.headers.Authorization, 'Bearer server_vercel_token');
   assert.equal(calls[1].options.headers.Authorization, 'Bearer server_vercel_token');
   assert.deepEqual(JSON.parse(calls[1].options.body), {

--- a/tests/site-launcher-page.test.js
+++ b/tests/site-launcher-page.test.js
@@ -12,6 +12,8 @@ test('site launcher exposes the simple customer publishing flow', async () => {
   assert.match(html, /id="site-purpose"/);
   assert.match(html, /id="site-slug"/);
   assert.match(html, /id="publish-site"/);
+  assert.match(html, /id="revision-request"[\s\S]*id="publish-site"/);
+  assert.doesNotMatch(html, /class="preview-header"[\s\S]*id="publish-site"[\s\S]*<\/div>\s*<iframe/);
   assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
   assert.match(html, /src="\/gun-init\.js"/);
 
@@ -28,6 +30,8 @@ test('site launcher exposes the simple customer publishing flow', async () => {
   assert.match(app, /waitForSharedSecret\('openai'/);
   assert.match(app, /waitForSharedSecret\('vercel'/);
   assert.match(app, /hasDefaultRecord\(data\)/);
+  assert.match(app, /Generating\.\.\./);
+  assert.match(app, /Creating the deployment in the 3dvr workspace/);
 
   assert.match(portalHome, /href="launch-site\/"/);
   assert.match(portalHome, />Launch Site</);


### PR DESCRIPTION
## What changed

- Scopes generated-site Vercel deployment creation to the 3dvr team by default, not only alias assignment.
- Moves the launcher Publish button into the form under the Revision field, next to Revise Draft.
- Updates launcher status and button labels while generating, revising, and publishing so users see what is happening instead of only disabled controls.

## Root cause

The Vercel publish API passed `teamId` only when assigning the alias. Deployment creation itself still used the account implied by the token, which can hit the tmsteph Hobby limit. The launcher also placed Publish in the preview header and did not make in-progress button text explicit.

## Validation

- `node --test tests/github-publish-api.test.js tests/site-launcher-page.test.js tests/web-builder-defaults.test.js tests/openai-site.test.js`
- Local mobile browser smoke at 390px with OpenAI/Vercel requests intercepted: Publish is under Revision, no preview-header Publish button, no horizontal overflow, Generate/Publish buttons show active labels, and status updates through each backend step.