### PR TITLE
[codex] Add manifestation builder page

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,11 @@
             <span class="app-card__title">Purpose Movement</span>
             <span class="app-card__meta">Find your purpose, visualize your movement, and launch the first doorway.</span>
           </a>
+          <a href="manifest/" class="app-card" data-app-keywords="manifest manifestation reality builder attention body vision evidence action woop alignment master key intention portal lab">
+            <span class="app-card__icon" aria-hidden="true">RB</span>
+            <span class="app-card__title">Reality Builder</span>
+            <span class="app-card__meta">Manifestation for builders: clarify desire, train attention, and take one real action.</span>
+          </a>
           <a href="launch-room/" class="app-card" data-app-keywords="launch room projects website builder sites lead capture crm contacts tasks billing email operator sales">
             <span class="app-card__icon" aria-hidden="true">LR</span>
             <span class="app-card__title">Launch Room</span>

--- a/manifest/app.js
+++ b/manifest/app.js
@@ -1,0 +1,84 @@
+const storageKey = '3dvr.manifest.dailyCard.v1';
+
+const form = document.getElementById('manifestDailyForm');
+const copyButton = document.getElementById('copyManifestCard');
+const clearButton = document.getElementById('clearManifestCard');
+const statusText = document.getElementById('manifestStatus');
+const fields = {
+  want: document.getElementById('manifestWant'),
+  why: document.getElementById('manifestWhy'),
+  block: document.getElementById('manifestBlock'),
+  action: document.getElementById('manifestAction'),
+  evidence: document.getElementById('manifestEvidence')
+};
+
+function readCard() {
+  return Object.fromEntries(
+    Object.entries(fields).map(([key, field]) => [key, field.value.trim()])
+  );
+}
+
+function writeCard(card = {}) {
+  Object.entries(fields).forEach(([key, field]) => {
+    field.value = card[key] || '';
+  });
+}
+
+function saveCard(card) {
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(card));
+    statusText.textContent = 'Daily card saved on this device. Continue in Life OS when you want to track follow-through.';
+  } catch (error) {
+    statusText.textContent = 'Storage is unavailable. Copy the card before leaving.';
+  }
+}
+
+function loadCard() {
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (raw) {
+      writeCard(JSON.parse(raw));
+      statusText.textContent = 'Loaded your saved daily card from this device.';
+    }
+  } catch (error) {
+    statusText.textContent = 'Saved card could not be loaded. You can still write or copy a new one.';
+  }
+}
+
+function formatCard(card) {
+  return [
+    '3DVR Reality Builder daily card',
+    `What do I want? ${card.want || '(not set)'}`,
+    `Why does it matter? ${card.why || '(not set)'}`,
+    `What blocks me? ${card.block || '(not set)'}`,
+    `What will I do today? ${card.action || '(not set)'}`,
+    `What evidence did I notice? ${card.evidence || '(not set)'}`
+  ].join('\n');
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  saveCard(readCard());
+});
+
+copyButton.addEventListener('click', async () => {
+  const card = readCard();
+  try {
+    await navigator.clipboard.writeText(formatCard(card));
+    statusText.textContent = 'Daily card copied to clipboard.';
+  } catch (error) {
+    statusText.textContent = 'Copy is unavailable. Select the fields manually instead.';
+  }
+});
+
+clearButton.addEventListener('click', () => {
+  writeCard();
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch (error) {
+    // Keep the form usable when storage is blocked.
+  }
+  statusText.textContent = 'Daily card cleared from this device.';
+});
+
+loadCard();

