### PR TITLE
Update portal release notes through v0.0.50

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -99,18 +99,12 @@
   <div class="section">
     <h2>Latest Release</h2>
     <article class="release-card">
-      <a class="release-link" href="v0.0.48.html">v0.0.48</a>
-      <span class="release-meta">Week of June 1, 2026</span>
+      <a class="release-link" href="v0.0.50.html">v0.0.50</a>
+      <span class="release-meta">Week of June 15, 2026</span>
       <p class="release-summary">
-        Wellness and consciousness apps like <a href="../intention-lab/">Intention Lab</a>,
-        <a href="../body-mode/">Body Mode</a>,
-        <a href="../portal-lab/">Portal Lab</a>,
-        and <a href="../inner-alignment/">Inner Alignment</a>, plus
-        <a href="../docs/focus-flow-os-plan.md">Focus Flow planning</a>,
-        <a href="../reseller-policy/">partner policy</a>, GunJS backup tooling,
-        <a href="../life-force-room/">Life Force Room</a>,
-        <a href="../master-key-room/">Master Key Room</a>,
-        and <a href="../games.html">Games</a> access.
+        <a href="../web-builder-app/">Launch Site</a> custom-domain publishing, DNS verification, Vercel alias
+        handling, <a href="../sober-spark/">Sober Spark</a>, <a href="../projects/">Seed Deck</a>,
+        <a href="../vr-portal/">Spatial VR Portal</a>, portal access cleanup, and admin defaults preservation.
       </p>
     </article>
   </div>
@@ -118,10 +112,30 @@
     <h2>Release History</h2>
     <ul class="release-grid">
       <li class="release-card">
+        <a class="release-link" href="v0.0.50.html">v0.0.50</a>
+        <span class="release-meta">Week of June 15, 2026</span>
+        <p class="release-summary">
+          Launch Site custom-domain publishing, DNS verification, Vercel alias handling,
+          <a href="../sober-spark/">Sober Spark</a>, <a href="../projects/">Seed Deck</a>,
+          <a href="../vr-portal/">Spatial VR Portal</a>, portal access cleanup, and admin defaults preservation.
+        </p>
+      </li>
+      <li class="release-card">
+        <a class="release-link" href="v0.0.49.html">v0.0.49</a>
+        <span class="release-meta">Week of June 8, 2026</span>
+        <p class="release-summary">
+          <a href="../stellar-flight.html">Stellar Drift</a> keyboard flight and enemies,
+          <a href="../games.html">Games</a> hub polish, <a href="../pong.html">Pong Arena</a> tuning,
+          CRM capture simplification, problem-validation docs, Manifestation Practice, and 3DVR Girl.
+        </p>
+      </li>
+      <li class="release-card">
         <a class="release-link" href="v0.0.48.html">v0.0.48</a>
         <span class="release-meta">Week of June 1, 2026</span>
         <p class="release-summary">
-          Wellness and consciousness apps, <a href="../docs/focus-flow-os-plan.md">Focus Flow planning</a>,
+          Wellness and consciousness apps like <a href="../intention-lab/">Intention Lab</a>,
+          <a href="../body-mode/">Body Mode</a>, and <a href="../portal-lab/">Portal Lab</a>, plus
+          <a href="../docs/focus-flow-os-plan.md">Focus Flow planning</a>,
           <a href="../reseller-policy/">partner policy</a>, GunJS backup tooling, new experimental rooms, and
           <a href="../games.html">Games</a> access.
         </p>

--- a/releases/v0.0.48.html
+++ b/releases/v0.0.48.html
@@ -24,7 +24,7 @@
   <p><a class="back-link" href="index.html">Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
     <a class="release-nav-link" href="v0.0.47.html">Previous release</a>
-    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+    <a class="release-nav-link" href="v0.0.49.html">Next release</a>
   </nav>
   <h1>Release v0.0.48</h1>
   <div class="tag">Week of June 1, 2026</div>
@@ -87,8 +87,7 @@
   <div class="section">
     <h2>Release Cadence</h2>
     <p>
