### PR TITLE
[codex] Prioritize CRM fallback note

### DIFF
--- a/crm/app.js
+++ b/crm/app.js
@@ -1730,7 +1730,7 @@ function updateCounts(total, visible) {
   if (elements.visibleCount) elements.visibleCount.textContent = String(visible);
   if (!elements.emptyState) return;
   if (total === 0) {
-    elements.emptyState.textContent = 'No notes yet. Save a quick conversation to get started.';
+    elements.emptyState.textContent = 'No notes yet. Save a fallback note to get started.';
     elements.emptyState.classList.remove('hidden');
   } else if (visible === 0) {
     elements.emptyState.textContent = 'No records match this filter yet.';
@@ -3168,7 +3168,7 @@ async function handleQuickConversationSubmit(event) {
       note: body,
       nextStep,
     }),
-    source: existing?.source || 'Quick capture',
+    source: existing?.source || 'Fast fallback note',
     created: existing?.created || now,
     updated: now,
     lastContacted: now,
@@ -3181,7 +3181,7 @@ async function handleQuickConversationSubmit(event) {
     appendTouchLogEntry(savedRecord, {
       touchType: getQuickConversationTouchType(channel),
       note: body,
-      source: 'Quick capture',
+      source: 'Fast fallback note',
       statusAfter: savedRecord.status || DEFAULT_PERSON_STATUS,
       timestamp: now,
     });

--- a/crm/index.html
+++ b/crm/index.html
@@ -114,9 +114,9 @@
     <div class="max-w-5xl mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
       <div>
         <p class="text-xs font-semibold tracking-[0.32em] text-teal-400 uppercase">CRM</p>
-        <h1 class="text-3xl font-bold">Quick conversations</h1>
-        <p class="text-sm text-gray-300">Save who you talked to, what happened, and the next small step.</p>
-        <p class="text-xs text-gray-400 mt-2">Messy notes are fine. The goal is to get it out of your head quickly.</p>
+        <h1 class="text-3xl font-bold">People CRM</h1>
+        <p class="text-sm text-gray-300">Add a person fast, capture the next step, and clean up the details later.</p>
+        <p class="text-xs text-gray-400 mt-2">Use the fast fallback note first. Messy notes are fine.</p>
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../sales/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Sales</a>
@@ -154,24 +154,67 @@
     <section id="quickConversationCapture" class="rounded-3xl border border-teal-400/20 bg-gradient-to-br from-gray-800/85 to-gray-950/90 p-5 shadow-2xl shadow-black/20">
       <div class="grid gap-5 lg:grid-cols-[0.75fr,1.25fr] lg:items-start">
         <div class="space-y-2">
-          <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Quick capture</p>
-          <h2 class="text-2xl font-semibold">Ask, tap, save.</h2>
+          <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Fast add</p>
+          <h2 class="text-2xl font-semibold">Start with the fallback note.</h2>
           <p class="text-sm text-gray-300">
-            Pull this up during a real conversation. Tap the useful signal, dictate tiny notes, and save the next step.
+            Drop in a name, what happened, and the next step. This is the main path for quickly adding new people.
           </p>
           <button
             id="openConversationCapture"
             type="button"
-            class="mt-3 inline-flex w-full items-center justify-center rounded-2xl bg-teal-400 px-5 py-4 text-base font-bold text-gray-950 shadow-lg shadow-teal-950/30 hover:bg-teal-300 sm:w-auto"
+            class="mt-3 inline-flex w-full items-center justify-center rounded-2xl border border-white/10 bg-white/10 px-5 py-4 text-base font-bold text-white shadow-lg shadow-black/20 hover:bg-white/15 sm:w-auto"
           >
-            + Capture Conversation
+            + Intake form
           </button>
+          <p class="text-xs text-gray-400">Use the intake form only when you need the full structured version.</p>
         </div>
         <div class="space-y-5">
+          <details class="rounded-3xl border border-teal-300/40 bg-teal-950/35 p-4 shadow-2xl shadow-teal-950/20 sm:p-5" open>
+            <summary class="cursor-pointer text-lg font-bold text-teal-100">Fast fallback note</summary>
+            <p class="mt-2 text-sm text-teal-100/80">Fastest path: write the messy note, add a name if you know it, and save.</p>
+            <form id="quickConversationForm" class="mt-4 grid gap-3">
+              <label for="quickConversationNote" class="sr-only">Conversation note</label>
+              <textarea
+                id="quickConversationNote"
+                rows="5"
+                class="w-full rounded-2xl border border-teal-200/30 bg-white text-gray-950 p-4 text-base leading-relaxed shadow-inner"
+                placeholder="Example: Talked to Victor. He still wants the Alibaba store. Ask him to send one product link tomorrow."
+              ></textarea>
+              <div class="grid gap-3 md:grid-cols-[1fr,0.7fr]">
+                <div>
+                  <label for="quickConversationPerson" class="block text-xs font-semibold uppercase tracking-[0.22em] text-teal-100/70 mb-1">Who</label>
+                  <input id="quickConversationPerson" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional name" autocomplete="name" />
+                </div>
+                <div>
+                  <label for="quickConversationChannel" class="block text-xs font-semibold uppercase tracking-[0.22em] text-teal-100/70 mb-1">Kind</label>
+                  <select id="quickConversationChannel" class="w-full p-3 rounded-xl text-black">
+                    <option value="conversation">Conversation</option>
+                    <option value="message">Text / DM</option>
+                    <option value="call">Call</option>
+                    <option value="email">Email</option>
+                    <option value="group-chat">Group chat</option>
+                  </select>
+                </div>
+              </div>
+              <div class="grid gap-3 md:grid-cols-[1fr,auto] md:items-end">
+                <div>
+                  <label for="quickConversationNextStep" class="block text-xs font-semibold uppercase tracking-[0.22em] text-teal-100/70 mb-1">Next step</label>
+                  <input id="quickConversationNextStep" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional: ask for product link, send examples, follow up Friday..." />
+                </div>
+                <button type="submit" class="rounded-xl bg-teal-300 px-6 py-3 font-bold text-gray-950 hover:bg-teal-200">Save person note</button>
+              </div>
+              <p id="quickConversationStatus" class="hidden rounded-xl border px-3 py-2 text-sm" role="status" aria-live="polite"></p>
+            </form>
+          </details>
+
           <div
             id="conversationCapturePanel"
-            class="hidden rounded-3xl border border-teal-300/20 bg-gray-950/45 p-4 sm:p-5"
+            class="hidden rounded-3xl border border-white/10 bg-gray-950/45 p-4 sm:p-5"
           >
+            <div class="mb-4">
+              <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-200">Intake form</p>
+              <p class="mt-1 text-sm text-gray-300">Use this longer form when you want structured details beyond the fallback note.</p>
+            </div>
             <form id="conversationCaptureForm" class="grid gap-5">
               <section class="space-y-3">
                 <div>
@@ -335,7 +378,7 @@
               </section>
 
               <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-                <button type="submit" class="rounded-2xl bg-teal-400 px-5 py-4 font-bold text-gray-950 hover:bg-teal-300">Save Conversation</button>
+                <button type="submit" class="rounded-2xl bg-teal-400 px-5 py-4 font-bold text-gray-950 hover:bg-teal-300">Save intake</button>
                 <button id="resetConversationCapture" type="button" class="rounded-2xl border border-white/10 bg-white/10 px-5 py-4 font-semibold text-white hover:bg-white/15">Clear</button>
               </div>
               <p id="conversationCaptureStatus" class="hidden rounded-xl border px-3 py-2 text-sm" role="status" aria-live="polite"></p>
@@ -343,43 +386,6 @@
           </div>
 
           <div id="conversationCaptureSummary" class="hidden rounded-2xl border border-emerald-400/25 bg-emerald-950/35 p-4"></div>
-
-          <details class="rounded-2xl border border-white/10 bg-white/5 p-4">
-            <summary class="cursor-pointer text-sm font-semibold text-gray-200">Fast fallback note</summary>
-            <form id="quickConversationForm" class="mt-4 grid gap-3">
-              <label for="quickConversationNote" class="sr-only">Conversation note</label>
-              <textarea
-                id="quickConversationNote"
-                rows="4"
-                class="w-full rounded-2xl border border-white/10 bg-white text-gray-950 p-4 text-base leading-relaxed"
-                placeholder="Example: Talked to Victor. He still wants the Alibaba store. Ask him to send one product link tomorrow."
-              ></textarea>
-              <div class="grid gap-3 md:grid-cols-[1fr,0.7fr]">
-                <div>
-                  <label for="quickConversationPerson" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Who</label>
-                  <input id="quickConversationPerson" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional name" autocomplete="name" />
-                </div>
-                <div>
-                  <label for="quickConversationChannel" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Kind</label>
-                  <select id="quickConversationChannel" class="w-full p-3 rounded-xl text-black">
-                    <option value="conversation">Conversation</option>
-                    <option value="message">Text / DM</option>
-                    <option value="call">Call</option>
-                    <option value="email">Email</option>
-                    <option value="group-chat">Group chat</option>
-                  </select>
-                </div>
-              </div>
-              <div class="grid gap-3 md:grid-cols-[1fr,auto] md:items-end">
-                <div>
-                  <label for="quickConversationNextStep" class="block text-xs font-semibold uppercase tracking-[0.22em] text-gray-400 mb-1">Next step</label>
-                  <input id="quickConversationNextStep" type="text" class="w-full p-3 rounded-xl text-black" placeholder="Optional: ask for product link, send examples, follow up Friday..." />
-                </div>
-                <button type="submit" class="rounded-xl bg-teal-500 px-5 py-3 font-semibold text-gray-950 hover:bg-teal-400">Save note</button>
-              </div>
-              <p id="quickConversationStatus" class="hidden rounded-xl border px-3 py-2 text-sm" role="status" aria-live="polite"></p>
-            </form>
-          </details>
 
           <section class="rounded-2xl border border-white/10 bg-gray-950/35 p-4">
             <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
@@ -609,7 +615,7 @@
         <div class="space-y-2">
           <p class="text-xs font-semibold tracking-[0.32em] text-teal-300 uppercase">Add a person</p>
           <h2 class="text-xl font-semibold">Use this only when you know the basics.</h2>
-          <p class="text-sm text-gray-300">For normal day-to-day notes, use Quick capture at the top.</p>
+          <p class="text-sm text-gray-300">For normal day-to-day notes, use the fast fallback note at the top.</p>
         </div>
         <form id="quickLeadForm" class="grid gap-3">
           <input id="quickLeadName" type="text" placeholder="Lead name" class="w-full p-2 rounded text-black" />
@@ -652,7 +658,7 @@
           <p id="crmImportStatus" class="hidden rounded-lg border px-3 py-2 text-xs" role="status" aria-live="polite"></p>
         </div>
         <div class="grid gap-2 sm:grid-cols-2">
-          <span class="bg-white/10 text-white px-3 py-2 rounded text-sm text-center border border-white/10">Use Quick capture for messy notes</span>
+          <span class="bg-white/10 text-white px-3 py-2 rounded text-sm text-center border border-white/10">Use the fallback note for messy notes</span>
           <button id="openGroupCreate" type="button" class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm">New group</button>
           <button id="openProblemCreate" type="button" class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm">Log problem</button>
           <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-3 py-2 rounded text-sm text-center">Open contacts</a>
@@ -691,7 +697,7 @@
           </div>
           <div id="crmDuplicateSummary" class="hidden bg-amber-900/40 border border-amber-500/30 rounded-lg p-3 text-sm text-amber-100 mb-4"></div>
           <div id="contactList" class="space-y-3"></div>
-          <div id="emptyState" class="text-sm text-gray-400 hidden">No notes yet. Save a quick conversation to get started.</div>
+          <div id="emptyState" class="text-sm text-gray-400 hidden">No notes yet. Save a fallback note to get started.</div>
         </div>
       </div>
     </section>

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -13,7 +13,7 @@ test('CRM page exposes workflow filters and import controls for fast lead retrie
   const html = await read('crm/index.html');
   assert.match(html, /id="quickConversationCapture"/);
   assert.match(html, /id="openConversationCapture"/);
-  assert.match(html, /\+ Capture Conversation/);
+  assert.match(html, /\+ Intake form/);
   assert.match(html, /id="conversationCapturePanel"/);
   assert.match(html, /id="conversationCaptureForm"/);
   assert.match(html, /id="conversationCaptureName"/);
@@ -29,14 +29,18 @@ test('CRM page exposes workflow filters and import controls for fast lead retrie
   assert.match(html, /id="conversationCapturePlanFilter"/);
   assert.match(html, /id="conversationCaptureActionFilter"/);
   assert.match(html, /id="conversationCaptureInterestFilter"/);
-  assert.match(html, /Ask, tap, save\./);
-  assert.match(html, /Save Conversation/);
+  assert.match(html, /Start with the fallback note\./);
+  assert.match(html, /Save intake/);
   assert.match(html, /id="quickConversationForm"/);
   assert.match(html, /id="quickConversationNote"/);
   assert.match(html, /id="quickConversationPerson"/);
   assert.match(html, /id="quickConversationChannel"/);
   assert.match(html, /id="quickConversationNextStep"/);
-  assert.match(html, /Ask, tap, save\./);
+  assert.match(html, /Fastest path: write the messy note/);
+  assert.ok(
+    html.indexOf('id="quickConversationForm"') < html.indexOf('id="conversationCapturePanel"'),
+    'expected the fallback note to appear before the intake form'
+  );
   assert.match(html, /overflow-x: hidden/);
   assert.match(html, /overflow-wrap: anywhere/);
   assert.match(html, /#crmFloatingIdentity/);
@@ -106,7 +110,7 @@ test('CRM app includes keyboard search shortcut, workflow filters, and import wi
   assert.match(js, /handleQuickConversationSubmit/);
   assert.match(js, /findQuickConversationRecord/);
   assert.match(js, /appendConversationNote/);
-  assert.match(js, /source: 'Quick capture'/);
+  assert.match(js, /source: 'Fast fallback note'/);
   assert.match(js, /touchType: getQuickConversationTouchType\(channel\)/);
   assert.match(js, /quickConversationForm\?\.addEventListener\('submit', handleQuickConversationSubmit\)/);
   assert.match(js, /personWorkflowFilter\?\.addEventListener\('change', applyFilter\)/);


### PR DESCRIPTION
## What changed

- Promoted the CRM fast fallback note to the primary, open-by-default quick-add surface.
- Renamed the long structured capture CTA and form copy to "Intake form".
- Updated quick-note empty-state/source labels and the CRM workflow test expectations.

## Why

The fallback note is the intended fastest path for adding new people. The old "Capture Conversation" label made the secondary structured flow feel like the primary path and was too long.

## Validation

- Passed: `node --test tests/crm-contacts-workflow.test.js`
- Ran: `npm test`
- `npm test` completed with 5 unrelated baseline failures outside this CRM change: auth entrypoint copy, Playwright runtime installer expectations, and Vercel insights tag coverage.