### PR TITLE
[codex] Point Forge buyers to 300 sprint

### DIFF
--- a/forge/index.html
+++ b/forge/index.html
@@ -125,7 +125,7 @@
             <div>
               <span class="eyebrow">Sell this next</span>
               <h3 id="forgeOfferTitle">Turn this brief into a paid launch sprint.</h3>
-              <p>Get direct help sharpening the offer, sending the first test messages, and building only what proves demand.</p>
+              <p>Use the brief as the deposit trigger: a 72-hour pass that sharpens the offer, builds the first page, writes the test message, and sets up a tiny reply tracker.</p>
             </div>
             <ul class="forge-offer__list">
               <li>Offer and test message review</li>
@@ -133,9 +133,12 @@
               <li>Reply tracker and 7-day follow-up</li>
             </ul>
             <div class="forge-offer__actions">
-              <a class="cta primary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dpro">Start $20 Founder</a>
+              <a
+                class="cta primary"
+                href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D300%26label%3DForge%20Revenue%20Sprint%26description%3D72-hour%20Movement%20Brief%20to%20paid%20offer%20page%2C%20first%20test%20message%2C%20and%20reply%20tracker"
+              >Start $300 sprint</a>
               <a class="cta ghost" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dbuilder">Go $50 Builder</a>
-              <a class="cta ghost" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dcustom">Custom deposit</a>
+              <a class="cta ghost" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dpro">Start $20 Founder</a>
             </div>
           </article>
         </aside>

--- a/index.html
+++ b/index.html
@@ -407,14 +407,14 @@
             <span class="app-card__cta">Enter the Forge</span>
           </a>
           <a
-            href="sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dpro"
+            href="sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D300%26label%3DForge%20Revenue%20Sprint%26description%3D72-hour%20Movement%20Brief%20to%20paid%20offer%20page%2C%20first%20test%20message%2C%20and%20reply%20tracker"
             class="app-card"
-            data-app-keywords="forge sprint paid launch offer revenue founder money validation test message landing page builder"
+            data-app-keywords="forge sprint paid launch offer revenue deposit money validation test message landing page builder"
           >
-            <span class="app-card__icon" aria-hidden="true">$20</span>
+            <span class="app-card__icon" aria-hidden="true">$300</span>
             <span class="app-card__title">Forge Sprint</span>
-            <span class="app-card__meta">Turn a Movement Brief into a paid offer test, first messages, and a tiny launch artifact.</span>
-            <span class="app-card__cta">Start paid sprint</span>
+            <span class="app-card__meta">Turn a Movement Brief into a 72-hour paid offer page, first test message, and reply tracker.</span>
+            <span class="app-card__cta">Start $300 sprint</span>
           </a>
           <a
             href="ideas/lead-rescue-sprint.html"

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -78,7 +78,7 @@ describe('portal customer journey pages', () => {
     assert.match(html, /<span class="app-card__title">3DVR Forge<\/span>/);
     assert.match(html, /Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test\./);
     assert.match(html, /<span class="app-card__title">Forge Sprint<\/span>/);
-    assert.match(html, /Start paid sprint/);
+    assert.match(html, /Start \$300 sprint/);
     assert.match(html, /<span class="app-card__title">Client Onboarding Sprint<\/span>/);
     assert.match(html, /A 72-hour paid setup that turns a yes into intake, checklist, and first-week follow-up\./);
     assert.match(html, /ideas\/client-onboarding-sprint\.html/);

--- a/tests/forge.test.js
+++ b/tests/forge.test.js
@@ -29,9 +29,10 @@ describe('3DVR Forge product route', () => {
     assert.match(html, /aria-label="Forge another brief">New brief<\/button>/);
     assert.match(html, /Sell this next/);
     assert.match(html, /Turn this brief into a paid launch sprint\./);
-    assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dpro">Start \$20 Founder<\/a>/);
+    assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D300%26label%3DForge%20Revenue%20Sprint/);
+    assert.match(html, /Start \$300 sprint<\/a>/);
     assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dbuilder">Go \$50 Builder<\/a>/);
-    assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dcustom">Custom deposit<\/a>/);
+    assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dpro">Start \$20 Founder<\/a>/);
     assert.match(html, /Make test message/);
     assert.match(html, /Make Codex prompt/);
     assert.match(html, /Make landing page copy/);
@@ -175,8 +176,9 @@ describe('3DVR Forge product route', () => {
     assert.match(html, /href="forge\/" class="app-card" data-app-keywords="[^"]*\bfrustration\b[^"]*\bmovement brief\b[^"]*"/);
     assert.match(html, /<span class="app-card__title">3DVR Forge<\/span>/);
     assert.match(html, /Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test\./);
-    assert.match(html, /href="sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dpro"[\s\S]*?<span class="app-card__title">Forge Sprint<\/span>/);
-    assert.match(html, /Turn a Movement Brief into a paid offer test, first messages, and a tiny launch artifact\./);
+    assert.match(html, /href="sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D300%26label%3DForge%20Revenue%20Sprint/);
+    assert.match(html, /<span class="app-card__title">Forge Sprint<\/span>/);
+    assert.match(html, /Turn a Movement Brief into a 72-hour paid offer page, first test message, and reply tracker\./);
     assert.match(html, /projects:\s*\[[\s\S]*?'3DVR Forge'/);
     assert.match(html, /projects:\s*\[[\s\S]*?'Forge Sprint'/);
     assert.match(html, /money:\s*\[[\s\S]*?'Forge Sprint'/);

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -109,7 +109,7 @@ test('homepage app search can find Forge Sprint by paid offer keywords', async (
     html,
     /<a[\s\S]*?data-app-keywords="[^"]*\bpaid\b[^"]*\boffer\b[^"]*\brevenue\b[^"]*"[\s\S]*?<span class="app-card__title">Forge Sprint<\/span>/
   );
-  assert.match(html, /Start paid sprint/);
+  assert.match(html, /Start \$300 sprint/);
 });
 
 test('homepage app search can find the manifestation practice', async () => {


### PR DESCRIPTION
## Summary
- Point the portal Forge Sprint card at a $300 one-time Forge Revenue Sprint deposit.
- Make Forge’s final paid CTA use the same custom billing prefill instead of the $20 Founder plan.
- Keep Builder and Founder as secondary choices.

## Why
Forge creates a Movement Brief and launch artifacts, so the highest-intent money path should sell the 72-hour sprint directly instead of downshifting to a low monthly plan.

## Validation
- `node --test tests/forge.test.js tests/homepage-search-ux.test.js tests/customer-journey-pages.test.js tests/client-onboarding-sprint.test.js tests/stripe-billing-api.test.js`
- `node --check forge/app.js && node --check src/forge/api.js && node --check billing/app.js`
- `git diff --check HEAD~1 HEAD`
- WebKit mobile smoke at 390px verified homepage/Forge $300 links and billing custom prefill with no horizontal overflow.