### PR TITLE
[codex] Clean up portal app dock and revenue path

### DIFF
--- a/billing/app.js
+++ b/billing/app.js
@@ -451,6 +451,19 @@ function updatePlanQuery(plan = '') {
   window.history.replaceState({}, '', `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`)
 }
 
+function readBillingQuery() {
+  return new URLSearchParams(window.location.search)
+}
+
+function billingQueryValue(...keys) {
+  const params = readBillingQuery()
+  for (const key of keys) {
+    const value = String(params.get(key) || '').trim()
+    if (value) return value
+  }
+  return ''
+}
+
 function billingCenterHref(plan = '') {
   const nextUrl = new URL(window.location.href)
   const selectedPlan = plan || state.selectedPlan || selectedPlanFromUrl()
@@ -472,7 +485,7 @@ function refreshSignInLink(plan = '') {
 }
 
 function selectedPlanFromUrl() {
-  const params = new URLSearchParams(window.location.search)
+  const params = readBillingQuery()
   return normalizePlanKey(params.get('plan'))
 }
 
@@ -499,6 +512,26 @@ function configHintForPlan(plan = '') {
   if (plan === 'builder') return 'STRIPE_PRICE_BUILDER_ID or STRIPE_PRICE_STUDIO_ID'
   if (plan === 'embedded') return 'STRIPE_PRICE_EMBEDDED_ID or STRIPE_PRICE_EXECUTION_ID'
   return 'the matching Stripe price env var'
+}
+
+function prefillCustomCheckoutFromUrl() {
+  if (selectedPlanFromUrl() !== 'custom') {
+    return
+  }
+
+  const amount = billingQueryValue('amount', 'customAmount')
+  const label = billingQueryValue('label', 'customLabel')
+  const description = billingQueryValue('description', 'customDescription')
+
+  if (amount && customAmountInput && !customAmountInput.value) {
+    customAmountInput.value = amount.replace(/[^0-9.]/g, '')
+  }
+  if (label && customLabelInput && !customLabelInput.value) {
+    customLabelInput.value = label.slice(0, 80)
+  }
+  if (description && customDescriptionInput && !customDescriptionInput.value) {
+    customDescriptionInput.value = description.slice(0, 600)
+  }
 }
 
 function highlightPlan(plan = '', options = {}) {
@@ -1588,6 +1621,7 @@ function bindEvents() {
     }
 
     highlightPlan('custom', { updateUrl: true })
+    prefillCustomCheckoutFromUrl()
 
     if (!requireSignedInForPaidFlow({ plan: 'custom', redirectOnFailure: true })) {
       return
@@ -1661,6 +1695,7 @@ async function init() {
 
   handleFlashFromQuery()
   highlightPlan(selectedPlanFromUrl())
+  prefillCustomCheckoutFromUrl()
   bindEvents()
   renderAccountSummary()
 

--- a/ideas/client-onboarding-sprint.html
+++ b/ideas/client-onboarding-sprint.html
@@ -1,0 +1,275 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Client Onboarding Sprint | 3DVR</title>
+  <meta
+    name="description"
+    content="A 72-hour paid sprint for freelancers and small agencies that need one cleaner client onboarding path, follow-up lane, and next-step checklist."
+  >
+  <link rel="stylesheet" href="audience-leads.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+  <script src="audience-leads.js" defer></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+  <style>
+    :root {
+      --onboard-bg: #0d1118;
+      --onboard-panel: rgba(244, 247, 255, 0.08);
+      --onboard-border: rgba(143, 188, 255, 0.24);
+      --onboard-text: #f7f9ff;
+      --onboard-muted: #c1ccdc;
+      --onboard-blue: #9fc2ff;
+      --onboard-green: #7ee7bf;
+      --onboard-gold: #f3cc72;
+    }
+
+    body {
+      background:
+        linear-gradient(135deg, rgba(126, 231, 191, 0.16), transparent 34%),
+        linear-gradient(230deg, rgba(159, 194, 255, 0.16), transparent 42%),
+        var(--onboard-bg);
+      color: var(--onboard-text);
+    }
+
+    .page {
+      max-width: 1160px;
+    }
+
+    .panel {
+      border-color: var(--onboard-border);
+      border-radius: 8px;
+      background: var(--onboard-panel);
+    }
+
+    .signal-box,
+    .offer-box,
+    .probe-box {
+      border: 1px solid var(--onboard-border);
+      border-radius: 8px;
+      padding: 16px;
+      background: rgba(7, 13, 22, 0.76);
+    }
+
+    .signal-box {
+      display: grid;
+      gap: 12px;
+      margin: 22px 0;
+    }
+
+    .signal-box strong,
+    .offer-box strong,
+    .probe-box strong {
+      color: var(--onboard-green);
+    }
+
+    .price-line {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .price-line strong {
+      color: var(--onboard-gold);
+      font-size: 1.35rem;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 32px;
+      border: 1px solid rgba(159, 194, 255, 0.34);
+      border-radius: 999px;
+      padding: 5px 10px;
+      color: #dce8ff;
+      background: rgba(159, 194, 255, 0.1);
+      font-size: 0.9rem;
+      font-weight: 700;
+    }
+
+    .deliverables {
+      display: grid;
+      gap: 12px;
+      margin: 20px 0;
+    }
+
+    .deliverable {
+      border: 1px solid rgba(126, 231, 191, 0.2);
+      border-radius: 8px;
+      padding: 14px;
+      background: rgba(126, 231, 191, 0.07);
+    }
+
+    .deliverable strong {
+      display: block;
+      color: #d8fff2;
+    }
+
+    .deliverable span,
+    .offer-box p,
+    .probe-box p {
+      color: var(--onboard-muted);
+    }
+
+    .button-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 22px;
+    }
+
+    .text-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      color: var(--onboard-blue);
+      font-weight: 800;
+    }
+
+    .form-panel {
+      border-color: rgba(243, 204, 114, 0.32);
+    }
+
+    @media (min-width: 900px) {
+      .layout {
+        grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <nav class="top-nav" aria-label="Client Onboarding Sprint navigation">
+      <a href="/ideas/">Ideas Lab</a>
+      <a href="/sales/">Sales</a>
+      <a href="/index.html">Portal Home</a>
+    </nav>
+
+    <main class="layout">
+      <section class="panel" aria-labelledby="headline">
+        <p class="kicker">Paid sprint for freelancers and small agencies</p>
+        <h1 id="headline">Turn a yes into a clean client start.</h1>
+        <p class="subhead">
+          3DVR Client Onboarding Sprint gives independent service teams one simple path from interested lead to paid
+          next step, intake, checklist, and follow-up.
+        </p>
+
+        <div class="signal-box" aria-label="Auto-business signal">
+          <strong>Built from today&apos;s AI market run.</strong>
+          <span>
+            The strongest discovered market was freelancers and small agencies. The top opportunity was client
+            onboarding, with lead follow-up and recurring-revenue tracking close behind.
+          </span>
+        </div>
+
+        <div class="body-text">
+          <p>
+            The money leak happens after someone says they are interested. The next step is unclear, the intake is
+            scattered, and the lead cools before work starts.
+          </p>
+          <p>This sprint builds the missing handoff:</p>
+          <ul>
+            <li>A focused buyer path for one service offer.</li>
+            <li>A client intake form that captures pain, timing, and scope.</li>
+            <li>A short onboarding checklist you can reuse.</li>
+            <li>Three follow-up messages for the first week.</li>
+          </ul>
+        </div>
+
+        <div class="price-line">
+          <strong>$300 setup sprint</strong>
+          <span class="pill">72-hour delivery</span>
+          <span class="pill">$50/month lane if ongoing</span>
+        </div>
+
+        <div class="deliverables" aria-label="Sprint deliverables">
+          <div class="deliverable">
+            <strong>Client start map</strong>
+            <span>The clean path from inquiry to paid next step, including the exact question to ask first.</span>
+          </div>
+          <div class="deliverable">
+            <strong>Intake and checklist</strong>
+            <span>A simple form plus a reusable onboarding checklist for the first seven days.</span>
+          </div>
+          <div class="deliverable">
+            <strong>Follow-up sequence</strong>
+            <span>First reply, 24-hour nudge, and clear-decision message for leads that stall.</span>
+          </div>
+          <div class="deliverable">
+            <strong>Decision rule</strong>
+            <span>What to keep, rewrite, or stop after the first 25 lead touches.</span>
+          </div>
+        </div>
+
+        <div class="offer-box" aria-label="Offer proof">
+          <strong>Why this is the right first sale</strong>
+          <p>
+            It is small enough to buy without a long sales cycle, concrete enough to judge in a week, and directly tied
+            to missed client revenue.
+          </p>
+        </div>
+
+        <div class="probe-box" aria-label="Market probe">
+          <strong>Public probe copy</strong>
+          <p>Question for freelancers and small agencies:
+
+Where does client onboarding break first after someone says yes or asks for more info?
+
+I am testing whether the first useful product should be a sharper offer audit, a lead follow-up lane, a client onboarding checklist, or a recurring revenue tracker.</p>
+        </div>
+
+        <div class="button-row">
+          <a
+            class="cta"
+            href="/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D300%26label%3DClient%2520Onboarding%2520Sprint%26description%3D72-hour%2520client%2520onboarding%2520and%2520follow-up%2520setup"
+          >Start $300 sprint</a>
+          <a class="text-link" href="#fit-check">Request fit check</a>
+          <a class="text-link" href="/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dbuilder">Continue $50/month</a>
+        </div>
+      </section>
+
+      <aside id="fit-check" class="panel form-panel" aria-label="Client Onboarding Sprint intake">
+        <h2>Send the messy onboarding path.</h2>
+        <p>
+          Share what you sell, what happens after someone says yes, and where the next step gets slow or unclear.
+        </p>
+        <form
+          class="form-grid"
+          data-audience-form
+          data-audience-key="client-onboarding-sprint"
+          data-audience-label="Client Onboarding Sprint"
+          data-source-label="Auto-business · Client Onboarding Sprint"
+          data-question-label="What do you sell and where does onboarding or follow-up break?"
+        >
+          <label>
+            <span>Name</span>
+            <input name="name" type="text" autocomplete="name" required placeholder="Taylor Morgan">
+          </label>
+          <label>
+            <span>Email</span>
+            <input name="email" type="email" autocomplete="email" required placeholder="you@example.com">
+          </label>
+          <label>
+            <span>Where does onboarding break?</span>
+            <textarea
+              name="prompt"
+              placeholder="What you sell, who says yes, what happens next, and where follow-up or onboarding gets stuck."
+            ></textarea>
+          </label>
+          <button type="submit">Request fit check</button>
+          <p class="status" data-form-status role="status" aria-live="polite"></p>
+        </form>
+      </aside>
+    </main>
+
+    <footer class="footer-note">
+      Intake writes to the 3DVR Gun relay under <code>3dvr-audience-tests/v1/client-onboarding-sprint/signups</code>.
+    </footer>
+  </div>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/ideas/index.html
+++ b/ideas/index.html
@@ -150,6 +150,25 @@
         </div>
         <a class="cta" href="/ideas/lead-rescue-sprint.html">Open offer</a>
       </div>
+      <div class="card" data-idea-card data-idea-path="/ideas/client-onboarding-sprint.html">
+        <h2>Client Onboarding Sprint</h2>
+        <p>A $300 paid sprint that turns a yes into intake, checklist, and first-week follow-up.</p>
+        <div class="stats">
+          <div class="stat">
+            <span class="label">Page views</span>
+            <span class="value" data-idea-views>0</span>
+          </div>
+          <div class="stat">
+            <span class="label">CTA clicks</span>
+            <span class="value" data-idea-cta-count>0</span>
+          </div>
+          <div class="stat">
+            <span class="label">Last seen</span>
+            <span class="value" data-idea-last>Never</span>
+          </div>
+        </div>
+        <a class="cta" href="/ideas/client-onboarding-sprint.html">Open offer</a>
+      </div>
     </div>
     <div class="actions">
       <button type="button" class="ghost" data-reset-stats>Reset stats</button>

--- a/ideas/lead-rescue-sprint.html
+++ b/ideas/lead-rescue-sprint.html
@@ -240,7 +240,10 @@ I am testing a 72-hour setup that turns one service offer into a page, intake pa
         <div class="button-row">
           <a class="cta" href="#fit-check">Request free fit check</a>
           <a class="text-link" href="/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dbuilder">Start $50 Builder</a>
-          <a class="text-link" href="/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dcustom">Custom sprint deposit</a>
+          <a
+            class="text-link"
+            href="/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D300%26label%3DLead%2520Rescue%2520Sprint%26description%3D72-hour%2520offer%2520page%2520lead%2520capture%2520and%2520follow-up%2520setup"
+          >Start $300 sprint</a>
         </div>
 
         <div class="not-fit">

--- a/index-style.css
+++ b/index-style.css
@@ -927,6 +927,46 @@ body[data-view-mode="human-os"]:not([data-active-room=""]) .human-os-map {
   transform: translateX(18px);
 }
 
+.app-lane-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-width: 0;
+  margin-top: 0.1rem;
+}
+
+.app-lane-filter button {
+  min-height: 2.15rem;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 999px;
+  padding: 0.38rem 0.72rem;
+  background: rgba(148, 163, 184, 0.08);
+  color: rgba(226, 232, 240, 0.82);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color var(--transition-base),
+    background var(--transition-base),
+    color var(--transition-base),
+    transform var(--transition-base);
+}
+
+.app-lane-filter button:hover,
+.app-lane-filter button:focus-visible {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.56);
+  background: rgba(56, 189, 248, 0.14);
+  color: var(--color-text);
+}
+
+.app-lane-filter button[data-active='true'] {
+  border-color: rgba(34, 211, 238, 0.5);
+  background: rgba(34, 211, 238, 0.2);
+  color: rgba(236, 254, 255, 0.96);
+  box-shadow: 0 10px 28px rgba(8, 145, 178, 0.18);
+}
+
 .hero-actions {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 9rem), 1fr));

--- a/index.html
+++ b/index.html
@@ -385,6 +385,18 @@
               <span class="app-toggle__switch" aria-hidden="true"></span>
             </label>
           </div>
+          <div class="app-lane-filter" aria-label="Filter app dock by lane">
+            <button type="button" data-app-lane-filter="all" data-active="true" aria-pressed="true">All</button>
+            <button type="button" data-app-lane-filter="money" aria-pressed="false">Money</button>
+            <button type="button" data-app-lane-filter="work" aria-pressed="false">Work</button>
+            <button type="button" data-app-lane-filter="projects" aria-pressed="false">Projects</button>
+            <button type="button" data-app-lane-filter="life" aria-pressed="false">Life</button>
+            <button type="button" data-app-lane-filter="ideas" aria-pressed="false">Ideas</button>
+            <button type="button" data-app-lane-filter="learning" aria-pressed="false">Learn</button>
+            <button type="button" data-app-lane-filter="community" aria-pressed="false">Community</button>
+            <button type="button" data-app-lane-filter="play" aria-pressed="false">Games</button>
+            <button type="button" data-app-lane-filter="experimental" aria-pressed="false">Experimental</button>
+          </div>
         </div>
         <p id="appSearchEmpty" class="app-search__empty" role="status" aria-live="polite" hidden>No apps match your search yet.</p>
         <div class="app-grid" data-app-list>
@@ -412,6 +424,16 @@
             <span class="app-card__icon" aria-hidden="true">$300</span>
             <span class="app-card__title">Lead Rescue Sprint</span>
             <span class="app-card__meta">A 72-hour paid setup for freelancers and small agencies losing interested buyers after the first reply.</span>
+            <span class="app-card__cta">Open paid offer</span>
+          </a>
+          <a
+            href="ideas/client-onboarding-sprint.html"
+            class="app-card"
+            data-app-keywords="client onboarding sprint freelancers small agencies checklist follow up paid offer crm intake sales revenue"
+          >
+            <span class="app-card__icon" aria-hidden="true">$300</span>
+            <span class="app-card__title">Client Onboarding Sprint</span>
+            <span class="app-card__meta">A 72-hour paid setup that turns a yes into intake, checklist, and first-week follow-up.</span>
             <span class="app-card__cta">Open paid offer</span>
           </a>
           <a href="start/" class="app-card">
@@ -1196,14 +1218,14 @@
       const authModal = document.getElementById('auth-modal');
 
       if (!signedIn && !guest) {
-        authModal.style.display = 'flex';
-        authModal.setAttribute('aria-hidden', 'false');
-      } else {
-        authModal.style.display = 'none';
-        authModal.setAttribute('aria-hidden', 'true');
+        ensureGuestId();
+        localStorage.setItem('guest', 'true');
       }
 
-      if (guest) {
+      authModal.style.display = 'none';
+      authModal.setAttribute('aria-hidden', 'true');
+
+      if (guest || localStorage.getItem('guest') === 'true') {
         ensureGuestId();
       }
     });
