### PR TITLE
[codex] Make Forge use AI generation

### DIFF
--- a/api/openai-site.js
+++ b/api/openai-site.js
@@ -1,3 +1,5 @@
+import { createForgeHandler } from '../src/forge/api.js';
+
 export const DEFAULT_MODEL = 'gpt-4.1-mini';
 export const SUPPORTED_SITE_MODELS = Object.freeze([
   'gpt-4o-mini',
@@ -454,5 +456,18 @@ export function createSiteGeneratorHandler(options = {}) {
   };
 }
 
-const handler = createSiteGeneratorHandler();
+export function createOpenAiSiteRouter(options = {}) {
+  const siteHandler = createSiteGeneratorHandler(options);
+  const forgeHandler = createForgeHandler(options.forge || options);
+
+  return async function handler(req, res) {
+    if (req?.body?.forge === true || req?.query?.provider === 'forge') {
+      return forgeHandler(req, res);
+    }
+
+    return siteHandler(req, res);
+  };
+}
+
+const handler = createOpenAiSiteRouter();
 export default handler;

--- a/forge/app.js
+++ b/forge/app.js
@@ -1,4 +1,11 @@
+import { readDefaultSecret } from '../web-builder-app/defaults.js';
+
 const STORAGE_KEY = '3dvr.forge.session.v1';
+const FORGE_MODEL = 'gpt-4.1-mini';
+const SHARED_DEFAULTS_WAIT_MS = 6000;
+
+const gun = window.Gun ? window.Gun({ peers: window.__GUN_PEERS__ || undefined }) : null;
+const defaultsNode = gun?.get('3dvr-portal')?.get('ai-workbench')?.get('defaults');
 
 const stage = {
   INTRO: 'intro',
@@ -78,10 +85,83 @@ let session = {
   answers: {},
   brief: null,
   nextOutput: '',
+  notice: '',
+  briefSource: '',
+};
+let isBusy = false;
+const sharedSecrets = {
+  openai: '',
+};
+const sharedSecretResolvers = {
+  openai: [],
 };
 
 function clean(value) {
   return String(value || '').trim().replace(/\s+/g, ' ');
+}
+
+function setNotice(message) {
+  session.notice = message;
+}
+
+function hasDefaultRecord(data) {
+  return Boolean(
+    data &&
+    typeof data === 'object' &&
+    Object.keys(data).some((key) => key !== '_')
+  );
+}
+
+function resolveSharedSecretWaiters(targetKey) {
+  const waiters = sharedSecretResolvers[targetKey] || [];
+  while (waiters.length) {
+    waiters.shift()?.();
+  }
+}
+
+function subscribeToSharedDefaults() {
+  if (!defaultsNode) {
+    resolveSharedSecretWaiters('openai');
+    return;
+  }
+
+  defaultsNode.on((data) => {
+    if (!hasDefaultRecord(data)) {
+      return;
+    }
+
+    sharedSecrets.openai = readDefaultSecret(data, 'openai');
+    if (sharedSecrets.openai) {
+      resolveSharedSecretWaiters('openai');
+    }
+  });
+}
+
+function wait(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForSharedSecret(targetKey, message) {
+  if (sharedSecrets[targetKey]) {
+    return true;
+  }
+
+  if (!defaultsNode) {
+    return false;
+  }
+
+  setNotice(message);
+  render();
+  await Promise.race([
+    new Promise((resolve) => {
+      sharedSecretResolvers[targetKey]?.push(resolve);
+    }),
+    wait(SHARED_DEFAULTS_WAIT_MS),
+  ]);
+
+  return Boolean(sharedSecrets[targetKey]);
 }
 
 function sentence(value, fallback) {
@@ -220,6 +300,93 @@ function buildMockMovementBrief(currentSession) {
   };
 }
 
+function normalizeFollowUpsResponse(value) {
+  const list = Array.isArray(value) ? value : [];
+  const normalized = list
+    .map((item, index) => ({
+      key: clean(item?.key)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '') || `followup_${index + 1}`,
+      question: clean(item?.question),
+    }))
+    .filter((item) => item.question)
+    .slice(0, 3);
+
+  defaultFollowUps.forEach((fallback) => {
+    if (normalized.length < 3) {
+      normalized.push(fallback);
+    }
+  });
+
+  return normalized.slice(0, 3);
+}
+
+function normalizeStringList(value, fallback, limit) {
+  const list = Array.isArray(value) ? value : [];
+  const normalized = list.map(clean).filter(Boolean).slice(0, limit);
+
+  fallback.forEach((item) => {
+    if (normalized.length < Math.min(3, limit)) {
+      normalized.push(item);
+    }
+  });
+
+  return normalized.slice(0, limit);
+}
+
+function normalizeBriefResponse(value) {
+  const fallback = buildMockMovementBrief(session);
+
+  return {
+    projectName: clean(value?.projectName) || fallback.projectName,
+    coreFrustration: clean(value?.coreFrustration) || fallback.coreFrustration,
+    audience: clean(value?.audience) || fallback.audience,
+    projectConcept: clean(value?.projectConcept) || fallback.projectConcept,
+    tinyExperiment: clean(value?.tinyExperiment) || fallback.tinyExperiment,
+    firstActions: normalizeStringList(value?.firstActions, fallback.firstActions, 3),
+    testMessage: clean(value?.testMessage) || fallback.testMessage,
+    codexPrompt: clean(value?.codexPrompt) || fallback.codexPrompt,
+    realityCheck: normalizeStringList(value?.realityCheck, fallback.realityCheck, 5),
+  };
+}
+
+async function parseApiError(response) {
+  const errorText = await response.text();
+  if (!errorText) {
+    return 'The Forge API is not available.';
+  }
+
+  try {
+    const parsed = JSON.parse(errorText);
+    return parsed?.error || parsed?.message || errorText;
+  } catch {
+    return errorText;
+  }
+}
+
+async function requestForge(mode, payload = {}) {
+  await waitForSharedSecret('openai', 'Loading shared Forge key...');
+
+  const response = await fetch('/api/openai-site', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      forge: true,
+      mode,
+      model: FORGE_MODEL,
+      ...(sharedSecrets.openai ? { apiKey: sharedSecrets.openai } : {}),
+      ...payload,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseApiError(response));
+  }
+
+  return response.json();
+}
+
 function saveSession() {
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
@@ -285,6 +452,13 @@ function renderTranscript() {
 }
 
 function currentPrompt() {
+  if (session.stage === stage.GENERATING) {
+    return {
+      label: 'The Forge is shaping your Movement Brief.',
+      button: 'Forging...',
+    };
+  }
+
   if (session.stage === stage.INITIAL || session.stage === stage.INTRO) {
     return {
       label: 'Rant, ramble, complain, dream, or describe the thing you can’t stop thinking about.',
@@ -419,12 +593,18 @@ function render() {
   refs.inputLabel.textContent = prompt.label;
   refs.submit.textContent = prompt.button;
   refs.answer.value = '';
-  refs.answer.disabled = session.stage === stage.GENERATING || session.stage === stage.BRIEF;
-  refs.submit.disabled = session.stage === stage.GENERATING || session.stage === stage.BRIEF;
+  refs.answer.disabled = isBusy || session.stage === stage.GENERATING || session.stage === stage.BRIEF;
+  refs.submit.disabled = isBusy || session.stage === stage.GENERATING || session.stage === stage.BRIEF;
   refs.briefPanel.hidden = session.stage !== stage.BRIEF;
-  refs.status.textContent = session.stage === stage.BRIEF
-    ? 'Movement Brief generated. Copy it or choose one next move.'
-    : 'No login required. This v1 runs in your browser.';
+  if (isBusy) {
+    refs.status.textContent = session.notice || 'Forge AI is working...';
+  } else if (session.notice) {
+    refs.status.textContent = session.notice;
+  } else {
+    refs.status.textContent = session.stage === stage.BRIEF
+      ? 'Movement Brief generated. Copy it or choose one next move.'
+      : 'No login required. This v1 runs in your browser.';
+  }
 
   renderTranscript();
   renderBrief();
@@ -442,21 +622,59 @@ function startForge() {
   window.requestAnimationFrame(() => refs.answer.focus());
 }
 
-function generateBrief() {
-  session.stage = stage.GENERATING;
+async function prepareFollowUps(initial) {
+  isBusy = true;
+  setNotice('Forge AI is sharpening three follow-up questions...');
   render();
 
-  window.setTimeout(() => {
+  try {
+    const result = await requestForge('followups', { initial });
+    session.followUps = normalizeFollowUpsResponse(result?.questions);
+    setNotice('Good raw material. Answer these three sharper questions.');
+  } catch (error) {
+    session.followUps = chooseFollowUps(initial);
+    setNotice(`Forge AI is unavailable, so local questions are loaded. ${error.message || ''}`.trim());
+  } finally {
+    isBusy = false;
+    session.stage = stage.FOLLOWUPS;
+    saveSession();
+    render();
+    window.requestAnimationFrame(() => refs.answer.focus());
+  }
+}
+
+async function generateBrief() {
+  session.stage = stage.GENERATING;
+  isBusy = true;
+  setNotice('Forge AI is shaping your Movement Brief...');
+  render();
+
+  try {
+    const result = await requestForge('brief', {
+      initial: session.initial,
+      followUps: session.followUps,
+      answers: session.answers,
+    });
+    session.brief = normalizeBriefResponse(result?.brief);
+    session.briefSource = 'ai';
+    setNotice('Movement Brief generated with Forge AI. Copy it or choose one next move.');
+  } catch (error) {
     session.brief = buildMockMovementBrief(session);
+    session.briefSource = 'local-fallback';
+    setNotice(`Forge AI is unavailable, so a local fallback brief was generated. ${error.message || ''}`.trim());
+  } finally {
+    isBusy = false;
     session.stage = stage.BRIEF;
     saveSession();
     render();
     refs.briefPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }, 420);
+  }
 }
 
-function handleSubmit(event) {
+async function handleSubmit(event) {
   event.preventDefault();
+  if (isBusy) return;
+
   const value = clean(refs.answer.value);
   if (!value) {
     refs.status.textContent = 'Give the Forge raw material first.';
@@ -469,7 +687,7 @@ function handleSubmit(event) {
     session.followUpIndex = 0;
     session.stage = stage.FOLLOWUPS;
     saveSession();
-    render();
+    await prepareFollowUps(value);
     return;
   }
 
@@ -480,7 +698,7 @@ function handleSubmit(event) {
 
   if (session.followUpIndex >= session.followUps.length - 1) {
     saveSession();
-    generateBrief();
+    await generateBrief();
     return;
   }
 
@@ -529,6 +747,8 @@ function resetForge() {
     answers: {},
     brief: null,
     nextOutput: '',
+    notice: '',
+    briefSource: '',
   };
   refs.nextOutput.hidden = true;
   refs.nextOutputBody.textContent = '';
@@ -555,5 +775,6 @@ refs.copyNextOutput?.addEventListener('click', () => {
   }
 });
 
+subscribeToSharedDefaults();
 loadSession();
 render();

--- a/forge/index.html
+++ b/forge/index.html
@@ -12,6 +12,8 @@
   <link rel="stylesheet" href="../styles/global.css">
   <link rel="stylesheet" href="../index-style.css">
   <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
   <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="landing theme-dark forge-page">

--- a/src/forge/api.js
+++ b/src/forge/api.js
@@ -1,0 +1,380 @@
+export const DEFAULT_FORGE_MODEL = 'gpt-4.1-mini';
+export const SUPPORTED_FORGE_MODELS = Object.freeze([
+  'gpt-4o-mini',
+  'gpt-4.1-mini',
+  'gpt-5.4-mini',
+  'gpt-5.4'
+]);
+
+const FORGE_FOLLOWUPS_SCHEMA = {
+  name: 'forge_followups_response',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['questions'],
+    properties: {
+      questions: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['key', 'question'],
+          properties: {
+            key: { type: 'string' },
+            question: { type: 'string' }
+          }
+        }
+      }
+    }
+  }
+};
+
+const FORGE_BRIEF_SCHEMA = {
+  name: 'forge_movement_brief_response',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: [
+      'projectName',
+      'coreFrustration',
+      'audience',
+      'projectConcept',
+      'tinyExperiment',
+      'firstActions',
+      'testMessage',
+      'codexPrompt',
+      'realityCheck'
+    ],
+    properties: {
+      projectName: { type: 'string' },
+      coreFrustration: { type: 'string' },
+      audience: { type: 'string' },
+      projectConcept: { type: 'string' },
+      tinyExperiment: { type: 'string' },
+      firstActions: {
+        type: 'array',
+        items: { type: 'string' }
+      },
+      testMessage: { type: 'string' },
+      codexPrompt: { type: 'string' },
+      realityCheck: {
+        type: 'array',
+        items: { type: 'string' }
+      }
+    }
+  }
+};
+
+const DEFAULT_FOLLOWUPS = Object.freeze([
+  {
+    key: 'audience',
+    question: 'Who else has this problem?'
+  },
+  {
+    key: 'tried',
+    question: 'What have you already tried?'
+  },
+  {
+    key: 'tiny',
+    question: 'What would a tiny version look like in 7 days?'
+  }
+]);
+
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function resolveDate(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+function formatIsoDate(value) {
+  return resolveDate(value).toISOString().slice(0, 10);
+}
+
+function isGpt5FamilyModel(model) {
+  return /^gpt-5([.-]|$)/.test(String(model || '').trim());
+}
+
+function normalizeRequestedModel(value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    return DEFAULT_FORGE_MODEL;
+  }
+
+  return SUPPORTED_FORGE_MODELS.includes(normalized) ? normalized : '';
+}
+
+function clean(value, maxLength = 4000) {
+  return String(value || '').trim().replace(/\s+/g, ' ').slice(0, maxLength);
+}
+
+function normalizeQuestionKey(value, index) {
+  const key = clean(value, 40)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  return key || `followup_${index + 1}`;
+}
+
+function normalizeFollowUps(value) {
+  const list = Array.isArray(value) ? value : [];
+  const normalized = list
+    .map((item, index) => ({
+      key: normalizeQuestionKey(item?.key, index),
+      question: clean(item?.question, 220)
+    }))
+    .filter(item => item.question)
+    .slice(0, 3);
+
+  DEFAULT_FOLLOWUPS.forEach((fallback) => {
+    if (normalized.length < 3) {
+      normalized.push(fallback);
+    }
+  });
+
+  return normalized.slice(0, 3);
+}
+
+function normalizeStringList(value, fallback, { min = 3, max = 5 } = {}) {
+  const source = Array.isArray(value) ? value : [];
+  const normalized = source
+    .map(item => clean(item, 900))
+    .filter(Boolean)
+    .slice(0, max);
+
+  fallback.forEach((item) => {
+    if (normalized.length < min) {
+      normalized.push(item);
+    }
+  });
+
+  return normalized.slice(0, max);
+}
+
+function normalizeBrief(value) {
+  const fallbackActions = [
+    'Name the audience in one sentence.',
+    'Send the test message to 10 real people.',
+    'Build only after at least one useful reply.'
+  ];
+  const fallbackReality = [
+    'Too vague unless the audience is specific.',
+    'This is a test, not a full startup yet.',
+    'A direct message may validate the idea faster than an app.'
+  ];
+
+  return {
+    projectName: clean(value?.projectName, 120) || 'Useful Project Test',
+    coreFrustration: clean(value?.coreFrustration, 900) || 'The raw frustration is real, but the project still needs sharper edges.',
+    audience: clean(value?.audience, 500) || 'frustrated working people with hidden skills',
+    projectConcept: clean(value?.projectConcept, 1400) || 'A small useful offer that turns the frustration into a testable project.',
+    tinyExperiment: clean(value?.tinyExperiment, 900) || 'In 7 days, make one clear promise and send it to 10 people.',
+    firstActions: normalizeStringList(value?.firstActions, fallbackActions, { min: 3, max: 3 }),
+    testMessage: clean(value?.testMessage, 1200) || 'I am testing a small project idea. Does this feel useful, too vague, or not your problem?',
+    codexPrompt: clean(value?.codexPrompt, 2600) || 'Build a minimal, mobile-first prototype for this project. Keep it focused and add a simple verification path.',
+    realityCheck: normalizeStringList(value?.realityCheck, fallbackReality, { min: 3, max: 5 })
+  };
+}
+
+function extractResponseText(responseData) {
+  const outputItems = Array.isArray(responseData?.output) ? responseData.output : [];
+
+  for (const item of outputItems) {
+    if (item?.type !== 'message') continue;
+    const contentItems = Array.isArray(item.content) ? item.content : [];
+    for (const content of contentItems) {
+      if (content?.type !== 'output_text') continue;
+      const text = typeof content.text === 'string' ? content.text.trim() : '';
+      if (text) {
+        return text;
+      }
+    }
+  }
+
+  return '';
+}
+
+function parseJsonResponse(responseData) {
+  const raw = extractResponseText(responseData);
+  if (!raw) {
+    throw new Error('No content returned from OpenAI.');
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse OpenAI response: ${error.message}`);
+  }
+}
+
+export function buildForgeInstructions(now = new Date()) {
+  const currentDate = resolveDate(now);
+
+  return [
+    'You are 3DVR Forge, a builder-oriented AI product inside the 3DVR Portal.',
+    `Today is ${formatIsoDate(currentDate)}.`,
+    'Your job is to turn messy frustration, rants, ideas, or dreams into launchable project tests.',
+    'Do not act like a therapist. Act like a practical blacksmith for projects.',
+    'Use a direct, supportive, unsyrupy tone. Challenge vague claims.',
+    'Prefer tiny tests over platform fantasies. Tell the user when they should send a message before building software.',
+    'The target user is a frustrated working person with hidden skills who wants to build something useful but does not know where to begin.',
+    'For followups mode, ask exactly three short adaptive questions. They should feel conversational, not like a form.',
+    'For brief mode, produce a complete Movement Brief with concrete next steps, a test message, a Codex-ready build prompt, and a blunt reality check.',
+    'Do not include markdown fences. Return only the JSON object requested by the schema.'
+  ].join(' ');
+}
+
+function buildForgeInput({ mode, initial, followUps, answers }) {
+  return JSON.stringify({
+    mode,
+    initial: clean(initial, 4000),
+    followUps: normalizeFollowUps(followUps),
+    answers: answers && typeof answers === 'object' ? answers : {}
+  }, null, 2);
+}
+
+export function buildForgeOpenAiRequest({
+  mode,
+  initial,
+  followUps = DEFAULT_FOLLOWUPS,
+  answers = {},
+  model = DEFAULT_FORGE_MODEL,
+  now = new Date()
+}) {
+  const selectedMode = mode === 'followups' ? 'followups' : 'brief';
+  const requestBody = {
+    model,
+    instructions: buildForgeInstructions(now),
+    input: buildForgeInput({
+      mode: selectedMode,
+      initial,
+      followUps,
+      answers
+    }),
+    store: false,
+    text: {
+      format: {
+        type: 'json_schema',
+        ...(selectedMode === 'followups' ? FORGE_FOLLOWUPS_SCHEMA : FORGE_BRIEF_SCHEMA)
+      }
+    }
+  };
+
+  if (!isGpt5FamilyModel(model)) {
+    requestBody.temperature = selectedMode === 'followups' ? 0.45 : 0.35;
+  }
+
+  return requestBody;
+}
+
+export function createForgeHandler(options = {}) {
+  const {
+    apiKey = process.env.OPENAI_API_KEY,
+    model = normalizeRequestedModel(options.model || process.env.OPENAI_FORGE_MODEL || DEFAULT_FORGE_MODEL) || DEFAULT_FORGE_MODEL,
+    fetchImpl = globalThis.fetch,
+    now = () => new Date()
+  } = options;
+
+  return async function handler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method !== 'POST') {
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    const {
+      mode: requestedMode,
+      initial,
+      followUps,
+      answers,
+      apiKey: requestApiKey,
+      model: requestedModel
+    } = req.body || {};
+    const mode = requestedMode === 'followups' ? 'followups' : 'brief';
+    const effectiveApiKey = typeof requestApiKey === 'string' && requestApiKey.trim()
+      ? requestApiKey.trim()
+      : apiKey;
+    const effectiveModel = requestedModel === undefined
+      ? model
+      : normalizeRequestedModel(requestedModel);
+
+    if (!effectiveApiKey) {
+      return res.status(500).json({ error: 'OpenAI API key is not configured.' });
+    }
+
+    if (!effectiveModel) {
+      return res.status(400).json({
+        error: `Unsupported model. Choose one of: ${SUPPORTED_FORGE_MODELS.join(', ')}.`
+      });
+    }
+
+    if (!initial || typeof initial !== 'string' || !initial.trim()) {
+      return res.status(400).json({ error: 'An initial frustration, rant, idea, or dream is required.' });
+    }
+
+    if (mode === 'brief' && (!answers || typeof answers !== 'object')) {
+      return res.status(400).json({ error: 'Follow-up answers are required before forging a brief.' });
+    }
+
+    try {
+      const currentDate = resolveDate(now());
+      const requestBody = buildForgeOpenAiRequest({
+        mode,
+        initial,
+        followUps,
+        answers,
+        model: effectiveModel,
+        now: currentDate
+      });
+
+      const response = await fetchImpl('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${effectiveApiKey}`
+        },
+        body: JSON.stringify(requestBody)
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText || 'OpenAI error' });
+      }
+
+      const data = await response.json();
+      const parsed = parseJsonResponse(data);
+
+      if (mode === 'followups') {
+        return res.status(200).json({
+          mode,
+          questions: normalizeFollowUps(parsed.questions),
+          model: effectiveModel,
+          createdAt: currentDate.getTime()
+        });
+      }
+
+      return res.status(200).json({
+        mode,
+        brief: normalizeBrief(parsed),
+        model: effectiveModel,
+        createdAt: currentDate.getTime()
+      });
+    } catch (error) {
+      return res.status(500).json({ error: error.message || 'Unexpected error during Forge generation.' });
+    }
+  };
+}
+
+const handler = createForgeHandler();
+export default handler;

--- a/tests/forge-api.test.js
+++ b/tests/forge-api.test.js
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildForgeInstructions,
+  buildForgeOpenAiRequest,
+  createForgeHandler,
+  DEFAULT_FORGE_MODEL,
+  SUPPORTED_FORGE_MODELS
+} from '../src/forge/api.js';
+import { createOpenAiSiteRouter } from '../api/openai-site.js';
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    ended: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end(payload) {
+      this.ended = true;
+      this.body = payload ?? this.body;
+      return this;
+    },
+    setHeader(key, value) {
+      this.headers[key] = value;
+    }
+  };
+}
+
+function createOpenAiResponse(payload, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return payload;
+    },
+    async text() {
+      return JSON.stringify(payload);
+    }
+  };
+}
+
+function createOutputText(payload) {
+  return {
+    output: [
+      {
+        type: 'message',
+        content: [
+          {
+            type: 'output_text',
+            text: JSON.stringify(payload)
+          }
+        ]
+      }
+    ]
+  };
+}
+
+test('buildForgeInstructions injects date and blacksmith tone rules', () => {
+  const instructions = buildForgeInstructions(new Date('2026-06-28T12:00:00.000Z'));
+
+  assert.match(instructions, /Today is 2026-06-28\./);
+  assert.match(instructions, /Do not act like a therapist/i);
+  assert.match(instructions, /practical blacksmith/i);
+  assert.match(instructions, /Prefer tiny tests over platform fantasies/i);
+  assert.match(instructions, /Movement Brief/i);
+});
+
+test('buildForgeOpenAiRequest creates a structured follow-up request', () => {
+  const request = buildForgeOpenAiRequest({
+    mode: 'followups',
+    initial: 'I am frustrated by buried stagehand skills.',
+    model: DEFAULT_FORGE_MODEL,
+    now: new Date('2026-06-28T12:00:00.000Z')
+  });
+
+  assert.equal(request.model, DEFAULT_FORGE_MODEL);
+  assert.equal(request.store, false);
+  assert.equal(request.temperature, 0.45);
+  assert.equal(request.text.format.type, 'json_schema');
+  assert.equal(request.text.format.name, 'forge_followups_response');
+  assert.match(request.input, /buried stagehand skills/);
+});
+
+test('buildForgeOpenAiRequest creates a structured brief request and omits temperature for gpt-5 family models', () => {
+  const request = buildForgeOpenAiRequest({
+    mode: 'brief',
+    initial: 'I want to turn rants into project tests.',
+    answers: {
+      audience: 'burned-out workers',
+      tried: 'journaling',
+      tiny: 'one-page test'
+    },
+    model: 'gpt-5.4',
+    now: new Date('2026-06-28T12:00:00.000Z')
+  });
+
+  assert.equal(request.model, 'gpt-5.4');
+  assert.equal('temperature' in request, false);
+  assert.equal(request.text.format.name, 'forge_movement_brief_response');
+  assert.match(request.instructions, /Return only the JSON object/);
+});
+
+test('supported Forge models mirror the builder model options', () => {
+  assert.equal(DEFAULT_FORGE_MODEL, 'gpt-4.1-mini');
+  assert.deepEqual(SUPPORTED_FORGE_MODELS, [
+    'gpt-4o-mini',
+    'gpt-4.1-mini',
+    'gpt-5.4-mini',
+    'gpt-5.4'
+  ]);
+});
+
+test('Forge handler returns adaptive follow-up questions from OpenAI', async () => {
+  let requestUrl = '';
+  let requestBody = null;
+  const handler = createForgeHandler({
+    apiKey: 'sk-test',
+    now: () => new Date('2026-06-28T12:00:00.000Z'),
+    fetchImpl: async (url, options = {}) => {
+      requestUrl = String(url);
+      requestBody = JSON.parse(options.body || '{}');
+      return createOpenAiResponse(createOutputText({
+        questions: [
+          { key: 'audience', question: 'Who else feels this same pressure?' },
+          { key: 'stakes', question: 'What gets worse if nobody solves it?' },
+          { key: 'tiny', question: 'What could you test in one week?' }
+        ]
+      }));
+    }
+  });
+  const res = createMockRes();
+
+  await handler({
+    method: 'POST',
+    headers: {},
+    body: {
+      mode: 'followups',
+      initial: 'I am tired of useful builders being underused.'
+    }
+  }, res);
+
+  assert.equal(requestUrl, 'https://api.openai.com/v1/responses');
+  assert.equal(requestBody.text.format.name, 'forge_followups_response');
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.mode, 'followups');
+  assert.equal(res.body.model, DEFAULT_FORGE_MODEL);
+  assert.equal(res.body.questions.length, 3);
+  assert.equal(res.body.questions[1].key, 'stakes');
+});
+
+test('Forge handler returns a normalized Movement Brief from OpenAI', async () => {
+  const handler = createForgeHandler({
+    apiKey: 'sk-test',
+    now: () => new Date('2026-06-28T12:00:00.000Z'),
+    fetchImpl: async () => createOpenAiResponse(createOutputText({
+      projectName: 'Rant to Project Forge',
+      coreFrustration: 'People have useful ideas but no sharp first test.',
+      audience: 'frustrated working people with hidden skills',
+      projectConcept: 'A focused project-shaping session.',
+      tinyExperiment: 'Send a test message to 10 people in 7 days.',
+      firstActions: [
+        'Write the promise.',
+        'Name 10 people.',
+        'Send the message.'
+      ],
+      testMessage: 'I am testing a project-shaping tool. Useful, vague, or not your problem?',
+      codexPrompt: 'Build a minimal Forge prototype with one conversation and one brief output.',
+      realityCheck: [
+        'Audience is still broad.',
+        'Do not build accounts yet.',
+        'A direct-message test is faster.'
+      ]
+    }))
+  });
+  const res = createMockRes();
+
+  await handler({
+    method: 'POST',
+    headers: {},
+    body: {
+      mode: 'brief',
+      initial: 'I want to turn rants into project tests.',
+      followUps: [
+        { key: 'audience', question: 'Who else has this problem?' },
+        { key: 'tried', question: 'What have you tried?' },
+        { key: 'tiny', question: 'What is tiny?' }
+      ],
+      answers: {
+        audience: 'frustrated workers',
+        tried: 'notes',
+        tiny: 'message test'
+      }
+    }
+  }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.mode, 'brief');
+  assert.equal(res.body.brief.projectName, 'Rant to Project Forge');
+  assert.equal(res.body.brief.firstActions.length, 3);
+  assert.equal(res.body.brief.realityCheck.length, 3);
+  assert.match(res.body.brief.codexPrompt, /Build a minimal Forge prototype/);
+});
+
+test('Forge handler validates key, model, and request shape', async () => {
+  const noKey = createForgeHandler({ apiKey: '' });
+  const noKeyRes = createMockRes();
+  await noKey({ method: 'POST', headers: {}, body: { initial: 'raw idea', answers: {} } }, noKeyRes);
+  assert.equal(noKeyRes.statusCode, 500);
+  assert.match(noKeyRes.body.error, /OpenAI API key/);
+
+  const unsupported = createForgeHandler({ apiKey: 'sk-test' });
+  const unsupportedRes = createMockRes();
+  await unsupported({
+    method: 'POST',
+    headers: {},
+    body: {
+      initial: 'raw idea',
+      answers: {},
+      model: 'gpt-5-mini'
+    }
+  }, unsupportedRes);
+  assert.equal(unsupportedRes.statusCode, 400);
+  assert.match(unsupportedRes.body.error, /Unsupported model/);
+
+  const missingAnswers = createForgeHandler({ apiKey: 'sk-test' });
+  const missingAnswersRes = createMockRes();
+  await missingAnswers({
+    method: 'POST',
+    headers: {},
+    body: {
+      mode: 'brief',
+      initial: 'raw idea'
+    }
+  }, missingAnswersRes);
+  assert.equal(missingAnswersRes.statusCode, 400);
+  assert.match(missingAnswersRes.body.error, /answers are required/i);
+});
+
+test('OpenAI site route dispatches Forge requests without adding another API function', async () => {
+  let requestBody = null;
+  const handler = createOpenAiSiteRouter({
+    apiKey: 'sk-test',
+    now: () => new Date('2026-06-28T12:00:00.000Z'),
+    fetchImpl: async (_url, options = {}) => {
+      requestBody = JSON.parse(options.body || '{}');
+      return createOpenAiResponse(createOutputText({
+        questions: [
+          { key: 'audience', question: 'Who feels it?' },
+          { key: 'signal', question: 'What signal matters?' },
+          { key: 'tiny', question: 'What can ship in 7 days?' }
+        ]
+      }));
+    }
+  });
+  const res = createMockRes();
+
+  await handler({
+    method: 'POST',
+    headers: {},
+    query: {},
+    body: {
+      forge: true,
+      mode: 'followups',
+      initial: 'I am underused and want to build.'
+    }
+  }, res);
+
+  assert.equal(requestBody.text.format.name, 'forge_followups_response');
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.mode, 'followups');
+  assert.equal(res.body.questions.length, 3);
+});

