### PR TITLE
[codex] Add Fractal Explorer

### DIFF
--- a/fractal-explorer/app.js
+++ b/fractal-explorer/app.js
@@ -1,0 +1,390 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+const canvas = document.getElementById('fractal-canvas');
+const statusEl = document.getElementById('status');
+const controls = {
+  power: document.getElementById('power'),
+  iterations: document.getElementById('iterations'),
+  detail: document.getElementById('detail'),
+  bloom: document.getElementById('bloom'),
+  palette: document.getElementById('palette')
+};
+
+const outputs = {
+  power: document.getElementById('power-value'),
+  iterations: document.getElementById('iterations-value'),
+  detail: document.getElementById('detail-value'),
+  bloom: document.getElementById('bloom-value')
+};
+
+const params = new URLSearchParams(window.location.search);
+const state = {
+  yaw: numberParam('yaw', 0.58),
+  pitch: numberParam('pitch', 0.23),
+  distance: numberParam('distance', 3.45),
+  paused: false,
+  dragging: false,
+  pointerX: 0,
+  pointerY: 0,
+  startYaw: 0,
+  startPitch: 0,
+  lastUrlWrite: 0
+};
+
+const uniforms = {
+  uResolution: { value: new THREE.Vector2(1, 1) },
+  uTime: { value: 0 },
+  uPower: { value: numberParam('power', 8) },
+  uIterations: { value: intParam('iterations', 9) },
+  uSteps: { value: intParam('detail', 72) },
+  uBloom: { value: numberParam('bloom', 0.35) },
+  uPalette: { value: intParam('palette', 0) },
+  uYaw: { value: state.yaw },
+  uPitch: { value: state.pitch },
+  uDistance: { value: state.distance }
+};
+
+const renderer = new THREE.WebGLRenderer({
+  canvas,
+  antialias: false,
+  alpha: false,
+  preserveDrawingBuffer: true,
+  powerPreference: 'high-performance'
+});
+renderer.setClearColor(0x070b12, 1);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.6));
+
+const scene = new THREE.Scene();
+const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+const material = new THREE.ShaderMaterial({
+  uniforms,
+  vertexShader: `
+    varying vec2 vUv;
+
+    void main() {
+      vUv = uv;
+      gl_Position = vec4(position.xy, 0.0, 1.0);
+    }
+  `,
+  fragmentShader: `
+    precision highp float;
+
+    uniform vec2 uResolution;
+    uniform float uTime;
+    uniform float uPower;
+    uniform int uIterations;
+    uniform int uSteps;
+    uniform float uBloom;
+    uniform int uPalette;
+    uniform float uYaw;
+    uniform float uPitch;
+    uniform float uDistance;
+
+    varying vec2 vUv;
+
+    mat3 cameraBasis(vec3 ro, vec3 target) {
+      vec3 forward = normalize(target - ro);
+      vec3 right = normalize(cross(forward, vec3(0.0, 1.0, 0.0)));
+      vec3 up = cross(right, forward);
+      return mat3(right, up, forward);
+    }
+
+    float mandelbulbDE(vec3 p) {
+      vec3 z = p;
+      float dr = 1.0;
+      float r = 0.0;
+
+      for (int i = 0; i < 14; i++) {
+        if (i >= uIterations) break;
+        r = max(length(z), 0.0001);
+        if (r > 4.0) break;
+
+        float theta = acos(clamp(z.z / r, -1.0, 1.0));
+        float phi = atan(z.y, z.x);
+        float zr = pow(r, uPower);
+        dr = pow(r, uPower - 1.0) * uPower * dr + 1.0;
+
+        theta *= uPower;
+        phi *= uPower;
+
+        z = zr * vec3(
+          sin(theta) * cos(phi),
+          sin(theta) * sin(phi),
+          cos(theta)
+        ) + p;
+      }
+
+      return 0.5 * log(r) * r / dr;
+    }
+
+    vec3 calcNormal(vec3 p) {
+      vec2 e = vec2(0.0014, 0.0);
+      return normalize(vec3(
+        mandelbulbDE(p + e.xyy) - mandelbulbDE(p - e.xyy),
+        mandelbulbDE(p + e.yxy) - mandelbulbDE(p - e.yxy),
+        mandelbulbDE(p + e.yyx) - mandelbulbDE(p - e.yyx)
+      ));
+    }
+
+    float ambientOcclusion(vec3 p, vec3 n) {
+      float occ = 0.0;
+      float scale = 1.0;
+      for (int i = 1; i <= 5; i++) {
+        float h = 0.025 * float(i);
+        float d = mandelbulbDE(p + n * h);
+        occ += (h - d) * scale;
+        scale *= 0.58;
+      }
+      return clamp(1.0 - occ * 2.2, 0.0, 1.0);
+    }
+
+    vec3 palette(float v, float shade) {
+      if (uPalette == 1) {
+        return mix(vec3(0.17, 0.08, 0.04), vec3(1.0, 0.56, 0.22), v) * shade;
+      }
+      if (uPalette == 2) {
+        return mix(vec3(0.04, 0.12, 0.22), vec3(0.62, 0.94, 1.0), v) * shade;
+      }
+      if (uPalette == 3) {
+        return vec3(v * shade);
+      }
+      vec3 a = vec3(0.05, 0.12, 0.22);
+      vec3 b = vec3(0.14, 0.92, 0.78);
+      vec3 c = vec3(0.78, 0.32, 1.0);
+      return mix(mix(a, b, smoothstep(0.0, 0.65, v)), c, smoothstep(0.55, 1.0, v)) * shade;
+    }
+
+    void main() {
+      vec2 uv = (gl_FragCoord.xy * 2.0 - uResolution.xy) / min(uResolution.x, uResolution.y);
+      vec3 target = vec3(0.0, 0.0, 0.0);
+      vec3 ro = vec3(
+        sin(uYaw) * cos(uPitch),
+        sin(uPitch),
+        cos(uYaw) * cos(uPitch)
+      ) * uDistance;
+      mat3 basis = cameraBasis(ro, target);
+      vec3 rd = normalize(basis * vec3(uv * 1.25, 1.65));
+
+      float t = 0.0;
+      float glow = 0.0;
+      float hit = 0.0;
+      vec3 p = ro;
+
+      for (int i = 0; i < 112; i++) {
+        if (i >= uSteps) break;
+        p = ro + rd * t;
+        float d = mandelbulbDE(p);
+        glow += exp(-22.0 * abs(d)) * 0.008;
+        if (d < max(0.0008, 0.00035 * t)) {
+          hit = 1.0;
+          break;
+        }
+        t += clamp(d * 0.78, 0.006, 0.11);
+        if (t > 9.0) break;
+      }
+
+      vec3 color = vec3(0.01, 0.025, 0.045) + vec3(0.02, 0.08, 0.11) * (1.0 - length(uv) * 0.45);
+
+      if (hit > 0.5) {
+        vec3 n = calcNormal(p);
+        vec3 lightDir = normalize(vec3(-0.48, 0.72, 0.5));
+        float diff = max(dot(n, lightDir), 0.0);
+        float rim = pow(max(1.0 - dot(n, -rd), 0.0), 2.3);
+        float ao = ambientOcclusion(p, n);
+        float depth = smoothstep(0.8, 4.4, t);
+        float bands = 0.5 + 0.5 * sin(10.0 * length(p) + uTime * 0.12);
+        float shade = (0.28 + diff * 0.88 + rim * 0.52) * ao;
+        color = palette(mix(bands, 1.0 - depth, 0.28), shade);
+        color += rim * vec3(0.26, 0.68, 0.92);
+      }
+
+      color += glow * uBloom * vec3(0.6, 1.0, 0.94);
+      color = pow(color, vec3(0.86));
+      gl_FragColor = vec4(color, 1.0);
+    }
+  `
+});
+
+scene.add(new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material));
+
+hydrateControls();
+resize();
+animate(0);
+
+window.addEventListener('resize', resize);
+canvas.addEventListener('pointerdown', onPointerDown);
+window.addEventListener('pointermove', onPointerMove);
+window.addEventListener('pointerup', onPointerUp);
+canvas.addEventListener('wheel', onWheel, { passive: false });
+
+for (const [key, input] of Object.entries(controls)) {
+  input.addEventListener('input', () => {
+    if (key === 'palette') {
+      uniforms.uPalette.value = Number(input.value);
+    } else if (key === 'iterations') {
+      uniforms.uIterations.value = Number(input.value);
+    } else if (key === 'detail') {
+      uniforms.uSteps.value = Number(input.value);
+    } else if (key === 'power') {
+      uniforms.uPower.value = Number(input.value);
+    } else if (key === 'bloom') {
+      uniforms.uBloom.value = Number(input.value);
+    }
+    syncOutputs();
+    writeUrlSoon();
+  });
+}
+
+document.getElementById('reset-view').addEventListener('click', () => {
+  state.yaw = 0.58;
+  state.pitch = 0.23;
+  state.distance = 3.45;
+  updateCameraUniforms();
+  writeUrlSoon(true);
+});
+
+document.getElementById('pause').addEventListener('click', (event) => {
+  state.paused = !state.paused;
+  event.currentTarget.textContent = state.paused ? 'Resume' : 'Pause';
+  event.currentTarget.setAttribute('aria-pressed', String(state.paused));
+});
+
+document.getElementById('randomize').addEventListener('click', () => {
+  controls.power.value = String((4.8 + Math.random() * 5.2).toFixed(1));
+  controls.iterations.value = String(7 + Math.floor(Math.random() * 6));
+  controls.detail.value = String(56 + Math.floor(Math.random() * 11) * 4);
+  controls.bloom.value = String((0.16 + Math.random() * 0.5).toFixed(2));
+  controls.palette.value = String(Math.floor(Math.random() * 4));
+  state.yaw = Math.random() * Math.PI * 2;
+  state.pitch = -0.25 + Math.random() * 0.65;
+  state.distance = 2.7 + Math.random() * 1.35;
+  updateUniformsFromControls();
+  writeUrlSoon(true);
+});
+
+document.getElementById('copy-link').addEventListener('click', async () => {
+  writeUrlSoon(true);
+  try {
+    await navigator.clipboard.writeText(window.location.href);
+    setStatus('Share link copied.');
+  } catch (error) {
+    setStatus('Share link is in the address bar.');
+  }
+});
+
+function numberParam(name, fallback) {
+  if (!params.has(name)) return fallback;
+  const value = Number(params.get(name));
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function intParam(name, fallback) {
+  const value = Math.round(numberParam(name, fallback));
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function hydrateControls() {
+  controls.power.value = String(clamp(uniforms.uPower.value, 2, 12));
+  controls.iterations.value = String(clamp(uniforms.uIterations.value, 4, 14));
+  controls.detail.value = String(clamp(uniforms.uSteps.value, 36, 112));
+  controls.bloom.value = String(clamp(uniforms.uBloom.value, 0, 0.9));
+  controls.palette.value = String(clamp(uniforms.uPalette.value, 0, 3));
+  updateUniformsFromControls();
+}
+
+function updateUniformsFromControls() {
+  uniforms.uPower.value = Number(controls.power.value);
+  uniforms.uIterations.value = Number(controls.iterations.value);
+  uniforms.uSteps.value = Number(controls.detail.value);
+  uniforms.uBloom.value = Number(controls.bloom.value);
+  uniforms.uPalette.value = Number(controls.palette.value);
+  updateCameraUniforms();
+  syncOutputs();
+}
+
+function updateCameraUniforms() {
+  state.pitch = clamp(state.pitch, -1.15, 1.15);
+  state.distance = clamp(state.distance, 1.85, 6.2);
+  uniforms.uYaw.value = state.yaw;
+  uniforms.uPitch.value = state.pitch;
+  uniforms.uDistance.value = state.distance;
+}
+
+function syncOutputs() {
+  outputs.power.textContent = Number(controls.power.value).toFixed(1);
+  outputs.iterations.textContent = controls.iterations.value;
+  outputs.detail.textContent = controls.detail.value;
+  outputs.bloom.textContent = Number(controls.bloom.value).toFixed(2);
+}
+
+function resize() {
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  renderer.setSize(width, height, false);
+  uniforms.uResolution.value.set(width * renderer.getPixelRatio(), height * renderer.getPixelRatio());
+}
+
+function animate(time) {
+  if (!state.paused) {
+    uniforms.uTime.value = time * 0.001;
+  }
+  renderer.render(scene, camera);
+  requestAnimationFrame(animate);
+}
+
+function onPointerDown(event) {
+  state.dragging = true;
+  state.pointerX = event.clientX;
+  state.pointerY = event.clientY;
+  state.startYaw = state.yaw;
+  state.startPitch = state.pitch;
+  canvas.setPointerCapture?.(event.pointerId);
+}
+
+function onPointerMove(event) {
+  if (!state.dragging) return;
+  const dx = event.clientX - state.pointerX;
+  const dy = event.clientY - state.pointerY;
+  state.yaw = state.startYaw - dx * 0.006;
+  state.pitch = state.startPitch + dy * 0.0045;
+  updateCameraUniforms();
+  writeUrlSoon();
+}
+
+function onPointerUp(event) {
+  if (!state.dragging) return;
+  state.dragging = false;
+  canvas.releasePointerCapture?.(event.pointerId);
+  writeUrlSoon(true);
+}
+
+function onWheel(event) {
+  event.preventDefault();
+  state.distance += Math.sign(event.deltaY) * 0.18;
+  updateCameraUniforms();
+  writeUrlSoon();
+}
+
+function writeUrlSoon(force = false) {
+  const now = performance.now();
+  if (!force && now - state.lastUrlWrite < 180) return;
+  state.lastUrlWrite = now;
+  const next = new URL(window.location.href);
+  next.searchParams.set('power', Number(controls.power.value).toFixed(1));
+  next.searchParams.set('iterations', controls.iterations.value);
+  next.searchParams.set('detail', controls.detail.value);
+  next.searchParams.set('bloom', Number(controls.bloom.value).toFixed(2));
+  next.searchParams.set('palette', controls.palette.value);
+  next.searchParams.set('yaw', state.yaw.toFixed(3));
+  next.searchParams.set('pitch', state.pitch.toFixed(3));
+  next.searchParams.set('distance', state.distance.toFixed(2));
+  window.history.replaceState(null, '', next);
+}
+
+function setStatus(message) {
+  statusEl.textContent = message;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, Number(value)));
+}

