### PR TITLE
[codex] add launch page draft generation

### DIFF
--- a/launch-room/app.js
+++ b/launch-room/app.js
@@ -4,6 +4,8 @@ const form = document.getElementById('movementBriefForm');
 const clearButton = document.querySelector('[data-action="clear"]');
 const copyButton = document.querySelector('[data-action="copy"]');
 const downloadButton = document.querySelector('[data-action="download"]');
+const buildLaunchPageButton = document.querySelector('[data-action="build-launch-page"]');
+const copyLaunchPageButton = document.querySelector('[data-action="copy-launch-page"]');
 const status = document.getElementById('draftStatus');
 const fields = {
   movementName: document.getElementById('movementName'),
@@ -20,6 +22,16 @@ const briefTargets = {
   tinyProject: document.querySelector('[data-brief="tinyProject"]'),
   checklist: document.querySelector('[data-brief="checklist"]'),
   actions: document.querySelector('[data-brief="actions"]')
+};
+const launchPageSection = document.querySelector('[data-launch-page-section]');
+const launchPageTargets = {
+  headline: document.querySelector('[data-launch-page="headline"]'),
+  subheadline: document.querySelector('[data-launch-page="subheadline"]'),
+  mission: document.querySelector('[data-launch-page="mission"]'),
+  audience: document.querySelector('[data-launch-page="audience"]'),
+  invitation: document.querySelector('[data-launch-page="invitation"]'),
+  contact: document.querySelector('[data-launch-page="contact"]'),
+  footer: document.querySelector('[data-launch-page="footer"]')
 };
 
 function clean(value) {
@@ -151,6 +163,59 @@ function briefToMarkdown(brief) {
   ].join('\n');
 }
 
+function buildLaunchPage(brief) {
+  const audience = asClause(brief.audience);
+  const tinyProject = asClause(brief.tinyProject);
+
+  return {
+    headline: `${brief.movementName} starts here.`,
+    subheadline: `A simple first step for ${audience}: ${tinyProject}.`,
+    mission: brief.mission,
+    audience: `This is for ${audience}, especially anyone ready for a practical first move instead of another vague plan.`,
+    invitation: `Start with ${tinyProject}. Read it, try it, and share what would make it more useful.`,
+    contact: `Want to help shape ${brief.movementName}? Send a note, share your story, or ask for the first version.`,
+    footer: 'Built with 3DVR Launch Room'
+  };
+}
+
+function launchPageToMarkdown(launchPage) {
+  return [
+    `# ${launchPage.headline}`,
+    '',
+    launchPage.subheadline,
+    '',
+    '## Mission',
+    launchPage.mission,
+    '',
+    '## Who This Is For',
+    launchPage.audience,
+    '',
+    '## First Invitation',
+    launchPage.invitation,
+    '',
+    '## Contact',
+    launchPage.contact,
+    '',
+    launchPage.footer,
+    ''
+  ].join('\n');
+}
+
+function renderLaunchPage(brief) {
+  const launchPage = buildLaunchPage(brief);
+
+  launchPageTargets.headline.textContent = launchPage.headline;
+  launchPageTargets.subheadline.textContent = launchPage.subheadline;
+  launchPageTargets.mission.textContent = launchPage.mission;
+  launchPageTargets.audience.textContent = launchPage.audience;
+  launchPageTargets.invitation.textContent = launchPage.invitation;
+  launchPageTargets.contact.textContent = launchPage.contact;
+  launchPageTargets.footer.textContent = launchPage.footer;
+  launchPageSection.hidden = false;
+
+  return launchPage;
+}
+
 function renderBrief(state) {
   const brief = buildBrief(state);
 
@@ -182,6 +247,23 @@ function renderBrief(state) {
     : 'Saved locally in this browser.';
 }
 
+async function writeTextToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const fallback = document.createElement('textarea');
+    fallback.value = text;
+    fallback.setAttribute('readonly', '');
+    fallback.style.position = 'fixed';
+    fallback.style.inset = '0 auto auto 0';
+    fallback.style.opacity = '0';
+    document.body.append(fallback);
+    fallback.select();
+    document.execCommand('copy');
+    fallback.remove();
+  }
+}
+
 function sync() {
   const state = getState();
   saveDraft(state);
@@ -192,22 +274,8 @@ async function copyBrief() {
   const brief = buildBrief(getState());
   const markdown = briefToMarkdown(brief);
 
-  try {
-    await navigator.clipboard.writeText(markdown);
-    status.textContent = 'Movement Brief copied to clipboard.';
-  } catch {
-    const fallback = document.createElement('textarea');
-    fallback.value = markdown;
-    fallback.setAttribute('readonly', '');
-    fallback.style.position = 'fixed';
-    fallback.style.inset = '0 auto auto 0';
-    fallback.style.opacity = '0';
-    document.body.append(fallback);
-    fallback.select();
-    document.execCommand('copy');
-    fallback.remove();
-    status.textContent = 'Movement Brief copied to clipboard.';
-  }
+  await writeTextToClipboard(markdown);
+  status.textContent = 'Movement Brief copied to clipboard.';
 }
 
 function downloadBrief() {
@@ -224,6 +292,22 @@ function downloadBrief() {
   link.remove();
   URL.revokeObjectURL(url);
   status.textContent = 'Movement Brief downloaded as Markdown.';
+}
+
+function generateLaunchPage() {
+  const brief = buildBrief(getState());
+
+  renderLaunchPage(brief);
+  status.textContent = 'Launch Page Draft generated locally.';
+  launchPageSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+async function copyLaunchPage() {
+  const brief = buildBrief(getState());
+  const launchPage = renderLaunchPage(brief);
+
+  await writeTextToClipboard(launchPageToMarkdown(launchPage));
+  status.textContent = 'Launch Page Draft copied to clipboard.';
 }
 
 const initialState = {
@@ -258,9 +342,14 @@ clearButton.addEventListener('click', () => {
   });
   saveDraft(getState());
   renderBrief(getState());
+  launchPageSection.hidden = true;
   fields.worldPain.focus();
 });
 
 copyButton.addEventListener('click', copyBrief);
 
 downloadButton.addEventListener('click', downloadBrief);
+
+buildLaunchPageButton.addEventListener('click', generateLaunchPage);
+
+copyLaunchPageButton.addEventListener('click', copyLaunchPage);

--- a/launch-room/index.html
+++ b/launch-room/index.html
@@ -103,6 +103,7 @@
             <div class="launch-room__brief-actions" aria-label="Movement Brief actions">
               <button class="cta ghost" type="button" data-action="copy">Copy Brief</button>
               <button class="cta ghost" type="button" data-action="download">Download Markdown</button>
+              <button class="cta ghost" type="button" data-action="build-launch-page">Build Launch Page</button>
             </div>
 
             <div class="brief-stack" aria-live="polite">
@@ -141,6 +142,60 @@
                 <ol class="brief-list" data-brief="actions"></ol>
               </article>
             </div>
+
+            <section
+              class="launch-page-draft"
+              data-launch-page-section
+              aria-labelledby="launchPageDraftTitle"
+              hidden
+            >
+              <div class="app-hub__intro">
+                <span class="eyebrow">Next step</span>
+                <h2 id="launchPageDraftTitle">Launch Page Draft</h2>
+                <p>Simple page copy based on the Movement Brief above.</p>
+              </div>
+
+              <div class="launch-room__brief-actions" aria-label="Launch Page Draft actions">
+                <button class="cta ghost" type="button" data-action="copy-launch-page">Copy Launch Page</button>
+              </div>
+
+              <div class="brief-stack" aria-live="polite">
+                <article class="brief-card brief-card--title">
+                  <p class="brief-card__label">Hero headline</p>
+                  <h3 data-launch-page="headline"></h3>
+                </article>
+
+                <article class="brief-card">
+                  <p class="brief-card__label">Short subheadline</p>
+                  <p data-launch-page="subheadline"></p>
+                </article>
+
+                <article class="brief-card">
+                  <p class="brief-card__label">Mission section</p>
+                  <p data-launch-page="mission"></p>
+                </article>
+
+                <article class="brief-card">
+                  <p class="brief-card__label">Who this is for</p>
+                  <p data-launch-page="audience"></p>
+                </article>
+
+                <article class="brief-card">
+                  <p class="brief-card__label">First invitation / call to action</p>
+                  <p data-launch-page="invitation"></p>
+                </article>
+
+                <article class="brief-card">
+                  <p class="brief-card__label">Simple contact CTA</p>
+                  <p data-launch-page="contact"></p>
+                </article>
+
+                <article class="brief-card">
+                  <p class="brief-card__label">Footer line</p>
+                  <p data-launch-page="footer"></p>
+                </article>
+              </div>
+            </section>
           </aside>
         </div>
       </section>

--- a/launch-room/styles.css
+++ b/launch-room/styles.css
@@ -123,6 +123,17 @@
   gap: 0.75rem;
 }
 
+.launch-page-draft {
+  display: grid;
+  gap: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.launch-page-draft[hidden] {
+  display: none;
+}
+
 .brief-card {
   display: grid;
   gap: 0.45rem;

--- a/tests/launch-room.test.js
+++ b/tests/launch-room.test.js
@@ -31,13 +31,26 @@ test('launch room ships a local-first Movement Brief flow', async () => {
   assert.match(html, /Generate My Movement Brief/);
   assert.match(html, /Copy Brief/);
   assert.match(html, /Download Markdown/);
+  assert.match(html, /Build Launch Page/);
   assert.match(html, /Movement Brief/);
   assert.match(html, /Launch Checklist/);
   assert.match(html, /Next 3 Actions/);
+  assert.match(html, /Launch Page Draft/);
+  assert.match(html, /Hero headline/);
+  assert.match(html, /Short subheadline/);
+  assert.match(html, /Mission section/);
+  assert.match(html, /Who this is for/);
+  assert.match(html, /First invitation \/ call to action/);
+  assert.match(html, /Simple contact CTA/);
+  assert.match(html, /Copy Launch Page/);
 
   assert.match(app, /STORAGE_KEY = '3dvr\.launch-room\.movement-brief\.v1'/);
   assert.match(app, /function buildBrief/);
   assert.match(app, /function briefToMarkdown/);
+  assert.match(app, /function buildLaunchPage/);
+  assert.match(app, /function launchPageToMarkdown/);
+  assert.match(app, /function renderLaunchPage/);
+  assert.match(app, /Built with 3DVR Launch Room/);
   assert.match(app, /navigator\.clipboard\.writeText/);
   assert.match(app, /type: 'text\/markdown'/);
   assert.match(app, /localStorage/);


### PR DESCRIPTION
## Summary
- Add a `Build Launch Page` action beside Copy Brief and Download Markdown
- Generate a local-first Launch Page Draft from the existing Movement Brief data
- Include hero headline, subheadline, mission, audience, invitation, contact CTA, and 3DVR Launch Room footer
- Add a simple `Copy Launch Page` action while preserving existing brief copy/download behavior
- Keep the Launch Room layout mobile-friendly and update focused coverage

## Validation
- `node --check launch-room/app.js` passed
- `node --test tests/launch-room.test.js` passed