### PR TITLE
[codex] Stop CRM PWA from auto-opening add lead

### DIFF
--- a/app-manifests/crm.webmanifest
+++ b/app-manifests/crm.webmanifest
@@ -3,7 +3,7 @@
   "name": "3DVR CRM",
   "short_name": "3DVR CRM",
   "description": "Add people fast, capture next steps, and keep your 3DVR relationships moving.",
-  "start_url": "/crm/?source=pwa",
+  "start_url": "/crm/",
   "scope": "/crm/",
   "display": "standalone",
   "background_color": "#0e1116",

--- a/crm/app.js
+++ b/crm/app.js
@@ -3091,7 +3091,8 @@ function scheduleRender() {
 function applyUrlDraftIfNeeded() {
   if (state.draftApplied) return;
   const draft = state.urlDraft;
-  const hasDraft = params.has('type') || Object.values(draft).some(value => Boolean(value));
+  const { source, ...draftFields } = draft;
+  const hasDraft = params.has('type') || Object.values(draftFields).some(value => Boolean(value));
   if (!hasDraft) return;
   state.draftApplied = true;
   openCreateOverlay({

--- a/crm/crm.webmanifest
+++ b/crm/crm.webmanifest
@@ -3,7 +3,7 @@
   "name": "3DVR CRM",
   "short_name": "3DVR CRM",
   "description": "Add people fast, capture next steps, and keep your 3DVR relationships moving.",
-  "start_url": "./?source=pwa",
+  "start_url": "./",
   "scope": "./",
   "display": "standalone",
   "background_color": "#0e1116",

--- a/crm/root.webmanifest
+++ b/crm/root.webmanifest
@@ -3,7 +3,7 @@
   "name": "3DVR CRM",
   "short_name": "3DVR CRM",
   "description": "Add people fast, capture next steps, and keep your 3DVR relationships moving.",
-  "start_url": "/?source=pwa",
+  "start_url": "/",
   "scope": "/",
   "display": "standalone",
   "background_color": "#0e1116",

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -144,6 +144,14 @@ test('CRM saves records locally before waiting on Gun mobile relay acknowledgeme
   assert.match(js, /hydrateLocalCrmCache\(\);\s+updateFilterButtons\(\);/);
 });
 
+test('CRM PWA source launch does not auto-open the add lead overlay', async () => {
+  const js = await read('crm/app.js');
+
+  assert.match(js, /const \{ source, \.\.\.draftFields \} = draft;/);
+  assert.match(js, /Object\.values\(draftFields\)\.some\(value => Boolean\(value\)\)/);
+  assert.doesNotMatch(js, /Object\.values\(draft\)\.some\(value => Boolean\(value\)\)/);
+});
+
 test('Contacts page exposes CRM link filter and phone import controls', async () => {
   const html = await read('contacts/index.html');
   assert.match(html, /id="filterCrmLink"/);

--- a/tests/crm-pwa-config.test.js
+++ b/tests/crm-pwa-config.test.js
@@ -22,7 +22,7 @@ describe('CRM PWA configuration', () => {
 
     assert.equal(manifest.id, '/crm/');
     assert.equal(manifest.scope, '/crm/');
-    assert.equal(manifest.start_url, '/crm/?source=pwa');
+    assert.equal(manifest.start_url, '/crm/');
     assert.equal(manifest.display, 'standalone');
   });
 
@@ -32,7 +32,7 @@ describe('CRM PWA configuration', () => {
 
     assert.equal(manifest.id, './');
     assert.equal(manifest.scope, './');
-    assert.equal(manifest.start_url, './?source=pwa');
+    assert.equal(manifest.start_url, './');
     assert.equal(manifest.display, 'standalone');
     assert.equal(manifest.short_name, '3DVR CRM');
   });
@@ -43,7 +43,7 @@ describe('CRM PWA configuration', () => {
 
     assert.equal(manifest.id, '/');
     assert.equal(manifest.scope, '/');
-    assert.equal(manifest.start_url, '/?source=pwa');
+    assert.equal(manifest.start_url, '/');
     assert.equal(manifest.display, 'standalone');
     assert.equal(manifest.short_name, '3DVR CRM');
   });

--- a/tests/sales-crm-handoff.test.js
+++ b/tests/sales-crm-handoff.test.js
@@ -17,7 +17,7 @@ test('sales hub routes offers into prefilled CRM drafts', async () => {
   assert.match(crmHtml, /Builder draft/);
   assert.match(crmHtml, /Embedded draft/);
   assert.match(crmHtml, /Custom draft/);
-  assert.match(crmHtml, /type="module" src="\.\/app\.js"/);
+  assert.match(crmHtml, /type="module" src="\/crm\/app\.js"/);
   assert.doesNotMatch(crmHtml, /const gun = Gun\(window\.__GUN_PEERS__/);
   assert.match(crmAppJs, /SALES_DRAFT_PRESETS/);
   assert.match(crmAppJs, /applyUrlDraftIfNeeded/);


### PR DESCRIPTION
## Summary
- Fix CRM startup so `source` by itself does not count as a URL draft and therefore does not auto-open the Add lead overlay.
- Remove `?source=pwa` from CRM PWA manifest start URLs so new installs launch cleanly.
- Update CRM tests for the PWA source-launch case and the existing `/crm/app.js` module path.

## Root Cause
The installed PWA launched with `?source=pwa`. CRM also uses `source` as a draft field, and `applyUrlDraftIfNeeded()` treated any populated draft field as a reason to open the Add lead overlay.

## Validation
- `node --test tests/crm-pwa-config.test.js tests/crm-contacts-workflow.test.js tests/sales-crm-handoff.test.js`
- `node --check crm/app.js`
- CRM manifest JSON parse checks for `app-manifests/crm.webmanifest`, `crm/crm.webmanifest`, and `crm/root.webmanifest`