### PR TITLE
[codex] Import sprint fit checks into Growth Operator

### DIFF
--- a/growth-operator/app.js
+++ b/growth-operator/app.js
@@ -8,6 +8,39 @@ const DEFAULT_PEERS = [
   'wss://gun-relay-3dvr.fly.dev/gun'
 ];
 
+const AUDIENCE_LEAD_SOURCES = Object.freeze([
+  {
+    key: 'forge-revenue-sprint',
+    offer: '$300 Forge Revenue Sprint',
+    nextStep: 'Review the messy brief and draft the first paid-offer reply.'
+  },
+  {
+    key: 'lead-rescue-sprint',
+    offer: '$300 Lead Rescue Sprint',
+    nextStep: 'Review the lead leak and draft a short rescue-sprint reply.'
+  },
+  {
+    key: 'client-onboarding-sprint',
+    offer: '$300 Client Onboarding Sprint',
+    nextStep: 'Review the onboarding break and draft a fit-check reply.'
+  },
+  {
+    key: 'offer-audit',
+    offer: '48-Hour Offer Audit',
+    nextStep: 'Review the offer and draft the smallest paid audit next step.'
+  },
+  {
+    key: 'ai-leverage',
+    offer: 'AI leverage sprint',
+    nextStep: 'Review the workflow pain and draft a simple leverage sprint reply.'
+  },
+  {
+    key: 'freedom-from-work',
+    offer: 'Project-shaping sprint',
+    nextStep: 'Review the stuck-at-work context and draft a low-pressure project reply.'
+  }
+]);
+
 const LANE_LABELS = Object.freeze({
   lead: 'Lead',
   support: 'Support',
@@ -33,6 +66,7 @@ const gun = typeof Gun === 'function' ? Gun(window.__GUN_PEERS__ || DEFAULT_PEER
 const portalRoot = gun ? gun.get(ROOT_KEY) : null;
 const operatorRoot = portalRoot ? portalRoot.get(OPERATOR_NODE) : null;
 const itemsRoot = operatorRoot ? operatorRoot.get('items') : null;
+const audienceRoot = gun ? gun.get('3dvr-audience-tests').get('v1') : null;
 const agentQueueRoot = portalRoot
   ? portalRoot.get('agentOps').get(AGENT_OWNER_ALIAS).get('taskQueue')
   : null;
@@ -244,6 +278,48 @@ function buildDraft(item) {
     '',
     billingUrl ? `Start here if you want to make it official: ${billingUrl}` : 'Want me to send the simplest next step?'
   ].filter(Boolean).join('\n');
+}
+
+function audienceLeadId(sourceKey, lead) {
+  const sourceId = normalizeText(lead?.id) || `${normalizeEmail(lead?.email)}-${normalizeText(lead?.createdAt)}`;
+  return `audience-${sourceKey}-${slug(sourceId)}`;
+}
+
+function normalizeAudienceLead(source, lead) {
+  if (!source || !lead || typeof lead !== 'object') return null;
+  const name = normalizeText(lead.name || lead.company || lead.business);
+  const email = normalizeEmail(lead.email);
+  if (!name || !email) return null;
+
+  const promptLabel = normalizeText(lead.promptLabel) || 'Fit-check note';
+  const prompt = normalizeText(lead.prompt);
+  const audienceLabel = normalizeText(lead.audienceLabel) || source.key;
+  const sourceLabel = normalizeText(lead.source) || 'Audience fit check';
+  const createdAt = normalizeText(lead.createdAt) || new Date().toISOString();
+  const context = [
+    `${audienceLabel} fit-check from ${sourceLabel}.`,
+    prompt ? `${promptLabel}: ${prompt}` : '',
+    normalizeText(lead.referrer) ? `Referrer: ${normalizeText(lead.referrer)}` : ''
+  ].filter(Boolean).join('\n\n');
+
+  const item = {
+    id: audienceLeadId(source.key, lead),
+    name,
+    email,
+    lane: 'lead',
+    stage: 'drafted',
+    offer: source.offer,
+    context,
+    draft: '',
+    nextStep: source.nextStep,
+    source: `audience:${source.key}`,
+    approvedAt: '',
+    sentAt: '',
+    createdAt,
+    updatedAt: new Date().toISOString()
+  };
+  item.draft = buildDraft(item);
+  return normalizeItem(item);
 }
 
 function buildItemFromForm() {
@@ -540,6 +616,33 @@ function subscribeGun() {
   updateStatus('Gun sync: connected to 3dvr-portal/growthOperator/items.');
 }
 
+function subscribeAudienceLeads() {
+  if (!audienceRoot || !itemsRoot) {
+    return;
+  }
+
+  AUDIENCE_LEAD_SOURCES.forEach(source => {
+    audienceRoot.get(source.key).get('signups').map().on(async (record) => {
+      const lead = normalizeAudienceLead(source, cleanGunRecord(record));
+      if (!lead?.id) return;
+
+      const existing = normalizeItem(state.items[lead.id]);
+      if (existing) return;
+
+      state.items[lead.id] = lead;
+      persistLocalItems();
+      render();
+
+      try {
+        await putGun(itemsRoot.get(lead.id), lead);
+        updateStatus(`Imported ${lead.name} from ${source.offer} fit-checks.`);
+      } catch (error) {
+        updateStatus(`Imported ${lead.name} locally. ${error.message || 'Gun sync failed.'}`);
+      }
+    });
+  });
+}
+
 function bindEvents() {
   els.form?.addEventListener('submit', addItem);
   els.operatorEmailToken?.addEventListener('input', persistOperatorToken);
@@ -589,6 +692,7 @@ function init() {
   bindEvents();
   render();
   subscribeGun();
+  subscribeAudienceLeads();
 }
 
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {

--- a/growth-operator/index.html
+++ b/growth-operator/index.html
@@ -43,7 +43,7 @@
         <aside class="status-card">
           <span>Operating rule</span>
           <strong>Prepare the work. Send only approved email.</strong>
-          <p id="syncStatus" role="status" aria-live="polite">Connecting to 3dvr-portal/growthOperator.</p>
+          <p id="syncStatus" role="status" aria-live="polite">Connecting to 3dvr-portal/growthOperator and sprint fit-check leads.</p>
         </aside>
       </div>
     </header>
@@ -126,7 +126,10 @@
           <div>
             <p class="eyebrow">Operator queue</p>
             <h2>Find, email, support, deliver.</h2>
-            <p>Everything saves locally first and mirrors to <code>3dvr-portal/growthOperator/items</code>.</p>
+            <p>
+              Everything saves locally first and mirrors to <code>3dvr-portal/growthOperator/items</code>.
+              Sprint fit-checks auto-import from <code>3dvr-audience-tests/v1</code>.
+            </p>
           </div>
           <button id="draftAllButton" class="button" type="button">Draft next emails</button>
         </div>

--- a/tests/growth-operator.test.js
+++ b/tests/growth-operator.test.js
@@ -35,6 +35,8 @@ test('growth operator ships a separate lead, email, support, and delivery app', 
   assert.match(html, /id="deliveryQueueCount"/);
   assert.match(html, /\/api\/calendar\/reminder-email/);
   assert.match(html, /3dvr-portal\/growthOperator\/items/);
+  assert.match(html, /sprint fit-check leads/);
+  assert.match(html, /3dvr-audience-tests\/v1/);
   assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
   assert.match(html, /type="module" src="app\.js"/);
 });
@@ -44,6 +46,16 @@ test('growth operator app queues agent work and can send approved outreach throu
 
   assert.match(js, /OPERATOR_NODE = 'growthOperator'/);
   assert.match(js, /AGENT_OWNER_ALIAS = '3dvr-managed'/);
+  assert.match(js, /AUDIENCE_LEAD_SOURCES = Object\.freeze/);
+  assert.match(js, /key: 'forge-revenue-sprint'/);
+  assert.match(js, /key: 'lead-rescue-sprint'/);
+  assert.match(js, /key: 'client-onboarding-sprint'/);
+  assert.match(js, /key: 'offer-audit'/);
+  assert.match(js, /audienceRoot = gun \? gun\.get\('3dvr-audience-tests'\)\.get\('v1'\) : null/);
+  assert.match(js, /function normalizeAudienceLead/);
+  assert.match(js, /source: `audience:\$\{source\.key\}`/);
+  assert.match(js, /subscribeAudienceLeads/);
+  assert.match(js, /itemsRoot\.get\(lead\.id\), lead/);
   assert.match(js, /portalRoot\.get\('agentOps'\)\.get\(AGENT_OWNER_ALIAS\)\.get\('taskQueue'\)/);
   assert.match(js, /buildAgentTask/);
   assert.match(js, /find-leads/);


### PR DESCRIPTION
## Summary
- Auto-import public offer fit-check signups into Growth Operator.
- Convert Forge Revenue Sprint, Lead Rescue, Client Onboarding, Offer Audit, AI Leverage, and Freedom From Work signups into draft-ready lead items.
- Keep the approval-first send path: imported leads are drafted, not sent.

## Why
The portal now has paid sprint landing pages capturing buyer context into Gun, but the operator queue did not ingest those signups. This closes the loop so new fit-checks become visible leads that can be reviewed, drafted, approved, and followed up.

## Validation
- `node --test tests/growth-operator.test.js tests/forge-revenue-sprint.test.js tests/client-onboarding-sprint.test.js tests/offer-audit-page.test.js`
- `node --check growth-operator/app.js`
- `git diff --check HEAD~1 HEAD`
- WebKit mobile smoke at 390px verified Growth Operator loads without page errors and no horizontal overflow.