### PR TITLE
Add Open Form / 3DVR Connect portal card

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,6 +552,12 @@
             <span class="app-card__title">Life Force Room</span>
             <span class="app-card__meta">Explore desire, embodiment, consent, and creative transmutation through a symbolic 3D room.</span>
           </a>
+          <a href="experimental/" class="app-card" data-app-tier="experimental" data-app-keywords="open form 3dvr connect premium landing sensual menswear intimacy wellness consent room system lifestyle">
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">O3D</span>
+            <span class="app-card__title">Open Form / 3DVR Connect</span>
+            <span class="app-card__meta">Explore the premium landing concept for Mediterranean linenwear, private intimacy products, and consent-based community design.</span>
+          </a>
           <a href="seated-spine-reset/" class="app-card" data-app-keywords="wellness posture spine stretch av tech conference laptop chair breathing">
             <span class="app-card__icon" aria-hidden="true">AV</span>
             <span class="app-card__title">Seated Spine Reset</span>


### PR DESCRIPTION
## Summary
- Adds a portal card in the main app dock for the existing `experimental/` landing page.
- Marks it as experimental and keeps the card metadata aligned with the new brand/navigation sections.

The landing page exists at `experimental/index.html` and is now directly discoverable from the portal.