### PR TITLE
Preserve admin shared defaults on blank input

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -779,6 +779,10 @@
           Publish shared defaults for OpenAI, Vercel, and GitHub. Web Builder can load them in one click while
           rate limits still apply per identity.
         </p>
+        <p class="text-muted">
+          Leave a key field blank to keep the saved value for that provider. Use <strong>Clear defaults</strong>
+          only when you want to remove the saved shared keys.
+        </p>
         <div class="form-group">
           <label for="default-api-key">Default OpenAI API key</label>
           <input id="default-api-key" type="password" placeholder="sk-..." />
@@ -2496,6 +2500,15 @@
     }
   }
 
+  function readPreservedDefaultPlain(field) {
+    const value = defaultRecord?.[field];
+    return typeof value === 'string' && value.trim() ? value : null;
+  }
+
+  function readPreservedDefaultCipher(field) {
+    return defaultRecord?.[field] || null;
+  }
+
   function setRecoveryStatus(message, tone = 'muted') {
     if (!recoveryStatusEl) return;
     recoveryStatusEl.innerText = message;
@@ -2840,9 +2853,10 @@
     const passphrase = (defaultPassphraseInput.value || '').trim();
     const hint = (defaultHintInput.value || '').trim();
     const hasPassphrase = Boolean(passphrase);
+    const hasNewKey = Boolean(apiKey || vercelToken || githubToken);
 
-    if (!apiKey && !vercelToken && !githubToken) {
-      updateDefaultStatus('Add at least one key before publishing defaults.');
+    if (!hasNewKey) {
+      updateDefaultStatus('Enter at least one new key. Blank fields keep saved defaults; Clear defaults removes them.');
       return false;
     }
 
@@ -2864,14 +2878,21 @@
       const cipher = hasPassphrase && apiKey ? await Gun.SEA.encrypt(apiKey, passphrase) : null;
       const vercelCipher = hasPassphrase && vercelToken ? await Gun.SEA.encrypt(vercelToken, passphrase) : null;
       const githubCipher = hasPassphrase && githubToken ? await Gun.SEA.encrypt(githubToken, passphrase) : null;
+      const nextApiKey = apiKey || readPreservedDefaultPlain('apiKey');
+      const nextVercelToken = vercelToken || readPreservedDefaultPlain('vercelToken');
+      const nextGithubToken = githubToken || readPreservedDefaultPlain('githubToken');
+      const nextApiKeyCipher = apiKey ? cipher : readPreservedDefaultCipher('apiKeyCipher');
+      const nextVercelTokenCipher = vercelToken ? vercelCipher : readPreservedDefaultCipher('vercelTokenCipher');
+      const nextGithubTokenCipher = githubToken ? githubCipher : readPreservedDefaultCipher('githubTokenCipher');
+      const nextHint = hasPassphrase ? (hint || defaultRecord?.hint || '') : (defaultRecord?.hint || '');
       const payload = {
-        apiKey: apiKey || null,
-        vercelToken: vercelToken || null,
-        githubToken: githubToken || null,
-        apiKeyCipher: cipher,
-        vercelTokenCipher: vercelCipher,
-        githubTokenCipher: githubCipher,
-        hint: hasPassphrase ? hint : '',
+        apiKey: nextApiKey,
+        vercelToken: nextVercelToken,
+        githubToken: nextGithubToken,
+        apiKeyCipher: nextApiKeyCipher,
+        vercelTokenCipher: nextVercelTokenCipher,
+        githubTokenCipher: nextGithubTokenCipher,
+        hint: nextHint,
         updatedAt: Date.now(),
         updatedBy: alias || 'admin'
       };
@@ -2888,9 +2909,13 @@
       defaultGithubInput.value = '';
       defaultPassphraseInput.value = '';
       defaultHintInput.value = '';
+      defaultRecord = {
+        ...defaultRecord,
+        ...payload
+      };
       updateDefaultStatus(hasPassphrase
-        ? 'Published. Password-free defaults and encrypted copies are both ready.'
-        : 'Published. Password-free defaults are ready and encrypted copies were cleared.');
+        ? 'Published. Blank fields kept their saved defaults; updated keys refreshed encrypted copies.'
+        : 'Published. Blank fields kept their saved defaults.');
       return true;
     } catch (error) {
       updateDefaultStatus(hasPassphrase

--- a/tests/admin-agent-ops.test.js
+++ b/tests/admin-agent-ops.test.js
@@ -129,3 +129,22 @@ test('portal home links to the agent ops dashboard', async () => {
   assert.match(html, /Agent Ops/);
   assert.match(html, /portal session, control the 3dvr-agent/);
 });
+
+test('admin shared defaults preserve saved provider keys when fields are blank', async () => {
+  const adminUrl = new URL('../admin/index.html', import.meta.url);
+  assert.equal(await fileExists(adminUrl), true, 'admin/index.html should exist');
+
+  const html = await readFile(adminUrl, 'utf8');
+  assert.match(html, /Leave a key field blank to keep the saved value for that provider/);
+  assert.match(html, /function readPreservedDefaultPlain\(field\)/);
+  assert.match(html, /function readPreservedDefaultCipher\(field\)/);
+  assert.match(html, /const nextApiKey = apiKey \|\| readPreservedDefaultPlain\('apiKey'\)/);
+  assert.match(html, /const nextVercelToken = vercelToken \|\| readPreservedDefaultPlain\('vercelToken'\)/);
+  assert.match(html, /const nextGithubToken = githubToken \|\| readPreservedDefaultPlain\('githubToken'\)/);
+  assert.match(html, /apiKey: nextApiKey/);
+  assert.match(html, /vercelToken: nextVercelToken/);
+  assert.match(html, /githubToken: nextGithubToken/);
+  assert.doesNotMatch(html, /apiKey: apiKey \|\| null/);
+  assert.doesNotMatch(html, /vercelToken: vercelToken \|\| null/);
+  assert.doesNotMatch(html, /githubToken: githubToken \|\| null/);
+});


### PR DESCRIPTION
## Summary

- Treat blank shared-default key fields in `/admin/` as “keep the saved provider key.”
- Preserve existing plain and encrypted OpenAI, Vercel, and GitHub defaults unless a new value is entered.
- Keep the existing Clear defaults button as the explicit wipe path.
- Add admin copy and a regression assertion so the old `input || null` wipe behavior does not come back.

## Validation

- `node --test tests/admin-agent-ops.test.js tests/web-builder-defaults.test.js tests/site-launcher-page.test.js`
- `git diff --check`

## Impact

Admins can rotate one shared key without re-entering all three provider credentials. No billing, auth, or Stripe behavior changed.