-      v0.0.48 is the current Monday release for the week of June 1. The next planned release should continue from
-      PRs merged after #672 unless a hotfix needs to be called out separately.
+      v0.0.48 remains the June 1 weekly release. The next release continues in v0.0.49 with PRs merged after #672.
     </p>
   </div>
 

--- a/releases/v0.0.49.html
+++ b/releases/v0.0.49.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.49 (Week of June 8, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+    .release-nav-link.is-disabled { opacity: 0.4; pointer-events: none; cursor: default; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.48.html">Previous release</a>
+    <a class="release-nav-link" href="v0.0.50.html">Next release</a>
+  </nav>
+  <h1>Release v0.0.49</h1>
+  <div class="tag">Week of June 8, 2026</div>
+  <div class="release-summary">
+    <p>
+      This weekly release tightens play, capture, and validation surfaces while turning a set of portal strategy notes
+      into clearer operating language.
+    </p>
+    <ul class="release-summary-list">
+      <li>
+        <strong>Games and flight controls:</strong>
+        <a href="../stellar-flight.html">Stellar Drift</a> gained keyboard flight, spacebar firing, tuned arrow aim,
+        and random enemies while <a href="../games.html">Games</a>, <a href="../pong.html">Pong Arena</a>, and the
+        Zero-G Ski Range experience moved toward sharper desktop play.
+      </li>
+      <li>
+        <strong>Capture and validation:</strong>
+        <a href="../crm/">CRM</a> conversation capture, simplified capture flows, the
+        <a href="../docs/project-desk-mvp.md">Project Desk portal relationship</a>, and problem-validation docs made
+        the start path more concrete.
+      </li>
+      <li>
+        <strong>Portal operating language:</strong>
+        the cybernetic portal, civic operating system, worker power, portal vision card, and agent execution notes
+        clarified what the portal is for before adding more layers.
+      </li>
+      <li>
+        <strong>Practice and prototypes:</strong>
+        <a href="../meditation/affirmations.html">Manifestation Practice</a>, <a href="../3dvr-girl/">3DVR Girl</a>,
+        and the customer-facing start-page pass gave experimental work clearer homes.
+      </li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Merged PRs</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/673">#673 Add Stellar Drift keyboard flight</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/674">#674 Add direct app links to release notes</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/675">#675 Inline release app links in summaries</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/676">#676 Map Stellar Drift spacebar to fire</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/677">#677 Add CRM conversation capture flow</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/678">#678 Tune Stellar Drift arrow aim speed</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/679">#679 Add cybernetic portal design document</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/680">#680 Add civic operating system plan</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/681">#681 Add worker power planning docs</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/682">#682 Relax agent line length guidance</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/683">#683 Add portal vision card</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/684">#684 Add agent execution principles</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/685">#685 Add start page review plan</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/686">#686 Make start page hero customer-facing</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/687">#687 Add AI-native startup playbook notes</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/688">#688 Refresh games hub with themed icons and blurbs</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/689">#689 Revamp games page UI with themed SVG icons and add tests</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/690">#690 Add problem validation doc</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/691">#691 Remove Memory Match and tune Pong desktop play</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/692">#692 Add problem validation and start page critique</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/693">#693 Simplify conversation capture</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/694">#694 Use project stage questions on start router</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/695">#695 Add grounded manifestation practice</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/696">#696 Add manifestation practice app card</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/697">#697 Add 3DVR Girl portal</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/698">#698 Redesign Zero-G Ski Range as FPS trainer</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/699">#699 Add random enemies to Stellar Drift</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/700">#700 Redesign Pong with Three.js arena</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/701">#701 Fix Pong controls and mouse lock</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/702">#702 Document Project Desk portal relationship</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/703">#703 Remove 3DVR Girl preview capture</a></li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Release Cadence</h2>
+    <p>
+      v0.0.49 catches the work merged after v0.0.48 and before the site-launcher/custom-domain sprint that follows
+      in v0.0.50.
+    </p>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">&copy; 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/releases/v0.0.50.html
+++ b/releases/v0.0.50.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.50 (Week of June 15, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+    .release-nav-link.is-disabled { opacity: 0.4; pointer-events: none; cursor: default; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.49.html">Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+  </nav>
+  <h1>Release v0.0.50</h1>
+  <div class="tag">Week of June 15, 2026</div>
+  <div class="release-summary">
+    <p>
+      This release brings the portal back onto the current PR stream, with a complete Launch Site publish path,
+      cleaner access surfaces, and fewer rough edges on experimental apps.
+    </p>
+    <ul class="release-summary-list">
+      <li>
+        <strong>Launch Site publishing:</strong>
+        <a href="../web-builder-app/">Launch Site</a> moved from a simple deploy path to a tested production workflow:
+        3dvr team deployments, readiness polling, domain registration, DNS verification, and custom-domain alias handling.
+      </li>
+      <li>
+        <strong>Portal access cleanup:</strong>
+        guest entry, app search, home backlinks, the hero tagline, and the removed botanical border all moved the portal
+        toward faster first-party access.
+      </li>
+      <li>
+        <strong>New and refined work surfaces:</strong>
+        <a href="../sober-spark/">Sober Spark</a>, <a href="../projects/">Seed Deck</a>,
+        <a href="../vr-portal/">Spatial VR Portal</a>, and CRM conversation saves landed or became more usable.
+      </li>
+      <li>
+        <strong>Admin and defaults:</strong>
+        shared builder defaults and admin key preservation now avoid wiping working configuration when only one value changes.
+      </li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Merged PRs</h2>
+    <ul class="link-list">
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/704">#704 Add Sober Spark stimulation app</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/705">#705 Add 3DVR home backlinks to portal start pages</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/706">#706 Move 3DVR Girl to experimental apps</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/707">#707 Add plant border accents to portal</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/708">#708 Fix one-click guest entry</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/709">#709 Tone down portal plant border</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/710">#710 Shorten portal home backlink label</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/711">#711 Fix portal botanical border</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/712">#712 Highlight portal app search</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/713">#713 Fix CRM conversation capture saves</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/714">#714 Add project launchpad MVP</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/715">#715 Update projects app as Seed Deck</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/716">#716 Expand Sober Spark stimulation modes</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/717">#717 Remove portal botanical border</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/719">#719 Add simple site launcher to main</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/720">#720 Add Sober Spark navigation controls</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/721">#721 Refine Sober Spark focus mode</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/722">#722 Add spatial VR portal prototype</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/723">#723 Wait for shared builder defaults</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/724">#724 Fix spatial portal visibility and desktop layout</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/725">#725 Improve site launcher publish flow</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/726">#726 Fix Sober Spark directional keys</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/727">#727 Preserve admin shared defaults on blank input</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/728">#728 Pin site launches to 3dvr Vercel team</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/729">#729 Wait for Vercel deployments before aliasing</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/730">#730 Fallback when Vercel alias domain is missing</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/731">#731 Register Vercel domains before aliasing</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/732">#732 Verify Vercel project domains before aliasing</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/733">#733 Show Vercel DNS verification records</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/734">#734 Autofix Vercel domain verification DNS</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/735">#735 Poll Vercel domain verification after DNS</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/736">#736 Treat unchanged Vercel aliases as assigned</a></li>
+      <li><a href="https://github.com/tmsteph/3dvr-portal/pull/737">#737 Trim portal hero copy</a></li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Release Cadence</h2>
+    <p>
+      v0.0.50 is the current weekly release. It closes the gap from the June 15 publish sprint and leaves the next
+      release to continue from PRs merged after #737.
+    </p>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">&copy; 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -15,12 +15,22 @@ async function fileExists(path) {
 }
 
 describe('release hub backfill', () => {
-  it('updates the release index with the weekly milestones through v0.0.48', async () => {
+  it('updates the release index with the weekly milestones through v0.0.50', async () => {
     const indexUrl = new URL('index.html', baseDir);
     assert.equal(await fileExists(indexUrl), true, 'releases/index.html should exist');
 
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /Latest Release/);
+    assert.match(html, /href="v0\.0\.50\.html">v0\.0\.50</);
+    assert.match(html, /Week of June 15, 2026/);
+    assert.match(html, /Launch Site/);
+    assert.match(html, /custom-domain publishing/);
+    assert.match(html, /href="\.\.\/sober-spark\/">Sober Spark</);
+    assert.match(html, /href="\.\.\/projects\/">Seed Deck</);
+    assert.match(html, /href="v0\.0\.49\.html">v0\.0\.49</);
+    assert.match(html, /Week of June 8, 2026/);
+    assert.match(html, /Stellar Drift/);
+    assert.match(html, /href="\.\.\/games\.html">Games<\/a> hub polish/);
     assert.match(html, /href="v0\.0\.48\.html">v0\.0\.48</);
     assert.match(html, /Week of June 1, 2026/);
     assert.match(html, /Wellness and consciousness apps/);
@@ -66,7 +76,9 @@ describe('release hub backfill', () => {
 
   it('ships the new milestone pages with coherent navigation, summaries, and source links', async () => {
     const releases = [
-      ['v0.0.48.html', /Week of June 1, 2026/, /Focus Flow direction/i, /pull\/670/],
+      ['v0.0.50.html', /Week of June 15, 2026/, /Launch Site publishing/i, /pull\/736/],
+      ['v0.0.49.html', /Week of June 8, 2026/, /Games and flight controls/i, /href="v0\.0\.50\.html"/],
+      ['v0.0.48.html', /Week of June 1, 2026/, /Focus Flow direction/i, /href="v0\.0\.49\.html"/],
       ['v0.0.47.html', /Week of May 25, 2026/, /Market Lab/i, /href="v0\.0\.48\.html"/],
       ['v0.0.46.html', /Week of May 18, 2026/, /Pure Gun media/i, /3dvr-web\/pull\/185/],
       ['v0.0.45.html', /Week of May 11, 2026/, /tenant-aware task scheduling/i, /3dvr-agent\/commit\/ec7c967/],
@@ -93,8 +105,25 @@ describe('release hub backfill', () => {
   });
 
   it('links shipped apps and docs inline where the release summaries mention them', async () => {
+    const release50 = await readFile(new URL('v0.0.50.html', baseDir), 'utf8');
+    const release49 = await readFile(new URL('v0.0.49.html', baseDir), 'utf8');
     const release47 = await readFile(new URL('v0.0.47.html', baseDir), 'utf8');
     const release48 = await readFile(new URL('v0.0.48.html', baseDir), 'utf8');
+
+    assert.match(release50, /href="\.\.\/web-builder-app\/">Launch Site</);
+    assert.match(release50, /href="\.\.\/sober-spark\/">Sober Spark</);
+    assert.match(release50, /href="\.\.\/projects\/">Seed Deck</);
+    assert.match(release50, /href="\.\.\/vr-portal\/">Spatial VR Portal</);
+    assert.match(release50, /pull\/734/);
+    assert.match(release50, /pull\/737/);
+
+    assert.match(release49, /href="\.\.\/stellar-flight\.html">Stellar Drift</);
+    assert.match(release49, /href="\.\.\/games\.html">Games</);
+    assert.match(release49, /href="\.\.\/pong\.html">Pong Arena</);
+    assert.match(release49, /href="\.\.\/meditation\/affirmations\.html">Manifestation Practice</);
+    assert.match(release49, /href="\.\.\/3dvr-girl\/">3DVR Girl</);
+    assert.match(release49, /pull\/673/);
+    assert.match(release49, /pull\/703/);
 
     assert.doesNotMatch(release47, /<h2>Open the Work<\/h2>/);
     assert.match(release47, /href="\.\.\/revenue-desk\/">Revenue Desk</);


### PR DESCRIPTION
## Summary
- add v0.0.49 and v0.0.50 release pages from the recent merged PR stream
- make v0.0.50 the latest release and link v0.0.48 forward
- update release hub coverage for the new pages and app links

## Tests
- node --test tests/releases-hub.test.js