### PR TITLE
Harden portal mobile browser loading

### DIFF
--- a/.github/workflows/vercel-dev-preview.yml
+++ b/.github/workflows/vercel-dev-preview.yml
@@ -26,35 +26,49 @@ jobs:
   deploy-preview:
     name: Deploy preview alias
     runs-on: ubuntu-latest
-    if: ${{ env.VERCEL_TOKEN != '' && env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != '' }}
     env:
-      SHOULD_ALIAS: ${{
-        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.set_alias == 'true')
-      }}
+      SHOULD_ALIAS: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.set_alias == 'true') }}
     steps:
+      - name: Check Vercel preview configuration
+        id: config
+        shell: bash
+        run: |
+          if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID" ] && [ -n "$VERCEL_PROJECT_ID" ]; then
+            echo "can_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Vercel Dev Preview because one or more Vercel secrets are not configured."
+          fi
+
       - name: Checkout repository
+        if: ${{ steps.config.outputs.can_deploy == 'true' }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ steps.config.outputs.can_deploy == 'true' }}
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies
+        if: ${{ steps.config.outputs.can_deploy == 'true' }}
         run: npm ci
 
       - name: Install Vercel CLI
+        if: ${{ steps.config.outputs.can_deploy == 'true' }}
         run: npm install --global vercel
 
       - name: Pull preview environment from Vercel
+        if: ${{ steps.config.outputs.can_deploy == 'true' }}
         run: vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
 
       - name: Build preview artifact
+        if: ${{ steps.config.outputs.can_deploy == 'true' }}
         run: vercel build --token=$VERCEL_TOKEN
 
       - name: Deploy preview artifact
+        if: ${{ steps.config.outputs.can_deploy == 'true' }}
         id: deploy
         run: |
           DEPLOY_URL=$(vercel deploy --prebuilt --target=preview --token=$VERCEL_TOKEN --yes)
@@ -62,5 +76,5 @@ jobs:
           echo "Preview URL: $DEPLOY_URL"
 
       - name: Alias deployment to stable dev URL
-        if: ${{ env.VERCEL_DEV_ALIAS != '' && env.SHOULD_ALIAS == 'true' }}
+        if: ${{ steps.config.outputs.can_deploy == 'true' && env.VERCEL_DEV_ALIAS != '' && env.SHOULD_ALIAS == 'true' }}
         run: vercel alias set ${{ steps.deploy.outputs.url }} $VERCEL_DEV_ALIAS --token=$VERCEL_TOKEN

--- a/index.html
+++ b/index.html
@@ -9,6 +9,67 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="score.js"></script>
   <script src="/pwa-install.js" defer></script>
+  <style>
+    html {
+      background: #0d1117;
+      color: #e6edf3;
+    }
+    body.landing {
+      margin: 0;
+      min-height: 100vh;
+      background: #0d1117;
+      color: #e6edf3;
+      font-family: Arial, Helvetica, sans-serif;
+      line-height: 1.5;
+    }
+    .landing-shell {
+      min-height: 100vh;
+      box-sizing: border-box;
+      padding: 16px;
+    }
+    .app-boot {
+      position: fixed;
+      inset: 0;
+      z-index: 999;
+      display: grid;
+      place-items: center;
+      gap: 16px;
+      background: #0d1117;
+      color: #e6edf3;
+      text-align: center;
+    }
+    .app-ready .app-boot {
+      display: none;
+    }
+    .top-nav__primary,
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .top-nav__toggle,
+    .top-nav__search,
+    .cta,
+    .top-buttons a {
+      border: 1px solid rgba(88, 166, 255, 0.45);
+      border-radius: 999px;
+      background: #10233d;
+      color: #e6f3ff;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      padding: 10px 14px;
+      text-decoration: none;
+      font-weight: 700;
+    }
+    .hero-panel {
+      border: 1px solid #30363d;
+      border-radius: 12px;
+      background: #161b22;
+      padding: 20px;
+    }
+  </style>
   <link rel="stylesheet" href="styles/global.css">
   <link rel="stylesheet" href="index-style.css">
   <script src="portal-swirl-logo.js" defer></script>

