### PR TITLE
Register Vercel domains before aliasing

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -9,6 +9,12 @@ const DEFAULT_VERCEL_READY_TIMEOUT_MS = 30_000;
 const DEFAULT_VERCEL_READY_POLL_INTERVAL_MS = 1_000;
 const VERCEL_READY_STATE = 'READY';
 const VERCEL_FAILED_READY_STATES = new Set(['ERROR', 'CANCELED']);
+const VERCEL_DOMAIN_EXISTS_CODES = new Set([
+  'domain_already_exists',
+  'domain_already_in_project',
+  'domain_already_in_use',
+  'domain_exists'
+]);
 
 function resolveSiteLaunchVercelTeamId(configuredTeamId) {
   return [
@@ -34,6 +40,31 @@ function parseProvider(req) {
     return fromBody;
   }
   return 'github';
+}
+
+function parseVercelErrorPayload(errorText) {
+  if (!errorText) {
+    return { code: '', details: null };
+  }
+
+  try {
+    const parsed = JSON.parse(errorText);
+    return {
+      code: parsed?.error?.code || parsed?.code || '',
+      details: parsed?.error || parsed
+    };
+  } catch (parseError) {
+    return { code: '', details: null };
+  }
+}
+
+function createVercelApiError(label, response, errorText) {
+  const { code, details } = parseVercelErrorPayload(errorText);
+  const error = new Error(`${label} ${response.status}: ${errorText || 'Unknown error'}`);
+  error.status = response.status;
+  error.code = code;
+  error.details = details;
+  return error;
 }
 
 function resolveGithubRepo(body = {}) {
@@ -125,11 +156,49 @@ export function sanitizeLaunchSubdomain(value) {
   return normalized;
 }
 
+export function sanitizeCustomDomain(value) {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/.*$/, '')
+    .replace(/^\.+|\.+$/g, '');
+
+  if (!normalized || normalized.length > 253 || !normalized.includes('.')) {
+    return '';
+  }
+
+  if (normalized.includes('..') || normalized.includes('*')) {
+    return '';
+  }
+
+  const labels = normalized.split('.');
+  if (labels.some(label => (
+    !label
+    || label.length > 63
+    || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+  ))) {
+    return '';
+  }
+
+  return normalized;
+}
+
 export function resolveLaunchDomain(body = {}, options = {}) {
   const baseDomain = String(options.baseDomain || process.env.SITE_LAUNCH_BASE_DOMAIN || '3dvr.tech')
     .trim()
     .toLowerCase()
     .replace(/^\.+|\.+$/g, '');
+
+  const customDomain = sanitizeCustomDomain(body.customDomain || body.domain);
+  if (customDomain) {
+    return {
+      subdomain: customDomain.split('.')[0],
+      domain: customDomain,
+      baseDomain: customDomain.split('.').slice(-2).join('.'),
+      customDomain: true
+    };
+  }
 
   const requestedSubdomain = body.subdomain || body.siteSlug || body.slug || body.alias;
   const subdomain = sanitizeLaunchSubdomain(requestedSubdomain);
@@ -241,17 +310,7 @@ async function assignVercelAlias({ token, deploymentId, domain, teamId, fetchImp
 
   if (!response.ok) {
     const errorText = await response.text();
-    const error = new Error(`Vercel alias error ${response.status}: ${errorText || 'Unknown error'}`);
-    error.status = response.status;
-    try {
-      const parsed = JSON.parse(errorText);
-      error.code = parsed?.error?.code || parsed?.code || '';
-      error.details = parsed?.error || parsed;
-    } catch (parseError) {
-      error.code = '';
-      error.details = null;
-    }
-    throw error;
+    throw createVercelApiError('Vercel alias error', response, errorText);
   }
 
   const data = await response.json();
@@ -259,6 +318,65 @@ async function assignVercelAlias({ token, deploymentId, domain, teamId, fetchImp
     alias: data.alias || domain,
     aliasUrl: `https://${data.alias || domain}`,
     aliasAssigned: true
+  };
+}
+
+function isVercelDomainExistsError(error) {
+  const code = String(error?.code || '').trim();
+  const message = String(error?.message || '').toLowerCase();
+  return VERCEL_DOMAIN_EXISTS_CODES.has(code)
+    || (message.includes('domain') && (
+      message.includes('already exists')
+      || message.includes('already added')
+      || message.includes('already in use')
+    ));
+}
+
+async function addVercelProjectDomain({
+  token,
+  projectName,
+  domain,
+  teamId,
+  fetchImpl = globalThis.fetch
+}) {
+  if (!domain || !projectName) {
+    return null;
+  }
+
+  const url = withVercelTeamScope(
+    `https://api.vercel.com/v10/projects/${encodeURIComponent(projectName)}/domains`,
+    teamId
+  );
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ name: domain })
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    const error = createVercelApiError('Vercel project domain error', response, errorText);
+    if (isVercelDomainExistsError(error)) {
+      return {
+        projectDomain: domain,
+        projectDomainAdded: false,
+        projectDomainReady: true,
+        projectDomainStatus: 'exists'
+      };
+    }
+    throw error;
+  }
+
+  const data = await response.json();
+  return {
+    projectDomain: data.name || domain,
+    projectDomainAdded: true,
+    projectDomainReady: data.verified !== false,
+    projectDomainVerified: data.verified,
+    projectDomainVerification: data.verification
   };
 }
 
@@ -272,7 +390,28 @@ function toVercelAliasFallback({ error, domain }) {
     aliasError: message,
     aliasErrorCode: code || undefined,
     aliasStatus: error?.status,
+    aliasDetails: error?.details || undefined,
     domainSetupUrl: code === 'domain_not_found' ? 'https://vercel.com/dashboard/domains' : undefined
+  };
+}
+
+function toVercelProjectDomainFallback({ error, domain }) {
+  const code = String(error?.code || '').trim();
+  const message = error?.message || 'Vercel project domain setup failed.';
+  return {
+    alias: domain,
+    aliasUrl: null,
+    aliasAssigned: false,
+    aliasError: message,
+    aliasErrorCode: code || undefined,
+    aliasStatus: error?.status,
+    aliasDetails: error?.details || undefined,
+    projectDomain: domain,
+    projectDomainAdded: false,
+    projectDomainReady: false,
+    projectDomainError: message,
+    projectDomainErrorCode: code || undefined,
+    domainSetupUrl: 'https://vercel.com/dashboard/domains'
   };
 }
 
