### PR TITLE
[codex] Poll Vercel domain verification after DNS

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -8,7 +8,8 @@ const DEFAULT_SITE_LAUNCH_VERCEL_TEAM_ID = 'team_KXuVUd00RMnDsjoqwdREcZ7J';
 const DEFAULT_SITE_LAUNCH_VERCEL_DNS_TEAM_ID = 'team_xxJGO7S7h1ZP4BHidYV0CX9Z';
 const DEFAULT_VERCEL_READY_TIMEOUT_MS = 30_000;
 const DEFAULT_VERCEL_READY_POLL_INTERVAL_MS = 1_000;
-const DEFAULT_VERCEL_DNS_VERIFY_RETRY_DELAY_MS = 1_000;
+const DEFAULT_VERCEL_DNS_VERIFY_RETRY_DELAY_MS = 2_000;
+const DEFAULT_VERCEL_DNS_VERIFY_MAX_ATTEMPTS = 5;
 const VERCEL_READY_STATE = 'READY';
 const VERCEL_FAILED_READY_STATES = new Set(['ERROR', 'CANCELED']);
 const VERCEL_DOMAIN_EXISTS_CODES = new Set([
@@ -588,7 +589,8 @@ async function verifyVercelProjectDomainWithDnsRetry({
   projectDomainResult,
   fetchImpl = globalThis.fetch,
   sleepImpl = delay,
-  retryDelayMs = DEFAULT_VERCEL_DNS_VERIFY_RETRY_DELAY_MS
+  retryDelayMs = DEFAULT_VERCEL_DNS_VERIFY_RETRY_DELAY_MS,
+  retryAttempts = DEFAULT_VERCEL_DNS_VERIFY_MAX_ATTEMPTS
 }) {
   try {
     return await verifyVercelProjectDomain({
@@ -624,22 +626,38 @@ async function verifyVercelProjectDomainWithDnsRetry({
       throw error;
     }
 
-    if (retryDelayMs > 0) {
-      await sleepImpl(retryDelayMs);
+    const maxAttempts = Math.max(1, Number(retryAttempts) || DEFAULT_VERCEL_DNS_VERIFY_MAX_ATTEMPTS);
+    let retryError = null;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      if (retryDelayMs > 0) {
+        await sleepImpl(retryDelayMs);
+      }
+
+      try {
+        const verifiedDomainResult = await verifyVercelProjectDomain({
+          token,
+          projectName,
+          domain,
+          teamId,
+          fetchImpl
+        });
+
+        return {
+          ...verifiedDomainResult,
+          ...dnsResult
+        };
+      } catch (nextError) {
+        retryError = nextError;
+      }
     }
 
-    const verifiedDomainResult = await verifyVercelProjectDomain({
-      token,
-      projectName,
-      domain,
-      teamId,
-      fetchImpl
-    });
-
-    return {
-      ...verifiedDomainResult,
-      ...dnsResult
+    retryError.dnsVerificationResult = dnsResult;
+    retryError.details = {
+      ...(retryError.details || {}),
+      verification: normalizeVercelVerificationRecords(verification)
     };
+    throw retryError;
   }
 }
 
@@ -677,6 +695,7 @@ function toVercelUnverifiedDomainFallback({ domain, projectDomainResult, error }
     projectDomainReady: false,
     projectDomainVerified: false,
     projectDomainVerification: verification,
+    ...(error?.dnsVerificationResult || {}),
     projectDomainStatus: 'pending',
     projectDomainError: message,
     projectDomainErrorCode: code,
@@ -801,6 +820,7 @@ async function createVercelDeployment({
   readyTimeoutMs,
   readyPollIntervalMs,
   dnsVerifyRetryDelayMs,
+  dnsVerifyRetryAttempts,
   fetchImpl = globalThis.fetch
 }) {
   const sanitizedProjectName = sanitizeProjectName(projectName);
@@ -887,7 +907,8 @@ async function createVercelDeployment({
           projectDomainResult,
           fetchImpl,
           sleepImpl,
-          retryDelayMs: dnsVerifyRetryDelayMs
+          retryDelayMs: dnsVerifyRetryDelayMs,
+          retryAttempts: dnsVerifyRetryAttempts
         });
         projectDomainResult = {
           ...projectDomainResult,
@@ -960,6 +981,7 @@ export function createGithubPublishHandler(options = {}) {
     vercelReadyTimeoutMs,
     vercelReadyPollIntervalMs,
     vercelDnsVerifyRetryDelayMs,
+    vercelDnsVerifyRetryAttempts,
     siteLaunchBaseDomain = process.env.SITE_LAUNCH_BASE_DOMAIN
   } = options;
   const vercelTeamId = resolveSiteLaunchVercelTeamId(configuredVercelTeamId);
@@ -1006,6 +1028,7 @@ export function createGithubPublishHandler(options = {}) {
           readyTimeoutMs: vercelReadyTimeoutMs,
           readyPollIntervalMs: vercelReadyPollIntervalMs,
           dnsVerifyRetryDelayMs: vercelDnsVerifyRetryDelayMs,
+          dnsVerifyRetryAttempts: vercelDnsVerifyRetryAttempts,
           fetchImpl
         });
 

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -679,7 +679,7 @@ test('vercel deploy provider adds DNS verification records before retrying custo
 
       if (String(url).includes('/v9/projects/3dvr-test/domains/test.3dvr.tech/verify')) {
         verifyCount += 1;
-        if (verifyCount === 1) {
+        if (verifyCount <= 2) {
           return {
             ok: false,
             status: 400,
@@ -764,13 +764,14 @@ test('vercel deploy provider adds DNS verification records before retrying custo
       status: 'added'
     }
   ]);
-  assert.equal(calls.length, 6);
+  assert.equal(calls.length, 7);
   assert.match(calls[0].url, /\/v13\/deployments\?teamId=team_3dvr$/);
   assert.match(calls[1].url, /\/v10\/projects\/3dvr-test\/domains\?teamId=team_3dvr$/);
   assert.match(calls[2].url, /\/v9\/projects\/3dvr-test\/domains\/test\.3dvr\.tech\/verify\?teamId=team_3dvr$/);
   assert.match(calls[3].url, /\/v3\/domains\/3dvr\.tech\/records\?teamId=team_dns$/);
   assert.match(calls[4].url, /\/v9\/projects\/3dvr-test\/domains\/test\.3dvr\.tech\/verify\?teamId=team_3dvr$/);
-  assert.match(calls[5].url, /\/v2\/deployments\/dpl_dns_verify\/aliases\?teamId=team_3dvr$/);
+  assert.match(calls[5].url, /\/v9\/projects\/3dvr-test\/domains\/test\.3dvr\.tech\/verify\?teamId=team_3dvr$/);
+  assert.match(calls[6].url, /\/v2\/deployments\/dpl_dns_verify\/aliases\?teamId=team_3dvr$/);
   assert.deepEqual(JSON.parse(calls[3].options.body), {
     name: '_vercel',
     type: 'TXT',


### PR DESCRIPTION
## Summary
- Polls Vercel project-domain verification after adding the required DNS TXT record.
- Increases the default post-DNS wait to five attempts, two seconds apart.
- Preserves DNS-record metadata in the fallback response if verification still does not complete.

## Root Cause
The first production test after #734 showed that the portal created the `_vercel.3dvr.tech` TXT record, but Vercel's verify endpoint did not see the fresh TXT on the immediate retry and returned `missing_txt_record`.

## Validation
- `node --check api/github-publish.js`
- `node --check tests/github-publish-api.test.js`
- `node --test tests/github-publish-api.test.js`

## Production Observation
`test3.3dvr.tech` got its `_vercel` TXT record created by the live portal API, but the one-shot verification retry was too soon. This PR makes that path poll before surfacing a pending-domain response.