### PR TITLE
[codex] Improve Forge guidance flow

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -3,7 +3,8 @@ import { readDefaultSecret } from '../web-builder-app/defaults.js';
 const STORAGE_KEY = '3dvr.forge.session.v1';
 const FORGE_GUN_SESSION_ID_KEY = '3dvr.forge.sessionId.v1';
 const FORGE_MODEL = 'gpt-4.1-mini';
-const SHARED_DEFAULTS_WAIT_MS = 6000;
+const SHARED_DEFAULTS_WAIT_MS = 1200;
+const FORGE_API_TIMEOUT_MS = 10000;
 
 const gun = window.Gun ? window.Gun({ peers: window.__GUN_PEERS__ || undefined }) : null;
 const portalRoot = gun?.get('3dvr-portal') || null;
@@ -21,46 +22,38 @@ const stage = {
 const defaultFollowUps = [
   {
     key: 'audience',
-    question: 'Who else has this problem?',
+    question: 'Who is this for? You can say me.',
   },
   {
-    key: 'tried',
-    question: 'What have you already tried?',
-  },
-  {
-    key: 'tiny',
-    question: 'What would a tiny version look like in 7 days?',
+    key: 'help',
+    question: 'What would help this week?',
   },
 ];
 
 const followUpPool = {
   shape: {
     key: 'shape',
-    question: 'Do you want this to become a tool, service, community, content project, or business?',
+    question: 'What should this become first? A page, service, tool, or message?',
   },
   resources: {
     key: 'resources',
-    question: 'What skills or resources do you already have?',
+    question: 'What do you already have? A skill, tool, friend, or place to start?',
   },
 };
 
 const starterSparks = [
-  'I need money, I do not have much free time, and I keep thinking there is a useful project hiding in the tools I already have.',
-  'I am tired of watching capable people lose momentum because their ideas, follow-up, and first offer are scattered everywhere.',
-  'I know there is something I should build, but every version gets too big before I can test whether anyone actually wants it.',
-  'I want to turn 3DVR into something people can buy this week, not another giant platform promise.',
+  'I need money and I do not know what to do first.',
+  'I need better work and I do not know where to start.',
+  'I have an idea but it feels too big.',
+  'I feel stuck and need one small next step.',
 ];
 
 const briefOrder = [
-  ['projectName', 'Project Name'],
-  ['coreFrustration', 'Core Frustration'],
-  ['audience', 'Audience'],
-  ['projectConcept', 'Project Concept'],
-  ['tinyExperiment', 'Tiny 7-Day Experiment'],
-  ['firstActions', 'First 3 Actions'],
-  ['testMessage', 'Test Message'],
-  ['codexPrompt', 'Codex Build Prompt'],
-  ['realityCheck', 'Reality Check'],
+  ['projectName', 'Name'],
+  ['firstActions', 'Do these 3 things'],
+  ['testMessage', 'Message to send'],
+  ['tinyExperiment', '7-day test'],
+  ['realityCheck', 'Watch out'],
 ];
 
 const refs = {
@@ -69,6 +62,9 @@ const refs = {
   inputLabel: document.querySelector('[data-input-label]'),
   submit: document.querySelector('[data-submit-answer]'),
   spark: document.querySelector('[data-spark-idea]'),
+  easyAnswer: document.querySelector('[data-easy-answer]'),
+  presets: document.querySelector('[data-forge-presets]'),
+  presetButtons: Array.from(document.querySelectorAll('[data-preset-idea]')),
   reset: document.querySelector('[data-reset-forge]'),
   transcript: document.querySelector('[data-transcript]'),
   progress: document.querySelector('[data-forge-progress]'),
@@ -303,10 +299,10 @@ function chooseFollowUps(initial) {
   }
 
   if (/\b(skill|build|make|code|design|write|film|stage|tech|crew|freelance)\b/.test(lower)) {
-    chosen[2] = followUpPool.resources;
+    chosen[1] = followUpPool.resources;
   }
 
-  return chosen.slice(0, 3);
+  return chosen.slice(0, 2);
 }
 
 function deriveProjectName(initial, answers) {
@@ -343,47 +339,47 @@ function buildLocalForgeGuidance(initial = '') {
 
   if (moneyPressure) {
     return {
-      diagnosis: 'This is cash pressure, not a giant product problem yet. The first move is to find a small paid promise that can be tested with real people this week.',
+      diagnosis: 'This looks like money pressure. Start with one small offer, not a big app.',
       solutionPaths: [
-        'Package one narrow service as a paid sprint, such as setup, cleanup, onboarding, follow-up, or troubleshooting.',
-        'Use your existing network before building: send a short offer message to 10 people who might know the pain.',
-        'Reduce pressure while testing by finding one bill, subscription, or commitment to negotiate or pause.'
+        'Offer one small paid service to people you already know.',
+        'Ask 10 people what they would pay for before building.',
+        'Cut or pause one bill while you test the offer.'
       ],
       nextActions: [
-        'Write one sentence that starts with: I help [specific person] get [specific outcome] in [short time].',
-        'Name 10 people or businesses you can contact without needing a new audience.',
-        'Do not build software until at least one person replies with a real problem, budget, or referral.'
+        'Write: I help [person] do [thing] this week.',
+        'Name 10 people you can text.',
+        'Build only after one person shows real interest.'
       ]
     };
   }
 
   if (jobPressure) {
     return {
-      diagnosis: 'This sounds like work pressure and underused skill. The first solution is not inspiration; it is a sharper job, freelance, or project signal.',
+      diagnosis: 'This looks like work pressure. Start with one proof of skill.',
       solutionPaths: [
-        'Turn the frustration into a skill proof: one short portfolio artifact, teardown, checklist, or case study.',
-        'Build a better-work search lane with target roles, warm contacts, and follow-up messages.',
-        'Test a freelance version of the skill before waiting for a perfect job opening.'
+        'Make one small proof that shows what you can do.',
+        'Text one warm person and ask who needs that skill.',
+        'Test a tiny freelance offer before waiting for a perfect job.'
       ],
       nextActions: [
-        'List the three skills you want someone to pay or hire you for.',
-        'Find five roles, crews, clients, or businesses where those skills matter.',
-        'Send one direct message that asks for a conversation, not a job.'
+        'Pick one skill you want to be paid for.',
+        'Name five places where that skill helps.',
+        'Send one message asking for advice, not a job.'
       ]
     };
   }
 
   return {
-    diagnosis: 'Good raw material. The emotional force is real, but the audience and first useful version are still too wide.',
+    diagnosis: 'This is still wide. Make it smaller.',
     solutionPaths: [
-      'Turn it into a service if someone needs human help now.',
-      'Turn it into a tool if the same repeated task keeps showing up.',
-      'Turn it into content or a community if people mainly need language, examples, and momentum.'
+      'Make one page, checklist, message, or tiny service.',
+      'Start with one person before a big audience.',
+      'Use a direct message before building software.'
     ],
     nextActions: [
-      'Name the exact person this helps first.',
-      'Write the smallest promise that would be useful in seven days.',
-      'Send the promise to real people before adding features.'
+      'Name who this helps.',
+      'Write one useful promise.',
+      'Send it before adding features.'
     ]
   };
 }
@@ -392,10 +388,8 @@ function buildMockMovementBrief(currentSession) {
   const initial = clean(currentSession.initial);
   const answers = currentSession.answers;
   const projectName = deriveProjectName(initial, answers);
-  const audience = clause(answers.audience, 'frustrated working people with hidden skills');
-  const tiny = clause(answers.tiny, 'a one-page promise plus a message sent to 10 people');
-  const tried = clause(answers.tried, 'thinking about it alone');
-  const resources = clause(answers.resources, 'your existing skills, phone, laptop, and direct network');
+  const audience = clause(answers.audience, 'me first, then people like me');
+  const tiny = clause(answers.help || answers.tiny, 'one page, one message, or one checklist that helps this week');
   const shape = guessProjectShape(answers, initial);
   const coreFrustration = sentence(
     initial,
@@ -403,15 +397,15 @@ function buildMockMovementBrief(currentSession) {
   );
   const isRevenuePressure = /\b(money|income|cash|revenue|paid|client|clients|bills?|rent|sales?|no time|busy)\b/i.test(`${initial} ${Object.values(answers).join(' ')}`);
   const projectConcept = isRevenuePressure
-    ? `${projectName} is a ${shape} for ${audience}. It starts from this tension: ${coreFrustration} The first useful version should test a clear paid offer with real people before building a 3D scene, dashboard, or platform.`
-    : `${projectName} is a ${shape} for ${audience}. It starts from this tension: ${coreFrustration} The first useful version should avoid platform fantasy and prove whether people respond.`;
-  const tinyExperiment = `In 7 days, make ${tiny}. Send it to 10 specific people, ask what feels useful or unclear, and track replies without building a full app.`;
+    ? `${projectName} is a ${shape} for ${audience}. Test a clear paid offer before building.`
+    : `${projectName} is a ${shape} for ${audience}. Test if people care before building.`;
+  const tinyExperiment = `This week: make ${tiny}. Send it to 10 people. Track replies.`;
   const firstActions = [
-    `Write a one-paragraph project promise for ${audience}.`,
-    `Send the test message to 10 people before adding features.`,
-    `Turn the strongest reply into the next tiny build or service step.`,
+    'Write one clear promise.',
+    'Text 10 people.',
+    'Build after one yes.',
   ];
-  const testMessage = `I am testing an idea called ${projectName}. It is for ${audience} who are dealing with this: ${coreFrustration} The tiny version is ${tiny}. Does this feel useful, too vague, or not your problem?`;
+  const testMessage = `Quick question: I am testing ${projectName}. It is for ${audience}. Would this help you this week?`;
   const codexPrompt = [
     `Build a minimal first version of ${projectName}.`,
     '',
@@ -428,10 +422,8 @@ function buildMockMovementBrief(currentSession) {
     '- Add tests or a simple verification path for the core interaction.',
   ].join('\n');
   const realityCheck = [
-    'Good raw material. Too vague right now unless the audience is named in plain language.',
-    `You already tried ${tried}; do not repeat that as the next step.`,
-    `Use ${resources} first. This is probably not a startup yet. It is a test.`,
-    'Do not build an app yet if a direct message can test the signal faster.',
+    'Pick one kind of person first.',
+    'Send the message before building.',
   ];
 
   return {
@@ -481,15 +473,15 @@ function normalizeFollowUpsResponse(value) {
       question: clean(item?.question),
     }))
     .filter((item) => item.question)
-    .slice(0, 3);
+    .slice(0, 2);
 
   defaultFollowUps.forEach((fallback) => {
-    if (normalized.length < 3) {
+    if (normalized.length < 2) {
       normalized.push(fallback);
     }
   });
 
-  return normalized.slice(0, 3);
+  return normalized.slice(0, 2);
 }
 
 function mergeFollowUpsResponse(value, lockedCount = 0) {
@@ -509,7 +501,7 @@ function mergeFollowUpsResponse(value, lockedCount = 0) {
   defaultFollowUps.forEach(add);
   Object.values(followUpPool).forEach(add);
 
-  return merged.slice(0, 3);
+  return merged.slice(0, 2);
 }
 
 function normalizeStringList(value, fallback, limit) {
@@ -537,7 +529,7 @@ function normalizeBriefResponse(value) {
     firstActions: normalizeStringList(value?.firstActions, fallback.firstActions, 3),
     testMessage: clean(value?.testMessage) || fallback.testMessage,
     codexPrompt: clean(value?.codexPrompt) || fallback.codexPrompt,
-    realityCheck: normalizeStringList(value?.realityCheck, fallback.realityCheck, 5),
+    realityCheck: normalizeStringList(value?.realityCheck, fallback.realityCheck, 2),
   };
 }
 
@@ -558,17 +550,32 @@ async function parseApiError(response) {
 async function requestForge(mode, payload = {}) {
   await waitForSharedSecret('openai', 'Loading shared Forge key...');
 
-  const response = await fetch('/api/openai-site', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      forge: true,
-      mode,
-      model: FORGE_MODEL,
-      ...(sharedSecrets.openai ? { apiKey: sharedSecrets.openai } : {}),
-      ...payload,
-    }),
-  });
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), FORGE_API_TIMEOUT_MS);
+  let response;
+
+  try {
+    response = await fetch('/api/openai-site', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        forge: true,
+        mode,
+        model: FORGE_MODEL,
+        ...(sharedSecrets.openai ? { apiKey: sharedSecrets.openai } : {}),
+        ...payload,
+      }),
+    });
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new Error('Forge request timed out.');
+    }
+
+    throw error;
+  } finally {
+    window.clearTimeout(timeout);
+  }
 
   if (!response.ok) {
     throw new Error(await parseApiError(response));
@@ -768,11 +775,11 @@ function formatGuidanceMessage(guidance) {
   return [
     `What I see: ${guidance.diagnosis}`,
     '',
-    'Possible solution paths:',
-    ...guidance.solutionPaths.map((item) => `- ${item}`),
+    'Try this:',
+    `- ${guidance.solutionPaths[0] || 'Make it smaller.'}`,
     '',
-    'Do next:',
-    ...guidance.nextActions.map((item) => `- ${item}`),
+    'Then do this:',
+    `- ${guidance.nextActions[0] || 'Pick one next step.'}`,
   ].join('\n');
 }
 
@@ -808,13 +815,13 @@ function renderGuidance() {
   refs.guidancePaths.replaceChildren();
   refs.guidanceActions.replaceChildren();
 
-  session.guidance.solutionPaths.forEach((item) => {
+  session.guidance.solutionPaths.slice(0, 1).forEach((item) => {
     const li = document.createElement('li');
     li.textContent = item;
     refs.guidancePaths.appendChild(li);
   });
 
-  session.guidance.nextActions.forEach((item) => {
+  session.guidance.nextActions.slice(0, 1).forEach((item) => {
     const li = document.createElement('li');
     li.textContent = item;
     refs.guidanceActions.appendChild(li);
@@ -836,8 +843,8 @@ function renderProgress() {
     ? 100
     : Math.max(18, Math.round(((answered + 1) / (total + 1)) * 100));
   const label = session.stage === stage.GENERATING
-    ? 'Forging the brief'
-    : `Question ${active} of ${total}`;
+    ? 'Making the plan'
+    : `Step ${active} of ${total}`;
 
   refs.progress.hidden = false;
   refs.progressLabel.textContent = label;
@@ -847,17 +854,17 @@ function renderProgress() {
 function currentPrompt() {
   if (session.stage === stage.GENERATING) {
     return {
-      label: 'The Forge is shaping your Movement Brief.',
-      button: 'Forging...',
-      placeholder: 'Hold tight. Forge is turning the raw material into a Movement Brief.',
+      label: 'Making your plan.',
+      button: 'Making...',
+      placeholder: 'Hold tight. Forge is making a simple plan.',
     };
   }
 
   if (session.stage === stage.INITIAL || session.stage === stage.INTRO) {
     return {
-      label: 'Rant, ramble, complain, dream, or describe the thing you can’t stop thinking about.',
-      button: 'Send to Forge',
-      placeholder: 'Example: I need money, I do not have much time, and I keep thinking there is a useful project in 3DVR.',
+      label: 'Tell me what feels stuck. One sentence is enough.',
+      button: 'Help me sort it',
+      placeholder: 'Example: I need money and I do not know what to do first.',
     };
   }
 
@@ -865,14 +872,38 @@ function currentPrompt() {
   const total = session.followUps.length || 3;
   const active = Math.min(session.followUpIndex + 1, total);
   return {
-    label: followUp?.question ? `Question ${active} of ${total}: ${followUp.question}` : 'Ready to forge the brief.',
-    button: session.followUpIndex >= session.followUps.length - 1 ? 'Forge brief' : 'Answer',
-    placeholder: 'Answer in plain language. A rough answer is enough.',
+    label: followUp?.question ? `Step ${active} of ${total}: ${followUp.question}` : 'Ready to make the plan.',
+    button: session.followUpIndex >= session.followUps.length - 1 ? 'Make my plan' : 'Next',
+    placeholder: 'A short answer is enough. You can say I do not know.',
   };
+}
+
+function simpleAnswerForCurrentPrompt() {
+  const followUp = session.followUps[session.followUpIndex];
+  const key = followUp?.key || '';
+
+  if (key === 'audience') {
+    return 'Me first, then people like me.';
+  }
+
+  if (key === 'help' || key === 'tiny') {
+    return 'a simple page, message, or checklist I can use this week.';
+  }
+
+  if (key === 'shape') {
+    return 'Start with a simple page or service.';
+  }
+
+  if (key === 'resources') {
+    return 'My skills, my phone, and a few people I can ask.';
+  }
+
+  return 'I do not know yet. Help me pick the simplest next step.';
 }
 
 function renderBriefSection(key, label, value) {
   const node = refs.sectionTemplate.content.firstElementChild.cloneNode(true);
+  node.dataset.briefSection = key;
   node.classList.toggle('brief-section--strong', key === 'projectName' || key === 'realityCheck');
   node.classList.toggle(
     'brief-section--wide',
@@ -993,7 +1024,7 @@ function render() {
   const prompt = currentPrompt();
   const statusText = isBusy
     ? (session.notice || 'Forge AI is working...')
-    : session.notice || (session.stage === stage.BRIEF ? 'Movement Brief ready.' : 'Ready.');
+    : session.notice || (session.stage === stage.BRIEF ? 'Plan ready.' : 'Ready.');
 
   document.body.dataset.forgeStage = session.stage;
   refs.conversationPanel.hidden = session.stage === stage.BRIEF;
@@ -1004,6 +1035,12 @@ function render() {
   refs.answer.disabled = isBusy || session.stage === stage.GENERATING || session.stage === stage.BRIEF;
   refs.submit.disabled = isBusy || session.stage === stage.GENERATING || session.stage === stage.BRIEF;
   refs.spark.hidden = isBusy || Boolean(session.initial) || session.stage !== stage.INITIAL;
+  if (refs.easyAnswer) {
+    refs.easyAnswer.hidden = isBusy || session.stage !== stage.FOLLOWUPS;
+  }
+  if (refs.presets) {
+    refs.presets.hidden = isBusy || Boolean(session.initial) || session.stage !== stage.INITIAL;
+  }
   refs.reset.hidden = !session.initial && session.stage === stage.INITIAL;
   refs.briefPanel.hidden = session.stage !== stage.BRIEF;
   refs.status.textContent = statusText;
@@ -1022,18 +1059,18 @@ function render() {
 
 async function prepareFollowUps(initial) {
   isBusy = true;
-  setNotice('Reading for solution paths and the next sharp question...');
+  setNotice('Finding a simple first step...');
   render();
 
   try {
     const result = await requestForge('followups', { initial });
     session.guidance = normalizeForgeGuidanceResponse(result?.guidance, initial);
     session.followUps = normalizeFollowUpsResponse(result?.questions);
-    setNotice('Forge suggested first solution paths. Answer one question to sharpen the brief.');
+    setNotice('Start here. Answer two easy steps, or use the simple answer.');
   } catch (error) {
     session.guidance = buildLocalForgeGuidance(initial);
     session.followUps = chooseFollowUps(initial);
-    setNotice(`Local solution paths loaded. ${error.message || ''}`.trim());
+    setNotice('Simple path loaded. Keep going.');
   } finally {
     isBusy = false;
     session.stage = stage.FOLLOWUPS;
@@ -1045,7 +1082,7 @@ async function prepareFollowUps(initial) {
 
 async function refineForgeTurn() {
   isBusy = true;
-  setNotice('Updating solution paths from your answer...');
+  setNotice('Updating the plan...');
   render();
 
   try {
@@ -1056,9 +1093,9 @@ async function refineForgeTurn() {
     });
     session.guidance = normalizeForgeGuidanceResponse(result?.guidance, session.initial);
     session.followUps = mergeFollowUpsResponse(result?.questions, session.followUpIndex);
-    setNotice('Forge updated the solution paths. Answer the next sharp question.');
+    setNotice('Plan updated. One more small step.');
   } catch (error) {
-    setNotice(`Kept the current solution path. ${error.message || ''}`.trim());
+    setNotice('Kept the simple path. Keep going.');
   } finally {
     isBusy = false;
     saveSession();
@@ -1070,7 +1107,7 @@ async function refineForgeTurn() {
 async function generateBrief() {
   session.stage = stage.GENERATING;
   isBusy = true;
-  setNotice('Shaping your Movement Brief...');
+  setNotice('Making your plan...');
   render();
 
   try {
@@ -1081,11 +1118,11 @@ async function generateBrief() {
     });
     session.brief = normalizeBriefResponse(result?.brief);
     session.briefSource = 'ai';
-    setNotice('Movement Brief ready.');
+    setNotice('Plan ready.');
   } catch (error) {
     session.brief = buildMockMovementBrief(session);
     session.briefSource = 'local-fallback';
-    setNotice(`Local fallback brief ready. ${error.message || ''}`.trim());
+    setNotice('Plan ready.');
   } finally {
     isBusy = false;
     session.stage = stage.BRIEF;
@@ -1101,7 +1138,7 @@ async function handleSubmit(event) {
 
   const value = clean(refs.answer.value);
   if (!value) {
-    refs.status.textContent = 'Give the Forge raw material first.';
+    refs.status.textContent = 'Type one sentence or pick a starter.';
     return;
   }
 
@@ -1111,8 +1148,10 @@ async function handleSubmit(event) {
     session.followUps = chooseFollowUps(value);
     session.followUpIndex = 0;
     session.stage = stage.FOLLOWUPS;
+    setNotice('Start here. Answer two easy steps, or use the simple answer.');
     saveSession();
-    await prepareFollowUps(value);
+    render();
+    window.requestAnimationFrame(() => refs.answer.focus());
     return;
   }
 
@@ -1128,8 +1167,10 @@ async function handleSubmit(event) {
   }
 
   session.followUpIndex += 1;
+  setNotice('Good. One more small step.');
   saveSession();
-  await refineForgeTurn();
+  render();
+  window.requestAnimationFrame(() => refs.answer.focus());
 }
 
 async function writeText(text, successMessage) {
@@ -1161,8 +1202,8 @@ function downloadBrief() {
   link.click();
   link.remove();
   URL.revokeObjectURL(url);
-  refs.status.textContent = 'Movement Brief downloaded.';
-  if (refs.briefStatus) refs.briefStatus.textContent = 'Movement Brief downloaded.';
+  refs.status.textContent = 'Plan downloaded.';
+  if (refs.briefStatus) refs.briefStatus.textContent = 'Plan downloaded.';
 }
 
 function resetForge() {
@@ -1188,17 +1229,36 @@ function sparkIdea() {
   const spark = starterSparks[sparkIndex % starterSparks.length];
   sparkIndex += 1;
   refs.answer.value = spark;
-  refs.status.textContent = 'Spark loaded. Edit it or send it.';
+  refs.status.textContent = 'Example loaded. Edit it or send it.';
+  refs.answer.focus();
+}
+
+function usePresetIdea(event) {
+  const idea = clean(event.currentTarget?.dataset?.presetIdea);
+  if (!idea) return;
+
+  refs.answer.value = idea;
+  refs.status.textContent = 'Starter loaded. Edit it or send it.';
+  refs.answer.focus();
+}
+
+function useSimpleAnswer() {
+  refs.answer.value = simpleAnswerForCurrentPrompt();
+  refs.status.textContent = 'Simple answer added. You can edit it.';
   refs.answer.focus();
 }
 
 refs.form?.addEventListener('submit', handleSubmit);
 refs.spark?.addEventListener('click', sparkIdea);
+refs.easyAnswer?.addEventListener('click', useSimpleAnswer);
+refs.presetButtons.forEach((button) => {
+  button.addEventListener('click', usePresetIdea);
+});
 refs.reset?.addEventListener('click', resetForge);
 refs.resetBrief?.addEventListener('click', resetForge);
 refs.copyBrief?.addEventListener('click', () => {
   if (session.brief) {
-    writeText(briefToMarkdown(session.brief), 'Movement Brief copied.');
+    writeText(briefToMarkdown(session.brief), 'Plan copied.');
   }
 });
 refs.downloadBrief?.addEventListener('click', downloadBrief);

--- a/forge/index.html
+++ b/forge/index.html
@@ -6,7 +6,7 @@
   <title>3DVR Forge | Turn frustration into a project</title>
   <meta
     name="description"
-    content="3DVR Forge turns messy thoughts, rants, and ideas into a Movement Brief, tiny 7-day experiment, and next actions."
+    content="3DVR Forge helps you sort a stuck idea, pick one next step, and leave with a simple plan."
   >
   <meta name="theme-color" content="#111827">
   <link rel="stylesheet" href="../styles/global.css">
@@ -32,7 +32,7 @@
         <div class="forge-panel forge-conversation" data-forge-panel="conversation">
           <div class="forge-panel__header">
             <span class="eyebrow">3DVR Forge</span>
-            <h1 id="forgeRoomTitle">What’s been bothering you lately?</h1>
+            <h1 id="forgeRoomTitle">What feels stuck?</h1>
           </div>
 
           <div class="forge-progress" data-forge-progress hidden>
@@ -46,17 +46,17 @@
 
           <article class="forge-guidance" data-guidance-panel hidden aria-live="polite">
             <div class="forge-guidance__header">
-              <span class="eyebrow">Forge read</span>
-              <h2>First solution paths</h2>
+              <span class="eyebrow">Next step</span>
+              <h2>Start here</h2>
               <p data-guidance-diagnosis></p>
             </div>
             <div class="forge-guidance__grid">
               <section>
-                <h3>Possible paths</h3>
+                <h3>Try this</h3>
                 <ul data-guidance-paths></ul>
               </section>
               <section>
-                <h3>Do next</h3>
+                <h3>Then do this</h3>
                 <ol data-guidance-actions></ol>
               </section>
             </div>
@@ -64,20 +64,27 @@
 
           <form class="forge-input" data-forge-form>
             <label for="forgeAnswer" class="forge-input__label" data-input-label>
-              Rant, ramble, complain, dream, or describe the thing you can't stop thinking about.
+              One sentence is enough.
             </label>
             <textarea
               id="forgeAnswer"
               rows="7"
               maxlength="2400"
-              placeholder="Rant, complain, dream, or describe the thing you can’t stop thinking about."
+              placeholder="Example: I need money and I do not know what to do first."
               data-forge-answer
               autofocus
               required
             ></textarea>
+            <div class="forge-presets" data-forge-presets aria-label="Quick start ideas">
+              <button type="button" data-preset-idea="I need money and I do not know what to do first.">Need money</button>
+              <button type="button" data-preset-idea="I need better work and I do not know where to start.">Need work</button>
+              <button type="button" data-preset-idea="I have an idea but it feels too big.">Have idea</button>
+              <button type="button" data-preset-idea="I feel stuck and need one small next step.">Feel stuck</button>
+            </div>
             <div class="forge-input__actions">
-              <button class="cta primary" type="submit" data-submit-answer>Send to Forge</button>
-              <button class="cta ghost forge-spark" type="button" data-spark-idea>Spark idea</button>
+              <button class="cta primary" type="submit" data-submit-answer>Help me sort it</button>
+              <button class="cta ghost forge-easy-answer" type="button" data-easy-answer hidden>Use simple answer</button>
+              <button class="cta ghost forge-spark" type="button" data-spark-idea>Use example</button>
               <button class="cta ghost" type="button" data-reset-forge>Reset</button>
             </div>
             <p class="forge-status" data-forge-status role="status" aria-live="polite">
@@ -88,29 +95,29 @@
 
         <aside class="forge-panel forge-brief" data-forge-panel="brief" hidden aria-labelledby="movementBriefTitle">
           <div class="forge-panel__header">
-            <span class="eyebrow">Movement Brief</span>
-            <h2 id="movementBriefTitle">Movement Brief</h2>
+            <span class="eyebrow">Plan</span>
+            <h2 id="movementBriefTitle">Your next step plan</h2>
           </div>
 
-          <div class="forge-brief__actions" aria-label="Movement Brief actions">
-            <button class="cta ghost" type="button" data-copy-brief aria-label="Copy Movement Brief">Copy</button>
-            <button class="cta ghost" type="button" data-download-brief aria-label="Download Movement Brief as Markdown">Download</button>
-            <button class="cta ghost" type="button" data-reset-brief aria-label="Forge another brief">New brief</button>
+          <div class="forge-brief__actions" aria-label="Plan actions">
+            <button class="cta ghost" type="button" data-copy-brief aria-label="Copy plan">Copy</button>
+            <button class="cta ghost" type="button" data-download-brief aria-label="Download plan as Markdown">Download</button>
+            <button class="cta ghost" type="button" data-reset-brief aria-label="Start a new plan">New plan</button>
           </div>
-          <p class="forge-status" data-brief-status role="status" aria-live="polite">Movement Brief ready.</p>
+          <p class="forge-status" data-brief-status role="status" aria-live="polite">Plan ready.</p>
 
           <div class="movement-brief-grid" data-brief-output></div>
 
           <div class="forge-next-moves" aria-labelledby="nextMoveTitle">
             <div>
               <span class="eyebrow">Next move</span>
-              <h3 id="nextMoveTitle">Do not overbuild yet.</h3>
+              <h3 id="nextMoveTitle">Pick one thing to use now.</h3>
             </div>
             <div class="forge-next-moves__buttons">
-              <button type="button" data-next-move="testMessage">Make test message</button>
-              <button type="button" data-next-move="codexPrompt">Make Codex prompt</button>
-              <button type="button" data-next-move="landingCopy">Make landing page copy</button>
-              <button type="button" data-next-move="checklist">Make 7-day checklist</button>
+              <button type="button" data-next-move="testMessage">Copy message</button>
+              <button type="button" data-next-move="checklist">7-day list</button>
+              <button type="button" data-next-move="landingCopy">Page words</button>
+              <button type="button" data-next-move="codexPrompt">Build prompt</button>
             </div>
             <article class="next-output" data-next-output hidden>
               <div class="next-output__header">
@@ -120,27 +127,6 @@
               <pre data-next-output-body></pre>
             </article>
           </div>
-
-          <article class="forge-offer" aria-labelledby="forgeOfferTitle">
-            <div>
-              <span class="eyebrow">Sell this next</span>
-              <h3 id="forgeOfferTitle">Turn this brief into a paid launch sprint.</h3>
-              <p>Use the brief as the deposit trigger: a 72-hour pass that sharpens the offer, builds the first page, writes the test message, and sets up a tiny reply tracker.</p>
-            </div>
-            <ul class="forge-offer__list">
-              <li>Offer and test message review</li>
-              <li>Landing page or build prompt pass</li>
-              <li>Reply tracker and 7-day follow-up</li>
-            </ul>
-            <div class="forge-offer__actions">
-              <a
-                class="cta primary"
-                href="../ideas/forge-revenue-sprint.html"
-              >Start $300 sprint</a>
-              <a class="cta ghost" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dbuilder">Go $50 Builder</a>
-              <a class="cta ghost" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dpro">Start $20 Founder</a>
-            </div>
-          </article>
         </aside>
       </section>
     </main>

--- a/forge/styles.css
+++ b/forge/styles.css
@@ -267,6 +267,36 @@ body[data-forge-stage="brief"] .forge-workspace {
   outline-offset: 2px;
 }
 
+.forge-presets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7.5rem, 1fr));
+  gap: 0.5rem;
+}
+
+.forge-presets[hidden] {
+  display: none;
+}
+
+.forge-presets button {
+  min-width: 0;
+  min-height: 2.5rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid rgba(56, 189, 248, 0.26);
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--forge-text);
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.forge-presets button:hover,
+.forge-presets button:focus-visible {
+  border-color: rgba(56, 189, 248, 0.58);
+  outline: none;
+}
+
 .forge-input__actions,
 .forge-brief__actions {
   display: flex;
@@ -278,6 +308,12 @@ body[data-forge-stage="brief"] .forge-workspace {
   border-color: rgba(250, 204, 21, 0.34);
   background: rgba(250, 204, 21, 0.11);
   color: rgba(254, 249, 195, 0.96);
+}
+
+.forge-easy-answer {
+  border-color: rgba(52, 211, 153, 0.34);
+  background: rgba(52, 211, 153, 0.1);
+  color: rgba(209, 250, 229, 0.96);
 }
 
 .forge-status {
@@ -336,45 +372,6 @@ body[data-forge-stage="brief"] .forge-workspace {
   padding-left: 1.2rem;
   display: grid;
   gap: 0.45rem;
-}
-
-.forge-offer {
-  display: grid;
-  gap: 0.85rem;
-  padding: 1rem;
-  border: 1px solid rgba(52, 211, 153, 0.28);
-  border-radius: var(--radius-md);
-  background: linear-gradient(145deg, rgba(6, 78, 59, 0.26), rgba(9, 13, 21, 0.9));
-}
-
-.forge-offer h3,
-.forge-offer p {
-  margin: 0;
-}
-
-.forge-offer h3 {
-  margin-top: 0.35rem;
-  font-size: clamp(1.25rem, 1rem + 0.7vw, 1.75rem);
-  line-height: 1.1;
-}
-
-.forge-offer p,
-.forge-offer__list {
-  color: var(--forge-muted);
-  line-height: 1.55;
-}
-
-.forge-offer__list {
-  display: grid;
-  gap: 0.35rem;
-  margin: 0;
-  padding-left: 1.15rem;
-}
-
-.forge-offer__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
 }
 
 .forge-next-moves {
@@ -492,17 +489,19 @@ body[data-forge-stage="brief"] .forge-workspace {
 
   .forge-input__actions {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.6rem;
   }
 
   .forge-input__actions .cta {
-    width: auto;
+    width: 100%;
     min-width: 0;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
   }
 
   .forge-input__actions .cta.ghost {
-    min-width: 6.4rem;
+    min-width: 0;
   }
 
   .forge-brief__actions {
@@ -517,10 +516,6 @@ body[data-forge-stage="brief"] .forge-workspace {
     padding: 0.54rem 0.36rem;
     font-size: 0.74rem;
     line-height: 1.12;
-  }
-
-  .forge-offer__actions .cta {
-    width: 100%;
   }
 
   .forge-next-moves__buttons {

--- a/index.html
+++ b/index.html
@@ -409,8 +409,8 @@
           <a href="forge/" class="app-card" data-app-keywords="forge frustration rant reflect project movement brief experiment codex prompt test message launch">
             <span class="app-card__icon" aria-hidden="true">FG</span>
             <span class="app-card__title">3DVR Forge</span>
-            <span class="app-card__meta">Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test.</span>
-            <span class="app-card__cta">Enter the Forge</span>
+            <span class="app-card__meta">Get clear, pick one step, and leave with a simple plan or message.</span>
+            <span class="app-card__cta">Get help</span>
           </a>
           <a
             href="friends-family/"

--- a/src/forge/api.js
+++ b/src/forge/api.js
@@ -79,15 +79,11 @@ const FORGE_BRIEF_SCHEMA = {
 const DEFAULT_FOLLOWUPS = Object.freeze([
   {
     key: 'audience',
-    question: 'Who else has this problem?'
+    question: 'Who is this for? You can say me.'
   },
   {
-    key: 'tried',
-    question: 'What have you already tried?'
-  },
-  {
-    key: 'tiny',
-    question: 'What would a tiny version look like in 7 days?'
+    key: 'help',
+    question: 'What would help this week?'
   }
 ]);
 
@@ -140,31 +136,31 @@ function normalizeFollowUps(value) {
       question: clean(item?.question, 220)
     }))
     .filter(item => item.question)
-    .slice(0, 3);
+    .slice(0, 2);
 
   DEFAULT_FOLLOWUPS.forEach((fallback) => {
-    if (normalized.length < 3) {
+    if (normalized.length < 2) {
       normalized.push(fallback);
     }
   });
 
-  return normalized.slice(0, 3);
+  return normalized.slice(0, 2);
 }
 
 function normalizeFollowUpGuidance(value = {}) {
   const fallbackSolutions = [
-    'Turn the frustration into one paid or useful promise for a specific person.',
-    'Test demand with direct messages before building a larger product.',
-    'Create the smallest support artifact: a page, checklist, script, or tracker.'
+    'Turn the stuck feeling into one small promise for one person.',
+    'Test with a message before building a larger product.',
+    'Make the smallest useful thing: a page, checklist, script, or tracker.'
   ];
   const fallbackActions = [
-    'Write the plain-language problem in one sentence.',
-    'Pick one audience you can reach this week.',
-    'Send a low-pressure test message before building.'
+    'Write the problem in one plain sentence.',
+    'Pick one person you can reach this week.',
+    'Send a low-pressure message before building.'
   ];
 
   return {
-    diagnosis: clean(value?.diagnosis, 700) || 'Good raw material. The frustration has energy, but it needs a sharper audience and a smaller first test.',
+    diagnosis: clean(value?.diagnosis, 700) || 'Good start. Make it smaller and easier to test.',
     solutionPaths: normalizeStringList(value?.solutionPaths, fallbackSolutions, { min: 2, max: 3 }),
     nextActions: normalizeStringList(value?.nextActions, fallbackActions, { min: 2, max: 3 })
   };
@@ -188,14 +184,13 @@ function normalizeStringList(value, fallback, { min = 3, max = 5 } = {}) {
 
 function normalizeBrief(value) {
   const fallbackActions = [
-    'Name the audience in one sentence.',
-    'Send the test message to 10 real people.',
-    'Build only after at least one useful reply.'
+    'Write one clear promise.',
+    'Text 10 people.',
+    'Build after one yes.'
   ];
   const fallbackReality = [
-    'Too vague unless the audience is specific.',
-    'This is a test, not a full startup yet.',
-    'A direct message may validate the idea faster than an app.'
+    'Pick one kind of person first.',
+    'Send the message before building.'
   ];
 
   return {
@@ -203,11 +198,11 @@ function normalizeBrief(value) {
     coreFrustration: clean(value?.coreFrustration, 900) || 'The raw frustration is real, but the project still needs sharper edges.',
     audience: clean(value?.audience, 500) || 'frustrated working people with hidden skills',
     projectConcept: clean(value?.projectConcept, 1400) || 'A small useful offer that turns the frustration into a testable project.',
-    tinyExperiment: clean(value?.tinyExperiment, 900) || 'In 7 days, make one clear promise and send it to 10 people.',
+    tinyExperiment: clean(value?.tinyExperiment, 900) || 'This week: make one promise. Send it to 10 people. Track replies.',
     firstActions: normalizeStringList(value?.firstActions, fallbackActions, { min: 3, max: 3 }),
-    testMessage: clean(value?.testMessage, 1200) || 'I am testing a small project idea. Does this feel useful, too vague, or not your problem?',
+    testMessage: clean(value?.testMessage, 1200) || 'Quick question: I am testing a small project idea. Would this help you this week?',
     codexPrompt: clean(value?.codexPrompt, 2600) || 'Build the smallest mobile-first support artifact for this project. Start with the offer, outreach script, and reply tracking before product features.',
-    realityCheck: normalizeStringList(value?.realityCheck, fallbackReality, { min: 3, max: 5 })
+    realityCheck: normalizeStringList(value?.realityCheck, fallbackReality, { min: 2, max: 2 })
   };
 }
 
@@ -258,8 +253,8 @@ export function buildForgeInstructions(now = new Date()) {
     'The Codex build prompt should create the smallest support artifact, such as a landing page, outreach script, checklist, or reply tracker. Avoid accounts, dashboards, metaverse concepts, and complex persistence unless the user specifically needs them.',
     'If the user answers with placeholders such as test, unsure, or I do not know, say what is missing instead of inventing certainty.',
     'The target user is a frustrated working person with hidden skills who wants to build something useful but does not know where to begin.',
-    'For followups mode, do not only ask questions. Give a concise diagnosis, two or three plausible solution paths, two or three concrete next actions, then ask exactly three short adaptive questions. If prior answers are present, update the diagnosis and solution paths from those answers, then ask only for the missing sharp details. The questions should sharpen a choice, not restart the conversation.',
-    'For brief mode, produce a complete Movement Brief with concrete next steps, a test message, a Codex-ready build prompt, and a blunt reality check.',
+    'For followups mode, do not only ask questions. Give one concise diagnosis, two plausible solution paths, two concrete next actions, then ask exactly two short, easy questions. The questions must be answerable in one sentence. Let the user say "I do not know." If prior answers are present, update the diagnosis and solution paths from those answers, then ask only for missing simple details.',
+    'For brief mode, produce a complete Movement Brief with concrete next steps, a test message, a Codex-ready build prompt, and a blunt reality check. Keep visible user-facing fields short: first actions should be one line each with six words or less, test message should be under 35 words, tiny experiment should be under 20 words, and realityCheck must contain exactly two plain bullets.',
     'Do not include markdown fences. Return only the JSON object requested by the schema.'
   ].join(' ');
 }

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -76,7 +76,7 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Command center/);
     assert.match(html, /Same account, same apps, deeper levels of control\./);
     assert.match(html, /<span class="app-card__title">3DVR Forge<\/span>/);
-    assert.match(html, /Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test\./);
+    assert.match(html, /Get clear, pick one step, and leave with a simple plan or message\./);
     assert.match(html, /<span class="app-card__title">Forge Sprint<\/span>/);
     assert.match(html, /Start \$300 sprint/);
     assert.match(html, /<span class="app-card__title">Client Onboarding Sprint<\/span>/);

--- a/tests/forge-api.test.js
+++ b/tests/forge-api.test.js
@@ -76,6 +76,9 @@ test('buildForgeInstructions injects date and blacksmith tone rules', () => {
   assert.match(instructions, /Avoid accounts, dashboards, metaverse concepts/i);
   assert.match(instructions, /instead of inventing certainty/i);
   assert.match(instructions, /Movement Brief/i);
+  assert.match(instructions, /exactly two short, easy questions/i);
+  assert.match(instructions, /exactly two plain bullets/i);
+  assert.match(instructions, /I do not know/i);
 });
 
 test('buildForgeOpenAiRequest creates a structured follow-up request', () => {
@@ -179,7 +182,7 @@ test('Forge handler returns solution guidance and adaptive follow-up questions f
   assert.match(res.body.guidance.diagnosis, /first audience is still too broad/);
   assert.equal(res.body.guidance.solutionPaths.length, 2);
   assert.equal(res.body.guidance.nextActions.length, 2);
-  assert.equal(res.body.questions.length, 3);
+  assert.equal(res.body.questions.length, 2);
   assert.equal(res.body.questions[1].key, 'stakes');
 });
 
@@ -216,14 +219,12 @@ test('Forge handler returns a normalized Movement Brief from OpenAI', async () =
       mode: 'brief',
       initial: 'I want to turn rants into project tests.',
       followUps: [
-        { key: 'audience', question: 'Who else has this problem?' },
-        { key: 'tried', question: 'What have you tried?' },
-        { key: 'tiny', question: 'What is tiny?' }
+        { key: 'audience', question: 'Who is this for? You can say me.' },
+        { key: 'help', question: 'What would help this week?' }
       ],
       answers: {
         audience: 'frustrated workers',
-        tried: 'notes',
-        tiny: 'message test'
+        help: 'message test'
       }
     }
   }, res);
@@ -232,7 +233,7 @@ test('Forge handler returns a normalized Movement Brief from OpenAI', async () =
   assert.equal(res.body.mode, 'brief');
   assert.equal(res.body.brief.projectName, 'Rant to Project Forge');
   assert.equal(res.body.brief.firstActions.length, 3);
-  assert.equal(res.body.brief.realityCheck.length, 3);
+  assert.equal(res.body.brief.realityCheck.length, 2);
   assert.match(res.body.brief.codexPrompt, /Build a minimal Forge prototype/);
 });
 
@@ -313,5 +314,5 @@ test('OpenAI site route dispatches Forge requests without adding another API fun
   assert.equal(res.statusCode, 200);
   assert.equal(res.body.mode, 'followups');
   assert.match(res.body.guidance.diagnosis, /smaller first proof/);
-  assert.equal(res.body.questions.length, 3);
+  assert.equal(res.body.questions.length, 2);
 });

--- a/tests/forge.test.js
+++ b/tests/forge.test.js
@@ -12,36 +12,40 @@ describe('3DVR Forge product route', () => {
     assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
     assert.match(html, /src="\/gun-init\.js"/);
     assert.match(html, /3DVR Forge/);
-    assert.match(html, /What(?:&rsquo;|’)s been bothering you lately\?/);
+    assert.match(html, /What feels stuck\?/);
     assert.match(html, /data-forge-form/);
     assert.match(html, /data-forge-answer/);
+    assert.match(html, /data-forge-presets/);
+    assert.match(html, /data-preset-idea="I need money and I do not know what to do first\."/);
+    assert.match(html, /Need money<\/button>/);
     assert.match(html, /data-forge-progress/);
     assert.match(html, /data-guidance-panel/);
-    assert.match(html, /data-spark-idea>Spark idea<\/button>/);
-    assert.match(html, /Forge read/);
+    assert.match(html, /data-easy-answer hidden>Use simple answer<\/button>/);
+    assert.match(html, /data-spark-idea>Use example<\/button>/);
+    assert.match(html, /Next step/);
+    assert.match(html, /Start here/);
     assert.match(html, /autofocus/);
-    assert.match(html, /Send to Forge/);
+    assert.match(html, /Help me sort it/);
     assert.match(html, /Ready\./);
     assert.match(html, /data-brief-output/);
     assert.match(html, /data-brief-status/);
-    assert.match(html, /aria-label="Copy Movement Brief">Copy<\/button>/);
-    assert.match(html, /aria-label="Download Movement Brief as Markdown">Download<\/button>/);
-    assert.match(html, /aria-label="Forge another brief">New brief<\/button>/);
-    assert.match(html, /Sell this next/);
-    assert.match(html, /Turn this brief into a paid launch sprint\./);
-    assert.match(html, /href="\.\.\/ideas\/forge-revenue-sprint\.html"/);
-    assert.match(html, /Start \$300 sprint<\/a>/);
-    assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dbuilder">Go \$50 Builder<\/a>/);
-    assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dpro">Start \$20 Founder<\/a>/);
-    assert.match(html, /Make test message/);
-    assert.match(html, /Make Codex prompt/);
-    assert.match(html, /Make landing page copy/);
-    assert.match(html, /Make 7-day checklist/);
+    assert.match(html, /aria-label="Copy plan">Copy<\/button>/);
+    assert.match(html, /aria-label="Download plan as Markdown">Download<\/button>/);
+    assert.match(html, /aria-label="Start a new plan">New plan<\/button>/);
+    assert.doesNotMatch(html, /Sell this next/);
+    assert.doesNotMatch(html, /Turn this brief into a paid launch sprint\./);
+    assert.doesNotMatch(html, /Start \$300 sprint<\/a>/);
+    assert.doesNotMatch(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dbuilder">Go \$50 Builder<\/a>/);
+    assert.doesNotMatch(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dpro">Start \$20 Founder<\/a>/);
+    assert.match(html, /Copy message/);
+    assert.match(html, /Build prompt/);
+    assert.match(html, /Page words/);
+    assert.match(html, /7-day list/);
     assert.doesNotMatch(html, /data-enter-forge/);
     assert.doesNotMatch(html, /<section class="forge-hero"/);
     assert.doesNotMatch(html, /Rant\. Reflect\. Forge a project\./);
     assert.doesNotMatch(html, /Readable output/);
-    assert.match(html, /sign-in\.html\?redirect=%2Fbilling/);
+    assert.doesNotMatch(html, /sign-in\.html\?redirect=%2Fbilling/);
     assert.doesNotMatch(html, /create an account/i);
   });
 
@@ -68,7 +72,7 @@ describe('3DVR Forge product route', () => {
     assert.match(app, /refs\.spark\.hidden = isBusy \|\| Boolean\(session\.initial\) \|\| session\.stage !== stage\.INITIAL/);
     assert.match(app, /refs\.reset\.hidden = !session\.initial && session\.stage === stage\.INITIAL/);
     assert.match(app, /if \(!session\.initial\) return/);
-    assert.match(app, /button:\s*'Send to Forge'/);
+    assert.match(app, /button:\s*'Help me sort it'/);
     assert.match(app, /subscribeToSharedDefaults/);
     assert.match(app, /waitForSharedSecret\('openai'/);
     assert.match(app, /readDefaultSecret\(data, 'openai'\)/);
@@ -94,47 +98,44 @@ describe('3DVR Forge product route', () => {
     assert.match(app, /function renderGuidance\(\)/);
     assert.match(app, /function renderProgress\(\)/);
     assert.match(app, /function sparkIdea\(\)/);
-    assert.match(app, /Spark loaded\. Edit it or send it\./);
-    assert.match(app, /Question \$\{active\} of \$\{total\}/);
+    assert.match(app, /function usePresetIdea\(event\)/);
+    assert.match(app, /function useSimpleAnswer\(\)/);
+    assert.match(app, /Example loaded\. Edit it or send it\./);
+    assert.match(app, /Step \$\{active\} of \$\{total\}/);
     assert.match(app, /What I see:/);
-    assert.match(app, /Possible solution paths:/);
-    assert.match(app, /Do next:/);
-    assert.match(app, /Updating solution paths from your answer/);
-    assert.match(app, /Forge updated the solution paths/);
+    assert.match(app, /Try this:/);
+    assert.match(app, /Then do this:/);
+    assert.match(app, /Updating the plan/);
+    assert.match(app, /Plan updated/);
     assert.match(app, /function chooseFollowUps\(initial\)/);
     assert.match(app, /function buildMockMovementBrief\(currentSession\)/);
     assert.match(app, /normalizeFollowUpsResponse/);
     assert.match(app, /normalizeBriefResponse/);
-    assert.match(app, /Local fallback brief ready/);
-    assert.match(app, /Local solution paths loaded/);
-    assert.match(app, /Forge suggested first solution paths/);
+    assert.match(app, /Plan ready/);
+    assert.match(app, /Simple path loaded/);
+    assert.match(app, /Start here\. Answer two easy steps/);
     assert.match(app, /7-Day Revenue Signal Test/);
-    assert.match(app, /This is cash pressure, not a giant product problem yet/);
+    assert.match(app, /This looks like money pressure/);
     assert.match(app, /paid micro-offer and direct outreach test/);
     assert.doesNotMatch(app, /data-enter-forge/);
-    assert.match(app, /Who else has this problem\?/);
-    assert.match(app, /What have you already tried\?/);
-    assert.match(app, /What would a tiny version look like in 7 days\?/);
-    assert.match(app, /What skills or resources do you already have\?/);
-    assert.match(app, /Do you want this to become a tool, service, community, content project, or business\?/);
+    assert.match(app, /Who is this for\? You can say me\./);
+    assert.match(app, /What would help this week\?/);
+    assert.match(app, /What do you already have\? A skill, tool, friend, or place to start\?/);
+    assert.match(app, /What should this become first\? A page, service, tool, or message\?/);
 
     [
-      'Project Name',
-      'Core Frustration',
-      'Audience',
-      'Project Concept',
-      'Tiny 7-Day Experiment',
-      'First 3 Actions',
-      'Test Message',
-      'Codex Build Prompt',
-      'Reality Check',
+      'Name',
+      'Do these 3 things',
+      'Message to send',
+      '7-day test',
+      'Watch out',
     ].forEach((section) => {
       assert.match(app, new RegExp(section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     });
 
     assert.match(app, /Good raw material\. Too vague right now/);
-    assert.match(app, /This is probably not a startup yet\. It is a test\./);
-    assert.match(app, /Do not build an app yet/);
+    assert.match(app, /Build after one yes/);
+    assert.match(app, /Send the message before building/);
     assert.match(app, /navigator\.clipboard\.writeText/);
     assert.match(app, /type: 'text\/markdown'/);
     assert.match(app, /safeWriteStorage\(STORAGE_KEY/);
@@ -155,9 +156,11 @@ describe('3DVR Forge product route', () => {
     assert.match(css, /\.forge-progress\s*\{/);
     assert.match(css, /\.forge-guidance\s*\{/);
     assert.match(css, /\.forge-spark\s*\{/);
+    assert.match(css, /\.forge-easy-answer\s*\{/);
+    assert.match(css, /\.forge-presets\s*\{/);
     assert.match(css, /\.forge-message p\s*\{[\s\S]*?white-space:\s*pre-wrap;/);
-    assert.match(css, /\.forge-offer\s*\{/);
-    assert.match(css, /\.forge-offer__actions/);
+    assert.doesNotMatch(css, /\.forge-offer\s*\{/);
+    assert.doesNotMatch(css, /\.forge-offer__actions/);
     assert.match(css, /\.forge-brief__actions\s*\{/);
     assert.match(css, /\.forge-next-moves__buttons\s*\{/);
     assert.match(css, /min-width:\s*0/);
@@ -175,7 +178,7 @@ describe('3DVR Forge product route', () => {
     assert.match(html, /href="forge\/" class="cta primary">Enter the Forge<\/a>/);
     assert.match(html, /href="forge\/" class="app-card" data-app-keywords="[^"]*\bfrustration\b[^"]*\bmovement brief\b[^"]*"/);
     assert.match(html, /<span class="app-card__title">3DVR Forge<\/span>/);
-    assert.match(html, /Rant, reflect, and turn messy thoughts into a Movement Brief and 7-day test\./);
+    assert.match(html, /Get clear, pick one step, and leave with a simple plan or message\./);
     assert.match(html, /href="ideas\/forge-revenue-sprint\.html"/);
     assert.match(html, /<span class="app-card__title">Forge Sprint<\/span>/);
     assert.match(html, /Turn a Movement Brief into a buyable 72-hour offer page, first test message, and reply tracker\./);

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -99,7 +99,7 @@ test('homepage app search can find Forge by project-shaping keywords', async () 
     /href="forge\/" class="app-card" data-app-keywords="[^"]*\bfrustration\b[^"]*\bcodex prompt\b[^"]*"/
   );
   assert.match(html, /<span class="app-card__title">3DVR Forge<\/span>/);
-  assert.match(html, /Movement Brief and 7-day test/);
+  assert.match(html, /simple plan or message/);
 });
 
 test('homepage app search can find Forge Sprint by paid offer keywords', async () => {


### PR DESCRIPTION
## What changed

- Simplified the Forge entry into one direct prompt with starter buttons.
- Reworked the flow into two easy guided steps with a one-click simple answer.
- Made local guidance immediate instead of pausing between questions for AI updates.
- Shortened the final plan to five compact sections with shorter actions, message, test, and reality check.
- Added a client-side Forge API timeout so the UI falls back instead of hanging.
- Updated the portal Forge card and regression tests for the new flow.

## Why

Forge felt too text-heavy and question-heavy. The new flow gives direction sooner, asks easier questions, and keeps the final output actionable on mobile.

## Validation

- `node --test tests/forge.test.js tests/forge-api.test.js tests/homepage-search-ux.test.js tests/customer-journey-pages.test.js`
- `git diff --check`
- Mobile Playwright walkthrough at 390px: initial, guidance, second step, and plan screens all had `scrollWidth === clientWidth` and no overflowing elements.
