### PR TITLE
Add Orbital Courier game

### DIFF
--- a/games.html
+++ b/games.html
@@ -136,6 +136,11 @@ h1 {
   --icon-bg: linear-gradient(135deg, #312e81, #c026d3);
 }
 
+.game-card.courier {
+  --card-glow: linear-gradient(135deg, rgba(47, 111, 86, 0.38), rgba(215, 166, 64, 0.42));
+  --icon-bg: linear-gradient(135deg, #2f6f56, #d7a640);
+}
+
 .game-card.jetpack {
   --card-glow: linear-gradient(135deg, rgba(248, 113, 113, 0.38), rgba(250, 204, 21, 0.42));
   --icon-bg: linear-gradient(135deg, #ef4444, #f59e0b);
@@ -198,6 +203,21 @@ h1 {
     </span>
     <span class="game-title">Stellar Drift Flight</span>
     <p class="game-blurb">Thread a starfighter through deep-space drift lanes.</p>
+  </a>
+  <a class="game-card courier" href="orbital-courier/">
+    <span class="game-icon" aria-hidden="true">
+      <svg viewBox="0 0 96 96" role="img">
+        <circle cx="48" cy="52" r="28" fill="currentColor" opacity="0.92"/>
+        <path d="M27 52c10 8 28 9 42 1" fill="none" stroke="#fff" stroke-width="5" stroke-linecap="round" opacity="0.58"/>
+        <path d="M36 30c8 4 19 5 29 1" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" opacity="0.42"/>
+        <circle cx="34" cy="43" r="5" fill="#fff" opacity="0.88"/>
+        <circle cx="66" cy="59" r="6" fill="#fff" opacity="0.74"/>
+        <path d="M35 43c11 3 20 8 31 16" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-dasharray="2 7" opacity="0.86"/>
+        <path d="M48 12l6 13 14 2-10 10 2 14-12-7-12 7 2-14-10-10 14-2 6-13z" fill="#fff" opacity="0.82"/>
+      </svg>
+    </span>
+    <span class="game-title">Orbital Courier</span>
+    <p class="game-blurb">Run quick delivery routes around a tiny spherical village world.</p>
   </a>
   <a class="game-card jetpack" href="jetpack/">
     <span class="game-icon" aria-hidden="true">

--- a/orbital-courier/index.html
+++ b/orbital-courier/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Orbital Courier - 3DVR Games</title>
+  <meta name="description" content="A tiny spherical delivery game for the 3DVR portal arcade.">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="style.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body data-issue-launcher="off">
+  <canvas id="game-canvas" aria-label="Orbital Courier 3D spherical delivery world"></canvas>
+
+  <button id="menu-toggle" class="nav-toggle" type="button" aria-controls="game-nav" aria-expanded="false">Menu</button>
+  <nav id="game-nav" class="top-buttons" aria-label="Game links">
+    <a href="../index.html">Portal</a>
+    <a href="../games.html">Game Hub</a>
+    <a href="../space-jetpack/">Space Jetpack</a>
+    <a href="https://3dvr.tech/#subscribe" target="_blank" rel="noopener">Subscribe</a>
+  </nav>
+
+  <main class="game-shell" aria-label="Orbital Courier game interface">
+    <section class="hud" aria-live="polite">
+      <div class="hud__brand">
+        <span class="hud__eyebrow">3DVR Games</span>
+        <h1>Orbital Courier</h1>
+      </div>
+
+      <div class="hud__stats" aria-label="Run status">
+        <div>
+          <span>Deliveries</span>
+          <strong id="deliveries-count">0</strong>
+        </div>
+        <div>
+          <span>Time</span>
+          <strong id="time-left">02:00</strong>
+        </div>
+        <div>
+          <span>Load</span>
+          <strong id="load-state">Empty</strong>
+        </div>
+      </div>
+
+      <div class="route-panel">
+        <span class="route-panel__label">Current route</span>
+        <p id="route-text">Press Start Route to begin a delivery run.</p>
+      </div>
+
+      <div class="signal-strip" aria-label="Village signal feed">
+        <span id="signal-one">Market ping</span>
+        <span id="signal-two">Harbor wave</span>
+        <span id="signal-three">Hilltop ready</span>
+      </div>
+
+      <div class="hud__actions">
+        <button id="start-button" type="button">Start Route</button>
+        <button id="pause-button" type="button">Pause</button>
+        <button id="reset-button" type="button">Reset</button>
+      </div>
+    </section>
+
+    <section id="intro-panel" class="intro-panel" aria-labelledby="intro-title">
+      <div>
+        <span class="intro-panel__kicker">Tiny planet, quick errands</span>
+        <h2 id="intro-title">Carry signal parcels between neighborhoods before the route window closes.</h2>
+        <p>Move with WASD, arrows, or the touch stick. Get close to the green pickup beacon, then carry the parcel to the gold drop-off beacon.</p>
+      </div>
+      <button id="intro-start-button" type="button">Start Route</button>
+    </section>
+
+    <div class="instruction-chip" role="status">
+      <span id="instruction-text">Start a route, then steer toward the glowing pickup.</span>
+    </div>
+
+    <div class="touch-controls" aria-label="Touch controls">
+      <div class="touch-pad" data-touch-pad aria-label="Move courier">
+        <span class="touch-pad__nub" data-touch-nub></span>
+      </div>
+      <button id="boost-button" class="boost-button" type="button">Pulse</button>
+    </div>
+  </main>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script type="module" src="main.js"></script>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/orbital-courier/main.js
+++ b/orbital-courier/main.js
@@ -1,0 +1,712 @@
+const THREE = globalThis.THREE;
+
+const PLANET_RADIUS = 18;
+const SURFACE_OFFSET = 1.15;
+const RUN_LENGTH_SECONDS = 120;
+const PICKUP_RADIUS = 1.7;
+const DROPOFF_RADIUS = 1.9;
+
+const locations = [
+  { name: 'Olive Market', lat: 34, lon: -18 },
+  { name: 'Harbor Steps', lat: 12, lon: 58 },
+  { name: 'Sun Kiln', lat: -18, lon: 132 },
+  { name: 'North Garden', lat: 53, lon: 96 },
+  { name: 'Blue Gate', lat: -42, lon: -82 },
+  { name: 'Terrace Loop', lat: 8, lon: -138 },
+  { name: 'Hill Studio', lat: 61, lon: -146 },
+  { name: 'Dune Station', lat: -9, lon: 12 },
+].map((location) => ({
+  ...location,
+  normal: normalFromLatLon(location.lat, location.lon),
+}));
+
+const signalLines = [
+  'Market ping',
+  'Harbor wave',
+  'Studio ready',
+  'Terrace bell',
+  'Garden hello',
+  'Blue Gate sync',
+  'Dune check',
+  'Kiln route',
+];
+
+const state = {
+  phase: 'ready',
+  deliveries: 0,
+  carrying: false,
+  timeLeft: RUN_LENGTH_SECONDS,
+  route: null,
+  routeIndex: 0,
+  boostTime: 0,
+  pulseCooldown: 0,
+  lastTime: 0,
+};
+
+const input = {
+  x: 0,
+  y: 0,
+  keys: new Set(),
+  pointerId: null,
+  touchVector: { x: 0, y: 0 },
+};
+
+const dom = {
+  canvas: document.getElementById('game-canvas'),
+  deliveries: document.getElementById('deliveries-count'),
+  time: document.getElementById('time-left'),
+  load: document.getElementById('load-state'),
+  routeText: document.getElementById('route-text'),
+  instruction: document.getElementById('instruction-text'),
+  start: document.getElementById('start-button'),
+  introStart: document.getElementById('intro-start-button'),
+  pause: document.getElementById('pause-button'),
+  reset: document.getElementById('reset-button'),
+  boost: document.getElementById('boost-button'),
+  intro: document.getElementById('intro-panel'),
+  touchPad: document.querySelector('[data-touch-pad]'),
+  touchNub: document.querySelector('[data-touch-nub]'),
+  menuToggle: document.getElementById('menu-toggle'),
+  gameNav: document.getElementById('game-nav'),
+  signals: [
+    document.getElementById('signal-one'),
+    document.getElementById('signal-two'),
+    document.getElementById('signal-three'),
+  ],
+};
+
+const scene = new THREE.Scene();
+scene.fog = new THREE.FogExp2(0xf0dfbd, 0.011);
+
+const camera = new THREE.PerspectiveCamera(52, window.innerWidth / window.innerHeight, 0.1, 220);
+let renderer;
+
+try {
+  renderer = new THREE.WebGLRenderer({
+    canvas: dom.canvas,
+    antialias: true,
+    alpha: false,
+    powerPreference: 'high-performance',
+    preserveDrawingBuffer: true,
+  });
+} catch (error) {
+  renderer = createCanvasFallbackRenderer(dom.canvas);
+}
+
+renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.8));
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setClearColor(0xf0dfbd);
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 0.78;
+
+const tempNormal = new THREE.Vector3(0.2, 0.94, 0.28).normalize();
+const player = createCourier();
+const planet = createPlanet();
+const markerGroup = new THREE.Group();
+const villageGroup = new THREE.Group();
+const orbitGroup = new THREE.Group();
+const pickupMarker = createBeacon(0x2f6f56, 'pickup');
+const dropoffMarker = createBeacon(0xd7a640, 'dropoff');
+const tempVector = new THREE.Vector3();
+const tempEast = new THREE.Vector3();
+const tempNorth = new THREE.Vector3();
+const tempMove = new THREE.Vector3();
+const heading = new THREE.Vector3(1, 0, 0);
+
+scene.add(planet, markerGroup, villageGroup, orbitGroup, player.group);
+markerGroup.add(pickupMarker, dropoffMarker);
+createVillages();
+createOrbitSignals();
+setupLights();
+spawnRoute();
+placePlayer(tempNormal);
+updateHud();
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, Number.isFinite(value) ? value : min));
+}
+
+function normalFromLatLon(lat, lon) {
+  const phi = (90 - lat) * Math.PI / 180;
+  const theta = (lon + 180) * Math.PI / 180;
+  return new THREE.Vector3(
+    -Math.sin(phi) * Math.cos(theta),
+    Math.cos(phi),
+    Math.sin(phi) * Math.sin(theta),
+  ).normalize();
+}
+
+function createPlanet() {
+  const group = new THREE.Group();
+  const planetGeometry = new THREE.SphereGeometry(PLANET_RADIUS, 96, 64);
+  const planetMaterial = new THREE.MeshStandardMaterial({
+    color: 0xc9904e,
+    roughness: 0.9,
+    metalness: 0.02,
+  });
+  const sphere = new THREE.Mesh(planetGeometry, planetMaterial);
+  group.add(sphere);
+
+  const seaMaterial = new THREE.MeshStandardMaterial({
+    color: 0x4a9ca1,
+    roughness: 0.6,
+    metalness: 0.03,
+    transparent: true,
+    opacity: 0.9,
+  });
+  [
+    { lat: 18, lon: -42, scale: [3.4, 0.1, 2.1] },
+    { lat: -24, lon: 58, scale: [4.1, 0.1, 1.8] },
+    { lat: 43, lon: 142, scale: [2.5, 0.1, 1.5] },
+    { lat: -48, lon: -132, scale: [2.9, 0.1, 1.6] },
+  ].forEach((patch) => {
+    const mesh = new THREE.Mesh(new THREE.CircleGeometry(1, 36), seaMaterial);
+    mesh.scale.set(...patch.scale);
+    placeSurfaceObject(mesh, normalFromLatLon(patch.lat, patch.lon), 0.04, 'z');
+    group.add(mesh);
+  });
+
+  const pathMaterial = new THREE.MeshStandardMaterial({
+    color: 0xf5e5b5,
+    roughness: 0.92,
+    metalness: 0,
+  });
+  for (let index = 0; index < 11; index += 1) {
+    const lon = index * 33 - 154;
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.05, 2.9), pathMaterial);
+    mesh.rotation.y = index * 0.4;
+    placeSurfaceObject(mesh, normalFromLatLon(index % 2 ? 14 : -8, lon), 0.06);
+    group.add(mesh);
+  }
+
+  return group;
+}
+
+function createCourier() {
+  const group = new THREE.Group();
+  const tunic = new THREE.MeshStandardMaterial({ color: 0xfff4d2, roughness: 0.46, metalness: 0.04 });
+  const satchel = new THREE.MeshStandardMaterial({ color: 0xbd6146, roughness: 0.58, metalness: 0.02 });
+  const glow = new THREE.MeshStandardMaterial({
+    color: 0x4a9ca1,
+    emissive: 0x4a9ca1,
+    emissiveIntensity: 0.48,
+    roughness: 0.38,
+  });
+
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.3, 0.38, 0.86, 18), tunic);
+  body.position.y = 0.58;
+  group.add(body);
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.24, 20, 16), tunic);
+  head.position.y = 1.19;
+  group.add(head);
+
+  const bag = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.3, 0.18), satchel);
+  bag.position.set(0.31, 0.61, 0.08);
+  group.add(bag);
+
+  const signal = new THREE.Mesh(new THREE.SphereGeometry(0.1, 16, 12), glow);
+  signal.position.set(-0.24, 1.38, 0);
+  group.add(signal);
+
+  group.scale.setScalar(0.92);
+  return {
+    group,
+    normal: tempNormal.clone(),
+    speed: 8.8,
+  };
+}
+
+function createBeacon(color, mode) {
+  const group = new THREE.Group();
+  group.userData.mode = mode;
+
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    emissive: color,
+    emissiveIntensity: 0.46,
+    roughness: 0.3,
+  });
+  const paleMaterial = new THREE.MeshStandardMaterial({
+    color: 0xfff8e8,
+    roughness: 0.62,
+  });
+
+  const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.08, 1.1, 16), paleMaterial);
+  pole.position.y = 0.58;
+  group.add(pole);
+
+  const lamp = new THREE.Mesh(new THREE.SphereGeometry(0.22, 20, 14), material);
+  lamp.position.y = 1.22;
+  group.add(lamp);
+
+  const ring = new THREE.Mesh(new THREE.TorusGeometry(0.58, 0.025, 10, 48), material);
+  ring.rotation.x = Math.PI / 2;
+  ring.position.y = 0.1;
+  group.add(ring);
+
+  return group;
+}
+
+function createVillages() {
+  const roofMaterial = new THREE.MeshStandardMaterial({ color: 0xbd6146, roughness: 0.66 });
+  const wallMaterial = new THREE.MeshStandardMaterial({ color: 0xffedc7, roughness: 0.74 });
+
+  locations.forEach((location, index) => {
+    const house = new THREE.Group();
+    const base = new THREE.Mesh(new THREE.BoxGeometry(0.58, 0.34, 0.48), wallMaterial);
+    base.position.y = 0.22;
+    house.add(base);
+
+    const roof = new THREE.Mesh(new THREE.ConeGeometry(0.43, 0.34, 4), roofMaterial);
+    roof.position.y = 0.58;
+    roof.rotation.y = Math.PI / 4;
+    house.add(roof);
+
+    house.scale.setScalar(index % 3 === 0 ? 1.08 : 0.92);
+    placeSurfaceObject(house, location.normal, 0.08);
+    villageGroup.add(house);
+  });
+}
+
+function createOrbitSignals() {
+  const goldMaterial = new THREE.MeshStandardMaterial({
+    color: 0xd7a640,
+    emissive: 0xd7a640,
+    emissiveIntensity: 0.28,
+    roughness: 0.32,
+  });
+  const mossMaterial = new THREE.MeshStandardMaterial({
+    color: 0x2f6f56,
+    emissive: 0x2f6f56,
+    emissiveIntensity: 0.22,
+    roughness: 0.42,
+  });
+
+  for (let index = 0; index < 18; index += 1) {
+    const pip = new THREE.Mesh(new THREE.SphereGeometry(index % 4 === 0 ? 0.12 : 0.08, 14, 10), index % 2 ? goldMaterial : mossMaterial);
+    const angle = index / 18 * Math.PI * 2;
+    pip.position.set(Math.cos(angle) * 24, Math.sin(index * 1.7) * 2.6, Math.sin(angle) * 24);
+    orbitGroup.add(pip);
+  }
+}
+
+function setupLights() {
+  scene.add(new THREE.HemisphereLight(0xfff2ce, 0x49746e, 0.92));
+
+  const sun = new THREE.DirectionalLight(0xfff7dc, 1.18);
+  sun.position.set(26, 34, 18);
+  scene.add(sun);
+
+  const rim = new THREE.DirectionalLight(0x8ec7be, 0.72);
+  rim.position.set(-30, 12, -20);
+  scene.add(rim);
+}
+
+function placeSurfaceObject(object, normal, offset = 0, alignAxis = 'y') {
+  object.position.copy(normal).multiplyScalar(PLANET_RADIUS + offset);
+  const sourceAxis = alignAxis === 'z' ? new THREE.Vector3(0, 0, 1) : new THREE.Vector3(0, 1, 0);
+  object.quaternion.setFromUnitVectors(sourceAxis, normal);
+}
+
+function placePlayer(normal) {
+  player.normal.copy(normal).normalize();
+  player.group.position.copy(player.normal).multiplyScalar(PLANET_RADIUS + SURFACE_OFFSET);
+  player.group.up.copy(player.normal);
+  player.group.lookAt(player.group.position.clone().add(heading));
+}
+
+function spawnRoute() {
+  const pickup = locations[state.routeIndex % locations.length];
+  let dropoff = locations[(state.routeIndex * 3 + 4) % locations.length];
+
+  if (pickup === dropoff) {
+    dropoff = locations[(state.routeIndex + 1) % locations.length];
+  }
+
+  state.route = { pickup, dropoff };
+  state.carrying = false;
+  placeSurfaceObject(pickupMarker, pickup.normal, 0.08);
+  placeSurfaceObject(dropoffMarker, dropoff.normal, 0.08);
+  pickupMarker.visible = true;
+  dropoffMarker.visible = false;
+  updateSignals();
+  updateHud();
+}
+
+function updateSignals() {
+  dom.signals.forEach((element, index) => {
+    element.textContent = signalLines[(state.routeIndex + index) % signalLines.length];
+  });
+}
+
+function startRun() {
+  if (state.phase === 'playing') {
+    return;
+  }
+
+  if (state.phase === 'complete') {
+    resetRun();
+  }
+
+  state.phase = 'playing';
+  dom.intro.hidden = true;
+  dom.start.textContent = 'Running';
+  dom.pause.textContent = 'Pause';
+  dom.instruction.textContent = state.carrying ? 'Parcel onboard. Find the gold drop-off beacon.' : 'Find the green pickup beacon.';
+}
+
+function pauseRun() {
+  if (state.phase === 'playing') {
+    state.phase = 'paused';
+    dom.pause.textContent = 'Resume';
+    dom.instruction.textContent = 'Paused. Resume when ready.';
+    return;
+  }
+
+  if (state.phase === 'paused') {
+    startRun();
+  }
+}
+
+function resetRun() {
+  state.phase = 'ready';
+  state.deliveries = 0;
+  state.timeLeft = RUN_LENGTH_SECONDS;
+  state.routeIndex = 0;
+  state.boostTime = 0;
+  state.pulseCooldown = 0;
+  dom.intro.hidden = false;
+  dom.intro.querySelector('h2').textContent = 'Carry signal parcels between neighborhoods before the route window closes.';
+  dom.intro.querySelector('p').textContent = 'Move with WASD, arrows, or the touch stick. Get close to the green pickup beacon, then carry the parcel to the gold drop-off beacon.';
+  dom.introStart.textContent = 'Start Route';
+  dom.start.textContent = 'Start Route';
+  dom.pause.textContent = 'Pause';
+  dom.instruction.textContent = 'Start a route, then steer toward the glowing pickup.';
+  placePlayer(new THREE.Vector3(0.2, 0.94, 0.28).normalize());
+  spawnRoute();
+  updateHud();
+}
+
+function completeRun() {
+  state.phase = 'complete';
+  dom.intro.hidden = false;
+  dom.intro.querySelector('h2').textContent = `Route window complete: ${state.deliveries} deliveries logged.`;
+  dom.intro.querySelector('p').textContent = 'Reset or start again to roll a new neighborhood run.';
+  dom.introStart.textContent = 'Run Again';
+  dom.start.textContent = 'Start Route';
+  dom.pause.textContent = 'Pause';
+  dom.instruction.textContent = 'Run complete. Start again for another delivery window.';
+}
+
+function updateHud() {
+  dom.deliveries.textContent = String(state.deliveries);
+  dom.time.textContent = formatTime(state.timeLeft);
+  dom.load.textContent = state.carrying ? 'Parcel' : 'Empty';
+
+  if (!state.route) {
+    return;
+  }
+
+  const action = state.carrying ? 'Drop off at' : 'Pick up at';
+  const target = state.carrying ? state.route.dropoff.name : state.route.pickup.name;
+  const other = state.carrying ? state.route.pickup.name : state.route.dropoff.name;
+  dom.routeText.textContent = `${action} ${target}. Route pair: ${state.route.pickup.name} to ${state.route.dropoff.name}.`;
+  dom.instruction.textContent = state.carrying
+    ? `Parcel from ${other} onboard. Head to the gold beacon.`
+    : `Head to the green beacon at ${target}.`;
+}
+
+function formatTime(value) {
+  const safe = Math.max(0, Math.ceil(value));
+  const minutes = Math.floor(safe / 60);
+  const seconds = String(safe % 60).padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+function updatePlayer(delta) {
+  const move = getMoveVector();
+  const worldUp = Math.abs(player.normal.y) > 0.92 ? new THREE.Vector3(1, 0, 0) : new THREE.Vector3(0, 1, 0);
+  tempEast.crossVectors(worldUp, player.normal).normalize();
+  tempNorth.crossVectors(player.normal, tempEast).normalize();
+  tempMove.set(0, 0, 0)
+    .addScaledVector(tempEast, move.x)
+    .addScaledVector(tempNorth, move.y);
+
+  const length = tempMove.length();
+  if (length > 0.001) {
+    tempMove.normalize();
+    heading.copy(tempMove);
+    const speed = player.speed * (state.boostTime > 0 ? 1.55 : 1);
+    player.normal.addScaledVector(tempMove, delta * speed / PLANET_RADIUS).normalize();
+  }
+
+  placePlayer(player.normal);
+}
+
+function getMoveVector() {
+  const keyboardX = Number(input.keys.has('ArrowRight') || input.keys.has('KeyD')) - Number(input.keys.has('ArrowLeft') || input.keys.has('KeyA'));
+  const keyboardY = Number(input.keys.has('ArrowUp') || input.keys.has('KeyW')) - Number(input.keys.has('ArrowDown') || input.keys.has('KeyS'));
+  const x = clamp(keyboardX + input.touchVector.x, -1, 1);
+  const y = clamp(keyboardY - input.touchVector.y, -1, 1);
+  const magnitude = Math.hypot(x, y);
+
+  if (magnitude > 1) {
+    return { x: x / magnitude, y: y / magnitude };
+  }
+
+  return { x, y };
+}
+
+function updateRouteProgress() {
+  if (!state.route || state.phase !== 'playing') {
+    return;
+  }
+
+  if (!state.carrying) {
+    const pickupDistance = surfaceDistance(player.normal, state.route.pickup.normal);
+    if (pickupDistance < PICKUP_RADIUS) {
+      state.carrying = true;
+      pickupMarker.visible = false;
+      dropoffMarker.visible = true;
+      dom.instruction.textContent = 'Parcel loaded. Follow the gold beacon to deliver.';
+      updateHud();
+    }
+    return;
+  }
+
+  const dropoffDistance = surfaceDistance(player.normal, state.route.dropoff.normal);
+  if (dropoffDistance < DROPOFF_RADIUS) {
+    state.deliveries += 1;
+    state.routeIndex += 1;
+    state.timeLeft = Math.min(RUN_LENGTH_SECONDS, state.timeLeft + 12);
+    dom.instruction.textContent = 'Delivered. A new route is live.';
+    spawnRoute();
+    updateHud();
+  }
+}
+
+function surfaceDistance(a, b) {
+  return Math.acos(clamp(a.dot(b), -1, 1)) * PLANET_RADIUS;
+}
+
+function updateMarkers(time) {
+  const pickupScale = 1 + Math.sin(time * 4.2) * 0.08;
+  const dropoffScale = 1 + Math.sin(time * 3.4 + 1.2) * 0.08;
+  pickupMarker.scale.setScalar(pickupScale);
+  dropoffMarker.scale.setScalar(dropoffScale);
+  pickupMarker.rotation.y += 0.018;
+  dropoffMarker.rotation.y -= 0.016;
+}
+
+function updateCamera(delta) {
+  const cameraNormal = player.normal.clone().multiplyScalar(52);
+  const cameraBack = heading.clone().multiplyScalar(-12);
+  const targetPosition = cameraNormal.add(cameraBack).add(new THREE.Vector3(0, 7.5, 0));
+  const lookTarget = player.group.position.clone().multiplyScalar(0.82);
+  camera.position.lerp(targetPosition, 1 - Math.pow(0.001, delta));
+  camera.lookAt(lookTarget);
+}
+
+function updateRun(delta) {
+  if (state.phase !== 'playing') {
+    return;
+  }
+
+  state.timeLeft -= delta;
+  state.boostTime = Math.max(0, state.boostTime - delta);
+  state.pulseCooldown = Math.max(0, state.pulseCooldown - delta);
+
+  if (state.timeLeft <= 0) {
+    state.timeLeft = 0;
+    updateHud();
+    completeRun();
+    return;
+  }
+
+  updatePlayer(delta);
+  updateRouteProgress();
+  updateHud();
+}
+
+function pulseBoost() {
+  if (state.phase !== 'playing' || state.pulseCooldown > 0) {
+    return;
+  }
+
+  state.boostTime = 1.15;
+  state.pulseCooldown = 2.2;
+  dom.instruction.textContent = 'Pulse active.';
+}
+
+function animate(time = 0) {
+  requestAnimationFrame(animate);
+  const now = time * 0.001;
+  const delta = clamp(now - state.lastTime, 0, 0.045);
+  state.lastTime = now;
+
+  planet.rotation.y += delta * 0.035;
+  orbitGroup.rotation.y += delta * 0.22;
+  updateMarkers(now);
+  updateRun(delta);
+  updateCamera(delta || 0.016);
+  renderer.render(scene, camera);
+}
+
+function attachInput() {
+  window.addEventListener('keydown', (event) => {
+    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Space'].includes(event.code)) {
+      event.preventDefault();
+    }
+
+    if (event.code === 'Space') {
+      pulseBoost();
+      return;
+    }
+
+    if (event.code === 'Enter') {
+      startRun();
+      return;
+    }
+
+    input.keys.add(event.code);
+  });
+
+  window.addEventListener('keyup', (event) => {
+    input.keys.delete(event.code);
+  });
+
+  dom.touchPad.addEventListener('pointerdown', (event) => {
+    input.pointerId = event.pointerId;
+    dom.touchPad.setPointerCapture(event.pointerId);
+    updateTouchVector(event);
+  });
+
+  dom.touchPad.addEventListener('pointermove', (event) => {
+    if (event.pointerId === input.pointerId) {
+      updateTouchVector(event);
+    }
+  });
+
+  ['pointerup', 'pointercancel', 'lostpointercapture'].forEach((eventName) => {
+    dom.touchPad.addEventListener(eventName, () => {
+      input.pointerId = null;
+      input.touchVector.x = 0;
+      input.touchVector.y = 0;
+      dom.touchNub.style.transform = 'translate(-50%, -50%)';
+    });
+  });
+
+  window.addEventListener('resize', resize);
+  dom.start.addEventListener('click', startRun);
+  dom.introStart.addEventListener('click', startRun);
+  dom.pause.addEventListener('click', pauseRun);
+  dom.reset.addEventListener('click', resetRun);
+  dom.boost.addEventListener('click', pulseBoost);
+  dom.menuToggle.addEventListener('click', () => {
+    const isOpen = dom.gameNav.classList.toggle('is-open');
+    dom.menuToggle.setAttribute('aria-expanded', String(isOpen));
+  });
+}
+
+function updateTouchVector(event) {
+  const rect = dom.touchPad.getBoundingClientRect();
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  const radius = rect.width * 0.38;
+  const x = clamp((event.clientX - centerX) / radius, -1, 1);
+  const y = clamp((event.clientY - centerY) / radius, -1, 1);
+  const magnitude = Math.hypot(x, y);
+  const safeX = magnitude > 1 ? x / magnitude : x;
+  const safeY = magnitude > 1 ? y / magnitude : y;
+
+  input.touchVector.x = safeX;
+  input.touchVector.y = safeY;
+  dom.touchNub.style.transform = `translate(calc(-50% + ${safeX * radius}px), calc(-50% + ${safeY * radius}px))`;
+}
+
+function resize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function createCanvasFallbackRenderer(canvas) {
+  const context = canvas.getContext('2d');
+  canvas.dataset.webglFallback = 'true';
+
+  return {
+    domElement: canvas,
+    setPixelRatio() {},
+    setClearColor() {},
+    setSize(width, height) {
+      const dpr = Math.min(window.devicePixelRatio || 1, 1.8);
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+    },
+    render() {
+      drawFallback(context, canvas.clientWidth || window.innerWidth, canvas.clientHeight || window.innerHeight);
+    },
+  };
+}
+
+function drawFallback(context, width, height) {
+  const time = performance.now() * 0.001;
+  context.clearRect(0, 0, width, height);
+  const sky = context.createLinearGradient(0, 0, 0, height);
+  sky.addColorStop(0, '#94c7bd');
+  sky.addColorStop(0.58, '#f0dfbd');
+  sky.addColorStop(1, '#c97955');
+  context.fillStyle = sky;
+  context.fillRect(0, 0, width, height);
+
+  const radius = Math.min(width, height) * 0.24;
+  const cx = width * 0.5;
+  const cy = height * 0.55;
+  context.beginPath();
+  context.arc(cx, cy, radius, 0, Math.PI * 2);
+  context.fillStyle = '#d8b56f';
+  context.fill();
+
+  context.fillStyle = '#4a9ca1';
+  context.beginPath();
+  context.ellipse(cx - radius * 0.25, cy - radius * 0.1, radius * 0.26, radius * 0.11, 0.4, 0, Math.PI * 2);
+  context.fill();
+  context.beginPath();
+  context.ellipse(cx + radius * 0.3, cy + radius * 0.2, radius * 0.32, radius * 0.12, -0.2, 0, Math.PI * 2);
+  context.fill();
+
+  const playerAngle = time * 0.8;
+  context.fillStyle = '#fff4d2';
+  context.beginPath();
+  context.arc(cx + Math.cos(playerAngle) * radius * 0.7, cy + Math.sin(playerAngle) * radius * 0.32, 9, 0, Math.PI * 2);
+  context.fill();
+
+  context.fillStyle = '#2f6f56';
+  context.beginPath();
+  context.arc(cx - radius * 0.5, cy - radius * 0.18, 8, 0, Math.PI * 2);
+  context.fill();
+
+  context.fillStyle = '#d7a640';
+  context.beginPath();
+  context.arc(cx + radius * 0.48, cy + radius * 0.12, 8, 0, Math.PI * 2);
+  context.fill();
+}
+
+attachInput();
+animate();
+
+window.OrbitalCourier = {
+  getState: () => ({
+    phase: state.phase,
+    deliveries: state.deliveries,
+    carrying: state.carrying,
+    route: state.route ? {
+      pickup: state.route.pickup.name,
+      dropoff: state.route.dropoff.name,
+    } : null,
+  }),
+  startRun,
+  resetRun,
+};