@@ -1483,6 +1505,9 @@
     const experimentalToggle = document.querySelector(
       '[data-experimental-toggle]'
     );
+    const laneFilterButtons = Array.from(
+      document.querySelectorAll('[data-app-lane-filter]')
+    );
     const appHub = document.querySelector('.app-hub');
     const appGrid = document.querySelector('[data-app-list]');
     let appCards = appGrid
@@ -1502,6 +1527,7 @@
     const roomReveal = document.querySelector('[data-room-reveal]');
     const roomTitle = document.querySelector('[data-room-title]');
     const roomSubtitle = document.querySelector('[data-room-subtitle]');
+    let activeAppLane = 'all';
     const roomMeta = {
       purpose: {
         title: '🧭 My Purpose',
@@ -1540,6 +1566,17 @@
         subtitle: 'Games, spatial prototypes, physics experiments, and 3D engine rooms.',
       },
     };
+    const roomSearchTerms = {
+      purpose: 'purpose direction values meaning manifestation vision start here',
+      life: 'life habits health wellness body rhythm posture nervous system reset',
+      ideas: 'ideas notes scratchpad memory capture writing brainstorm',
+      projects: 'projects launch build website app builder execution forge',
+      work: 'work clients crm sales contacts calendar leads follow up jobs',
+      learning: 'learning education docs open source ai lab knowledge',
+      community: 'community chat video collaborators members peer support',
+      money: 'money finance billing revenue cashflow offers rewards income',
+      play: 'games play 3d spatial physics xr arcade engine',
+    };
     const humanRoomTitles = {
       purpose: [
         'Purpose',
@@ -1574,6 +1611,7 @@
         '3DVR Forge',
         'Forge Sprint',
         'Lead Rescue Sprint',
+        'Client Onboarding Sprint',
         'Projects',
         'Launch Room',
         'Launch Site',
@@ -1587,6 +1625,7 @@
       work: [
         'Revenue Desk',
         'Lead Rescue Sprint',
+        'Client Onboarding Sprint',
         'Growth Operator',
         'CRM',
         'Sales',
@@ -1627,6 +1666,7 @@
         'Billing',
         'Forge Sprint',
         'Lead Rescue Sprint',
+        'Client Onboarding Sprint',
         'Money AI',
         'money-printer',
         'Offer Audit',
@@ -1683,6 +1723,21 @@
         if (rooms && rooms.length > 0) {
           card.dataset.humanRooms = rooms.join(' ');
         }
+        const roomSearchText = (rooms || [])
+          .map((room) => `${room} ${roomMeta[room]?.title || ''} ${roomSearchTerms[room] || ''}`)
+          .join(' ');
+        const searchableParts = [
+          title,
+          card.querySelector('.app-card__meta')?.textContent?.trim(),
+          card.dataset.appKeywords,
+          card.dataset.appTier,
+          card.getAttribute('href')?.replace(/[/.#?=&_-]+/g, ' '),
+          roomSearchText,
+        ];
+        card.dataset.appSearchText = searchableParts
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
       });
     }
     const prefersReducedMotionQuery =
@@ -1696,6 +1751,14 @@
     const shouldShowExperimental = () => Boolean(experimentalToggle?.checked);
     const getViewMode = () => document.body.dataset.viewMode || 'human-os';
     const getActiveRoom = () => document.body.dataset.activeRoom || '';
+    const setActiveAppLane = (lane = 'all') => {
+      activeAppLane = lane || 'all';
+      laneFilterButtons.forEach((button) => {
+        const active = button.dataset.appLaneFilter === activeAppLane;
+        button.dataset.active = active ? 'true' : 'false';
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    };
     const isHumanRoomCard = (card) => {
       const activeRoom = getActiveRoom();
       if (!activeRoom) return false;
@@ -1703,6 +1766,9 @@
     };
     const shouldHideCardForState = (card) => {
       if (getViewMode() === 'workshop') {
+        if (activeAppLane === 'experimental') {
+          return !isExperimental(card);
+        }
         return isExperimental(card) && !shouldShowExperimental();
       }
 
@@ -1712,6 +1778,17 @@
       }
 
       return !isHumanRoomCard(card);
+    };
+    const shouldHideCardForLane = (card) => {
+      if (getViewMode() !== 'workshop') {
+        return false;
+      }
+      if (activeAppLane === 'all' || activeAppLane === 'experimental') {
+        return false;
+      }
+      return !(card.dataset.humanRooms || '')
+        .split(/\s+/)
+        .includes(activeAppLane);
     };
     const syncRoomReveal = () => {
       const activeRoom = getActiveRoom();
@@ -1736,6 +1813,9 @@
       const mode = nextMode === 'workshop' ? 'workshop' : 'human-os';
       document.body.dataset.viewMode = mode;
       document.body.dataset.activeRoom = mode === 'human-os' ? nextRoom : '';
+      if (mode === 'human-os' && activeAppLane !== 'all') {
+        setActiveAppLane('all');
+      }
       viewModeButtons.forEach((button) => {
         const active = button.dataset.viewModeButton === mode;
         button.dataset.active = active ? 'true' : 'false';
@@ -1753,8 +1833,9 @@
       if (!query) {
         appCards.forEach((card) => {
           const hideForState = shouldHideCardForState(card);
-          card.hidden = hideForState;
-          if (!hideForState) {
+          const hideForLane = shouldHideCardForLane(card);
+          card.hidden = hideForState || hideForLane;
+          if (!card.hidden) {
             if (appGrid) {
               appGrid.appendChild(card);
             }
@@ -1779,18 +1860,22 @@
           .querySelector('.app-card__meta')
           ?.textContent?.toLowerCase() ?? '';
         const keywordText = card.dataset.appKeywords?.toLowerCase() ?? '';
+        const searchText = card.dataset.appSearchText?.toLowerCase() ?? '';
         const titleIncludesQuery = titleText.includes(query);
         const metaIncludesQuery = metaText.includes(query);
         const keywordIncludesQuery = keywordText.includes(query);
-        const matches = titleIncludesQuery || metaIncludesQuery || keywordIncludesQuery;
+        const searchTextIncludesQuery = searchText.includes(query);
+        const matches =
+          titleIncludesQuery || metaIncludesQuery || keywordIncludesQuery || searchTextIncludesQuery;
         const hideForState = shouldHideCardForState(card);
+        const hideForLane = shouldHideCardForLane(card);
 
-        card.hidden = !matches || hideForState;
-        if (matches && !hideForState) {
+        card.hidden = !matches || hideForState || hideForLane;
+        if (matches && !hideForState && !hideForLane) {
           visibleCount += 1;
           if (titleIncludesQuery) {
             nameMatches.push(card);
-          } else if (metaIncludesQuery || keywordIncludesQuery) {
+          } else if (metaIncludesQuery || keywordIncludesQuery || searchTextIncludesQuery) {
             descriptionMatches.push(card);
           }
         }
@@ -2015,6 +2100,17 @@
       });
     }
 
+    laneFilterButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        setViewMode('workshop');
+        setActiveAppLane(button.dataset.appLaneFilter || 'all');
+        updateAppFilter(searchInput?.value ?? '');
+        window.requestAnimationFrame(() => {
+          scrollAppsIntoView({ alignSearch: true });
+        });
+      });
+    });
+
     viewModeButtons.forEach((button) => {
       button.addEventListener('click', () => {
         setViewMode(button.dataset.viewModeButton);
@@ -2081,6 +2177,7 @@
 
     const initialSearchValue = searchInput?.value ?? '';
     setViewMode('workshop');
+    setActiveAppLane('all');
     updateAppFilter(initialSearchValue);
   </script>
   <script defer src="/issue-launcher.js"></script>

--- a/sales/index.html
+++ b/sales/index.html
@@ -54,7 +54,28 @@
           <p class="text-xs uppercase tracking-[0.3em] text-blue-200">One lead. One offer. One ask.</p>
         </div>
 
-        <div class="grid gap-4 md:grid-cols-3">
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <article class="rounded-xl border border-sky-400/20 bg-sky-950/30 p-4 space-y-3">
+            <div class="flex items-start justify-between gap-2">
+              <div>
+                <p class="text-xs uppercase tracking-[0.3em] text-sky-200">Onboarding</p>
+                <h3 class="text-lg font-semibold mt-1">Client Onboarding Sprint</h3>
+                <p class="text-sm font-semibold text-sky-100 mt-1">$300 setup</p>
+              </div>
+              <span class="rounded-full bg-sky-500/15 px-3 py-1 text-xs font-semibold text-sky-100">AI pick</span>
+            </div>
+            <p class="text-sm text-slate-300">For freelancers and small agencies turning interested leads into clean client starts.</p>
+            <ul class="space-y-1 text-sm text-slate-300">
+              <li>• Intake and onboarding checklist</li>
+              <li>• First-week follow-up sequence</li>
+              <li>• 25-touch decision rule</li>
+            </ul>
+            <div class="flex flex-wrap gap-2 pt-1">
+              <a href="../ideas/client-onboarding-sprint.html" class="inline-flex items-center justify-center rounded-lg bg-white text-sky-950 px-4 py-2 text-sm font-semibold hover:bg-sky-50">Open offer</a>
+              <a href="../crm/?draft=1&lead=Client%20Onboarding%20Sprint&status=Lead&offer=300&next=Send%20fit%20check&source=sales-hub&tags=client-onboarding%2Csales-hub" class="inline-flex items-center justify-center rounded-lg bg-white/10 border border-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20">Draft CRM</a>
+              <a href="../email-operator/index.html?draft=1&threadId=sales-client-onboarding&lead=Client%20Onboarding%20Sprint&company=Freelancer%20or%20small%20agency&segment=Freelancers%20and%20small%20agencies&pain=Client%20onboarding%20and%20follow-up%20break%20after%20first%20interest&offer=%24300%20Client%20Onboarding%20Sprint&next=Send%20fit%20check&signal=AI%20auto-business%20selected%20client%20onboarding%20as%20top%20opportunity&source=sales-hub&tags=offer%2Fclient-onboarding%2Csource%2Fsales-hub&subject=3dvr%20Client%20Onboarding%20Sprint" class="inline-flex items-center justify-center rounded-lg bg-white/10 border border-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20">Open operator</a>
+            </div>
+          </article>
           <article class="rounded-xl border border-emerald-400/20 bg-emerald-950/30 p-4 space-y-3">
             <div class="flex items-start justify-between gap-2">
               <div>

--- a/tests/billing-page.test.js
+++ b/tests/billing-page.test.js
@@ -134,6 +134,12 @@ describe('billing center', () => {
     assert.ok(js.includes("label = 'Refresh account first'"));
     assert.ok(js.includes('authPub: livePub'));
     assert.ok(js.includes("window.location.assign(signInHref(targetPlan))"));
+    assert.ok(js.includes('function prefillCustomCheckoutFromUrl()'));
+    assert.ok(js.includes("billingQueryValue('amount', 'customAmount')"));
+    assert.ok(js.includes("billingQueryValue('label', 'customLabel')"));
+    assert.ok(js.includes("billingQueryValue('description', 'customDescription')"));
+    assert.ok(js.includes("customAmountInput.value = amount.replace(/[^0-9.]/g, '')"));
+    assert.ok(js.includes('prefillCustomCheckoutFromUrl()'));
     assert.ok(!js.includes('cancel the extra plan'));
     assert.ok(!js.includes("label = 'Review duplicates'"));
   });

--- a/tests/client-onboarding-sprint.test.js
+++ b/tests/client-onboarding-sprint.test.js
@@ -1,0 +1,51 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const rootDir = new URL('../', import.meta.url);
+const sprintPageUrl = new URL('ideas/client-onboarding-sprint.html', rootDir);
+const ideasIndexUrl = new URL('ideas/index.html', rootDir);
+const portalIndexUrl = new URL('index.html', rootDir);
+
+async function fileExists(url) {
+  try {
+    await access(url, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('Client Onboarding Sprint offer', () => {
+  it('ships a buyable paid sprint page with Gun-backed intake', async () => {
+    assert.equal(await fileExists(sprintPageUrl), true, 'client onboarding sprint page should exist');
+    const html = await readFile(sprintPageUrl, 'utf8');
+
+    assert.match(html, /Turn a yes into a clean client start\./);
+    assert.match(html, /freelancers and small agencies/);
+    assert.match(html, /\$300 setup sprint/);
+    assert.match(html, /72-hour delivery/);
+    assert.match(html, /Client start map/);
+    assert.match(html, /Intake and checklist/);
+    assert.match(html, /Follow-up sequence/);
+    assert.match(html, /Decision rule/);
+    assert.match(html, /Start \$300 sprint/);
+    assert.match(html, /redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D300/);
+    assert.match(html, /label%3DClient%2520Onboarding%2520Sprint/);
+    assert.match(html, /data-audience-key="client-onboarding-sprint"/);
+    assert.match(html, /3dvr-audience-tests\/v1\/client-onboarding-sprint\/signups/);
+  });
+
+  it('links the sprint from the Ideas Lab and portal app dock', async () => {
+    const [ideas, portal] = await Promise.all([
+      readFile(ideasIndexUrl, 'utf8'),
+      readFile(portalIndexUrl, 'utf8')
+    ]);
+
+    assert.match(ideas, /\/ideas\/client-onboarding-sprint\.html/);
+    assert.match(ideas, /A \$300 paid sprint that turns a yes into intake, checklist, and first-week follow-up\./);
+    assert.match(portal, /ideas\/client-onboarding-sprint\.html/);
+    assert.match(portal, /Client Onboarding Sprint/);
+  });
+});

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -79,6 +79,9 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test\./);
     assert.match(html, /<span class="app-card__title">Forge Sprint<\/span>/);
     assert.match(html, /Start paid sprint/);
+    assert.match(html, /<span class="app-card__title">Client Onboarding Sprint<\/span>/);
+    assert.match(html, /A 72-hour paid setup that turns a yes into intake, checklist, and first-week follow-up\./);
+    assert.match(html, /ideas\/client-onboarding-sprint\.html/);
     assert.match(html, /data-active-room=""/);
     assert.match(html, /data-view-mode-button="workshop"/);
     assert.doesNotMatch(html, /Suggested launcher lanes/);

--- a/tests/guest-upgrade-entrypoints.test.js
+++ b/tests/guest-upgrade-entrypoints.test.js
@@ -19,6 +19,9 @@ describe('guest account entrypoints', () => {
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /onclick="startAccountFromHere\(\)"/);
     assert.match(html, /function startAccountFromHere\(\)/);
+    assert.match(html, /localStorage\.setItem\('guest', 'true'\)/);
+    assert.match(html, /authModal\.style\.display = 'none'/);
+    assert.doesNotMatch(html, /authModal\.style\.display = 'flex'/);
     assert.doesNotMatch(html, /upgradeParam/);
     assert.doesNotMatch(html, /&upgrade=guest/);
     assert.match(html, /\/sign-in\.html\?redirect=/);

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -1,6 +1,38 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const rootDir = new URL('../', import.meta.url);
+
+function appCardHrefs(html) {
+  return Array.from(html.matchAll(/<a\s+([\s\S]*?class="app-card"[\s\S]*?)>/g))
+    .map((match) => match[1].match(/href="([^"]+)"/)?.[1])
+    .filter(Boolean);
+}
+
+async function routeExists(href) {
+  if (/^(https?:|mailto:|#)/.test(href)) return true;
+
+  const clean = href.split(/[?#]/)[0];
+  const rel = clean.startsWith('/') ? clean.slice(1) : clean;
+  const candidates = [
+    rel,
+    rel.endsWith('/') ? `${rel}index.html` : `${rel}.html`,
+    rel.endsWith('/') ? rel : `${rel}/index.html`,
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await access(new URL(candidate, rootDir), constants.F_OK);
+      return true;
+    } catch {
+      // Try the next route shape.
+    }
+  }
+
+  return false;
+}
 
 test('homepage search shortcuts stay scoped to one top-level control per viewport', async () => {
   const [navbarJs, indexCss] = await Promise.all([
@@ -30,6 +62,33 @@ test('homepage app search can find CRM by CRM keywords', async () => {
   assert.match(html, /<span class="app-card__title">CRM<\/span>/);
   assert.match(html, /card\.dataset\.appKeywords/);
   assert.match(html, /keywordIncludesQuery/);
+});
+
+test('homepage app dock has lane filters and generated search context', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /class="app-lane-filter"/);
+  assert.match(html, /data-app-lane-filter="money"/);
+  assert.match(html, /data-app-lane-filter="work"/);
+  assert.match(html, /data-app-lane-filter="projects"/);
+  assert.match(html, /data-app-lane-filter="experimental"/);
+  assert.match(html, /const roomSearchTerms =/);
+  assert.match(html, /card\.dataset\.appSearchText = searchableParts/);
+  assert.match(html, /const shouldHideCardForLane =/);
+  assert.match(html, /searchTextIncludesQuery/);
+});
+
+test('homepage app dock does not ship dead local app routes', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const missing = [];
+
+  for (const href of appCardHrefs(html)) {
+    if (!(await routeExists(href))) {
+      missing.push(href);
+    }
+  }
+
+  assert.deepEqual(missing, []);
 });
 
 test('homepage app search can find Forge by project-shaping keywords', async () => {

--- a/tests/sales-index.test.js
+++ b/tests/sales-index.test.js
@@ -7,6 +7,11 @@ test('sales index leads with the revenue close section', async () => {
 
   assert.match(html, /Pick one lead, one offer, and one ask\. Keep the close path simple\./);
   assert.match(html, /<p class="text-xs uppercase tracking-\[0\.3em\] text-blue-300">Today&apos;s close<\/p>/);
+  assert.match(html, /Client Onboarding Sprint/);
+  assert.match(html, /AI pick/);
+  assert.match(html, /\$300 setup/);
+  assert.match(html, /\.\.\/ideas\/client-onboarding-sprint\.html/);
+  assert.match(html, /threadId=sales-client-onboarding/);
   assert.match(html, /\$50 \/ month/);
   assert.match(html, /\$200 \/ month/);
   assert.match(html, /Ask Builder/);


### PR DESCRIPTION
## Summary
- Add lane filters and generated search context to make the 108-app portal dock easier to navigate.
- Make the homepage guest-first so the auth modal no longer blocks exploration on first load.
- Add a buyable Client Onboarding Sprint offer, wire it into Portal, Ideas Lab, and Sales, and prefill custom billing checkout links.
- Add regression coverage for portal app routes, lane/search behavior, the new offer page, guest-first auth, sales placement, and billing prefill.

## UX Walkthrough
- Ran local server at `http://127.0.0.1:3000`.
- Captured WebKit screenshots for mobile 390px, mobile 360px, and desktop flows under `/tmp/3dvr-portal-ux-2026-06-28`.
- Checked homepage, Money lane filter, `client onboarding` search, Client Onboarding Sprint offer page, Sales hub, and custom billing prefill.
- Found and fixed a blocker where the auth modal opened on first homepage load and intercepted app navigation.
- Verified no horizontal overflow in the walked views: `scrollWidth === clientWidth` at 390px, 360px, and desktop.

## Validation
- `node --test tests/homepage-search-ux.test.js tests/customer-journey-pages.test.js tests/client-onboarding-sprint.test.js tests/billing-page.test.js tests/sales-index.test.js tests/guest-upgrade-entrypoints.test.js`
- `node --check billing/app.js`
- Parsed 5 homepage inline scripts with `new Function(...)`
- `git diff --check`