--- a/pwa-install.js
+++ b/pwa-install.js
@@ -8,6 +8,37 @@
     ? resolvedScopeUrl.pathname
     : `${resolvedScopeUrl.pathname}/`;
   const scopeHref = new URL(scopePath, window.location.origin).href;
+  const reloadGuardKey = `3dvr-service-worker-reload:${scopePath}`;
+  const reloadCooldownMs = 30000;
+  let restoredFromPageCache = false;
+
+  window.addEventListener('pageshow', (event) => {
+    restoredFromPageCache = Boolean(event.persisted);
+    if (restoredFromPageCache) {
+      window.setTimeout(() => {
+        restoredFromPageCache = false;
+      }, 1000);
+    }
+  });
+
+  const shouldReloadForControllerChange = () => {
+    if (restoredFromPageCache || document.visibilityState === 'hidden') {
+      return false;
+    }
+
+    try {
+      const now = Date.now();
+      const lastReloadAt = Number(sessionStorage.getItem(reloadGuardKey) || 0);
+      if (now - lastReloadAt < reloadCooldownMs) {
+        return false;
+      }
+      sessionStorage.setItem(reloadGuardKey, String(now));
+    } catch (error) {
+      console.warn('Service worker reload guard unavailable', error);
+    }
+
+    return true;
+  };
 
   const toPathname = (url) => {
     if (!url) return '';
@@ -25,7 +56,9 @@
     if (waitingActivationRequested) return;
     waitingActivationRequested = true;
     navigator.serviceWorker.addEventListener('controllerchange', () => {
-      window.location.reload();
+      if (shouldReloadForControllerChange()) {
+        window.location.reload();
+      }
     }, { once: true });
   };
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,14 +3,14 @@
 importScripts('/chat/notification-routing.js');
 
 // Increment this to bust old caches when you deploy
-const CACHE_VERSION = 'v15';
+const CACHE_VERSION = 'v16';
 const STATIC_CACHE = `3dvr-static-${CACHE_VERSION}`;
 const HTML_CACHE = `3dvr-html-${CACHE_VERSION}`;
 const chatNotificationRouting = self.ChatNotificationRouting || null;
 
