### PR TITLE
[codex] Move CRM install prompt to bottom

### DIFF
--- a/crm/index.html
+++ b/crm/index.html
@@ -135,14 +135,6 @@
   </style>
 </head>
 <body class="bg-gray-900 text-white font-sans min-h-screen">
-  <div class="install-banner" data-install-banner hidden>
-    <div class="install-banner__text">
-      <p class="install-banner__title">Install CRM</p>
-      <p class="install-banner__meta">Open your people pipeline quickly from your phone or desktop.</p>
-    </div>
-    <button type="button" class="install-banner__action" data-install-button>Install app</button>
-  </div>
-
   <header class="bg-gray-950/70 border-b border-white/10">
     <div class="max-w-5xl mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
       <div>
@@ -152,6 +144,7 @@
         <p class="text-xs text-gray-400 mt-2">Use the fast fallback note first. Messy notes are fine.</p>
       </div>
       <nav class="flex flex-wrap gap-2 text-sm">
+        <a href="https://portal.3dvr.tech/index.html" class="bg-teal-500/20 hover:bg-teal-500/30 text-teal-100 px-3 py-1.5 rounded transition border border-teal-300/20">← Portal</a>
         <a href="../sales/index.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Sales</a>
         <a href="/crm/flow.html" class="bg-teal-500 hover:bg-teal-400 text-gray-950 px-3 py-1.5 rounded transition font-semibold">Flow view</a>
         <a href="../sales/outreach.html" class="bg-white/10 hover:bg-white/20 text-white px-3 py-1.5 rounded transition">Outreach</a>
@@ -735,6 +728,20 @@
       </div>
     </section>
   </main>
+
+  <div
+    class="install-banner install-banner--bottom"
+    data-install-banner
+    data-install-dismiss-key="3dvr:crm-install-dismissed"
+    hidden
+  >
+    <div class="install-banner__text">
+      <p class="install-banner__title">Install CRM</p>
+      <p class="install-banner__meta">Open your people pipeline quickly from your phone or desktop.</p>
+    </div>
+    <button type="button" class="install-banner__action" data-install-button>Install CRM</button>
+    <button type="button" class="install-banner__dismiss" data-install-dismiss aria-label="Dismiss install prompt">×</button>
+  </div>
 
   <div id="crmCreateOverlay" class="hidden fixed inset-0 z-50 bg-black/70 backdrop-blur-sm px-4 py-8 overflow-y-auto" role="dialog" aria-modal="true" aria-labelledby="crmCreateTitle">
     <div class="w-full max-w-2xl mx-auto bg-gray-900/95 border border-white/10 rounded-2xl shadow-2xl p-6">

--- a/crm/install-banner.css
+++ b/crm/install-banner.css
@@ -11,6 +11,21 @@
   max-width: 1100px;
 }
 
+.install-banner--bottom {
+  position: fixed;
+  left: max(16px, env(safe-area-inset-left));
+  right: max(16px, env(safe-area-inset-right));
+  bottom: max(16px, env(safe-area-inset-bottom));
+  z-index: 60;
+  width: min(680px, calc(100% - 32px));
+  max-width: calc(100% - 32px);
+  margin: 0 auto;
+  background: rgba(17, 24, 39, 0.96);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(16px);
+}
+
 .install-banner[hidden],
 .install-banner.is-hidden {
   display: none;
@@ -23,6 +38,10 @@
   color: var(--text-primary, #0f172a);
 }
 
+.install-banner--bottom .install-banner__text {
+  color: #f8fafc;
+}
+
 .install-banner__title {
   margin: 0;
   font-size: 1rem;
@@ -33,6 +52,10 @@
   margin: 0;
   color: var(--text-muted, #4b5563);
   font-size: 0.93rem;
+}
+
+.install-banner--bottom .install-banner__meta {
+  color: #cbd5e1;
 }
 
 .install-banner__action {
@@ -48,6 +71,25 @@
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
 }
 
+.install-banner__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.install-banner__dismiss:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
 .install-banner__action:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
@@ -58,4 +100,26 @@
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+}
+
+@media (max-width: 640px) {
+  .install-banner--bottom {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .install-banner--bottom .install-banner__action {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .install-banner--bottom .install-banner__dismiss {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+
+  .install-banner--bottom .install-banner__text {
+    padding-right: 2.5rem;
+  }
 }

--- a/crm/pwa-install.js
+++ b/crm/pwa-install.js
@@ -98,9 +98,21 @@
 
   const installBanner = document.querySelector('[data-install-banner]');
   const installButton = installBanner?.querySelector('[data-install-button]');
+  const dismissButton = installBanner?.querySelector('[data-install-dismiss]');
+  const dismissKey = installBanner?.dataset.installDismissKey || '';
   let deferredPrompt = null;
 
   if (!installBanner || !installButton) return;
+
+  const wasDismissed = () => {
+    if (!dismissKey) return false;
+    try {
+      return localStorage.getItem(dismissKey) === 'true';
+    } catch (error) {
+      console.warn('Unable to read install banner dismissal', error);
+      return false;
+    }
+  };
 
   const isInstalled = () => {
     return window.matchMedia('(display-mode: standalone)').matches
@@ -113,7 +125,19 @@
     installBanner.setAttribute('hidden', '');
   };
 
+  const dismissBanner = () => {
+    if (dismissKey) {
+      try {
+        localStorage.setItem(dismissKey, 'true');
+      } catch (error) {
+        console.warn('Unable to store install banner dismissal', error);
+      }
+    }
+    hideBanner();
+  };
+
   const showBanner = () => {
+    if (wasDismissed()) return;
     installBanner.classList.remove('is-hidden');
     installBanner.removeAttribute('hidden');
   };
@@ -128,6 +152,7 @@
   });
 
   window.addEventListener('appinstalled', hideBanner);
+  dismissButton?.addEventListener('click', dismissBanner);
 
   installButton.addEventListener('click', async () => {
     if (!deferredPrompt) return;
@@ -142,4 +167,5 @@
   });
 
   if (isInstalled()) hideBanner();
+  if (wasDismissed()) hideBanner();
 })();

--- a/tests/crm-contacts-workflow.test.js
+++ b/tests/crm-contacts-workflow.test.js
@@ -46,6 +46,13 @@ test('CRM page exposes workflow filters and import controls for fast lead retrie
   assert.match(html, /#crmFloatingIdentity/);
   assert.match(html, /\.crm-card \.truncate/);
   assert.match(html, /id="crmPrimaryActions"/);
+  assert.match(html, /href="https:\/\/portal\.3dvr\.tech\/index\.html"/);
+  assert.match(html, /← Portal/);
+  assert.match(html, /data-install-banner/);
+  assert.match(html, /install-banner--bottom/);
+  assert.match(html, /Install CRM/);
+  assert.match(html, /data-install-dismiss/);
+  assert.match(html, /3dvr:crm-install-dismissed/);
   assert.match(html, /Add person/);
   assert.match(html, /Open contacts/);
   assert.match(html, /Search people and saved notes/);


### PR DESCRIPTION
## Summary
- Move the CRM install prompt out of the top of the page and dock it at the bottom.
- Add a dismiss button that persists dismissal with a CRM-specific localStorage key.
- Add a top navigation link back to the main portal.
- Cover the CRM page markup in the existing workflow test.

## Impact
The CRM page keeps the primary header and workspace content clear while still offering home-screen installation from the bottom of the viewport. Users can dismiss the install prompt and keep it dismissed.

## Validation
- `node --test tests/crm-contacts-workflow.test.js`

Not merged per request.