### PR TITLE
Turn Fascia Release into a single-screen experience

### DIFF
--- a/fascia-release/index.html
+++ b/fascia-release/index.html
@@ -6,53 +6,54 @@
   <title>Fascia Release | 3DVR Portal</title>
   <meta
     name="description"
-    content="A gentle neck, jaw, tongue, and computer tension reset with low-intensity guidance and clear safety notes."
+    content="A gentle neck, jaw, tongue, and computer tension reset presented as a single-screen interactive experience."
   />
   <style>
     :root {
-      --paper: #f4ede2;
-      --surface: #fcfaf6;
-      --surface-soft: #f7f1e8;
-      --ink: #211913;
-      --muted: #61574d;
-      --line: #d8c7b2;
-      --line-strong: #b79460;
-      --gold: #b08a44;
-      --green: #4f7f64;
-      --clay: #8d4d43;
+      --paper: #f6efe5;
+      --surface: rgba(255, 250, 244, 0.9);
+      --surface-strong: #fffaf3;
+      --surface-soft: #f8f1e8;
+      --ink: #231a13;
+      --muted: #675c50;
+      --line: rgba(60, 45, 32, 0.14);
+      --line-strong: rgba(180, 138, 68, 0.38);
+      --gold: #aa8440;
+      --green: #4d7c60;
+      --clay: #8e4f44;
       --deep: #15110d;
-      --shadow: 0 20px 50px rgba(34, 23, 15, 0.12);
-      --radius: 0.8rem;
-      --max: 1180px;
-      --pad: clamp(1rem, 3vw, 1.8rem);
+      --shadow: 0 22px 60px rgba(35, 24, 15, 0.12);
+      --radius: 0.85rem;
+      --pad: clamp(1rem, 2.8vw, 1.8rem);
+      --max: 1220px;
     }
 
-    * {
-      box-sizing: border-box;
-    }
+    * { box-sizing: border-box; }
 
     html,
     body {
       margin: 0;
       min-height: 100%;
+      overflow: hidden;
     }
 
     body {
       background:
-        radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.6), transparent 26%),
-        radial-gradient(circle at 82% 8%, rgba(176, 138, 68, 0.1), transparent 22%),
-        linear-gradient(180deg, #f7f1e7 0%, #efe3d1 100%);
+        radial-gradient(circle at 14% 12%, rgba(255, 255, 255, 0.68), transparent 25%),
+        radial-gradient(circle at 84% 8%, rgba(176, 138, 68, 0.12), transparent 22%),
+        linear-gradient(180deg, #f8f1e6 0%, #efe2cf 100%);
       color: var(--ink);
       font-family: "Avenir Next", Avenir, "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-      line-height: 1.6;
+      line-height: 1.5;
+    }
+
+    button,
+    a {
+      font: inherit;
     }
 
     a {
       color: inherit;
-    }
-
-    button {
-      font: inherit;
     }
 
     .shell {
@@ -60,12 +61,15 @@
       margin: 0 auto;
     }
 
+    .app {
+      height: 100dvh;
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr) auto;
+    }
+
     .topbar {
-      position: sticky;
-      top: 0;
-      z-index: 10;
-      border-bottom: 1px solid rgba(46, 35, 26, 0.14);
-      background: rgba(247, 241, 231, 0.94);
+      border-bottom: 1px solid rgba(50, 38, 26, 0.12);
+      background: rgba(248, 241, 231, 0.9);
       backdrop-filter: blur(14px);
     }
 
@@ -75,328 +79,305 @@
       align-items: center;
       justify-content: space-between;
       gap: 1rem;
-      padding: 0.75rem 0;
+      padding: 0.7rem 0;
     }
 
     .brand {
       margin: 0;
       color: var(--deep);
-      font-size: 0.9rem;
-      letter-spacing: 0.16em;
+      font-size: 0.88rem;
+      font-weight: 800;
       text-transform: uppercase;
-      font-weight: 700;
+      letter-spacing: 0.18em;
       white-space: nowrap;
     }
 
