### PR TITLE
[codex] Clarify Friends and Family offer outcomes

### DIFF
--- a/friends-family/index.html
+++ b/friends-family/index.html
@@ -6,7 +6,7 @@
   <title>Friends &amp; Family Pass | 3DVR Portal</title>
   <meta
     name="description"
-    content="Join 3DVR free as an early tester, or support the portal for $5/month with the Friends & Family Pass."
+    content="Join 3DVR free as an early tester, or support the portal for $5/month to help people organize ideas, visualize projects, and take control of life and money."
   >
   <style>
     :root {
@@ -401,10 +401,11 @@
       <main>
         <section class="hero" aria-labelledby="friends-family-title">
           <p class="kicker">Small first offer</p>
-          <h1 id="friends-family-title">Help 3DVR grow while it is still early.</h1>
+          <h1 id="friends-family-title">Organize your ideas. See the next move.</h1>
           <p class="lead">
-            Join free as an early tester, or support the build for $5/month. This is the friends and family lane:
-            simple access, honest updates, and a low-pressure way to keep the portal moving.
+            3DVR is for people with scattered ideas, unfinished plans, money stress, and the feeling that life could
+            be more under their control. Join free to try it, or support the build for $5/month while we turn it into
+            a practical place for organizing ideas, visualizing projects, and moving toward more freedom.
           </p>
           <div class="actions" aria-label="Friends and Family actions">
             <a class="button button--primary" href="../free-trial.html">Join free</a>
@@ -419,11 +420,11 @@
             <span class="offer__label">Early tester</span>
             <h2>Free</h2>
             <div class="price">$0</div>
-            <p>Use the portal, try Forge, send feedback, and help shape what becomes useful.</p>
+            <p>Use the portal to sort out ideas, map what you want, and find one next step without paying first.</p>
             <ul>
               <li>No card required.</li>
-              <li>Good for curious friends and first testers.</li>
-              <li>Best if you just want to see what 3DVR is becoming.</li>
+              <li>Good if your thoughts, goals, or projects feel scattered.</li>
+              <li>Best if you want to see whether 3DVR helps you feel clearer.</li>
             </ul>
             <a class="button button--ghost" href="../free-trial.html">Start free</a>
           </article>
@@ -432,11 +433,11 @@
             <span class="offer__label">Friends &amp; Family Pass</span>
             <h2>Supporter</h2>
             <div class="price">$5<span>/month</span></div>
-            <p>Support the portal while it grows and get a clearer upgrade path when you need more help.</p>
+            <p>Support the portal while it grows into a life, ideas, and money-clarity toolkit.</p>
             <ul>
               <li>Everything in free access.</li>
-              <li>Early looks at Forge, portal tools, games, and small experiments.</li>
-              <li>Light monthly updates on what shipped and what is next.</li>
+              <li>Early looks at tools for idea organization, project visualization, and practical next steps.</li>
+              <li>Light monthly updates on what shipped, what changed, and what supporters can try next.</li>
             </ul>
             <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
               Choose $5/month
@@ -448,16 +449,16 @@
           <div class="detail">
             <strong>What supporters get</strong>
             <ul>
-              <li>Early access to rough tools before they are polished.</li>
-              <li>A way to suggest problems, ideas, and workflows worth building.</li>
-              <li>A simple recurring vote of confidence that helps fund the next experiments.</li>
+              <li>Early access to simple tools for organizing messy ideas into a clearer plan.</li>
+              <li>Ways to visualize projects, offers, life direction, and money moves before overbuilding.</li>
+              <li>A small recurring vote of confidence that helps fund the next round of useful tools.</li>
             </ul>
           </div>
           <div class="detail">
             <strong>What this is not</strong>
             <p class="boundary">
-              This is not a custom-build contract, agency retainer, or promise that every request gets built.
-              It is a small support pass for early access, feedback, and momentum.
+              This is not financial advice, a custom-build contract, an agency retainer, or a promise that every
+              request gets built. It is a small support pass for early access, feedback, and momentum.
             </p>
           </div>
         </section>
@@ -472,7 +473,9 @@
           </div>
           <textarea class="invite-message" data-invite-message readonly>Hey, I am getting 3DVR off the ground.
 
-It is a small portal for turning ideas into pages, apps, follow-up systems, useful tools, and weird little games.
+It is a small portal for organizing ideas, visualizing projects, and turning scattered thoughts into practical next steps.
+
+The bigger direction is helping people take more control of their life, work, and money without getting stuck in tech.
 
 You can join free as an early tester, or support it for $5/month if you want to help it keep moving while it is still small.
 

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
               <a href="friends-family/" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">$5</span>
                 <span class="shortcut-card__title">Friends &amp; Family Pass</span>
-                <span class="shortcut-card__meta">Free tester path or $5/month support while 3DVR is still small.</span>
+                <span class="shortcut-card__meta">Organize ideas, visualize projects, and support 3DVR for $5/month.</span>
               </a>
               <a href="start/index.html" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">🧭</span>
@@ -419,7 +419,7 @@
           >
             <span class="app-card__icon" aria-hidden="true">$5</span>
             <span class="app-card__title">Friends &amp; Family Pass</span>
-            <span class="app-card__meta">A shareable free tester or $5/month supporter offer for people close to 3DVR.</span>
+            <span class="app-card__meta">A shareable free or $5/month path for organizing ideas, visualizing projects, and taking control.</span>
             <span class="app-card__cta">Open small offer</span>
           </a>
           <a

--- a/tests/friends-family-pass.test.js
+++ b/tests/friends-family-pass.test.js
@@ -21,12 +21,14 @@ test('friends and family pass is a shareable small offer page', async () => {
   const html = await readFile(pageUrl, 'utf8');
 
   assert.match(html, /Friends &amp; Family Pass \| 3DVR Portal/);
-  assert.match(html, /Help 3DVR grow while it is still early\./);
-  assert.match(html, /Join free as an early tester/);
+  assert.match(html, /Organize your ideas\. See the next move\./);
+  assert.match(html, /organizing ideas, visualizing projects, and moving toward more freedom/);
   assert.match(html, /Support for \$5\/month/);
   assert.match(html, /href="\.\.\/free-trial\.html"/);
   assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dstarter"/);
-  assert.match(html, /This is not a custom-build contract/);
+  assert.match(html, /This is not financial advice/);
+  assert.match(html, /Ways to visualize projects, offers, life direction, and money moves/);
+  assert.match(html, /take more control of their life, work, and money/);
   assert.match(html, /data-copy-message/);
   assert.match(html, /data-invite-message/);
   assert.match(html, /https:\/\/portal\.3dvr\.tech\/friends-family\//);
@@ -50,10 +52,12 @@ test('portal home links the pass in navigation, support lanes, app dock, and roo
     html,
     /<a href="friends-family\/" class="shortcut-card">[\s\S]*?<span class="shortcut-card__title">Friends &amp; Family Pass<\/span>/
   );
+  assert.match(html, /Organize ideas, visualize projects, and support 3DVR for \$5\/month/);
   assert.match(
     html,
     /href="friends-family\/"[\s\S]*?class="app-card"[\s\S]*?<span class="app-card__title">Friends &amp; Family Pass<\/span>/
   );
+  assert.match(html, /A shareable free or \$5\/month path for organizing ideas, visualizing projects, and taking control\./);
   assert.match(html, /data-app-keywords="[^"]*friends family supporter support five 5[^"]*"/);
   assert.match(html, /'Friends & Family Pass'/);
   assert.match(html, /money:\s*\[[\s\S]*?'Friends & Family Pass'/);


### PR DESCRIPTION
## Summary
- Reposition the Friends & Family Pass around plain outcomes instead of internal product names.
- Emphasize organizing ideas, visualizing projects, life/money clarity, and practical control.
- Add a clear boundary that the pass is not financial advice or custom work.

## Why
People new to 3DVR will not know what Forge, Portal, or the app names mean yet. The offer should sell the transformation first: clearer ideas, clearer next steps, and a lightweight path toward more control.

## Validation
- `node --test tests/friends-family-pass.test.js tests/homepage-search-ux.test.js tests/customer-journey-pages.test.js`
- `git diff --check`
- WebKit mobile smoke at 390px and 360px: `/friends-family/` had `scrollWidth === clientWidth` and no overflowing elements.