--- a/orbital-courier/style.css
+++ b/orbital-courier/style.css
@@ -1,0 +1,456 @@
+:root {
+  --ink: #17201d;
+  --paper: rgba(255, 251, 240, 0.9);
+  --paper-strong: rgba(255, 251, 240, 0.98);
+  --clay: #bd6146;
+  --moss: #2f6f56;
+  --gold: #d7a640;
+  --sea: #4a9ca1;
+  --shadow: rgba(19, 28, 25, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  background: #f0dfbd;
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+#game-canvas {
+  background:
+    radial-gradient(circle at 50% 38%, rgba(255, 245, 206, 0.5), transparent 26rem),
+    linear-gradient(180deg, #94c7bd 0%, #f0dfbd 58%, #c97955 100%);
+  display: block;
+  height: 100vh;
+  inset: 0;
+  position: fixed;
+  touch-action: none;
+  width: 100vw;
+}
+
+.top-buttons {
+  align-items: center;
+  background: rgba(255, 251, 240, 0.76);
+  border: 1px solid rgba(23, 32, 29, 0.1);
+  border-radius: 999px;
+  box-shadow: 0 14px 36px rgba(19, 28, 25, 0.12);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  left: 50%;
+  padding: 7px;
+  position: fixed;
+  top: 14px;
+  transform: translateX(-50%);
+  width: min(92vw, 620px);
+  z-index: 8;
+}
+
+.top-buttons a {
+  background: rgba(255, 255, 255, 0.54);
+  border-radius: 999px;
+  color: #26312d;
+  flex: 1 1 auto;
+  font-size: 0.78rem;
+  font-weight: 800;
+  min-width: max-content;
+  padding: 8px 12px;
+  text-align: center;
+  text-decoration: none;
+}
+
+.nav-toggle {
+  display: none;
+}
+
+.game-shell {
+  inset: 0;
+  pointer-events: none;
+  position: fixed;
+  z-index: 5;
+}
+
+.hud,
+.intro-panel,
+.instruction-chip,
+.touch-controls {
+  pointer-events: auto;
+}
+
+.hud {
+  background: linear-gradient(180deg, rgba(255, 251, 240, 0.94), rgba(255, 251, 240, 0.72));
+  border: 1px solid rgba(23, 32, 29, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 22px 54px var(--shadow);
+  display: grid;
+  gap: 14px;
+  left: 18px;
+  padding: 16px;
+  position: absolute;
+  top: 80px;
+  width: min(360px, calc(100vw - 36px));
+}
+
+.hud__brand {
+  display: grid;
+  gap: 3px;
+}
+
+.hud__eyebrow,
+.route-panel__label,
+.intro-panel__kicker {
+  color: var(--moss);
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hud h1,
+.intro-panel h2 {
+  line-height: 1.05;
+  margin: 0;
+}
+
+.hud h1 {
+  font-size: clamp(1.7rem, 5vw, 2.45rem);
+}
+
+.hud__stats {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.hud__stats div {
+  background: rgba(255, 255, 255, 0.56);
+  border: 1px solid rgba(23, 32, 29, 0.08);
+  border-radius: 8px;
+  min-width: 0;
+  padding: 9px;
+}
+
+.hud__stats span {
+  color: #62716b;
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 800;
+  margin-bottom: 4px;
+}
+
+.hud__stats strong {
+  display: block;
+  font-size: 1.1rem;
+  line-height: 1;
+  overflow-wrap: anywhere;
+}
+
+.route-panel {
+  background: rgba(47, 111, 86, 0.1);
+  border: 1px solid rgba(47, 111, 86, 0.16);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.route-panel p {
+  font-size: 0.95rem;
+  font-weight: 750;
+  line-height: 1.35;
+  margin: 5px 0 0;
+}
+
+.signal-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.signal-strip span {
+  background: rgba(189, 97, 70, 0.12);
+  border: 1px solid rgba(189, 97, 70, 0.2);
+  border-radius: 999px;
+  color: #5f3328;
+  font-size: 0.72rem;
+  font-weight: 850;
+  padding: 7px 9px;
+}
+
+.hud__actions {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 0.72fr 0.72fr;
+}
+
+button {
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+}
+
+.hud__actions button,
+.intro-panel button,
+.boost-button {
+  background: var(--ink);
+  box-shadow: 0 10px 24px rgba(23, 32, 29, 0.2);
+  color: #fff8e8;
+  min-height: 44px;
+  padding: 10px 12px;
+}
+
+.hud__actions button:nth-child(2) {
+  background: var(--sea);
+}
+
+.hud__actions button:nth-child(3) {
+  background: var(--clay);
+}
+
+button:focus-visible,
+a:focus-visible {
+  outline: 3px solid rgba(215, 166, 64, 0.72);
+  outline-offset: 3px;
+}
+
+.intro-panel {
+  align-items: start;
+  background: linear-gradient(135deg, rgba(255, 251, 240, 0.96), rgba(250, 224, 171, 0.84));
+  border: 1px solid rgba(23, 32, 29, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 24px 64px var(--shadow);
+  display: grid;
+  gap: 16px;
+  max-width: 520px;
+  padding: 20px;
+  position: absolute;
+  right: 22px;
+  top: 118px;
+  width: min(520px, calc(100vw - 44px));
+}
+
+.intro-panel[hidden] {
+  display: none;
+}
+
+.intro-panel h2 {
+  font-size: clamp(1.45rem, 4vw, 2.25rem);
+  margin-top: 7px;
+}
+
+.intro-panel p {
+  color: #4d5c55;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 10px 0 0;
+}
+
+.intro-panel button {
+  background: var(--moss);
+  justify-self: start;
+  min-width: 152px;
+}
+
+.instruction-chip {
+  background: rgba(23, 32, 29, 0.82);
+  border: 1px solid rgba(255, 248, 232, 0.24);
+  border-radius: 999px;
+  bottom: 22px;
+  box-shadow: 0 16px 36px rgba(23, 32, 29, 0.2);
+  color: #fff8e8;
+  font-size: 0.88rem;
+  font-weight: 850;
+  left: 50%;
+  max-width: min(560px, calc(100vw - 40px));
+  padding: 11px 16px;
+  position: absolute;
+  text-align: center;
+  transform: translateX(-50%);
+}
+
+.touch-controls {
+  align-items: end;
+  bottom: 22px;
+  display: flex;
+  gap: 14px;
+  position: absolute;
+  right: 18px;
+}
+
+.touch-pad {
+  background: rgba(255, 251, 240, 0.44);
+  border: 1px solid rgba(23, 32, 29, 0.14);
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 10px rgba(255, 255, 255, 0.15), 0 16px 36px rgba(23, 32, 29, 0.14);
+  display: none;
+  height: 118px;
+  position: relative;
+  touch-action: none;
+  width: 118px;
+}
+
+.touch-pad__nub {
+  background: var(--paper-strong);
+  border: 2px solid rgba(23, 32, 29, 0.18);
+  border-radius: 50%;
+  box-shadow: 0 10px 22px rgba(23, 32, 29, 0.18);
+  height: 42px;
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 42px;
+}
+
+.boost-button {
+  background: var(--gold);
+  color: #2b2412;
+  display: none;
+  height: 64px;
+  min-width: 72px;
+}
+
+@media (hover: none), (pointer: coarse) {
+  .touch-pad,
+  .boost-button {
+    display: block;
+  }
+}
+
+@media (max-width: 820px) {
+  .nav-toggle {
+    background: rgba(255, 251, 240, 0.92);
+    border: 1px solid rgba(23, 32, 29, 0.12);
+    border-radius: 999px;
+    box-shadow: 0 10px 24px rgba(23, 32, 29, 0.14);
+    color: var(--ink);
+    display: block;
+    font-size: 0.86rem;
+    min-height: 42px;
+    padding: 9px 14px;
+    position: fixed;
+    right: 14px;
+    top: 12px;
+    z-index: 10;
+  }
+
+  .top-buttons {
+    align-items: stretch;
+    border-radius: 8px;
+    display: none;
+    left: auto;
+    right: 14px;
+    top: 62px;
+    transform: none;
+    width: min(280px, calc(100vw - 28px));
+  }
+
+  .top-buttons.is-open {
+    display: grid;
+  }
+
+  .hud {
+    gap: 10px;
+    left: 12px;
+    padding: 12px;
+    right: 12px;
+    top: 12px;
+    width: auto;
+  }
+
+  .hud h1 {
+    font-size: 1.45rem;
+  }
+
+  .hud__brand {
+    padding-right: 76px;
+  }
+
+  .hud__stats div {
+    padding: 8px;
+  }
+
+  .hud__stats strong {
+    font-size: 0.98rem;
+  }
+
+  .route-panel p {
+    font-size: 0.84rem;
+  }
+
+  .signal-strip {
+    display: none;
+  }
+
+  .hud__actions {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+
+  .hud__actions button {
+    min-height: 40px;
+    padding: 8px;
+  }
+
+  .touch-pad,
+  .boost-button {
+    display: block;
+  }
+
+  .intro-panel {
+    left: 12px;
+    max-width: none;
+    padding: 16px;
+    right: 12px;
+    top: 260px;
+    width: auto;
+  }
+
+  .intro-panel h2 {
+    font-size: 1.35rem;
+  }
+
+  .intro-panel p {
+    font-size: 0.9rem;
+  }
+
+  .touch-controls {
+    bottom: 18px;
+    left: 18px;
+    right: auto;
+  }
+
+  .instruction-chip {
+    bottom: 156px;
+    font-size: 0.78rem;
+    padding: 10px 13px;
+  }
+}
+
+@media (max-height: 680px) and (max-width: 820px) {
+  .intro-panel {
+    top: 210px;
+  }
+
+  .intro-panel p {
+    display: none;
+  }
+
+  .instruction-chip {
+    bottom: 18px;
+    left: auto;
+    right: 14px;
+    transform: none;
+    width: min(280px, calc(100vw - 164px));
+  }
+}

--- a/tests/games-page-icons.test.js
+++ b/tests/games-page-icons.test.js
@@ -6,6 +6,7 @@ const gameCards = [
   ['pong', 'Pong Arena'],
   ['tribes', 'Zero-G Ski Range'],
   ['stellar', 'Stellar Drift Flight'],
+  ['courier', 'Orbital Courier'],
   ['jetpack', 'Jetpack Corridor'],
   ['asteroids', 'Space Jetpack: 3DVR Asteroids']
 ];

--- a/tests/orbital-courier.test.js
+++ b/tests/orbital-courier.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('Orbital Courier game route', () => {
+  it('adds a standalone spherical delivery game to the games hub', async () => {
+    const html = await readFile(new URL('../orbital-courier/index.html', import.meta.url), 'utf8');
+    const js = await readFile(new URL('../orbital-courier/main.js', import.meta.url), 'utf8');
+    const css = await readFile(new URL('../orbital-courier/style.css', import.meta.url), 'utf8');
+    const hub = await readFile(new URL('../games.html', import.meta.url), 'utf8');
+
+    assert.match(html, /Orbital Courier/);
+    assert.match(html, /id="game-canvas"/);
+    assert.match(html, /id="start-button"/);
+    assert.match(html, /id="pause-button"/);
+    assert.match(html, /id="reset-button"/);
+    assert.match(html, /data-touch-pad/);
+    assert.match(html, /id="boost-button"/);
+    assert.match(html, /cdnjs\.cloudflare\.com\/ajax\/libs\/three\.js\/r128\/three\.min\.js/);
+    assert.match(html, /type="module" src="main\.js"/);
+    assert.doesNotMatch(html, /messenger\.abeto\.co/i);
+
+    assert.match(js, /new THREE\.WebGLRenderer/);
+    assert.match(js, /new THREE\.SphereGeometry\(PLANET_RADIUS/);
+    assert.match(js, /normalFromLatLon/);
+    assert.match(js, /spawnRoute/);
+    assert.match(js, /surfaceDistance/);
+    assert.match(js, /RUN_LENGTH_SECONDS = 120/);
+    assert.match(js, /requestAnimationFrame\(animate\)/);
+    assert.match(js, /addEventListener\('pointerdown'/);
+    assert.match(js, /window\.OrbitalCourier/);
+    assert.doesNotMatch(js, /messenger\.abeto\.co/i);
+
+    assert.match(css, /#game-canvas/);
+    assert.match(css, /\.touch-pad/);
+    assert.match(css, /\.instruction-chip/);
+    assert.match(css, /@media \(hover: none\), \(pointer: coarse\)/);
+
+    assert.match(hub, /class="game-card courier"/);
+    assert.match(hub, /href="orbital-courier\/"/);
+    assert.match(hub, /<span class="game-title">Orbital Courier<\/span>/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `orbital-courier/`, a standalone Three.js spherical delivery game inspired by high-level small-world courier mechanics without copying external code, assets, names, or branding.
- Adds keyboard controls, touch joystick controls, a start/pause/reset flow, timed delivery runs, pickup/drop-off beacons, and HUD/status signals.
- Registers Orbital Courier as a card in `games.html` and adds route coverage in `tests/orbital-courier.test.js` plus the games hub card test.

## Validation
- `node --check orbital-courier/main.js`
- `node --test tests/orbital-courier.test.js tests/games-page-icons.test.js`
- Playwright desktop/mobile render pass at `http://127.0.0.1:3017/orbital-courier/`, including full-viewport canvas checks, nonblank varied canvas pixel sampling, screenshots, and Start -> playing state.
- `npm test` was run; it completed with unrelated existing failures in `tests/auth-entrypoints.test.js`, `tests/playwright-install-runtime.test.js`, and `tests/vercel-insights-tag.test.js`.