### PR TITLE
[codex] Simplify Friends and Family offer copy

### DIFF
--- a/friends-family/index.html
+++ b/friends-family/index.html
@@ -6,7 +6,7 @@
   <title>Friends &amp; Family Pass | 3DVR Portal</title>
   <meta
     name="description"
-    content="Join 3DVR free as an early tester, or support the portal for $5/month to help people organize ideas, visualize projects, and take control of life and money."
+    content="Try 3DVR free or support it for $5/month. Organize ideas, visualize a plan, and take the next step."
   >
   <style>
     :root {
@@ -20,7 +20,6 @@
       --blue: #7dd3fc;
       --green: #86efac;
       --gold: #fde68a;
-      --danger: #fca5a5;
       --shadow: 0 24px 80px rgba(2, 6, 23, 0.35);
     }
 
@@ -200,8 +199,7 @@
       background: rgba(15, 23, 42, 0.62);
     }
 
-    .offer-grid,
-    .details-grid {
+    .offer-grid {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 16px;
@@ -210,8 +208,8 @@
     }
 
     .offer,
-    .detail,
-    .message-panel {
+    .message-panel,
+    .fine-print {
       min-width: 0;
       border: 1px solid var(--border);
       border-radius: 8px;
@@ -254,31 +252,17 @@
       font-weight: 800;
     }
 
-    .offer p,
-    .detail p {
+    .offer p {
       margin-bottom: 0;
       color: var(--muted);
     }
 
-    .offer ul,
-    .detail ul {
+    .offer ul {
       display: grid;
       gap: 8px;
       margin: 0;
       padding-left: 20px;
       color: var(--muted);
-    }
-
-    .detail {
-      padding: 18px;
-      background: rgba(23, 34, 53, 0.76);
-    }
-
-    .detail strong {
-      display: block;
-      margin-bottom: 6px;
-      color: var(--text);
-      font-size: 1.05rem;
     }
 
     .message-panel {
@@ -305,15 +289,15 @@
     .invite-message {
       display: block;
       width: 100%;
-      min-height: 190px;
       max-width: 100%;
-      resize: vertical;
+      margin: 0;
       border: 1px solid rgba(125, 211, 252, 0.22);
       border-radius: 8px;
       padding: 14px;
       color: var(--text);
       background: #08111f;
       line-height: 1.5;
+      word-break: break-word;
     }
 
     .copy-status {
@@ -324,10 +308,15 @@
       font-weight: 800;
     }
 
-    .boundary {
-      border-left: 3px solid var(--danger);
-      padding-left: 14px;
-      color: #fee2e2;
+    .fine-print {
+      padding: 14px 16px;
+      color: var(--soft);
+      background: rgba(15, 23, 42, 0.58);
+      box-shadow: none;
+    }
+
+    .fine-print p {
+      margin: 0;
     }
 
     .footer {
@@ -363,8 +352,7 @@
         padding-top: 24px;
       }
 
-      .offer-grid,
-      .details-grid {
+      .offer-grid {
         grid-template-columns: 1fr;
       }
 
@@ -401,12 +389,8 @@
       <main>
         <section class="hero" aria-labelledby="friends-family-title">
           <p class="kicker">Small first offer</p>
-          <h1 id="friends-family-title">Organize your ideas. See the next move.</h1>
-          <p class="lead">
-            3DVR is for people with scattered ideas, unfinished plans, money stress, and the feeling that life could
-            be more under their control. Join free to try it, or support the build for $5/month while we turn it into
-            a practical place for organizing ideas, visualizing projects, and moving toward more freedom.
-          </p>
+          <h1 id="friends-family-title">Get clear. Take the next step.</h1>
+          <p class="lead">Organize ideas, visualize a plan, and move forward without getting stuck in tech.</p>
           <div class="actions" aria-label="Friends and Family actions">
             <a class="button button--primary" href="../free-trial.html">Join free</a>
             <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
@@ -420,11 +404,11 @@
             <span class="offer__label">Early tester</span>
             <h2>Free</h2>
             <div class="price">$0</div>
-            <p>Use the portal to sort out ideas, map what you want, and find one next step without paying first.</p>
+            <p>Try the portal and see if it helps you get unstuck.</p>
             <ul>
+              <li>Sort messy ideas.</li>
+              <li>Find one next move.</li>
               <li>No card required.</li>
-              <li>Good if your thoughts, goals, or projects feel scattered.</li>
-              <li>Best if you want to see whether 3DVR helps you feel clearer.</li>
             </ul>
             <a class="button button--ghost" href="../free-trial.html">Start free</a>
           </article>
@@ -433,11 +417,11 @@
             <span class="offer__label">Friends &amp; Family Pass</span>
             <h2>Supporter</h2>
             <div class="price">$5<span>/month</span></div>
-            <p>Support the portal while it grows into a life, ideas, and money-clarity toolkit.</p>
+            <p>Support the build while it grows.</p>
             <ul>
-              <li>Everything in free access.</li>
-              <li>Early looks at tools for idea organization, project visualization, and practical next steps.</li>
-              <li>Light monthly updates on what shipped, what changed, and what supporters can try next.</li>
+              <li>Free access included.</li>
+              <li>Early tools and updates.</li>
+              <li>Easy upgrade later.</li>
             </ul>
             <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
               Choose $5/month
@@ -445,42 +429,21 @@
           </article>
         </section>
 
-        <section class="details-grid" aria-label="What the pass includes">
-          <div class="detail">
-            <strong>What supporters get</strong>
-            <ul>
-              <li>Early access to simple tools for organizing messy ideas into a clearer plan.</li>
-              <li>Ways to visualize projects, offers, life direction, and money moves before overbuilding.</li>
-              <li>A small recurring vote of confidence that helps fund the next round of useful tools.</li>
-            </ul>
-          </div>
-          <div class="detail">
-            <strong>What this is not</strong>
-            <p class="boundary">
-              This is not financial advice, a custom-build contract, an agency retainer, or a promise that every
-              request gets built. It is a small support pass for early access, feedback, and momentum.
-            </p>
-          </div>
+        <section class="fine-print" aria-label="Small print">
+          <p>Not financial advice or custom work. Just early access, feedback, and support.</p>
         </section>
 
         <section class="message-panel" aria-labelledby="copy-title">
           <div class="message-panel__top">
             <div>
-              <h2 id="copy-title">Copy this invite</h2>
-              <p>Use this for friends and family. Edit the tone before sending if you want it to sound more like you.</p>
+              <h2 id="copy-title">Share it</h2>
+              <p>Short enough to text.</p>
             </div>
             <button class="button button--ghost" type="button" data-copy-message>Copy message</button>
           </div>
-          <textarea class="invite-message" data-invite-message readonly>Hey, I am getting 3DVR off the ground.
-
-It is a small portal for organizing ideas, visualizing projects, and turning scattered thoughts into practical next steps.
-
-The bigger direction is helping people take more control of their life, work, and money without getting stuck in tech.
-
-You can join free as an early tester, or support it for $5/month if you want to help it keep moving while it is still small.
-
-Start here:
-https://portal.3dvr.tech/friends-family/</textarea>
+          <p class="invite-message" data-invite-message>
+            Try 3DVR free or support it for $5/month: https://portal.3dvr.tech/friends-family/
+          </p>
           <p class="copy-status" data-copy-status aria-live="polite"></p>
         </section>
       </main>
@@ -508,16 +471,22 @@ https://portal.3dvr.tech/friends-family/</textarea>
     }
 
     copyButton?.addEventListener('click', async () => {
-      const message = inviteMessage?.value || '';
+      const message = (inviteMessage?.value || inviteMessage?.textContent || '').trim();
       if (!message) return;
 
       try {
         await navigator.clipboard.writeText(message);
         setCopyStatus('Copied. Send it to one person who might actually care.');
       } catch (error) {
-        inviteMessage.focus();
-        inviteMessage.select();
+        const temporaryInput = document.createElement('textarea');
+        temporaryInput.value = message;
+        temporaryInput.setAttribute('readonly', '');
+        temporaryInput.style.position = 'fixed';
+        temporaryInput.style.left = '-9999px';
+        document.body.appendChild(temporaryInput);
+        temporaryInput.select();
         const copied = document.execCommand('copy');
+        temporaryInput.remove();
         setCopyStatus(copied ? 'Copied.' : 'Select the message and copy it manually.');
       }
     });

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
               <a href="friends-family/" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">$5</span>
                 <span class="shortcut-card__title">Friends &amp; Family Pass</span>
-                <span class="shortcut-card__meta">Organize ideas, visualize projects, and support 3DVR for $5/month.</span>
+                <span class="shortcut-card__meta">Get clear, try free, or support 3DVR for $5/month.</span>
               </a>
               <a href="start/index.html" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">🧭</span>
@@ -419,7 +419,7 @@
           >
             <span class="app-card__icon" aria-hidden="true">$5</span>
             <span class="app-card__title">Friends &amp; Family Pass</span>
-            <span class="app-card__meta">A shareable free or $5/month path for organizing ideas, visualizing projects, and taking control.</span>
+            <span class="app-card__meta">A shareable free or $5/month path for getting clearer and moving forward.</span>
             <span class="app-card__cta">Open small offer</span>
           </a>
           <a

--- a/tests/friends-family-pass.test.js
+++ b/tests/friends-family-pass.test.js
@@ -21,17 +21,20 @@ test('friends and family pass is a shareable small offer page', async () => {
   const html = await readFile(pageUrl, 'utf8');
 
   assert.match(html, /Friends &amp; Family Pass \| 3DVR Portal/);
-  assert.match(html, /Organize your ideas\. See the next move\./);
-  assert.match(html, /organizing ideas, visualizing projects, and moving toward more freedom/);
+  assert.match(html, /Get clear\. Take the next step\./);
+  assert.match(html, /Organize ideas, visualize a plan, and move forward without getting stuck in tech\./);
   assert.match(html, /Support for \$5\/month/);
   assert.match(html, /href="\.\.\/free-trial\.html"/);
   assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dstarter"/);
-  assert.match(html, /This is not financial advice/);
-  assert.match(html, /Ways to visualize projects, offers, life direction, and money moves/);
-  assert.match(html, /take more control of their life, work, and money/);
+  assert.match(html, /Sort messy ideas\./);
+  assert.match(html, /Find one next move\./);
+  assert.match(html, /Not financial advice or custom work/);
+  assert.match(html, /Short enough to text\./);
   assert.match(html, /data-copy-message/);
   assert.match(html, /data-invite-message/);
   assert.match(html, /https:\/\/portal\.3dvr\.tech\/friends-family\//);
+  assert.doesNotMatch(html, /What supporters get/);
+  assert.doesNotMatch(html, /The bigger direction/);
   assert.match(html, /navigator\.clipboard\.writeText\(message\)/);
 });
 
@@ -41,7 +44,7 @@ test('friends and family page uses defensive mobile sizing', async () => {
   assert.match(html, /html,\s*body\s*\{[\s\S]*?width:\s*100%;[\s\S]*?max-width:\s*100%;[\s\S]*?overflow-x:\s*hidden;/);
   assert.match(html, /\*,\s*\*::before,\s*\*::after\s*\{[\s\S]*?box-sizing:\s*border-box;/);
   assert.match(html, /\.shell\s*\{[\s\S]*?width:\s*min\(100%, 1080px\);[\s\S]*?max-width:\s*100%;/);
-  assert.match(html, /@media \(max-width: 760px\)\s*\{[\s\S]*?\.offer-grid,[\s\S]*?\.details-grid\s*\{[\s\S]*?grid-template-columns:\s*1fr;/);
+  assert.match(html, /@media \(max-width: 760px\)\s*\{[\s\S]*?\.offer-grid\s*\{[\s\S]*?grid-template-columns:\s*1fr;/);
 });
 
 test('portal home links the pass in navigation, support lanes, app dock, and rooms', async () => {
@@ -52,12 +55,12 @@ test('portal home links the pass in navigation, support lanes, app dock, and roo
     html,
     /<a href="friends-family\/" class="shortcut-card">[\s\S]*?<span class="shortcut-card__title">Friends &amp; Family Pass<\/span>/
   );
-  assert.match(html, /Organize ideas, visualize projects, and support 3DVR for \$5\/month/);
+  assert.match(html, /Get clear, try free, or support 3DVR for \$5\/month/);
   assert.match(
     html,
     /href="friends-family\/"[\s\S]*?class="app-card"[\s\S]*?<span class="app-card__title">Friends &amp; Family Pass<\/span>/
   );
-  assert.match(html, /A shareable free or \$5\/month path for organizing ideas, visualizing projects, and taking control\./);
+  assert.match(html, /A shareable free or \$5\/month path for getting clearer and moving forward\./);
   assert.match(html, /data-app-keywords="[^"]*friends family supporter support five 5[^"]*"/);
   assert.match(html, /'Friends & Family Pass'/);
   assert.match(html, /money:\s*\[[\s\S]*?'Friends & Family Pass'/);


### PR DESCRIPTION
## Summary
- Cut the Friends & Family page down to a short promise, two choices, one fine-print line, and one share line.
- Shorten the portal home copy for the Friends & Family shortcut and app card.
- Update tests to guard against the long explanatory sections coming back.

## Why
The offer should be readable at a glance. New users should not need to understand 3DVR product names or read a long page before choosing free or $5/month support.

## Validation
- `node --test tests/friends-family-pass.test.js tests/homepage-search-ux.test.js tests/customer-journey-pages.test.js`
- `git diff --check`
- WebKit mobile smoke at 390px: `/friends-family/` had `scrollWidth === clientWidth` and no overflowing elements.
