### PR TITLE
[codex] Add CRM subdomain PWA support

### DIFF
--- a/app-manifests/crm.webmanifest
+++ b/app-manifests/crm.webmanifest
@@ -1,0 +1,16 @@
+{
+  "id": "/crm/",
+  "name": "3DVR CRM",
+  "short_name": "3DVR CRM",
+  "description": "Add people fast, capture next steps, and keep your 3DVR relationships moving.",
+  "start_url": "/crm/?source=pwa",
+  "scope": "/crm/",
+  "display": "standalone",
+  "background_color": "#0e1116",
+  "theme_color": "#0e1116",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/crm/crm.webmanifest
+++ b/crm/crm.webmanifest
@@ -1,0 +1,21 @@
+{
+  "id": "./",
+  "name": "3DVR CRM",
+  "short_name": "3DVR CRM",
+  "description": "Add people fast, capture next steps, and keep your 3DVR relationships moving.",
+  "start_url": "./?source=pwa",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0e1116",
+  "theme_color": "#0e1116",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    {
+      "src": "/icons/maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/crm/index.html
+++ b/crm/index.html
@@ -4,15 +4,39 @@
   <meta charset="UTF-8" />
   <title>CRM | 3dvr portal</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#0e1116" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="icon" href="https://fav.farm/🧠" />
+  <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+  <script>
+    (() => {
+      const manifest = document.createElement('link');
+      manifest.rel = 'manifest';
+      manifest.href = window.location.hostname === 'crm.3dvr.tech'
+        ? '/crm.webmanifest'
+        : '/crm/crm.webmanifest';
+      document.head.append(manifest);
+    })();
+  </script>
+  <link rel="stylesheet" href="/crm/install-banner.css" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="/gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/axe.js"></script>
-  <script src="../score.js"></script>
-  <script src="../oauth.js"></script>
-  <script type="module" src="./app.js"></script>
+  <script src="/score.js"></script>
+  <script src="/oauth.js"></script>
+  <script
+    src="/crm/pwa-install.js"
+    data-sw-url="/crm/service-worker.js"
+    data-sw-scope="/crm/"
+    data-sw-standalone-host="crm.3dvr.tech"
+    data-sw-standalone-scope="/"
+    defer
+  ></script>
+  <script type="module" src="/crm/app.js"></script>
   <script defer src="/_vercel/insights/script.js"></script>
   <style>
     html,
@@ -110,6 +134,14 @@
   </style>
 </head>
 <body class="bg-gray-900 text-white font-sans min-h-screen">
+  <div class="install-banner" data-install-banner hidden>
+    <div class="install-banner__text">
+      <p class="install-banner__title">Install CRM</p>
+      <p class="install-banner__meta">Open your people pipeline quickly from your phone or desktop.</p>
+    </div>
+    <button type="button" class="install-banner__action" data-install-button>Install app</button>
+  </div>
+
   <header class="bg-gray-950/70 border-b border-white/10">
     <div class="max-w-5xl mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
       <div>
@@ -120,7 +152,7 @@
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="../sales/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Sales</a>
-        <a href="./flow.html" class="bg-teal-500 hover:bg-teal-400 text-gray-950 px-3 py-1.5 rounded transition font-semibold">Flow view</a>
+        <a href="/crm/flow.html" class="bg-teal-500 hover:bg-teal-400 text-gray-950 px-3 py-1.5 rounded transition font-semibold">Flow view</a>
         <a href="../sales/outreach.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Outreach</a>
         <a href="../sales/training/" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Training</a>
         <a href="../contacts/index.html" data-contacts-link class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Contacts</a>

--- a/crm/install-banner.css
+++ b/crm/install-banner.css
@@ -1,0 +1,61 @@
+.install-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 auto 16px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: var(--bg-panel, rgba(255, 255, 255, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.08);
+  max-width: 1100px;
+}
+
+.install-banner[hidden],
+.install-banner.is-hidden {
+  display: none;
+}
+
+.install-banner__text {
+  display: grid;
+  gap: 4px;
+  line-height: 1.4;
+  color: var(--text-primary, #0f172a);
+}
+
+.install-banner__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.install-banner__meta {
+  margin: 0;
+  color: var(--text-muted, #4b5563);
+  font-size: 0.93rem;
+}
+
+.install-banner__action {
+  margin-left: auto;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--accent, #2563eb);
+  background: var(--accent, #2563eb);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
+}
+
+.install-banner__action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
+}
+
+.install-banner__action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}

--- a/crm/pwa-install.js
+++ b/crm/pwa-install.js
@@ -1,0 +1,145 @@
+(() => {
+  const scriptEl = document.currentScript;
+  const resolutionBaseUrl = new URL(window.location.href);
+  const configuredWorkerUrl = scriptEl?.dataset?.swUrl || '/service-worker.js';
+  const standaloneHost = scriptEl?.dataset?.swStandaloneHost || '';
+  const standaloneScope = scriptEl?.dataset?.swStandaloneScope || '';
+  const isStandaloneHost = Boolean(standaloneHost)
+    && window.location.hostname.toLowerCase() === standaloneHost.toLowerCase();
+  const configuredScope = isStandaloneHost && standaloneScope
+    ? standaloneScope
+    : (scriptEl?.dataset?.swScope || '/');
+  const resolvedWorkerUrl = new URL(configuredWorkerUrl, resolutionBaseUrl);
+  const resolvedScopeUrl = new URL(configuredScope, resolutionBaseUrl);
+  const scopePath = resolvedScopeUrl.pathname.endsWith('/')
+    ? resolvedScopeUrl.pathname
+    : `${resolvedScopeUrl.pathname}/`;
+  const scopeHref = new URL(scopePath, window.location.origin).href;
+
+  const toPathname = (url) => {
+    if (!url) return '';
+    try {
+      return new URL(url, window.location.origin).pathname;
+    } catch (error) {
+      console.warn('Unable to parse service worker URL', error);
+      return '';
+    }
+  };
+
+  let waitingActivationRequested = false;
+
+  const bindControllerRefresh = () => {
+    if (waitingActivationRequested) return;
+    waitingActivationRequested = true;
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      window.location.reload();
+    }, { once: true });
+  };
+
+  const requestWaitingActivation = (registration) => {
+    if (!registration || !registration.waiting) return false;
+    const waitingWorker = registration.waiting;
+    if (typeof waitingWorker.postMessage !== 'function') return false;
+    waitingWorker.postMessage({ type: 'SKIP_WAITING' });
+    return true;
+  };
+
+  const wireServiceWorkerUpdates = (registration) => {
+    if (!registration) return;
+
+    if (requestWaitingActivation(registration)) {
+      bindControllerRefresh();
+    }
+
+    registration.addEventListener('updatefound', () => {
+      const installingWorker = registration.installing;
+      if (!installingWorker) return;
+
+      installingWorker.addEventListener('statechange', () => {
+        if (installingWorker.state !== 'installed') return;
+        if (!registration.waiting) return;
+        bindControllerRefresh();
+        requestWaitingActivation(registration);
+      });
+    });
+  };
+
+  const registerServiceWorker = async () => {
+    if (!('serviceWorker' in navigator)) return null;
+
+    try {
+      const registration = await navigator.serviceWorker.getRegistration(scopePath);
+      const activeScriptPath = toPathname(registration?.active?.scriptURL);
+      const isExpectedWorker = Boolean(registration)
+        && activeScriptPath === resolvedWorkerUrl.pathname
+        && registration.scope === scopeHref;
+
+      if (isExpectedWorker) {
+        registration.update().catch((error) => {
+          console.warn('Service worker update skipped', error);
+        });
+        wireServiceWorkerUpdates(registration);
+        return registration;
+      }
+
+      const nextRegistration = await navigator.serviceWorker.register(
+        `${resolvedWorkerUrl.pathname}${resolvedWorkerUrl.search}`,
+        { scope: scopePath }
+      );
+      wireServiceWorkerUpdates(nextRegistration);
+      return nextRegistration;
+    } catch (error) {
+      console.error('Service worker registration failed', error);
+      return null;
+    }
+  };
+
+  registerServiceWorker();
+
+  const installBanner = document.querySelector('[data-install-banner]');
+  const installButton = installBanner?.querySelector('[data-install-button]');
+  let deferredPrompt = null;
+
+  if (!installBanner || !installButton) return;
+
+  const isInstalled = () => {
+    return window.matchMedia('(display-mode: standalone)').matches
+      || window.navigator.standalone
+      || document.referrer.startsWith('android-app://');
+  };
+
+  const hideBanner = () => {
+    installBanner.classList.add('is-hidden');
+    installBanner.setAttribute('hidden', '');
+  };
+
+  const showBanner = () => {
+    installBanner.classList.remove('is-hidden');
+    installBanner.removeAttribute('hidden');
+  };
+
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+
+    if (!isInstalled()) {
+      showBanner();
+    }
+  });
+
+  window.addEventListener('appinstalled', hideBanner);
+
+  installButton.addEventListener('click', async () => {
+    if (!deferredPrompt) return;
+
+    installButton.disabled = true;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    deferredPrompt = null;
+    installButton.disabled = false;
+
+    if (outcome === 'accepted') hideBanner();
+  });
+
+  if (isInstalled()) hideBanner();
+})();

