### PR TITLE
[codex] Add portfolio validation sprint offer

### DIFF
--- a/growth-operator/app.js
+++ b/growth-operator/app.js
@@ -20,6 +20,11 @@ const AUDIENCE_LEAD_SOURCES = Object.freeze([
     nextStep: 'Review the lead leak and draft a short rescue-sprint reply.'
   },
   {
+    key: 'freelance-portfolio-validation-sprint',
+    offer: '$500 Freelance Portfolio Validation Sprint',
+    nextStep: 'Review the portfolio gap and draft a paid pilot validation reply.'
+  },
+  {
     key: 'client-onboarding-sprint',
     offer: '$300 Client Onboarding Sprint',
     nextStep: 'Review the onboarding break and draft a fit-check reply.'

--- a/ideas/freelance-portfolio-validation-sprint.html
+++ b/ideas/freelance-portfolio-validation-sprint.html
@@ -1,0 +1,315 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Freelance Portfolio Validation Sprint | 3DVR</title>
+  <meta
+    name="description"
+    content="A 7-day paid sprint for freelance designers and creative builders who need one portfolio proof piece, buyer feedback, and a paid pilot offer."
+  >
+  <link rel="stylesheet" href="audience-leads.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+  <script src="audience-leads.js" defer></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+  <style>
+    :root {
+      --portfolio-bg: #0d1018;
+      --portfolio-panel: rgba(248, 250, 252, 0.08);
+      --portfolio-border: rgba(151, 191, 255, 0.26);
+      --portfolio-text: #f8fafc;
+      --portfolio-muted: #c6d0df;
+      --portfolio-blue: #9dc3ff;
+      --portfolio-green: #8ef0c2;
+      --portfolio-gold: #f5d06f;
+    }
+
+    body {
+      background:
+        linear-gradient(135deg, rgba(157, 195, 255, 0.16), transparent 34%),
+        linear-gradient(230deg, rgba(142, 240, 194, 0.14), transparent 42%),
+        var(--portfolio-bg);
+      color: var(--portfolio-text);
+    }
+
+    .page {
+      max-width: 1160px;
+    }
+
+    .panel {
+      border-color: var(--portfolio-border);
+      border-radius: 8px;
+      background: var(--portfolio-panel);
+    }
+
+    .sprint-box,
+    .proof-box,
+    .copy-box,
+    .deliverable {
+      border: 1px solid var(--portfolio-border);
+      border-radius: 8px;
+      padding: 16px;
+      background: rgba(7, 11, 18, 0.76);
+    }
+
+    .sprint-box {
+      display: grid;
+      gap: 12px;
+      margin: 22px 0;
+    }
+
+    .sprint-box strong,
+    .proof-box strong,
+    .copy-box strong {
+      color: var(--portfolio-green);
+    }
+
+    .price-line {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .price-line strong {
+      color: var(--portfolio-gold);
+      font-size: 1.35rem;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 32px;
+      border: 1px solid rgba(245, 208, 111, 0.34);
+      border-radius: 999px;
+      padding: 5px 10px;
+      color: #fff3cc;
+      background: rgba(245, 208, 111, 0.1);
+      font-size: 0.9rem;
+      font-weight: 700;
+    }
+
+    .deliverables {
+      display: grid;
+      gap: 12px;
+      margin: 20px 0;
+    }
+
+    .deliverable {
+      border-color: rgba(142, 240, 194, 0.2);
+      background: rgba(142, 240, 194, 0.07);
+    }
+
+    .deliverable strong {
+      display: block;
+      color: #ddfff0;
+    }
+
+    .deliverable span,
+    .proof-box p,
+    .copy-box p {
+      color: var(--portfolio-muted);
+    }
+
+    .proof-box a {
+      color: #dbeafe;
+      font-weight: 800;
+    }
+
+    .button-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 22px;
+    }
+
+    .cta,
+    .text-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      border-radius: 999px;
+      font-weight: 800;
+      text-decoration: none;
+    }
+
+    .cta {
+      padding: 12px 20px;
+      color: #0f172a;
+      background: var(--portfolio-gold);
+      box-shadow: 0 14px 30px rgba(245, 208, 111, 0.22);
+    }
+
+    .text-link {
+      color: var(--portfolio-blue);
+    }
+
+    .not-fit {
+      border: 1px solid rgba(248, 113, 113, 0.26);
+      border-radius: 8px;
+      margin-top: 18px;
+      padding: 14px;
+      color: #ffe2e2;
+      background: rgba(248, 113, 113, 0.08);
+    }
+
+    .copy-box {
+      margin-top: 18px;
+      white-space: pre-wrap;
+    }
+
+    .form-panel {
+      border-color: rgba(245, 208, 111, 0.32);
+    }
+
+    @media (min-width: 900px) {
+      .layout {
+        grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <nav class="top-nav" aria-label="Portfolio Validation Sprint navigation">
+      <a href="/ideas/">Ideas Lab</a>
+      <a href="/growth-operator/">Growth Operator</a>
+      <a href="/index.html">Portal Home</a>
+    </nav>
+
+    <main class="layout">
+      <section class="panel" aria-labelledby="headline">
+        <p class="kicker">Paid validation sprint for freelance designers</p>
+        <h1 id="headline">Turn one hidden skill into a proof piece clients can react to.</h1>
+        <p class="subhead">
+          3DVR Portfolio Validation Sprint helps freelance designers and creative builders create one sharp portfolio
+          proof piece, get real buyer feedback, and ask for a paid pilot without rebuilding their whole brand.
+        </p>
+
+        <div class="sprint-box" aria-label="Sprint summary">
+          <strong>Built from the current money-printer command brief.</strong>
+          <span>
+            The strongest immediate opportunity is a service-first offer for independent creatives who have skill but
+            need a clearer artifact, audience, and first paid ask.
+          </span>
+        </div>
+
+        <div class="body-text">
+          <p>
+            A broad portfolio says "I can do many things." A validation piece says "I understand this specific buyer
+            problem and can create a result worth paying for." That is the shift this sprint tests.
+          </p>
+          <p>This sprint keeps the scope concrete:</p>
+          <ul>
+            <li>Pick one reachable buyer and one painful business problem.</li>
+            <li>Create a small proof piece that shows the before and after.</li>
+            <li>Ask real buyers for feedback using a short test message.</li>
+            <li>Turn useful replies into one paid pilot offer.</li>
+          </ul>
+        </div>
+
+        <div class="proof-box" aria-label="Market proof">
+          <strong>Why this market is worth testing</strong>
+          <p>
+            Web Designer Academy's 2025 pricing report calls out getting clients, recurring revenue, selling services,
+            and pricing as top designer challenges. Upwork also continues to report a large independent work market,
+            which makes a narrow paid validation sprint easier to test manually.
+          </p>
+          <p>
+            Sources:
+            <a href="https://webdesigneracademy.com/state-of-web-designer-pricing-2025/" target="_blank" rel="noopener noreferrer">Web Designer Academy pricing report</a>
+            and
+            <a href="https://www.upwork.com/resources/freelancing-stats" target="_blank" rel="noopener noreferrer">Upwork freelancing stats</a>.
+          </p>
+        </div>
+
+        <div class="price-line">
+          <strong>$500 validation sprint</strong>
+          <span class="pill">7-day delivery</span>
+          <span class="pill">Proof before platform</span>
+        </div>
+
+        <div class="deliverables" aria-label="Sprint deliverables">
+          <div class="deliverable">
+            <strong>Proof-piece brief</strong>
+            <span>One buyer, problem, promise, proof angle, and acceptance criteria for the portfolio artifact.</span>
+          </div>
+          <div class="deliverable">
+            <strong>Portfolio proof copy</strong>
+            <span>Headline, context, before/after story, and CTA copy for the proof piece or case-study page.</span>
+          </div>
+          <div class="deliverable">
+            <strong>Buyer feedback script</strong>
+            <span>Short outreach messages for warm contacts, target buyers, and one follow-up.</span>
+          </div>
+          <div class="deliverable">
+            <strong>Paid pilot offer</strong>
+            <span>A small paid next step, objection notes, and a rule for whether to keep, rewrite, or kill it.</span>
+          </div>
+        </div>
+
+        <div class="not-fit">
+          Not a fit if you want passive income, a generic portfolio redesign, or a shortcut around talking to buyers.
+          This is a paid market test around one proof piece.
+        </div>
+
+        <div class="copy-box" aria-label="First outreach copy">
+          <strong>First test message</strong>
+          <p>Quick question: I am testing a 7-day sprint for freelance designers who have skill but need one proof piece that a real buyer can react to. If your portfolio had to win one specific type of client, what would it need to prove?</p>
+        </div>
+
+        <div class="button-row">
+          <a
+            class="cta"
+            href="/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D500%26label%3DFreelance%2520Portfolio%2520Validation%2520Sprint%26description%3D7-day%2520portfolio%2520proof%2520piece%252C%2520buyer%2520feedback%2520script%252C%2520and%2520paid%2520pilot%2520offer"
+          >Start $500 sprint</a>
+          <a class="text-link" href="#fit-check">Request fit check</a>
+          <a class="text-link" href="/ideas/offer-audit.html">Start with $300 offer audit</a>
+        </div>
+      </section>
+
+      <aside id="fit-check" class="panel form-panel" aria-label="Portfolio Validation Sprint intake">
+        <h2>Send the portfolio problem.</h2>
+        <p>
+          Share what you do, who you want to attract, and what your current portfolio fails to prove. The first response
+          should sharpen the buyer and proof angle before building anything.
+        </p>
+        <form
+          class="form-grid"
+          data-audience-form
+          data-audience-key="freelance-portfolio-validation-sprint"
+          data-audience-label="Freelance Portfolio Validation Sprint"
+          data-source-label="Money Printer · Portfolio Validation Sprint"
+          data-question-label="What do you do, who do you want to attract, and what does your portfolio fail to prove?"
+        >
+          <label>
+            <span>Name</span>
+            <input name="name" type="text" autocomplete="name" required placeholder="Taylor Morgan">
+          </label>
+          <label>
+            <span>Email</span>
+            <input name="email" type="email" autocomplete="email" required placeholder="you@example.com">
+          </label>
+          <label>
+            <span>Portfolio problem</span>
+            <textarea
+              name="prompt"
+              placeholder="What you sell, who you want more of, current portfolio link or summary, and what buyers are not understanding yet."
+            ></textarea>
+          </label>
+          <button type="submit">Request fit check</button>
+          <p class="status" data-form-status role="status" aria-live="polite"></p>
+        </form>
+      </aside>
+    </main>
+
+    <footer class="footer-note">
+      Intake writes to the 3DVR Gun relay under <code>3dvr-audience-tests/v1/freelance-portfolio-validation-sprint/signups</code>.
+    </footer>
+  </div>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/ideas/index.html
+++ b/ideas/index.html
@@ -169,6 +169,25 @@
         </div>
         <a class="cta" href="/ideas/client-onboarding-sprint.html">Open offer</a>
       </div>
+      <div class="card" data-idea-card data-idea-path="/ideas/freelance-portfolio-validation-sprint.html">
+        <h2>Portfolio Validation Sprint</h2>
+        <p>A $500 paid sprint for freelance designers who need one proof piece, buyer feedback, and a paid pilot offer.</p>
+        <div class="stats">
+          <div class="stat">
+            <span class="label">Page views</span>
+            <span class="value" data-idea-views>0</span>
+          </div>
+          <div class="stat">
+            <span class="label">CTA clicks</span>
+            <span class="value" data-idea-cta-count>0</span>
+          </div>
+          <div class="stat">
+            <span class="label">Last seen</span>
+            <span class="value" data-idea-last>Never</span>
+          </div>
+        </div>
+        <a class="cta" href="/ideas/freelance-portfolio-validation-sprint.html">Open offer</a>
+      </div>
       <div class="card" data-idea-card data-idea-path="/ideas/forge-revenue-sprint.html">
         <h2>Forge Revenue Sprint</h2>
         <p>A $300 paid sprint that turns a Movement Brief into a buyable offer page and first buyer message.</p>

--- a/index.html
+++ b/index.html
@@ -427,6 +427,16 @@
             <span class="app-card__cta">Open paid offer</span>
           </a>
           <a
+            href="ideas/freelance-portfolio-validation-sprint.html"
+            class="app-card"
+            data-app-keywords="portfolio validation sprint freelance designer proof piece client acquisition paid pilot offer creative buyer feedback"
+          >
+            <span class="app-card__icon" aria-hidden="true">$500</span>
+            <span class="app-card__title">Portfolio Validation Sprint</span>
+            <span class="app-card__meta">A 7-day sprint for freelance designers who need one proof piece, buyer feedback, and a paid pilot offer.</span>
+            <span class="app-card__cta">Open paid offer</span>
+          </a>
+          <a
             href="ideas/client-onboarding-sprint.html"
             class="app-card"
             data-app-keywords="client onboarding sprint freelancers small agencies checklist follow up paid offer crm intake sales revenue"
@@ -1613,6 +1623,7 @@
         '3DVR Forge',
         'Forge Sprint',
         'Lead Rescue Sprint',
+        'Portfolio Validation Sprint',
         'Client Onboarding Sprint',
         'Projects',
         'Launch Room',
@@ -1627,6 +1638,7 @@
       work: [
         'Revenue Desk',
         'Lead Rescue Sprint',
+        'Portfolio Validation Sprint',
         'Client Onboarding Sprint',
         'Growth Operator',
         'CRM',
@@ -1668,6 +1680,7 @@
         'Billing',
         'Forge Sprint',
         'Lead Rescue Sprint',
+        'Portfolio Validation Sprint',
         'Client Onboarding Sprint',
         'Money AI',
         'money-printer',

--- a/tests/freelance-portfolio-validation-sprint.test.js
+++ b/tests/freelance-portfolio-validation-sprint.test.js
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const rootDir = new URL('../', import.meta.url);
+const sprintPageUrl = new URL('ideas/freelance-portfolio-validation-sprint.html', rootDir);
+const ideasIndexUrl = new URL('ideas/index.html', rootDir);
+const portalIndexUrl = new URL('index.html', rootDir);
+const growthOperatorUrl = new URL('growth-operator/app.js', rootDir);
+
+async function fileExists(url) {
+  try {
+    await access(url, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('Freelance Portfolio Validation Sprint offer', () => {
+  it('ships a buyable paid sprint page with Gun-backed intake', async () => {
+    assert.equal(await fileExists(sprintPageUrl), true, 'portfolio validation sprint page should exist');
+    const html = await readFile(sprintPageUrl, 'utf8');
+
+    assert.match(html, /Freelance Portfolio Validation Sprint/);
+    assert.match(html, /Turn one hidden skill into a proof piece clients can react to\./);
+    assert.match(html, /\$500 validation sprint/);
+    assert.match(html, /7-day delivery/);
+    assert.match(html, /Proof-piece brief/);
+    assert.match(html, /Portfolio proof copy/);
+    assert.match(html, /Buyer feedback script/);
+    assert.match(html, /Paid pilot offer/);
+    assert.match(html, /Start \$500 sprint/);
+    assert.match(html, /redirect=%2Fbilling%2F%3Fplan%3Dcustom%26amount%3D500/);
+    assert.match(html, /label%3DFreelance%2520Portfolio%2520Validation%2520Sprint/);
+    assert.match(html, /data-audience-key="freelance-portfolio-validation-sprint"/);
+    assert.match(html, /3dvr-audience-tests\/v1\/freelance-portfolio-validation-sprint\/signups/);
+    assert.match(html, /Web Designer Academy pricing report/);
+    assert.match(html, /Upwork freelancing stats/);
+  });
+
+  it('links the sprint from Ideas Lab, portal search, and Growth Operator imports', async () => {
+    const [ideas, portal, growthOperator] = await Promise.all([
+      readFile(ideasIndexUrl, 'utf8'),
+      readFile(portalIndexUrl, 'utf8'),
+      readFile(growthOperatorUrl, 'utf8')
+    ]);
+
+    assert.match(ideas, /\/ideas\/freelance-portfolio-validation-sprint\.html/);
+    assert.match(ideas, /A \$500 paid sprint for freelance designers/);
+    assert.match(portal, /ideas\/freelance-portfolio-validation-sprint\.html/);
+    assert.match(portal, /Portfolio Validation Sprint/);
+    assert.match(portal, /data-app-keywords="[^"]*portfolio validation sprint[^"]*paid pilot/);
+    assert.match(growthOperator, /key: 'freelance-portfolio-validation-sprint'/);
+    assert.match(growthOperator, /\$500 Freelance Portfolio Validation Sprint/);
+  });
+});

--- a/tests/growth-operator.test.js
+++ b/tests/growth-operator.test.js
@@ -49,6 +49,7 @@ test('growth operator app queues agent work and can send approved outreach throu
   assert.match(js, /AUDIENCE_LEAD_SOURCES = Object\.freeze/);
   assert.match(js, /key: 'forge-revenue-sprint'/);
   assert.match(js, /key: 'lead-rescue-sprint'/);
+  assert.match(js, /key: 'freelance-portfolio-validation-sprint'/);
   assert.match(js, /key: 'client-onboarding-sprint'/);
   assert.match(js, /key: 'offer-audit'/);
   assert.match(js, /audienceRoot = gun \? gun\.get\('3dvr-audience-tests'\)\.get\('v1'\) : null/);


### PR DESCRIPTION
## Summary
- Add a new $500 Freelance Portfolio Validation Sprint offer page.
- Link it from the portal app dock and Ideas Lab.
- Import its fit-check leads into Growth Operator as draft-ready leads.
- Cover the page, billing prefill, portal link, and Growth Operator source wiring with tests.

## Why
The money-printer brief identified Freelance Portfolio Validation Sprint as the best immediate opportunity: freelance designers with skill but unclear proof, buyer feedback, and paid-pilot positioning. This creates a concrete offer and capture path instead of leaving it as a command-brief idea.

## Validation
- `node --test tests/freelance-portfolio-validation-sprint.test.js tests/growth-operator.test.js tests/homepage-search-ux.test.js tests/customer-journey-pages.test.js tests/billing-page.test.js tests/stripe-billing-api.test.js`
- `node --check growth-operator/app.js`
- `git diff --check HEAD~1 HEAD`
- WebKit mobile smoke at 390px verified the new page, portal link, Growth Operator load, no horizontal overflow, and $500 custom billing prefill.