### PR TITLE
[codex] Feature portal games in hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,6 +188,19 @@
               <a href="sales/index.html" class="cta ghost">Open Sales</a>
               <a href="web-builder-app/index.html" class="cta ghost">Open Web Builder</a>
             </div>
+            <div class="workspace-strip" aria-label="Featured games">
+              <span class="workspace-strip__label">Featured games</span>
+              <div class="workspace-ribbon">
+                <a class="workspace-pill" href="stellar-flight.html">
+                  <strong>Game: Stellar Drift</strong>
+                  <span>Fly a starfighter through deep-space drift lanes.</span>
+                </a>
+                <a class="workspace-pill" href="jetpack.html">
+                  <strong>Game: Jetpack Corridor</strong>
+                  <span>Dodge, boost, and thread the corridor in a quick-play jetpack game.</span>
+                </a>
+              </div>
+            </div>
             <div class="workspace-strip" aria-label="Core workspaces">
               <span class="workspace-strip__label">Core workspaces</span>
               <div class="workspace-ribbon">

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -11,6 +11,13 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Open CRM/);
     assert.match(html, /Open Sales/);
     assert.match(html, /Open Web Builder/);
+    assert.match(html, /Featured games/);
+    assert.match(html, /href="stellar-flight\.html"[\s\S]*?Game: Stellar Drift/);
+    assert.match(html, /href="jetpack\.html"[\s\S]*?Game: Jetpack Corridor/);
+    assert.ok(
+      html.indexOf('Featured games') < html.indexOf('Core workspaces'),
+      'expected featured games to appear before core workspaces'
+    );
     assert.doesNotMatch(html, /System layers/);
     assert.doesNotMatch(html, /Cloud workspace for identity, notes, CRM, billing, messaging, and AI\./);
     assert.doesNotMatch(html, /Launcher, multi-panel workspace, media tools, and in-browser runtime experiments\./);


### PR DESCRIPTION
## Summary
- Add a Featured games strip near the top of the portal homepage hero.
- Link directly to Stellar Drift and Jetpack Corridor.
- Label both entries as games so they read clearly as quick-play experiences.
- Add homepage test coverage for placement before Core workspaces.

## Impact
Stellar Drift and Jetpack Corridor are now visible in the top portal experience instead of only being discoverable through the games hub or lower app dock.

## Validation
- `node --test tests/customer-journey-pages.test.js tests/homepage-search-ux.test.js tests/games-page-icons.test.js`

Not merged.