### PR TITLE
[codex] Redirect CRM subdomain root

### DIFF
--- a/tests/crm-pwa-config.test.js
+++ b/tests/crm-pwa-config.test.js
@@ -102,6 +102,7 @@ describe('CRM PWA configuration', () => {
     const vercelText = await readProjectFile('vercel.json');
     const config = JSON.parse(vercelText);
     const rules = Array.isArray(config.headers) ? config.headers : [];
+    const redirects = Array.isArray(config.redirects) ? config.redirects : [];
     const rewrites = Array.isArray(config.rewrites) ? config.rewrites : [];
 
     const manifestRule = rules.find((rule) => rule.source === '/crm/crm.webmanifest');
@@ -112,6 +113,13 @@ describe('CRM PWA configuration', () => {
     const crmRootManifestRewrite = rewrites.find((rule) =>
       rule.source === '/crm.webmanifest'
       && rule.destination === '/crm/root.webmanifest'
+      && Array.isArray(rule.has)
+      && rule.has.some((entry) => entry.type === 'host' && entry.value === 'crm.3dvr.tech')
+    );
+    const crmRootRedirect = redirects.find((rule) =>
+      rule.source === '/'
+      && rule.destination === '/crm/'
+      && rule.permanent === false
       && Array.isArray(rule.has)
       && rule.has.some((entry) => entry.type === 'host' && entry.value === 'crm.3dvr.tech')
     );
@@ -128,6 +136,7 @@ describe('CRM PWA configuration', () => {
     assert.ok(pwaInstallRule);
     assert.ok(workerRule);
     assert.ok(crmRootManifestRewrite);
+    assert.ok(crmRootRedirect);
     assert.ok(crmHostRewrite);
     assert.equal(
       findHeaderValue(manifestRule.headers, 'Cache-Control'),

--- a/vercel.json
+++ b/vercel.json
@@ -198,6 +198,19 @@
       ]
     }
   ],
+  "redirects": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "crm.3dvr.tech"
+        }
+      ],
+      "destination": "/crm/",
+      "permanent": false
+    }
+  ],
   "rewrites": [
     {
       "source": "/crm.webmanifest",


### PR DESCRIPTION
## Summary
- Add a host-specific temporary redirect from `crm.3dvr.tech/` to `/crm/` so the physical portal `index.html` cannot win at the subdomain root.
- Extend CRM PWA config coverage to assert the root redirect remains present.

## Validation
- `node --test tests/crm-pwa-config.test.js`
- `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8'))"`

## Context
- `crm.3dvr.tech/crm/`, `crm.3dvr.tech/crm.webmanifest`, and `crm.3dvr.tech/crm/service-worker.js` were already live and correct after PR #823. Bare `crm.3dvr.tech/` still served the portal root because the static root file wins over the rewrite, so this redirect makes the public entry land on the CRM app.