--- a/crm/root.webmanifest
+++ b/crm/root.webmanifest
@@ -1,0 +1,21 @@
+{
+  "id": "/",
+  "name": "3DVR CRM",
+  "short_name": "3DVR CRM",
+  "description": "Add people fast, capture next steps, and keep your 3DVR relationships moving.",
+  "start_url": "/?source=pwa",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#0e1116",
+  "theme_color": "#0e1116",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    {
+      "src": "/icons/maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/crm/service-worker.js
+++ b/crm/service-worker.js
@@ -1,0 +1,133 @@
+/* crm/service-worker.js */
+
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `crm-static-${CACHE_VERSION}`;
+const HTML_CACHE = `crm-html-${CACHE_VERSION}`;
+const SCOPE_URL = new URL(self.registration.scope);
+const ORIGIN_URL = new URL(self.location.origin);
+const APP_BASE_URL = new URL('/crm/', ORIGIN_URL);
+const scopeAsset = (asset = '') => new URL(asset, SCOPE_URL).pathname;
+const appAsset = (asset = '') => new URL(asset, APP_BASE_URL).pathname;
+const rootAsset = (asset = '') => new URL(asset, ORIGIN_URL).pathname;
+
+const STATIC_ASSETS = [
+  scopeAsset(''),
+  appAsset('index.html'),
+  appAsset('app.js'),
+  appAsset('crm-editing.js'),
+  appAsset('install-banner.css'),
+  appAsset('pwa-install.js'),
+  appAsset('crm.webmanifest'),
+  appAsset('root.webmanifest'),
+  rootAsset('gun-init.js'),
+  rootAsset('score.js'),
+  rootAsset('oauth.js'),
+  rootAsset('icons/icon-192.png'),
+  rootAsset('icons/icon-512.png'),
+  rootAsset('icons/maskable-512.png')
+];
+
+const createReloadedRequests = (assets) =>
+  assets.map((asset) => new Request(asset, { cache: 'reload' }));
+
+const networkFirst = async (request, cacheName, fallbackUrl = null) => {
+  try {
+    const fresh = await fetch(request, { cache: 'reload' });
+    if (fresh && (fresh.ok || fresh.type === 'opaque')) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, fresh.clone());
+    }
+    return fresh;
+  } catch (error) {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    if (fallbackUrl) return caches.match(fallbackUrl);
+    throw error;
+  }
+};
+
+const staleWhileRevalidate = (event, cacheName) => {
+  event.respondWith((async () => {
+    const cache = await caches.open(cacheName);
+    const cached = await cache.match(event.request);
+
+    const fetchPromise = fetch(event.request, { cache: 'reload' })
+      .then((response) => {
+        if (response && (response.ok || response.type === 'opaque')) {
+          cache.put(event.request, response.clone());
+        }
+        return response;
+      })
+      .catch(() => null);
+
+    if (cached) {
+      event.waitUntil(fetchPromise);
+      return cached;
+    }
+
+    const fresh = await fetchPromise;
+    if (fresh) return fresh;
+    return Response.error();
+  })());
+};
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(createReloadedRequests(STATIC_ASSETS)))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.map((key) => {
+        const isCrmCache = key.startsWith('crm-static-') || key.startsWith('crm-html-');
+        if (isCrmCache && ![STATIC_CACHE, HTML_CACHE].includes(key)) {
+          return caches.delete(key);
+        }
+        return Promise.resolve();
+      }))
+    )
+  );
+  self.clients.claim();
+});
+
+const isGunRealtime = (url) =>
+  url.includes('/gun') || url.startsWith('wss://') || url.startsWith('ws://');
+const isApiRequest = (pathname) => pathname.startsWith('/api/');
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  const url = new URL(request.url);
+
+  if (request.method !== 'GET') return;
+  if (isGunRealtime(url.href) || isApiRequest(url.pathname)) return;
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirst(request, HTML_CACHE, appAsset('index.html')));
+    return;
+  }
+
+  if (['style', 'script'].includes(request.destination)) {
+    event.respondWith(networkFirst(request, STATIC_CACHE, request));
+    return;
+  }
+
+  if (['image', 'font'].includes(request.destination)) {
+    staleWhileRevalidate(event, STATIC_CACHE);
+    return;
+  }
+
+  event.respondWith(
+    fetch(request).catch(() => caches.match(request))
+  );
+});
+
+self.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || typeof data !== 'object') return;
+  if (data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/tests/crm-pwa-config.test.js
+++ b/tests/crm-pwa-config.test.js
@@ -1,0 +1,148 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+
+const readProjectFile = async (path) =>
+  readFile(resolve(projectRoot, path), 'utf8');
+
+const findHeaderValue = (headers, key) => {
+  const match = headers.find((header) => header.key === key);
+  return match ? match.value : null;
+};
+
+describe('CRM PWA configuration', () => {
+  it('keeps the portal CRM manifest scoped to /crm', async () => {
+    const manifestText = await readProjectFile('app-manifests/crm.webmanifest');
+    const manifest = JSON.parse(manifestText);
+
+    assert.equal(manifest.id, '/crm/');
+    assert.equal(manifest.scope, '/crm/');
+    assert.equal(manifest.start_url, '/crm/?source=pwa');
+    assert.equal(manifest.display, 'standalone');
+  });
+
+  it('ships a portable CRM manifest for /crm and the CRM subdomain', async () => {
+    const manifestText = await readProjectFile('crm/crm.webmanifest');
+    const manifest = JSON.parse(manifestText);
+
+    assert.equal(manifest.id, './');
+    assert.equal(manifest.scope, './');
+    assert.equal(manifest.start_url, './?source=pwa');
+    assert.equal(manifest.display, 'standalone');
+    assert.equal(manifest.short_name, '3DVR CRM');
+  });
+
+  it('ships a root-scoped CRM manifest for crm.3dvr.tech', async () => {
+    const manifestText = await readProjectFile('crm/root.webmanifest');
+    const manifest = JSON.parse(manifestText);
+
+    assert.equal(manifest.id, '/');
+    assert.equal(manifest.scope, '/');
+    assert.equal(manifest.start_url, '/?source=pwa');
+    assert.equal(manifest.display, 'standalone');
+    assert.equal(manifest.short_name, '3DVR CRM');
+  });
+
+  it('registers a CRM-scoped worker and install manifest from the CRM app shell', async () => {
+    const html = await readProjectFile('crm/index.html');
+
+    assert.match(html, /manifest\.href = window\.location\.hostname === 'crm\.3dvr\.tech'/);
+    assert.match(html, /\? '\/crm\.webmanifest'/);
+    assert.match(html, /: '\/crm\/crm\.webmanifest'/);
+    assert.match(html, /href="\/crm\/install-banner\.css"/);
+    assert.match(html, /src="\/crm\/pwa-install\.js"/);
+    assert.match(html, /data-sw-url="\/crm\/service-worker\.js"/);
+    assert.match(html, /data-sw-scope="\/crm\/"/);
+    assert.match(html, /data-sw-standalone-host="crm\.3dvr\.tech"/);
+    assert.match(html, /data-sw-standalone-scope="\/"/);
+    assert.match(html, /src="\/crm\/app\.js"/);
+    assert.match(html, /href="\/crm\/flow\.html"/);
+    assert.match(html, /data-install-banner/);
+    assert.match(html, /data-install-button/);
+  });
+
+  it('ships a CRM-specific service worker', async () => {
+    const workerSource = await readProjectFile('crm/service-worker.js');
+
+    assert.match(workerSource, /const CACHE_VERSION = 'v1';/);
+    assert.match(workerSource, /crm-static-/);
+    assert.match(workerSource, /crm-html-/);
+    assert.match(workerSource, /const APP_BASE_URL = new URL\('\/crm\/', ORIGIN_URL\);/);
+    assert.match(workerSource, /scopeAsset\(''\)/);
+    assert.match(workerSource, /appAsset\('index\.html'\)/);
+    assert.match(workerSource, /appAsset\('app\.js'\)/);
+    assert.match(workerSource, /appAsset\('crm-editing\.js'\)/);
+    assert.match(workerSource, /appAsset\('install-banner\.css'\)/);
+    assert.match(workerSource, /appAsset\('pwa-install\.js'\)/);
+    assert.match(workerSource, /appAsset\('crm\.webmanifest'\)/);
+    assert.match(workerSource, /appAsset\('root\.webmanifest'\)/);
+    assert.match(workerSource, /rootAsset\('icons\/icon-192\.png'\)/);
+    assert.match(workerSource, /request\.mode === 'navigate'/);
+    assert.match(workerSource, /networkFirst\(request, HTML_CACHE, appAsset\('index\.html'\)\)/);
+    assert.match(workerSource, /type === 'SKIP_WAITING'/);
+  });
+
+  it('resolves CRM install paths relative to the active page URL', async () => {
+    const source = await readProjectFile('crm/pwa-install.js');
+
+    assert.match(source, /const resolutionBaseUrl = new URL\(window\.location\.href\);/);
+    assert.match(source, /const standaloneHost = scriptEl\?\.dataset\?\.swStandaloneHost/);
+    assert.match(source, /const standaloneScope = scriptEl\?\.dataset\?\.swStandaloneScope/);
+    assert.match(source, /new URL\(configuredWorkerUrl,\s*resolutionBaseUrl\)/);
+    assert.match(source, /new URL\(configuredScope,\s*resolutionBaseUrl\)/);
+    assert.match(source, /postMessage\(\{\s*type:\s*'SKIP_WAITING'\s*\}\)/);
+  });
+
+  it('serves CRM PWA files and crm.3dvr.tech from the main Vercel project', async () => {
+    const vercelText = await readProjectFile('vercel.json');
+    const config = JSON.parse(vercelText);
+    const rules = Array.isArray(config.headers) ? config.headers : [];
+    const rewrites = Array.isArray(config.rewrites) ? config.rewrites : [];
+
+    const manifestRule = rules.find((rule) => rule.source === '/crm/crm.webmanifest');
+    const rootManifestRule = rules.find((rule) => rule.source === '/crm/root.webmanifest');
+    const rootAliasManifestRule = rules.find((rule) => rule.source === '/crm.webmanifest');
+    const pwaInstallRule = rules.find((rule) => rule.source === '/crm/pwa-install.js');
+    const workerRule = rules.find((rule) => rule.source === '/crm/service-worker.js');
+    const crmRootManifestRewrite = rewrites.find((rule) =>
+      rule.source === '/crm.webmanifest'
+      && rule.destination === '/crm/root.webmanifest'
+      && Array.isArray(rule.has)
+      && rule.has.some((entry) => entry.type === 'host' && entry.value === 'crm.3dvr.tech')
+    );
+    const crmHostRewrite = rewrites.find((rule) =>
+      rule.source === '/'
+      && rule.destination === '/crm/index.html'
+      && Array.isArray(rule.has)
+      && rule.has.some((entry) => entry.type === 'host' && entry.value === 'crm.3dvr.tech')
+    );
+
+    assert.ok(manifestRule);
+    assert.ok(rootManifestRule);
+    assert.ok(rootAliasManifestRule);
+    assert.ok(pwaInstallRule);
+    assert.ok(workerRule);
+    assert.ok(crmRootManifestRewrite);
+    assert.ok(crmHostRewrite);
+    assert.equal(
+      findHeaderValue(manifestRule.headers, 'Cache-Control'),
+      'public, max-age=0, must-revalidate'
+    );
+    assert.equal(
+      findHeaderValue(rootManifestRule.headers, 'Cache-Control'),
+      'public, max-age=0, must-revalidate'
+    );
+    assert.equal(
+      findHeaderValue(rootAliasManifestRule.headers, 'Cache-Control'),
+      'public, max-age=0, must-revalidate'
+    );
+    assert.equal(findHeaderValue(pwaInstallRule.headers, 'Cache-Control'), 'no-cache');
+    assert.equal(findHeaderValue(workerRule.headers, 'Cache-Control'), 'no-cache');
+    assert.equal(findHeaderValue(workerRule.headers, 'Service-Worker-Allowed'), '/');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -92,6 +92,33 @@
       ]
     },
     {
+      "source": "/crm/crm.webmanifest",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/crm/root.webmanifest",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/crm.webmanifest",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/pwa-install.js",
       "headers": [
         {
@@ -102,6 +129,15 @@
     },
     {
       "source": "/contacts/pwa-install.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }
+      ]
+    },
+    {
+      "source": "/crm/pwa-install.js",
       "headers": [
         {
           "key": "Cache-Control",
@@ -147,9 +183,42 @@
           "value": "/calendar/"
         }
       ]
+    },
+    {
+      "source": "/crm/service-worker.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        },
+        {
+          "key": "Service-Worker-Allowed",
+          "value": "/"
+        }
+      ]
     }
   ],
   "rewrites": [
+    {
+      "source": "/crm.webmanifest",
+      "has": [
+        {
+          "type": "host",
+          "value": "crm.3dvr.tech"
+        }
+      ],
+      "destination": "/crm/root.webmanifest"
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "crm.3dvr.tech"
+        }
+      ],
+      "destination": "/crm/index.html"
+    },
     {
       "source": "/",
       "has": [


### PR DESCRIPTION
## Summary
- Add CRM-specific PWA manifests, install banner assets, install registration, and a scoped service worker.
- Route `crm.3dvr.tech` to the existing CRM implementation through Vercel, with a root-scoped manifest and service worker scope for the subdomain while keeping `/crm/` scoped behavior inside the portal.
- Add config coverage for CRM manifest scopes, install wiring, worker assets, Vercel headers, and host rewrites.

## Validation
- `node --test tests/crm-pwa-config.test.js tests/calendar-pwa-config.test.js tests/contacts-pwa-config.test.js`
- `node --check crm/app.js && node --check crm/service-worker.js && node --check crm/pwa-install.js && node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); JSON.parse(require('fs').readFileSync('crm/crm.webmanifest','utf8')); JSON.parse(require('fs').readFileSync('crm/root.webmanifest','utf8')); JSON.parse(require('fs').readFileSync('app-manifests/crm.webmanifest','utf8'));"`
- Local dev smoke for `/crm/`, `/crm/root.webmanifest`, and `/crm/service-worker.js`.

## Note
- The global `vercel` binary is not installed in this shell, and `npx vercel@latest --version` failed while populating npm cache, so Vercel-host rewrite behavior was validated through config tests rather than `vercel dev`.