-    .nav {
+    .view-nav {
       display: flex;
       flex-wrap: wrap;
       justify-content: flex-end;
-      gap: 0.5rem;
+      gap: 0.45rem;
     }
 
-    .nav button {
-      border: 1px solid rgba(46, 35, 26, 0.16);
-      background: rgba(255, 255, 255, 0.72);
+    .view-nav button {
+      border: 1px solid rgba(50, 38, 26, 0.16);
+      background: rgba(255, 255, 255, 0.68);
       color: var(--muted);
       border-radius: 999px;
-      padding: 0.5rem 0.85rem;
+      padding: 0.48rem 0.8rem;
       cursor: pointer;
-      transition: background 180ms ease, border-color 180ms ease, color 180ms ease;
+      transition: transform 180ms ease, background 180ms ease, border-color 180ms ease, color 180ms ease;
     }
 
-    .nav button[aria-pressed="true"] {
+    .view-nav button[aria-pressed="true"] {
       background: var(--deep);
       border-color: var(--deep);
       color: #fff;
     }
 
-    main {
-      padding-bottom: 4rem;
+    .view-nav button:active,
+    .panel button:active {
+      transform: translateY(1px);
     }
 
-    section {
-      padding: clamp(3rem, 5vw, 4.5rem) 0;
-      border-bottom: 1px solid rgba(45, 36, 26, 0.1);
+    .workspace {
+      min-height: 0;
+      padding: clamp(1rem, 2.5vw, 1.6rem) 0;
     }
 
-    section:last-of-type {
-      border-bottom: none;
+    .workspace-grid {
+      height: 100%;
+      min-height: 0;
+      display: grid;
+      gap: 1rem;
+    }
+
+    .panel {
+      min-height: 0;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .lead-panel {
+      padding: clamp(1.2rem, 2.8vw, 1.8rem);
+      display: grid;
+      gap: 1rem;
+      align-content: start;
+    }
+
+    .eyebrow {
+      margin: 0;
+      color: var(--gold);
+      font-size: 0.76rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-weight: 800;
     }
 
     h1,
     h2,
-    h3 {
+    h3,
+    p {
       margin: 0;
-      line-height: 1.06;
-      letter-spacing: 0.01em;
     }
 
     h1,
     h2 {
       font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+      line-height: 1.02;
+      letter-spacing: 0.01em;
     }
 
     h1 {
-      font-size: clamp(2.45rem, 6vw, 4.5rem);
-      max-width: 12ch;
+      font-size: clamp(2.35rem, 5.6vw, 4.1rem);
+      max-width: 11ch;
     }
 
     h2 {
-      font-size: clamp(1.45rem, 3vw, 2.1rem);
+      font-size: clamp(1.35rem, 3vw, 1.95rem);
     }
 
-    .eyebrow {
-      margin: 0 0 0.8rem;
-      color: var(--gold);
-      font-size: 0.76rem;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-      font-weight: 800;
-    }
-
-    .lead {
-      max-width: 68ch;
-      margin: 1rem 0 0;
+    .lede {
+      max-width: 60ch;
       color: var(--muted);
-      font-size: 1.05rem;
+      font-size: 1.03rem;
     }
 
-    .hero {
-      padding-top: 3rem;
-    }
-
-    .hero-grid {
-      display: grid;
-      gap: 1rem;
-      align-items: start;
-    }
-
-    .card,
-    .panel {
-      border-radius: var(--radius);
-      border: 1px solid rgba(46, 35, 26, 0.14);
-      background: var(--surface);
-      box-shadow: var(--shadow);
-    }
-
-    .hero-copy {
-      padding: clamp(1.35rem, 4vw, 2.4rem);
-      display: grid;
-      gap: 1rem;
-    }
-
-    .keyline {
-      margin: 0;
-      max-width: 66ch;
+    .quote {
+      max-width: 55ch;
+      padding-left: 0.9rem;
+      border-left: 3px solid var(--line-strong);
       font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
-      font-size: clamp(1.2rem, 2.2vw, 1.55rem);
+      font-size: clamp(1.18rem, 2.1vw, 1.4rem);
       font-style: italic;
-      color: #3d332b;
+      color: #3d3127;
     }
 
-    .hero-actions {
+    .tag-row,
+    .step-pills {
       display: flex;
       flex-wrap: wrap;
-      gap: 0.7rem;
+      gap: 0.45rem;
     }
 
-    .button {
+    .tag {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-height: 2.9rem;
-      padding: 0.78rem 1rem;
-      border-radius: 0.65rem;
-      border: 1px solid transparent;
-      background: transparent;
-      color: var(--deep);
-      cursor: pointer;
+      border: 1px solid rgba(50, 38, 26, 0.14);
+      border-radius: 999px;
+      padding: 0.38rem 0.68rem;
+      background: rgba(255, 255, 255, 0.62);
+      color: #51453d;
+      font-size: 0.84rem;
       text-decoration: none;
-      font-weight: 700;
-      transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
-    }
-
-    .button:active {
-      transform: translateY(1px);
-    }
-
-    .button--primary {
-      background: var(--deep);
-      color: #fff;
-    }
-
-    .button--secondary {
-      border-color: rgba(46, 35, 26, 0.2);
-      background: rgba(255, 255, 255, 0.55);
-    }
-
-    .hero-aside {
-      display: grid;
-      gap: 1rem;
-    }
-
-    .safety-card {
-      padding: 1.1rem;
-      background: #fff8f0;
-      border-left: 4px solid var(--clay);
-      display: grid;
-      gap: 0.7rem;
-    }
-
-    .safety-card h2 {
-      font-size: 1.1rem;
-      font-family: "Avenir Next", Avenir, "Segoe UI", system-ui, sans-serif;
-    }
-
-    .safety-card p {
-      margin: 0;
-      color: var(--muted);
-    }
-
-    .callout {
-      margin: 0;
-      padding: 0.95rem 1rem;
-      background: rgba(180, 138, 96, 0.12);
-      border-radius: 0.7rem;
-      border: 1px solid rgba(180, 138, 96, 0.22);
-      color: #4b3d31;
     }
 
     .visual-stack {
       display: grid;
-      gap: 1rem;
+      gap: 0.85rem;
     }
 
-    .visual-panel {
-      min-height: 12rem;
-      padding: 1rem;
+    .visual {
+      min-height: 7.8rem;
+      border: 1px dashed rgba(50, 38, 26, 0.18);
+      border-radius: 0.72rem;
+      background:
+        linear-gradient(160deg, rgba(255, 255, 255, 0.74), rgba(233, 218, 194, 0.92)),
+        repeating-linear-gradient(135deg, rgba(50, 38, 26, 0.04), rgba(50, 38, 26, 0.04) 13px, transparent 13px, transparent 26px);
       display: grid;
       place-items: center;
       text-align: center;
-      background:
-        linear-gradient(160deg, rgba(255, 255, 255, 0.7), rgba(233, 217, 192, 0.9)),
-        repeating-linear-gradient(
-          135deg,
-          rgba(46, 35, 26, 0.04),
-          rgba(46, 35, 26, 0.04) 14px,
-          transparent 14px,
-          transparent 28px
-        );
-      border: 1px dashed rgba(46, 35, 26, 0.18);
       color: var(--muted);
+      padding: 0.95rem;
     }
 
-    .visual-panel strong {
+    .visual strong {
       display: block;
       color: var(--deep);
-      font-size: 1rem;
-      margin-bottom: 0.4rem;
+      margin-bottom: 0.35rem;
     }
 
-    .placeholder-grid {
+    .stage-panel {
+      padding: clamp(1.1rem, 2.6vw, 1.6rem);
       display: grid;
       gap: 1rem;
+      min-height: 0;
+      background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.12)),
+        rgba(252, 249, 244, 0.94);
     }
 
-    .pill-row {
+    .stage-head {
+      display: grid;
+      gap: 0.45rem;
+    }
+
+    .stage-meta {
       display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      margin-top: 1rem;
-    }
-
-    .pill {
-      display: inline-flex;
       align-items: center;
-      justify-content: center;
-      border-radius: 999px;
-      border: 1px solid rgba(46, 35, 26, 0.16);
-      padding: 0.42rem 0.75rem;
-      background: rgba(255, 255, 255, 0.72);
-      color: #51453d;
-      font-size: 0.85rem;
-      text-decoration: none;
-    }
-
-    .section-lead {
-      max-width: 72ch;
-      margin: 0.85rem 0 0;
-      color: var(--muted);
-    }
-
-    .step-grid,
-    .support-grid,
-    .source-grid {
-      margin-top: 1.25rem;
-      display: grid;
-      gap: 1rem;
-      grid-template-columns: 1fr;
-    }
-
-    .step-card,
-    .support-card,
-    .source-card {
-      padding: 1rem;
-      border-radius: var(--radius);
-      border: 1px solid rgba(46, 35, 26, 0.14);
-      background: var(--surface);
-    }
-
-    .step-meta {
-      display: flex;
-      gap: 0.75rem;
-      align-items: baseline;
       justify-content: space-between;
+      gap: 0.75rem;
       flex-wrap: wrap;
       color: var(--gold);
-      font-size: 0.78rem;
-      letter-spacing: 0.14em;
       text-transform: uppercase;
+      letter-spacing: 0.14em;
+      font-size: 0.74rem;
       font-weight: 800;
     }
 
-    .step-card p,
-    .support-card p,
-    .source-card p {
-      margin: 0.75rem 0 0;
-      color: #4a4037;
-    }
-
-    .step-card ul,
-    .support-card ul {
-      margin: 0.8rem 0 0;
-      padding-left: 1.1rem;
-      color: #4a4037;
-    }
-
-    .support-card {
-      background: var(--surface-soft);
-    }
-
-    .rule-band {
+    .stage-card {
+      min-height: 0;
       display: grid;
-      gap: 1rem;
+      gap: 0.95rem;
+      align-content: start;
     }
 
-    .rule-card {
-      padding: clamp(1.1rem, 3vw, 1.6rem);
-      border-radius: var(--radius);
-      border: 1px solid rgba(46, 35, 26, 0.14);
-      background: linear-gradient(135deg, #fdf8ef, #f3e8d6);
-      box-shadow: var(--shadow);
+    .control-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
     }
 
-    .rule-card h2 {
-      margin-bottom: 0.5rem;
+    .control-row button {
+      border: 1px solid rgba(50, 38, 26, 0.16);
+      background: rgba(255, 255, 255, 0.7);
+      color: var(--deep);
+      border-radius: 0.65rem;
+      padding: 0.7rem 0.9rem;
+      cursor: pointer;
+      font-weight: 700;
     }
 
-    .rule-quote {
-      margin: 0;
-      max-width: 54ch;
-      font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
-      font-size: clamp(1.4rem, 2.5vw, 1.85rem);
-      color: #32281f;
+    .control-row button.primary {
+      background: var(--deep);
+      color: #fff;
+      border-color: var(--deep);
+    }
+
+    .progress {
+      display: grid;
+      gap: 0.45rem;
+    }
+
+    .progress-track {
+      height: 0.45rem;
+      border-radius: 999px;
+      background: rgba(50, 38, 26, 0.08);
+      overflow: hidden;
+    }
+
+    .progress-track span {
+      display: block;
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, var(--gold), #d0a55d);
+      width: 20%;
+      transition: width 220ms ease;
+    }
+
+    .step-picker {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+    }
+
+    .step-picker button {
+      border: 1px solid rgba(50, 38, 26, 0.14);
+      background: rgba(255, 255, 255, 0.66);
+      color: var(--muted);
+      border-radius: 999px;
+      padding: 0.42rem 0.68rem;
+      cursor: pointer;
+      font-size: 0.84rem;
+      font-weight: 700;
+    }
+
+    .step-picker button[aria-pressed="true"] {
+      background: rgba(77, 124, 96, 0.16);
+      color: var(--deep);
+      border-color: rgba(77, 124, 96, 0.4);
+    }
+
+    .stack-grid {
+      display: grid;
+      gap: 0.85rem;
+      min-height: 0;
+    }
+
+    .stack-card,
+    .info-card,
+    .source-card {
+      border-radius: 0.75rem;
+      border: 1px solid rgba(50, 38, 26, 0.14);
+      background: var(--surface-strong);
+      padding: 0.9rem;
+    }
+
+    .stack-card p,
+    .info-card p,
+    .source-card p {
+      color: #4a4037;
+    }
+
+    .stack-card ul,
+    .info-card ul {
+      margin: 0.7rem 0 0;
+      padding-left: 1.05rem;
+      color: #4a4037;
+    }
+
+    .split-grid {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .source-grid {
+      display: grid;
+      gap: 0.85rem;
     }
 
     .source-card a {
@@ -404,344 +385,456 @@
       text-decoration: none;
     }
 
-    .source-card a:hover {
-      text-decoration: underline;
-    }
-
     .source-card small {
       display: block;
-      margin-top: 0.45rem;
+      margin-top: 0.3rem;
       color: var(--muted);
     }
 
-    .footnote {
-      margin-top: 1rem;
-      padding: 1rem;
-      border-radius: var(--radius);
-      background: rgba(176, 138, 68, 0.12);
-      border: 1px solid rgba(176, 138, 68, 0.2);
-      color: #4d4033;
+    .status-bar {
+      border-top: 1px solid rgba(50, 38, 26, 0.12);
+      background: rgba(248, 241, 231, 0.92);
     }
 
-    footer {
-      padding: 2rem 0 2.4rem;
+    .status-bar__inner {
+      min-height: 3.35rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      flex-wrap: wrap;
+      padding: 0.55rem 0;
       color: var(--muted);
+      font-size: 0.92rem;
     }
 
-    @media (min-width: 860px) {
-      .hero-grid {
-        grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.75fr);
+    .status-bar__inner strong {
+      color: var(--deep);
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.28rem 0.6rem;
+      border-radius: 999px;
+      border: 1px solid rgba(50, 38, 26, 0.14);
+      background: rgba(255, 255, 255, 0.68);
+      color: var(--gold);
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      font-weight: 800;
+    }
+
+    .view {
+      display: none;
+      min-height: 0;
+      align-content: start;
+      gap: 0.95rem;
+    }
+
+    .view.is-active {
+      display: grid;
+    }
+
+    .safety-accent {
+      border-left: 4px solid var(--clay);
+    }
+
+    .green-accent {
+      border-left: 4px solid var(--green);
+    }
+
+    @media (min-width: 980px) {
+      .workspace-grid {
+        grid-template-columns: minmax(310px, 0.9fr) minmax(0, 1.1fr);
       }
 
-      .step-grid,
-      .support-grid,
-      .source-grid {
+      .source-grid,
+      .split-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-
-      .source-grid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
       }
     }
 
     @media (prefers-reduced-motion: no-preference) {
-      .button,
-      .nav button,
-      .step-card,
-      .support-card,
+      .panel,
+      .stack-card,
+      .info-card,
       .source-card,
-      .visual-panel {
-        transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease, border-color 180ms ease;
+      .visual {
+        transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
       }
 
-      .button:hover,
-      .nav button:hover,
-      .step-card:hover,
-      .support-card:hover,
+      .panel:hover,
+      .stack-card:hover,
+      .info-card:hover,
       .source-card:hover,
-      .visual-panel:hover {
+      .visual:hover {
         transform: translateY(-2px);
-        box-shadow: 0 24px 56px rgba(34, 23, 15, 0.12);
+        box-shadow: 0 26px 56px rgba(35, 24, 15, 0.12);
       }
     }
   </style>
 </head>
 <body>
-  <header class="topbar">
-    <div class="shell topbar__inner">
-      <p class="brand">Fascia Release</p>
-      <nav class="nav" aria-label="Section navigation">
-        <button type="button" data-jump="hero" aria-pressed="true">Hero</button>
-        <button type="button" data-jump="routine" aria-pressed="false">Routine</button>
-        <button type="button" data-jump="rule" aria-pressed="false">Rule</button>
-        <button type="button" data-jump="avoid" aria-pressed="false">Avoid</button>
-        <button type="button" data-jump="sources" aria-pressed="false">Sources</button>
-      </nav>
-    </div>
-  </header>
+  <div class="app">
+    <header class="topbar">
+      <div class="shell topbar__inner">
+        <p class="brand">Fascia Release</p>
+        <nav class="view-nav" aria-label="Experience views">
+          <button type="button" data-view="intro" aria-pressed="true">Intro</button>
+          <button type="button" data-view="routine" aria-pressed="false">Routine</button>
+          <button type="button" data-view="rule" aria-pressed="false">Rule</button>
+          <button type="button" data-view="safety" aria-pressed="false">Safety</button>
+          <button type="button" data-view="sources" aria-pressed="false">Sources</button>
+        </nav>
+      </div>
+    </header>
 
-  <main>
-    <section id="hero" class="hero">
-      <div class="shell hero-grid">
-        <div class="card hero-copy">
+    <main class="workspace">
+      <div class="shell workspace-grid">
+        <section class="panel lead-panel" aria-labelledby="heroTitle">
           <p class="eyebrow">Gentle reset / 2-4 out of 10</p>
-          <h1>Fascia Release</h1>
-          <p class="lead">
-            Here is a gentle fascia-release reset for neck, jaw, tongue, and computer tension. Keep everything at
-            2-4/10 intensity. No forcing, cracking, aggressive stretching, or deep pressure on the front of the throat.
+          <h1 id="heroTitle">Fascia Release</h1>
+          <p class="lede">
+            A gentle fascia-release reset for neck, jaw, tongue, and computer tension. Keep everything at 2-4/10
+            intensity. No forcing, cracking, aggressive stretching, or deep pressure on the front of the throat.
           </p>
-          <p class="keyline">"Tongue soft, jaw heavy, eyes soft."</p>
-          <div class="hero-actions">
-            <button class="button button--primary" type="button" data-jump="routine">Open Routine</button>
-            <button class="button button--secondary" type="button" data-jump="rule">See Computer Jaw Rule</button>
-          </div>
-          <div class="pill-row" aria-label="Intent tags">
-            <span class="pill">Neck</span>
-            <span class="pill">Jaw</span>
-            <span class="pill">Tongue</span>
-            <span class="pill">Computer tension</span>
-            <span class="pill">Low intensity</span>
-          </div>
-        </div>
+          <p class="quote">"Tongue soft, jaw heavy, eyes soft."</p>
 
-        <aside class="hero-aside">
-          <div class="safety-card">
-            <h2>Seek care urgently if</h2>
-            <p>
-              arm or hand numbness gets worse, weakness appears, clumsiness shows up, balance changes, severe headache
-              with neck pain appears, dizziness starts, or symptoms follow an injury.
-            </p>
-            <p class="callout">
-              This page is a gentle reset, not a diagnosis or a substitute for medical care.
-            </p>
+          <div class="tag-row" aria-label="Focus areas">
+            <span class="tag">Neck</span>
+            <span class="tag">Jaw</span>
+            <span class="tag">Tongue</span>
+            <span class="tag">Computer tension</span>
+            <span class="tag">Low force</span>
           </div>
 
-          <div class="visual-stack">
-            <div class="visual-panel" role="img" aria-label="Placeholder image panel for a future neck and jaw visual">
+          <div class="visual-stack" aria-hidden="true">
+            <div class="visual">
               <div>
                 <strong>Placeholder image panel</strong>
-                Future three.js neck and jaw stage
+                Future three.js body-state view
               </div>
             </div>
-            <div class="visual-panel" role="img" aria-label="Placeholder image panel for a future breathing cue visual">
+            <div class="visual">
               <div>
                 <strong>Placeholder image panel</strong>
-                Breath loop and fascia map
+                Breath loop and jaw map
               </div>
             </div>
           </div>
 
-          <!-- Placeholder: future three.js visualization can replace these panels later. -->
-        </aside>
-      </div>
-    </section>
-
-    <section id="routine">
-      <div class="shell">
-        <p class="eyebrow">10-minute neck/jaw fascia release</p>
-        <h2>Move slowly. Stay small. Keep the whole routine calm.</h2>
-        <p class="section-lead">
-          The sequence below follows the original reset: downshift first, then jaw, SCM, suboccipitals, chest and
-          collarbone, and a final chin-tuck decompression.
-        </p>
-
-        <div class="step-grid">
-          <article class="step-card">
-            <div class="step-meta"><span>01</span><span>90 seconds</span></div>
-            <h3>Downshift first</h3>
-            <p>Sit or lie down. One hand on chest, one on belly. Inhale 4 seconds, exhale 6-8 seconds. On each exhale, quietly say, "tongue soft, jaw heavy, eyes soft."</p>
-            <ul>
-              <li>Use nose breathing if possible.</li>
-              <li>Let the exhale be longer than the inhale.</li>
-              <li>Drop the clench before anything else.</li>
-            </ul>
-          </article>
-
-          <article class="step-card">
-            <div class="step-meta"><span>02</span><span>2 minutes</span></div>
-            <h3>Tongue and jaw reset</h3>
-            <p>Place the tongue gently on the roof of the mouth behind the upper front teeth. Set the jaw to tongue up, teeth apart, lips lightly closed, jaw hanging.</p>
-            <ul>
-              <li>Do 5 tiny jaw openings, only 1-2 finger widths.</li>
-              <li>Massage the cheek muscle and jaw angle with small circles.</li>
-              <li>Keep pressure light and avoid digging into the joint.</li>
-            </ul>
-          </article>
-
-          <article class="step-card">
-            <div class="step-meta"><span>03</span><span>2 minutes</span></div>
-            <h3>SCM release</h3>
-            <p>Turn the head slightly left. On the right side, gently pinch the sternocleidomastoid between fingers, not the throat, and glide downward toward the collarbone.</p>
-            <ul>
-              <li>Use 3-5 slow passes per side.</li>
-              <li>Pressure stays gentle; do not dig.</li>
-              <li>This area is sensitive because of nearby nerves and vessels.</li>
-            </ul>
-          </article>
-
-          <article class="step-card">
-            <div class="step-meta"><span>04</span><span>2 minutes</span></div>
-            <h3>Suboccipital release</h3>
-            <p>Lie on your back. Put two tennis balls in a sock, or use fingertips, under the base of the skull. Let the head rest without rolling aggressively.</p>
-            <ul>
-              <li>Make tiny yes nods for 30 seconds.</li>
-              <li>Make tiny no motions for 30 seconds.</li>
-              <li>Then just breathe and melt for 60 seconds.</li>
-            </ul>
-          </article>
-
-          <article class="step-card">
-            <div class="step-meta"><span>05</span><span>90 seconds</span></div>
-            <h3>Pec and collarbone sweep</h3>
-            <p>Gently sweep under the collarbone from sternum outward to shoulder, then massage the pec area below the collarbone.</p>
-            <ul>
-              <li>Spend 45 seconds each side.</li>
-              <li>Let the shoulder stay relaxed.</li>
-              <li>This often matters more than the neck alone.</li>
-            </ul>
-          </article>
-
-          <article class="step-card">
-            <div class="step-meta"><span>06</span><span>1 minute</span></div>
-            <h3>Chin tuck decompression</h3>
-            <p>Sit tall, imagine the back of the skull floating upward, then slide the head backward like making a small double chin. Do not look down.</p>
-            <ul>
-              <li>Hold 3 seconds, then release.</li>
-              <li>Do 5-8 reps.</li>
-              <li>Keep discomfort very low, ideally 0-3/10.</li>
-            </ul>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section id="rule">
-      <div class="shell rule-band">
-        <div class="rule-card">
-          <p class="eyebrow">The computer jaw rule</p>
-          <h2>Use this 15-second reset every 20-30 minutes.</h2>
-          <p class="rule-quote">
-            "Feet grounded. Exhale. Tongue up. Teeth apart. Shoulders drop. Chin gently back. Eyes look far away."
-          </p>
-        </div>
-        <div class="support-grid">
-          <article class="support-card">
-            <h3>Why it helps</h3>
-            <p>
-              Computer work often recreates the same clench and forward-head pattern. A short reset can interrupt that
-              loop before it becomes the whole day.
+          <div class="stack-card safety-accent">
+            <p class="badge">Urgent care</p>
+            <p style="margin-top:0.5rem">
+              Seek care urgently if arm or hand numbness worsens, weakness appears, clumsiness starts, balance changes,
+              severe headache with neck pain appears, dizziness starts, or symptoms follow an injury.
             </p>
-          </article>
-          <article class="support-card">
-            <h3>Keep it tiny</h3>
-            <p>
-              The point is not to fix the body in one move. The point is to lower effort enough that the jaw and neck
-              stop bracing.
+          </div>
+        </section>
+
+        <section class="panel stage-panel" aria-live="polite" aria-labelledby="viewTitle">
+          <div class="stage-head">
+            <div class="stage-meta">
+              <span data-stage-label>Intro</span>
+              <span>Single-screen experience</span>
+            </div>
+            <h2 id="viewTitle" data-view-title>Reset without the scroll</h2>
+            <p class="lede" data-view-lead>
+              The full routine stays inside the frame. Switch views instead of moving down the page.
             </p>
-          </article>
-        </div>
-      </div>
-    </section>
+          </div>
 
-    <section id="avoid">
-      <div class="shell">
-        <p class="eyebrow">What I would avoid</p>
-        <h2>Stay away from hard, corrective, or aggressive work.</h2>
-        <div class="support-grid">
-          <article class="support-card">
-            <h3>Do not force the neck</h3>
-            <p>Skip hard cracking, aggressive stretching, and deep pressure on the front of the throat.</p>
-          </article>
-          <article class="support-card">
-            <h3>Do not force the jaw</h3>
-            <p>If the jaw clicks, locks, hurts, or the bite changes, stop trying to expand or align it yourself.</p>
-          </article>
-          <article class="support-card">
-            <h3>Use care with tools</h3>
-            <p>Aggressive gua sha or strong pressure over the throat is not part of this reset.</p>
-          </article>
-          <article class="support-card">
-            <h3>Get help when needed</h3>
-            <p>A dentist or TMJ-aware physical therapist is worth it if the symptoms persist or the bite feels changed.</p>
-          </article>
-        </div>
-      </div>
-    </section>
+          <div class="view is-active" data-view-panel="intro">
+            <div class="stack-grid">
+              <article class="info-card">
+                <h3>What this page is</h3>
+                <p>
+                  A calm, premium, low-force body reset designed to feel like a compact experience rather than a long
+                  article.
+                </p>
+              </article>
+              <article class="info-card">
+                <h3>How to use it</h3>
+                <p>
+                  Pick a view, then step through the routine at your own pace. The content changes in place.
+                </p>
+              </article>
+            </div>
+          </div>
 
-    <section id="sources">
-      <div class="shell">
-        <p class="eyebrow">Sources</p>
-        <h2>Reference points behind the routine.</h2>
-        <p class="section-lead">
-          These links are there for context and safety, not to turn the page into a diagnosis tool.
-        </p>
-        <div class="source-grid">
-          <article class="source-card">
-            <a href="https://www.nhsinform.scot/illnesses-and-conditions/muscle-bone-and-joints/neck-and-back-problems-and-conditions/neck-problems/?utm_source=chatgpt.com" target="_blank" rel="noopener">
-              <strong>NHS inform</strong>
-            </a>
-            <small>Urgent advice signs for neck problems.</small>
-          </article>
-          <article class="source-card">
-            <a href="https://www.mayoclinic.org/diseases-conditions/tmj/diagnosis-treatment/drc-20350945?utm_source=chatgpt.com" target="_blank" rel="noopener">
-              <strong>Mayo Clinic</strong>
-            </a>
-            <small>TMJ self-care and clenching awareness.</small>
-          </article>
-          <article class="source-card">
-            <a href="https://my.clevelandclinic.org/health/body/24939-sternocleidomastoid-scm-muscle?utm_source=chatgpt.com" target="_blank" rel="noopener">
-              <strong>Cleveland Clinic</strong>
-            </a>
-            <small>SCM basics and posture-related care.</small>
-          </article>
-        </div>
-        <div class="footnote">
-          The routine is intentionally small and low force. If symptoms are severe, escalating, or tied to injury,
-          seek medical advice instead of pushing through.
-        </div>
-      </div>
-    </section>
-  </main>
+          <div class="view" data-view-panel="routine">
+            <div class="progress">
+              <div class="stage-meta">
+                <span data-step-label>Step 1 of 6</span>
+                <span data-step-duration>90 seconds</span>
+              </div>
+              <div class="progress-track" aria-hidden="true"><span data-progress-fill></span></div>
+            </div>
 
-  <footer>
-    <div class="shell">
-      <p>Fascia Release is a gentle reset page for neck, jaw, tongue, and computer tension.</p>
-      <p>Placeholder: future three.js visuals can be added later without changing the sequence.</p>
-    </div>
-  </footer>
+            <div class="step-pills" role="tablist" aria-label="Routine steps">
+              <button type="button" data-step="0" aria-pressed="true">Downshift</button>
+              <button type="button" data-step="1" aria-pressed="false">Jaw</button>
+              <button type="button" data-step="2" aria-pressed="false">SCM</button>
+              <button type="button" data-step="3" aria-pressed="false">Base</button>
+              <button type="button" data-step="4" aria-pressed="false">Chest</button>
+              <button type="button" data-step="5" aria-pressed="false">Chin tuck</button>
+            </div>
+
+            <article class="stack-card green-accent">
+              <h3 data-step-title>Downshift first</h3>
+              <p data-step-body>
+                Sit or lie down. One hand on chest, one on belly. Inhale 4 seconds, exhale 6-8 seconds. On each exhale,
+                silently say, "tongue soft, jaw heavy, eyes soft."
+              </p>
+              <ul data-step-points>
+                <li>Use nose breathing if possible.</li>
+                <li>Let the exhale be longer than the inhale.</li>
+                <li>Drop the clench before anything else.</li>
+              </ul>
+            </article>
+
+            <div class="control-row" aria-label="Routine controls">
+              <button type="button" data-action="back">Back</button>
+              <button type="button" class="primary" data-action="next">Next</button>
+              <button type="button" data-action="jump" data-target="safety">Jump to safety</button>
+            </div>
+          </div>
+
+          <div class="view" data-view-panel="rule">
+            <article class="stack-card">
+              <p class="badge">The computer jaw rule</p>
+              <h3 style="margin-top:0.7rem">Use this 15-second reset every 20-30 minutes.</h3>
+              <p style="margin-top:0.8rem; font-family: 'Iowan Old Style', Palatino, Georgia, serif; font-size: clamp(1.2rem, 2.2vw, 1.55rem); font-style: italic; color: #3d3127;">
+                Feet grounded. Exhale. Tongue up. Teeth apart. Shoulders drop. Chin gently back. Eyes look far away.
+              </p>
+            </article>
+            <div class="split-grid">
+              <article class="info-card">
+                <h3>Why it matters</h3>
+                <p>
+                  Computer work recreates clench, shallow breathing, and forward head posture. A short reset interrupts
+                  the loop.
+                </p>
+              </article>
+              <article class="info-card">
+                <h3>Keep it tiny</h3>
+                <p>
+                  The point is not to fix the body in one move. The point is to lower effort enough that the jaw and
+                  neck stop bracing.
+                </p>
+              </article>
+            </div>
+          </div>
+
+          <div class="view" data-view-panel="safety">
+            <div class="split-grid">
+              <article class="stack-card safety-accent">
+                <h3>What to avoid</h3>
+                <ul>
+                  <li>Hard neck cracking.</li>
+                  <li>Aggressive stretching or deep throat pressure.</li>
+                  <li>Forcing jaw alignment or trying to expand the jaw yourself.</li>
+                </ul>
+              </article>
+              <article class="stack-card">
+                <h3>When to stop</h3>
+                <ul>
+                  <li>Jaw clicking, locking, or pain increases.</li>
+                  <li>The bite feels changed.</li>
+                  <li>Dizziness, numbness, weakness, or severe pain appears.</li>
+                </ul>
+              </article>
+            </div>
+            <article class="info-card">
+              <h3>Practical note</h3>
+              <p>
+                A dentist or TMJ-aware physical therapist is worth it if the symptoms persist or the bite feels changed.
+              </p>
+            </article>
+          </div>
+
+          <div class="view" data-view-panel="sources">
+            <div class="source-grid">
+              <article class="source-card">
+                <a href="https://www.nhsinform.scot/illnesses-and-conditions/muscle-bone-and-joints/neck-and-back-problems-and-conditions/neck-problems/?utm_source=chatgpt.com" target="_blank" rel="noopener">
+                  <strong>NHS inform</strong>
+                </a>
+                <small>Urgent advice signs for neck problems.</small>
+              </article>
+              <article class="source-card">
+                <a href="https://www.mayoclinic.org/diseases-conditions/tmj/diagnosis-treatment/drc-20350945?utm_source=chatgpt.com" target="_blank" rel="noopener">
+                  <strong>Mayo Clinic</strong>
+                </a>
+                <small>TMJ self-care and clenching awareness.</small>
+              </article>
+              <article class="source-card">
+                <a href="https://my.clevelandclinic.org/health/body/24939-sternocleidomastoid-scm-muscle?utm_source=chatgpt.com" target="_blank" rel="noopener">
+                  <strong>Cleveland Clinic</strong>
+                </a>
+                <small>SCM basics and posture-related care.</small>
+              </article>
+            </div>
+            <article class="stack-card">
+              <h3>Design intent</h3>
+              <p>
+                Placeholder panels are kept in the frame now so Three.js can take over later without changing the page
+                structure.
+              </p>
+            </article>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer class="status-bar">
+      <div class="shell status-bar__inner">
+        <div>
+          <strong>Fascia Release</strong> keeps the routine compact, gentle, and inside a single-screen flow.
+        </div>
+        <div>Experimental app • future Three.js-ready shell</div>
+      </div>
+    </footer>
+  </div>
 
   <script>
-    const sections = [...document.querySelectorAll('section[id]')];
-    const buttons = [...document.querySelectorAll('[data-jump]')];
+    const views = [...document.querySelectorAll('[data-view-panel]')];
+    const viewButtons = [...document.querySelectorAll('[data-view]')];
+    const stepButtons = [...document.querySelectorAll('[data-step]')];
+    const stepTitle = document.querySelector('[data-step-title]');
+    const stepBody = document.querySelector('[data-step-body]');
+    const stepPoints = document.querySelector('[data-step-points]');
+    const stepLabel = document.querySelector('[data-step-label]');
+    const stepDuration = document.querySelector('[data-step-duration]');
+    const progressFill = document.querySelector('[data-progress-fill]');
+    const stageLabel = document.querySelector('[data-stage-label]');
+    const viewTitle = document.querySelector('[data-view-title]');
+    const viewLead = document.querySelector('[data-view-lead]');
 
-    buttons.forEach((button) => {
+    const routine = [
+      {
+        title: 'Downshift first',
+        duration: '90 seconds',
+        body: 'Sit or lie down. One hand on chest, one on belly. Inhale 4 seconds, exhale 6-8 seconds. On each exhale, silently say, "tongue soft, jaw heavy, eyes soft."',
+        points: ['Use nose breathing if possible.', 'Let the exhale be longer than the inhale.', 'Drop the clench before anything else.']
+      },
+      {
+        title: 'Tongue and jaw reset',
+        duration: '2 minutes',
+        body: 'Place the tongue on the roof of the mouth behind the upper front teeth. Set tongue up, teeth apart, lips lightly closed, jaw hanging.',
+        points: ['Do 5 tiny jaw openings.', 'Massage the cheek muscle and jaw angle.', 'Keep pressure light and avoid the joint.']
+      },
+      {
+        title: 'SCM release',
+        duration: '2 minutes',
+        body: 'Turn the head slightly left. On the right side, gently pinch the sternocleidomastoid between fingers, not the throat, and glide downward toward the collarbone.',
+        points: ['Use 3-5 slow passes per side.', 'Pressure stays gentle.', 'Do not dig.']
+      },
+      {
+        title: 'Suboccipital release',
+        duration: '2 minutes',
+        body: 'Lie on your back. Put two tennis balls in a sock, or use fingertips, under the base of the skull. Let the head rest without rolling aggressively.',
+        points: ['Make tiny yes nods for 30 seconds.', 'Make tiny no motions for 30 seconds.', 'Then breathe and melt for 60 seconds.']
+      },
+      {
+        title: 'Pec and collarbone sweep',
+        duration: '90 seconds',
+        body: 'Gently sweep under the collarbone from sternum outward to shoulder, then massage the pec area below the collarbone.',
+        points: ['Spend 45 seconds each side.', 'Keep the shoulder relaxed.', 'This often matters more than the neck alone.']
+      },
+      {
+        title: 'Chin tuck decompression',
+        duration: '1 minute',
+        body: 'Sit tall, imagine the back of the skull floating upward, then slide the head backward like making a small double chin. Do not look down.',
+        points: ['Hold 3 seconds, then release.', 'Do 5-8 reps.', 'Keep discomfort very low.']
+      }
+    ];
+
+    const viewsMeta = {
+      intro: {
+        label: 'Intro',
+        title: 'Reset without the scroll',
+        lead: 'The routine stays inside the frame. Switch views instead of moving down the page.'
+      },
+      routine: {
+        label: 'Routine',
+        title: '10-minute neck/jaw fascia release',
+        lead: 'Use the buttons to move through the sequence one step at a time.'
+      },
+      rule: {
+        label: 'Rule',
+        title: 'The computer jaw rule',
+        lead: 'A tiny reset loop for screen-heavy days.'
+      },
+      safety: {
+        label: 'Safety',
+        title: 'What to avoid',
+        lead: 'Keep the work gentle. Do not force the neck or jaw.'
+      },
+      sources: {
+        label: 'Sources',
+        title: 'Reference points',
+        lead: 'Short links for the safety context behind the page.'
+      }
+    };
+
+    let currentView = 'intro';
+    let currentStep = 0;
+
+    function setView(nextView) {
+      currentView = nextView;
+      views.forEach((view) => view.classList.toggle('is-active', view.dataset.viewPanel === nextView));
+      viewButtons.forEach((button) => button.setAttribute('aria-pressed', String(button.dataset.view === nextView)));
+      stageLabel.textContent = viewsMeta[nextView].label;
+      viewTitle.textContent = viewsMeta[nextView].title;
+      viewLead.textContent = viewsMeta[nextView].lead;
+    }
+
+    function renderStep(index) {
+      currentStep = (index + routine.length) % routine.length;
+      const step = routine[currentStep];
+      stepTitle.textContent = step.title;
+      stepBody.textContent = step.body;
+      stepPoints.innerHTML = step.points.map((point) => `<li>${point}</li>`).join('');
+      stepLabel.textContent = `Step ${currentStep + 1} of ${routine.length}`;
+      stepDuration.textContent = step.duration;
+      progressFill.style.width = `${((currentStep + 1) / routine.length) * 100}%`;
+      stepButtons.forEach((button) => button.setAttribute('aria-pressed', String(Number(button.dataset.step) === currentStep)));
+    }
+
+    viewButtons.forEach((button) => {
+      button.addEventListener('click', () => setView(button.dataset.view));
+    });
+
+    stepButtons.forEach((button) => {
       button.addEventListener('click', () => {
-        const target = document.getElementById(button.dataset.jump);
-        if (target) {
-          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
+        setView('routine');
+        renderStep(Number(button.dataset.step));
       });
     });
 
-    const setActive = (id) => {
-      document.querySelectorAll('.nav button').forEach((button) => {
-        button.setAttribute('aria-pressed', String(button.dataset.jump === id));
+    document.querySelectorAll('[data-action="back"]').forEach((button) => {
+      button.addEventListener('click', () => {
+        setView('routine');
+        renderStep(currentStep - 1);
       });
-    };
+    });
 
-    if ('IntersectionObserver' in window) {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          const visible = entries.filter((entry) => entry.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
-          if (visible) {
-            setActive(visible.target.id);
-          }
-        },
-        { rootMargin: '-30% 0px -55% 0px', threshold: [0.1, 0.2, 0.3, 0.4, 0.5] }
-      );
+    document.querySelectorAll('[data-action="next"]').forEach((button) => {
+      button.addEventListener('click', () => {
+        setView('routine');
+        renderStep(currentStep + 1);
+      });
+    });
 
-      sections.forEach((section) => observer.observe(section));
-    }
+    document.querySelectorAll('[data-action="jump"]').forEach((button) => {
+      button.addEventListener('click', () => setView(button.dataset.target));
+    });
+
+    setView('intro');
+    renderStep(0);
   </script>
 </body>
 </html>

--- a/tests/3dvr-connect-and-fascia-release.test.js
+++ b/tests/3dvr-connect-and-fascia-release.test.js
@@ -24,8 +24,11 @@ test('Fascia Release ships as a standalone gentle reset and portal card', async 
   const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
 
   assert.match(html, /<title>Fascia Release \| 3DVR Portal<\/title>/);
-  assert.match(html, /Here is a gentle fascia-release reset for neck, jaw, tongue, and computer tension\./);
-  assert.match(html, /Inhale 4 seconds, exhale 6-8 seconds/);
+  assert.match(html, /presented as a single-screen interactive experience/);
+  assert.match(html, /overflow: hidden;/);
+  assert.match(html, /data-view-panel="routine"/);
+  assert.match(html, /data-step="0"/);
+  assert.match(html, /Reset without the scroll/);
   assert.match(html, /Tongue soft, jaw heavy, eyes soft/);
   assert.match(html, /Placeholder image panel/);
   assert.match(html, /Seek care urgently if/);


### PR DESCRIPTION
## Summary
- Reworks `Fascia Release` into a fixed-shell, single-screen experience so the reader switches views instead of scrolling.
- Adds a view switcher for Intro, Routine, Rule, Safety, and Sources.
- Keeps the portal card and experimental status intact.

## Verification
- `node --test tests/3dvr-connect-and-fascia-release.test.js tests/seated-spine-reset.test.js`