### PR TITLE
[codex] Add Friends and Family Pass

### DIFF
--- a/friends-family/index.html
+++ b/friends-family/index.html
@@ -1,0 +1,523 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Friends &amp; Family Pass | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="Join 3DVR free as an early tester, or support the portal for $5/month with the Friends & Family Pass."
+  >
+  <style>
+    :root {
+      --bg: #0c111b;
+      --panel: #121a29;
+      --panel-strong: #172235;
+      --border: rgba(226, 232, 240, 0.16);
+      --text: #f8fafc;
+      --muted: #cbd5e1;
+      --soft: #94a3b8;
+      --blue: #7dd3fc;
+      --green: #86efac;
+      --gold: #fde68a;
+      --danger: #fca5a5;
+      --shadow: 0 24px 80px rgba(2, 6, 23, 0.35);
+    }
+
+    html,
+    body {
+      width: 100%;
+      max-width: 100%;
+      min-height: 100%;
+      margin: 0;
+      overflow-x: hidden;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      background:
+        linear-gradient(135deg, rgba(125, 211, 252, 0.12), transparent 34%),
+        linear-gradient(225deg, rgba(134, 239, 172, 0.1), transparent 38%),
+        var(--bg);
+      line-height: 1.6;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    button,
+    textarea {
+      font: inherit;
+    }
+
+    .page {
+      display: flex;
+      justify-content: center;
+      width: 100%;
+      max-width: 100%;
+      padding: 20px;
+    }
+
+    .shell {
+      width: min(100%, 1080px);
+      max-width: 100%;
+      display: grid;
+      gap: 28px;
+    }
+
+    .top-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 14px;
+      width: 100%;
+      max-width: 100%;
+      min-width: 0;
+      padding: 12px 0;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      min-height: 40px;
+      font-weight: 900;
+      letter-spacing: 0.02em;
+      color: var(--text);
+    }
+
+    .nav-links {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .nav-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 38px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 8px 12px;
+      color: var(--muted);
+      background: rgba(15, 23, 42, 0.58);
+      font-size: 0.92rem;
+      font-weight: 800;
+    }
+
+    .hero {
+      display: grid;
+      gap: 20px;
+      padding: 44px 0 14px;
+    }
+
+    .kicker {
+      width: fit-content;
+      max-width: 100%;
+      margin: 0;
+      border: 1px solid rgba(253, 230, 138, 0.32);
+      border-radius: 999px;
+      padding: 6px 10px;
+      color: var(--gold);
+      background: rgba(253, 230, 138, 0.08);
+      font-size: 0.82rem;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1,
+    h2,
+    h3,
+    p {
+      margin-top: 0;
+    }
+
+    h1 {
+      max-width: 820px;
+      margin-bottom: 0;
+      font-size: clamp(2.35rem, 8vw, 5.4rem);
+      line-height: 0.98;
+      letter-spacing: 0;
+    }
+
+    .lead {
+      max-width: 720px;
+      margin: 0;
+      color: var(--muted);
+      font-size: clamp(1.05rem, 3vw, 1.35rem);
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      width: 100%;
+      max-width: 100%;
+    }
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 48px;
+      max-width: 100%;
+      border: 1px solid transparent;
+      border-radius: 999px;
+      padding: 12px 18px;
+      font-weight: 900;
+      line-height: 1.2;
+      text-align: center;
+      cursor: pointer;
+    }
+
+    .button--primary {
+      color: #07111f;
+      background: var(--green);
+      box-shadow: 0 16px 40px rgba(134, 239, 172, 0.18);
+    }
+
+    .button--secondary {
+      color: #07111f;
+      background: var(--gold);
+      box-shadow: 0 16px 40px rgba(253, 230, 138, 0.16);
+    }
+
+    .button--ghost {
+      border-color: var(--border);
+      color: var(--text);
+      background: rgba(15, 23, 42, 0.62);
+    }
+
+    .offer-grid,
+    .details-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      width: 100%;
+      max-width: 100%;
+    }
+
+    .offer,
+    .detail,
+    .message-panel {
+      min-width: 0;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: rgba(18, 26, 41, 0.88);
+      box-shadow: var(--shadow);
+    }
+
+    .offer {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+      padding: 20px;
+    }
+
+    .offer__label {
+      color: var(--blue);
+      font-size: 0.8rem;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .offer h2 {
+      margin-bottom: 0;
+      font-size: 1.55rem;
+      line-height: 1.15;
+      letter-spacing: 0;
+    }
+
+    .price {
+      color: var(--gold);
+      font-size: 2.4rem;
+      font-weight: 900;
+      line-height: 1;
+    }
+
+    .price span {
+      color: var(--soft);
+      font-size: 1rem;
+      font-weight: 800;
+    }
+
+    .offer p,
+    .detail p {
+      margin-bottom: 0;
+      color: var(--muted);
+    }
+
+    .offer ul,
+    .detail ul {
+      display: grid;
+      gap: 8px;
+      margin: 0;
+      padding-left: 20px;
+      color: var(--muted);
+    }
+
+    .detail {
+      padding: 18px;
+      background: rgba(23, 34, 53, 0.76);
+    }
+
+    .detail strong {
+      display: block;
+      margin-bottom: 6px;
+      color: var(--text);
+      font-size: 1.05rem;
+    }
+
+    .message-panel {
+      display: grid;
+      gap: 16px;
+      padding: 20px;
+      background: var(--panel);
+    }
+
+    .message-panel__top {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .message-panel h2 {
+      margin-bottom: 0;
+      font-size: 1.45rem;
+      letter-spacing: 0;
+    }
+
+    .invite-message {
+      display: block;
+      width: 100%;
+      min-height: 190px;
+      max-width: 100%;
+      resize: vertical;
+      border: 1px solid rgba(125, 211, 252, 0.22);
+      border-radius: 8px;
+      padding: 14px;
+      color: var(--text);
+      background: #08111f;
+      line-height: 1.5;
+    }
+
+    .copy-status {
+      min-height: 24px;
+      margin: 0;
+      color: var(--green);
+      font-size: 0.94rem;
+      font-weight: 800;
+    }
+
+    .boundary {
+      border-left: 3px solid var(--danger);
+      padding-left: 14px;
+      color: #fee2e2;
+    }
+
+    .footer {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 20px 0 30px;
+      color: var(--soft);
+      font-size: 0.94rem;
+    }
+
+    .footer a {
+      color: var(--blue);
+      font-weight: 800;
+    }
+
+    @media (max-width: 760px) {
+      .page {
+        padding: 16px;
+      }
+
+      .top-nav {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+
+      .nav-links {
+        justify-content: flex-start;
+      }
+
+      .hero {
+        padding-top: 24px;
+      }
+
+      .offer-grid,
+      .details-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .button {
+        width: 100%;
+      }
+    }
+
+    @media (max-width: 380px) {
+      .page {
+        padding: 12px;
+      }
+
+      .nav-links a,
+      .button {
+        font-size: 0.9rem;
+      }
+    }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <div class="page">
+    <div class="shell">
+      <nav class="top-nav" aria-label="Friends and Family navigation">
+        <a class="brand" href="../index.html">3DVR Portal</a>
+        <div class="nav-links">
+          <a href="../index.html">Portal</a>
+          <a href="../forge/">Forge</a>
+          <a href="../billing/index.html">Billing</a>
+        </div>
+      </nav>
+
+      <main>
+        <section class="hero" aria-labelledby="friends-family-title">
+          <p class="kicker">Small first offer</p>
+          <h1 id="friends-family-title">Help 3DVR grow while it is still early.</h1>
+          <p class="lead">
+            Join free as an early tester, or support the build for $5/month. This is the friends and family lane:
+            simple access, honest updates, and a low-pressure way to keep the portal moving.
+          </p>
+          <div class="actions" aria-label="Friends and Family actions">
+            <a class="button button--primary" href="../free-trial.html">Join free</a>
+            <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
+              Support for $5/month
+            </a>
+          </div>
+        </section>
+
+        <section class="offer-grid" aria-label="Friends and Family choices">
+          <article class="offer">
+            <span class="offer__label">Early tester</span>
+            <h2>Free</h2>
+            <div class="price">$0</div>
+            <p>Use the portal, try Forge, send feedback, and help shape what becomes useful.</p>
+            <ul>
+              <li>No card required.</li>
+              <li>Good for curious friends and first testers.</li>
+              <li>Best if you just want to see what 3DVR is becoming.</li>
+            </ul>
+            <a class="button button--ghost" href="../free-trial.html">Start free</a>
+          </article>
+
+          <article class="offer">
+            <span class="offer__label">Friends &amp; Family Pass</span>
+            <h2>Supporter</h2>
+            <div class="price">$5<span>/month</span></div>
+            <p>Support the portal while it grows and get a clearer upgrade path when you need more help.</p>
+            <ul>
+              <li>Everything in free access.</li>
+              <li>Early looks at Forge, portal tools, games, and small experiments.</li>
+              <li>Light monthly updates on what shipped and what is next.</li>
+            </ul>
+            <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
+              Choose $5/month
+            </a>
+          </article>
+        </section>
+
+        <section class="details-grid" aria-label="What the pass includes">
+          <div class="detail">
+            <strong>What supporters get</strong>
+            <ul>
+              <li>Early access to rough tools before they are polished.</li>
+              <li>A way to suggest problems, ideas, and workflows worth building.</li>
+              <li>A simple recurring vote of confidence that helps fund the next experiments.</li>
+            </ul>
+          </div>
+          <div class="detail">
+            <strong>What this is not</strong>
+            <p class="boundary">
+              This is not a custom-build contract, agency retainer, or promise that every request gets built.
+              It is a small support pass for early access, feedback, and momentum.
+            </p>
+          </div>
+        </section>
+
+        <section class="message-panel" aria-labelledby="copy-title">
+          <div class="message-panel__top">
+            <div>
+              <h2 id="copy-title">Copy this invite</h2>
+              <p>Use this for friends and family. Edit the tone before sending if you want it to sound more like you.</p>
+            </div>
+            <button class="button button--ghost" type="button" data-copy-message>Copy message</button>
+          </div>
+          <textarea class="invite-message" data-invite-message readonly>Hey, I am getting 3DVR off the ground.
+
+It is a small portal for turning ideas into pages, apps, follow-up systems, useful tools, and weird little games.
+
+You can join free as an early tester, or support it for $5/month if you want to help it keep moving while it is still small.
+
+Start here:
+https://portal.3dvr.tech/friends-family/</textarea>
+          <p class="copy-status" data-copy-status aria-live="polite"></p>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <span>3DVR.Tech - Open Web for Everyone</span>
+        <span>
+          <a href="../index.html">Back to portal</a>
+          &nbsp;|&nbsp;
+          <a href="../start/">Start flow</a>
+        </span>
+      </footer>
+    </div>
+  </div>
+
+  <script>
+    const copyButton = document.querySelector('[data-copy-message]');
+    const inviteMessage = document.querySelector('[data-invite-message]');
+    const copyStatus = document.querySelector('[data-copy-status]');
+
+    function setCopyStatus(message) {
+      if (copyStatus) {
+        copyStatus.textContent = message;
+      }
+    }
+
+    copyButton?.addEventListener('click', async () => {
+      const message = inviteMessage?.value || '';
+      if (!message) return;
+
+      try {
+        await navigator.clipboard.writeText(message);
+        setCopyStatus('Copied. Send it to one person who might actually care.');
+      } catch (error) {
+        inviteMessage.focus();
+        inviteMessage.select();
+        const copied = document.execCommand('copy');
+        setCopyStatus(copied ? 'Copied.' : 'Select the message and copy it manually.');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
         <a href="https://3dvr.tech">Home</a>
         <a href="start/">Start</a>
         <a href="forge/">Forge</a>
+        <a href="friends-family/">Support</a>
         <a href="start/#paid-lanes">Plans</a>
         <a href="#app-hub-title" data-app-search-trigger>Apps</a>
         <a href="games.html">Games</a>
@@ -280,6 +281,11 @@
                 <span class="shortcut-card__title">Community System</span>
                 <span class="shortcut-card__meta">Circles, weekly check-ins, and builder threads.</span>
               </a>
+              <a href="friends-family/" class="shortcut-card">
+                <span class="shortcut-card__icon" aria-hidden="true">$5</span>
+                <span class="shortcut-card__title">Friends &amp; Family Pass</span>
+                <span class="shortcut-card__meta">Free tester path or $5/month support while 3DVR is still small.</span>
+              </a>
               <a href="start/index.html" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">🧭</span>
                 <span class="shortcut-card__title">Start Your Thing</span>
@@ -405,6 +411,16 @@
             <span class="app-card__title">3DVR Forge</span>
             <span class="app-card__meta">Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test.</span>
             <span class="app-card__cta">Enter the Forge</span>
+          </a>
+          <a
+            href="friends-family/"
+            class="app-card"
+            data-app-keywords="friends family supporter support five 5 free tester early access billing starter community"
+          >
+            <span class="app-card__icon" aria-hidden="true">$5</span>
+            <span class="app-card__title">Friends &amp; Family Pass</span>
+            <span class="app-card__meta">A shareable free tester or $5/month supporter offer for people close to 3DVR.</span>
+            <span class="app-card__cta">Open small offer</span>
           </a>
           <a
             href="ideas/forge-revenue-sprint.html"
@@ -1674,10 +1690,12 @@
         '3DVR Connect',
         'News Lounge',
         'Profile',
+        'Friends & Family Pass',
       ],
       money: [
         'Finance',
         'Billing',
+        'Friends & Family Pass',
         'Forge Sprint',
         'Lead Rescue Sprint',
         'Portfolio Validation Sprint',

--- a/tests/friends-family-pass.test.js
+++ b/tests/friends-family-pass.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const pageUrl = new URL('../friends-family/index.html', import.meta.url);
+const portalUrl = new URL('../index.html', import.meta.url);
+
+async function fileExists(url) {
+  try {
+    await access(url, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test('friends and family pass is a shareable small offer page', async () => {
+  assert.equal(await fileExists(pageUrl), true, 'friends-family/index.html should exist');
+
+  const html = await readFile(pageUrl, 'utf8');
+
+  assert.match(html, /Friends &amp; Family Pass \| 3DVR Portal/);
+  assert.match(html, /Help 3DVR grow while it is still early\./);
+  assert.match(html, /Join free as an early tester/);
+  assert.match(html, /Support for \$5\/month/);
+  assert.match(html, /href="\.\.\/free-trial\.html"/);
+  assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dstarter"/);
+  assert.match(html, /This is not a custom-build contract/);
+  assert.match(html, /data-copy-message/);
+  assert.match(html, /data-invite-message/);
+  assert.match(html, /https:\/\/portal\.3dvr\.tech\/friends-family\//);
+  assert.match(html, /navigator\.clipboard\.writeText\(message\)/);
+});
+
+test('friends and family page uses defensive mobile sizing', async () => {
+  const html = await readFile(pageUrl, 'utf8');
+
+  assert.match(html, /html,\s*body\s*\{[\s\S]*?width:\s*100%;[\s\S]*?max-width:\s*100%;[\s\S]*?overflow-x:\s*hidden;/);
+  assert.match(html, /\*,\s*\*::before,\s*\*::after\s*\{[\s\S]*?box-sizing:\s*border-box;/);
+  assert.match(html, /\.shell\s*\{[\s\S]*?width:\s*min\(100%, 1080px\);[\s\S]*?max-width:\s*100%;/);
+  assert.match(html, /@media \(max-width: 760px\)\s*\{[\s\S]*?\.offer-grid,[\s\S]*?\.details-grid\s*\{[\s\S]*?grid-template-columns:\s*1fr;/);
+});
+
+test('portal home links the pass in navigation, support lanes, app dock, and rooms', async () => {
+  const html = await readFile(portalUrl, 'utf8');
+
+  assert.match(html, /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="friends-family\/">Support<\/a>/);
+  assert.match(
+    html,
+    /<a href="friends-family\/" class="shortcut-card">[\s\S]*?<span class="shortcut-card__title">Friends &amp; Family Pass<\/span>/
+  );
+  assert.match(
+    html,
+    /href="friends-family\/"[\s\S]*?class="app-card"[\s\S]*?<span class="app-card__title">Friends &amp; Family Pass<\/span>/
+  );
+  assert.match(html, /data-app-keywords="[^"]*friends family supporter support five 5[^"]*"/);
+  assert.match(html, /'Friends & Family Pass'/);
+  assert.match(html, /money:\s*\[[\s\S]*?'Friends & Family Pass'/);
+  assert.match(html, /community:\s*\[[\s\S]*?'Friends & Family Pass'/);
+});


### PR DESCRIPTION
## Summary
- Add a shareable Friends & Family Pass page with free tester and $5/month supporter paths.
- Link the offer from the portal top nav, support lanes, app dock, and Human O.S. room filters.
- Add regression coverage for the offer page, mobile sizing guardrails, portal wiring, and billing handoff.

## Why
The current paid sprint offers are too large for friends and family validation. This adds a low-friction offer that can be sent directly without overpromising custom work.

## Validation
- `node --test tests/friends-family-pass.test.js tests/homepage-search-ux.test.js tests/customer-journey-pages.test.js tests/billing-page.test.js tests/start-router.test.js`
- `git diff --check`
- WebKit mobile smoke at 390px: `/friends-family/` had `scrollWidth === clientWidth`, no overflowing elements, and the portal home linked the new card.