### PR TITLE
[codex] Default portal to workshop view

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
   <script defer src="/_vercel/insights/script.js"></script>
 </head>
-<body class="landing theme-dark" data-view-mode="human-os" data-active-room="">
+<body class="landing theme-dark" data-view-mode="workshop" data-active-room="">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <div class="app-boot" aria-hidden="true">
     <div class="app-boot__mark">
@@ -143,8 +143,8 @@
         <button type="button" class="top-nav__search" data-app-search-trigger>Search apps</button>
       </div>
       <div class="view-toggle-container" aria-label="Portal view mode">
-        <button class="toggle-btn" type="button" data-view-mode-button="human-os" data-active="true">Human O.S.</button>
-        <button class="toggle-btn" type="button" data-view-mode-button="workshop" data-active="false">Workshop</button>
+        <button class="toggle-btn" type="button" data-view-mode-button="human-os" data-active="false">Human O.S.</button>
+        <button class="toggle-btn" type="button" data-view-mode-button="workshop" data-active="true">Workshop</button>
       </div>
       <nav class="top-buttons" id="landingQuickLinks" aria-label="3DVR quick links">
         <a href="https://3dvr.tech">Home</a>
@@ -2046,7 +2046,7 @@
     });
 
     const initialSearchValue = searchInput?.value ?? '';
-    setViewMode('human-os');
+    setViewMode('workshop');
     updateAppFilter(initialSearchValue);
   </script>
   <script defer src="/issue-launcher.js"></script>

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -5,7 +5,7 @@ import { readFile } from 'node:fs/promises';
 describe('portal customer journey pages', () => {
   it('gives the portal home a clear concrete entry path', async () => {
     const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
-    assert.match(html, /data-view-mode="human-os" data-active-room=""/);
+    assert.match(html, /data-view-mode="workshop" data-active-room=""/);
     assert.match(html, /Find your purpose\. Organize your life\. Launch your world\./);
     assert.match(html, /What are you trying to organize today\?/);
     assert.match(html, /Human O\.S\./);


### PR DESCRIPTION
## Summary
- Defaults the portal view switch to Workshop instead of Human O.S.
- Keeps Human O.S. available from the toggle.
- Updates the homepage journey assertion for the new default state.

## Validation
- `node --test tests/customer-journey-pages.test.js tests/homepage-search-ux.test.js tests/portal-home-mobile-layout.test.js`
- Browser sanity check at 390px mobile viewport for Workshop default, visible app dock, hidden Human O.S. map, and no horizontal overflow.
