### PR TITLE
[codex] Handle Vercel browser check navigations

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -3,7 +3,7 @@
 importScripts('/chat/notification-routing.js');
 
 // Increment this to bust old caches when you deploy
-const CACHE_VERSION = 'v16';
+const CACHE_VERSION = 'v17';
 const STATIC_CACHE = `3dvr-static-${CACHE_VERSION}`;
 const HTML_CACHE = `3dvr-html-${CACHE_VERSION}`;
 const chatNotificationRouting = self.ChatNotificationRouting || null;
@@ -41,7 +41,7 @@ const STATIC_ASSETS = [
 const createReloadedRequests = (assets) =>
   assets.map((asset) => new Request(asset, { cache: 'reload' }));
 
-const SECURITY_CHECKPOINT_PATTERN = /Vercel Security Checkpoint|Failed to verify your browser|Code 705/i;
+const SECURITY_CHECKPOINT_PATTERN = /Vercel Security Checkpoint|Failed to verify your browser|We(?:'|’)?re (?:verifying|checking) your browser|Code\s*(?:705|805)/i;
 
 const createOfflinePortalFallbackResponse = () => new Response(`<!doctype html>
 <html lang="en">
@@ -115,6 +115,32 @@ const cacheHtmlResponse = async (request, response) => {
 
   const cache = await caches.open(HTML_CACHE);
   await cache.put(request, responseForCache);
+};
+
+const getCachedHtmlFallback = async (request) => {
+  const cached = await caches.match(request, { ignoreSearch: true });
+  return cached || createOfflinePortalFallbackResponse();
+};
+
+const networkFirstHtml = async (request) => {
+  const fresh = await fetch(request, { cache: 'reload' });
+  const contentType = fresh.headers.get('content-type') || '';
+
+  if (contentType.includes('text/html')) {
+    const responseForInspection = fresh.clone();
+    const text = await responseForInspection.text();
+
+    if (SECURITY_CHECKPOINT_PATTERN.test(text)) {
+      return getCachedHtmlFallback(request);
+    }
+
+    if (fresh.ok) {
+      const cache = await caches.open(HTML_CACHE);
+      await cache.put(request, fresh.clone());
+    }
+  }
+
+  return fresh;
 };
 
 const networkFirst = async (req, { cacheMode = 'default' } = {}) => {
@@ -249,13 +275,7 @@ self.addEventListener('fetch', (event) => {
   if (isHTML(req)) {
     // Network-first for HTML for freshness
     event.respondWith(
-      fetch(req, { cache: 'reload' }).then((res) => {
-        event.waitUntil(cacheHtmlResponse(req, res));
-        return res;
-      }).catch(async () => {
-        const cached = await caches.match(req, { ignoreSearch: true });
-        return cached || createOfflinePortalFallbackResponse();
-      })
+      networkFirstHtml(req).catch(() => getCachedHtmlFallback(req))
     );
     return;
   }

--- a/tests/mobile-browser-resilience.test.js
+++ b/tests/mobile-browser-resilience.test.js
@@ -48,14 +48,19 @@ test('root service worker does not cache stale portal HTML or Vercel checkpoints
   const source = await readProjectFile('service-worker.js');
   const staticAssetsBlock = source.match(/const STATIC_ASSETS = \[[\s\S]*?\];/)?.[0] || '';
 
-  assert.match(source, /const CACHE_VERSION = 'v16';/);
+  assert.match(source, /const CACHE_VERSION = 'v17';/);
   assert.doesNotMatch(staticAssetsBlock, /'\/'/);
   assert.match(source, /SECURITY_CHECKPOINT_PATTERN/);
   assert.match(source, /Vercel Security Checkpoint/);
   assert.match(source, /Failed to verify your browser/);
+  assert.match(source, /verifying\|checking/);
+  assert.match(source, /705\|805/);
+  assert.match(source, /networkFirstHtml/);
+  assert.match(source, /SECURITY_CHECKPOINT_PATTERN\.test\(text\)/);
+  assert.match(source, /return getCachedHtmlFallback\(request\)/);
   assert.match(source, /shouldCacheHtmlResponse/);
-  assert.match(source, /fetch\(req,\s*\{\s*cache:\s*'reload'\s*\}\)/);
-  assert.match(source, /caches\.match\(req,\s*\{\s*ignoreSearch:\s*true\s*\}\)/);
+  assert.match(source, /fetch\(request,\s*\{\s*cache:\s*'reload'\s*\}\)/);
+  assert.match(source, /caches\.match\(request,\s*\{\s*ignoreSearch:\s*true\s*\}\)/);
   assert.match(source, /createOfflinePortalFallbackResponse/);
 });
 


### PR DESCRIPTION
## Summary
- Bump the portal root service worker cache version.
- Detect newer Vercel browser-check checkpoint HTML, including `Code 805` and `We're verifying/checking your browser` text.
- For controlled HTML navigations, return the last good cached HTML or offline fallback instead of replacing the app with the checkpoint page.

## Context
DuckDuckGo mobile browser can initially load `portal.3dvr.tech`, then show a Vercel browser-check error after clicking a link. The existing worker avoided caching older checkpoint pages but still returned the checkpoint response to the page; this patch filters it before display.

## Validation
- `node --test tests/mobile-browser-resilience.test.js`
- `node --check service-worker.js`