-// What to cache at install (add your CSS/JS/assets here)
+// What to cache at install (add your CSS/JS/assets here). Keep HTML out of the
+// install cache so stale app shells cannot survive a deploy.
 const STATIC_ASSETS = [
-  '/',                     // App shell (Start URL)
   '/index-style.css',
   '/styles/global.css',
   '/home/style.css',
@@ -40,6 +40,82 @@ const STATIC_ASSETS = [
 
 const createReloadedRequests = (assets) =>
   assets.map((asset) => new Request(asset, { cache: 'reload' }));
+
+const SECURITY_CHECKPOINT_PATTERN = /Vercel Security Checkpoint|Failed to verify your browser|Code 705/i;
+
+const createOfflinePortalFallbackResponse = () => new Response(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>3DVR Portal offline</title>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #0d1117;
+      color: #e6edf3;
+      font-family: Arial, Helvetica, sans-serif;
+      line-height: 1.5;
+    }
+    main {
+      width: min(92vw, 440px);
+      border: 1px solid #30363d;
+      border-radius: 12px;
+      background: #161b22;
+      padding: 24px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    }
+    h1 { margin: 0 0 8px; font-size: 1.4rem; }
+    p { margin: 0 0 18px; color: #9ba3b4; }
+    a {
+      display: inline-block;
+      border-radius: 999px;
+      background: #58a6ff;
+      color: #07111f;
+      font-weight: 700;
+      padding: 10px 14px;
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Open the portal again</h1>
+    <p>The browser could not refresh the portal shell. Reconnect or reload to get a fresh copy.</p>
+    <a href="/">Reload portal</a>
+  </main>
+</body>
+</html>`, {
+  headers: {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'no-store'
+  }
+});
+
+const shouldCacheHtmlResponse = (response) => {
+  if (!response || !response.ok) return false;
+  const contentType = response.headers.get('content-type') || '';
+  return contentType.includes('text/html');
+};
+
+const cacheHtmlResponse = async (request, response) => {
+  if (!shouldCacheHtmlResponse(response)) return;
+
+  const responseForCache = response.clone();
+  const responseForInspection = response.clone();
+  const text = await responseForInspection.text();
+
+  if (SECURITY_CHECKPOINT_PATTERN.test(text)) {
+    return;
+  }
+
+  const cache = await caches.open(HTML_CACHE);
+  await cache.put(request, responseForCache);
+};
 
 const networkFirst = async (req, { cacheMode = 'default' } = {}) => {
   try {
@@ -89,7 +165,16 @@ self.addEventListener('install', (event) => {
   const assetsToCache = createReloadedRequests(STATIC_ASSETS);
 
   event.waitUntil(
-    caches.open(STATIC_CACHE).then((cache) => cache.addAll(assetsToCache))
+    caches.open(STATIC_CACHE).then((cache) =>
+      Promise.allSettled(
+        assetsToCache.map(async (request) => {
+          const response = await fetch(request);
+          if (response && (response.ok || response.type === 'opaque')) {
+            await cache.put(request, response);
+          }
+        })
+      )
+    )
   );
   self.skipWaiting();
 });
@@ -106,7 +191,7 @@ self.addEventListener('activate', (event) => {
 });
 
 // Simple helpers
-const isHTML = (req) => req.headers.get('accept')?.includes('text/html');
+const isHTML = (req) => req.mode === 'navigate' || req.headers.get('accept')?.includes('text/html');
 const isGunRealtime = (url) => url.includes('/gun') || url.startsWith('wss://') || url.startsWith('ws://');
 const isAPI = (url) => url.includes('/api/'); // adjust if you add APIs
 const isStyleRequest = (req) => req.destination === 'style';
@@ -164,11 +249,13 @@ self.addEventListener('fetch', (event) => {
   if (isHTML(req)) {
     // Network-first for HTML for freshness
     event.respondWith(
-      fetch(req).then((res) => {
-        const resClone = res.clone();
-        caches.open(HTML_CACHE).then((cache) => cache.put(req, resClone));
+      fetch(req, { cache: 'reload' }).then((res) => {
+        event.waitUntil(cacheHtmlResponse(req, res));
         return res;
-      }).catch(() => caches.match(req))
+      }).catch(async () => {
+        const cached = await caches.match(req, { ignoreSearch: true });
+        return cached || createOfflinePortalFallbackResponse();
+      })
     );
     return;
   }

--- a/tests/contacts-pwa-config.test.js
+++ b/tests/contacts-pwa-config.test.js
@@ -116,8 +116,11 @@ describe('contacts PWA configuration', () => {
     const config = JSON.parse(vercelText);
     const rules = Array.isArray(config.headers) ? config.headers : [];
 
-    const staticAssetsIndex = rules.findIndex(
-      (rule) => rule.source === '/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|woff2?)'
+    const codeAssetIndex = rules.findIndex(
+      (rule) => rule.source === '/(.*)\\.(css|js)'
+    );
+    const mediaAssetIndex = rules.findIndex(
+      (rule) => rule.source === '/(.*)\\.(png|jpg|jpeg|gif|svg|webp|woff2?)'
     );
     const pwaInstallIndex = rules.findIndex((rule) => rule.source === '/pwa-install.js');
     const contactsPwaInstallIndex = rules.findIndex(
@@ -131,24 +134,35 @@ describe('contacts PWA configuration', () => {
       (rule) => rule.source === '/contacts/contacts.webmanifest'
     );
 
-    assert.notEqual(staticAssetsIndex, -1);
+    assert.notEqual(codeAssetIndex, -1);
+    assert.notEqual(mediaAssetIndex, -1);
     assert.notEqual(pwaInstallIndex, -1);
     assert.notEqual(contactsPwaInstallIndex, -1);
     assert.notEqual(rootWorkerIndex, -1);
     assert.notEqual(contactsWorkerIndex, -1);
     assert.notEqual(contactsManifestIndex, -1);
 
-    assert.equal(staticAssetsIndex < pwaInstallIndex, true);
-    assert.equal(staticAssetsIndex < contactsPwaInstallIndex, true);
-    assert.equal(staticAssetsIndex < rootWorkerIndex, true);
-    assert.equal(staticAssetsIndex < contactsWorkerIndex, true);
+    assert.equal(codeAssetIndex < pwaInstallIndex, true);
+    assert.equal(codeAssetIndex < contactsPwaInstallIndex, true);
+    assert.equal(codeAssetIndex < rootWorkerIndex, true);
+    assert.equal(codeAssetIndex < contactsWorkerIndex, true);
 
+    const codeAssetRule = rules[codeAssetIndex];
+    const mediaAssetRule = rules[mediaAssetIndex];
     const pwaInstallRule = rules[pwaInstallIndex];
     const contactsPwaInstallRule = rules[contactsPwaInstallIndex];
     const rootWorkerRule = rules[rootWorkerIndex];
     const contactsWorkerRule = rules[contactsWorkerIndex];
     const contactsManifestRule = rules[contactsManifestIndex];
 
+    assert.equal(
+      findHeaderValue(codeAssetRule.headers, 'Cache-Control'),
+      'public, max-age=0, must-revalidate'
+    );
+    assert.equal(
+      findHeaderValue(mediaAssetRule.headers, 'Cache-Control'),
+      'public, max-age=31536000, immutable'
+    );
     assert.equal(findHeaderValue(pwaInstallRule.headers, 'Cache-Control'), 'no-cache');
     assert.equal(findHeaderValue(contactsPwaInstallRule.headers, 'Cache-Control'), 'no-cache');
     assert.equal(findHeaderValue(rootWorkerRule.headers, 'Cache-Control'), 'no-cache');

--- a/tests/mobile-browser-resilience.test.js
+++ b/tests/mobile-browser-resilience.test.js
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const readProjectFile = async (path) =>
+  readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const findHeaderValue = (headers, key) => {
+  const match = headers.find((header) => header.key === key);
+  return match ? match.value : null;
+};
+
+test('portal root and unversioned styles/scripts revalidate on mobile browsers', async () => {
+  const vercelText = await readProjectFile('vercel.json');
+  const config = JSON.parse(vercelText);
+  const rules = Array.isArray(config.headers) ? config.headers : [];
+
+  const rootRule = rules.find((rule) => rule.source === '/');
+  const indexRule = rules.find((rule) => rule.source === '/index.html');
+  const codeAssetRule = rules.find((rule) => rule.source === '/(.*)\\.(css|js)');
+  const mediaAssetRule = rules.find((rule) => rule.source === '/(.*)\\.(png|jpg|jpeg|gif|svg|webp|woff2?)');
+
+  assert.ok(rootRule);
+  assert.ok(indexRule);
+  assert.ok(codeAssetRule);
+  assert.ok(mediaAssetRule);
+  assert.equal(findHeaderValue(rootRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
+  assert.equal(findHeaderValue(indexRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
+  assert.equal(findHeaderValue(codeAssetRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
+  assert.equal(findHeaderValue(mediaAssetRule.headers, 'Cache-Control'), 'public, max-age=31536000, immutable');
+});
+
+test('homepage includes a dark critical fallback before external styles load', async () => {
+  const html = await readProjectFile('index.html');
+  const criticalStyleIndex = html.indexOf('<style>');
+  const globalCssIndex = html.indexOf('<link rel="stylesheet" href="styles/global.css">');
+  const indexCssIndex = html.indexOf('<link rel="stylesheet" href="index-style.css">');
+
+  assert.ok(criticalStyleIndex > -1);
+  assert.ok(globalCssIndex > criticalStyleIndex);
+  assert.ok(indexCssIndex > criticalStyleIndex);
+  assert.match(html, /body\.landing\s*\{[\s\S]*background:\s*#0d1117;/);
+  assert.match(html, /\.top-nav__toggle,[\s\S]*\.top-nav__search,[\s\S]*\.cta,[\s\S]*\.top-buttons a\s*\{/);
+  assert.match(html, /\.app-ready \.app-boot\s*\{[\s\S]*display:\s*none;/);
+});
+
+test('root service worker does not cache stale portal HTML or Vercel checkpoints', async () => {
+  const source = await readProjectFile('service-worker.js');
+  const staticAssetsBlock = source.match(/const STATIC_ASSETS = \[[\s\S]*?\];/)?.[0] || '';
+
+  assert.match(source, /const CACHE_VERSION = 'v16';/);
+  assert.doesNotMatch(staticAssetsBlock, /'\/'/);
+  assert.match(source, /SECURITY_CHECKPOINT_PATTERN/);
+  assert.match(source, /Vercel Security Checkpoint/);
+  assert.match(source, /Failed to verify your browser/);
+  assert.match(source, /shouldCacheHtmlResponse/);
+  assert.match(source, /fetch\(req,\s*\{\s*cache:\s*'reload'\s*\}\)/);
+  assert.match(source, /caches\.match\(req,\s*\{\s*ignoreSearch:\s*true\s*\}\)/);
+  assert.match(source, /createOfflinePortalFallbackResponse/);
+});
+
+test('root PWA installer prevents controllerchange reload loops', async () => {
+  const source = await readProjectFile('pwa-install.js');
+
+  assert.match(source, /reloadGuardKey/);
+  assert.match(source, /reloadCooldownMs = 30000/);
+  assert.match(source, /window\.addEventListener\('pageshow'/);
+  assert.match(source, /event\.persisted/);
+  assert.match(source, /sessionStorage\.getItem\(reloadGuardKey\)/);
+  assert.match(source, /document\.visibilityState === 'hidden'/);
+  assert.match(source, /shouldReloadForControllerChange\(\)/);
+  assert.match(source, /window\.location\.reload\(\)/);
+});

--- a/tests/vercel-dev-preview-workflow.test.js
+++ b/tests/vercel-dev-preview-workflow.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('Vercel Dev Preview workflow starts cleanly and gates deploy steps inside the job', async () => {
+  const workflow = await readFile(
+    new URL('../.github/workflows/vercel-dev-preview.yml', import.meta.url),
+    'utf8'
+  );
+
+  assert.doesNotMatch(workflow, /runs-on:\s*ubuntu-latest[\s\S]{0,120}if:\s*\$\{\{\s*env\.VERCEL_TOKEN/);
+  assert.doesNotMatch(workflow, /SHOULD_ALIAS:\s*\$\{\{\s*\n/);
+  assert.match(workflow, /id:\s*config/);
+  assert.match(workflow, /can_deploy=true/);
+  assert.match(workflow, /can_deploy=false/);
+  assert.match(workflow, /node-version:\s*20/);
+  assert.match(workflow, /if:\s*\$\{\{\s*steps\.config\.outputs\.can_deploy == 'true'\s*\}\}/);
+  assert.match(workflow, /Skipping Vercel Dev Preview because one or more Vercel secrets are not configured/);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,34 @@
   ],
   "headers": [
     {
-      "source": "/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|woff2?)",
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(css|js)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(png|jpg|jpeg|gif|svg|webp|woff2?)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary
- add a critical dark homepage fallback so the portal remains usable if external CSS is delayed or blocked
- revalidate unversioned CSS/JS assets and keep HTML fresh while leaving media immutable
- harden the root service worker against stale/challenge HTML and add a bounded offline fallback
- guard service worker controllerchange reloads to prevent mobile back-navigation loops
- fix the Vercel Dev Preview workflow so it starts cleanly and gates deploy steps inside the job

## Tests
- node --check service-worker.js && node --check pwa-install.js
- node --test tests/mobile-browser-resilience.test.js tests/vercel-dev-preview-workflow.test.js tests/contacts-pwa-config.test.js tests/calendar-pwa-config.test.js tests/chat-notification-routing.test.js tests/homepage-scroll.test.js tests/homepage-search-ux.test.js

## Notes
- Live production currently serves index-style.css with public, max-age=31536000, immutable; this PR changes CSS/JS to revalidate.
- Could not inspect Vercel Bot Protection settings locally because no Vercel auth/config was present and the CLI install failed in this Node/npm environment.