### PR TITLE
[codex] polish launch room brief flow

### DIFF
--- a/launch-room/app.js
+++ b/launch-room/app.js
@@ -2,6 +2,8 @@ const STORAGE_KEY = '3dvr.launch-room.movement-brief.v1';
 
 const form = document.getElementById('movementBriefForm');
 const clearButton = document.querySelector('[data-action="clear"]');
+const copyButton = document.querySelector('[data-action="copy"]');
+const downloadButton = document.querySelector('[data-action="download"]');
 const status = document.getElementById('draftStatus');
 const fields = {
   movementName: document.getElementById('movementName'),
@@ -70,6 +72,15 @@ function asSentence(text) {
   return normalized ? `${normalized.replace(/[.?!]+$/, '')}.` : '';
 }
 
+function slugify(text) {
+  const slug = clean(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return slug || 'movement-brief';
+}
+
 function buildBrief(state) {
   const movementName = titleCase(state.movementName) || 'Your movement';
   const worldPain = fallback(state.worldPain, 'the pattern you are ready to change');
@@ -96,6 +107,31 @@ function buildBrief(state) {
       `Next: show it to ${audience} and capture the first response.`
     ]
   };
+}
+
+function briefToMarkdown(brief) {
+  return [
+    `# ${brief.movementName}`,
+    '',
+    '## Mission',
+    brief.mission,
+    '',
+    '## Worldview / Why This Matters',
+    brief.worldview,
+    '',
+    '## First Audience',
+    brief.audience,
+    '',
+    '## First Tiny Project',
+    brief.tinyProject,
+    '',
+    '## Launch Checklist',
+    ...brief.checklist.map(item => `- ${item}`),
+    '',
+    '## Next 3 Actions',
+    ...brief.actions.map(item => `- ${item}`),
+    ''
+  ].join('\n');
 }
 
 function renderBrief(state) {
@@ -135,6 +171,44 @@ function sync() {
   renderBrief(state);
 }
 
+async function copyBrief() {
+  const brief = buildBrief(getState());
+  const markdown = briefToMarkdown(brief);
+
+  try {
+    await navigator.clipboard.writeText(markdown);
+    status.textContent = 'Movement Brief copied to clipboard.';
+  } catch {
+    const fallback = document.createElement('textarea');
+    fallback.value = markdown;
+    fallback.setAttribute('readonly', '');
+    fallback.style.position = 'fixed';
+    fallback.style.inset = '0 auto auto 0';
+    fallback.style.opacity = '0';
+    document.body.append(fallback);
+    fallback.select();
+    document.execCommand('copy');
+    fallback.remove();
+    status.textContent = 'Movement Brief copied to clipboard.';
+  }
+}
+
+function downloadBrief() {
+  const brief = buildBrief(getState());
+  const markdown = briefToMarkdown(brief);
+  const blob = new Blob([markdown], { type: 'text/markdown' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = `${slugify(brief.movementName)}.md`;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  status.textContent = 'Movement Brief downloaded as Markdown.';
+}
+
 const initialState = {
   movementName: '',
   worldPain: '',
@@ -167,5 +241,9 @@ clearButton.addEventListener('click', () => {
   });
   saveDraft(getState());
   renderBrief(getState());
-  fields.movementName.focus();
+  fields.worldPain.focus();
 });
+
+copyButton.addEventListener('click', copyBrief);
+
+downloadButton.addEventListener('click', downloadBrief);

--- a/launch-room/index.html
+++ b/launch-room/index.html
@@ -32,6 +32,9 @@
         <p class="hero-tagline">
           Turn a vague frustration into a Movement Brief you can use to start a real project.
         </p>
+        <p class="launch-room__emotional-line">
+          Most people don’t need another productivity app. They need a place to remember what they care about.
+        </p>
         <p class="launch-room__core-copy">
           Answer five prompts. The room will turn them into a readable brief with a movement name, mission,
           first audience, tiny first project, checklist, and next actions.
@@ -54,33 +57,33 @@
 
         <div class="launch-room__grid">
           <form id="movementBriefForm" class="launch-room__form" autocomplete="off">
-            <label class="brief-field" for="movementName">
-              <span>What should we call this movement?</span>
-              <input id="movementName" name="movementName" type="text" placeholder="Launch Room, for example">
-            </label>
-
             <label class="brief-field" for="worldPain">
               <span>What are you tired of seeing in the world?</span>
-              <textarea id="worldPain" name="worldPain" rows="4" placeholder="The current frustration, gap, or pattern."></textarea>
+              <textarea id="worldPain" name="worldPain" rows="4" placeholder="Example: People feel stuck in work that drains them and nobody asks what they actually want to build."></textarea>
             </label>
 
             <label class="brief-field" for="worldWish">
               <span>What do you wish existed instead?</span>
-              <textarea id="worldWish" name="worldWish" rows="4" placeholder="The better world or outcome."></textarea>
+              <textarea id="worldWish" name="worldWish" rows="4" placeholder="Example: A calm place where anyone can name what matters, see a path, and launch a small real project."></textarea>
             </label>
 
             <label class="brief-field" for="firstAudience">
               <span>Who would you help first?</span>
-              <textarea id="firstAudience" name="firstAudience" rows="3" placeholder="Be concrete: one person, group, or niche."></textarea>
+              <textarea id="firstAudience" name="firstAudience" rows="3" placeholder="Example: Creative parents, burned-out operators, or one friend with a useful idea but no launch plan."></textarea>
             </label>
 
             <label class="brief-field" for="tinyProject">
               <span>What tiny version could exist this week?</span>
-              <textarea id="tinyProject" name="tinyProject" rows="4" placeholder="A page, doc, checklist, prototype, or post."></textarea>
+              <textarea id="tinyProject" name="tinyProject" rows="4" placeholder="Example: A one-page brief, a simple landing page, a 7-day checklist, or a prototype people can react to."></textarea>
+            </label>
+
+            <label class="brief-field" for="movementName">
+              <span>What should we call this movement?</span>
+              <input id="movementName" name="movementName" type="text" placeholder="Example: Launch Room, Human Scale Work, or The First Tiny Project">
             </label>
 
             <div class="launch-room__actions">
-              <button class="cta primary" type="submit">Build Movement Brief</button>
+              <button class="cta primary" type="submit">Generate My Movement Brief</button>
               <button class="cta ghost" type="button" data-action="clear">Clear</button>
             </div>
             <p class="launch-room__status" id="draftStatus" aria-live="polite">
@@ -96,6 +99,10 @@
                 This is the first version of the movement document. It can grow later, but it already tells the
                 next story.
               </p>
+            </div>
+            <div class="launch-room__brief-actions" aria-label="Movement Brief actions">
+              <button class="cta ghost" type="button" data-action="copy">Copy Brief</button>
+              <button class="cta ghost" type="button" data-action="download">Download Markdown</button>
             </div>
 
             <div class="brief-stack" aria-live="polite">

--- a/launch-room/styles.css
+++ b/launch-room/styles.css
@@ -24,6 +24,15 @@
   line-height: 1.5;
 }
 
+.launch-room__emotional-line {
+  max-width: 760px;
+  margin: 0 auto;
+  color: rgba(241, 245, 249, 0.9);
+  font-size: clamp(1.18rem, 1rem + 0.85vw, 1.65rem);
+  font-weight: 750;
+  line-height: 1.32;
+}
+
 .launch-room__workspace,
 .launch-room__notes {
   display: grid;
@@ -103,6 +112,12 @@
   gap: 1rem;
 }
 
+.launch-room__brief-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 .brief-stack {
   display: grid;
   gap: 0.75rem;
@@ -180,6 +195,10 @@
   }
 
   .launch-room__actions .cta {
+    width: 100%;
+  }
+
+  .launch-room__brief-actions .cta {
     width: 100%;
   }
 }

--- a/tests/launch-room.test.js
+++ b/tests/launch-room.test.js
@@ -6,19 +6,40 @@ test('launch room ships a local-first Movement Brief flow', async () => {
   const html = await readFile(new URL('../launch-room/index.html', import.meta.url), 'utf8');
   const app = await readFile(new URL('../launch-room/app.js', import.meta.url), 'utf8');
 
+  const promptOrder = [
+    'What are you tired of seeing in the world?',
+    'What do you wish existed instead?',
+    'Who would you help first?',
+    'What tiny version could exist this week?',
+    'What should we call this movement?'
+  ];
+
   assert.match(html, /3DVR Launch Room/);
   assert.match(html, /Purpose → Vision → Movement → Project/);
+  assert.match(html, /Most people don’t need another productivity app/);
+  promptOrder.forEach(prompt => assert.notEqual(html.indexOf(prompt), -1));
+  assert.deepEqual(
+    promptOrder.map(prompt => html.indexOf(prompt)).sort((left, right) => left - right),
+    promptOrder.map(prompt => html.indexOf(prompt))
+  );
   assert.match(html, /id="movementName"/);
   assert.match(html, /id="worldPain"/);
   assert.match(html, /id="worldWish"/);
   assert.match(html, /id="firstAudience"/);
   assert.match(html, /id="tinyProject"/);
+  assert.match(html, /People feel stuck in work that drains them/);
+  assert.match(html, /Generate My Movement Brief/);
+  assert.match(html, /Copy Brief/);
+  assert.match(html, /Download Markdown/);
   assert.match(html, /Movement Brief/);
   assert.match(html, /Launch Checklist/);
   assert.match(html, /Next 3 Actions/);
 
   assert.match(app, /STORAGE_KEY = '3dvr\.launch-room\.movement-brief\.v1'/);
   assert.match(app, /function buildBrief/);
+  assert.match(app, /function briefToMarkdown/);
+  assert.match(app, /navigator\.clipboard\.writeText/);
+  assert.match(app, /type: 'text\/markdown'/);
   assert.match(app, /localStorage/);
   assert.match(app, /replaceChildren/);
 });


### PR DESCRIPTION
## Summary
- Reorder the five Launch Room prompts so the movement name comes last
- Add the stronger emotional hero line and clearer field examples
- Rename the primary CTA to `Generate My Movement Brief`
- Add local-only Copy Brief and Download Markdown actions for the generated brief
- Update focused Launch Room coverage for prompt order and new export controls

## Validation
- `node --check launch-room/app.js` passed
- `node --test tests/launch-room.test.js` passed
- No lint/build scripts are defined in `package.json`
- `npm test` was run and still fails on existing repository-wide issues unrelated to this Launch Room change: missing packages such as `nodemailer`, `gun`, and `stripe`; an existing auth entrypoint assertion; and existing Vercel insights tag coverage failures across tracked HTML pages.