### PR TITLE
[codex] Update CRM branding and icon

### DIFF
--- a/crm/index.html
+++ b/crm/index.html
@@ -2,13 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>CRM | 3dvr portal</title>
+  <title>3DVR CRM</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0e1116" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <link rel="icon" href="https://fav.farm/🧠" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/icons/icon-512.png" />
   <link rel="apple-touch-icon" href="/icons/icon-192.png" />
   <script>
     (() => {
@@ -146,7 +147,7 @@
     <div class="max-w-5xl mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
       <div>
         <p class="text-xs font-semibold tracking-[0.32em] text-teal-400 uppercase">CRM</p>
-        <h1 class="text-3xl font-bold">People CRM</h1>
+        <h1 class="text-3xl font-bold">3DVR CRM</h1>
         <p class="text-sm text-gray-300">Add a person fast, capture the next step, and clean up the details later.</p>
         <p class="text-xs text-gray-400 mt-2">Use the fast fallback note first. Messy notes are fine.</p>
       </div>

--- a/tests/crm-pwa-config.test.js
+++ b/tests/crm-pwa-config.test.js
@@ -62,6 +62,11 @@ describe('CRM PWA configuration', () => {
     assert.match(html, /data-sw-standalone-scope="\/"/);
     assert.match(html, /src="\/crm\/app\.js"/);
     assert.match(html, /href="\/crm\/flow\.html"/);
+    assert.match(html, /<title>3DVR CRM<\/title>/);
+    assert.match(html, /<h1 class="text-3xl font-bold">3DVR CRM<\/h1>/);
+    assert.match(html, /rel="icon" type="image\/png" sizes="192x192" href="\/icons\/icon-192\.png"/);
+    assert.doesNotMatch(html, /People CRM/);
+    assert.doesNotMatch(html, /fav\.farm/);
     assert.match(html, /data-install-banner/);
     assert.match(html, /data-install-button/);
   });


### PR DESCRIPTION
## Summary
- Rename the CRM page title and main heading from `People CRM` to `3DVR CRM`.
- Replace the external emoji favicon with local PNG app icons already used by the CRM PWA manifests.
- Add config-test coverage so the CRM shell keeps the real icon and avoids the old `People CRM` label.

## Validation
- `node --test tests/crm-pwa-config.test.js`
- `node --check crm/app.js`