### PR TITLE
[codex] Add Purpose guided app

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -1125,6 +1125,18 @@ body.landing {
   color: var(--color-text-muted);
 }
 
+.app-card__cta {
+  width: fit-content;
+  margin-top: 0.1rem;
+  padding: 0.46rem 0.74rem;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 211, 238, 0.26);
+  background: rgba(34, 211, 238, 0.12);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
 .gamified-dashboard {
   display: grid;
   gap: 2.5rem;

--- a/index.html
+++ b/index.html
@@ -375,6 +375,12 @@
             <span class="app-card__title">Life</span>
             <span class="app-card__meta">Track daily check-ins, weekly reflection, and the five parts of your life that need attention.</span>
           </a>
+          <a href="/purpose/" class="app-card">
+            <span class="app-card__icon" aria-hidden="true">✦</span>
+            <span class="app-card__title">Purpose</span>
+            <span class="app-card__meta">Organize your life. Find your purpose. Launch meaningful projects.</span>
+            <span class="app-card__cta">Open Purpose</span>
+          </a>
           <a href="alive-system/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">⚡</span>
             <span class="app-card__title">Alive System</span>

--- a/purpose/app.js
+++ b/purpose/app.js
@@ -1,0 +1,453 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+export const PURPOSE_STORAGE_KEY = '3dvr-purpose-draft-v1';
+
+export const prompts = Object.freeze([
+  'What feels scattered or unfinished in your life right now?',
+  'What keeps calling your attention?',
+  'Who do you care about helping or becoming useful to?',
+  'What would you like to build, learn, change, or organize?',
+  'What small move could you make this week?'
+]);
+
+const promptKeys = Object.freeze([
+  'scattered',
+  'attention',
+  'people',
+  'project',
+  'move'
+]);
+
+const initialState = Object.freeze({
+  version: 1,
+  step: 'start',
+  promptIndex: 0,
+  answers: ['', '', '', '', ''],
+  map: null,
+  updatedAt: null
+});
+
+function cleanText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function sentenceFrom(value, fallback) {
+  const text = cleanText(value);
+  if (!text) return fallback;
+  return text.length > 210 ? `${text.slice(0, 207).trim()}...` : text;
+}
+
+function firstPhrase(value, fallback) {
+  const text = cleanText(value);
+  if (!text) return fallback;
+  const split = text.split(/[.!?;\n]/).map((part) => part.trim()).filter(Boolean);
+  const phrase = split[0] || text;
+  return phrase.length > 90 ? `${phrase.slice(0, 87).trim()}...` : phrase;
+}
+
+export function normalizePurposeState(value = {}) {
+  const source = value && typeof value === 'object' ? value : {};
+  const answers = Array.isArray(source.answers) ? source.answers : [];
+
+  return {
+    version: 1,
+    step: ['start', 'prompt', 'map'].includes(source.step) ? source.step : 'start',
+    promptIndex: Math.min(4, Math.max(0, Number.parseInt(source.promptIndex, 10) || 0)),
+    answers: promptKeys.map((_key, index) => cleanText(answers[index])),
+    map: source.map && typeof source.map === 'object' ? source.map : null,
+    updatedAt: source.updatedAt || null
+  };
+}
+
+export function createPurposeStorage(storage = globalThis.localStorage) {
+  const parse = (raw) => {
+    if (!raw) return { ...initialState, answers: [...initialState.answers] };
+    try {
+      return normalizePurposeState(JSON.parse(raw));
+    } catch {
+      return { ...initialState, answers: [...initialState.answers] };
+    }
+  };
+
+  return {
+    load() {
+      return parse(storage.getItem(PURPOSE_STORAGE_KEY));
+    },
+    save(value) {
+      const payload = normalizePurposeState({
+        ...value,
+        updatedAt: new Date().toISOString()
+      });
+      storage.setItem(PURPOSE_STORAGE_KEY, JSON.stringify(payload));
+      return payload;
+    },
+    clear() {
+      storage.removeItem(PURPOSE_STORAGE_KEY);
+    },
+    export(value) {
+      return JSON.stringify(normalizePurposeState(value), null, 2);
+    },
+    import(value) {
+      const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+      const imported = normalizePurposeState(parsed);
+      return this.save(imported);
+    },
+    migrateToAccount() {
+      return {
+        ok: false,
+        reason: 'account-save-not-wired'
+      };
+    }
+  };
+}
+
+export function generatePurposeMap(answers) {
+  const normalized = normalizePurposeState({ answers }).answers;
+  const [scattered, attention, people, project, move] = normalized;
+  const projectPhrase = firstPhrase(project, 'a meaningful project that brings order to what matters');
+  const peoplePhrase = firstPhrase(people, 'the people you want to become useful to');
+  const attentionPhrase = firstPhrase(attention, 'the signal that keeps asking for your attention');
+  const scatteredPhrase = firstPhrase(scattered, 'unfinished responsibilities and ideas');
+  const movePhrase = firstPhrase(move, 'one small move you can make this week');
+
+  const smallMoves = [
+    `Name the open loop: write one sentence about "${scatteredPhrase}".`,
+    `Give ${attentionPhrase.toLowerCase()} a 25-minute block on your calendar.`,
+    `Take the first visible step: ${movePhrase}.`
+  ];
+
+  return {
+    currentSeason: `You are in a sorting season: ${sentenceFrom(scattered, 'different parts of life are asking to be gathered into one clear view')}.`,
+    patternShowingUp: `Your attention keeps returning to ${attentionPhrase.toLowerCase()}, especially in relation to ${peoplePhrase.toLowerCase()}.`,
+    possiblePurposeDirection: `Become someone who can help with ${peoplePhrase.toLowerCase()} by turning scattered experience into useful structure.`,
+    meaningfulProjectSeed: `Start with ${projectPhrase.toLowerCase()}. Keep it small enough to move this week and meaningful enough to care about.`,
+    thisWeeksSmallMoves: smallMoves
+  };
+}
+
+export function purposeMapToMarkdown(map, answers = []) {
+  const safeMap = map || generatePurposeMap(answers);
+  return [
+    '# Purpose Map',
+    '',
+    `## Current Season\n${safeMap.currentSeason}`,
+    '',
+    `## Pattern Showing Up\n${safeMap.patternShowingUp}`,
+    '',
+    `## Possible Purpose Direction\n${safeMap.possiblePurposeDirection}`,
+    '',
+    `## Meaningful Project Seed\n${safeMap.meaningfulProjectSeed}`,
+    '',
+    '## This Week\'s 3 Small Moves',
+    ...safeMap.thisWeeksSmallMoves.map((item, index) => `${index + 1}. ${item}`)
+  ].join('\n');
+}
+
+function downloadText(filename, text, type) {
+  const blob = new Blob([text], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function initPurposeScene(canvas, getAnsweredCount) {
+  if (!canvas) return null;
+
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: true,
+    powerPreference: 'high-performance'
+  });
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+  camera.position.set(0, 0.6, 7.6);
+
+  const nodePositions = [
+    new THREE.Vector3(-2.7, 0.5, 0),
+    new THREE.Vector3(-1.1, 1.45, -0.25),
+    new THREE.Vector3(0.65, 0.55, 0.18),
+    new THREE.Vector3(2.3, 1.2, -0.16),
+    new THREE.Vector3(1.45, -1.15, 0.24)
+  ];
+
+  const group = new THREE.Group();
+  scene.add(group);
+
+  const ambient = new THREE.AmbientLight(0xffead2, 1.35);
+  scene.add(ambient);
+  const point = new THREE.PointLight(0x8ee9d8, 18, 16);
+  point.position.set(0, 2, 4);
+  scene.add(point);
+
+  const nodeGeometry = new THREE.SphereGeometry(0.095, 32, 16);
+  const dormantMaterial = new THREE.MeshBasicMaterial({ color: 0x6d5e66, transparent: true, opacity: 0.48 });
+  const nodes = nodePositions.map((position) => {
+    const mesh = new THREE.Mesh(nodeGeometry, dormantMaterial.clone());
+    mesh.position.copy(position);
+    group.add(mesh);
+    return mesh;
+  });
+
+  const lineGeometry = new THREE.BufferGeometry().setFromPoints(nodePositions);
+  const lineMaterial = new THREE.LineBasicMaterial({ color: 0x8ee9d8, transparent: true, opacity: 0.12 });
+  const line = new THREE.Line(lineGeometry, lineMaterial);
+  group.add(line);
+
+  const ring = new THREE.Mesh(
+    new THREE.TorusGeometry(2.25, 0.008, 12, 160),
+    new THREE.MeshBasicMaterial({ color: 0xffad8f, transparent: true, opacity: 0.18 })
+  );
+  ring.rotation.set(1.1, 0.2, 0.15);
+  group.add(ring);
+
+  const starsGeometry = new THREE.BufferGeometry();
+  const starCount = 180;
+  const stars = new Float32Array(starCount * 3);
+  for (let index = 0; index < starCount; index += 1) {
+    stars[index * 3] = (Math.random() - 0.5) * 11;
+    stars[index * 3 + 1] = (Math.random() - 0.5) * 7;
+    stars[index * 3 + 2] = (Math.random() - 0.5) * 5 - 1.8;
+  }
+  starsGeometry.setAttribute('position', new THREE.BufferAttribute(stars, 3));
+  const starsMesh = new THREE.Points(
+    starsGeometry,
+    new THREE.PointsMaterial({ color: 0xfff2d1, size: 0.018, transparent: true, opacity: 0.58 })
+  );
+  scene.add(starsMesh);
+
+  const resize = () => {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.8));
+    renderer.setSize(width, height, false);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  };
+
+  let frameId = 0;
+  const render = (time = 0) => {
+    const answered = getAnsweredCount();
+    group.rotation.y = Math.sin(time * 0.00018) * 0.16;
+    group.rotation.x = Math.sin(time * 0.00013) * 0.08;
+    starsMesh.rotation.y += 0.00022;
+    line.material.opacity = answered >= 5 ? 0.62 : 0.14 + answered * 0.075;
+    ring.material.opacity = answered >= 5 ? 0.34 : 0.16;
+
+    nodes.forEach((node, index) => {
+      const isActive = index < answered;
+      node.material.color.setHex(isActive ? 0xffd98a : 0x6d5e66);
+      node.material.opacity = isActive ? 1 : 0.42;
+      const pulse = isActive ? 1.25 + Math.sin(time * 0.002 + index) * 0.12 : 0.82;
+      node.scale.setScalar(pulse);
+    });
+
+    renderer.render(scene, camera);
+    frameId = requestAnimationFrame(render);
+  };
+
+  resize();
+  window.addEventListener('resize', resize);
+  frameId = requestAnimationFrame(render);
+
+  return {
+    destroy() {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', resize);
+      renderer.dispose();
+      nodeGeometry.dispose();
+      lineGeometry.dispose();
+      ring.geometry.dispose();
+      starsGeometry.dispose();
+    }
+  };
+}
+
+function initPurposeApp() {
+  const storage = createPurposeStorage();
+  let state = storage.load();
+
+  const views = Array.from(document.querySelectorAll('[data-view]'));
+  const answerInput = document.querySelector('[data-answer]');
+  const promptTitle = document.getElementById('promptTitle');
+  const promptProgress = document.getElementById('promptProgress');
+  const progressFill = document.querySelector('[data-progress-fill]');
+  const validation = document.querySelector('[data-validation]');
+  const mapOutput = document.querySelector('[data-map-output]');
+  const mapTemplate = document.getElementById('mapTemplate');
+  const statusLine = document.querySelector('[data-status]');
+  const portalLink = document.querySelector('[data-portal-link]');
+
+  if (portalLink && window.location.hostname === 'purpose.3dvr.tech') {
+    portalLink.hidden = true;
+  }
+
+  const answeredCount = () => state.answers.filter(Boolean).length;
+  initPurposeScene(document.getElementById('purposeScene'), answeredCount);
+
+  const setStatus = (message) => {
+    if (statusLine) statusLine.textContent = message;
+  };
+
+  const save = () => {
+    state = storage.save(state);
+  };
+
+  const showView = (name) => {
+    views.forEach((view) => {
+      view.hidden = view.dataset.view !== name;
+    });
+    state.step = name;
+    save();
+  };
+
+  const renderPrompt = () => {
+    const index = state.promptIndex;
+    if (promptTitle) promptTitle.textContent = prompts[index];
+    if (promptProgress) promptProgress.textContent = `Prompt ${index + 1} of ${prompts.length}`;
+    if (progressFill) progressFill.style.width = `${((index + 1) / prompts.length) * 100}%`;
+    if (answerInput) {
+      answerInput.value = state.answers[index] || '';
+      setTimeout(() => answerInput.focus(), 20);
+    }
+    if (validation) validation.textContent = '';
+  };
+
+  const renderMap = () => {
+    state.map = generatePurposeMap(state.answers);
+    save();
+    if (!mapOutput || !mapTemplate) return;
+    mapOutput.replaceChildren();
+    const rows = [
+      ['Current Season', state.map.currentSeason],
+      ['Pattern Showing Up', state.map.patternShowingUp],
+      ['Possible Purpose Direction', state.map.possiblePurposeDirection],
+      ['Meaningful Project Seed', state.map.meaningfulProjectSeed],
+      ['This Week\'s 3 Small Moves', state.map.thisWeeksSmallMoves.map((move, index) => `${index + 1}. ${move}`).join('\n')]
+    ];
+    rows.forEach(([label, body]) => {
+      const node = mapTemplate.content.cloneNode(true);
+      node.querySelector('.map-section__label').textContent = label;
+      node.querySelector('.map-section__body').textContent = body;
+      mapOutput.appendChild(node);
+    });
+  };
+
+  document.querySelector('[data-start]')?.addEventListener('click', () => {
+    state.promptIndex = Math.min(state.promptIndex || 0, 4);
+    renderPrompt();
+    showView('prompt');
+  });
+
+  document.querySelector('[data-next]')?.addEventListener('click', () => {
+    const answer = cleanText(answerInput?.value);
+    if (answer.length < 3) {
+      if (validation) validation.textContent = 'Write at least a few words before continuing.';
+      return;
+    }
+    state.answers[state.promptIndex] = answer;
+    if (state.promptIndex >= prompts.length - 1) {
+      renderMap();
+      showView('map');
+      setStatus('Purpose Map saved on this device.');
+      return;
+    }
+    state.promptIndex += 1;
+    save();
+    renderPrompt();
+  });
+
+  document.querySelector('[data-back]')?.addEventListener('click', () => {
+    if (state.promptIndex <= 0) {
+      showView('start');
+      return;
+    }
+    state.promptIndex -= 1;
+    save();
+    renderPrompt();
+  });
+
+  answerInput?.addEventListener('input', () => {
+    state.answers[state.promptIndex] = cleanText(answerInput.value);
+    save();
+  });
+
+  document.querySelector('[data-copy]')?.addEventListener('click', async () => {
+    const markdown = purposeMapToMarkdown(state.map, state.answers);
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setStatus('Purpose Map copied.');
+    } catch {
+      downloadText('purpose-map.md', markdown, 'text/markdown;charset=utf-8');
+      setStatus('Clipboard unavailable, so the Purpose Map was downloaded instead.');
+    }
+  });
+
+  document.querySelectorAll('[data-download-markdown]').forEach((button) => {
+    button.addEventListener('click', () => {
+      downloadText('purpose-map.md', purposeMapToMarkdown(state.map, state.answers), 'text/markdown;charset=utf-8');
+      setStatus('Markdown downloaded.');
+    });
+  });
+
+  document.querySelector('[data-export-json]')?.addEventListener('click', () => {
+    downloadText('purpose-map.json', storage.export(state), 'application/json;charset=utf-8');
+    setStatus('JSON exported.');
+  });
+
+  document.querySelector('[data-import-json]')?.addEventListener('change', async (event) => {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+    try {
+      state = storage.import(await file.text());
+      state.map = generatePurposeMap(state.answers);
+      state.step = 'map';
+      save();
+      renderMap();
+      showView('map');
+      setStatus('Imported Purpose Map.');
+    } catch {
+      setStatus('That JSON file could not be imported.');
+    } finally {
+      event.target.value = '';
+    }
+  });
+
+  document.querySelector('[data-device-save]')?.addEventListener('click', () => {
+    save();
+    setStatus('Saved on this device.');
+  });
+
+  document.querySelector('[data-start-over]')?.addEventListener('click', () => {
+    if (!window.confirm('Start over and clear this Purpose Map from this device?')) return;
+    storage.clear();
+    state = { ...initialState, answers: [...initialState.answers] };
+    showView('start');
+    setStatus('');
+  });
+
+  document.querySelectorAll('[data-future-action]').forEach((button) => {
+    button.addEventListener('click', () => {
+      setStatus('This path is ready for a future 3DVR workflow. Your Purpose Map is saved locally.');
+    });
+  });
+
+  if (state.step === 'map' && answeredCount() === prompts.length) {
+    renderMap();
+    showView('map');
+  } else if (state.step === 'prompt' || answeredCount() > 0) {
+    renderPrompt();
+    showView('prompt');
+  } else {
+    showView('start');
+  }
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  initPurposeApp();
+}

