### PR TITLE
[codex] Trim portal hero copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,6 @@
             <h1 id="landing-title">One portal. Fast access.</h1>
             <p class="hero-tagline">
               Find the apps, contacts, notes, websites, subscriptions, and support tools you need
-              without digging through unfinished system layers.
             </p>
             <div class="hero-actions">
               <a href="revenue-desk/" class="cta primary">Open Revenue Desk</a>


### PR DESCRIPTION
## Summary
- Removes the second clause from the portal homepage hero tagline.
- The line now stops after: “Find the apps, contacts, notes, websites, subscriptions, and support tools you need”.

## Validation
- `node --test tests/customer-journey-pages.test.js`