### PR TITLE
[codex] Add Launch Room page

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,11 @@
             <span class="app-card__title">Purpose Movement</span>
             <span class="app-card__meta">Find your purpose, visualize your movement, and launch the first doorway.</span>
           </a>
+          <a href="launch-room/" class="app-card" data-app-keywords="launch room projects website builder sites lead capture crm contacts tasks billing email operator sales">
+            <span class="app-card__icon" aria-hidden="true">LR</span>
+            <span class="app-card__title">Launch Room</span>
+            <span class="app-card__meta">Turn a rough idea into a page, a plan, lead capture, and a payment path.</span>
+          </a>
           <a href="revenue-desk/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">REV</span>
             <span class="app-card__title">Revenue Desk</span>

--- a/launch-room/index.html
+++ b/launch-room/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>3DVR Launch Room | 3DVR Portal</title>
+  <meta name="theme-color" content="#0b1220">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="../index-style.css">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="landing theme-dark launch-room">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+  <div class="landing-shell launch-room__shell">
+    <header class="top-nav">
+      <nav class="top-buttons" aria-label="Launch Room navigation">
+        <a href="../index.html">Portal</a>
+        <a href="../projects/index.html">Projects</a>
+        <a href="../web-builder-app/index.html">Web Builder</a>
+        <a href="../website-builder.html">Sites</a>
+        <a href="../lead-generation.html">Lead Capture</a>
+        <a href="../billing/index.html">Billing</a>
+      </nav>
+    </header>
+
+    <main id="mainContent" class="landing-content">
+      <section class="hero launch-room__hero" aria-labelledby="launchRoomTitle">
+        <span class="hero-eyebrow">Guided builder workspace</span>
+        <h1 id="launchRoomTitle">3DVR Launch Room</h1>
+        <p class="hero-tagline">
+          3DVR Launch Room is a guided workspace for independent builders turning rough ideas into real digital projects.
+        </p>
+        <p class="launch-room__core-copy">
+          Bring your idea into the Launch Room. Leave with a page, a plan, a way to collect leads, and a path to payment.
+        </p>
+        <div class="hero-actions">
+          <a href="../projects/index.html" class="cta primary">Start with Projects</a>
+          <a href="../web-builder-app/index.html" class="cta ghost">Build the page</a>
+          <a href="../lead-generation.html" class="cta ghost">Collect leads</a>
+        </div>
+      </section>
+
+      <section class="launch-room__flow" aria-labelledby="flowTitle">
+        <div class="app-hub__intro">
+          <span class="eyebrow">Launch path</span>
+          <h2 id="flowTitle">One room, existing portal tools</h2>
+          <p>
+            The Launch Room does not replace the portal modules. It gives builders a clear order for using them.
+          </p>
+        </div>
+        <div class="app-grid launch-room__steps">
+          <a href="../projects/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">1</span>
+            <span class="app-card__title">Shape the project</span>
+            <span class="app-card__meta">Use Projects to name the idea, owner, audience, and first shippable outcome.</span>
+          </a>
+          <a href="../web-builder-app/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">2</span>
+            <span class="app-card__title">Make the page</span>
+            <span class="app-card__meta">Use Website Builder / Sites to draft, preview, revise, and publish the public page.</span>
+          </a>
+          <a href="../lead-generation.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">3</span>
+            <span class="app-card__title">Capture demand</span>
+            <span class="app-card__meta">Use Lead Capture to turn interest into form submissions the team can follow up on.</span>
+          </a>
+          <a href="../billing/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">4</span>
+            <span class="app-card__title">Open payment</span>
+            <span class="app-card__meta">Use Billing to connect the offer to plans, subscriptions, and customer status.</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="launch-room__modules" aria-labelledby="modulesTitle">
+        <div class="app-hub__intro">
+          <span class="eyebrow">Module map</span>
+          <h2 id="modulesTitle">How the portal connects</h2>
+          <p>
+            Each module keeps doing its own job. Launch Room explains when to use it and links straight there.
+          </p>
+        </div>
+        <div class="launch-room__module-grid">
+          <a href="../projects/index.html" class="launch-room__module">
+            <strong>Projects</strong>
+            <span>Turns the rough idea into a visible project with context, next steps, and ownership.</span>
+          </a>
+          <div class="launch-room__module">
+            <strong>Website Builder / Sites</strong>
+            <span>Creates the first public page so the idea has a real destination to share.</span>
+            <span class="launch-room__module-links">
+              <a href="../web-builder-app/index.html">Open Web Builder</a>
+              <a href="../website-builder.html">Open Sites</a>
+            </span>
+          </div>
+          <a href="../lead-generation.html" class="launch-room__module">
+            <strong>Lead Capture</strong>
+            <span>Collects names, emails, and notes from people who want to hear more.</span>
+          </a>
+          <a href="../crm/index.html" class="launch-room__module">
+            <strong>CRM</strong>
+            <span>Tracks the pipeline after a lead becomes a conversation, opportunity, or deal.</span>
+          </a>
+          <a href="../contacts/index.html" class="launch-room__module">
+            <strong>Contacts</strong>
+            <span>Keeps people, companies, tags, and relationship context reusable across launches.</span>
+          </a>
+          <a href="../tasks/" class="launch-room__module">
+            <strong>Tasks</strong>
+            <span>Breaks the launch into concrete work: page edits, follow-ups, pricing, and handoff items.</span>
+          </a>
+          <a href="../billing/index.html" class="launch-room__module">
+            <strong>Billing</strong>
+            <span>Gives the project a payment path through plans, checkout, and subscription status.</span>
+          </a>
+          <a href="../email-operator/index.html" class="launch-room__module">
+            <strong>Email Operator</strong>
+            <span>Turns approvals, replies, and follow-ups into practical outreach without duplicating CRM work.</span>
+          </a>
+          <a href="../sales/index.html" class="launch-room__module">
+            <strong>Sales</strong>
+            <span>Provides launch scripts, lead review, buyer steps, and revenue playbooks.</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="info-panels" aria-label="Launch Room outcomes">
+        <article class="info-card">
+          <h3>What leaves the room</h3>
+          <ul>
+            <li>A project record with the idea, audience, and next move.</li>
+            <li>A launch page or site draft ready to improve.</li>
+            <li>A lead path connected to CRM and Contacts.</li>
+            <li>A billing path for subscriptions, setup work, or support.</li>
+          </ul>
+        </article>
+        <article class="info-card">
+          <h3>Use it when</h3>
+          <p>
+            You have an idea that is still too vague to sell, but ready enough to turn into a page,
+            a follow-up list, and a practical path toward payment.
+          </p>
+          <div class="hero-actions launch-room__footer-actions">
+            <a href="../sales/index.html" class="cta primary">Open Sales</a>
+            <a href="../crm/index.html" class="cta ghost">Open CRM</a>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      3DVR.Tech &copy; 2025 - Open Web for Everyone | <a href="../index.html">Back to Portal</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/launch-room/styles.css
+++ b/launch-room/styles.css
@@ -1,0 +1,104 @@
+.launch-room__shell {
+  max-width: 1120px;
+}
+
+.launch-room .top-nav {
+  margin-bottom: 2rem;
+}
+
+.launch-room__hero {
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.launch-room__core-copy {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(34, 211, 238, 0.35);
+  border-radius: var(--radius-lg);
+  background: rgba(34, 211, 238, 0.12);
+  color: rgba(248, 250, 252, 0.94);
+  font-size: clamp(1.15rem, 1vw + 0.95rem, 1.55rem);
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.launch-room__flow,
+.launch-room__modules {
+  display: grid;
+  gap: 1.6rem;
+}
+
+.launch-room__steps {
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.launch-room__steps .app-card__icon {
+  font-weight: 800;
+  font-size: 1.2rem;
+}
+
+.launch-room__module-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.launch-room__module {
+  display: grid;
+  gap: 0.45rem;
+  padding: 1.2rem;
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md);
+  background: rgba(17, 24, 39, 0.62);
+  color: var(--color-text);
+  box-shadow: 0 24px 60px rgba(4, 9, 20, 0.38);
+}
+
+.launch-room__module:hover {
+  border-color: rgba(56, 189, 248, 0.48);
+  background: rgba(30, 41, 59, 0.72);
+  color: var(--color-text);
+}
+
+.launch-room__module strong {
+  font-size: 1.02rem;
+}
+
+.launch-room__module span {
+  color: var(--color-text-muted);
+  font-size: 0.94rem;
+}
+
+.launch-room__module-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.launch-room__module-links a {
+  padding: 0.35rem 0.65rem;
+  border: 1px solid rgba(56, 189, 248, 0.32);
+  border-radius: 999px;
+  color: var(--accent-strong);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.launch-room__module-links a:hover {
+  background: rgba(56, 189, 248, 0.14);
+  color: var(--color-text);
+}
+
+.launch-room__footer-actions {
+  justify-content: flex-start;
+  margin-top: 1rem;
+}
+
+@media (max-width: 640px) {
+  .launch-room__core-copy {
+    padding: 1rem;
+  }
+}

--- a/tests/launch-room.test.js
+++ b/tests/launch-room.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('launch room route connects the existing portal modules', async () => {
+  const html = await readFile(new URL('../launch-room/index.html', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../launch-room/styles.css', import.meta.url), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /3DVR Launch Room/);
+  assert.match(html, /guided workspace for independent builders turning rough ideas into real digital projects/);
+  assert.match(html, /Bring your idea into the Launch Room\. Leave with a page, a plan, a way to collect leads, and a path to payment\./);
+  assert.match(html, /href="..\/projects\/index\.html"/);
+  assert.match(html, /href="..\/web-builder-app\/index\.html"/);
+  assert.match(html, /href="..\/website-builder\.html"/);
+  assert.match(html, /href="..\/lead-generation\.html"/);
+  assert.match(html, /href="..\/crm\/index\.html"/);
+  assert.match(html, /href="..\/contacts\/index\.html"/);
+  assert.match(html, /href="..\/tasks\/"/);
+  assert.match(html, /href="..\/billing\/index\.html"/);
+  assert.match(html, /href="..\/email-operator\/index\.html"/);
+  assert.match(html, /href="..\/sales\/index\.html"/);
+
+  assert.match(css, /\.launch-room__module-grid/);
+  assert.match(css, /\.launch-room__core-copy/);
+
+  assert.match(portal, /href="launch-room\/"/);
+  assert.match(portal, /Launch Room/);
+});


### PR DESCRIPTION
## What changed

Adds the missing `/launch-room/` route for 3DVR Launch Room and links it from the portal app grid.

The page reuses existing portal landing/app-card styles and explains how Launch Room connects the existing modules: Projects, Website Builder / Sites, Lead Capture, CRM, Contacts, Tasks, Billing, Email Operator, and Sales.

## Why

The Launch Room content existed only in the local archived Stripe worktree, so it was not live on `main` and the existing Purpose Movement link pointed to a missing route.

## Validation

- `node --test tests/launch-room.test.js`
- Local browser smoke against `http://127.0.0.1:3003/launch-room/` confirmed the route loads, the portal card exists, all nine module labels are present, and there is no desktop horizontal overflow.

Note: the plain Python local server 404s `/_vercel/insights/script.js`, which is expected outside Vercel.