### PR TITLE
Wait for Vercel deployments before aliasing

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -5,6 +5,10 @@ const setCorsHeaders = (res) => {
 };
 
 const DEFAULT_SITE_LAUNCH_VERCEL_TEAM_ID = 'team_KXuVUd00RMnDsjoqwdREcZ7J';
+const DEFAULT_VERCEL_READY_TIMEOUT_MS = 30_000;
+const DEFAULT_VERCEL_READY_POLL_INTERVAL_MS = 1_000;
+const VERCEL_READY_STATE = 'READY';
+const VERCEL_FAILED_READY_STATES = new Set(['ERROR', 'CANCELED']);
 
 function resolveSiteLaunchVercelTeamId(configuredTeamId) {
   return [
@@ -12,6 +16,12 @@ function resolveSiteLaunchVercelTeamId(configuredTeamId) {
     process.env.SITE_LAUNCH_VERCEL_TEAM_ID,
     DEFAULT_SITE_LAUNCH_VERCEL_TEAM_ID
   ].map(value => String(value || '').trim()).find(Boolean);
+}
+
+function delay(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
 }
 
 function parseProvider(req) {
@@ -252,12 +262,91 @@ function withVercelTeamScope(url, teamId) {
   return scopedUrl.toString();
 }
 
+function readVercelReadyState(deployment) {
+  return String(deployment?.readyState || '').trim().toUpperCase();
+}
+
+function toVercelDeploymentResult(deployment) {
+  return {
+    id: deployment.id,
+    url: deployment.url ? `https://${deployment.url}` : undefined,
+    inspectUrl: deployment.inspectUrl
+  };
+}
+
+async function fetchVercelDeploymentStatus({ token, deploymentId, teamId, fetchImpl = globalThis.fetch }) {
+  const url = withVercelTeamScope(
+    `https://api.vercel.com/v13/deployments/${encodeURIComponent(deploymentId)}`,
+    teamId
+  );
+  const response = await fetchImpl(url, {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Vercel deployment status error ${response.status}: ${errorText || 'Unknown error'}`);
+  }
+
+  return response.json();
+}
+
+async function waitForVercelDeploymentReady({
+  token,
+  deploymentId,
+  teamId,
+  initialDeployment,
+  fetchImpl = globalThis.fetch,
+  sleepImpl = delay,
+  timeoutMs = DEFAULT_VERCEL_READY_TIMEOUT_MS,
+  pollIntervalMs = DEFAULT_VERCEL_READY_POLL_INTERVAL_MS
+}) {
+  let latestDeployment = initialDeployment;
+  let readyState = readVercelReadyState(latestDeployment);
+
+  if (readyState === VERCEL_READY_STATE) {
+    return latestDeployment;
+  }
+
+  if (VERCEL_FAILED_READY_STATES.has(readyState)) {
+    throw new Error(`Vercel deployment ${deploymentId} ended with readyState ${readyState}; alias was not assigned.`);
+  }
+
+  const maxAttempts = Math.max(1, Math.ceil(timeoutMs / Math.max(pollIntervalMs, 1)));
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    await sleepImpl(pollIntervalMs);
+    latestDeployment = await fetchVercelDeploymentStatus({
+      token,
+      deploymentId,
+      teamId,
+      fetchImpl
+    });
+    readyState = readVercelReadyState(latestDeployment);
+
+    if (readyState === VERCEL_READY_STATE) {
+      return latestDeployment;
+    }
+
+    if (VERCEL_FAILED_READY_STATES.has(readyState)) {
+      throw new Error(`Vercel deployment ${deploymentId} ended with readyState ${readyState}; alias was not assigned.`);
+    }
+  }
+
+  throw new Error(`Vercel deployment ${deploymentId} was not READY within ${Math.ceil(timeoutMs / 1000)} seconds; alias was not assigned.`);
+}
+
 async function createVercelDeployment({
   token,
   projectName,
   html,
   launchDomain,
   teamId,
+  sleepImpl,
+  readyTimeoutMs,
+  readyPollIntervalMs,
   fetchImpl = globalThis.fetch
 }) {
   const files = [
@@ -295,13 +384,20 @@ async function createVercelDeployment({
   }
 
   const data = await response.json();
-  const result = {
-    id: data.id,
-    url: data.url ? `https://${data.url}` : undefined,
-    inspectUrl: data.inspectUrl
-  };
+  let deployment = data;
 
   if (launchDomain?.domain && data.id) {
+    deployment = await waitForVercelDeploymentReady({
+      token,
+      deploymentId: data.id,
+      teamId,
+      initialDeployment: data,
+      fetchImpl,
+      sleepImpl,
+      timeoutMs: readyTimeoutMs,
+      pollIntervalMs: readyPollIntervalMs
+    });
+
     const aliasResult = await assignVercelAlias({
       token,
       deploymentId: data.id,
@@ -311,21 +407,24 @@ async function createVercelDeployment({
     });
 
     return {
-      ...result,
+      ...toVercelDeploymentResult(deployment),
       ...aliasResult,
       subdomain: launchDomain.subdomain,
       baseDomain: launchDomain.baseDomain
     };
   }
 
-  return result;
+  return toVercelDeploymentResult(deployment);
 }
 
 export function createGithubPublishHandler(options = {}) {
   const {
     fetchImpl = globalThis.fetch,
+    sleepImpl = delay,
     vercelToken = process.env.VERCEL_TOKEN,
     vercelTeamId: configuredVercelTeamId,
+    vercelReadyTimeoutMs,
+    vercelReadyPollIntervalMs,
     siteLaunchBaseDomain = process.env.SITE_LAUNCH_BASE_DOMAIN
   } = options;
   const vercelTeamId = resolveSiteLaunchVercelTeamId(configuredVercelTeamId);
@@ -366,6 +465,9 @@ export function createGithubPublishHandler(options = {}) {
           html: body.html,
           launchDomain,
           teamId: vercelTeamId,
+          sleepImpl,
+          readyTimeoutMs: vercelReadyTimeoutMs,
+          readyPollIntervalMs: vercelReadyPollIntervalMs,
           fetchImpl
         });
 

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -292,7 +292,8 @@ test('vercel deploy provider can use server token and assign a 3dvr subdomain', 
             return {
               id: 'dpl_launch_123',
               url: '3dvr-river-city-wellness.vercel.app',
-              inspectUrl: 'https://vercel.com/example/launch/dpl_launch_123'
+              inspectUrl: 'https://vercel.com/example/launch/dpl_launch_123',
+              readyState: 'READY'
             };
           }
         };
@@ -340,6 +341,159 @@ test('vercel deploy provider can use server token and assign a 3dvr subdomain', 
   assert.deepEqual(JSON.parse(calls[1].options.body), {
     alias: 'river-city-wellness.3dvr.tech'
   });
+});
+
+test('vercel deploy provider waits for deployment readiness before aliasing', async () => {
+  const calls = [];
+  let statusPollCount = 0;
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    vercelTeamId: 'team_3dvr',
+    siteLaunchBaseDomain: '3dvr.tech',
+    vercelReadyTimeoutMs: 3,
+    vercelReadyPollIntervalMs: 1,
+    sleepImpl: async () => {},
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
+
+      if (String(url).includes('/v13/deployments') && options.method === 'POST') {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_launch_queued',
+              url: '3dvr-ready-test.vercel.app',
+              inspectUrl: 'https://vercel.com/example/launch/dpl_launch_queued',
+              readyState: 'BUILDING'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v13/deployments/dpl_launch_queued')) {
+        statusPollCount += 1;
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_launch_queued',
+              url: '3dvr-ready-test.vercel.app',
+              inspectUrl: 'https://vercel.com/example/launch/dpl_launch_queued',
+              readyState: statusPollCount === 1 ? 'BUILDING' : 'READY'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v2/deployments/dpl_launch_queued/aliases')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              alias: 'ready-test.3dvr.tech'
+            };
+          }
+        };
+      }
+
+      throw new Error(`Unexpected url ${url}`);
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-ready-test',
+      subdomain: 'ready-test',
+      html: '<html><body>deployment readiness test content</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.aliasAssigned, true);
+  assert.equal(res.body.aliasUrl, 'https://ready-test.3dvr.tech');
+  assert.equal(calls.length, 4);
+  assert.match(calls[0].url, /\/v13\/deployments\?teamId=team_3dvr$/);
+  assert.match(calls[1].url, /\/v13\/deployments\/dpl_launch_queued\?teamId=team_3dvr$/);
+  assert.match(calls[2].url, /\/v13\/deployments\/dpl_launch_queued\?teamId=team_3dvr$/);
+  assert.match(calls[3].url, /\/v2\/deployments\/dpl_launch_queued\/aliases\?teamId=team_3dvr$/);
+  assert.equal(calls[3].options.method, 'POST');
+});
+
+test('vercel deploy provider reports failed deployment readiness before aliasing', async () => {
+  const calls = [];
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    vercelTeamId: 'team_3dvr',
+    siteLaunchBaseDomain: '3dvr.tech',
+    vercelReadyTimeoutMs: 1,
+    vercelReadyPollIntervalMs: 1,
+    sleepImpl: async () => {},
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
+
+      if (String(url).includes('/v13/deployments') && options.method === 'POST') {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_launch_failed',
+              url: '3dvr-failed-test.vercel.app',
+              inspectUrl: 'https://vercel.com/example/launch/dpl_launch_failed',
+              readyState: 'BUILDING'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v13/deployments/dpl_launch_failed')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_launch_failed',
+              readyState: 'ERROR'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/aliases')) {
+        throw new Error('alias should not run for a failed deployment');
+      }
+
+      throw new Error(`Unexpected url ${url}`);
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-failed-test',
+      subdomain: 'failed-test',
+      html: '<html><body>deployment readiness failure content</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 500);
+  assert.match(res.body.error, /readyState ERROR/);
+  assert.equal(calls.length, 2);
+  assert.doesNotMatch(calls.map(call => call.url).join('\n'), /aliases/);
 });
 
 test('vercel deploy provider rejects reserved launch subdomains', async () => {


### PR DESCRIPTION
## Summary
- Poll the Vercel deployment status when a launch subdomain is requested.
- Assign the 3dvr.tech alias only after Vercel reports `readyState: READY`.
- Return a clearer error when a deployment reaches a failed state before aliasing.

## Validation
- `node --test tests/github-publish-api.test.js`
- `node --test tests/github-publish-api.test.js tests/site-launcher-page.test.js tests/web-builder-defaults.test.js tests/openai-site.test.js`
- `git diff --check`

## Live deploy note
- The production endpoint does not have `VERCEL_TOKEN` configured server-side; a real publish-button deploy still requires the browser shared-default token path.