### PR TITLE
[codex] Simplify offer reading level

### DIFF
--- a/friends-family/index.html
+++ b/friends-family/index.html
@@ -6,7 +6,7 @@
   <title>Friends &amp; Family Pass | 3DVR Portal</title>
   <meta
     name="description"
-    content="Try 3DVR free or support it for $5/month. Organize ideas, visualize a plan, and take the next step."
+    content="Try 3DVR free or help it grow for $5/month. Plan your ideas, see the next step, and take it."
   >
   <style>
     :root {
@@ -389,12 +389,12 @@
       <main>
         <section class="hero" aria-labelledby="friends-family-title">
           <p class="kicker">Small first offer</p>
-          <h1 id="friends-family-title">Get clear. Take the next step.</h1>
-          <p class="lead">Organize ideas, visualize a plan, and move forward without getting stuck in tech.</p>
+          <h1 id="friends-family-title">Get clear. Take one step.</h1>
+          <p class="lead">Plan your ideas. See what to do next. Move without tech stress.</p>
           <div class="actions" aria-label="Friends and Family actions">
             <a class="button button--primary" href="../free-trial.html">Join free</a>
             <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
-              Support for $5/month
+              Help for $5/month
             </a>
           </div>
         </section>
@@ -404,33 +404,33 @@
             <span class="offer__label">Early tester</span>
             <h2>Free</h2>
             <div class="price">$0</div>
-            <p>Try the portal and see if it helps you get unstuck.</p>
+            <p>Try 3DVR and see if it helps.</p>
             <ul>
-              <li>Sort messy ideas.</li>
-              <li>Find one next move.</li>
-              <li>No card required.</li>
+              <li>Sort ideas.</li>
+              <li>Pick one step.</li>
+              <li>No card.</li>
             </ul>
             <a class="button button--ghost" href="../free-trial.html">Start free</a>
           </article>
 
           <article class="offer">
             <span class="offer__label">Friends &amp; Family Pass</span>
-            <h2>Supporter</h2>
+            <h2>Help it grow</h2>
             <div class="price">$5<span>/month</span></div>
-            <p>Support the build while it grows.</p>
+            <p>Help build 3DVR while it is small.</p>
             <ul>
-              <li>Free access included.</li>
-              <li>Early tools and updates.</li>
+              <li>Free access.</li>
+              <li>Early tools.</li>
               <li>Easy upgrade later.</li>
             </ul>
             <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
-              Choose $5/month
+              Help for $5/month
             </a>
           </article>
         </section>
 
         <section class="fine-print" aria-label="Small print">
-          <p>Not financial advice or custom work. Just early access, feedback, and support.</p>
+          <p>Not money advice or custom work. Just early access, notes, and support.</p>
         </section>
 
         <section class="message-panel" aria-labelledby="copy-title">
@@ -442,7 +442,7 @@
             <button class="button button--ghost" type="button" data-copy-message>Copy message</button>
           </div>
           <p class="invite-message" data-invite-message>
-            Try 3DVR free or support it for $5/month: https://portal.3dvr.tech/friends-family/
+            Try 3DVR free or help it grow for $5/month: https://portal.3dvr.tech/friends-family/
           </p>
           <p class="copy-status" data-copy-status aria-live="polite"></p>
         </section>

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
               <a href="friends-family/" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">$5</span>
                 <span class="shortcut-card__title">Friends &amp; Family Pass</span>
-                <span class="shortcut-card__meta">Get clear, try free, or support 3DVR for $5/month.</span>
+                <span class="shortcut-card__meta">Get clear, try free, or help 3DVR for $5/month.</span>
               </a>
               <a href="start/index.html" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">🧭</span>
@@ -419,7 +419,7 @@
           >
             <span class="app-card__icon" aria-hidden="true">$5</span>
             <span class="app-card__title">Friends &amp; Family Pass</span>
-            <span class="app-card__meta">A shareable free or $5/month path for getting clearer and moving forward.</span>
+            <span class="app-card__meta">A free or $5/month path to get clear and take one step.</span>
             <span class="app-card__cta">Open small offer</span>
           </a>
           <a

--- a/tests/friends-family-pass.test.js
+++ b/tests/friends-family-pass.test.js
@@ -21,14 +21,14 @@ test('friends and family pass is a shareable small offer page', async () => {
   const html = await readFile(pageUrl, 'utf8');
 
   assert.match(html, /Friends &amp; Family Pass \| 3DVR Portal/);
-  assert.match(html, /Get clear\. Take the next step\./);
-  assert.match(html, /Organize ideas, visualize a plan, and move forward without getting stuck in tech\./);
-  assert.match(html, /Support for \$5\/month/);
+  assert.match(html, /Get clear\. Take one step\./);
+  assert.match(html, /Plan your ideas\. See what to do next\. Move without tech stress\./);
+  assert.match(html, /Help for \$5\/month/);
   assert.match(html, /href="\.\.\/free-trial\.html"/);
   assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dstarter"/);
-  assert.match(html, /Sort messy ideas\./);
-  assert.match(html, /Find one next move\./);
-  assert.match(html, /Not financial advice or custom work/);
+  assert.match(html, /Sort ideas\./);
+  assert.match(html, /Pick one step\./);
+  assert.match(html, /Not money advice or custom work/);
   assert.match(html, /Short enough to text\./);
   assert.match(html, /data-copy-message/);
   assert.match(html, /data-invite-message/);
@@ -55,12 +55,12 @@ test('portal home links the pass in navigation, support lanes, app dock, and roo
     html,
     /<a href="friends-family\/" class="shortcut-card">[\s\S]*?<span class="shortcut-card__title">Friends &amp; Family Pass<\/span>/
   );
-  assert.match(html, /Get clear, try free, or support 3DVR for \$5\/month/);
+  assert.match(html, /Get clear, try free, or help 3DVR for \$5\/month/);
   assert.match(
     html,
     /href="friends-family\/"[\s\S]*?class="app-card"[\s\S]*?<span class="app-card__title">Friends &amp; Family Pass<\/span>/
   );
-  assert.match(html, /A shareable free or \$5\/month path for getting clearer and moving forward\./);
+  assert.match(html, /A free or \$5\/month path to get clear and take one step\./);
   assert.match(html, /data-app-keywords="[^"]*friends family supporter support five 5[^"]*"/);
   assert.match(html, /'Friends & Family Pass'/);
   assert.match(html, /money:\s*\[[\s\S]*?'Friends & Family Pass'/);


### PR DESCRIPTION
## Summary
- Simplify the Friends & Family page copy to shorter, plainer words.
- Replace abstract phrasing like "visualize," "supporter," and "moving forward" with direct language.
- Keep the legal boundary short while preserving the free and $5/month paths.

## Why
The page should read closer to a text message than a startup landing page. Simpler copy makes the offer easier to understand before people know any 3DVR product names.

## Validation
- `node --test tests/friends-family-pass.test.js tests/homepage-search-ux.test.js tests/customer-journey-pages.test.js`
- `git diff --check`
- WebKit mobile smoke at 390px: `/friends-family/` had `scrollWidth === clientWidth` and no overflowing elements.
