### PR TITLE
[codex] Move Agent Ops dock card to experimental

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,7 +344,8 @@
             <span class="app-card__title">Growth Operator</span>
             <span class="app-card__meta">Find leads, prepare approved email, triage support, and keep delivery moving.</span>
           </a>
-          <a href="/admin/" class="app-card">
+          <a href="/admin/" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">🛠️</span>
             <span class="app-card__title">Agent Ops</span>
             <span class="app-card__meta">Inspect the portal session, control the 3dvr-agent, and prepare the DigitalOcean host.</span>

--- a/tests/admin-agent-ops.test.js
+++ b/tests/admin-agent-ops.test.js
@@ -125,7 +125,8 @@ test('portal home links to the agent ops dashboard', async () => {
   assert.equal(await fileExists(portalIndex), true, 'index.html should exist');
 
   const html = await readFile(portalIndex, 'utf8');
-  assert.match(html, /href="\/admin\/"/);
+  assert.match(html, /href="\/admin\/" class="app-card" data-app-tier="experimental"/);
+  assert.match(html, /<span class="app-card__badge">Experimental<\/span>/);
   assert.match(html, /Agent Ops/);
   assert.match(html, /portal session, control the 3dvr-agent/);
 });


### PR DESCRIPTION
## What changed

- Marks the portal dock `Agent Ops` app card as `data-app-tier="experimental"`.
- Adds the standard `Experimental` badge to the Agent Ops card.
- Updates the Agent Ops homepage test to assert the experimental tier and badge.

## Validation

- `node --test tests/admin-agent-ops.test.js tests/revenue-desk.test.js tests/growth-operator.test.js` passed.
- I also attempted `npm test` before installing dependencies in the clean worktree; it failed on unrelated baseline/dependency issues, so I validated the focused dock and Agent Ops tests after `npm ci`.