--- a/tests/forge.test.js
+++ b/tests/forge.test.js
@@ -9,6 +9,8 @@ describe('3DVR Forge product route', () => {
     assert.match(html, /<title>3DVR Forge \| Turn frustration into a project<\/title>/);
     assert.match(html, /href="\.\.\/index\.html">Portal<\/a>/);
     assert.match(html, /href="\.\.\/launch-room\/">Launch Room<\/a>/);
+    assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+    assert.match(html, /src="\/gun-init\.js"/);
     assert.match(html, /3DVR Forge/);
     assert.match(html, /Turn your frustration into a project\./);
     assert.match(html, /Rant, ramble, complain, dream, or describe the thing you can't stop thinking about\./);
@@ -25,17 +27,30 @@ describe('3DVR Forge product route', () => {
     assert.doesNotMatch(html, /create an account/i);
   });
 
-  it('includes a simple state machine and mockable Movement Brief generator', async () => {
+  it('uses the Forge API first and keeps local fallback behavior', async () => {
     const app = await readFile(new URL('../forge/app.js', import.meta.url), 'utf8');
 
+    assert.match(app, /import \{ readDefaultSecret \} from '\.\.\/web-builder-app\/defaults\.js'/);
     assert.match(app, /const STORAGE_KEY = '3dvr\.forge\.session\.v1'/);
+    assert.match(app, /const FORGE_MODEL = 'gpt-4\.1-mini'/);
+    assert.match(app, /SHARED_DEFAULTS_WAIT_MS/);
     assert.match(app, /INTRO: 'intro'/);
     assert.match(app, /INITIAL: 'initial'/);
     assert.match(app, /FOLLOWUPS: 'followups'/);
     assert.match(app, /GENERATING: 'generating'/);
     assert.match(app, /BRIEF: 'brief'/);
+    assert.match(app, /subscribeToSharedDefaults/);
+    assert.match(app, /waitForSharedSecret\('openai'/);
+    assert.match(app, /readDefaultSecret\(data, 'openai'\)/);
+    assert.match(app, /fetch\('\/api\/openai-site'/);
+    assert.match(app, /forge:\s*true/);
+    assert.match(app, /requestForge\('followups'/);
+    assert.match(app, /requestForge\('brief'/);
     assert.match(app, /function chooseFollowUps\(initial\)/);
     assert.match(app, /function buildMockMovementBrief\(currentSession\)/);
+    assert.match(app, /normalizeFollowUpsResponse/);
+    assert.match(app, /normalizeBriefResponse/);
+    assert.match(app, /local fallback brief was generated/);
     assert.match(app, /Who else has this problem\?/);
     assert.match(app, /What have you already tried\?/);
     assert.match(app, /What would a tiny version look like in 7 days\?/);
@@ -61,7 +76,6 @@ describe('3DVR Forge product route', () => {
     assert.match(app, /Do not build an app yet/);
     assert.match(app, /navigator\.clipboard\.writeText/);
     assert.match(app, /type: 'text\/markdown'/);
-    assert.match(app, /window\.setTimeout/);
     assert.match(app, /window\.localStorage\.setItem\(STORAGE_KEY/);
   });
 


### PR DESCRIPTION
## Summary
- Add /api/forge as a structured OpenAI Responses endpoint for Forge follow-up questions and Movement Brief generation.
- Wire /forge to shared Web Builder OpenAI defaults over Gun, with server env-key fallback and local fallback when AI is unavailable.
- Replace the mock-only final generation path with API-first followups and brief generation.
- Add API and route tests covering schema requests, validation, fallback wiring, and shared-default patterns.

## Tests
- node --test tests/forge-api.test.js tests/forge.test.js tests/web-builder-defaults.test.js tests/site-launcher-page.test.js tests/customer-journey-pages.test.js tests/homepage-search-ux.test.js tests/portal-home-mobile-layout.test.js
- Playwright mobile browser flow at 390px with /api/forge mocked, confirming followups + brief API calls and no horizontal overflow.