### PR TITLE
[codex] Add Purpose Movement deck

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,6 +319,11 @@
             <span class="app-card__title">Start Here</span>
             <span class="app-card__meta">Choose the right path for your idea, offer, or next 3dvr.tech collaboration.</span>
           </a>
+          <a href="purpose-movement/" class="app-card" data-app-keywords="purpose vision movement signal launch mirror portal">
+            <span class="app-card__icon" aria-hidden="true">PM</span>
+            <span class="app-card__title">Purpose Movement</span>
+            <span class="app-card__meta">Find your purpose, visualize your movement, and launch the first doorway.</span>
+          </a>
           <a href="revenue-desk/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">REV</span>
             <span class="app-card__title">Revenue Desk</span>

--- a/purpose-movement/index.html
+++ b/purpose-movement/index.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Purpose Movement | 3DVR Portal</title>
+  <meta name="theme-color" content="#0b1220">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#slides">Skip to slides</a>
+  <header class="deck-hero">
+    <nav class="deck-nav" aria-label="Purpose Movement navigation">
+      <a href="../index.html">Portal</a>
+      <a href="../start/">Start Here</a>
+      <a href="../launch-room/">Launch Room</a>
+      <a href="../fractal-explorer/">Fractal Explorer</a>
+    </nav>
+    <p class="eyebrow">3DVR framing deck</p>
+    <h1>Purpose to Vision to Movement to Launch</h1>
+    <p class="hero-copy">
+      3DVR begins before the launch. It helps people discover the world inside them,
+      visualize their movement, and build the first doorway into it.
+    </p>
+  </header>
+
+  <main id="slides" class="deck-shell" aria-label="3DVR purpose movement presentation">
+    <section class="slide slide--lead" aria-labelledby="slide-1">
+      <p class="slide-number">Slide 1</p>
+      <h2 id="slide-1">The Shift</h2>
+      <p>We may be starting too far ahead.</p>
+      <p>
+        3DVR does not need to begin with launch tools, dashboards, domains, forms,
+        payments, or project management.
+      </p>
+      <p>Most people are not ready for that yet.</p>
+      <blockquote>
+        <p>"My purpose is real."</p>
+        <p>"My ideas matter."</p>
+        <p>"The thing I care about could become something."</p>
+        <p>"Maybe I'm not just supposed to consume the world - maybe I'm supposed to help create one."</p>
+      </blockquote>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-2">
+      <p class="slide-number">Slide 2</p>
+      <h2 id="slide-2">The Problem</h2>
+      <p>Most people are stuck before the project stage.</p>
+      <p>They are not asking: "How do I launch a website?"</p>
+      <p>They are asking, quietly:</p>
+      <blockquote>
+        <p>"What am I here to do?"</p>
+        <p>"Why do I feel called toward something I can't explain?"</p>
+        <p>"Why do I keep caring about this issue?"</p>
+        <p>"How do I turn my weirdness, pain, skill, or dream into something real?"</p>
+      </blockquote>
+      <p>The world gives people tools before it gives them permission.</p>
+      <p>3DVR can give them the mirror first.</p>
+    </section>
+
+    <section class="slide slide--accent" aria-labelledby="slide-3">
+      <p class="slide-number">Slide 3</p>
+      <h2 id="slide-3">The Deeper Insight</h2>
+      <p>Everyone has a purpose.</p>
+      <p>But most people need help embracing it.</p>
+      <p>They need motivation, visualization, reflection, and a first doorway.</p>
+      <p>Before they can build a project, they need to see the world they are carrying inside them.</p>
+      <blockquote>
+        <p><strong>3DVR helps people see the movement inside themselves.</strong></p>
+      </blockquote>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-4">
+      <p class="slide-number">Slide 4</p>
+      <h2 id="slide-4">What 3DVR Really Does</h2>
+      <p>3DVR is not just a website builder.</p>
+      <p>3DVR is not just a launch dashboard.</p>
+      <p>3DVR is a purpose activation system.</p>
+      <ul>
+        <li>discover their purpose</li>
+        <li>visualize their movement</li>
+        <li>name their world</li>
+        <li>invite others in</li>
+        <li>launch the first doorway</li>
+        <li>eventually build the tools and infrastructure around it</li>
+      </ul>
+    </section>
+
+    <section class="slide slide--path" aria-labelledby="slide-5">
+      <p class="slide-number">Slide 5</p>
+      <h2 id="slide-5">The Core Journey</h2>
+      <p class="path-line">Purpose -> Vision -> Movement -> First Signal -> Launch Tools</p>
+      <p>Not:</p>
+      <p class="muted-line">Website -> Features -> Dashboard -> Business</p>
+      <p>The practical tools still matter.</p>
+      <p>But they come after the person feels the spark.</p>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-6">
+      <p class="slide-number">Slide 6</p>
+      <h2 id="slide-6">Purpose</h2>
+      <p>Purpose begins with noticing.</p>
+      <ul>
+        <li>What keeps bothering you?</li>
+        <li>What do you care about even when you try not to?</li>
+        <li>What pain in the world feels personal to you?</li>
+        <li>What have people always come to you for?</li>
+        <li>What future do you secretly want to help create?</li>
+      </ul>
+      <p>This is the beginning of the signal.</p>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-7">
+      <p class="slide-number">Slide 7</p>
+      <h2 id="slide-7">Vision</h2>
+      <p>Once the signal appears, 3DVR helps make it visible.</p>
+      <p>Not just with words, but with imagery, metaphor, mood, story, symbols, scenes, and identity.</p>
+      <p>The goal is for the person to say:</p>
+      <blockquote>
+        <p>"That's it."</p>
+        <p>"That feels like me."</p>
+        <p>"That's the world I've been trying to describe."</p>
+      </blockquote>
+      <p>Visualization turns a vague calling into something emotionally real.</p>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-8">
+      <p class="slide-number">Slide 8</p>
+      <h2 id="slide-8">Movement</h2>
+      <p>The next step is naming the movement.</p>
+      <p>Not necessarily a huge social movement.</p>
+      <p>A movement can begin as:</p>
+      <ul>
+        <li>a small circle</li>
+        <li>a gathering</li>
+        <li>a project</li>
+        <li>a workshop</li>
+        <li>a local service</li>
+        <li>a learning group</li>
+        <li>an open-source contribution path</li>
+        <li>a creative community</li>
+        <li>a farm dream</li>
+        <li>a healing space</li>
+        <li>a tool people need</li>
+      </ul>
+      <blockquote>
+        <p>Purpose becomes stronger when it has a container.</p>
+      </blockquote>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-9">
+      <p class="slide-number">Slide 9</p>
+      <h2 id="slide-9">First Signal</h2>
+      <p>Before building a whole platform, the person sends a first signal.</p>
+      <ul>
+        <li>a manifesto</li>
+        <li>a simple landing page</li>
+        <li>a social post</li>
+        <li>a first invitation</li>
+        <li>a signup form</li>
+        <li>a meetup idea</li>
+        <li>a project sketch</li>
+        <li>a visual identity</li>
+        <li>a coming soon page</li>
+      </ul>
+      <p>This is the first doorway.</p>
+      <blockquote>
+        <p>"This is what I'm exploring. Who else feels this?"</p>
+      </blockquote>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-10">
+      <p class="slide-number">Slide 10</p>
+      <h2 id="slide-10">Launch Tools</h2>
+      <p>Only after purpose, vision, movement, and first signal do the practical tools become powerful.</p>
+      <ul>
+        <li>domain</li>
+        <li>landing page</li>
+        <li>email</li>
+        <li>forms</li>
+        <li>booking</li>
+        <li>payments</li>
+        <li>events</li>
+        <li>community space</li>
+        <li>contributor board</li>
+        <li>open-source pathways</li>
+        <li>project dashboard</li>
+        <li>AI assistant</li>
+        <li>launch room</li>
+      </ul>
+      <p>Now the tools are not generic. They serve the person's movement.</p>
+    </section>
+
+    <section class="slide slide--promise" aria-labelledby="slide-11">
+      <p class="slide-number">Slide 11</p>
+      <h2 id="slide-11">The Emotional Promise</h2>
+      <p>The promise is not: "We help you make a website."</p>
+      <blockquote>
+        <p><strong>We help you discover the world inside you and build the first doorway into it.</strong></p>
+      </blockquote>
+      <p>Or:</p>
+      <blockquote>
+        <p><strong>Find your purpose. Visualize your movement. Launch your world.</strong></p>
+      </blockquote>
+      <p>Or:</p>
+      <blockquote>
+        <p><strong>Everyone has a world inside them. 3DVR helps bring it online.</strong></p>
+      </blockquote>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-12">
+      <p class="slide-number">Slide 12</p>
+      <h2 id="slide-12">The Product Experience</h2>
+      <p>The first 3DVR experience should feel like a mirror and a portal.</p>
+      <p>A mirror because it reflects the person's hidden pattern back to them.</p>
+      <p>A portal because it helps them step into the world they are here to create.</p>
+      <div class="room-grid" aria-label="Possible rooms">
+        <span>Mirror Room</span>
+        <span>Vision Room</span>
+        <span>Movement Room</span>
+        <span>Signal Room</span>
+        <span>Launch Room</span>
+        <span>Community Room</span>
+        <span>Open Source Room</span>
+      </div>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-13">
+      <p class="slide-number">Slide 13</p>
+      <h2 id="slide-13">What Makes This Different</h2>
+      <p>Most platforms ask: "What business do you want to start?"</p>
+      <p>3DVR asks: "What future are you here to help create?"</p>
+      <p>Most website builders create pages.</p>
+      <p>3DVR creates doorways.</p>
+      <p>Most productivity tools organize tasks.</p>
+      <p>3DVR helps people become builders of meaningful worlds.</p>
+    </section>
+
+    <section class="slide" aria-labelledby="slide-14">
+      <p class="slide-number">Slide 14</p>
+      <h2 id="slide-14">The Test</h2>
+      <p>We do not need to build the whole platform first.</p>
+      <p>We test the experience manually.</p>
+      <blockquote>
+        <p>Can we help someone feel seen, name their purpose, visualize their movement, and take one brave first step?</p>
+      </blockquote>
+      <p>The first experiment: help 5-10 people create their first doorway.</p>
+      <p>Each person leaves with:</p>
+      <ul>
+        <li>a movement name</li>
+        <li>a mission statement</li>
+        <li>a visual direction</li>
+        <li>a first invitation</li>
+        <li>a simple page or post</li>
+        <li>one next action</li>
+      </ul>
+    </section>
+
+    <section class="slide slide--north-star" aria-labelledby="slide-15">
+      <p class="slide-number">Slide 15</p>
+      <h2 id="slide-15">The North Star</h2>
+      <p>3DVR should become an on-ramp from passive life to active creation.</p>
+      <div class="shift-grid" aria-label="Creator shifts">
+        <span>consumer -> creator</span>
+        <span>worker -> builder</span>
+        <span>idea-holder -> movement-starter</span>
+        <span>isolated dreamer -> public signal</span>
+        <span>vague purpose -> visible world</span>
+      </div>
+      <blockquote>
+        <p><strong>3DVR exists to help ordinary people become founders of meaningful movements.</strong></p>
+      </blockquote>
+      <p>
+        Not necessarily companies. Movements can be creative, local, spiritual, technical,
+        open-source, educational, ecological, artistic, therapeutic, or community-based.
+      </p>
+    </section>
+
+    <section class="slide slide--final" aria-labelledby="slide-16">
+      <p class="slide-number">Slide 16</p>
+      <h2 id="slide-16">Final Framing</h2>
+      <p>3DVR begins before the launch.</p>
+      <p>It begins at the moment someone realizes:</p>
+      <blockquote>
+        <p>"Maybe this thing inside me is real."</p>
+        <p>"Maybe I'm allowed to build around it."</p>
+        <p>"Maybe other people need this too."</p>
+        <p>"Maybe I can start."</p>
+      </blockquote>
+      <p>That is the doorway.</p>
+      <p>And 3DVR helps them walk through it.</p>
+      <div class="final-actions">
+        <a href="../start/">Open Start Here</a>
+        <a href="../launch-room/">Open Launch Room</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/purpose-movement/styles.css
+++ b/purpose-movement/styles.css
@@ -1,0 +1,256 @@
+:root {
+  --page-bg: #071019;
+  --panel: rgba(15, 23, 42, 0.78);
+  --panel-strong: rgba(15, 23, 42, 0.92);
+  --line: rgba(226, 232, 240, 0.16);
+  --ink: #f8fafc;
+  --muted: #b9c6d8;
+  --accent: #2dd4bf;
+  --accent-2: #fbbf24;
+  --violet: #a78bfa;
+  --shadow: 0 28px 80px rgba(0, 0, 0, 0.34);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 16% 8%, rgba(45, 212, 191, 0.22), transparent 28rem),
+    radial-gradient(circle at 82% 0%, rgba(167, 139, 250, 0.2), transparent 24rem),
+    linear-gradient(145deg, #071019 0%, #0b1220 54%, #111827 100%);
+  color: var(--ink);
+  font-family: Inter, Poppins, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 5;
+  padding: 0.6rem 0.85rem;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #042f2e;
+  font-weight: 800;
+  transform: translateY(-150%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.deck-hero,
+.deck-shell {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.deck-hero {
+  min-height: min(68vh, 620px);
+  display: grid;
+  align-content: center;
+  gap: 1.2rem;
+  padding: clamp(1.5rem, 5vw, 5rem) 0 2rem;
+}
+
+.deck-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-self: start;
+}
+
+.deck-nav a,
+.final-actions a {
+  min-height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.62rem 0.88rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.62);
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 750;
+}
+
+.deck-nav a:hover,
+.final-actions a:hover {
+  border-color: rgba(45, 212, 191, 0.55);
+  color: var(--ink);
+}
+
+.eyebrow,
+.slide-number {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 850;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.deck-hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3rem, 7vw, 7.4rem);
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+
+.hero-copy {
+  max-width: 720px;
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(1.08rem, 1vw + 0.85rem, 1.45rem);
+}
+
+.deck-shell {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  padding: 0 0 5rem;
+}
+
+.slide {
+  display: grid;
+  gap: 0.85rem;
+  padding: clamp(1.1rem, 3vw, 2rem);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.slide--lead,
+.slide--promise,
+.slide--north-star,
+.slide--final {
+  background:
+    linear-gradient(135deg, rgba(45, 212, 191, 0.16), rgba(15, 23, 42, 0.78) 42%),
+    var(--panel);
+}
+
+.slide--accent,
+.slide--path {
+  border-color: rgba(251, 191, 36, 0.34);
+  background:
+    linear-gradient(135deg, rgba(251, 191, 36, 0.11), rgba(15, 23, 42, 0.82) 48%),
+    var(--panel);
+}
+
+.slide h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2vw + 1rem, 3.25rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.slide p,
+.slide li {
+  max-width: 820px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.02rem;
+}
+
+.slide strong {
+  color: var(--ink);
+}
+
+.slide ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 0.5rem 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.slide li {
+  padding: 0.68rem 0.78rem;
+  border: 1px solid rgba(226, 232, 240, 0.1);
+  border-radius: 8px;
+  background: rgba(2, 6, 23, 0.28);
+}
+
+blockquote {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 1rem;
+  border-left: 4px solid var(--accent);
+  border-radius: 8px;
+  background: rgba(2, 6, 23, 0.34);
+}
+
+blockquote p {
+  color: var(--ink);
+  font-size: clamp(1.05rem, 0.6vw + 0.95rem, 1.35rem);
+}
+
+.path-line,
+.muted-line {
+  padding: 0.9rem 1rem;
+  border-radius: 8px;
+  font-weight: 850;
+  color: var(--ink) !important;
+  background: rgba(45, 212, 191, 0.15);
+}
+
+.muted-line {
+  color: var(--muted) !important;
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.room-grid,
+.shift-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.7rem;
+}
+
+.room-grid span,
+.shift-grid span {
+  padding: 0.9rem;
+  border: 1px solid rgba(45, 212, 191, 0.26);
+  border-radius: 8px;
+  background: rgba(45, 212, 191, 0.08);
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.shift-grid span {
+  border-color: rgba(167, 139, 250, 0.3);
+  background: rgba(167, 139, 250, 0.09);
+}
+
+.final-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+}
+
+@media (max-width: 700px) {
+  .deck-hero,
+  .deck-shell {
+    width: min(100% - 1rem, 1120px);
+  }
+
+  .deck-hero {
+    min-height: auto;
+    padding-top: 1rem;
+  }
+
+  .deck-hero h1 {
+    font-size: clamp(2.5rem, 16vw, 4.7rem);
+  }
+
+  .slide ul,
+  .room-grid,
+  .shift-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/purpose-movement.test.js
+++ b/tests/purpose-movement.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('purpose movement page ships the 3DVR framing deck', async () => {
+  const html = await readFile(new URL('../purpose-movement/index.html', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../purpose-movement/styles.css', import.meta.url), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /Purpose to Vision to Movement to Launch/);
+  assert.match(html, /3DVR helps people see the movement inside themselves/);
+  assert.match(html, /Purpose -&gt; Vision|Purpose -&gt; Vision|Purpose -> Vision/);
+  assert.match(html, /We help you discover the world inside you and build the first doorway into it/);
+  assert.match(html, /3DVR exists to help ordinary people become founders of meaningful movements/);
+  assert.match(html, /id="slide-16"/);
+  assert.match(html, /href="..\/launch-room\/"/);
+
+  assert.match(css, /\.deck-hero/);
+  assert.match(css, /\.slide--north-star/);
+
+  assert.match(portal, /href="purpose-movement\/"/);
+  assert.match(portal, /Purpose Movement/);
+});


### PR DESCRIPTION
## Summary

Adds a new `Purpose Movement` app page to the portal.

- Adds `/purpose-movement/` as a 16-slide textual deck for the `Purpose -> Vision -> Movement -> Launch` framing.
- Registers the page in the main portal app grid near `Start Here` as a core on-ramp.
- Adds focused static coverage for the deck content, route links, stylesheet hooks, and portal registration.

## Validation

- `node --test tests/purpose-movement.test.js`
- Playwright smoke check against `http://127.0.0.1:3002/purpose-movement/` from a fresh worktree: 16 slides loaded, no network/console errors, no horizontal overflow on desktop or mobile.