### PR TITLE
[codex] Fix portal mobile homepage overflow

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -2,6 +2,8 @@ body.landing {
   display: flex;
   justify-content: center;
   align-items: stretch;
+  width: 100%;
+  max-width: 100%;
 }
 
 .app-boot {
@@ -99,8 +101,13 @@ body.landing {
 .landing-shell {
   position: relative;
   z-index: 1;
-  width: min(1120px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: min(100%, 1120px);
+  max-width: 100%;
   padding: 6rem 1.5rem 4rem;
+  margin: 0 auto;
 }
 
 .site-backlink {
@@ -163,6 +170,8 @@ body.landing {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
   margin-bottom: 1.5rem;
 }
 
@@ -376,10 +385,16 @@ body.landing {
   display: flex;
   flex-direction: column;
   gap: 2.2rem;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .hero {
   position: relative;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -390,9 +405,10 @@ body.landing {
 
 .hero-breath {
   position: absolute;
-  inset: -38% -20% -24%;
+  inset: 0;
   display: grid;
   place-items: center;
+  overflow: hidden;
   pointer-events: none;
   z-index: 0;
   opacity: 0.85;
@@ -460,6 +476,9 @@ body.landing {
   z-index: 1;
   display: grid;
   gap: 1.25rem;
+  width: min(100%, 100%);
+  max-width: 100%;
+  min-width: 0;
   padding: clamp(1.25rem, 2vw, 1.9rem);
   border-radius: calc(var(--radius-lg) + 0.2rem);
   border: 1px solid rgba(56, 189, 248, 0.16);
@@ -474,6 +493,7 @@ body.landing {
   display: grid;
   gap: 1rem;
   align-content: start;
+  min-width: 0;
   text-align: left;
 }
 
@@ -564,6 +584,7 @@ body.landing {
 .hero-shortcuts {
   display: grid;
   gap: 0.85rem;
+  min-width: 0;
   padding-top: 1rem;
   border-top: 1px solid rgba(148, 163, 184, 0.14);
 }
@@ -581,12 +602,14 @@ body.landing {
 .shortcut-grid {
   display: grid;
   gap: 0.85rem;
+  min-width: 0;
 }
 
 .shortcut-card {
   position: relative;
   display: grid;
   gap: 0.65rem;
+  min-width: 0;
   padding: 1rem;
   border-radius: 1.1rem;
   background: rgba(15, 23, 42, 0.62);
@@ -652,11 +675,13 @@ body.landing {
   display: grid;
   gap: 1.5rem;
   align-items: stretch;
+  min-width: 0;
 }
 
 .app-hub__intro {
   display: grid;
   gap: 0.75rem;
+  min-width: 0;
 }
 
 .app-hub__intro h2 {
@@ -675,6 +700,7 @@ body.landing {
   display: grid;
   gap: 0.85rem;
   align-content: start;
+  min-width: 0;
 }
 
 .app-hub__controls {
@@ -687,6 +713,7 @@ body.landing {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
+  min-width: 0;
   padding: 0.45rem 0.6rem;
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.35);
@@ -737,22 +764,26 @@ body.landing {
 }
 
 .hero-actions {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 9rem), 1fr));
   gap: 0.8rem;
-  justify-content: flex-start;
+  width: 100%;
+  max-width: 42rem;
+  min-width: 0;
   margin-top: 0.2rem;
 }
 
 .plan-strip {
   display: grid;
   gap: 0.6rem;
+  min-width: 0;
   margin-top: 0.2rem;
 }
 
 .workspace-strip {
   display: grid;
   gap: 0.6rem;
+  min-width: 0;
   margin-top: 0.15rem;
 }
 
@@ -767,12 +798,14 @@ body.landing {
 .workspace-ribbon {
   display: grid;
   gap: 0.65rem;
+  min-width: 0;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .workspace-pill {
   display: grid;
   gap: 0.28rem;
+  min-width: 0;
   padding: 0.85rem 0.95rem;
   border-radius: 1rem;
   text-decoration: none;
@@ -822,6 +855,7 @@ body.landing {
   flex-wrap: wrap;
   gap: 0.65rem;
   width: 100%;
+  min-width: 0;
   margin: 0;
 }
 
@@ -829,6 +863,7 @@ body.landing {
   display: grid;
   gap: 0.25rem;
   min-width: 118px;
+  flex: 1 1 118px;
   padding: 0.7rem 0.85rem;
   border-radius: 0.95rem;
   text-decoration: none;
@@ -863,6 +898,7 @@ body.landing {
   align-items: center;
   justify-content: center;
   gap: 0.45rem;
+  min-width: 0;
   padding: 0.85rem 1.8rem;
   border-radius: 999px;
   font-weight: 600;
@@ -875,6 +911,8 @@ body.landing {
     color var(--transition-base),
     border-color var(--transition-base);
   text-decoration: none;
+  text-align: center;
+  white-space: normal;
 }
 
 .cta.primary {
@@ -910,6 +948,8 @@ body.landing {
   padding: 0.95rem 1rem;
   margin: 0;
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 1.1rem;
   border: 1px solid var(--surface-border);
   background: var(--surface);
@@ -968,6 +1008,7 @@ body.landing {
 .launcher-lanes {
   display: grid;
   gap: 1rem;
+  min-width: 0;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   margin-top: 1.4rem;
 }
@@ -975,6 +1016,7 @@ body.landing {
 .launcher-lane {
   display: grid;
   gap: 0.55rem;
+  min-width: 0;
   padding: 1rem 1.05rem;
   border-radius: 1.15rem;
   text-decoration: none;
@@ -1045,6 +1087,7 @@ body.landing {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1.2rem;
+  min-width: 0;
   margin-top: 1.2rem;
 }
 
@@ -1054,6 +1097,7 @@ body.landing {
   display: grid;
   align-content: start;
   gap: 0.9rem;
+  min-width: 0;
   padding: 1.65rem;
   border-radius: var(--radius-lg);
   background: var(--surface);
@@ -1140,6 +1184,7 @@ body.landing {
 .gamified-dashboard {
   display: grid;
   gap: 2.5rem;
+  min-width: 0;
 }
 
 .gamified-dashboard__header {
@@ -1163,6 +1208,7 @@ body.landing {
 .gamified-dashboard__grid {
   display: grid;
   gap: 1.75rem;
+  min-width: 0;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
@@ -1177,6 +1223,7 @@ body.landing {
   isolation: isolate;
   display: grid;
   gap: 1rem;
+  min-width: 0;
   transition: transform var(--transition-base),
     box-shadow var(--transition-base),
     border-color var(--transition-base),
@@ -1297,6 +1344,7 @@ body.landing {
 .info-panels {
   display: grid;
   gap: 1.6rem;
+  min-width: 0;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
@@ -1308,6 +1356,7 @@ body.landing {
   box-shadow: 0 32px 80px rgba(4, 9, 20, 0.6);
   display: grid;
   gap: 0.9rem;
+  min-width: 0;
 }
 
 .info-card h3 {
@@ -1541,12 +1590,22 @@ footer a {
     width: clamp(8.4rem, 38vw, 10.2rem);
   }
 
+  .top-nav__toggle {
+    width: 100%;
+  }
+
   .hero-eyebrow {
     width: 100%;
   }
 
   .hero-panel {
     gap: 1rem;
+    border-radius: var(--radius-lg);
+  }
+
+  .hero-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    max-width: 100%;
   }
 
   .plan-pill {
@@ -1555,6 +1614,13 @@ footer a {
 
   .workspace-ribbon {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .launcher-lanes,
+  .app-grid,
+  .gamified-dashboard__grid,
+  .info-panels {
+    grid-template-columns: 1fr;
   }
 
   .app-hub__header {
@@ -1648,6 +1714,7 @@ footer a {
   }
 
   .hero-actions {
+    grid-template-columns: 1fr;
     gap: 0.65rem;
   }
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -30,6 +30,9 @@
 }
 
 html {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
 }
@@ -48,6 +51,8 @@ html {
 
 body {
   margin: 0;
+  width: 100%;
+  max-width: 100%;
   min-height: 100vh;
   max-width: 100%;
   overflow-x: clip;
@@ -57,6 +62,7 @@ body {
   color: var(--color-text);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -193,6 +199,7 @@ body.theme-dark::after {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  max-width: calc(100% - 3rem);
   padding: 0.75rem 1rem;
   background: var(--identity-bg);
   border: 1px solid var(--identity-border);
@@ -207,6 +214,7 @@ body.theme-dark::after {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  min-width: 0;
   font-size: 0.95rem;
   color: inherit;
   text-decoration: none;
@@ -215,10 +223,12 @@ body.theme-dark::after {
 
 .floating-identity__label {
   font-weight: 600;
+  overflow-wrap: anywhere;
 }
 
 .floating-identity__value {
   opacity: 0.8;
+  overflow-wrap: anywhere;
 }
 
 .floating-identity__stats:focus-visible {
@@ -251,6 +261,7 @@ body.theme-dark::after {
     position: static;
     margin: 1rem auto 0;
     width: min(100%, 420px);
+    max-width: 100%;
     justify-content: space-between;
   }
 

--- a/tests/portal-home-mobile-layout.test.js
+++ b/tests/portal-home-mobile-layout.test.js
@@ -1,0 +1,155 @@
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, join, resolve, sep } from 'node:path';
+import { chromium } from 'playwright';
+
+const projectRoot = resolve(new URL('..', import.meta.url).pathname);
+const mimeTypes = new Map([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.ico', 'image/x-icon'],
+  ['.js', 'application/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'],
+  ['.webmanifest', 'application/manifest+json; charset=utf-8']
+]);
+
+let server;
+let baseUrl;
+
+function resolveSafePath(pathname) {
+  const normalized = pathname === '/' ? '/index.html' : pathname;
+  const absolutePath = resolve(projectRoot, `.${normalized}`);
+  if (absolutePath !== projectRoot && !absolutePath.startsWith(`${projectRoot}${sep}`)) {
+    return null;
+  }
+  return absolutePath;
+}
+
+async function launchChromium(t) {
+  try {
+    return await chromium.launch({
+      headless: true,
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-gpu',
+        '--disable-software-rasterizer',
+        '--disable-dev-shm-usage',
+        '--use-gl=swiftshader'
+      ],
+      env: {
+        ...process.env,
+        LIBGL_ALWAYS_SOFTWARE: '1'
+      }
+    });
+  } catch (error) {
+    const message = error && typeof error.message === 'string' ? error.message : String(error);
+    if (message.includes('dependencies to run browsers') || message.includes('Executable doesn')) {
+      t.skip('Playwright Chromium is not installed in this environment.');
+      return null;
+    }
+    throw error;
+  }
+}
+
+describe('portal home mobile layout', () => {
+  before(async () => {
+    server = createServer(async (request, response) => {
+      try {
+        const requestUrl = new URL(request.url || '/', 'http://' + request.headers.host);
+        const safePath = resolveSafePath(requestUrl.pathname);
+        if (!safePath) {
+          response.writeHead(403, { 'content-type': 'text/plain; charset=utf-8' });
+          response.end('Forbidden');
+          return;
+        }
+
+        let targetPath = safePath;
+        const fileInfo = await stat(targetPath).catch(() => null);
+        if (fileInfo && fileInfo.isDirectory()) {
+          targetPath = join(targetPath, 'index.html');
+        }
+
+        const body = await readFile(targetPath);
+        response.writeHead(200, {
+          'cache-control': 'no-store',
+          'content-type': mimeTypes.get(extname(targetPath).toLowerCase()) || 'application/octet-stream'
+        });
+        response.end(body);
+      } catch {
+        response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+        response.end('Not found');
+      }
+    });
+
+    await new Promise(resolveServer => server.listen(0, '127.0.0.1', resolveServer));
+    const address = server.address();
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  after(async () => {
+    if (server?.listening) {
+      await new Promise((resolveClose, rejectClose) => {
+        server.close(error => {
+          if (error) rejectClose(error);
+          else resolveClose();
+        });
+      });
+    }
+  });
+
+  it('does not overflow horizontally at Android Chrome widths', async t => {
+    const browser = await launchChromium(t);
+    if (!browser) return;
+
+    try {
+      for (const width of [360, 375, 390, 412]) {
+        const context = await browser.newContext({
+          viewport: { width, height: 844 },
+          isMobile: true,
+          hasTouch: true,
+          deviceScaleFactor: 3,
+          userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36'
+        });
+        const page = await context.newPage();
+        await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+        await page.waitForSelector('.hero-panel', { timeout: 10000 });
+        await page.waitForTimeout(100);
+
+        const result = await page.evaluate(() => {
+          const clientWidth = document.documentElement.clientWidth;
+          const scrollWidth = document.documentElement.scrollWidth;
+          const overflowing = Array.from(document.body.querySelectorAll('*'))
+            .map(element => {
+              const rect = element.getBoundingClientRect();
+              return {
+                tag: element.tagName.toLowerCase(),
+                className: typeof element.className === 'string' ? element.className : '',
+                left: Math.floor(rect.left),
+                right: Math.ceil(rect.right),
+                width: Math.ceil(rect.width)
+              };
+            })
+            .filter(item => item.width > 0 && (item.left < -1 || item.right > clientWidth + 1));
+
+          return { clientWidth, scrollWidth, overflowing };
+        });
+
+        assert.equal(
+          result.scrollWidth,
+          result.clientWidth,
+          `Expected no document overflow at ${width}px: ${JSON.stringify(result.overflowing.slice(0, 5))}`
+        );
+        assert.deepEqual(result.overflowing, [], `Expected no element to exceed viewport at ${width}px`);
+
+        await context.close();
+      }
+    } finally {
+      await browser.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Constrain the portal home shell, hero panel, grids, and injected identity bar to safe mobile widths.
- Replace the hero action row with responsive grid behavior so buttons do not push past narrow Android Chrome viewports.
- Add a Chromium mobile regression test for 360, 375, 390, and 412 px widths that checks document and element overflow.

## Root Cause
The landing shell used a full-width calculation with horizontal padding applied outside that width, and several grid/flex children lacked defensive `min-width: 0` constraints. A decorative hero layer also extended outside the viewport, which could contribute to Android Chrome horizontal misalignment.

## Validation
- `node --test tests/customer-journey-pages.test.js`
- `node --test tests/portal-home-mobile-layout.test.js`