--- a/purpose/index.html
+++ b/purpose/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Purpose by 3DVR</title>
+  <meta
+    name="description"
+    content="Purpose by 3DVR helps you organize your life, find your purpose, and launch meaningful projects."
+  />
+  <meta name="theme-color" content="#120f17" />
+  <link rel="stylesheet" href="/purpose/styles.css" />
+</head>
+<body>
+  <canvas id="purposeScene" aria-hidden="true"></canvas>
+  <div class="ambient-vignette" aria-hidden="true"></div>
+
+  <main class="purpose-shell" id="app">
+    <header class="purpose-topbar">
+      <a class="portal-link" href="/" data-portal-link>Back to Portal</a>
+      <div class="brand-mark" aria-label="Purpose by 3DVR">
+        <span class="brand-mark__sigil" aria-hidden="true"></span>
+        <span>Purpose by 3DVR</span>
+      </div>
+    </header>
+
+    <section class="stage-panel" data-view="start" aria-labelledby="startTitle">
+      <p class="eyebrow">Guided life map</p>
+      <h1 id="startTitle">Organize your life. Find your purpose. Launch meaningful projects.</h1>
+      <p class="positive-line">Your life has patterns. Purpose helps you see them.</p>
+      <p class="description">
+        Purpose by 3DVR helps you turn scattered thoughts, responsibilities, dreams, and ideas into a clear map for what matters next.
+      </p>
+      <div class="panel-actions">
+        <button class="button button--primary" type="button" data-start>Start My Purpose Map</button>
+      </div>
+      <p class="privacy-note">Your answers stay on this device unless you choose to export, share, or create an account to save.</p>
+    </section>
+
+    <section class="stage-panel stage-panel--prompt" data-view="prompt" hidden aria-labelledby="promptTitle">
+      <div class="prompt-header">
+        <p class="eyebrow" id="promptProgress">Prompt 1 of 5</p>
+        <div class="progress-track" aria-hidden="true">
+          <span class="progress-track__fill" data-progress-fill></span>
+        </div>
+      </div>
+      <h2 id="promptTitle">What feels scattered or unfinished in your life right now?</h2>
+      <label class="answer-field" for="promptAnswer">
+        <span>Your answer</span>
+        <textarea
+          id="promptAnswer"
+          rows="7"
+          maxlength="900"
+          placeholder="Write a few honest lines. Short notes are enough."
+          data-answer
+        ></textarea>
+      </label>
+      <p class="validation-message" data-validation role="status" aria-live="polite"></p>
+      <div class="panel-actions panel-actions--split">
+        <button class="button button--quiet" type="button" data-back>Back</button>
+        <button class="button button--primary" type="button" data-next>Continue</button>
+      </div>
+    </section>
+
+    <section class="stage-panel stage-panel--map" data-view="map" hidden aria-labelledby="mapTitle">
+      <p class="eyebrow">Purpose Map</p>
+      <h2 id="mapTitle">A clear next shape is forming.</h2>
+      <p class="map-intro">
+        This summary is generated on this device from your five answers. Edit your answers any time and regenerate.
+      </p>
+
+      <article class="purpose-map" data-map-output aria-live="polite"></article>
+
+      <div class="save-panel" aria-label="Save options">
+        <p>Want to save this and come back later? Create a free 3DVR account to save your Purpose Map, sync across devices, and keep building.</p>
+        <div class="save-actions">
+          <a class="button button--primary" href="/sign-in.html?redirect=%2Fpurpose%2F" data-create-account>Create Account to Save</a>
+          <button class="button button--quiet" type="button" data-device-save>Keep Using This Device</button>
+          <button class="button button--quiet" type="button" data-download-markdown>Download Instead</button>
+        </div>
+      </div>
+
+      <div class="tool-row" aria-label="Purpose Map actions">
+        <button type="button" data-copy>Copy Purpose Map</button>
+        <button type="button" data-download-markdown>Download Markdown</button>
+        <button type="button" data-export-json>Export JSON</button>
+        <label class="import-button">
+          Import JSON
+          <input type="file" accept="application/json,.json" data-import-json />
+        </label>
+        <button type="button" data-start-over>Start Over</button>
+      </div>
+
+      <div class="future-actions" aria-label="Future paths">
+        <button type="button" data-future-action="project">Turn into Project Seed</button>
+        <button type="button" data-future-action="launch">Open Launch Room</button>
+        <button type="button" data-future-action="notes">Save to Notes</button>
+      </div>
+
+      <p class="status-line" data-status role="status" aria-live="polite"></p>
+    </section>
+  </main>
+
+  <template id="mapTemplate">
+    <section class="map-section">
+      <span class="map-section__label"></span>
+      <p class="map-section__body"></p>
+    </section>
+  </template>
+
+  <script type="module" src="/purpose/app.js"></script>
+</body>
+</html>

