### PR TITLE
[codex] Shrink portal desktop hero buttons

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -1540,6 +1540,20 @@ footer a {
   .top-nav--expanded .top-buttons {
     display: flex;
   }
+
+  .hero-actions {
+    grid-template-columns: repeat(4, max-content);
+    width: fit-content;
+    max-width: 100%;
+  }
+
+  .hero-actions .cta {
+    min-height: 2.55rem;
+    padding: 0.58rem 1rem;
+    font-size: 0.92rem;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
 }
 
 @media (max-width: 960px) {

--- a/index.html
+++ b/index.html
@@ -394,7 +394,8 @@
             <span class="app-card__meta">Organize your life. Find your purpose. Launch meaningful projects.</span>
             <span class="app-card__cta">Open Purpose</span>
           </a>
-          <a href="alive-system/" class="app-card">
+          <a href="alive-system/" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">⚡</span>
             <span class="app-card__title">Alive System</span>
             <span class="app-card__meta">Track energy, urges, social reps, and dopamine redirects through the portal Gun relay.</span>
@@ -552,7 +553,8 @@
             <span class="app-card__title">Education Suite</span>
             <span class="app-card__meta">Practice web design now, then follow the roadmap into Python, languages, databases, and cloud labs.</span>
           </a>
-          <a href="attention-visualized/" class="app-card">
+          <a href="attention-visualized/" class="app-card" data-app-tier="experimental">
+            <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">AI</span>
             <span class="app-card__title">Attention Visualized</span>
             <span class="app-card__meta">See self-attention, softmax, Q/K/V, and tiny JavaScript attention in one browser lab.</span>
@@ -749,8 +751,10 @@
           <a
             href="body-mode/"
             class="app-card"
+            data-app-tier="experimental"
             data-app-keywords="body mode wellness posture breathing nervous system sensory reset sleep action"
           >
+            <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">BODY</span>
             <span class="app-card__title">Body Mode</span>
             <span class="app-card__meta">

--- a/tests/alive-system.test.js
+++ b/tests/alive-system.test.js
@@ -27,6 +27,10 @@ describe('alive system app', () => {
     assert.match(js, /portal-alive-system-cache/);
 
     assert.match(portalIndex, /href="alive-system\/"/);
+    assert.match(
+      portalIndex,
+      /<a href="alive-system\/" class="app-card" data-app-tier="experimental">\s*<span class="app-card__badge">Experimental<\/span>/
+    );
     assert.match(portalIndex, /<span class="app-card__title">Alive System<\/span>/);
     assert.match(readme, /\[Alive System\]\(https:\/\/3dvr-portal\.vercel\.app\/alive-system\/\)/);
     assert.match(readme, /gun\.get\('3dvr-portal'\)\.get\('alive-system'\)/);

--- a/tests/attention-visualized.test.js
+++ b/tests/attention-visualized.test.js
@@ -70,6 +70,10 @@ test('portal homepage links to attention visualized near Learn', async () => {
   assert.ok(learnIndex < attentionIndex, 'Attention Visualized should render after Learn');
   assert.ok(attentionIndex < logicIndex, 'Attention Visualized should render before Logic Lab');
   assert.match(html, /href="attention-visualized\/"/);
+  assert.match(
+    html,
+    /<a href="attention-visualized\/" class="app-card" data-app-tier="experimental">\s*<span class="app-card__badge">Experimental<\/span>/
+  );
   assert.match(html, /See self-attention, softmax, Q\/K\/V, and tiny JavaScript attention in one browser lab\./);
 });
 

--- a/tests/body-mode.test.js
+++ b/tests/body-mode.test.js
@@ -140,6 +140,10 @@ test('Portal registry and docs link to Body Mode', async () => {
   const manifest = await readFile(new URL('../app-manifests/body-mode.webmanifest', import.meta.url), 'utf8');
 
   assert.match(portal, /href="body-mode\/"/);
+  assert.match(
+    portal,
+    /href="body-mode\/"\s*class="app-card"\s*data-app-tier="experimental"\s*data-app-keywords="body mode wellness posture breathing nervous system sensory reset sleep action"\s*>\s*<span class="app-card__badge">Experimental<\/span>/
+  );
   assert.match(portal, />Body Mode</);
   assert.match(portal, /sensory-friendly breath, posture, reflection, and action tools/);
   assert.match(wellness, /href="body-mode\/"/);

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -74,6 +74,7 @@ describe('portal customer journey pages', () => {
     assert.match(globalCss, /text-size-adjust:\s*100%/);
     assert.match(css, /@media \(max-width: 380px\)/);
     assert.match(css, /\.hero-actions \.cta\s*\{/);
+    assert.match(css, /@media \(min-width: 721px\) \{[\s\S]*?\.hero-actions \{[\s\S]*?grid-template-columns:\s*repeat\(4,\s*max-content\);[\s\S]*?\.hero-actions \.cta \{[\s\S]*?padding:\s*0\.58rem 1rem;/);
     assert.match(css, /font-size:\s*clamp\(2rem,\s*8\.8vw,\s*2\.35rem\)/);
     assert.doesNotMatch(css, /botanical-border/);
     assert.doesNotMatch(css, /body\.landing::before/);


### PR DESCRIPTION
## Summary
- Shrink the portal hero action buttons on desktop while leaving the mobile layout unchanged.
- Move Alive System, Attention Visualized, and Body Mode into the experimental app tier.
- Add focused tests for the desktop button sizing and experimental app classification.

## Validation
- `npm test -- tests/customer-journey-pages.test.js tests/revenue-desk.test.js tests/homepage-search-ux.test.js tests/alive-system.test.js tests/attention-visualized.test.js tests/body-mode.test.js tests/education-suite.test.js`

## Notes
- A full `npm test` run still has existing baseline failures unrelated to this change, including Vercel insights tag assertions and copy/content assertions.