### PR TITLE
Show Vercel DNS verification records

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -67,6 +67,20 @@ function createVercelApiError(label, response, errorText) {
   return error;
 }
 
+function extractVercelVerificationFromMessage(message) {
+  const text = String(message || '');
+  const match = text.match(/Domain\s+([^\s]+)\s+is\s+missing\s+required\s+([A-Z]+)\s+Record\s+"([^"]+)"/i);
+  if (!match) {
+    return undefined;
+  }
+
+  return [{
+    type: match[2].toUpperCase(),
+    domain: match[1],
+    value: match[3]
+  }];
+}
+
 function resolveGithubRepo(body = {}) {
   const explicit = String(body.repo || '').trim();
   if (explicit && explicit.includes('/')) {
@@ -433,6 +447,9 @@ function toVercelAliasFallback({ error, domain }) {
 function toVercelUnverifiedDomainFallback({ domain, projectDomainResult, error }) {
   const code = String(error?.code || '').trim() || 'domain_not_verified';
   const message = error?.message || `Vercel project domain ${domain} is not verified yet.`;
+  const verification = error?.details?.verification
+    || extractVercelVerificationFromMessage(error?.details?.message || error?.message)
+    || projectDomainResult?.projectDomainVerification;
   return {
     alias: domain,
     aliasUrl: null,
@@ -445,7 +462,7 @@ function toVercelUnverifiedDomainFallback({ domain, projectDomainResult, error }
     projectDomainAdded: projectDomainResult?.projectDomainAdded,
     projectDomainReady: false,
     projectDomainVerified: false,
-    projectDomainVerification: error?.details?.verification || projectDomainResult?.projectDomainVerification,
+    projectDomainVerification: verification,
     projectDomainStatus: 'pending',
     projectDomainError: message,
     projectDomainErrorCode: code,

--- a/launch-site/app.js
+++ b/launch-site/app.js
@@ -341,9 +341,19 @@ async function publishSite() {
 }
 
 function formatAliasError(result = {}) {
+  const verification = Array.isArray(result.projectDomainVerification)
+    ? result.projectDomainVerification.find(record => record?.type && record?.domain && record?.value)
+    : null;
+  if (verification) {
+    return `Add a ${verification.type} record for ${verification.domain} with value ${verification.value}, then publish again.`;
+  }
   if (result.aliasErrorCode === 'domain_not_found') {
     const domain = result.alias || `${collectFormState().slug}.3dvr.tech`;
     return `${domain} is not available in the Vercel team yet.`;
+  }
+  if (result.aliasErrorCode === 'missing_txt_record' || result.aliasErrorCode === 'domain_not_verified') {
+    const domain = result.alias || `${collectFormState().slug}.3dvr.tech`;
+    return `${domain} needs DNS verification before it can be attached.`;
   }
   return result.aliasError || 'Custom address setup failed.';
 }

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -580,9 +580,8 @@ test('vercel deploy provider verifies project domains before aliasing', async ()
           async text() {
             return JSON.stringify({
               error: {
-                code: 'domain_not_verified',
-                message: 'The domain test.3dvr.tech is not verified and cannot be used as an alias',
-                verification: [{ type: 'TXT', domain: '_vercel.test.3dvr.tech', value: 'vc-domain-verify=test' }]
+                code: 'missing_txt_record',
+                message: 'Domain _vercel.3dvr.tech is missing required TXT Record "vc-domain-verify=test.3dvr.tech,b1983a19514666902356"'
               }
             });
           }
@@ -614,12 +613,12 @@ test('vercel deploy provider verifies project domains before aliasing', async ()
   assert.equal(res.statusCode, 200);
   assert.equal(res.body.aliasAssigned, false);
   assert.equal(res.body.alias, 'test.3dvr.tech');
-  assert.equal(res.body.aliasErrorCode, 'domain_not_verified');
+  assert.equal(res.body.aliasErrorCode, 'missing_txt_record');
   assert.equal(res.body.projectDomainAdded, true);
   assert.equal(res.body.projectDomainReady, false);
   assert.equal(res.body.projectDomainStatus, 'pending');
   assert.deepEqual(res.body.projectDomainVerification, [
-    { type: 'TXT', domain: '_vercel.test.3dvr.tech', value: 'vc-domain-verify=test' }
+    { type: 'TXT', domain: '_vercel.3dvr.tech', value: 'vc-domain-verify=test.3dvr.tech,b1983a19514666902356' }
   ]);
   assert.equal(res.body.url, 'https://3dvr-test.vercel.app');
   assert.equal(calls.length, 3);

--- a/tests/site-launcher-page.test.js
+++ b/tests/site-launcher-page.test.js
@@ -38,6 +38,8 @@ test('site launcher exposes the simple customer publishing flow', async () => {
   assert.match(app, /formatAliasError\(result\)/);
   assert.match(app, /Published on Vercel\. The custom address still needs domain setup\./);
   assert.match(app, /domain_not_found/);
+  assert.match(app, /missing_txt_record/);
+  assert.match(app, /Add a \$\{verification\.type\} record/);
 
   assert.match(portalHome, /href="launch-site\/"/);
   assert.match(portalHome, />Launch Site</);


### PR DESCRIPTION
## Summary
- Parse Vercel `missing_txt_record` verification responses into structured DNS record metadata.
- Prefer the latest verify-endpoint TXT record over stale project-domain verification data.
- Show a concise Launch Site instruction like `Add a TXT record for _vercel.3dvr.tech...` instead of raw Vercel JSON.

## Validation
- `node --test tests/github-publish-api.test.js tests/site-launcher-page.test.js tests/web-builder-defaults.test.js tests/openai-site.test.js`
- `git diff --check`

## Production test path
- Once this lands, the production workflow should publish the `.vercel.app` URL and show the exact DNS TXT record required for the custom address. To let Codex run the full production workflow directly, configure a server-side `VERCEL_TOKEN` on the production Vercel project or provide a temporary token through a secure channel.