### PR TITLE
[codex] Add 3DVR Forge product route

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -1,0 +1,559 @@
+const STORAGE_KEY = '3dvr.forge.session.v1';
+
+const stage = {
+  INTRO: 'intro',
+  INITIAL: 'initial',
+  FOLLOWUPS: 'followups',
+  GENERATING: 'generating',
+  BRIEF: 'brief',
+};
+
+const defaultFollowUps = [
+  {
+    key: 'audience',
+    question: 'Who else has this problem?',
+  },
+  {
+    key: 'tried',
+    question: 'What have you already tried?',
+  },
+  {
+    key: 'tiny',
+    question: 'What would a tiny version look like in 7 days?',
+  },
+];
+
+const followUpPool = {
+  shape: {
+    key: 'shape',
+    question: 'Do you want this to become a tool, service, community, content project, or business?',
+  },
+  resources: {
+    key: 'resources',
+    question: 'What skills or resources do you already have?',
+  },
+};
+
+const briefOrder = [
+  ['projectName', 'Project Name'],
+  ['coreFrustration', 'Core Frustration'],
+  ['audience', 'Audience'],
+  ['projectConcept', 'Project Concept'],
+  ['tinyExperiment', 'Tiny 7-Day Experiment'],
+  ['firstActions', 'First 3 Actions'],
+  ['testMessage', 'Test Message'],
+  ['codexPrompt', 'Codex Build Prompt'],
+  ['realityCheck', 'Reality Check'],
+];
+
+const refs = {
+  enter: document.querySelector('[data-enter-forge]'),
+  form: document.querySelector('[data-forge-form]'),
+  answer: document.querySelector('[data-forge-answer]'),
+  inputLabel: document.querySelector('[data-input-label]'),
+  submit: document.querySelector('[data-submit-answer]'),
+  reset: document.querySelector('[data-reset-forge]'),
+  transcript: document.querySelector('[data-transcript]'),
+  status: document.querySelector('[data-forge-status]'),
+  conversationPanel: document.querySelector('[data-forge-panel="conversation"]'),
+  briefPanel: document.querySelector('[data-forge-panel="brief"]'),
+  briefOutput: document.querySelector('[data-brief-output]'),
+  copyBrief: document.querySelector('[data-copy-brief]'),
+  downloadBrief: document.querySelector('[data-download-brief]'),
+  resetBrief: document.querySelector('[data-reset-brief]'),
+  messageTemplate: document.getElementById('messageTemplate'),
+  sectionTemplate: document.getElementById('briefSectionTemplate'),
+  nextMoveButtons: Array.from(document.querySelectorAll('[data-next-move]')),
+  nextOutput: document.querySelector('[data-next-output]'),
+  nextOutputTitle: document.querySelector('[data-next-output-title]'),
+  nextOutputBody: document.querySelector('[data-next-output-body]'),
+  copyNextOutput: document.querySelector('[data-copy-next-output]'),
+};
+
+let session = {
+  stage: stage.INTRO,
+  initial: '',
+  followUps: defaultFollowUps,
+  followUpIndex: 0,
+  answers: {},
+  brief: null,
+  nextOutput: '',
+};
+
+function clean(value) {
+  return String(value || '').trim().replace(/\s+/g, ' ');
+}
+
+function sentence(value, fallback) {
+  const text = clean(value) || fallback;
+  return `${text.replace(/[.?!]+$/, '')}.`;
+}
+
+function clause(value, fallback) {
+  return (clean(value) || fallback).replace(/[.?!]+$/, '');
+}
+
+function titleCase(value) {
+  return clean(value)
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function meaningfulWords(value) {
+  const stop = new Set([
+    'the',
+    'and',
+    'but',
+    'with',
+    'that',
+    'this',
+    'they',
+    'them',
+    'just',
+    'really',
+    'feel',
+    'like',
+    'into',
+    'from',
+    'have',
+    'been',
+    'about',
+    'because',
+  ]);
+  return clean(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .filter((word) => word.length > 2 && !stop.has(word));
+}
+
+function chooseFollowUps(initial) {
+  const lower = clean(initial).toLowerCase();
+  const chosen = [...defaultFollowUps];
+
+  if (/\b(app|software|tool|site|website|business|startup|service|community|content)\b/.test(lower)) {
+    chosen[1] = followUpPool.shape;
+  }
+
+  if (/\b(skill|build|make|code|design|write|film|stage|tech|crew|freelance)\b/.test(lower)) {
+    chosen[2] = followUpPool.resources;
+  }
+
+  return chosen.slice(0, 3);
+}
+
+function deriveProjectName(initial, answers) {
+  const shape = clause(answers.shape, '');
+  const words = meaningfulWords(`${initial} ${shape}`).slice(0, 4);
+  if (/\bstage|crew|theater|theatre|tech\b/i.test(initial)) return 'Crew Signal Forge';
+  if (/\bjob|work|burned|burnt|boss|shift\b/i.test(initial)) return 'Unlaunched Work Test';
+  if (/\bclient|customer|service\b/i.test(initial)) return 'Service Signal Test';
+  if (words.length >= 2) return `${titleCase(words.join(' '))} Project`;
+  return 'Useful Project Test';
+}
+
+function guessProjectShape(answers) {
+  const shape = clean(answers.shape).toLowerCase();
+  if (shape) return shape;
+  const tiny = clean(answers.tiny).toLowerCase();
+  if (tiny.includes('page') || tiny.includes('site')) return 'landing page and outreach test';
+  if (tiny.includes('group') || tiny.includes('community')) return 'small community test';
+  if (tiny.includes('service') || tiny.includes('offer')) return 'service offer';
+  if (tiny.includes('app') || tiny.includes('tool')) return 'simple tool prototype';
+  return 'small useful offer';
+}
+
+function buildMockMovementBrief(currentSession) {
+  const initial = clean(currentSession.initial);
+  const answers = currentSession.answers;
+  const projectName = deriveProjectName(initial, answers);
+  const audience = clause(answers.audience, 'frustrated working people with hidden skills');
+  const tiny = clause(answers.tiny, 'a one-page promise plus a message sent to 10 people');
+  const tried = clause(answers.tried, 'thinking about it alone');
+  const resources = clause(answers.resources, 'your existing skills, phone, laptop, and direct network');
+  const shape = guessProjectShape(answers);
+  const coreFrustration = sentence(
+    initial,
+    'You can feel a useful project trying to form, but it is still scattered and under-tested'
+  );
+  const projectConcept = `${projectName} is a ${shape} for ${audience}. It starts from this tension: ${coreFrustration} The first useful version should avoid platform fantasy and prove whether people respond.`;
+  const tinyExperiment = `In 7 days, make ${tiny}. Send it to 10 specific people, ask what feels useful or unclear, and track replies without building a full app.`;
+  const firstActions = [
+    `Write a one-paragraph project promise for ${audience}.`,
+    `Send the test message to 10 people before adding features.`,
+    `Turn the strongest reply into the next tiny build or service step.`,
+  ];
+  const testMessage = `I am testing an idea called ${projectName}. It is for ${audience} who are dealing with this: ${coreFrustration} The tiny version is ${tiny}. Does this feel useful, too vague, or not your problem?`;
+  const codexPrompt = [
+    `Build a minimal first version of ${projectName}.`,
+    '',
+    `Audience: ${audience}.`,
+    `Core frustration: ${coreFrustration}`,
+    `Tiny experiment: ${tinyExperiment}`,
+    '',
+    'Requirements:',
+    '- Make a focused landing page or single-screen prototype.',
+    '- Include one clear call to action for feedback or signups.',
+    '- Keep the implementation small and mobile-first.',
+    '- Do not add accounts, dashboards, or complex persistence unless required.',
+    '- Add tests or a simple verification path for the core interaction.',
+  ].join('\n');
+  const realityCheck = [
+    'Good raw material. Too vague right now unless the audience is named in plain language.',
+    `You already tried ${tried}; do not repeat that as the next step.`,
+    `Use ${resources} first. This is probably not a startup yet. It is a test.`,
+    'Do not build an app yet if a direct message can test the signal faster.',
+  ];
+
+  return {
+    projectName,
+    coreFrustration,
+    audience,
+    projectConcept,
+    tinyExperiment,
+    firstActions,
+    testMessage,
+    codexPrompt,
+    realityCheck,
+  };
+}
+
+function saveSession() {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  } catch {
+    // Forge v1 should stay usable even when storage is blocked.
+  }
+}
+
+function clearSession() {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+function loadSession() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      session = {
+        ...session,
+        ...parsed,
+        followUps: Array.isArray(parsed.followUps) ? parsed.followUps : defaultFollowUps,
+        answers: parsed.answers && typeof parsed.answers === 'object' ? parsed.answers : {},
+      };
+    }
+  } catch {
+    clearSession();
+  }
+}
+
+function addMessage(role, text) {
+  const node = refs.messageTemplate.content.firstElementChild.cloneNode(true);
+  node.classList.toggle('forge-message--user', role === 'You');
+  node.querySelector('.forge-message__role').textContent = role;
+  node.querySelector('p').textContent = text;
+  refs.transcript.appendChild(node);
+}
+
+function renderTranscript() {
+  refs.transcript.replaceChildren();
+  addMessage('Forge', 'What’s been bothering you lately? Rant, ramble, complain, dream, or describe the thing you can’t stop thinking about.');
+
+  if (session.initial) {
+    addMessage('You', session.initial);
+  }
+
+  session.followUps.forEach((followUp, index) => {
+    if (index < session.followUpIndex || session.answers[followUp.key]) {
+      addMessage('Forge', followUp.question);
+    }
+    if (session.answers[followUp.key]) {
+      addMessage('You', session.answers[followUp.key]);
+    }
+  });
+
+  if (session.stage === stage.GENERATING) {
+    addMessage('Forge', 'Good raw material. Too vague right now. Let’s sharpen it into a test.');
+  }
+}
+
+function currentPrompt() {
+  if (session.stage === stage.INITIAL || session.stage === stage.INTRO) {
+    return {
+      label: 'Rant, ramble, complain, dream, or describe the thing you can’t stop thinking about.',
+      button: session.initial ? 'Continue' : 'Start forging',
+    };
+  }
+
+  const followUp = session.followUps[session.followUpIndex];
+  return {
+    label: followUp?.question || 'Ready to forge the brief.',
+    button: session.followUpIndex >= session.followUps.length - 1 ? 'Forge Movement Brief' : 'Answer',
+  };
+}
+
+function renderBriefSection(key, label, value) {
+  const node = refs.sectionTemplate.content.firstElementChild.cloneNode(true);
+  node.classList.toggle('brief-section--strong', key === 'projectName' || key === 'realityCheck');
+  node.querySelector('.brief-section__label').textContent = label;
+  const body = node.querySelector('.brief-section__body');
+
+  if (Array.isArray(value)) {
+    const list = document.createElement(key === 'firstActions' ? 'ol' : 'ul');
+    value.forEach((item) => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      list.appendChild(li);
+    });
+    body.appendChild(list);
+  } else if (key === 'projectName') {
+    const heading = document.createElement('h3');
+    heading.textContent = value;
+    body.appendChild(heading);
+  } else {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = value;
+    body.appendChild(paragraph);
+  }
+
+  refs.briefOutput.appendChild(node);
+}
+
+function renderBrief() {
+  refs.briefOutput.replaceChildren();
+  if (!session.brief) return;
+
+  briefOrder.forEach(([key, label]) => {
+    renderBriefSection(key, label, session.brief[key]);
+  });
+}
+
+function briefToMarkdown(brief) {
+  if (!brief) return '';
+  return [
+    `# ${brief.projectName}`,
+    '',
+    '## Core Frustration',
+    brief.coreFrustration,
+    '',
+    '## Audience',
+    brief.audience,
+    '',
+    '## Project Concept',
+    brief.projectConcept,
+    '',
+    '## Tiny 7-Day Experiment',
+    brief.tinyExperiment,
+    '',
+    '## First 3 Actions',
+    ...brief.firstActions.map((item) => `- ${item}`),
+    '',
+    '## Test Message',
+    brief.testMessage,
+    '',
+    '## Codex Build Prompt',
+    brief.codexPrompt,
+    '',
+    '## Reality Check',
+    ...brief.realityCheck.map((item) => `- ${item}`),
+    '',
+  ].join('\n');
+}
+
+function makeLandingCopy(brief) {
+  return [
+    `${brief.projectName}`,
+    '',
+    `${brief.projectConcept}`,
+    '',
+    `For: ${brief.audience}.`,
+    '',
+    `This week's test: ${brief.tinyExperiment}`,
+    '',
+    'Want to react to the first version? Reply with what feels useful, vague, or missing.',
+  ].join('\n');
+}
+
+function makeChecklist(brief) {
+  return [
+    'Day 1: Rewrite the project promise in one paragraph.',
+    'Day 2: Choose 10 real people who match the audience.',
+    'Day 3: Send the test message.',
+    'Day 4: Track replies and objections.',
+    'Day 5: Build only the smallest useful artifact.',
+    'Day 6: Show the artifact to 3 people.',
+    'Day 7: Decide whether to continue, change the audience, or stop.',
+    '',
+    `Project: ${brief.projectName}`,
+  ].join('\n');
+}
+
+function renderNextOutput(kind) {
+  if (!session.brief) return;
+
+  const outputs = {
+    testMessage: ['Test Message', session.brief.testMessage],
+    codexPrompt: ['Codex Build Prompt', session.brief.codexPrompt],
+    landingCopy: ['Landing Page Copy', makeLandingCopy(session.brief)],
+    checklist: ['7-Day Checklist', makeChecklist(session.brief)],
+  };
+  const [title, body] = outputs[kind] || outputs.testMessage;
+
+  session.nextOutput = body;
+  refs.nextOutputTitle.textContent = title;
+  refs.nextOutputBody.textContent = body;
+  refs.nextOutput.hidden = false;
+  saveSession();
+}
+
+function render() {
+  const prompt = currentPrompt();
+
+  refs.inputLabel.textContent = prompt.label;
+  refs.submit.textContent = prompt.button;
+  refs.answer.value = '';
+  refs.answer.disabled = session.stage === stage.GENERATING || session.stage === stage.BRIEF;
+  refs.submit.disabled = session.stage === stage.GENERATING || session.stage === stage.BRIEF;
+  refs.briefPanel.hidden = session.stage !== stage.BRIEF;
+  refs.status.textContent = session.stage === stage.BRIEF
+    ? 'Movement Brief generated. Copy it or choose one next move.'
+    : 'No login required. This v1 runs in your browser.';
+
+  renderTranscript();
+  renderBrief();
+
+  if (session.nextOutput && refs.nextOutput.hidden && session.stage === stage.BRIEF) {
+    refs.nextOutputBody.textContent = session.nextOutput;
+    refs.nextOutput.hidden = false;
+  }
+}
+
+function startForge() {
+  session.stage = session.initial ? stage.FOLLOWUPS : stage.INITIAL;
+  render();
+  refs.conversationPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  window.requestAnimationFrame(() => refs.answer.focus());
+}
+
+function generateBrief() {
+  session.stage = stage.GENERATING;
+  render();
+
+  window.setTimeout(() => {
+    session.brief = buildMockMovementBrief(session);
+    session.stage = stage.BRIEF;
+    saveSession();
+    render();
+    refs.briefPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, 420);
+}
+
+function handleSubmit(event) {
+  event.preventDefault();
+  const value = clean(refs.answer.value);
+  if (!value) {
+    refs.status.textContent = 'Give the Forge raw material first.';
+    return;
+  }
+
+  if (session.stage === stage.INTRO || session.stage === stage.INITIAL) {
+    session.initial = value;
+    session.followUps = chooseFollowUps(value);
+    session.followUpIndex = 0;
+    session.stage = stage.FOLLOWUPS;
+    saveSession();
+    render();
+    return;
+  }
+
+  const followUp = session.followUps[session.followUpIndex];
+  if (followUp) {
+    session.answers[followUp.key] = value;
+  }
+
+  if (session.followUpIndex >= session.followUps.length - 1) {
+    saveSession();
+    generateBrief();
+    return;
+  }
+
+  session.followUpIndex += 1;
+  saveSession();
+  render();
+}
+
+async function writeText(text, successMessage) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const fallback = document.createElement('textarea');
+    fallback.value = text;
+    fallback.setAttribute('readonly', '');
+    fallback.style.position = 'fixed';
+    fallback.style.left = '-9999px';
+    document.body.appendChild(fallback);
+    fallback.select();
+    document.execCommand('copy');
+    fallback.remove();
+  }
+  refs.status.textContent = successMessage;
+}
+
+function downloadBrief() {
+  if (!session.brief) return;
+  const blob = new Blob([briefToMarkdown(session.brief)], { type: 'text/markdown' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${session.brief.projectName.toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'forge-brief'}.md`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  refs.status.textContent = 'Movement Brief downloaded.';
+}
+
+function resetForge() {
+  session = {
+    stage: stage.INTRO,
+    initial: '',
+    followUps: defaultFollowUps,
+    followUpIndex: 0,
+    answers: {},
+    brief: null,
+    nextOutput: '',
+  };
+  refs.nextOutput.hidden = true;
+  refs.nextOutputBody.textContent = '';
+  clearSession();
+  render();
+}
+
+refs.enter?.addEventListener('click', startForge);
+refs.form?.addEventListener('submit', handleSubmit);
+refs.reset?.addEventListener('click', resetForge);
+refs.resetBrief?.addEventListener('click', resetForge);
+refs.copyBrief?.addEventListener('click', () => {
+  if (session.brief) {
+    writeText(briefToMarkdown(session.brief), 'Movement Brief copied.');
+  }
+});
+refs.downloadBrief?.addEventListener('click', downloadBrief);
+refs.nextMoveButtons.forEach((button) => {
+  button.addEventListener('click', () => renderNextOutput(button.dataset.nextMove));
+});
+refs.copyNextOutput?.addEventListener('click', () => {
+  if (session.nextOutput) {
+    writeText(session.nextOutput, 'Next move copied.');
+  }
+});
+
+loadSession();
+render();

--- a/forge/index.html
+++ b/forge/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>3DVR Forge | Turn frustration into a project</title>
+  <meta
+    name="description"
+    content="3DVR Forge turns messy thoughts, rants, and ideas into a Movement Brief, tiny 7-day experiment, and next actions."
+  >
+  <meta name="theme-color" content="#111827">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="../index-style.css">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="landing theme-dark forge-page">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+  <div class="landing-shell forge-shell">
+    <header class="top-nav">
+      <nav class="top-buttons" aria-label="Forge navigation">
+        <a href="../index.html">Portal</a>
+        <a href="../launch-room/">Launch Room</a>
+        <a href="../web-builder-app/">Codex Bench</a>
+      </nav>
+    </header>
+
+    <main id="mainContent" class="landing-content">
+      <section class="forge-hero" aria-labelledby="forgeTitle">
+        <div class="forge-hero__copy">
+          <span class="hero-eyebrow">3DVR Forge</span>
+          <h1 id="forgeTitle">Turn your frustration into a project.</h1>
+          <p class="forge-hero__subheadline">
+            Rant, ramble, complain, dream, or describe the thing you can't stop thinking about.
+            3DVR Forge turns it into a Movement Brief, a tiny experiment, and your next actions.
+          </p>
+          <div class="forge-hero__actions">
+            <button class="cta primary" type="button" data-enter-forge>Enter the Forge</button>
+          </div>
+        </div>
+        <aside class="forge-principle" aria-label="Forge promise">
+          <p>Rant. Reflect. Forge a project.</p>
+          <span>In 15 minutes, turn a frustration into a project brief and a 7-day test plan.</span>
+        </aside>
+      </section>
+
+      <section class="forge-workspace" aria-labelledby="forgeRoomTitle">
+        <div class="forge-panel forge-conversation" data-forge-panel="conversation">
+          <div class="forge-panel__header">
+            <span class="eyebrow">Forge Room</span>
+            <h2 id="forgeRoomTitle">What’s been bothering you lately?</h2>
+            <p>
+              Say the messy version first. The Forge will challenge vague parts and shape the raw material into a test.
+            </p>
+          </div>
+
+          <div class="forge-transcript" data-transcript aria-live="polite"></div>
+
+          <form class="forge-input" data-forge-form>
+            <label for="forgeAnswer" class="forge-input__label" data-input-label>
+              Rant, ramble, complain, dream, or describe the thing you can't stop thinking about.
+            </label>
+            <textarea
+              id="forgeAnswer"
+              rows="7"
+              maxlength="2400"
+              placeholder="Example: I keep seeing skilled people stuck in draining jobs, but they have useful ideas and no clean way to test them."
+              data-forge-answer
+              required
+            ></textarea>
+            <div class="forge-input__actions">
+              <button class="cta primary" type="submit" data-submit-answer>Start forging</button>
+              <button class="cta ghost" type="button" data-reset-forge>Reset</button>
+            </div>
+            <p class="forge-status" data-forge-status role="status" aria-live="polite">
+              No login required. This v1 runs in your browser.
+            </p>
+          </form>
+        </div>
+
+        <aside class="forge-panel forge-brief" data-forge-panel="brief" hidden aria-labelledby="movementBriefTitle">
+          <div class="forge-panel__header">
+            <span class="eyebrow">Movement Brief</span>
+            <h2 id="movementBriefTitle">Readable output</h2>
+            <p>Good raw material becomes a testable project. Copy it, send it, or hand the build prompt to Codex.</p>
+          </div>
+
+          <div class="forge-brief__actions" aria-label="Movement Brief actions">
+            <button class="cta ghost" type="button" data-copy-brief>Copy Brief</button>
+            <button class="cta ghost" type="button" data-download-brief>Download Markdown</button>
+            <button class="cta ghost" type="button" data-reset-brief>Forge Another</button>
+          </div>
+
+          <div class="movement-brief-grid" data-brief-output></div>
+
+          <div class="forge-next-moves" aria-labelledby="nextMoveTitle">
+            <div>
+              <span class="eyebrow">Next move</span>
+              <h3 id="nextMoveTitle">Do not overbuild yet.</h3>
+            </div>
+            <div class="forge-next-moves__buttons">
+              <button type="button" data-next-move="testMessage">Make test message</button>
+              <button type="button" data-next-move="codexPrompt">Make Codex prompt</button>
+              <button type="button" data-next-move="landingCopy">Make landing page copy</button>
+              <button type="button" data-next-move="checklist">Make 7-day checklist</button>
+            </div>
+            <article class="next-output" data-next-output hidden>
+              <div class="next-output__header">
+                <h4 data-next-output-title>Next move</h4>
+                <button type="button" data-copy-next-output>Copy</button>
+              </div>
+              <pre data-next-output-body></pre>
+            </article>
+          </div>
+        </aside>
+      </section>
+    </main>
+
+    <footer>
+      3DVR.Tech &copy; 2025 - Open Web for Everyone | <a href="../index.html">Back to Portal</a>
+    </footer>
+  </div>
+
+  <template id="messageTemplate">
+    <article class="forge-message">
+      <span class="forge-message__role"></span>
+      <p></p>
+    </article>
+  </template>
+
+  <template id="briefSectionTemplate">
+    <article class="brief-section">
+      <p class="brief-section__label"></p>
+      <div class="brief-section__body"></div>
+    </article>
+  </template>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/forge/styles.css
+++ b/forge/styles.css
@@ -1,0 +1,384 @@
+:root {
+  color-scheme: dark;
+  --forge-bg: #0b111c;
+  --forge-panel: rgba(17, 24, 39, 0.76);
+  --forge-panel-strong: rgba(24, 32, 45, 0.92);
+  --forge-line: rgba(248, 190, 96, 0.2);
+  --forge-line-strong: rgba(248, 190, 96, 0.42);
+  --forge-text: #fff7ed;
+  --forge-muted: #cbd5e1;
+  --forge-hot: #f59e0b;
+  --forge-ember: #ef4444;
+  --forge-blue: #38bdf8;
+  --forge-green: #34d399;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  overflow-x: hidden;
+}
+
+.forge-page {
+  background:
+    radial-gradient(circle at 16% 10%, rgba(245, 158, 11, 0.18), transparent 30rem),
+    radial-gradient(circle at 82% 18%, rgba(56, 189, 248, 0.14), transparent 34rem),
+    linear-gradient(180deg, #0b111c 0%, #111827 52%, #090d15 100%);
+  color: var(--forge-text);
+}
+
+.forge-shell {
+  width: min(100%, 1180px);
+}
+
+.forge-page .top-nav {
+  margin-bottom: 1.4rem;
+}
+
+.forge-hero {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border: 1px solid var(--forge-line);
+  border-radius: calc(var(--radius-lg) + 0.15rem);
+  background:
+    linear-gradient(145deg, rgba(26, 32, 44, 0.92), rgba(12, 18, 29, 0.78)),
+    var(--forge-panel);
+  box-shadow: 0 34px 90px rgba(3, 7, 18, 0.48);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.forge-hero::before {
+  content: "";
+  position: absolute;
+  inset: -30% 45% auto -20%;
+  height: 22rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(245, 158, 11, 0.26), transparent 68%);
+  z-index: -1;
+}
+
+.forge-hero__copy {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.forge-hero h1 {
+  max-width: 13ch;
+  margin: 0;
+  font-size: clamp(2.6rem, 7vw, 5.4rem);
+  line-height: 0.93;
+  letter-spacing: 0;
+}
+
+.forge-hero__subheadline {
+  max-width: 690px;
+  margin: 0;
+  color: var(--forge-muted);
+  font-size: clamp(1.02rem, 0.9rem + 0.55vw, 1.32rem);
+  line-height: 1.65;
+}
+
+.forge-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.forge-principle {
+  display: grid;
+  gap: 0.6rem;
+  align-content: end;
+  padding: 1rem;
+  border: 1px solid rgba(245, 158, 11, 0.24);
+  border-radius: var(--radius-lg);
+  background: rgba(9, 13, 21, 0.66);
+}
+
+.forge-principle p {
+  margin: 0;
+  color: var(--forge-hot);
+  font-size: clamp(1.3rem, 1rem + 1vw, 2rem);
+  font-weight: 850;
+  line-height: 1.1;
+}
+
+.forge-principle span {
+  color: var(--forge-muted);
+  line-height: 1.5;
+}
+
+.forge-workspace {
+  display: grid;
+  gap: 1rem;
+}
+
+.forge-panel {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  padding: clamp(1rem, 2vw, 1.35rem);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-lg);
+  background: var(--forge-panel);
+  box-shadow: 0 24px 70px rgba(3, 7, 18, 0.38);
+}
+
+.forge-panel[hidden] {
+  display: none;
+}
+
+.forge-panel__header {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.forge-panel__header h2 {
+  margin: 0;
+  font-size: clamp(1.7rem, 1.1rem + 2vw, 3rem);
+  line-height: 1;
+}
+
+.forge-panel__header p {
+  margin: 0;
+  max-width: 720px;
+  color: var(--forge-muted);
+  line-height: 1.6;
+}
+
+.forge-transcript {
+  display: grid;
+  gap: 0.75rem;
+  min-height: 5rem;
+}
+
+.forge-message {
+  display: grid;
+  gap: 0.35rem;
+  max-width: 92%;
+  padding: 0.85rem 0.95rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(11, 15, 24, 0.7);
+}
+
+.forge-message--user {
+  justify-self: end;
+  background: rgba(14, 116, 144, 0.28);
+  border-color: rgba(56, 189, 248, 0.28);
+}
+
+.forge-message__role {
+  color: var(--forge-hot);
+  font-size: 0.75rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.forge-message p {
+  margin: 0;
+  color: var(--forge-text);
+  line-height: 1.55;
+}
+
+.forge-input {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.forge-input__label {
+  color: var(--forge-muted);
+  font-weight: 750;
+}
+
+.forge-input textarea {
+  width: 100%;
+  min-height: 11rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: var(--radius-md);
+  background: rgba(8, 13, 23, 0.96);
+  color: var(--forge-text);
+  font: inherit;
+  line-height: 1.55;
+  resize: vertical;
+}
+
+.forge-input textarea:focus-visible {
+  outline: 2px solid rgba(245, 158, 11, 0.62);
+  outline-offset: 2px;
+}
+
+.forge-input__actions,
+.forge-brief__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.forge-status {
+  margin: 0;
+  color: var(--forge-muted);
+  font-size: 0.92rem;
+}
+
+.movement-brief-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.brief-section {
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: var(--radius-md);
+  background: rgba(9, 13, 21, 0.82);
+}
+
+.brief-section--strong {
+  border-color: var(--forge-line-strong);
+  background: linear-gradient(145deg, rgba(120, 53, 15, 0.24), rgba(9, 13, 21, 0.9));
+}
+
+.brief-section__label {
+  margin: 0;
+  color: var(--forge-hot);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.brief-section__body {
+  color: var(--forge-muted);
+  line-height: 1.58;
+}
+
+.brief-section__body h3,
+.brief-section__body p {
+  margin: 0;
+}
+
+.brief-section__body h3 {
+  color: var(--forge-text);
+  font-size: clamp(1.35rem, 1rem + 1vw, 2rem);
+  line-height: 1.1;
+}
+
+.brief-section__body ul,
+.brief-section__body ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.forge-next-moves {
+  display: grid;
+  gap: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.forge-next-moves h3,
+.next-output h4 {
+  margin: 0;
+}
+
+.forge-next-moves__buttons {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+}
+
+.forge-next-moves__buttons button,
+.next-output__header button {
+  min-height: 2.65rem;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid rgba(245, 158, 11, 0.26);
+  border-radius: 999px;
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--forge-text);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.forge-next-moves__buttons button:hover,
+.forge-next-moves__buttons button:focus-visible,
+.next-output__header button:hover,
+.next-output__header button:focus-visible {
+  border-color: rgba(245, 158, 11, 0.58);
+  outline: none;
+}
+
+.next-output {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+  border-radius: var(--radius-md);
+  background: rgba(6, 78, 59, 0.18);
+}
+
+.next-output[hidden] {
+  display: none;
+}
+
+.next-output__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.next-output pre {
+  margin: 0;
+  white-space: pre-wrap;
+  color: var(--forge-muted);
+  font: inherit;
+  line-height: 1.55;
+}
+
+@media (min-width: 940px) {
+  .forge-hero {
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 0.42fr);
+    align-items: stretch;
+  }
+
+  .forge-workspace {
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+    align-items: start;
+  }
+}
+
+@media (max-width: 640px) {
+  .forge-shell {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .forge-hero,
+  .forge-panel,
+  .brief-section,
+  .next-output {
+    border-radius: 1rem;
+  }
+
+  .forge-hero h1 {
+    font-size: clamp(2.35rem, 13vw, 3.3rem);
+  }
+
+  .forge-input__actions .cta,
+  .forge-brief__actions .cta {
+    width: 100%;
+  }
+}

--- a/index-style.css
+++ b/index-style.css
@@ -1720,8 +1720,8 @@ footer a {
   }
 
   .hero-actions {
-    grid-template-columns: repeat(4, max-content);
-    width: fit-content;
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+    width: min(100%, 44rem);
     max-width: 100%;
   }
 

--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
       <nav class="top-buttons" id="landingQuickLinks" aria-label="3DVR quick links">
         <a href="https://3dvr.tech">Home</a>
         <a href="start/">Start</a>
+        <a href="forge/">Forge</a>
         <a href="start/#paid-lanes">Plans</a>
         <a href="#app-hub-title" data-app-search-trigger>Apps</a>
         <a href="games.html">Games</a>
@@ -187,7 +188,8 @@
               What are you trying to organize today?
             </p>
             <div class="hero-actions">
-              <a href="revenue-desk/" class="cta primary">Open Revenue Desk</a>
+              <a href="forge/" class="cta primary">Enter the Forge</a>
+              <a href="revenue-desk/" class="cta ghost">Open Revenue Desk</a>
               <a href="crm/index.html" class="cta ghost">Open CRM</a>
               <a href="sales/index.html" class="cta ghost">Open Sales</a>
               <a href="web-builder-app/index.html" class="cta ghost">Open Web Builder</a>
@@ -386,6 +388,12 @@
         </div>
         <p id="appSearchEmpty" class="app-search__empty" role="status" aria-live="polite" hidden>No apps match your search yet.</p>
         <div class="app-grid" data-app-list>
+          <a href="forge/" class="app-card" data-app-keywords="forge frustration rant reflect project movement brief experiment codex prompt test message launch">
+            <span class="app-card__icon" aria-hidden="true">FG</span>
+            <span class="app-card__title">3DVR Forge</span>
+            <span class="app-card__meta">Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test.</span>
+            <span class="app-card__cta">Enter the Forge</span>
+          </a>
           <a href="start/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">🧭</span>
             <span class="app-card__title">Start Here</span>
@@ -1543,6 +1551,7 @@
         'Workbench Ideas',
       ],
       projects: [
+        '3DVR Forge',
         'Projects',
         'Launch Room',
         'Launch Site',

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -25,6 +25,8 @@ describe('portal customer journey pages', () => {
     assert.match(html, /document\.body\.dataset\.viewMode = mode/);
     assert.match(html, /document\.body\.dataset\.activeRoom = mode === 'human-os' \? nextRoom : ''/);
     assert.doesNotMatch(html, /Grow into your own operating system/);
+    assert.match(html, /href="forge\/">Forge<\/a>/);
+    assert.match(html, /href="forge\/" class="cta primary">Enter the Forge<\/a>/);
     assert.match(html, /Open CRM/);
     assert.match(html, /Open Sales/);
     assert.match(html, /Open Web Builder/);
@@ -73,6 +75,8 @@ describe('portal customer journey pages', () => {
     assert.match(html, /App dock/);
     assert.match(html, /Command center/);
     assert.match(html, /Same account, same apps, deeper levels of control\./);
+    assert.match(html, /<span class="app-card__title">3DVR Forge<\/span>/);
+    assert.match(html, /Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test\./);
     assert.match(html, /data-active-room=""/);
     assert.match(html, /data-view-mode-button="workshop"/);
     assert.doesNotMatch(html, /Suggested launcher lanes/);
@@ -95,7 +99,7 @@ describe('portal customer journey pages', () => {
     assert.match(globalCss, /text-size-adjust:\s*100%/);
     assert.match(css, /@media \(max-width: 380px\)/);
     assert.match(css, /\.hero-actions \.cta\s*\{/);
-    assert.match(css, /@media \(min-width: 721px\) \{[\s\S]*?\.hero-actions \{[\s\S]*?grid-template-columns:\s*repeat\(4,\s*max-content\);[\s\S]*?\.hero-actions \.cta \{[\s\S]*?padding:\s*0\.58rem 1rem;/);
+    assert.match(css, /@media \(min-width: 721px\) \{[\s\S]*?\.hero-actions \{[\s\S]*?grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(9rem,\s*1fr\)\);[\s\S]*?\.hero-actions \.cta \{[\s\S]*?padding:\s*0\.58rem 1rem;/);
     assert.match(css, /font-size:\s*clamp\(2rem,\s*8\.8vw,\s*2\.35rem\)/);
     assert.doesNotMatch(css, /botanical-border/);
     assert.doesNotMatch(css, /body\.landing::before/);

--- a/tests/forge.test.js
+++ b/tests/forge.test.js
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('3DVR Forge product route', () => {
+  it('ships a guest-first Forge landing and conversation shell', async () => {
+    const html = await readFile(new URL('../forge/index.html', import.meta.url), 'utf8');
+
+    assert.match(html, /<title>3DVR Forge \| Turn frustration into a project<\/title>/);
+    assert.match(html, /href="\.\.\/index\.html">Portal<\/a>/);
+    assert.match(html, /href="\.\.\/launch-room\/">Launch Room<\/a>/);
+    assert.match(html, /3DVR Forge/);
+    assert.match(html, /Turn your frustration into a project\./);
+    assert.match(html, /Rant, ramble, complain, dream, or describe the thing you can't stop thinking about\./);
+    assert.match(html, /Enter the Forge/);
+    assert.match(html, /What(?:&rsquo;|’)s been bothering you lately\?/);
+    assert.match(html, /data-forge-form/);
+    assert.match(html, /data-forge-answer/);
+    assert.match(html, /data-brief-output/);
+    assert.match(html, /Make test message/);
+    assert.match(html, /Make Codex prompt/);
+    assert.match(html, /Make landing page copy/);
+    assert.match(html, /Make 7-day checklist/);
+    assert.doesNotMatch(html, /sign[- ]?in/i);
+    assert.doesNotMatch(html, /create an account/i);
+  });
+
+  it('includes a simple state machine and mockable Movement Brief generator', async () => {
+    const app = await readFile(new URL('../forge/app.js', import.meta.url), 'utf8');
+
+    assert.match(app, /const STORAGE_KEY = '3dvr\.forge\.session\.v1'/);
+    assert.match(app, /INTRO: 'intro'/);
+    assert.match(app, /INITIAL: 'initial'/);
+    assert.match(app, /FOLLOWUPS: 'followups'/);
+    assert.match(app, /GENERATING: 'generating'/);
+    assert.match(app, /BRIEF: 'brief'/);
+    assert.match(app, /function chooseFollowUps\(initial\)/);
+    assert.match(app, /function buildMockMovementBrief\(currentSession\)/);
+    assert.match(app, /Who else has this problem\?/);
+    assert.match(app, /What have you already tried\?/);
+    assert.match(app, /What would a tiny version look like in 7 days\?/);
+    assert.match(app, /What skills or resources do you already have\?/);
+    assert.match(app, /Do you want this to become a tool, service, community, content project, or business\?/);
+
+    [
+      'Project Name',
+      'Core Frustration',
+      'Audience',
+      'Project Concept',
+      'Tiny 7-Day Experiment',
+      'First 3 Actions',
+      'Test Message',
+      'Codex Build Prompt',
+      'Reality Check',
+    ].forEach((section) => {
+      assert.match(app, new RegExp(section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    });
+
+    assert.match(app, /Good raw material\. Too vague right now/);
+    assert.match(app, /This is probably not a startup yet\. It is a test\./);
+    assert.match(app, /Do not build an app yet/);
+    assert.match(app, /navigator\.clipboard\.writeText/);
+    assert.match(app, /type: 'text\/markdown'/);
+    assert.match(app, /window\.setTimeout/);
+    assert.match(app, /window\.localStorage\.setItem\(STORAGE_KEY/);
+  });
+
+  it('keeps the Forge CSS mobile-safe and free from viewport-width overflow traps', async () => {
+    const css = await readFile(new URL('../forge/styles.css', import.meta.url), 'utf8');
+
+    assert.match(css, /html,\s*body\s*\{\s*overflow-x:\s*hidden;/);
+    assert.match(css, /\.forge-shell\s*\{\s*width:\s*min\(100%,\s*1180px\);/);
+    assert.match(css, /\.forge-workspace\s*\{\s*display:\s*grid;/);
+    assert.match(css, /min-width:\s*0/);
+    assert.match(css, /@media \(min-width: 940px\)/);
+    assert.match(css, /@media \(max-width: 640px\)/);
+    assert.doesNotMatch(css, /width:\s*100vw/);
+    assert.doesNotMatch(css, /(^|[;{]\s*)min-width:\s*\d{3,}px/m);
+  });
+
+  it('promotes Forge from the portal without changing the workshop default', async () => {
+    const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+    assert.match(html, /data-view-mode="workshop" data-active-room=""/);
+    assert.match(html, /<a href="forge\/">Forge<\/a>/);
+    assert.match(html, /href="forge\/" class="cta primary">Enter the Forge<\/a>/);
+    assert.match(html, /href="forge\/" class="app-card" data-app-keywords="[^"]*\bfrustration\b[^"]*\bmovement brief\b[^"]*"/);
+    assert.match(html, /<span class="app-card__title">3DVR Forge<\/span>/);
+    assert.match(html, /Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test\./);
+    assert.match(html, /projects:\s*\[[\s\S]*?'3DVR Forge'/);
+  });
+});

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -32,6 +32,17 @@ test('homepage app search can find CRM by CRM keywords', async () => {
   assert.match(html, /keywordIncludesQuery/);
 });
 
+test('homepage app search can find Forge by project-shaping keywords', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(
+    html,
+    /href="forge\/" class="app-card" data-app-keywords="[^"]*\bfrustration\b[^"]*\bcodex prompt\b[^"]*"/
+  );
+  assert.match(html, /<span class="app-card__title">3DVR Forge<\/span>/);
+  assert.match(html, /Movement Brief and 7-day test/);
+});
+
 test('homepage app search can find the manifestation practice', async () => {
   const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
 
@@ -49,5 +60,14 @@ test('homepage top navigation keeps Games one click away', async () => {
   assert.match(
     html,
     /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="games\.html">Games<\/a>/
+  );
+});
+
+test('homepage top navigation keeps Forge one click away', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(
+    html,
+    /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="forge\/">Forge<\/a>/
   );
 });


### PR DESCRIPTION
## Summary
- Add /forge as a focused 3DVR Forge product route with a conversation-first mock AI flow.
- Generate a Movement Brief with project name, frustration, audience, concept, 7-day experiment, first actions, test message, Codex prompt, and reality check.
- Promote Forge from the portal nav, hero actions, app dock, and Human O.S. projects room while keeping Workshop as the default view.
- Make hero action wrapping responsive so the expanded CTA set stays mobile-safe.

## Tests
- node --test tests/forge.test.js tests/customer-journey-pages.test.js tests/homepage-search-ux.test.js tests/portal-home-mobile-layout.test.js
- Playwright Chromium manual flow at 360, 375, 390, and 412px for /forge/, including generated brief and scrollWidth === clientWidth.