### PR TITLE
[codex] fix launch page draft reveal

### DIFF
--- a/launch-room/app.js
+++ b/launch-room/app.js
@@ -23,7 +23,9 @@ const briefTargets = {
   checklist: document.querySelector('[data-brief="checklist"]'),
   actions: document.querySelector('[data-brief="actions"]')
 };
+const LAUNCH_PAGE_TITLE = 'Launch Page Draft';
 const launchPageSection = document.querySelector('[data-launch-page-section]');
+const launchPageTitle = document.querySelector('[data-launch-page-title]');
 const launchPageTargets = {
   headline: document.querySelector('[data-launch-page="headline"]'),
   subheadline: document.querySelector('[data-launch-page="subheadline"]'),
@@ -204,6 +206,7 @@ function launchPageToMarkdown(launchPage) {
 function renderLaunchPage(brief) {
   const launchPage = buildLaunchPage(brief);
 
+  launchPageTitle.textContent = LAUNCH_PAGE_TITLE;
   launchPageTargets.headline.textContent = launchPage.headline;
   launchPageTargets.subheadline.textContent = launchPage.subheadline;
   launchPageTargets.mission.textContent = launchPage.mission;
@@ -298,8 +301,9 @@ function generateLaunchPage() {
   const brief = buildBrief(getState());
 
   renderLaunchPage(brief);
-  status.textContent = 'Launch Page Draft generated locally.';
+  status.textContent = 'Launch Page Draft generated.';
   launchPageSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  launchPageTitle.focus({ preventScroll: true });
 }
 
 async function copyLaunchPage() {

--- a/launch-room/index.html
+++ b/launch-room/index.html
@@ -151,7 +151,7 @@
             >
               <div class="app-hub__intro">
                 <span class="eyebrow">Next step</span>
-                <h2 id="launchPageDraftTitle">Launch Page Draft</h2>
+                <h2 id="launchPageDraftTitle" data-launch-page-title tabindex="-1">Launch Page Draft</h2>
                 <p>Simple page copy based on the Movement Brief above.</p>
               </div>
 

--- a/tests/launch-room.test.js
+++ b/tests/launch-room.test.js
@@ -32,10 +32,12 @@ test('launch room ships a local-first Movement Brief flow', async () => {
   assert.match(html, /Copy Brief/);
   assert.match(html, /Download Markdown/);
   assert.match(html, /Build Launch Page/);
+  assert.match(html, /data-action="build-launch-page"/);
   assert.match(html, /Movement Brief/);
   assert.match(html, /Launch Checklist/);
   assert.match(html, /Next 3 Actions/);
   assert.match(html, /Launch Page Draft/);
+  assert.match(html, /data-launch-page-title/);
   assert.match(html, /Hero headline/);
   assert.match(html, /Short subheadline/);
   assert.match(html, /Mission section/);
@@ -50,6 +52,13 @@ test('launch room ships a local-first Movement Brief flow', async () => {
   assert.match(app, /function buildLaunchPage/);
   assert.match(app, /function launchPageToMarkdown/);
   assert.match(app, /function renderLaunchPage/);
+  assert.match(app, /buildLaunchPageButton\.addEventListener\('click', generateLaunchPage\)/);
+  assert.match(app, /launchPageTitle\.textContent = LAUNCH_PAGE_TITLE/);
+  assert.match(app, /LAUNCH_PAGE_TITLE = 'Launch Page Draft'/);
+  assert.match(app, /launchPageSection\.hidden = false/);
+  assert.match(app, /status\.textContent = 'Launch Page Draft generated\.'/);
+  assert.match(app, /launchPageTitle\.focus/);
+  assert.match(app, /copyLaunchPageButton\.addEventListener\('click', copyLaunchPage\)/);
   assert.match(app, /Built with 3DVR Launch Room/);
   assert.match(app, /navigator\.clipboard\.writeText/);
   assert.match(app, /type: 'text\/markdown'/);


### PR DESCRIPTION
## Summary
- Make the Launch Page Draft reveal path explicit when `Build Launch Page` is clicked
- Focus the generated `Launch Page Draft` title after scrolling to the section
- Update the status text to the requested exact copy: `Launch Page Draft generated.`
- Strengthen focused tests for the build button, click handler, visible-section render path, and Copy Launch Page wiring

## Validation
- `node --check launch-room/app.js` passed
- `node --test tests/launch-room.test.js` passed
- Browser reproduction with all fields set to `test` confirmed the Launch Page Draft becomes visible, focused, and populated