### PR TITLE
[codex] Treat unchanged Vercel aliases as assigned

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -347,7 +347,18 @@ async function assignVercelAlias({ token, deploymentId, domain, teamId, fetchImp
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw createVercelApiError('Vercel alias error', response, errorText);
+    const error = createVercelApiError('Vercel alias error', response, errorText);
+    if (response.status === 409 && String(error.code || '').trim() === 'not_modified') {
+      const alias = error?.details?.alias || domain;
+      return {
+        alias,
+        aliasUrl: `https://${alias}`,
+        aliasAssigned: true,
+        aliasAlreadyAssigned: true,
+        aliasStatus: response.status
+      };
+    }
+    throw error;
   }
 
   const data = await response.json();

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -465,6 +465,86 @@ test('vercel deploy provider returns deployment URL when custom domain is missin
   assert.equal(calls.length, 3);
 });
 
+test('vercel deploy provider treats already-associated aliases as assigned', async () => {
+  const calls = [];
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    vercelTeamId: 'team_3dvr',
+    siteLaunchBaseDomain: '3dvr.tech',
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
+
+      if (String(url).includes('/v13/deployments')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_alias_exists',
+              url: '3dvr-test4.vercel.app',
+              inspectUrl: 'https://vercel.com/example/launch/dpl_alias_exists',
+              readyState: 'READY'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v10/projects/3dvr-test4/domains')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              name: 'test4.3dvr.tech',
+              verified: true
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v2/deployments/dpl_alias_exists/aliases')) {
+        return {
+          ok: false,
+          status: 409,
+          async text() {
+            return JSON.stringify({
+              error: {
+                alias: 'test4.3dvr.tech',
+                code: 'not_modified',
+                message: 'The domain you are trying to associate is already associated with this deployment'
+              }
+            });
+          }
+        };
+      }
+
+      throw new Error(`Unexpected url ${url}`);
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-test4',
+      subdomain: 'test4',
+      html: '<html><body>already associated alias test content</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.aliasAssigned, true);
+  assert.equal(res.body.aliasAlreadyAssigned, true);
+  assert.equal(res.body.aliasStatus, 409);
+  assert.equal(res.body.aliasUrl, 'https://test4.3dvr.tech');
+  assert.equal(res.body.projectDomainReady, true);
+  assert.equal(calls.length, 3);
+});
+
 test('vercel deploy provider reports custom domain setup failures with deployment URL', async () => {
   const calls = [];
   const handler = createGithubPublishHandler({


### PR DESCRIPTION
## Summary
- Treats Vercel alias `409 not_modified` as a successful assignment.
- Returns `aliasAssigned: true` and `aliasAlreadyAssigned: true` when Vercel says the domain is already associated with the deployment.
- Adds focused test coverage for that response.

## Root Cause
The live `test4.3dvr.tech` publish verified the project domain and served HTTP 200, but Vercel returned `not_modified` from the alias endpoint because the domain was already associated with the deployment. The portal was surfacing that successful no-op as an alias error.

## Validation
- `node --check api/github-publish.js`
- `node --check tests/github-publish-api.test.js`
- `node --test tests/github-publish-api.test.js`