### PR TITLE
Verify Vercel project domains before aliasing

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -374,9 +374,44 @@ async function addVercelProjectDomain({
   return {
     projectDomain: data.name || domain,
     projectDomainAdded: true,
+    projectDomainStatus: data.verified === false ? 'pending' : 'added',
     projectDomainReady: data.verified !== false,
     projectDomainVerified: data.verified,
     projectDomainVerification: data.verification
+  };
+}
+
+async function verifyVercelProjectDomain({
+  token,
+  projectName,
+  domain,
+  teamId,
+  fetchImpl = globalThis.fetch
+}) {
+  const url = withVercelTeamScope(
+    `https://api.vercel.com/v9/projects/${encodeURIComponent(projectName)}/domains/${encodeURIComponent(domain)}/verify`,
+    teamId
+  );
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw createVercelApiError('Vercel project domain verify error', response, errorText);
+  }
+
+  const data = await response.json();
+  return {
+    projectDomain: data.name || domain,
+    projectDomainReady: data.verified !== false,
+    projectDomainVerified: data.verified,
+    projectDomainVerification: data.verification,
+    projectDomainStatus: data.verified === false ? 'pending' : 'verified'
   };
 }
 
@@ -392,6 +427,29 @@ function toVercelAliasFallback({ error, domain }) {
     aliasStatus: error?.status,
     aliasDetails: error?.details || undefined,
     domainSetupUrl: code === 'domain_not_found' ? 'https://vercel.com/dashboard/domains' : undefined
+  };
+}
+
+function toVercelUnverifiedDomainFallback({ domain, projectDomainResult, error }) {
+  const code = String(error?.code || '').trim() || 'domain_not_verified';
+  const message = error?.message || `Vercel project domain ${domain} is not verified yet.`;
+  return {
+    alias: domain,
+    aliasUrl: null,
+    aliasAssigned: false,
+    aliasError: message,
+    aliasErrorCode: code,
+    aliasStatus: error?.status,
+    aliasDetails: error?.details || undefined,
+    projectDomain: projectDomainResult?.projectDomain || domain,
+    projectDomainAdded: projectDomainResult?.projectDomainAdded,
+    projectDomainReady: false,
+    projectDomainVerified: false,
+    projectDomainVerification: error?.details?.verification || projectDomainResult?.projectDomainVerification,
+    projectDomainStatus: 'pending',
+    projectDomainError: message,
+    projectDomainErrorCode: code,
+    domainSetupUrl: 'https://vercel.com/dashboard/domains'
   };
 }
 
