### PR TITLE
[codex] Reuse launch site Vercel project

### DIFF
--- a/api/github-publish.js
+++ b/api/github-publish.js
@@ -252,8 +252,9 @@ export function resolveLaunchDomain(body = {}, options = {}) {
 }
 
 function validateVercelRequest(body, options = {}) {
-  const { token, projectName, html } = body || {};
+  const { token, html } = body || {};
   const effectiveToken = token || options.defaultToken;
+  const projectName = options.projectName || body?.projectName;
 
   if (!effectiveToken || typeof effectiveToken !== 'string') {
     return 'A Vercel token is required. Configure VERCEL_TOKEN or provide a token.';
@@ -273,6 +274,18 @@ function validateVercelRequest(body, options = {}) {
   }
 
   return null;
+}
+
+function resolveSiteLaunchVercelProjectName(bodyProjectName, launchDomain, configuredProjectName) {
+  if (!launchDomain?.domain) {
+    return bodyProjectName;
+  }
+
+  return [
+    configuredProjectName,
+    process.env.SITE_LAUNCH_VERCEL_PROJECT_NAME,
+    bodyProjectName
+  ].map(value => String(value || '').trim()).find(Boolean);
 }
 
 async function fetchExistingFile({ token, repo, path, branch, fetchImpl }) {
@@ -993,6 +1006,7 @@ export function createGithubPublishHandler(options = {}) {
     vercelReadyPollIntervalMs,
     vercelDnsVerifyRetryDelayMs,
     vercelDnsVerifyRetryAttempts,
+    siteLaunchVercelProjectName,
     siteLaunchBaseDomain = process.env.SITE_LAUNCH_BASE_DOMAIN
   } = options;
   const vercelTeamId = resolveSiteLaunchVercelTeamId(configuredVercelTeamId);
@@ -1013,24 +1027,32 @@ export function createGithubPublishHandler(options = {}) {
     const provider = parseProvider(req);
 
     if (provider === 'vercel') {
-      const validationError = validateVercelRequest(body, { defaultToken: vercelToken });
+      const launchDomain = body.customDomain || body.domain || body.subdomain || body.siteSlug || body.slug || body.alias
+        ? resolveLaunchDomain(body, { baseDomain: siteLaunchBaseDomain })
+        : null;
+
+      if ((body.customDomain || body.domain || body.subdomain || body.siteSlug || body.slug || body.alias) && !launchDomain) {
+        return res.status(400).json({ error: 'Choose a valid launch address or custom domain.' });
+      }
+
+      const projectName = resolveSiteLaunchVercelProjectName(
+        body.projectName,
+        launchDomain,
+        siteLaunchVercelProjectName
+      );
+      const validationError = validateVercelRequest(body, {
+        defaultToken: vercelToken,
+        projectName
+      });
       if (validationError) {
         return res.status(400).json({ error: validationError });
       }
 
       try {
         const token = body.token || vercelToken;
-        const launchDomain = body.customDomain || body.domain || body.subdomain || body.siteSlug || body.slug || body.alias
-          ? resolveLaunchDomain(body, { baseDomain: siteLaunchBaseDomain })
-          : null;
-
-        if ((body.customDomain || body.domain || body.subdomain || body.siteSlug || body.slug || body.alias) && !launchDomain) {
-          return res.status(400).json({ error: 'Choose a valid launch address or custom domain.' });
-        }
-
         const result = await createVercelDeployment({
           token,
-          projectName: body.projectName,
+          projectName,
           html: body.html,
           launchDomain,
           teamId: vercelTeamId,
@@ -1045,7 +1067,8 @@ export function createGithubPublishHandler(options = {}) {
 
         return res.status(200).json({
           ...result,
-          projectName: body.projectName,
+          projectName,
+          requestedProjectName: body.projectName,
           createdAt: Date.now()
         });
       } catch (err) {

--- a/launch-site/app.js
+++ b/launch-site/app.js
@@ -24,6 +24,7 @@ const publishResult = document.getElementById('publish-result');
 const statusClasses = ['status--info', 'status--success', 'status--warning', 'status--error'];
 const draftStorageKey = 'site-launcher-current-draft';
 const sharedDefaultsWaitMs = 6000;
+const launchProjectName = '3dvr-launch-sites';
 
 let currentHtml = '';
 let currentTitle = '';
@@ -302,7 +303,7 @@ async function publishSite() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        projectName: `3dvr-${state.slug}`,
+        projectName: launchProjectName,
         subdomain: state.slug,
         ...(state.customDomain ? { customDomain: state.customDomain } : {}),
         html: currentHtml,

--- a/tests/github-publish-api.test.js
+++ b/tests/github-publish-api.test.js
@@ -259,6 +259,87 @@ test('vercel deploy provider ignores client team overrides', async () => {
   assert.doesNotMatch(calls[0].url, /team_tmsteph/);
 });
 
+test('vercel launch domains can publish through a configured shared project', async () => {
+  const calls = [];
+  let requestPayload = null;
+  const handler = createGithubPublishHandler({
+    vercelToken: 'server_vercel_token',
+    vercelTeamId: 'team_3dvr',
+    siteLaunchVercelProjectName: '3dvr-launch-sites',
+    siteLaunchBaseDomain: '3dvr.tech',
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), options });
+
+      if (String(url).includes('/v13/deployments')) {
+        requestPayload = JSON.parse(options.body);
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              id: 'dpl_shared_launch',
+              url: '3dvr-launch-sites.vercel.app',
+              inspectUrl: 'https://vercel.com/3dvr/3dvr-launch-sites/deployments/dpl_shared_launch',
+              readyState: 'READY'
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v10/projects/3dvr-launch-sites/domains')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              name: 'river-city-wellness.3dvr.tech',
+              verified: true
+            };
+          }
+        };
+      }
+
+      if (String(url).includes('/v2/deployments/dpl_shared_launch/aliases')) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              alias: 'river-city-wellness.3dvr.tech'
+            };
+          }
+        };
+      }
+
+      throw new Error(`Unexpected url ${url}`);
+    }
+  });
+
+  const req = {
+    method: 'POST',
+    query: { provider: 'vercel' },
+    headers: {},
+    body: {
+      projectName: '3dvr-river-city-wellness',
+      subdomain: 'river-city-wellness',
+      html: '<html><body>shared launch project deployment test</body></html>'
+    }
+  };
+  const res = createMockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(requestPayload.name, '3dvr-launch-sites');
+  assert.equal(res.body.projectName, '3dvr-launch-sites');
+  assert.equal(res.body.requestedProjectName, '3dvr-river-city-wellness');
+  assert.equal(res.body.aliasAssigned, true);
+  assert.equal(res.body.aliasUrl, 'https://river-city-wellness.3dvr.tech');
+  assert.match(calls[0].url, /\/v13\/deployments\?teamId=team_3dvr$/);
+  assert.match(calls[1].url, /\/v10\/projects\/3dvr-launch-sites\/domains\?teamId=team_3dvr$/);
+  assert.match(calls[2].url, /\/v2\/deployments\/dpl_shared_launch\/aliases\?teamId=team_3dvr$/);
+});
+
 test('sanitizeLaunchSubdomain normalizes customer site addresses', () => {
   assert.equal(sanitizeLaunchSubdomain(' River City Wellness! '), 'river-city-wellness');
   assert.equal(sanitizeLaunchSubdomain('ab'), '');

--- a/tests/site-launcher-page.test.js
+++ b/tests/site-launcher-page.test.js
@@ -25,6 +25,9 @@ test('site launcher exposes the simple customer publishing flow', async () => {
 
   assert.match(app, /fetch\('\/api\/openai-site'/);
   assert.match(app, /fetch\('\/api\/vercel-deploy'/);
+  assert.match(app, /const launchProjectName = '3dvr-launch-sites'/);
+  assert.match(app, /projectName: launchProjectName/);
+  assert.doesNotMatch(app, /projectName: `3dvr-\$\{state\.slug\}`/);
   assert.match(app, /subdomain: state\.slug/);
   assert.match(app, /customDomain: state\.customDomain/);
   assert.match(app, /sanitizeCustomDomain\(customDomainInput\.value\)/);


### PR DESCRIPTION
## Summary
- Publish Launch Site builds through a reusable `3dvr-launch-sites` Vercel project instead of creating `3dvr-${slug}` projects.
- Add a server-side shared-project override for launch-domain deploys so production can enforce one project even if a client sends a per-site project name.
- Cover the shared-project path in API and page tests.

## Why
The Launch Site flow was creating a new Vercel project for each slug, which can hit Hobby project limits and complicates custom-domain assignment. Reusing one project keeps per-site aliases while avoiding project churn.

## Validation
- `node --test tests/github-publish-api.test.js tests/site-launcher-page.test.js`
- `node --check api/github-publish.js && node --check launch-site/app.js`
- Production smoke via `https://portal.3dvr.tech/api/vercel-deploy` using `projectName: 3dvr-launch-sites`, subdomain `codex-launch-0617051739.3dvr.tech`: deployment `dpl_4HVhQqnpJkZiN8JE3gcJPYAXNyN2`, alias assigned, live URL returned HTTP 200.