--- a/fractal-explorer/index.html
+++ b/fractal-explorer/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fractal Explorer | 3DVR Portal</title>
+  <meta name="theme-color" content="#070b12">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+  <script type="module" src="app.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#controls">Skip to controls</a>
+  <main class="fractal-shell">
+    <canvas id="fractal-canvas" aria-label="Interactive raymarched Mandelbulb fractal"></canvas>
+
+    <header class="scene-header">
+      <p class="eyebrow">3D fractal navigator</p>
+      <h1>Fractal Explorer</h1>
+      <p>
+        A browser-based fractal workspace inspired by Mandelbulb3D's navigator:
+        raymarched geometry, live formula controls, lighting, and shareable presets.
+      </p>
+      <nav aria-label="Mandelbulb links">
+        <a href="../index.html">Portal</a>
+        <a href="../vr-portal/">Spatial Portal</a>
+        <button id="randomize" type="button">Mutate</button>
+        <button id="copy-link" type="button">Copy Link</button>
+      </nav>
+    </header>
+
+    <section class="control-panel" id="controls" aria-labelledby="controls-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Live formula</p>
+        <h2 id="controls-title">Navigator controls</h2>
+      </div>
+
+      <label>
+        <span>Power <output id="power-value">8.0</output></span>
+        <input id="power" type="range" min="2" max="12" value="8" step="0.1">
+      </label>
+
+      <label>
+        <span>Iterations <output id="iterations-value">9</output></span>
+        <input id="iterations" type="range" min="4" max="14" value="9" step="1">
+      </label>
+
+      <label>
+        <span>Detail <output id="detail-value">72</output></span>
+        <input id="detail" type="range" min="36" max="112" value="72" step="4">
+      </label>
+
+      <label>
+        <span>Bloom <output id="bloom-value">0.35</output></span>
+        <input id="bloom" type="range" min="0" max="0.9" value="0.35" step="0.01">
+      </label>
+
+      <label>
+        <span>Palette</span>
+        <select id="palette">
+          <option value="0">Aurora</option>
+          <option value="1">Copper</option>
+          <option value="2">Ice</option>
+          <option value="3">Mono</option>
+        </select>
+      </label>
+
+      <div class="control-actions">
+        <button id="reset-view" type="button">Reset View</button>
+        <button id="pause" type="button" aria-pressed="false">Pause</button>
+      </div>
+
+      <p class="hint">Drag to orbit. Scroll or pinch to zoom. Changes update the URL so the scene can be shared.</p>
+      <p class="status" id="status" aria-live="polite">Rendering in WebGL.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/fractal-explorer/styles.css
+++ b/fractal-explorer/styles.css
@@ -1,0 +1,212 @@
+:root {
+  --panel: rgba(8, 13, 22, 0.72);
+  --panel-strong: rgba(8, 13, 22, 0.86);
+  --line: rgba(226, 232, 240, 0.18);
+  --ink: #f8fafc;
+  --muted: #b6c2d2;
+  --accent: #2dd4bf;
+  --accent-2: #38bdf8;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.45);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
+  background: #070b12;
+  color: var(--ink);
+  font-family: Inter, Poppins, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 10;
+  padding: 0.6rem 0.8rem;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #03201f;
+  transform: translateY(-150%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.fractal-shell {
+  position: relative;
+  min-height: 100vh;
+  isolation: isolate;
+}
+
+#fractal-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  display: block;
+  background: #070b12;
+}
+
+.scene-header,
+.control-panel {
+  position: fixed;
+  z-index: 2;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.scene-header {
+  top: clamp(0.85rem, 2vw, 1.5rem);
+  left: clamp(0.85rem, 2vw, 1.5rem);
+  width: min(31rem, calc(100vw - 2rem));
+  padding: clamp(1rem, 2vw, 1.35rem);
+}
+
+.eyebrow {
+  margin: 0 0 0.45rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.scene-header h1,
+.panel-heading h2 {
+  margin: 0;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.scene-header h1 {
+  font-size: clamp(2rem, 4vw, 4rem);
+}
+
+.scene-header p:not(.eyebrow) {
+  max-width: 34rem;
+  margin: 0.85rem 0 0;
+  color: var(--muted);
+}
+
+.scene-header nav,
+.control-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.scene-header a,
+.scene-header button,
+.control-panel button,
+.control-panel select {
+  min-height: 2.45rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.6rem 0.78rem;
+  background: rgba(15, 23, 42, 0.74);
+  color: var(--ink);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.scene-header a:hover,
+.scene-header button:hover,
+.control-panel button:hover,
+.control-panel select:hover {
+  border-color: rgba(45, 212, 191, 0.6);
+  color: var(--ink);
+}
+
+.control-panel {
+  right: clamp(0.85rem, 2vw, 1.5rem);
+  top: clamp(0.85rem, 2vw, 1.5rem);
+  width: min(22rem, calc(100vw - 2rem));
+  padding: 1rem;
+  display: grid;
+  gap: 0.95rem;
+}
+
+.panel-heading {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.panel-heading h2 {
+  font-size: 1.15rem;
+}
+
+.control-panel label {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.control-panel label > span {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.control-panel input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.control-panel select {
+  width: 100%;
+  color-scheme: dark;
+  background: var(--panel-strong);
+}
+
+.hint,
+.status {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.status {
+  color: var(--accent-2);
+}
+
+@media (max-width: 820px) {
+  body {
+    overflow: auto;
+  }
+
+  .scene-header,
+  .control-panel {
+    position: relative;
+    left: auto;
+    right: auto;
+    top: auto;
+    width: auto;
+    margin: 0.85rem;
+  }
+
+  .fractal-shell {
+    min-height: 100dvh;
+    padding-bottom: 0.85rem;
+    display: grid;
+    align-content: space-between;
+  }
+
+  #fractal-canvas {
+    position: fixed;
+    min-height: 100dvh;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -733,6 +733,12 @@
             <span class="app-card__title">Field Simulation</span>
             <span class="app-card__meta">Watch a grayscale field diffuse across the grid.</span>
           </a>
+          <a href="fractal-explorer/" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">🌀</span>
+            <span class="app-card__title">Fractal Explorer</span>
+            <span class="app-card__meta">Explore raymarched fractals with shareable browser presets.</span>
+          </a>
           <a href="gun-explorer/index.html" class="app-card" data-app-tier="experimental">
             <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">🗺️</span>

--- a/tests/fractal-explorer.test.js
+++ b/tests/fractal-explorer.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('fractal explorer ships a browser-based Three.js fractal navigator', async () => {
+  const html = await readFile(new URL('../fractal-explorer/index.html', import.meta.url), 'utf8');
+  const app = await readFile(new URL('../fractal-explorer/app.js', import.meta.url), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /Fractal Explorer/);
+  assert.match(html, /id="fractal-canvas"/);
+  assert.match(html, /id="copy-link"/);
+  assert.match(html, /id="power"/);
+  assert.match(html, /id="palette"/);
+
+  assert.match(app, /three@0\.165\.0\/build\/three\.module\.js/);
+  assert.match(app, /float mandelbulbDE/);
+  assert.match(app, /new THREE\.WebGLRenderer/);
+  assert.match(app, /window\.history\.replaceState/);
+  assert.match(app, /navigator\.clipboard\.writeText/);
+
+  assert.match(portal, /href="fractal-explorer\/"/);
+  assert.match(portal, /Fractal Explorer/);
+});


### PR DESCRIPTION
## Summary

Adds a browser-based Fractal Explorer route to the portal.

- Adds `/fractal-explorer/` with a full-screen Three.js/WebGL Mandelbulb raymarch shader.
- Adds live controls for power, iterations, detail, bloom, palette, orbit, zoom, mutation, and shareable URL presets.
- Registers the route in the experimental portal app grid.
- Adds a focused static test for the new route and portal registration.

## Validation

- `node --test tests/fractal-explorer.test.js`
- Playwright WebGL smoke check against `http://127.0.0.1:3001/fractal-explorer/` from a fresh worktree: canvas rendered with nonblank pixel samples and no browser errors.