--- a/purpose/styles.css
+++ b/purpose/styles.css
@@ -1,0 +1,436 @@
+:root {
+  color-scheme: dark;
+  --bg: #120f17;
+  --panel: rgba(27, 22, 32, 0.78);
+  --panel-strong: rgba(38, 31, 43, 0.9);
+  --line: rgba(248, 220, 170, 0.18);
+  --line-strong: rgba(248, 220, 170, 0.34);
+  --text: #fff9ef;
+  --muted: #d8c8b5;
+  --soft: #a99b8e;
+  --gold: #ffd98a;
+  --coral: #ffad8f;
+  --teal: #8ee9d8;
+  --violet: #b9a7ff;
+  --ink: #151116;
+  --shadow: 0 28px 90px rgba(0, 0, 0, 0.38);
+  --radius: 22px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  overflow-x: hidden;
+}
+
+body {
+  min-height: 100svh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(255, 217, 138, 0.16), transparent 32%),
+    radial-gradient(circle at 78% 20%, rgba(142, 233, 216, 0.14), transparent 30%),
+    radial-gradient(circle at 52% 88%, rgba(255, 173, 143, 0.12), transparent 34%),
+    linear-gradient(180deg, #151118 0%, #0f1219 55%, #131018 100%);
+}
+
+button,
+textarea,
+input {
+  font: inherit;
+}
+
+button,
+a,
+label.import-button {
+  -webkit-tap-highlight-color: transparent;
+}
+
+#purposeScene {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  z-index: 0;
+}
+
+.ambient-vignette {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background:
+    linear-gradient(90deg, rgba(18, 15, 23, 0.88), rgba(18, 15, 23, 0.38) 44%, rgba(18, 15, 23, 0.74)),
+    linear-gradient(180deg, rgba(18, 15, 23, 0.72), transparent 36%, rgba(18, 15, 23, 0.74));
+}
+
+.purpose-shell {
+  position: relative;
+  z-index: 2;
+  width: min(1120px, 100%);
+  min-height: 100svh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  align-items: center;
+  gap: clamp(18px, 3vw, 32px);
+  padding: clamp(16px, 3vw, 34px);
+}
+
+.purpose-topbar {
+  align-self: start;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-mark,
+.portal-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 42px;
+  padding: 10px 13px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(18, 15, 23, 0.54);
+  color: var(--muted);
+  text-decoration: none;
+  backdrop-filter: blur(16px);
+}
+
+.portal-link {
+  font-size: 0.9rem;
+}
+
+.brand-mark {
+  margin-left: auto;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.brand-mark__sigil {
+  width: 18px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 1px solid var(--gold);
+  box-shadow: 0 0 18px rgba(255, 217, 138, 0.55), inset 0 0 14px rgba(142, 233, 216, 0.3);
+}
+
+.stage-panel {
+  width: min(690px, 100%);
+  align-self: center;
+  display: grid;
+  gap: 18px;
+  padding: clamp(22px, 4vw, 42px);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(145deg, rgba(38, 31, 43, 0.88), rgba(16, 17, 24, 0.7)),
+    var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(22px);
+}
+
+.stage-panel--map {
+  width: min(860px, 100%);
+  align-self: start;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--gold);
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  font-weight: 800;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  max-width: 12ch;
+  font-size: clamp(2.55rem, 8vw, 5.35rem);
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+
+h2 {
+  font-size: clamp(1.75rem, 4.8vw, 3.25rem);
+  line-height: 1.02;
+  letter-spacing: 0;
+}
+
+.positive-line {
+  color: var(--teal);
+  font-size: clamp(1.05rem, 2.5vw, 1.35rem);
+  font-weight: 750;
+}
+
+.description,
+.map-intro,
+.privacy-note,
+.save-panel p,
+.status-line {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.description {
+  max-width: 58ch;
+  font-size: 1.03rem;
+}
+
+.privacy-note {
+  font-size: 0.9rem;
+}
+
+.panel-actions,
+.save-actions,
+.tool-row,
+.future-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.panel-actions--split {
+  justify-content: space-between;
+}
+
+.button,
+.tool-row button,
+.future-actions button,
+.import-button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 11px 15px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.button:hover,
+.tool-row button:hover,
+.future-actions button:hover,
+.import-button:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.button--primary {
+  border-color: transparent;
+  color: var(--ink);
+  background: linear-gradient(135deg, var(--gold), var(--coral) 58%, var(--teal));
+  font-weight: 850;
+}
+
+.button--quiet {
+  color: var(--muted);
+}
+
+.prompt-header {
+  display: grid;
+  gap: 10px;
+}
+
+.progress-track {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.progress-track__fill {
+  display: block;
+  width: 20%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--gold), var(--teal));
+  transition: width 240ms ease;
+}
+
+.answer-field {
+  display: grid;
+  gap: 9px;
+}
+
+.answer-field span {
+  color: var(--soft);
+  font-size: 0.88rem;
+  font-weight: 750;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 180px;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 18px;
+  padding: 16px;
+  color: var(--text);
+  background: rgba(11, 12, 18, 0.58);
+  outline: none;
+  line-height: 1.55;
+}
+
+textarea:focus {
+  border-color: rgba(255, 217, 138, 0.58);
+  box-shadow: 0 0 0 3px rgba(255, 217, 138, 0.14);
+}
+
+.validation-message {
+  min-height: 1.4em;
+  color: var(--coral);
+  font-size: 0.92rem;
+}
+
+.purpose-map {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.map-section {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.map-section:last-child {
+  grid-column: 1 / -1;
+}
+
+.map-section__label {
+  color: var(--gold);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.map-section__body {
+  color: var(--text);
+  line-height: 1.6;
+  white-space: pre-line;
+}
+
+.save-panel {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid rgba(142, 233, 216, 0.2);
+  border-radius: 18px;
+  background: rgba(142, 233, 216, 0.08);
+}
+
+.tool-row,
+.future-actions {
+  padding-top: 4px;
+}
+
+.tool-row button,
+.future-actions button,
+.import-button {
+  min-height: 40px;
+  padding: 9px 12px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.future-actions button {
+  border-style: dashed;
+}
+
+.import-button input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  .ambient-vignette {
+    background:
+      linear-gradient(180deg, rgba(18, 15, 23, 0.7), rgba(18, 15, 23, 0.46) 46%, rgba(18, 15, 23, 0.84));
+  }
+
+  .purpose-shell {
+    align-items: start;
+  }
+
+  .purpose-topbar {
+    align-items: stretch;
+  }
+
+  .portal-link,
+  .brand-mark {
+    min-height: 38px;
+    padding: 8px 11px;
+    font-size: 0.86rem;
+  }
+
+  .stage-panel {
+    margin-top: 10px;
+    border-radius: 20px;
+  }
+
+  h1 {
+    max-width: 11ch;
+  }
+
+  .purpose-map {
+    grid-template-columns: 1fr;
+  }
+
+  .button,
+  .tool-row button,
+  .future-actions button,
+  .import-button {
+    width: 100%;
+  }
+
+  .panel-actions--split {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/tests/purpose.test.js
+++ b/tests/purpose.test.js
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('Purpose app', () => {
+  it('ships a focused standalone Purpose experience and portal card', async () => {
+    const purposeHtml = await readFile(new URL('../purpose/index.html', import.meta.url), 'utf8');
+    const purposeCss = await readFile(new URL('../purpose/styles.css', import.meta.url), 'utf8');
+    const purposeJs = await readFile(new URL('../purpose/app.js', import.meta.url), 'utf8');
+    const portalIndex = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+    const vercelConfig = await readFile(new URL('../vercel.json', import.meta.url), 'utf8');
+
+    assert.match(purposeHtml, /Purpose by 3DVR/);
+    assert.match(purposeHtml, /Organize your life\. Find your purpose\. Launch meaningful projects\./);
+    assert.match(purposeHtml, /Your life has patterns\. Purpose helps you see them\./);
+    assert.match(purposeHtml, /Start My Purpose Map/);
+    assert.match(purposeHtml, /Your answers stay on this device unless you choose to export, share, or create an account to save\./);
+    assert.match(purposeHtml, /What feels scattered or unfinished in your life right now\?/);
+    assert.match(purposeHtml, /Want to save this and come back later\?/);
+    assert.match(purposeHtml, /Create Account to Save/);
+    assert.match(purposeHtml, /Keep Using This Device/);
+    assert.match(purposeHtml, /Download Instead/);
+    assert.match(purposeHtml, /Copy Purpose Map/);
+    assert.match(purposeHtml, /Export JSON/);
+    assert.match(purposeHtml, /Import JSON/);
+    assert.match(purposeHtml, /Start Over/);
+    assert.match(purposeHtml, /href="\/purpose\/styles\.css"/);
+    assert.match(purposeHtml, /src="\/purpose\/app\.js"/);
+
+    assert.match(purposeCss, /#purposeScene/);
+    assert.match(purposeCss, /@media \(max-width: 720px\)/);
+    assert.match(purposeCss, /prefers-reduced-motion/);
+
+    assert.match(purposeJs, /createPurposeStorage/);
+    assert.match(purposeJs, /load\(\)/);
+    assert.match(purposeJs, /save\(value\)/);
+    assert.match(purposeJs, /clear\(\)/);
+    assert.match(purposeJs, /export\(value\)/);
+    assert.match(purposeJs, /import\(value\)/);
+    assert.match(purposeJs, /migrateToAccount\(\)/);
+    assert.match(purposeJs, /generatePurposeMap/);
+    assert.match(purposeJs, /Current Season/);
+    assert.match(purposeJs, /Pattern Showing Up/);
+    assert.match(purposeJs, /Possible Purpose Direction/);
+    assert.match(purposeJs, /Meaningful Project Seed/);
+    assert.match(purposeJs, /This Week\\'s 3 Small Moves/);
+    assert.match(purposeJs, /new THREE\.WebGLRenderer/);
+    assert.match(purposeJs, /purpose\.3dvr\.tech/);
+
+    assert.match(portalIndex, /href="\/purpose\/" class="app-card"/);
+    assert.match(portalIndex, /<span class="app-card__title">Purpose<\/span>/);
+    assert.match(portalIndex, /Organize your life\. Find your purpose\. Launch meaningful projects\./);
+    assert.match(portalIndex, /<span class="app-card__cta">Open Purpose<\/span>/);
+
+    const config = JSON.parse(vercelConfig);
+    assert.ok(config.rewrites.some((rewrite) => (
+      rewrite.source === '/'
+      && rewrite.destination === '/purpose/index.html'
+      && rewrite.has?.some((item) => item.type === 'host' && item.value === 'purpose.3dvr.tech')
+    )));
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -151,6 +151,16 @@
   ],
   "rewrites": [
     {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "purpose.3dvr.tech"
+        }
+      ],
+      "destination": "/purpose/index.html"
+    },
+    {
       "source": "/webhooks/stripe",
       "destination": "/api/webhooks/stripe"
     },


### PR DESCRIPTION
## Summary

Adds Purpose by 3DVR as a focused, customer-ready guided experience.

- Adds a standalone `/purpose/` app with one Three.js constellation scene, five guided prompts, local autosave, deterministic Purpose Map generation, copy/download/export/import/start-over actions, and account-save ready state.
- Adds Purpose to the portal app dock with the requested title, description, CTA, and `/purpose/` link.
- Adds a Vercel host rewrite so `purpose.3dvr.tech/` can serve the same `/purpose/index.html` implementation without the portal shell.
- Adds a focused Node test for the Purpose copy, route wiring, storage abstraction, export/import affordances, and portal card.

## Validation

- `node --test tests/purpose.test.js`
- `node --check purpose/app.js`
- Local HTTP checks against the dev server:
  - `curl -I http://127.0.0.1:4177/purpose/`
  - `curl -I http://127.0.0.1:4177/purpose/styles.css`
  - `curl -I http://127.0.0.1:4177/purpose/app.js`

## Notes

I attempted a Playwright browser smoke test after installing dependencies and reinstalling Chromium, but this container's Chromium runtime exited before page creation (`browser.newPage: Target page, context or browser has been closed`). Static route and asset checks passed, and the focused Node test covers the shipped app wiring.