--- a/manifest/index.html
+++ b/manifest/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Manifestation for Builders | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="A grounded 3DVR manifestation path for calming the body, clarifying desire, training attention, and taking one real action."
+  >
+  <meta name="theme-color" content="#0b1220">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="../index-style.css">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script defer src="app.js"></script>
+</head>
+<body class="landing theme-dark manifest-page">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+  <div class="landing-shell manifest-shell">
+    <header class="top-nav">
+      <nav class="top-buttons" aria-label="Manifest navigation">
+        <a href="../index.html">Portal</a>
+        <a href="../meditation/">Breathing Room</a>
+        <a href="../meditation/affirmations.html#manifestationHeading">WOOP</a>
+        <a href="../inner-alignment/">Inner Alignment</a>
+        <a href="../life/index.html">Life OS</a>
+      </nav>
+    </header>
+
+    <main id="mainContent" class="landing-content">
+      <section class="hero manifest-hero" aria-labelledby="manifestTitle">
+        <span class="hero-eyebrow">Reality Builder</span>
+        <h1 id="manifestTitle">Manifestation for Builders</h1>
+        <p class="hero-tagline">
+          Calm your body. Clarify your desire. Train your attention. Take one real action.
+        </p>
+        <p class="manifest-formula">
+          3DVR Manifestation = attention + body state + vision + evidence + one real-world action.
+        </p>
+        <div class="hero-actions">
+          <a href="#dailyManifestation" class="cta primary">Manifest one real thing today</a>
+          <a href="../master-key-room/" class="cta ghost">Deep practice</a>
+          <a href="../portal-lab/" class="cta ghost">Mystery lab</a>
+        </div>
+      </section>
+
+      <section class="manifest-path" aria-labelledby="pathTitle">
+        <div class="app-hub__intro">
+          <span class="eyebrow">One human journey</span>
+          <h2 id="pathTitle">Use the existing rooms in a clear order.</h2>
+          <p>
+            This page does not replace the manifestation, wellness, or life tools. It gives them one grounded path.
+          </p>
+        </div>
+        <div class="manifest-step-grid">
+          <a href="../meditation/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">1</span>
+            <span class="app-card__title">Breathe</span>
+            <span class="app-card__meta">Start in the Breathing Room when your nervous system needs to settle.</span>
+          </a>
+          <a href="../meditation/affirmations.html#manifestationHeading" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">2</span>
+            <span class="app-card__title">Wish</span>
+            <span class="app-card__meta">Use WOOP to name the wish, outcome, obstacle, and if/then plan.</span>
+          </a>
+          <a href="../inner-alignment/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">3</span>
+            <span class="app-card__title">Align</span>
+            <span class="app-card__meta">Use Inner Alignment to connect body, breath, attention, imagination, and action.</span>
+          </a>
+          <a href="../life/index.html" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">4</span>
+            <span class="app-card__title">Track</span>
+            <span class="app-card__meta">Use Life OS to record the action, avoidance, evidence, and tomorrow's true task.</span>
+          </a>
+        </div>
+      </section>
+
+      <section id="dailyManifestation" class="manifest-daily" aria-labelledby="dailyTitle">
+        <div class="app-hub__intro">
+          <span class="eyebrow">3-minute manifestation</span>
+          <h2 id="dailyTitle">Desire becomes direction when it gets a next move.</h2>
+          <p>
+            Keep it practical. Name one thing, feel why it matters, face the obstacle, choose one action,
+            and record evidence from real life.
+          </p>
+        </div>
+        <form class="manifest-card" id="manifestDailyForm">
+          <div class="manifest-fields">
+            <label for="manifestWant">
+              <span>What do I want?</span>
+              <textarea id="manifestWant" name="want" rows="3" placeholder="A clear offer, a calmer body, a finished page, a real conversation."></textarea>
+            </label>
+            <label for="manifestWhy">
+              <span>Why does it matter?</span>
+              <textarea id="manifestWhy" name="why" rows="3" placeholder="The person, project, future, or value this desire serves."></textarea>
+            </label>
+            <label for="manifestBlock">
+              <span>What blocks me?</span>
+              <textarea id="manifestBlock" name="block" rows="3" placeholder="The fear, avoidance, distraction, or body state that usually interrupts."></textarea>
+            </label>
+            <label for="manifestAction">
+              <span>What will I do today?</span>
+              <textarea id="manifestAction" name="action" rows="3" placeholder="One physical action: send the message, publish the page, take the walk."></textarea>
+            </label>
+            <label for="manifestEvidence">
+              <span>What evidence did I notice?</span>
+              <textarea id="manifestEvidence" name="evidence" rows="3" placeholder="Signals from real life, not proof of magic: a reply, a calmer choice, a completed step."></textarea>
+            </label>
+          </div>
+          <div class="manifest-actions">
+            <button class="cta primary" type="submit">Save daily card</button>
+            <button class="cta ghost" id="copyManifestCard" type="button">Copy card</button>
+            <button class="cta ghost" id="clearManifestCard" type="button">Clear</button>
+          </div>
+          <p class="manifest-status" id="manifestStatus" role="status" aria-live="polite">
+            Saved locally on this device. Continue in Life OS when you want to track follow-through.
+          </p>
+        </form>
+      </section>
+
+      <section class="manifest-modes" aria-labelledby="modesTitle">
+        <div class="app-hub__intro">
+          <span class="eyebrow">Choose the mode</span>
+          <h2 id="modesTitle">Three paths, one grounded tone.</h2>
+          <p>
+            Stay connected to sleep, food, money, relationships, commitments, and measurable action.
+          </p>
+        </div>
+        <div class="manifest-mode-grid">
+          <article class="manifest-mode">
+            <h3>Daily Manifestation</h3>
+            <p>Breathe -> Wish -> Outcome -> Obstacle -> Action -> Save.</p>
+            <div class="manifest-links">
+              <a href="../meditation/">Breathing Room</a>
+              <a href="../meditation/affirmations.html#manifestationHeading">WOOP practice</a>
+              <a href="../life/index.html">Life OS</a>
+            </div>
+          </article>
+          <article class="manifest-mode">
+            <h3>Deep Practice</h3>
+            <p>Lesson -> Reflection -> Embodied practice -> One outward action.</p>
+            <div class="manifest-links">
+              <a href="../master-key-room/">Master Key Room</a>
+              <a href="../inner-alignment/">Inner Alignment</a>
+              <a href="../life/index.html">Weekly reflection</a>
+            </div>
+          </article>
+          <article class="manifest-mode">
+            <h3>Experimental / Mystery Lab</h3>
+            <p>Intention -> State check -> Experiment -> Reality check -> Journal.</p>
+            <div class="manifest-links">
+              <a href="../intention-lab/">Intention Lab</a>
+              <a href="../portal-lab/">Portal Lab</a>
+              <a href="../science/">Science Lab</a>
+              <a href="../field-simulation/index.html">Field Simulation</a>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="info-panels manifest-routing" aria-label="Manifest routing">
+        <article class="info-card">
+          <h3>I need clarity</h3>
+          <p>Start with the body and the daily truth loop before making a big plan.</p>
+          <div class="manifest-links">
+            <a href="../inner-alignment/">Open Inner Alignment</a>
+            <a href="../life/index.html">Open Life OS</a>
+          </div>
+        </article>
+        <article class="info-card">
+          <h3>I want to manifest something</h3>
+          <p>Turn the vision into a wish, outcome, obstacle, and if/then plan.</p>
+          <div class="manifest-links">
+            <a href="../meditation/affirmations.html#manifestationHeading">Open WOOP</a>
+            <a href="#dailyManifestation">Use daily card</a>
+          </div>
+        </article>
+        <article class="info-card">
+          <h3>I want a deeper course</h3>
+          <p>Train attention into reality through reflection, practice, and outward action.</p>
+          <div class="manifest-links">
+            <a href="../master-key-room/">Open Master Key Room</a>
+          </div>
+        </article>
+        <article class="info-card">
+          <h3>I want to experiment</h3>
+          <p>Explore mystery without losing your grounding. Evidence matters and action matters.</p>
+          <div class="manifest-links">
+            <a href="../portal-lab/">Open Portal Lab</a>
+            <a href="../intention-lab/">Open Intention Lab</a>
+          </div>
+        </article>
+      </section>
+
+      <section class="manifest-grounding" aria-labelledby="groundingTitle">
+        <span class="eyebrow">Ethical grounding</span>
+        <h2 id="groundingTitle">No magical control claims.</h2>
+        <p>
+          3DVR helps people calm the nervous system, clarify desire, focus attention, visualize possibility,
+          notice obstacles, take action, and build evidence that they are becoming someone new.
+        </p>
+        <div class="hero-actions">
+          <a href="../alive-system/" class="cta primary">Use Alive System for energy</a>
+          <a href="../launch-room/" class="cta ghost">Turn the signal into a project</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      3DVR.Tech &copy; 2025 - Open Web for Everyone | <a href="../index.html">Back to Portal</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/manifest/styles.css
+++ b/manifest/styles.css
@@ -1,0 +1,165 @@
+.manifest-shell {
+  max-width: 1120px;
+}
+
+.manifest-page .top-nav {
+  margin-bottom: 2rem;
+}
+
+.manifest-hero {
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.manifest-formula {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 1.15rem 1.35rem;
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  border-radius: var(--radius-lg);
+  background: rgba(16, 185, 129, 0.12);
+  color: rgba(248, 250, 252, 0.95);
+  font-size: clamp(1.06rem, 0.8vw + 0.92rem, 1.36rem);
+  font-weight: 800;
+  line-height: 1.45;
+}
+
+.manifest-path,
+.manifest-daily,
+.manifest-modes,
+.manifest-grounding {
+  display: grid;
+  gap: 1.6rem;
+}
+
+.manifest-step-grid,
+.manifest-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1rem;
+}
+
+.manifest-step-grid .app-card__icon {
+  font-weight: 800;
+  font-size: 1.2rem;
+}
+
+.manifest-card,
+.manifest-mode,
+.manifest-grounding {
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-lg);
+  background: rgba(17, 24, 39, 0.66);
+  box-shadow: 0 24px 60px rgba(4, 9, 20, 0.34);
+}
+
+.manifest-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 1.2rem;
+}
+
+.manifest-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.manifest-fields label {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--color-text);
+  font-weight: 800;
+}
+
+.manifest-fields textarea {
+  min-height: 8rem;
+  resize: vertical;
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.82);
+  color: var(--color-text);
+  font: inherit;
+  line-height: 1.45;
+  padding: 0.85rem;
+}
+
+.manifest-fields textarea:focus {
+  border-color: rgba(52, 211, 153, 0.68);
+  outline: 2px solid rgba(52, 211, 153, 0.18);
+}
+
+.manifest-fields textarea::placeholder {
+  color: rgba(203, 213, 225, 0.55);
+}
+
+.manifest-actions,
+.manifest-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.manifest-actions .cta {
+  border: 0;
+  cursor: pointer;
+}
+
+.manifest-status {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.94rem;
+}
+
+.manifest-mode {
+  display: grid;
+  align-content: start;
+  gap: 0.8rem;
+  padding: 1.2rem;
+}
+
+.manifest-mode h3 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.manifest-mode p,
+.manifest-grounding p {
+  margin: 0;
+  color: var(--color-text-muted);
+  line-height: 1.65;
+}
+
+.manifest-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.25rem;
+  padding: 0.42rem 0.7rem;
+  border: 1px solid rgba(52, 211, 153, 0.32);
+  border-radius: 999px;
+  color: var(--accent-strong);
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.manifest-links a:hover {
+  background: rgba(52, 211, 153, 0.14);
+  color: var(--color-text);
+}
+
+.manifest-routing.info-panels {
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.manifest-grounding {
+  padding: 1.35rem;
+}
+
+@media (max-width: 640px) {
+  .manifest-formula,
+  .manifest-card,
+  .manifest-mode,
+  .manifest-grounding {
+    padding: 1rem;
+  }
+}

--- a/tests/manifest-page.test.js
+++ b/tests/manifest-page.test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('manifest page wraps the existing manifestation apps into one grounded builder path', async () => {
+  const html = await readFile(new URL('../manifest/index.html', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../manifest/styles.css', import.meta.url), 'utf8');
+  const app = await readFile(new URL('../manifest/app.js', import.meta.url), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /Manifestation for Builders/);
+  assert.match(html, /Calm your body\. Clarify your desire\. Train your attention\. Take one real action\./);
+  assert.match(html, /attention \+ body state \+ vision \+ evidence \+ one real-world action/);
+  assert.match(html, /Manifest one real thing today/);
+  assert.match(html, /Explore mystery without losing your grounding/);
+  assert.match(html, /No magical control claims/);
+
+  for (const route of [
+    '../meditation/',
+    '../meditation/affirmations.html#manifestationHeading',
+    '../inner-alignment/',
+    '../life/index.html',
+    '../master-key-room/',
+    '../intention-lab/',
+    '../portal-lab/',
+    '../science/',
+    '../field-simulation/index.html',
+    '../alive-system/',
+    '../launch-room/'
+  ]) {
+    assert.match(html, new RegExp(`href="${route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+  }
+
+  for (const id of ['manifestWant', 'manifestWhy', 'manifestBlock', 'manifestAction', 'manifestEvidence']) {
+    assert.match(html, new RegExp(`id="${id}"`));
+  }
+
+  assert.match(css, /\.manifest-step-grid/);
+  assert.match(css, /\.manifest-card/);
+  assert.match(app, /3dvr\.manifest\.dailyCard\.v1/);
+  assert.match(app, /navigator\.clipboard\.writeText\(formatCard\(card\)\)/);
+  assert.match(app, /window\.localStorage\.setItem\(storageKey/);
+
+  assert.match(portal, /href="manifest\/"/);
+  assert.match(portal, /Reality Builder/);
+  assert.doesNotMatch(html, /guaranteed manifestation/i);
+  assert.doesNotMatch(html, /manifest anything instantly/i);
+  assert.doesNotMatch(html, /magical control over reality/i);
+});


### PR DESCRIPTION
## What changed

Adds a new `/manifest/` route titled **Manifestation for Builders** and links it from the portal app grid as **Reality Builder**.

The page wraps existing portal modules into one grounded journey:

- Breathing Room
- Affirmations / WOOP
- Inner Alignment
- Life OS
- Master Key Room
- Intention Lab
- Portal Lab
- Science Lab
- Field Simulation
- Alive System
- Launch Room

It also includes a small local daily card for: what I want, why it matters, what blocks me, what I will do today, and what evidence I noticed.

## Why

The manifestation/wellness cluster already has strong individual rooms, but users need one obvious path that frames manifestation as attention, body state, vision, evidence, and one real-world action.

## Impact

This keeps the grounded tone: no magical control claims, no guaranteed outcomes, and clear routing into existing apps instead of duplicating their deeper functionality.

## Validation

- `node --test tests/manifest-page.test.js`
- `node --test tests/manifest-page.test.js tests/affirmations-manifestation.test.js`
- Local Playwright smoke against `http://127.0.0.1:3004/manifest/` confirmed the route loads, the daily card saves to local storage, all three modes render, the portal card exists, and there is no desktop horizontal overflow.

Note: the plain Python local server 404s `/_vercel/insights/script.js`, which is expected outside Vercel.