@@ -577,6 +635,47 @@ async function createVercelDeployment({
         ...toVercelProjectDomainFallback({
           error,
           domain: launchDomain.domain
+        }),
+        subdomain: launchDomain.subdomain,
+        baseDomain: launchDomain.baseDomain,
+        customDomain: launchDomain.customDomain || undefined
+      };
+    }
+
+    if (projectDomainResult?.projectDomainReady === false) {
+      try {
+        const verifiedDomainResult = await verifyVercelProjectDomain({
+          token,
+          projectName: sanitizedProjectName,
+          domain: launchDomain.domain,
+          teamId,
+          fetchImpl
+        });
+        projectDomainResult = {
+          ...projectDomainResult,
+          ...verifiedDomainResult
+        };
+      } catch (error) {
+        return {
+          ...toVercelDeploymentResult(deployment),
+          ...toVercelUnverifiedDomainFallback({
+            domain: launchDomain.domain,
+            projectDomainResult,
+            error
+          }),
+          subdomain: launchDomain.subdomain,
+          baseDomain: launchDomain.baseDomain,
+          customDomain: launchDomain.customDomain || undefined
+        };
+      }
+    }
+
+    if (projectDomainResult?.projectDomainReady === false) {
+      return {
+        ...toVercelDeploymentResult(deployment),
+        ...toVercelUnverifiedDomainFallback({
+          domain: launchDomain.domain,
+          projectDomainResult
         }),
         subdomain: launchDomain.subdomain,
         baseDomain: launchDomain.baseDomain,

--- a/launch-site/app.js
+++ b/launch-site/app.js
@@ -323,10 +323,10 @@ async function publishSite() {
       if (result.aliasError) {
         publishResult.innerHTML += [
           '<span class="publish-note">',
-          `The 3dvr.tech address was not attached yet. ${escapeHtml(formatAliasError(result))}`,
+          `The custom address was not attached yet. ${escapeHtml(formatAliasError(result))}`,
           '</span>'
         ].join('');
-        setStatus('Published on Vercel. The 3dvr.tech address still needs domain setup.', 'warning');
+        setStatus('Published on Vercel. The custom address still needs domain setup.', 'warning');
       } else {
         setStatus('Published.', 'success');
       }

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -535,6 +535,99 @@ test('vercel deploy provider reports custom domain setup failures with deploymen
   assert.equal(calls.length, 2);
 });
 
+test('vercel deploy provider verifies project domains before aliasing', async () => {
+  const calls = [];
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    vercelTeamId: 'team_3dvr',
+    siteLaunchBaseDomain: '3dvr.tech',
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
+
+      if (String(url).includes('/v13/deployments')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_unverified_domain',
+              url: '3dvr-test.vercel.app',
+              inspectUrl: 'https://vercel.com/example/launch/dpl_unverified_domain',
+              readyState: 'READY'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v10/projects/3dvr-test/domains')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              name: 'test.3dvr.tech',
+              verified: false,
+              verification: [{ type: 'TXT', domain: '_vercel.test.3dvr.tech', value: 'vc-domain-verify=test' }]
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v9/projects/3dvr-test/domains/test.3dvr.tech/verify')) {
+        return {
+          ok: false,
+          status: 400,
+          async text() {
+            return JSON.stringify({
+              error: {
+                code: 'domain_not_verified',
+                message: 'The domain test.3dvr.tech is not verified and cannot be used as an alias',
+                verification: [{ type: 'TXT', domain: '_vercel.test.3dvr.tech', value: 'vc-domain-verify=test' }]
+              }
+            });
+          }
+        };
+      }
+
+      if (String(url).includes('/aliases')) {
+        throw new Error('alias should not run when project domain verification fails');
+      }
+
+      throw new Error(`Unexpected url ${url}`);
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-test',
+      subdomain: 'test',
+      html: '<html><body>domain verification test content</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.aliasAssigned, false);
+  assert.equal(res.body.alias, 'test.3dvr.tech');
+  assert.equal(res.body.aliasErrorCode, 'domain_not_verified');
+  assert.equal(res.body.projectDomainAdded, true);
+  assert.equal(res.body.projectDomainReady, false);
+  assert.equal(res.body.projectDomainStatus, 'pending');
+  assert.deepEqual(res.body.projectDomainVerification, [
+    { type: 'TXT', domain: '_vercel.test.3dvr.tech', value: 'vc-domain-verify=test' }
+  ]);
+  assert.equal(res.body.url, 'https://3dvr-test.vercel.app');
+  assert.equal(calls.length, 3);
+  assert.match(calls[0].url, /\/v13\/deployments\?teamId=team_3dvr$/);
+  assert.match(calls[1].url, /\/v10\/projects\/3dvr-test\/domains\?teamId=team_3dvr$/);
+  assert.match(calls[2].url, /\/v9\/projects\/3dvr-test\/domains\/test\.3dvr\.tech\/verify\?teamId=team_3dvr$/);
+});
+
 test('vercel deploy provider waits for deployment readiness before aliasing', async () => {
   const calls = [];
   let statusPollCount = 0;

--- a/tests/site-launcher-page.test.js
+++ b/tests/site-launcher-page.test.js
@@ -36,7 +36,7 @@ test('site launcher exposes the simple customer publishing flow', async () => {
   assert.match(app, /Generating\.\.\./);
   assert.match(app, /Creating the deployment in the 3dvr workspace/);
   assert.match(app, /formatAliasError\(result\)/);
-  assert.match(app, /Published on Vercel\. The 3dvr\.tech address still needs domain setup\./);
+  assert.match(app, /Published on Vercel\. The custom address still needs domain setup\./);
   assert.match(app, /domain_not_found/);
 
   assert.match(portalHome, /href="launch-site\/"/);


### PR DESCRIPTION
## Summary
- Call Vercel's project-domain verify endpoint when a project domain is added but not yet verified.
- Skip deployment aliasing when verification is still pending, returning the working `.vercel.app` URL and verification metadata instead of surfacing the alias 400.
- Update Launch Site warning copy to refer to the custom address generically.

## Validation
- `node --test tests/github-publish-api.test.js tests/site-launcher-page.test.js tests/web-builder-defaults.test.js tests/openai-site.test.js`
- `git diff --check`

## Notes
- This directly handles `domain_not_verified` from Vercel before the alias step. If DNS/ownership is still pending, the UI should keep the deployment URL and report setup state rather than failing the publish.