### PR TITLE
Fallback when Vercel alias domain is missing

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -241,7 +241,17 @@ async function assignVercelAlias({ token, deploymentId, domain, teamId, fetchImp
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Vercel alias error ${response.status}: ${errorText || 'Unknown error'}`);
+    const error = new Error(`Vercel alias error ${response.status}: ${errorText || 'Unknown error'}`);
+    error.status = response.status;
+    try {
+      const parsed = JSON.parse(errorText);
+      error.code = parsed?.error?.code || parsed?.code || '';
+      error.details = parsed?.error || parsed;
+    } catch (parseError) {
+      error.code = '';
+      error.details = null;
+    }
+    throw error;
   }
 
   const data = await response.json();
@@ -249,6 +259,20 @@ async function assignVercelAlias({ token, deploymentId, domain, teamId, fetchImp
     alias: data.alias || domain,
     aliasUrl: `https://${data.alias || domain}`,
     aliasAssigned: true
+  };
+}
+
+function toVercelAliasFallback({ error, domain }) {
+  const code = String(error?.code || '').trim();
+  const message = error?.message || 'Vercel alias assignment failed.';
+  return {
+    alias: domain,
+    aliasUrl: null,
+    aliasAssigned: false,
+    aliasError: message,
+    aliasErrorCode: code || undefined,
+    aliasStatus: error?.status,
+    domainSetupUrl: code === 'domain_not_found' ? 'https://vercel.com/dashboard/domains' : undefined
   };
 }
 
@@ -398,13 +422,21 @@ async function createVercelDeployment({
       pollIntervalMs: readyPollIntervalMs
     });
 
-    const aliasResult = await assignVercelAlias({
-      token,
-      deploymentId: data.id,
-      domain: launchDomain.domain,
-      teamId,
-      fetchImpl
-    });
+    let aliasResult;
+    try {
+      aliasResult = await assignVercelAlias({
+        token,
+        deploymentId: data.id,
+        domain: launchDomain.domain,
+        teamId,
+        fetchImpl
+      });
+    } catch (error) {
+      aliasResult = toVercelAliasFallback({
+        error,
+        domain: launchDomain.domain
+      });
+    }
 
     return {
       ...toVercelDeploymentResult(deployment),

--- a/launch-site/app.js
+++ b/launch-site/app.js
@@ -292,7 +292,16 @@ async function publishSite() {
     const liveUrl = result.aliasUrl || result.url || result.inspectUrl;
     if (liveUrl) {
       publishResult.innerHTML = `Live: <a href="${escapeAttribute(liveUrl)}" target="_blank" rel="noopener">${escapeHtml(liveUrl)}</a>`;
-      setStatus('Published.', 'success');
+      if (result.aliasError) {
+        publishResult.innerHTML += [
+          '<span class="publish-note">',
+          `The 3dvr.tech address was not attached yet. ${escapeHtml(formatAliasError(result))}`,
+          '</span>'
+        ].join('');
+        setStatus('Published on Vercel. The 3dvr.tech address still needs domain setup.', 'warning');
+      } else {
+        setStatus('Published.', 'success');
+      }
     } else {
       setStatus('Published, but no live URL was returned.', 'warning');
     }
@@ -301,6 +310,14 @@ async function publishSite() {
   } finally {
     setBusy(false);
   }
+}
+
+function formatAliasError(result = {}) {
+  if (result.aliasErrorCode === 'domain_not_found') {
+    const domain = result.alias || `${collectFormState().slug}.3dvr.tech`;
+    return `${domain} is not available in the Vercel team yet.`;
+  }
+  return result.aliasError || 'Custom address setup failed.';
 }
 
 function setBusy(isBusy, operation = '') {

--- a/launch-site/styles.css
+++ b/launch-site/styles.css
@@ -252,6 +252,12 @@ button:disabled {
   font-weight: 800;
 }
 
+.publish-note {
+  display: block;
+  margin-top: 6px;
+  color: #ffe0a3;
+}
+
 @media (max-width: 860px) {
   .topbar {
     align-items: flex-start;

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -343,6 +343,74 @@ test('vercel deploy provider can use server token and assign a 3dvr subdomain', 
   });
 });
 
+test('vercel deploy provider returns deployment URL when custom domain is missing', async () => {
+  const calls = [];
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    vercelTeamId: 'team_3dvr',
+    siteLaunchBaseDomain: '3dvr.tech',
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
+
+      if (String(url).includes('/v13/deployments')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_missing_domain',
+              url: '3dvr-test.vercel.app',
+              inspectUrl: 'https://vercel.com/example/launch/dpl_missing_domain',
+              readyState: 'READY'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v2/deployments/dpl_missing_domain/aliases')) {
+        return {
+          ok: false,
+          status: 404,
+          async text() {
+            return JSON.stringify({
+              code: 'domain_not_found',
+              message: 'The domain "test.3dvr.tech" could not be found in your account.',
+              statusCode: 404
+            });
+          }
+        };
+      }
+
+      throw new Error(`Unexpected url ${url}`);
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-test',
+      subdomain: 'test',
+      html: '<html><body>deployment test content</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.aliasAssigned, false);
+  assert.equal(res.body.alias, 'test.3dvr.tech');
+  assert.equal(res.body.aliasUrl, null);
+  assert.equal(res.body.aliasErrorCode, 'domain_not_found');
+  assert.equal(res.body.aliasStatus, 404);
+  assert.equal(res.body.domainSetupUrl, 'https://vercel.com/dashboard/domains');
+  assert.match(res.body.aliasError, /Vercel alias error 404/);
+  assert.equal(res.body.url, 'https://3dvr-test.vercel.app');
+  assert.equal(calls.length, 2);
+});
+
 test('vercel deploy provider waits for deployment readiness before aliasing', async () => {
   const calls = [];
   let statusPollCount = 0;

--- a/tests/site-launcher-page.test.js
+++ b/tests/site-launcher-page.test.js
@@ -32,6 +32,9 @@ test('site launcher exposes the simple customer publishing flow', async () => {
   assert.match(app, /hasDefaultRecord\(data\)/);
   assert.match(app, /Generating\.\.\./);
   assert.match(app, /Creating the deployment in the 3dvr workspace/);
+  assert.match(app, /formatAliasError\(result\)/);
+  assert.match(app, /Published on Vercel\. The 3dvr\.tech address still needs domain setup\./);
+  assert.match(app, /domain_not_found/);
 
   assert.match(portalHome, /href="launch-site\/"/);
   assert.match(portalHome, />Launch Site</);


### PR DESCRIPTION
## Summary
- Preserve successful Vercel deployments when custom alias assignment fails.
- Return alias failure metadata for `domain_not_found` instead of failing the whole publish request.
- Show the working Vercel URL in Launch Site with a warning that the 3dvr.tech address still needs Vercel domain setup.

## Validation
- `node --test tests/github-publish-api.test.js tests/site-launcher-page.test.js tests/web-builder-defaults.test.js tests/openai-site.test.js`
- `git diff --check`

## Live deploy note
- The reported error proves deployment creation and readiness are now succeeding, but `test.3dvr.tech` is not available in the Vercel team/account used for aliasing. This PR lets the publish still return the deployment URL while that domain ownership/config is fixed.