### PR TITLE
[codex] darken fascia release page

### DIFF
--- a/3dvr-connect/index.html
+++ b/3dvr-connect/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Open Form / 3DVR Connect</title>
+  <title>3DVR Connect | Open Form</title>
   <meta
     name="description"
-    content="Open Form landing page for Mediterranean linenwear, Open Form Private, and 3DVR Connect with consent-centered pathways."
+    content="3DVR Connect is the consent-centered community and play-space platform around Open Form."
   />
   <style>
     :root {
@@ -467,7 +467,7 @@
 <body>
   <header class="topbar">
     <div class="site-shell topbar-inner">
-      <p class="brand">Open Form / 3DVR Connect</p>
+      <p class="brand">3DVR Connect</p>
       <nav>
         <a class="pill" href="#hero">Hero</a>
         <a class="pill" href="#open-form">Open Form</a>
@@ -483,10 +483,10 @@
     <section id="hero" class="hero">
       <div class="site-shell">
         <p class="eyebrow">Premium lifestyle landing</p>
-        <h1>Open Form / 3DVR Connect</h1>
+        <h1>3DVR Connect</h1>
         <p>
-          Open Form is a sensual menswear and intimacy-wear label. 3DVR Connect is the consent-based
-          community and play-space platform around it.
+          3DVR Connect is the consent-based community and play-space platform around Open Form.
+          Open Form is a sensual menswear and intimacy-wear label around it.
         </p>
         <p class="quote-key">
           “Design the container. Let humans become human again.”
@@ -819,7 +819,7 @@
     <footer>
       <div class="site-shell">
         <p class="muted">
-          © 2026 Open Form / 3DVR Connect • Built as a premium, consent-centered landing prototype.
+          © 2026 3DVR Connect • Built as a premium, consent-centered landing prototype.
         </p>
         <p class="muted">
           Placeholder: wire CMS-backed product feeds, event calendars, membership onboarding, and consent tutorials.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Most of the portal experiences now ship with their own installable manifests, so
 - [Master Key Room](https://3dvr-portal.vercel.app/master-key-room/)
 - [Intention Lab](https://3dvr-portal.vercel.app/intention-lab/)
 - [Portal Lab](https://3dvr-portal.vercel.app/portal-lab/)
+- [3DVR Connect](https://3dvr-portal.vercel.app/3dvr-connect/)
+- [Fascia Release](https://3dvr-portal.vercel.app/fascia-release/)
 - [Seated Spine Reset](https://3dvr-portal.vercel.app/seated-spine-reset/)
 
 Open the page you want and use your browser’s **Install** or **Add to Home Screen** option to pin it like a native app.

--- a/fascia-release/index.html
+++ b/fascia-release/index.html
@@ -10,18 +10,20 @@
   />
   <style>
     :root {
-      --paper: #f4ede2;
-      --surface: #fcfaf6;
-      --surface-soft: #f7f1e8;
-      --ink: #211913;
-      --muted: #61574d;
-      --line: #d8c7b2;
-      --line-strong: #b79460;
-      --gold: #b08a44;
-      --green: #4f7f64;
-      --clay: #8d4d43;
-      --deep: #15110d;
-      --shadow: 0 20px 50px rgba(34, 23, 15, 0.12);
+      color-scheme: dark;
+      --bg: #05070c;
+      --surface: rgba(14, 20, 31, 0.92);
+      --surface-soft: rgba(18, 26, 40, 0.9);
+      --surface-strong: rgba(21, 31, 48, 0.96);
+      --ink: #edf2f7;
+      --muted: rgba(203, 213, 225, 0.74);
+      --line: rgba(148, 163, 184, 0.16);
+      --line-strong: rgba(94, 234, 212, 0.28);
+      --gold: #8dc8ff;
+      --green: #5eead4;
+      --clay: #f0b56d;
+      --deep: #0a1220;
+      --shadow: 0 24px 70px rgba(0, 0, 0, 0.42);
       --radius: 0.8rem;
       --max: 1180px;
       --pad: clamp(1rem, 3vw, 1.8rem);
@@ -39,12 +41,13 @@
 
     body {
       background:
-        radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.6), transparent 26%),
-        radial-gradient(circle at 82% 8%, rgba(176, 138, 68, 0.1), transparent 22%),
-        linear-gradient(180deg, #f7f1e7 0%, #efe3d1 100%);
+        radial-gradient(circle at 18% 12%, rgba(56, 189, 248, 0.16), transparent 30%),
+        radial-gradient(circle at 82% 8%, rgba(94, 234, 212, 0.1), transparent 24%),
+        linear-gradient(180deg, #05070c 0%, #0a1220 54%, #070b11 100%);
       color: var(--ink);
       font-family: "Avenir Next", Avenir, "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
       line-height: 1.6;
+      overflow-x: hidden;
     }
 
     a {
@@ -64,8 +67,8 @@
       position: sticky;
       top: 0;
       z-index: 10;
-      border-bottom: 1px solid rgba(46, 35, 26, 0.14);
-      background: rgba(247, 241, 231, 0.94);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+      background: rgba(5, 7, 12, 0.86);
       backdrop-filter: blur(14px);
     }
 
@@ -80,7 +83,7 @@
 
     .brand {
       margin: 0;
-      color: var(--deep);
+      color: var(--ink);
       font-size: 0.9rem;
       letter-spacing: 0.16em;
       text-transform: uppercase;
@@ -96,8 +99,8 @@
     }
 
     .nav button {
-      border: 1px solid rgba(46, 35, 26, 0.16);
-      background: rgba(255, 255, 255, 0.72);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(14, 20, 31, 0.86);
       color: var(--muted);
       border-radius: 999px;
       padding: 0.5rem 0.85rem;
@@ -106,8 +109,8 @@
     }
 
     .nav button[aria-pressed="true"] {
-      background: var(--deep);
-      border-color: var(--deep);
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.26), rgba(94, 234, 212, 0.22));
+      border-color: rgba(94, 234, 212, 0.48);
       color: #fff;
     }
 
@@ -117,7 +120,7 @@
 
     section {
       padding: clamp(3rem, 5vw, 4.5rem) 0;
-      border-bottom: 1px solid rgba(45, 36, 26, 0.1);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.08);
     }
 
     section:last-of-type {
@@ -175,7 +178,7 @@
     .card,
     .panel {
       border-radius: var(--radius);
-      border: 1px solid rgba(46, 35, 26, 0.14);
+      border: 1px solid var(--line);
       background: var(--surface);
       box-shadow: var(--shadow);
     }
@@ -192,7 +195,7 @@
       font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
       font-size: clamp(1.2rem, 2.2vw, 1.55rem);
       font-style: italic;
-      color: #3d332b;
+      color: rgba(248, 250, 252, 0.88);
     }
 
     .hero-actions {
@@ -210,7 +213,7 @@
       border-radius: 0.65rem;
       border: 1px solid transparent;
       background: transparent;
-      color: var(--deep);
+      color: var(--ink);
       cursor: pointer;
       text-decoration: none;
       font-weight: 700;
@@ -222,13 +225,14 @@
     }
 
     .button--primary {
-      background: var(--deep);
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), rgba(94, 234, 212, 0.22));
+      border-color: rgba(94, 234, 212, 0.35);
       color: #fff;
     }
 
     .button--secondary {
-      border-color: rgba(46, 35, 26, 0.2);
-      background: rgba(255, 255, 255, 0.55);
+      border-color: rgba(148, 163, 184, 0.2);
+      background: rgba(14, 20, 31, 0.76);
     }
 
     .hero-aside {
@@ -238,7 +242,7 @@
 
     .safety-card {
       padding: 1.1rem;
-      background: #fff8f0;
+      background: rgba(18, 26, 40, 0.96);
       border-left: 4px solid var(--clay);
       display: grid;
       gap: 0.7rem;
@@ -257,10 +261,10 @@
     .callout {
       margin: 0;
       padding: 0.95rem 1rem;
-      background: rgba(180, 138, 96, 0.12);
+      background: rgba(94, 234, 212, 0.08);
       border-radius: 0.7rem;
-      border: 1px solid rgba(180, 138, 96, 0.22);
-      color: #4b3d31;
+      border: 1px solid rgba(94, 234, 212, 0.16);
+      color: rgba(226, 232, 240, 0.86);
     }
 
     .visual-stack {
@@ -275,21 +279,21 @@
       place-items: center;
       text-align: center;
       background:
-        linear-gradient(160deg, rgba(255, 255, 255, 0.7), rgba(233, 217, 192, 0.9)),
+        linear-gradient(160deg, rgba(15, 23, 42, 0.96), rgba(10, 16, 28, 0.96)),
         repeating-linear-gradient(
           135deg,
-          rgba(46, 35, 26, 0.04),
-          rgba(46, 35, 26, 0.04) 14px,
+          rgba(148, 163, 184, 0.05),
+          rgba(148, 163, 184, 0.05) 14px,
           transparent 14px,
           transparent 28px
         );
-      border: 1px dashed rgba(46, 35, 26, 0.18);
+      border: 1px dashed rgba(148, 163, 184, 0.18);
       color: var(--muted);
     }
 
     .visual-panel strong {
       display: block;
-      color: var(--deep);
+      color: #f8fafc;
       font-size: 1rem;
       margin-bottom: 0.4rem;
     }
@@ -311,10 +315,10 @@
       align-items: center;
       justify-content: center;
       border-radius: 999px;
-      border: 1px solid rgba(46, 35, 26, 0.16);
+      border: 1px solid rgba(148, 163, 184, 0.18);
       padding: 0.42rem 0.75rem;
-      background: rgba(255, 255, 255, 0.72);
-      color: #51453d;
+      background: rgba(14, 20, 31, 0.86);
+      color: rgba(226, 232, 240, 0.9);
       font-size: 0.85rem;
       text-decoration: none;
     }
@@ -339,7 +343,7 @@
     .source-card {
       padding: 1rem;
       border-radius: var(--radius);
-      border: 1px solid rgba(46, 35, 26, 0.14);
+      border: 1px solid var(--line);
       background: var(--surface);
     }
 
@@ -360,14 +364,14 @@
     .support-card p,
     .source-card p {
       margin: 0.75rem 0 0;
-      color: #4a4037;
+      color: var(--muted);
     }
 
     .step-card ul,
     .support-card ul {
       margin: 0.8rem 0 0;
       padding-left: 1.1rem;
-      color: #4a4037;
+      color: var(--muted);
     }
 
     .support-card {
@@ -382,8 +386,8 @@
     .rule-card {
       padding: clamp(1.1rem, 3vw, 1.6rem);
       border-radius: var(--radius);
-      border: 1px solid rgba(46, 35, 26, 0.14);
-      background: linear-gradient(135deg, #fdf8ef, #f3e8d6);
+      border: 1px solid rgba(94, 234, 212, 0.16);
+      background: linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(10, 16, 28, 0.96));
       box-shadow: var(--shadow);
     }
 
@@ -396,7 +400,7 @@
       max-width: 54ch;
       font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
       font-size: clamp(1.4rem, 2.5vw, 1.85rem);
-      color: #32281f;
+      color: rgba(248, 250, 252, 0.92);
     }
 
     .source-card a {
@@ -418,9 +422,9 @@
       margin-top: 1rem;
       padding: 1rem;
       border-radius: var(--radius);
-      background: rgba(176, 138, 68, 0.12);
-      border: 1px solid rgba(176, 138, 68, 0.2);
-      color: #4d4033;
+      background: rgba(56, 189, 248, 0.08);
+      border: 1px solid rgba(56, 189, 248, 0.16);
+      color: rgba(226, 232, 240, 0.84);
     }
 
     footer {
@@ -461,7 +465,7 @@
       .source-card:hover,
       .visual-panel:hover {
         transform: translateY(-2px);
-        box-shadow: 0 24px 56px rgba(34, 23, 15, 0.12);
+        box-shadow: 0 24px 56px rgba(0, 0, 0, 0.3);
       }
     }
   </style>

--- a/fascia-release/index.html
+++ b/fascia-release/index.html
@@ -1,0 +1,747 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fascia Release | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="A gentle neck, jaw, tongue, and computer tension reset with low-intensity guidance and clear safety notes."
+  />
+  <style>
+    :root {
+      --paper: #f4ede2;
+      --surface: #fcfaf6;
+      --surface-soft: #f7f1e8;
+      --ink: #211913;
+      --muted: #61574d;
+      --line: #d8c7b2;
+      --line-strong: #b79460;
+      --gold: #b08a44;
+      --green: #4f7f64;
+      --clay: #8d4d43;
+      --deep: #15110d;
+      --shadow: 0 20px 50px rgba(34, 23, 15, 0.12);
+      --radius: 0.8rem;
+      --max: 1180px;
+      --pad: clamp(1rem, 3vw, 1.8rem);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      margin: 0;
+      min-height: 100%;
+    }
+
+    body {
+      background:
+        radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.6), transparent 26%),
+        radial-gradient(circle at 82% 8%, rgba(176, 138, 68, 0.1), transparent 22%),
+        linear-gradient(180deg, #f7f1e7 0%, #efe3d1 100%);
+      color: var(--ink);
+      font-family: "Avenir Next", Avenir, "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      line-height: 1.6;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    button {
+      font: inherit;
+    }
+
+    .shell {
+      width: min(var(--max), calc(100% - var(--pad) * 2));
+      margin: 0 auto;
+    }
+
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      border-bottom: 1px solid rgba(46, 35, 26, 0.14);
+      background: rgba(247, 241, 231, 0.94);
+      backdrop-filter: blur(14px);
+    }
+
+    .topbar__inner {
+      min-height: 4.2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.75rem 0;
+    }
+
+    .brand {
+      margin: 0;
+      color: var(--deep);
+      font-size: 0.9rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    .nav {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+
+    .nav button {
+      border: 1px solid rgba(46, 35, 26, 0.16);
+      background: rgba(255, 255, 255, 0.72);
+      color: var(--muted);
+      border-radius: 999px;
+      padding: 0.5rem 0.85rem;
+      cursor: pointer;
+      transition: background 180ms ease, border-color 180ms ease, color 180ms ease;
+    }
+
+    .nav button[aria-pressed="true"] {
+      background: var(--deep);
+      border-color: var(--deep);
+      color: #fff;
+    }
+
+    main {
+      padding-bottom: 4rem;
+    }
+
+    section {
+      padding: clamp(3rem, 5vw, 4.5rem) 0;
+      border-bottom: 1px solid rgba(45, 36, 26, 0.1);
+    }
+
+    section:last-of-type {
+      border-bottom: none;
+    }
+
+    h1,
+    h2,
+    h3 {
+      margin: 0;
+      line-height: 1.06;
+      letter-spacing: 0.01em;
+    }
+
+    h1,
+    h2 {
+      font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    }
+
+    h1 {
+      font-size: clamp(2.45rem, 6vw, 4.5rem);
+      max-width: 12ch;
+    }
+
+    h2 {
+      font-size: clamp(1.45rem, 3vw, 2.1rem);
+    }
+
+    .eyebrow {
+      margin: 0 0 0.8rem;
+      color: var(--gold);
+      font-size: 0.76rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      font-weight: 800;
+    }
+
+    .lead {
+      max-width: 68ch;
+      margin: 1rem 0 0;
+      color: var(--muted);
+      font-size: 1.05rem;
+    }
+
+    .hero {
+      padding-top: 3rem;
+    }
+
+    .hero-grid {
+      display: grid;
+      gap: 1rem;
+      align-items: start;
+    }
+
+    .card,
+    .panel {
+      border-radius: var(--radius);
+      border: 1px solid rgba(46, 35, 26, 0.14);
+      background: var(--surface);
+      box-shadow: var(--shadow);
+    }
+
+    .hero-copy {
+      padding: clamp(1.35rem, 4vw, 2.4rem);
+      display: grid;
+      gap: 1rem;
+    }
+
+    .keyline {
+      margin: 0;
+      max-width: 66ch;
+      font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+      font-size: clamp(1.2rem, 2.2vw, 1.55rem);
+      font-style: italic;
+      color: #3d332b;
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.7rem;
+    }
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 2.9rem;
+      padding: 0.78rem 1rem;
+      border-radius: 0.65rem;
+      border: 1px solid transparent;
+      background: transparent;
+      color: var(--deep);
+      cursor: pointer;
+      text-decoration: none;
+      font-weight: 700;
+      transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+    }
+
+    .button:active {
+      transform: translateY(1px);
+    }
+
+    .button--primary {
+      background: var(--deep);
+      color: #fff;
+    }
+
+    .button--secondary {
+      border-color: rgba(46, 35, 26, 0.2);
+      background: rgba(255, 255, 255, 0.55);
+    }
+
+    .hero-aside {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .safety-card {
+      padding: 1.1rem;
+      background: #fff8f0;
+      border-left: 4px solid var(--clay);
+      display: grid;
+      gap: 0.7rem;
+    }
+
+    .safety-card h2 {
+      font-size: 1.1rem;
+      font-family: "Avenir Next", Avenir, "Segoe UI", system-ui, sans-serif;
+    }
+
+    .safety-card p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .callout {
+      margin: 0;
+      padding: 0.95rem 1rem;
+      background: rgba(180, 138, 96, 0.12);
+      border-radius: 0.7rem;
+      border: 1px solid rgba(180, 138, 96, 0.22);
+      color: #4b3d31;
+    }
+
+    .visual-stack {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .visual-panel {
+      min-height: 12rem;
+      padding: 1rem;
+      display: grid;
+      place-items: center;
+      text-align: center;
+      background:
+        linear-gradient(160deg, rgba(255, 255, 255, 0.7), rgba(233, 217, 192, 0.9)),
+        repeating-linear-gradient(
+          135deg,
+          rgba(46, 35, 26, 0.04),
+          rgba(46, 35, 26, 0.04) 14px,
+          transparent 14px,
+          transparent 28px
+        );
+      border: 1px dashed rgba(46, 35, 26, 0.18);
+      color: var(--muted);
+    }
+
+    .visual-panel strong {
+      display: block;
+      color: var(--deep);
+      font-size: 1rem;
+      margin-bottom: 0.4rem;
+    }
+
+    .placeholder-grid {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .pill-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 999px;
+      border: 1px solid rgba(46, 35, 26, 0.16);
+      padding: 0.42rem 0.75rem;
+      background: rgba(255, 255, 255, 0.72);
+      color: #51453d;
+      font-size: 0.85rem;
+      text-decoration: none;
+    }
+
+    .section-lead {
+      max-width: 72ch;
+      margin: 0.85rem 0 0;
+      color: var(--muted);
+    }
+
+    .step-grid,
+    .support-grid,
+    .source-grid {
+      margin-top: 1.25rem;
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: 1fr;
+    }
+
+    .step-card,
+    .support-card,
+    .source-card {
+      padding: 1rem;
+      border-radius: var(--radius);
+      border: 1px solid rgba(46, 35, 26, 0.14);
+      background: var(--surface);
+    }
+
+    .step-meta {
+      display: flex;
+      gap: 0.75rem;
+      align-items: baseline;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      color: var(--gold);
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      font-weight: 800;
+    }
+
+    .step-card p,
+    .support-card p,
+    .source-card p {
+      margin: 0.75rem 0 0;
+      color: #4a4037;
+    }
+
+    .step-card ul,
+    .support-card ul {
+      margin: 0.8rem 0 0;
+      padding-left: 1.1rem;
+      color: #4a4037;
+    }
+
+    .support-card {
+      background: var(--surface-soft);
+    }
+
+    .rule-band {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .rule-card {
+      padding: clamp(1.1rem, 3vw, 1.6rem);
+      border-radius: var(--radius);
+      border: 1px solid rgba(46, 35, 26, 0.14);
+      background: linear-gradient(135deg, #fdf8ef, #f3e8d6);
+      box-shadow: var(--shadow);
+    }
+
+    .rule-card h2 {
+      margin-bottom: 0.5rem;
+    }
+
+    .rule-quote {
+      margin: 0;
+      max-width: 54ch;
+      font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+      font-size: clamp(1.4rem, 2.5vw, 1.85rem);
+      color: #32281f;
+    }
+
+    .source-card a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .source-card a:hover {
+      text-decoration: underline;
+    }
+
+    .source-card small {
+      display: block;
+      margin-top: 0.45rem;
+      color: var(--muted);
+    }
+
+    .footnote {
+      margin-top: 1rem;
+      padding: 1rem;
+      border-radius: var(--radius);
+      background: rgba(176, 138, 68, 0.12);
+      border: 1px solid rgba(176, 138, 68, 0.2);
+      color: #4d4033;
+    }
+
+    footer {
+      padding: 2rem 0 2.4rem;
+      color: var(--muted);
+    }
+
+    @media (min-width: 860px) {
+      .hero-grid {
+        grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.75fr);
+      }
+
+      .step-grid,
+      .support-grid,
+      .source-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .source-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .button,
+      .nav button,
+      .step-card,
+      .support-card,
+      .source-card,
+      .visual-panel {
+        transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease, border-color 180ms ease;
+      }
+
+      .button:hover,
+      .nav button:hover,
+      .step-card:hover,
+      .support-card:hover,
+      .source-card:hover,
+      .visual-panel:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 24px 56px rgba(34, 23, 15, 0.12);
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="shell topbar__inner">
+      <p class="brand">Fascia Release</p>
+      <nav class="nav" aria-label="Section navigation">
+        <button type="button" data-jump="hero" aria-pressed="true">Hero</button>
+        <button type="button" data-jump="routine" aria-pressed="false">Routine</button>
+        <button type="button" data-jump="rule" aria-pressed="false">Rule</button>
+        <button type="button" data-jump="avoid" aria-pressed="false">Avoid</button>
+        <button type="button" data-jump="sources" aria-pressed="false">Sources</button>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section id="hero" class="hero">
+      <div class="shell hero-grid">
+        <div class="card hero-copy">
+          <p class="eyebrow">Gentle reset / 2-4 out of 10</p>
+          <h1>Fascia Release</h1>
+          <p class="lead">
+            Here is a gentle fascia-release reset for neck, jaw, tongue, and computer tension. Keep everything at
+            2-4/10 intensity. No forcing, cracking, aggressive stretching, or deep pressure on the front of the throat.
+          </p>
+          <p class="keyline">"Tongue soft, jaw heavy, eyes soft."</p>
+          <div class="hero-actions">
+            <button class="button button--primary" type="button" data-jump="routine">Open Routine</button>
+            <button class="button button--secondary" type="button" data-jump="rule">See Computer Jaw Rule</button>
+          </div>
+          <div class="pill-row" aria-label="Intent tags">
+            <span class="pill">Neck</span>
+            <span class="pill">Jaw</span>
+            <span class="pill">Tongue</span>
+            <span class="pill">Computer tension</span>
+            <span class="pill">Low intensity</span>
+          </div>
+        </div>
+
+        <aside class="hero-aside">
+          <div class="safety-card">
+            <h2>Seek care urgently if</h2>
+            <p>
+              arm or hand numbness gets worse, weakness appears, clumsiness shows up, balance changes, severe headache
+              with neck pain appears, dizziness starts, or symptoms follow an injury.
+            </p>
+            <p class="callout">
+              This page is a gentle reset, not a diagnosis or a substitute for medical care.
+            </p>
+          </div>
+
+          <div class="visual-stack">
+            <div class="visual-panel" role="img" aria-label="Placeholder image panel for a future neck and jaw visual">
+              <div>
+                <strong>Placeholder image panel</strong>
+                Future three.js neck and jaw stage
+              </div>
+            </div>
+            <div class="visual-panel" role="img" aria-label="Placeholder image panel for a future breathing cue visual">
+              <div>
+                <strong>Placeholder image panel</strong>
+                Breath loop and fascia map
+              </div>
+            </div>
+          </div>
+
+          <!-- Placeholder: future three.js visualization can replace these panels later. -->
+        </aside>
+      </div>
+    </section>
+
+    <section id="routine">
+      <div class="shell">
+        <p class="eyebrow">10-minute neck/jaw fascia release</p>
+        <h2>Move slowly. Stay small. Keep the whole routine calm.</h2>
+        <p class="section-lead">
+          The sequence below follows the original reset: downshift first, then jaw, SCM, suboccipitals, chest and
+          collarbone, and a final chin-tuck decompression.
+        </p>
+
+        <div class="step-grid">
+          <article class="step-card">
+            <div class="step-meta"><span>01</span><span>90 seconds</span></div>
+            <h3>Downshift first</h3>
+            <p>Sit or lie down. One hand on chest, one on belly. Inhale 4 seconds, exhale 6-8 seconds. On each exhale, quietly say, "tongue soft, jaw heavy, eyes soft."</p>
+            <ul>
+              <li>Use nose breathing if possible.</li>
+              <li>Let the exhale be longer than the inhale.</li>
+              <li>Drop the clench before anything else.</li>
+            </ul>
+          </article>
+
+          <article class="step-card">
+            <div class="step-meta"><span>02</span><span>2 minutes</span></div>
+            <h3>Tongue and jaw reset</h3>
+            <p>Place the tongue gently on the roof of the mouth behind the upper front teeth. Set the jaw to tongue up, teeth apart, lips lightly closed, jaw hanging.</p>
+            <ul>
+              <li>Do 5 tiny jaw openings, only 1-2 finger widths.</li>
+              <li>Massage the cheek muscle and jaw angle with small circles.</li>
+              <li>Keep pressure light and avoid digging into the joint.</li>
+            </ul>
+          </article>
+
+          <article class="step-card">
+            <div class="step-meta"><span>03</span><span>2 minutes</span></div>
+            <h3>SCM release</h3>
+            <p>Turn the head slightly left. On the right side, gently pinch the sternocleidomastoid between fingers, not the throat, and glide downward toward the collarbone.</p>
+            <ul>
+              <li>Use 3-5 slow passes per side.</li>
+              <li>Pressure stays gentle; do not dig.</li>
+              <li>This area is sensitive because of nearby nerves and vessels.</li>
+            </ul>
+          </article>
+
+          <article class="step-card">
+            <div class="step-meta"><span>04</span><span>2 minutes</span></div>
+            <h3>Suboccipital release</h3>
+            <p>Lie on your back. Put two tennis balls in a sock, or use fingertips, under the base of the skull. Let the head rest without rolling aggressively.</p>
+            <ul>
+              <li>Make tiny yes nods for 30 seconds.</li>
+              <li>Make tiny no motions for 30 seconds.</li>
+              <li>Then just breathe and melt for 60 seconds.</li>
+            </ul>
+          </article>
+
+          <article class="step-card">
+            <div class="step-meta"><span>05</span><span>90 seconds</span></div>
+            <h3>Pec and collarbone sweep</h3>
+            <p>Gently sweep under the collarbone from sternum outward to shoulder, then massage the pec area below the collarbone.</p>
+            <ul>
+              <li>Spend 45 seconds each side.</li>
+              <li>Let the shoulder stay relaxed.</li>
+              <li>This often matters more than the neck alone.</li>
+            </ul>
+          </article>
+
+          <article class="step-card">
+            <div class="step-meta"><span>06</span><span>1 minute</span></div>
+            <h3>Chin tuck decompression</h3>
+            <p>Sit tall, imagine the back of the skull floating upward, then slide the head backward like making a small double chin. Do not look down.</p>
+            <ul>
+              <li>Hold 3 seconds, then release.</li>
+              <li>Do 5-8 reps.</li>
+              <li>Keep discomfort very low, ideally 0-3/10.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="rule">
+      <div class="shell rule-band">
+        <div class="rule-card">
+          <p class="eyebrow">The computer jaw rule</p>
+          <h2>Use this 15-second reset every 20-30 minutes.</h2>
+          <p class="rule-quote">
+            "Feet grounded. Exhale. Tongue up. Teeth apart. Shoulders drop. Chin gently back. Eyes look far away."
+          </p>
+        </div>
+        <div class="support-grid">
+          <article class="support-card">
+            <h3>Why it helps</h3>
+            <p>
+              Computer work often recreates the same clench and forward-head pattern. A short reset can interrupt that
+              loop before it becomes the whole day.
+            </p>
+          </article>
+          <article class="support-card">
+            <h3>Keep it tiny</h3>
+            <p>
+              The point is not to fix the body in one move. The point is to lower effort enough that the jaw and neck
+              stop bracing.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="avoid">
+      <div class="shell">
+        <p class="eyebrow">What I would avoid</p>
+        <h2>Stay away from hard, corrective, or aggressive work.</h2>
+        <div class="support-grid">
+          <article class="support-card">
+            <h3>Do not force the neck</h3>
+            <p>Skip hard cracking, aggressive stretching, and deep pressure on the front of the throat.</p>
+          </article>
+          <article class="support-card">
+            <h3>Do not force the jaw</h3>
+            <p>If the jaw clicks, locks, hurts, or the bite changes, stop trying to expand or align it yourself.</p>
+          </article>
+          <article class="support-card">
+            <h3>Use care with tools</h3>
+            <p>Aggressive gua sha or strong pressure over the throat is not part of this reset.</p>
+          </article>
+          <article class="support-card">
+            <h3>Get help when needed</h3>
+            <p>A dentist or TMJ-aware physical therapist is worth it if the symptoms persist or the bite feels changed.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="sources">
+      <div class="shell">
+        <p class="eyebrow">Sources</p>
+        <h2>Reference points behind the routine.</h2>
+        <p class="section-lead">
+          These links are there for context and safety, not to turn the page into a diagnosis tool.
+        </p>
+        <div class="source-grid">
+          <article class="source-card">
+            <a href="https://www.nhsinform.scot/illnesses-and-conditions/muscle-bone-and-joints/neck-and-back-problems-and-conditions/neck-problems/?utm_source=chatgpt.com" target="_blank" rel="noopener">
+              <strong>NHS inform</strong>
+            </a>
+            <small>Urgent advice signs for neck problems.</small>
+          </article>
+          <article class="source-card">
+            <a href="https://www.mayoclinic.org/diseases-conditions/tmj/diagnosis-treatment/drc-20350945?utm_source=chatgpt.com" target="_blank" rel="noopener">
+              <strong>Mayo Clinic</strong>
+            </a>
+            <small>TMJ self-care and clenching awareness.</small>
+          </article>
+          <article class="source-card">
+            <a href="https://my.clevelandclinic.org/health/body/24939-sternocleidomastoid-scm-muscle?utm_source=chatgpt.com" target="_blank" rel="noopener">
+              <strong>Cleveland Clinic</strong>
+            </a>
+            <small>SCM basics and posture-related care.</small>
+          </article>
+        </div>
+        <div class="footnote">
+          The routine is intentionally small and low force. If symptoms are severe, escalating, or tied to injury,
+          seek medical advice instead of pushing through.
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="shell">
+      <p>Fascia Release is a gentle reset page for neck, jaw, tongue, and computer tension.</p>
+      <p>Placeholder: future three.js visuals can be added later without changing the sequence.</p>
+    </div>
+  </footer>
+
+  <script>
+    const sections = [...document.querySelectorAll('section[id]')];
+    const buttons = [...document.querySelectorAll('[data-jump]')];
+
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const target = document.getElementById(button.dataset.jump);
+        if (target) {
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      });
+    });
+
+    const setActive = (id) => {
+      document.querySelectorAll('.nav button').forEach((button) => {
+        button.setAttribute('aria-pressed', String(button.dataset.jump === id));
+      });
+    };
+
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          const visible = entries.filter((entry) => entry.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+          if (visible) {
+            setActive(visible.target.id);
+          }
+        },
+        { rootMargin: '-30% 0px -55% 0px', threshold: [0.1, 0.2, 0.3, 0.4, 0.5] }
+      );
+
+      sections.forEach((section) => observer.observe(section));
+    }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -552,16 +552,22 @@
             <span class="app-card__title">Life Force Room</span>
             <span class="app-card__meta">Explore desire, embodiment, consent, and creative transmutation through a symbolic 3D room.</span>
           </a>
-          <a href="experimental/" class="app-card" data-app-tier="experimental" data-app-keywords="open form 3dvr connect premium landing sensual menswear intimacy wellness consent room system lifestyle">
+          <a href="3dvr-connect/" class="app-card" data-app-tier="experimental" data-app-keywords="3dvr connect open form consent community play space premium landing sensual menswear intimacy wellness">
             <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">O3D</span>
-            <span class="app-card__title">Open Form / 3DVR Connect</span>
-            <span class="app-card__meta">Explore the premium landing concept for Mediterranean linenwear, private intimacy products, and consent-based community design.</span>
+            <span class="app-card__title">3DVR Connect</span>
+            <span class="app-card__meta">Explore the consent-based community and play-space platform around Open Form.</span>
           </a>
           <a href="seated-spine-reset/" class="app-card" data-app-keywords="wellness posture spine stretch av tech conference laptop chair breathing">
             <span class="app-card__icon" aria-hidden="true">AV</span>
             <span class="app-card__title">Seated Spine Reset</span>
             <span class="app-card__meta">Run a quiet chair-based posture reset for neck, shoulders, spine, hips, and breath.</span>
+          </a>
+          <a href="fascia-release/" class="app-card" data-app-tier="experimental" data-app-keywords="fascia release neck jaw tongue computer tension gentle reset wellness">
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">FR</span>
+            <span class="app-card__title">Fascia Release</span>
+            <span class="app-card__meta">Run the gentle neck, jaw, tongue, and computer-tension reset with low-force guidance.</span>
           </a>
           <a href="meeting-notes/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🗒️</span>

--- a/tests/3dvr-connect-and-fascia-release.test.js
+++ b/tests/3dvr-connect-and-fascia-release.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('3DVR Connect ships as the public consent platform route and portal card', async () => {
+  const html = await readFile(new URL('../3dvr-connect/index.html', import.meta.url), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /<title>3DVR Connect \| Open Form<\/title>/);
+  assert.match(html, /3DVR Connect is the consent-based community and play-space platform around Open Form\./);
+  assert.match(html, /Open Form is a sensual menswear and intimacy-wear label around it\./);
+  assert.match(html, /<h2 class="section-title">3DVR Connect<\/h2>/);
+  assert.match(html, /Placeholder: event listings module and attendance workflows should be built here\./);
+  assert.match(html, /Placeholder: membership billing and entitlement wiring should be inserted in Connect flows\./);
+  assert.match(html, /Placeholder: consent onboarding flow and boundary management should mount adjacent to this component\./);
+  assert.match(html, /<p class="brand">3DVR Connect<\/p>/);
+  assert.match(portal, /<span class="app-card__badge">Experimental<\/span>/);
+  assert.match(portal, /<span class="app-card__title">3DVR Connect<\/span>/);
+  assert.doesNotMatch(portal, /href="experimental\/"/);
+});
+
+test('Fascia Release ships as a standalone gentle reset and portal card', async () => {
+  const html = await readFile(new URL('../fascia-release/index.html', import.meta.url), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /<title>Fascia Release \| 3DVR Portal<\/title>/);
+  assert.match(html, /Here is a gentle fascia-release reset for neck, jaw, tongue, and computer tension\./);
+  assert.match(html, /Inhale 4 seconds, exhale 6-8 seconds/);
+  assert.match(html, /Tongue soft, jaw heavy, eyes soft/);
+  assert.match(html, /Placeholder image panel/);
+  assert.match(html, /Seek care urgently if/);
+  assert.match(html, /The computer jaw rule/);
+  assert.match(html, /NHS inform/);
+  assert.match(html, /Mayo Clinic/);
+  assert.match(html, /Cleveland Clinic/);
+  assert.match(html, /<p class="brand">Fascia Release<\/p>/);
+  assert.match(portal, /<span class="app-card__title">Fascia Release<\/span>/);
+  assert.match(portal, /data-app-tier="experimental"/);
+});


### PR DESCRIPTION
## What changed
- Reworked `fascia-release/index.html` from a warm paper theme to the portal's dark wellness palette.
- Darkened the top bar, hero cards, routine cards, source cards, visual placeholders, and callouts so the whole page reads consistently at low light.

## Why
- The fascia-release page was still using a bright cream background and light panels.
- That made it the outlier in the wellness set and harder on the eyes than the rest of the portal.

## Validation
- Reviewed the rendered CSS for remaining bright surface colors.
- Confirmed the page no longer contains the old light-paper palette values.