@@ -373,6 +512,7 @@ async function createVercelDeployment({
   readyPollIntervalMs,
   fetchImpl = globalThis.fetch
 }) {
+  const sanitizedProjectName = sanitizeProjectName(projectName);
   const files = [
     { file: 'index.html', data: html },
     {
@@ -384,7 +524,7 @@ async function createVercelDeployment({
   ];
 
   const payload = {
-    name: sanitizeProjectName(projectName),
+    name: sanitizedProjectName,
     files,
     projectSettings: {
       framework: null
@@ -411,6 +551,7 @@ async function createVercelDeployment({
   let deployment = data;
 
   if (launchDomain?.domain && data.id) {
+    let projectDomainResult = null;
     deployment = await waitForVercelDeploymentReady({
       token,
       deploymentId: data.id,
@@ -421,6 +562,27 @@ async function createVercelDeployment({
       timeoutMs: readyTimeoutMs,
       pollIntervalMs: readyPollIntervalMs
     });
+
+    try {
+      projectDomainResult = await addVercelProjectDomain({
+        token,
+        projectName: sanitizedProjectName,
+        domain: launchDomain.domain,
+        teamId,
+        fetchImpl
+      });
+    } catch (error) {
+      return {
+        ...toVercelDeploymentResult(deployment),
+        ...toVercelProjectDomainFallback({
+          error,
+          domain: launchDomain.domain
+        }),
+        subdomain: launchDomain.subdomain,
+        baseDomain: launchDomain.baseDomain,
+        customDomain: launchDomain.customDomain || undefined
+      };
+    }
 
     let aliasResult;
     try {
@@ -440,9 +602,11 @@ async function createVercelDeployment({
 
     return {
       ...toVercelDeploymentResult(deployment),
+      ...projectDomainResult,
       ...aliasResult,
       subdomain: launchDomain.subdomain,
-      baseDomain: launchDomain.baseDomain
+      baseDomain: launchDomain.baseDomain,
+      customDomain: launchDomain.customDomain || undefined
     };
   }
 
@@ -483,12 +647,12 @@ export function createGithubPublishHandler(options = {}) {
 
       try {
         const token = body.token || vercelToken;
-        const launchDomain = body.subdomain || body.siteSlug || body.slug || body.alias
+        const launchDomain = body.customDomain || body.domain || body.subdomain || body.siteSlug || body.slug || body.alias
           ? resolveLaunchDomain(body, { baseDomain: siteLaunchBaseDomain })
           : null;
 
-        if ((body.subdomain || body.siteSlug || body.slug || body.alias) && !launchDomain) {
-          return res.status(400).json({ error: 'Choose a valid, available 3dvr.tech subdomain.' });
+        if ((body.customDomain || body.domain || body.subdomain || body.siteSlug || body.slug || body.alias) && !launchDomain) {
+          return res.status(400).json({ error: 'Choose a valid launch address or custom domain.' });
         }
 
         const result = await createVercelDeployment({

--- a/launch-site/app.js
+++ b/launch-site/app.js
@@ -10,6 +10,7 @@ const audienceInput = document.getElementById('site-audience');
 const actionInput = document.getElementById('site-action');
 const styleInput = document.getElementById('site-style');
 const slugInput = document.getElementById('site-slug');
+const customDomainInput = document.getElementById('custom-domain');
 const notesInput = document.getElementById('site-notes');
 const revisionInput = document.getElementById('revision-request');
 const generateButton = document.getElementById('generate-site');
@@ -76,6 +77,7 @@ function collectFormState() {
     action: actionInput.value.trim(),
     style: styleInput.value,
     slug: sanitizeSlug(slugInput.value),
+    customDomain: sanitizeCustomDomain(customDomainInput.value),
     notes: notesInput.value.trim()
   };
 }
@@ -88,6 +90,30 @@ function sanitizeSlug(value) {
     .replace(/^-+|-+$/g, '')
     .replace(/-{2,}/g, '-')
     .slice(0, 48);
+}
+
+function sanitizeCustomDomain(value) {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/.*$/, '')
+    .replace(/^\.+|\.+$/g, '');
+
+  if (!normalized || !normalized.includes('.') || normalized.includes('..') || normalized.includes('*')) {
+    return '';
+  }
+
+  const labels = normalized.split('.');
+  if (labels.some(label => (
+    !label
+    || label.length > 63
+    || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+  ))) {
+    return '';
+  }
+
+  return normalized;
 }
 
 function subscribeToSharedDefaults() {
@@ -265,7 +291,8 @@ async function publishSite() {
   }
 
   setBusy(true, 'publish');
-  setStatus(`Publishing ${state.slug}.3dvr.tech...`, 'info');
+  const launchAddress = state.customDomain || `${state.slug}.3dvr.tech`;
+  setStatus(`Publishing ${launchAddress}...`, 'info');
   publishResult.innerHTML = '';
 
   try {
@@ -277,6 +304,7 @@ async function publishSite() {
       body: JSON.stringify({
         projectName: `3dvr-${state.slug}`,
         subdomain: state.slug,
+        ...(state.customDomain ? { customDomain: state.customDomain } : {}),
         html: currentHtml,
         title: currentTitle,
         ...(sharedSecrets.vercel ? { token: sharedSecrets.vercel } : {})
@@ -386,6 +414,7 @@ function hydrateStoredDraft() {
     actionInput.value = formState.action || '';
     styleInput.value = formState.style || styleInput.value;
     slugInput.value = formState.slug || '';
+    customDomainInput.value = formState.customDomain || '';
     notesInput.value = formState.notes || '';
 
     previewTitle.textContent = currentTitle;

--- a/launch-site/index.html
+++ b/launch-site/index.html
@@ -58,6 +58,10 @@
               <span>.3dvr.tech</span>
             </span>
           </label>
+          <label for="custom-domain">Custom domain
+            <input id="custom-domain" name="customDomain" type="text" inputmode="url" autocomplete="url"
+              placeholder="launch.example.com">
+          </label>
         </div>
 
         <label for="site-notes">Details</label>

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   createGithubPublishHandler,
   resolveLaunchDomain,
+  sanitizeCustomDomain,
   sanitizeLaunchSubdomain
 } from '../api/github-publish.js';
 
@@ -275,6 +276,24 @@ test('resolveLaunchDomain limits aliases to the configured launch domain', () =>
   );
 });
 
+test('sanitizeCustomDomain normalizes full customer domains', () => {
+  assert.equal(sanitizeCustomDomain(' https://WWW.Example.com/path '), 'www.example.com');
+  assert.equal(sanitizeCustomDomain('example'), '');
+  assert.equal(sanitizeCustomDomain('bad domain.com'), '');
+});
+
+test('resolveLaunchDomain supports explicit custom domains', () => {
+  assert.deepEqual(
+    resolveLaunchDomain({ customDomain: 'Launch.CustomerSite.com' }, { baseDomain: '3dvr.tech' }),
+    {
+      subdomain: 'launch',
+      domain: 'launch.customersite.com',
+      baseDomain: 'customersite.com',
+      customDomain: true
+    }
+  );
+});
+
 test('vercel deploy provider can use server token and assign a 3dvr subdomain', async () => {
   const calls = [];
   const handler = createGithubPublishHandler({
@@ -294,6 +313,19 @@ test('vercel deploy provider can use server token and assign a 3dvr subdomain', 
               url: '3dvr-river-city-wellness.vercel.app',
               inspectUrl: 'https://vercel.com/example/launch/dpl_launch_123',
               readyState: 'READY'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v10/projects/3dvr-river-city-wellness/domains')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              name: 'river-city-wellness.3dvr.tech',
+              verified: true
             };
           }
         };
@@ -333,12 +365,19 @@ test('vercel deploy provider can use server token and assign a 3dvr subdomain', 
   assert.equal(res.body.aliasAssigned, true);
   assert.equal(res.body.aliasUrl, 'https://river-city-wellness.3dvr.tech');
   assert.equal(res.body.url, 'https://3dvr-river-city-wellness.vercel.app');
-  assert.equal(calls.length, 2);
+  assert.equal(res.body.projectDomainAdded, true);
+  assert.equal(res.body.projectDomainReady, true);
+  assert.equal(calls.length, 3);
   assert.match(calls[0].url, /\/v13\/deployments\?teamId=team_3dvr$/);
-  assert.match(calls[1].url, /\/v2\/deployments\/dpl_launch_123\/aliases\?teamId=team_3dvr$/);
+  assert.match(calls[1].url, /\/v10\/projects\/3dvr-river-city-wellness\/domains\?teamId=team_3dvr$/);
+  assert.match(calls[2].url, /\/v2\/deployments\/dpl_launch_123\/aliases\?teamId=team_3dvr$/);
   assert.equal(calls[0].options.headers.Authorization, 'Bearer server_vercel_token');
   assert.equal(calls[1].options.headers.Authorization, 'Bearer server_vercel_token');
+  assert.equal(calls[2].options.headers.Authorization, 'Bearer server_vercel_token');
   assert.deepEqual(JSON.parse(calls[1].options.body), {
+    name: 'river-city-wellness.3dvr.tech'
+  });
+  assert.deepEqual(JSON.parse(calls[2].options.body), {
     alias: 'river-city-wellness.3dvr.tech'
   });
 });
@@ -362,6 +401,19 @@ test('vercel deploy provider returns deployment URL when custom domain is missin
               url: '3dvr-test.vercel.app',
               inspectUrl: 'https://vercel.com/example/launch/dpl_missing_domain',
               readyState: 'READY'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v10/projects/3dvr-test/domains')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              name: 'test.3dvr.tech',
+              verified: true
             };
           }
         };
@@ -408,6 +460,78 @@ test('vercel deploy provider returns deployment URL when custom domain is missin
   assert.equal(res.body.domainSetupUrl, 'https://vercel.com/dashboard/domains');
   assert.match(res.body.aliasError, /Vercel alias error 404/);
   assert.equal(res.body.url, 'https://3dvr-test.vercel.app');
+  assert.equal(res.body.projectDomainAdded, true);
+  assert.equal(calls.length, 3);
+});
+
+test('vercel deploy provider reports custom domain setup failures with deployment URL', async () => {
+  const calls = [];
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    vercelTeamId: 'team_3dvr',
+    siteLaunchBaseDomain: '3dvr.tech',
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
+
+      if (String(url).includes('/v13/deployments')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_custom_domain',
+              url: '3dvr-customer-site.vercel.app',
+              inspectUrl: 'https://vercel.com/example/launch/dpl_custom_domain',
+              readyState: 'READY'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v10/projects/3dvr-customer-site/domains')) {
+        return {
+          ok: false,
+          status: 400,
+          async text() {
+            return JSON.stringify({
+              code: 'domain_not_verified',
+              message: 'Domain ownership must be verified before use.',
+              statusCode: 400
+            });
+          }
+        };
+      }
+
+      if (String(url).includes('/aliases')) {
+        throw new Error('alias should not run when project domain setup fails');
+      }
+
+      throw new Error(`Unexpected url ${url}`);
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-customer-site',
+      customDomain: 'launch.customer-site.com',
+      html: '<html><body>custom domain setup test content</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.aliasAssigned, false);
+  assert.equal(res.body.customDomain, true);
+  assert.equal(res.body.alias, 'launch.customer-site.com');
+  assert.equal(res.body.aliasErrorCode, 'domain_not_verified');
+  assert.equal(res.body.projectDomainAdded, false);
+  assert.equal(res.body.projectDomainReady, false);
+  assert.equal(res.body.url, 'https://3dvr-customer-site.vercel.app');
   assert.equal(calls.length, 2);
 });
 
@@ -455,6 +579,19 @@ test('vercel deploy provider waits for deployment readiness before aliasing', as
         };
       }
 
+      if (String(url).includes('/v10/projects/3dvr-ready-test/domains')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              name: 'ready-test.3dvr.tech',
+              verified: true
+            };
+          }
+        };
+      }
+
       if (String(url).includes('/v2/deployments/dpl_launch_queued/aliases')) {
         return {
           ok: true,
@@ -488,12 +625,13 @@ test('vercel deploy provider waits for deployment readiness before aliasing', as
   assert.equal(res.statusCode, 200);
   assert.equal(res.body.aliasAssigned, true);
   assert.equal(res.body.aliasUrl, 'https://ready-test.3dvr.tech');
-  assert.equal(calls.length, 4);
+  assert.equal(calls.length, 5);
   assert.match(calls[0].url, /\/v13\/deployments\?teamId=team_3dvr$/);
   assert.match(calls[1].url, /\/v13\/deployments\/dpl_launch_queued\?teamId=team_3dvr$/);
   assert.match(calls[2].url, /\/v13\/deployments\/dpl_launch_queued\?teamId=team_3dvr$/);
-  assert.match(calls[3].url, /\/v2\/deployments\/dpl_launch_queued\/aliases\?teamId=team_3dvr$/);
-  assert.equal(calls[3].options.method, 'POST');
+  assert.match(calls[3].url, /\/v10\/projects\/3dvr-ready-test\/domains\?teamId=team_3dvr$/);
+  assert.match(calls[4].url, /\/v2\/deployments\/dpl_launch_queued\/aliases\?teamId=team_3dvr$/);
+  assert.equal(calls[4].options.method, 'POST');
 });
 
 test('vercel deploy provider reports failed deployment readiness before aliasing', async () => {
@@ -587,5 +725,5 @@ test('vercel deploy provider rejects reserved launch subdomains', async () => {
   await handler(req, res);
 
   assert.equal(res.statusCode, 400);
-  assert.match(res.body.error, /valid, available/);
+  assert.match(res.body.error, /valid launch address or custom domain/);
 });

--- a/tests/site-launcher-page.test.js
+++ b/tests/site-launcher-page.test.js
@@ -11,6 +11,7 @@ test('site launcher exposes the simple customer publishing flow', async () => {
   assert.match(html, /id="business-name"/);
   assert.match(html, /id="site-purpose"/);
   assert.match(html, /id="site-slug"/);
+  assert.match(html, /id="custom-domain"/);
   assert.match(html, /id="publish-site"/);
   assert.match(html, /id="revision-request"[\s\S]*id="publish-site"/);
   assert.doesNotMatch(html, /class="preview-header"[\s\S]*id="publish-site"[\s\S]*<\/div>\s*<iframe/);
@@ -25,6 +26,8 @@ test('site launcher exposes the simple customer publishing flow', async () => {
   assert.match(app, /fetch\('\/api\/openai-site'/);
   assert.match(app, /fetch\('\/api\/vercel-deploy'/);
   assert.match(app, /subdomain: state\.slug/);
+  assert.match(app, /customDomain: state\.customDomain/);
+  assert.match(app, /sanitizeCustomDomain\(customDomainInput\.value\)/);
   assert.match(app, /readDefaultSecret\(data, 'openai'\)/);
   assert.match(app, /readDefaultSecret\(data, 'vercel'\)/);
   assert.match(app, /waitForSharedSecret\('openai'/);


### PR DESCRIPTION
## Summary
- Add the requested launch/custom domain to the generated Vercel project before assigning the deployment alias.
- Support full custom domains via an optional Launch Site field while keeping the existing `slug.3dvr.tech` flow.
- Return setup metadata with the deployment URL when Vercel requires domain verification or setup.

## Validation
- `node --test tests/github-publish-api.test.js tests/site-launcher-page.test.js tests/web-builder-defaults.test.js tests/openai-site.test.js`
- `git diff --check`

## Notes
- This follows Vercel's project-domain flow: add the domain to the project, then alias the ready deployment. If Vercel still requires DNS/ownership verification, the launcher keeps the working `.vercel.app` URL and reports the setup state.