### PR TITLE
[codex] add launch room movement brief flow

### DIFF
--- a/launch-room/app.js
+++ b/launch-room/app.js
@@ -1,0 +1,171 @@
+const STORAGE_KEY = '3dvr.launch-room.movement-brief.v1';
+
+const form = document.getElementById('movementBriefForm');
+const clearButton = document.querySelector('[data-action="clear"]');
+const status = document.getElementById('draftStatus');
+const fields = {
+  movementName: document.getElementById('movementName'),
+  worldPain: document.getElementById('worldPain'),
+  worldWish: document.getElementById('worldWish'),
+  firstAudience: document.getElementById('firstAudience'),
+  tinyProject: document.getElementById('tinyProject')
+};
+const briefTargets = {
+  movementName: document.querySelector('[data-brief="movementName"]'),
+  mission: document.querySelector('[data-brief="mission"]'),
+  worldview: document.querySelector('[data-brief="worldview"]'),
+  audience: document.querySelector('[data-brief="audience"]'),
+  tinyProject: document.querySelector('[data-brief="tinyProject"]'),
+  checklist: document.querySelector('[data-brief="checklist"]'),
+  actions: document.querySelector('[data-brief="actions"]')
+};
+
+function clean(value) {
+  return String(value || '').trim().replace(/\s+/g, ' ');
+}
+
+function titleCase(value) {
+  return clean(value)
+    .split(' ')
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function fallback(value, phrase) {
+  return clean(value) || phrase;
+}
+
+function loadDraft() {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveDraft(state) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Local-only draft persistence should fail quietly.
+  }
+}
+
+function getState() {
+  return Object.fromEntries(
+    Object.entries(fields).map(([key, input]) => [key, input.value])
+  );
+}
+
+function setState(state) {
+  Object.entries(fields).forEach(([key, input]) => {
+    input.value = state[key] || '';
+  });
+}
+
+function asSentence(text) {
+  const normalized = clean(text);
+  return normalized ? `${normalized.replace(/[.?!]+$/, '')}.` : '';
+}
+
+function buildBrief(state) {
+  const movementName = titleCase(state.movementName) || 'Your movement';
+  const worldPain = fallback(state.worldPain, 'the pattern you are ready to change');
+  const worldWish = fallback(state.worldWish, 'a better option that is easier to live inside');
+  const audience = fallback(state.firstAudience, 'the first people who need this most');
+  const tinyProject = fallback(state.tinyProject, 'a tiny version that can exist this week');
+
+  return {
+    movementName,
+    mission: `We are building ${movementName} to move beyond ${worldPain} and make ${worldWish} real for ${audience}.`,
+    worldview: `This matters because ${worldPain} keeps showing up while ${worldWish} stays out of reach. The movement gives people a clearer direction, and the tiny project proves the idea can become real without waiting for permission.`,
+    audience,
+    tinyProject,
+    checklist: [
+      `Write the movement in one sentence: ${movementName}.`,
+      `Keep the first audience narrow: ${audience}.`,
+      `Build the tiny version this week: ${tinyProject}.`,
+      'Share it with a few real people and note what feels true.',
+      'Use the feedback to tighten the next version instead of expanding too soon.'
+    ],
+    actions: [
+      `Today: turn the idea into one short paragraph and keep it visible.`,
+      `This week: ship ${asSentence(tinyProject).slice(0, -1) || 'the tiny version'}.`,
+      `Next: show it to ${audience} and capture the first response.`
+    ]
+  };
+}
+
+function renderBrief(state) {
+  const brief = buildBrief(state);
+
+  briefTargets.movementName.textContent = brief.movementName;
+  briefTargets.mission.textContent = brief.mission;
+  briefTargets.worldview.textContent = brief.worldview;
+  briefTargets.audience.textContent = brief.audience;
+  briefTargets.tinyProject.textContent = brief.tinyProject;
+
+  briefTargets.checklist.replaceChildren(
+    ...brief.checklist.map(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      return li;
+    })
+  );
+
+  briefTargets.actions.replaceChildren(
+    ...brief.actions.map(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      return li;
+    })
+  );
+
+  const hasContent = Object.values(state).some(value => clean(value));
+  status.textContent = hasContent
+    ? 'Draft saved locally in this browser.'
+    : 'Saved locally in this browser.';
+}
+
+function sync() {
+  const state = getState();
+  saveDraft(state);
+  renderBrief(state);
+}
+
+const initialState = {
+  movementName: '',
+  worldPain: '',
+  worldWish: '',
+  firstAudience: '',
+  tinyProject: '',
+  ...loadDraft()
+};
+
+setState(initialState);
+renderBrief(initialState);
+
+Object.values(fields).forEach(input => {
+  input.addEventListener('input', sync);
+});
+
+form.addEventListener('submit', event => {
+  event.preventDefault();
+  sync();
+  briefTargets.movementName.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+
+clearButton.addEventListener('click', () => {
+  setState({
+    movementName: '',
+    worldPain: '',
+    worldWish: '',
+    firstAudience: '',
+    tinyProject: ''
+  });
+  saveDraft(getState());
+  renderBrief(getState());
+  fields.movementName.focus();
+});

--- a/launch-room/index.html
+++ b/launch-room/index.html
@@ -4,7 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>3DVR Launch Room | 3DVR Portal</title>
-  <meta name="theme-color" content="#0b1220">
+  <meta
+    name="description"
+    content="Guided Purpose -> Vision -> Movement -> Project flow for turning a rough idea into a concrete Movement Brief."
+  >
   <link rel="stylesheet" href="../styles/global.css">
   <link rel="stylesheet" href="../index-style.css">
   <link rel="stylesheet" href="styles.css">
@@ -18,133 +21,135 @@
         <a href="../index.html">Portal</a>
         <a href="../projects/index.html">Projects</a>
         <a href="../web-builder-app/index.html">Web Builder</a>
-        <a href="../website-builder.html">Sites</a>
-        <a href="../lead-generation.html">Lead Capture</a>
-        <a href="../billing/index.html">Billing</a>
+        <a href="../billing/">Billing</a>
       </nav>
     </header>
 
     <main id="mainContent" class="landing-content">
       <section class="hero launch-room__hero" aria-labelledby="launchRoomTitle">
-        <span class="hero-eyebrow">Guided builder workspace</span>
+        <span class="hero-eyebrow">Purpose → Vision → Movement → Project</span>
         <h1 id="launchRoomTitle">3DVR Launch Room</h1>
         <p class="hero-tagline">
-          3DVR Launch Room is a guided workspace for independent builders turning rough ideas into real digital projects.
+          Turn a vague frustration into a Movement Brief you can use to start a real project.
         </p>
         <p class="launch-room__core-copy">
-          Bring your idea into the Launch Room. Leave with a page, a plan, a way to collect leads, and a path to payment.
+          Answer five prompts. The room will turn them into a readable brief with a movement name, mission,
+          first audience, tiny first project, checklist, and next actions.
         </p>
         <div class="hero-actions">
-          <a href="../projects/index.html" class="cta primary">Start with Projects</a>
+          <a href="../projects/index.html" class="cta primary">Open Projects</a>
           <a href="../web-builder-app/index.html" class="cta ghost">Build the page</a>
           <a href="../lead-generation.html" class="cta ghost">Collect leads</a>
         </div>
       </section>
 
-      <section class="launch-room__flow" aria-labelledby="flowTitle">
+      <section class="launch-room__workspace" aria-labelledby="workflowTitle">
         <div class="app-hub__intro">
-          <span class="eyebrow">Launch path</span>
-          <h2 id="flowTitle">One room, existing portal tools</h2>
+          <span class="eyebrow">Guided flow</span>
+          <h2 id="workflowTitle">From frustration to Movement Brief</h2>
           <p>
-            The Launch Room does not replace the portal modules. It gives builders a clear order for using them.
+            Keep the answers short. Specific is better than clever. The brief stays local in this browser for now.
           </p>
         </div>
-        <div class="app-grid launch-room__steps">
-          <a href="../projects/index.html" class="app-card">
-            <span class="app-card__icon" aria-hidden="true">1</span>
-            <span class="app-card__title">Shape the project</span>
-            <span class="app-card__meta">Use Projects to name the idea, owner, audience, and first shippable outcome.</span>
-          </a>
-          <a href="../web-builder-app/index.html" class="app-card">
-            <span class="app-card__icon" aria-hidden="true">2</span>
-            <span class="app-card__title">Make the page</span>
-            <span class="app-card__meta">Use Website Builder / Sites to draft, preview, revise, and publish the public page.</span>
-          </a>
-          <a href="../lead-generation.html" class="app-card">
-            <span class="app-card__icon" aria-hidden="true">3</span>
-            <span class="app-card__title">Capture demand</span>
-            <span class="app-card__meta">Use Lead Capture to turn interest into form submissions the team can follow up on.</span>
-          </a>
-          <a href="../billing/index.html" class="app-card">
-            <span class="app-card__icon" aria-hidden="true">4</span>
-            <span class="app-card__title">Open payment</span>
-            <span class="app-card__meta">Use Billing to connect the offer to plans, subscriptions, and customer status.</span>
-          </a>
+
+        <div class="launch-room__grid">
+          <form id="movementBriefForm" class="launch-room__form" autocomplete="off">
+            <label class="brief-field" for="movementName">
+              <span>What should we call this movement?</span>
+              <input id="movementName" name="movementName" type="text" placeholder="Launch Room, for example">
+            </label>
+
+            <label class="brief-field" for="worldPain">
+              <span>What are you tired of seeing in the world?</span>
+              <textarea id="worldPain" name="worldPain" rows="4" placeholder="The current frustration, gap, or pattern."></textarea>
+            </label>
+
+            <label class="brief-field" for="worldWish">
+              <span>What do you wish existed instead?</span>
+              <textarea id="worldWish" name="worldWish" rows="4" placeholder="The better world or outcome."></textarea>
+            </label>
+
+            <label class="brief-field" for="firstAudience">
+              <span>Who would you help first?</span>
+              <textarea id="firstAudience" name="firstAudience" rows="3" placeholder="Be concrete: one person, group, or niche."></textarea>
+            </label>
+
+            <label class="brief-field" for="tinyProject">
+              <span>What tiny version could exist this week?</span>
+              <textarea id="tinyProject" name="tinyProject" rows="4" placeholder="A page, doc, checklist, prototype, or post."></textarea>
+            </label>
+
+            <div class="launch-room__actions">
+              <button class="cta primary" type="submit">Build Movement Brief</button>
+              <button class="cta ghost" type="button" data-action="clear">Clear</button>
+            </div>
+            <p class="launch-room__status" id="draftStatus" aria-live="polite">
+              Saved locally in this browser.
+            </p>
+          </form>
+
+          <aside class="launch-room__brief" aria-labelledby="briefTitle">
+            <div class="app-hub__intro">
+              <span class="eyebrow">Movement Brief</span>
+              <h2 id="briefTitle">Readable output</h2>
+              <p>
+                This is the first version of the movement document. It can grow later, but it already tells the
+                next story.
+              </p>
+            </div>
+
+            <div class="brief-stack" aria-live="polite">
+              <article class="brief-card brief-card--title">
+                <p class="brief-card__label">Movement Name</p>
+                <h3 data-brief="movementName">Your movement</h3>
+              </article>
+
+              <article class="brief-card">
+                <p class="brief-card__label">Mission</p>
+                <p data-brief="mission">Answer the prompts to generate a mission.</p>
+              </article>
+
+              <article class="brief-card">
+                <p class="brief-card__label">Worldview / Why This Matters</p>
+                <p data-brief="worldview">The brief will explain the pattern you want to change and why this movement matters.</p>
+              </article>
+
+              <article class="brief-card">
+                <p class="brief-card__label">First Audience</p>
+                <p data-brief="audience">Name the first people you would help.</p>
+              </article>
+
+              <article class="brief-card">
+                <p class="brief-card__label">First Tiny Project</p>
+                <p data-brief="tinyProject">Describe the smallest version that could exist this week.</p>
+              </article>
+
+              <article class="brief-card brief-card--list">
+                <p class="brief-card__label">Launch Checklist</p>
+                <ol class="brief-list" data-brief="checklist"></ol>
+              </article>
+
+              <article class="brief-card brief-card--list">
+                <p class="brief-card__label">Next 3 Actions</p>
+                <ol class="brief-list" data-brief="actions"></ol>
+              </article>
+            </div>
+          </aside>
         </div>
       </section>
 
-      <section class="launch-room__modules" aria-labelledby="modulesTitle">
-        <div class="app-hub__intro">
-          <span class="eyebrow">Module map</span>
-          <h2 id="modulesTitle">How the portal connects</h2>
-          <p>
-            Each module keeps doing its own job. Launch Room explains when to use it and links straight there.
-          </p>
-        </div>
-        <div class="launch-room__module-grid">
-          <a href="../projects/index.html" class="launch-room__module">
-            <strong>Projects</strong>
-            <span>Turns the rough idea into a visible project with context, next steps, and ownership.</span>
-          </a>
-          <div class="launch-room__module">
-            <strong>Website Builder / Sites</strong>
-            <span>Creates the first public page so the idea has a real destination to share.</span>
-            <span class="launch-room__module-links">
-              <a href="../web-builder-app/index.html">Open Web Builder</a>
-              <a href="../website-builder.html">Open Sites</a>
-            </span>
-          </div>
-          <a href="../lead-generation.html" class="launch-room__module">
-            <strong>Lead Capture</strong>
-            <span>Collects names, emails, and notes from people who want to hear more.</span>
-          </a>
-          <a href="../crm/index.html" class="launch-room__module">
-            <strong>CRM</strong>
-            <span>Tracks the pipeline after a lead becomes a conversation, opportunity, or deal.</span>
-          </a>
-          <a href="../contacts/index.html" class="launch-room__module">
-            <strong>Contacts</strong>
-            <span>Keeps people, companies, tags, and relationship context reusable across launches.</span>
-          </a>
-          <a href="../tasks/" class="launch-room__module">
-            <strong>Tasks</strong>
-            <span>Breaks the launch into concrete work: page edits, follow-ups, pricing, and handoff items.</span>
-          </a>
-          <a href="../billing/index.html" class="launch-room__module">
-            <strong>Billing</strong>
-            <span>Gives the project a payment path through plans, checkout, and subscription status.</span>
-          </a>
-          <a href="../email-operator/index.html" class="launch-room__module">
-            <strong>Email Operator</strong>
-            <span>Turns approvals, replies, and follow-ups into practical outreach without duplicating CRM work.</span>
-          </a>
-          <a href="../sales/index.html" class="launch-room__module">
-            <strong>Sales</strong>
-            <span>Provides launch scripts, lead review, buyer steps, and revenue playbooks.</span>
-          </a>
-        </div>
-      </section>
-
-      <section class="info-panels" aria-label="Launch Room outcomes">
+      <section class="launch-room__notes" aria-label="Launch Room notes">
         <article class="info-card">
-          <h3>What leaves the room</h3>
-          <ul>
-            <li>A project record with the idea, audience, and next move.</li>
-            <li>A launch page or site draft ready to improve.</li>
-            <li>A lead path connected to CRM and Contacts.</li>
-            <li>A billing path for subscriptions, setup work, or support.</li>
-          </ul>
+          <h3>Local first</h3>
+          <p>Drafts stay in this browser. No backend is required for the first version.</p>
         </article>
         <article class="info-card">
-          <h3>Use it when</h3>
-          <p>
-            You have an idea that is still too vague to sell, but ready enough to turn into a page,
-            a follow-up list, and a practical path toward payment.
-          </p>
-          <div class="hero-actions launch-room__footer-actions">
-            <a href="../sales/index.html" class="cta primary">Open Sales</a>
-            <a href="../crm/index.html" class="cta ghost">Open CRM</a>
-          </div>
+          <h3>Use it for real projects</h3>
+          <p>The output is meant to become a page, a plan, a message, and a first concrete step.</p>
+        </article>
+        <article class="info-card">
+          <h3>Keep it small</h3>
+          <p>Short answers make sharper briefs. A tiny project that ships this week beats a perfect one that waits.</p>
         </article>
       </section>
     </main>
@@ -153,5 +158,7 @@
       3DVR.Tech &copy; 2025 - Open Web for Everyone | <a href="../index.html">Back to Portal</a>
     </footer>
   </div>
+
+  <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/launch-room/styles.css
+++ b/launch-room/styles.css
@@ -1,104 +1,185 @@
 .launch-room__shell {
-  max-width: 1120px;
+  max-width: 1180px;
 }
 
 .launch-room .top-nav {
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
 }
 
 .launch-room__hero {
-  max-width: 820px;
-  margin: 0 auto;
+  max-width: 840px;
+  margin: 0 auto 1.5rem;
 }
 
 .launch-room__core-copy {
-  max-width: 720px;
+  max-width: 760px;
   margin: 0 auto;
-  padding: 1.25rem 1.5rem;
-  border: 1px solid rgba(34, 211, 238, 0.35);
+  padding: 1.15rem 1.35rem;
+  border: 1px solid rgba(56, 189, 248, 0.28);
   border-radius: var(--radius-lg);
-  background: rgba(34, 211, 238, 0.12);
-  color: rgba(248, 250, 252, 0.94);
-  font-size: clamp(1.15rem, 1vw + 0.95rem, 1.55rem);
-  font-weight: 700;
-  line-height: 1.45;
+  background: rgba(14, 20, 31, 0.82);
+  color: rgba(241, 245, 249, 0.92);
+  font-size: clamp(1.05rem, 0.95rem + 0.5vw, 1.35rem);
+  font-weight: 650;
+  line-height: 1.5;
 }
 
-.launch-room__flow,
-.launch-room__modules {
+.launch-room__workspace,
+.launch-room__notes {
   display: grid;
-  gap: 1.6rem;
+  gap: 1.25rem;
 }
 
-.launch-room__steps {
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-}
-
-.launch-room__steps .app-card__icon {
-  font-weight: 800;
-  font-size: 1.2rem;
-}
-
-.launch-room__module-grid {
+.launch-room__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1rem;
 }
 
-.launch-room__module {
-  display: grid;
-  gap: 0.45rem;
-  padding: 1.2rem;
+.launch-room__form,
+.launch-room__brief,
+.info-card {
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-md);
-  background: rgba(17, 24, 39, 0.62);
-  color: var(--color-text);
+  background: rgba(17, 24, 39, 0.72);
   box-shadow: 0 24px 60px rgba(4, 9, 20, 0.38);
 }
 
-.launch-room__module:hover {
-  border-color: rgba(56, 189, 248, 0.48);
-  background: rgba(30, 41, 59, 0.72);
-  color: var(--color-text);
+.launch-room__form,
+.launch-room__brief {
+  padding: 1rem;
 }
 
-.launch-room__module strong {
-  font-size: 1.02rem;
+.launch-room__form {
+  display: grid;
+  gap: 0.9rem;
 }
 
-.launch-room__module span {
+.brief-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.brief-field span,
+.brief-card__label {
   color: var(--color-text-muted);
-  font-size: 0.94rem;
+  font-size: 0.82rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.launch-room__module-links {
+.brief-field input,
+.brief-field textarea {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: var(--radius-md);
+  background: rgba(11, 15, 24, 0.96);
+  color: var(--color-text);
+  padding: 0.88rem 0.95rem;
+  resize: vertical;
+}
+
+.brief-field input:focus-visible,
+.brief-field textarea:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.55);
+  outline-offset: 2px;
+}
+
+.launch-room__actions {
   display: flex;
   flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.launch-room__status {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+}
+
+.launch-room__brief {
+  display: grid;
+  gap: 1rem;
+}
+
+.brief-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.brief-card {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.95rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: var(--radius-md);
+  background: rgba(12, 18, 28, 0.92);
+}
+
+.brief-card--title h3 {
+  margin: 0;
+  font-size: clamp(1.35rem, 1rem + 1vw, 2rem);
+  line-height: 1.1;
+}
+
+.brief-card p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.brief-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
   gap: 0.5rem;
-  margin-top: 0.35rem;
-}
-
-.launch-room__module-links a {
-  padding: 0.35rem 0.65rem;
-  border: 1px solid rgba(56, 189, 248, 0.32);
-  border-radius: 999px;
-  color: var(--accent-strong);
-  font-size: 0.82rem;
-  font-weight: 700;
-}
-
-.launch-room__module-links a:hover {
-  background: rgba(56, 189, 248, 0.14);
   color: var(--color-text);
 }
 
-.launch-room__footer-actions {
-  justify-content: flex-start;
-  margin-top: 1rem;
+.brief-list li {
+  line-height: 1.45;
+}
+
+.info-card {
+  padding: 1rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.info-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.info-card p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+@media (min-width: 980px) {
+  .launch-room__grid {
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+    align-items: start;
+  }
+
+  .launch-room__notes {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 640px) {
-  .launch-room__core-copy {
-    padding: 1rem;
+  .launch-room__core-copy,
+  .launch-room__form,
+  .launch-room__brief,
+  .info-card {
+    padding: 0.9rem;
+  }
+
+  .launch-room__actions {
+    width: 100%;
+  }
+
+  .launch-room__actions .cta {
+    width: 100%;
   }
 }

--- a/tests/launch-room.test.js
+++ b/tests/launch-room.test.js
@@ -2,28 +2,23 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
-test('launch room route connects the existing portal modules', async () => {
+test('launch room ships a local-first Movement Brief flow', async () => {
   const html = await readFile(new URL('../launch-room/index.html', import.meta.url), 'utf8');
-  const css = await readFile(new URL('../launch-room/styles.css', import.meta.url), 'utf8');
-  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const app = await readFile(new URL('../launch-room/app.js', import.meta.url), 'utf8');
 
   assert.match(html, /3DVR Launch Room/);
-  assert.match(html, /guided workspace for independent builders turning rough ideas into real digital projects/);
-  assert.match(html, /Bring your idea into the Launch Room\. Leave with a page, a plan, a way to collect leads, and a path to payment\./);
-  assert.match(html, /href="..\/projects\/index\.html"/);
-  assert.match(html, /href="..\/web-builder-app\/index\.html"/);
-  assert.match(html, /href="..\/website-builder\.html"/);
-  assert.match(html, /href="..\/lead-generation\.html"/);
-  assert.match(html, /href="..\/crm\/index\.html"/);
-  assert.match(html, /href="..\/contacts\/index\.html"/);
-  assert.match(html, /href="..\/tasks\/"/);
-  assert.match(html, /href="..\/billing\/index\.html"/);
-  assert.match(html, /href="..\/email-operator\/index\.html"/);
-  assert.match(html, /href="..\/sales\/index\.html"/);
+  assert.match(html, /Purpose → Vision → Movement → Project/);
+  assert.match(html, /id="movementName"/);
+  assert.match(html, /id="worldPain"/);
+  assert.match(html, /id="worldWish"/);
+  assert.match(html, /id="firstAudience"/);
+  assert.match(html, /id="tinyProject"/);
+  assert.match(html, /Movement Brief/);
+  assert.match(html, /Launch Checklist/);
+  assert.match(html, /Next 3 Actions/);
 
-  assert.match(css, /\.launch-room__module-grid/);
-  assert.match(css, /\.launch-room__core-copy/);
-
-  assert.match(portal, /href="launch-room\/"/);
-  assert.match(portal, /Launch Room/);
+  assert.match(app, /STORAGE_KEY = '3dvr\.launch-room\.movement-brief\.v1'/);
+  assert.match(app, /function buildBrief/);
+  assert.match(app, /localStorage/);
+  assert.match(app, /replaceChildren/);
 });


### PR DESCRIPTION
## Summary
- Replace the Launch Room placeholder/module map with a local-first guided Purpose -> Vision -> Movement -> Project flow
- Add the five prompt inputs and generated Movement Brief sections
- Persist drafts in browser localStorage with no backend requirement
- Update the focused Launch Room test for the new flow

## Validation
- `node --test tests/launch-room.test.js` passed
- `node --check launch-room/app.js` passed
- Full `npm test` was run in the clean worktree but still fails on existing repo issues unrelated to this change: missing API test dependencies such as `nodemailer`, `gun`, and `stripe`; an existing auth entrypoint assertion mismatch; and existing Vercel insights tag checks across tracked HTML pages.