### PR TITLE
[codex] Fix mobile CRM first-save failures

### DIFF
--- a/crm/app.js
+++ b/crm/app.js
@@ -71,6 +71,8 @@ const draftIndex = new Map();
 const touchLogIndex = new Map();
 const conversationCaptureIndex = new Map();
 const duplicateSummaryById = new Map();
+const CRM_LOCAL_RECORDS_KEY = 'portal-crm-local-records-v1';
+const CRM_LOCAL_CONVERSATION_CAPTURES_KEY = 'portal-crm-local-conversation-captures-v1';
 const WEEKLY_CHALLENGE_GOAL = 3;
 const SALES_STALE_DAYS = 7;
 const DEFAULT_PERSON_STATUS = 'Warm - Awareness';
@@ -382,6 +384,123 @@ function generateId() {
     return crypto.randomUUID();
   }
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function safeParseJson(value, fallback) {
+  if (!value) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function readLocalMap(key) {
+  const parsed = safeParseJson(ls.getItem(key), {});
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+}
+
+function writeLocalMap(key, value) {
+  try {
+    ls.setItem(key, JSON.stringify(value && typeof value === 'object' ? value : {}));
+  } catch (err) {
+    console.warn('CRM local cache unavailable', err);
+  }
+}
+
+function cacheCrmRecord(record) {
+  if (!record?.id) return;
+  const stored = readLocalMap(CRM_LOCAL_RECORDS_KEY);
+  stored[record.id] = sanitizeCrmRecord(record);
+  writeLocalMap(CRM_LOCAL_RECORDS_KEY, stored);
+}
+
+function removeCachedCrmRecord(id) {
+  const stored = readLocalMap(CRM_LOCAL_RECORDS_KEY);
+  if (!stored[id]) return;
+  delete stored[id];
+  writeLocalMap(CRM_LOCAL_RECORDS_KEY, stored);
+}
+
+function cacheConversationCapture(capture) {
+  if (!capture?.id) return;
+  const stored = readLocalMap(CRM_LOCAL_CONVERSATION_CAPTURES_KEY);
+  stored[capture.id] = sanitizeConversationCaptureRecord(capture);
+  writeLocalMap(CRM_LOCAL_CONVERSATION_CAPTURES_KEY, stored);
+}
+
+function removeCachedConversationCapture(id) {
+  const stored = readLocalMap(CRM_LOCAL_CONVERSATION_CAPTURES_KEY);
+  if (!stored[id]) return;
+  delete stored[id];
+  writeLocalMap(CRM_LOCAL_CONVERSATION_CAPTURES_KEY, stored);
+}
+
+function hydrateLocalCrmCache() {
+  Object.entries(readLocalMap(CRM_LOCAL_RECORDS_KEY)).forEach(([id, record]) => {
+    const sanitized = sanitizeCrmRecord(record);
+    if (!sanitized.id) {
+      sanitized.id = id;
+    }
+    if (sanitized.id) {
+      crmIndex[sanitized.id] = { ...(crmIndex[sanitized.id] || {}), ...sanitized };
+    }
+  });
+
+  Object.entries(readLocalMap(CRM_LOCAL_CONVERSATION_CAPTURES_KEY)).forEach(([id, capture]) => {
+    const sanitized = sanitizeConversationCaptureRecord({ ...capture, id: capture?.id || id });
+    if (sanitized.id) {
+      conversationCaptureIndex.set(sanitized.id, sanitized);
+    }
+  });
+}
+
+function syncCrmRecordToGun(record) {
+  try {
+    crmRecords.get(record.id).put(record, ack => {
+      if (ack && ack.err) {
+        console.warn('CRM record saved locally; Gun sync will retry after refresh or the next edit.', ack.err);
+        return;
+      }
+      cacheCrmRecord(record);
+    });
+  } catch (err) {
+    console.warn('CRM record saved locally; Gun sync is unavailable right now.', err);
+  }
+}
+
+function syncConversationCaptureToGun(capture) {
+  try {
+    const sanitized = sanitizeConversationCaptureRecord(capture);
+    const payload = buildGunConversationCapturePayload(sanitized);
+    conversationCapturesRoot.get(sanitized.id).put(payload, ack => {
+      if (ack && ack.err) {
+        console.warn('Conversation capture saved locally; Gun sync will retry after refresh or the next edit.', ack.err);
+        return;
+      }
+      cacheConversationCapture(sanitized);
+    });
+  } catch (err) {
+    console.warn('Conversation capture saved locally; Gun sync is unavailable right now.', err);
+  }
+}
+
+function syncCachedCrmRecordsToGun() {
+  Object.values(readLocalMap(CRM_LOCAL_RECORDS_KEY)).forEach(record => {
+    const sanitized = sanitizeCrmRecord(record);
+    if (sanitized.id) {
+      syncCrmRecordToGun(sanitized);
+    }
+  });
+
+  Object.values(readLocalMap(CRM_LOCAL_CONVERSATION_CAPTURES_KEY)).forEach(capture => {
+    const sanitized = sanitizeConversationCaptureRecord(capture);
+    if (sanitized.id) {
+      syncConversationCaptureToGun(sanitized);
+    }
+  });
 }
 
 function toActivityCount(value) {
@@ -2043,33 +2162,21 @@ function renderSalesMoves() {
 }
 
 function putCrmRecord(record) {
-  return new Promise((resolve, reject) => {
-    crmRecords.get(record.id).put(record, ack => {
-      if (ack && ack.err) {
-        reject(new Error(String(ack.err)));
-        return;
-      }
-      crmIndex[record.id] = { ...(crmIndex[record.id] || {}), ...sanitizeCrmRecord(record), id: record.id };
-      scheduleRender();
-      resolve(record);
-    });
-  });
+  const sanitized = { ...sanitizeCrmRecord(record), id: record.id };
+  crmIndex[sanitized.id] = { ...(crmIndex[sanitized.id] || {}), ...sanitized };
+  cacheCrmRecord(sanitized);
+  scheduleRender();
+  syncCrmRecordToGun(sanitized);
+  return Promise.resolve(sanitized);
 }
 
 function putConversationCapture(capture) {
-  return new Promise((resolve, reject) => {
-    const sanitized = sanitizeConversationCaptureRecord(capture);
-    const payload = buildGunConversationCapturePayload(sanitized);
-    conversationCapturesRoot.get(sanitized.id).put(payload, ack => {
-      if (ack && ack.err) {
-        reject(new Error(String(ack.err)));
-        return;
-      }
-      conversationCaptureIndex.set(sanitized.id, sanitized);
-      renderConversationCaptures();
-      resolve(sanitized);
-    });
-  });
+  const sanitized = sanitizeConversationCaptureRecord(capture);
+  conversationCaptureIndex.set(sanitized.id, sanitized);
+  cacheConversationCapture(sanitized);
+  renderConversationCaptures();
+  syncConversationCaptureToGun(sanitized);
+  return Promise.resolve(sanitized);
 }
 
 function putContactRecord(id, payload, space = getPreferredContactsSpace()) {
@@ -2093,17 +2200,19 @@ function putContactRecord(id, payload, space = getPreferredContactsSpace()) {
 }
 
 function deleteCrmRecord(id) {
-  return new Promise((resolve, reject) => {
+  delete crmIndex[id];
+  removeCachedCrmRecord(id);
+  scheduleRender();
+  try {
     crmRecords.get(id).put(null, ack => {
       if (ack && ack.err) {
-        reject(new Error(String(ack.err)));
-        return;
+        console.warn('CRM record deleted locally; Gun delete will retry when the relay is reachable.', ack.err);
       }
-      delete crmIndex[id];
-      scheduleRender();
-      resolve();
     });
-  });
+  } catch (err) {
+    console.warn('CRM record deleted locally; Gun delete is unavailable right now.', err);
+  }
+  return Promise.resolve();
 }
 
 function putLeadDrafts(recordId, payload) {
@@ -3616,8 +3725,11 @@ function startSync() {
     if (!id) return;
     if (!data) {
       conversationCaptureIndex.delete(id);
+      removeCachedConversationCapture(id);
     } else {
-      conversationCaptureIndex.set(id, sanitizeConversationCaptureRecord({ ...data, id }));
+      const sanitized = sanitizeConversationCaptureRecord({ ...data, id });
+      conversationCaptureIndex.set(id, sanitized);
+      cacheConversationCapture(sanitized);
     }
     renderConversationCaptures();
   });
@@ -3626,15 +3738,20 @@ function startSync() {
     if (!id) return;
     if (!data) {
       delete crmIndex[id];
+      removeCachedCrmRecord(id);
     } else {
       const sanitized = sanitizeCrmRecord(data);
       crmIndex[id] = { ...(crmIndex[id] || {}), ...sanitized, id };
+      cacheCrmRecord(crmIndex[id]);
     }
     scheduleRender();
   });
+
+  syncCachedCrmRecordsToGun();
 }
 
 function init() {
+  hydrateLocalCrmCache();
   updateFilterButtons();
   refreshImportControls();
   refreshOauthImportControls();

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -130,6 +130,20 @@ test('CRM app includes keyboard search shortcut, workflow filters, and import wi
   assert.match(js, /runtime\.listContacts/);
 });
 
+test('CRM saves records locally before waiting on Gun mobile relay acknowledgements', async () => {
+  const js = await read('crm/app.js');
+  assert.match(js, /const CRM_LOCAL_RECORDS_KEY = 'portal-crm-local-records-v1'/);
+  assert.match(js, /const CRM_LOCAL_CONVERSATION_CAPTURES_KEY = 'portal-crm-local-conversation-captures-v1'/);
+  assert.match(js, /function hydrateLocalCrmCache\(\)/);
+  assert.match(js, /function syncCachedCrmRecordsToGun\(\)/);
+  assert.match(js, /function putCrmRecord\(record\) \{\s+const sanitized = \{ \.\.\.sanitizeCrmRecord\(record\), id: record\.id \};\s+crmIndex\[sanitized\.id\]/);
+  assert.match(js, /cacheCrmRecord\(sanitized\);\s+scheduleRender\(\);\s+syncCrmRecordToGun\(sanitized\);\s+return Promise\.resolve\(sanitized\);/);
+  assert.match(js, /function putConversationCapture\(capture\) \{\s+const sanitized = sanitizeConversationCaptureRecord\(capture\);/);
+  assert.match(js, /cacheConversationCapture\(sanitized\);\s+renderConversationCaptures\(\);\s+syncConversationCaptureToGun\(sanitized\);\s+return Promise\.resolve\(sanitized\);/);
+  assert.match(js, /CRM record saved locally; Gun sync will retry after refresh or the next edit\./);
+  assert.match(js, /hydrateLocalCrmCache\(\);\s+updateFilterButtons\(\);/);
+});
+
 test('Contacts page exposes CRM link filter and phone import controls', async () => {
   const html = await read('contacts/index.html');
   assert.match(html, /id="filterCrmLink"/);


### PR DESCRIPTION
## Summary

Fixes the CRM first-save failure that can happen on mobile when the Gun relay has not acknowledged writes yet.

- Makes CRM record saves local-first: update the in-memory board, cache to `localStorage`, render immediately, then sync to Gun in the background.
- Applies the same local-first path to mobile conversation captures so the intake/fallback capture paths do not depend on early relay acks.
- Hydrates cached CRM records and conversation captures on load, then retries Gun sync when the app starts.
- Keeps deletes local-first as well so local UI state is not blocked by relay timing.
- Adds regression coverage that asserts CRM saves no longer wait on Gun acknowledgements.

## Validation

- `node --check crm/app.js`
- `node --test tests/crm-contacts-workflow.test.js tests/crm-sales-cockpit.test.js tests/crm-touch-log-real.test.js`
- `git diff --check`

## Notes

I attempted a mobile Playwright smoke test with a Gun stub that returns `No ACK yet.`, but Chromium in this container exits before page creation (`browser.newPage: Target page, context or browser has been closed`). The branch is pushed so GitHub Actions can run the browser checks in CI.