### PR TITLE
[codex] Focus free plan on life direction

### DIFF
--- a/free-trial.html
+++ b/free-trial.html
@@ -295,52 +295,51 @@
         <a href="https://3dvr.tech/subscribe/">View plans</a>
       </div>
       <div class="signup-card">
-        <h2>Start with your email</h2>
-        <p class="form-intro">Share your email first and we’ll send your free-plan next step back into the
-          portal. No credit card required.</p>
+        <h2>Start free</h2>
+        <p class="form-intro">Share your email and get the free path back into the portal. No card.</p>
         <form id="trialForm">
           <label for="email" class="email-field">
-            <span class="email-label">Email for your free-plan next steps <span class="email-badge">Start here</span></span>
-            <span class="email-hint">Use the email you want attached to your portal account so your free path stays easy to find later.</span>
+            <span class="email-label">Email for your free path <span class="email-badge">Start here</span></span>
+            <span class="email-hint">Use the email you want for your portal account.</span>
             <input type="email" id="email" placeholder="you@example.com" required />
           </label>
-          <button type="submit">Send free-plan link</button>
+          <button type="submit">Send free link</button>
           <div class="message" id="message"></div>
           <div class="secure-note">This secure page is part of the 3dvr.tech portal flow.</div>
         </form>
       </div>
-      <span class="eyebrow">Free path</span>
-      <h1>Get organized and take your next step</h1>
-      <p class="lead">Share your email, then continue into one portal account for a free setup flow that helps you sort what matters and choose the right starting point. No credit card required.</p>
+      <span class="eyebrow">Free plan</span>
+      <h1>Organize your life. Find your next step.</h1>
+      <p class="lead">You are meant for more than staying stuck. Start free, sort what matters, and pick one small move for today.</p>
 
       <div class="journey" aria-label="Free plan journey">
         <div class="journey-step">
           <div class="journey-number">1</div>
           <div>
             <h2>Enter your email</h2>
-            <p class="step-copy">We use it to send your free-plan confirmation and the next step back into the portal.</p>
+            <p class="step-copy">We send the free link so you can come back later.</p>
           </div>
         </div>
         <div class="journey-step">
           <div class="journey-number">2</div>
           <div>
-            <h2>Create or use one portal account</h2>
-            <p class="step-copy">Keep your free access, future upgrades, and support attached to the same identity.</p>
+            <h2>Open your portal</h2>
+            <p class="step-copy">Use one place for your notes, next steps, and support.</p>
           </div>
         </div>
         <div class="journey-step">
           <div class="journey-number">3</div>
           <div>
-            <h2>Start with daily direction</h2>
-            <p class="step-copy">Open the start flow, choose your lane, and begin with a daily check-in, a support path, or a launch plan from the same portal account.</p>
+            <h2>Pick one move</h2>
+            <p class="step-copy">Do a quick check-in. Leave with one clear thing to do.</p>
           </div>
         </div>
       </div>
     </section>
 
     <aside class="aside">
-      <h2>Already know your next step?</h2>
-      <p>Use the same portal account for free access, billing changes, invoices, and ongoing support. If you already have an account or need a paid plan, jump straight there.</p>
+      <h2>Already have an account?</h2>
+      <p>Jump back in. The free path is for life, ideas, and the next small move.</p>
       <div class="next-steps">
         <a href="/start/">Open start flow</a>
         <a href="/sign-in.html">Sign in or create account</a>
@@ -358,7 +357,7 @@
       e.preventDefault();
       const email = document.getElementById('email').value;
       const messageEl = document.getElementById('message');
-      messageEl.textContent = 'Sending your free-plan next step...';
+      messageEl.textContent = 'Sending your free link...';
 
       try {
         const res = await fetch('/api/trial.js', {
@@ -369,7 +368,7 @@
 
         const data = await res.json();
         if (res.ok) {
-          messageEl.textContent = 'Free-plan request sent. Check your email, then continue in the portal start flow.';
+          messageEl.textContent = 'Free link sent. Check your email, then open the portal.';
         } else {
           messageEl.textContent = data.error || 'Something went wrong. Please try again.';
         }

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
               <div class="plan-ribbon plan-ribbon--compact">
                 <a class="plan-pill" href="free-trial.html">
                   <strong>Free</strong>
-                  <span>Get started</span>
+                  <span>Get clear</span>
                 </a>
                 <a class="plan-pill" href="sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
                   <strong>$5</strong>
@@ -258,13 +258,13 @@
           <div class="hero-shortcuts" aria-labelledby="quick-switch-title">
             <div class="hero-shortcuts__header">
               <span class="eyebrow">Support lanes</span>
-              <h2 id="quick-switch-title">Keep the support lanes nearby</h2>
+              <h2 id="quick-switch-title">Start free, then grow</h2>
             </div>
             <div class="shortcut-grid">
               <a href="life/index.html" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">🌿</span>
                 <span class="shortcut-card__title">Daily Direction</span>
-                <span class="shortcut-card__meta">Life: 3-minute check-in and one clear next step.</span>
+                <span class="shortcut-card__meta">Free: sort your life and choose one next step.</span>
               </a>
               <a href="alive-system/" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">⚡</span>
@@ -289,7 +289,7 @@
               <a href="start/index.html" class="shortcut-card">
                 <span class="shortcut-card__icon" aria-hidden="true">🧭</span>
                 <span class="shortcut-card__title">Start Your Thing</span>
-                <span class="shortcut-card__meta">Start Here: tools and paid help for a project, offer, or business.</span>
+                <span class="shortcut-card__meta">Start Here: organize life, ideas, work, and what wants to grow.</span>
               </a>
             </div>
           </div>

--- a/start/index.html
+++ b/start/index.html
@@ -28,10 +28,10 @@
       <div class="hero-grid">
         <div class="hero-content">
           <span class="tag">Start here</span>
-          <h1>Start your next 3dvr project.</h1>
+          <h1>Organize your life. Find your next step.</h1>
           <p>
-            Tell us where you are: getting organized, ready for direct help, or already managing
-            a subscription. We will route you to the cleanest next step.
+            Start free if life feels scattered. Sort what matters, see what wants to grow,
+            and take one small step.
           </p>
           <div class="hero-actions">
             <a class="button primary" href="../free-trial.html">Start free</a>
@@ -41,7 +41,7 @@
           <div class="hero-status">
             <span>No card for free</span>
             <span>One portal account</span>
-            <span>Switch plans later in Stripe</span>
+            <span>You are meant for more</span>
           </div>
         </div>
 
@@ -54,8 +54,8 @@
           </p>
           <div class="step-list">
             <div class="step-item">
-              <strong>1. I am getting organized</strong>
-              <span>Start free, create one portal account, and get one next step.</span>
+              <strong>1. I feel scattered</strong>
+              <span>Start free and find one next step.</span>
             </div>
             <div class="step-item">
               <strong>2. I want help launching something</strong>
@@ -78,25 +78,23 @@
       <section class="journey-shell" id="paths" aria-labelledby="paths-title">
         <div class="section-heading section-heading--left">
           <span class="tag tag--dark">3 clear needs</span>
-          <h2 id="paths-title">Start where you actually are</h2>
+          <h2 id="paths-title">Start where you are</h2>
           <p>
-            Pick the sentence that sounds most like your situation. The portal can stay in the
-            background until the next step is obvious.
+            Pick the sentence that feels true. The free path helps you get clear first.
           </p>
         </div>
 
         <div class="path-grid">
           <article class="path-card">
-            <span class="panel-label">I need to get organized</span>
-            <h3>Find one next step without a card</h3>
+            <span class="panel-label">I feel scattered</span>
+            <h3>Get clear for free</h3>
             <p>
-              Use the free path when the project still feels scattered and you need a small,
-              concrete place to begin.
+              Use this when life, ideas, money, or work all feel mixed together.
             </p>
             <ul class="path-list">
-              <li>One clear starting point</li>
-              <li>No credit card required</li>
-              <li>Upgrade only when direct help makes sense</li>
+              <li>Sort what matters</li>
+              <li>Pick one next step</li>
+              <li>No credit card</li>
             </ul>
             <div class="path-card__actions">
               <a class="button primary" href="../free-trial.html">Start free</a>
@@ -287,7 +285,7 @@
                   <input type="radio" name="support" value="free" checked />
                   <span class="choice__body">
                     <strong>Show me the next step</strong>
-                    <span>I want to get moving before I pay.</span>
+              <span>I want to feel clear before I pay.</span>
                   </span>
                 </label>
                 <label class="choice">
@@ -310,15 +308,14 @@
 
           <aside class="result-card" aria-live="polite">
             <span class="panel-label">Best next move</span>
-            <h3 id="routerTitle">Start free in the portal</h3>
+            <h3 id="routerTitle">Start free with Daily Direction</h3>
             <p id="routerCopy">
-              You need a clean first step more than more tools. Start free with your email, then
-              continue into one portal account.
+              You are not behind. You need one quiet place to sort your life and pick today’s next step.
             </p>
             <ul class="result-list" id="routerPoints">
-              <li>Email first, no credit card</li>
-              <li>One portal account for future upgrades</li>
-              <li>Daily direction is the first workspace</li>
+              <li>No card</li>
+              <li>Sort what matters</li>
+              <li>One small move today</li>
             </ul>
             <p class="result-plan" id="routerPlan">Best lane now: Free</p>
             <div class="result-actions">
@@ -333,8 +330,8 @@
       <section class="compact-grid" id="customer-path" aria-label="Quick actions and customer path">
         <article class="mini-panel">
           <span class="panel-label">Free first</span>
-          <h2>Keep the free path small and real</h2>
-          <p>If someone is not ready to pay, the next step should still feel concrete and useful.</p>
+          <h2>Free should still help</h2>
+          <p>Start with life, ideas, and one useful step. Pay later only if direct help makes sense.</p>
           <div class="quick-actions">
             <a class="button tertiary" href="../free-trial.html">Start free</a>
             <a class="button tertiary" href="../life/index.html">Open Daily Direction</a>

--- a/start/router.js
+++ b/start/router.js
@@ -7,13 +7,13 @@ function buildBillingStartHref(plan = '') {
 
 const ROUTES = {
   life: {
-    title: 'Start free in the portal',
+    title: 'Start free with Daily Direction',
     copy:
-      'You need a clean first step more than more tools. Start free with your email, then continue into one portal account.',
+      'You are not behind. You need one quiet place to sort your life and pick today’s next step.',
     points: [
-      'Email first, no credit card',
-      'One portal account for future upgrades',
-      'Daily direction is the first workspace',
+      'No card',
+      'Sort what matters',
+      'One small move today',
     ],
     plan: 'Best lane now: Free',
     primaryLabel: 'Start free',

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -55,16 +55,16 @@ describe('portal customer journey pages', () => {
     assert.match(html, /href="sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dstarter"/);
     assert.match(html, /href="sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dpro"/);
     assert.match(html, /href="sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dbuilder"/);
-    assert.match(html, /Get started/);
+    assert.match(html, /Get clear/);
     assert.match(html, /Family &amp; Friends/);
     assert.match(html, /Builder/);
-    assert.match(html, /Keep the support lanes nearby/);
+    assert.match(html, /Start free, then grow/);
     assert.match(html, /Daily Direction/);
-    assert.match(html, /Life: 3-minute check-in and one clear next step\./);
+    assert.match(html, /Free: sort your life and choose one next step\./);
     assert.match(html, /Support Group/);
     assert.match(html, /Cell: small-group accountability and weekly momentum\./);
     assert.match(html, /Start Your Thing/);
-    assert.match(html, /Start Here: tools and paid help for a project, offer, or business\./);
+    assert.match(html, /Start Here: organize life, ideas, work, and what wants to grow\./);
     assert.match(html, /Search the dock/);
     assert.match(html, /Sign in or create account/);
     assert.match(html, /Use one account to save your progress and sync your points across devices\./);
@@ -115,12 +115,13 @@ describe('portal customer journey pages', () => {
 
   it('keeps the free trial page tied to the portal account journey', async () => {
     const html = await readFile(new URL('../free-trial.html', import.meta.url), 'utf8');
-    assert.match(html, /Get organized and take your next step/);
-    assert.match(html, /Create or use one portal account/);
-    assert.match(html, /Start with daily direction/);
-    assert.match(html, /Send free-plan link/);
+    assert.match(html, /Organize your life\. Find your next step\./);
+    assert.match(html, /You are meant for more than staying stuck/);
+    assert.match(html, /Open your portal/);
+    assert.match(html, /Pick one move/);
+    assert.match(html, /Send free link/);
     assert.match(html, /Start here/);
-    assert.match(html, /Use the email you want attached to your portal account/);
+    assert.match(html, /Use the email you want for your portal account/);
     assert.match(html, /Sign in or create account/);
     assert.match(html, /Open billing center/);
     assert.match(html, /Open start flow/);
@@ -129,23 +130,22 @@ describe('portal customer journey pages', () => {
 
   it('turns the start page into a compact onboarding router with easy plan access', async () => {
     const html = await readFile(new URL('../start/index.html', import.meta.url), 'utf8');
-    assert.match(html, /Start your next 3dvr project\./);
-    assert.match(html, /getting organized, ready for direct help, or already managing/);
+    assert.match(html, /Organize your life\. Find your next step\./);
+    assert.match(html, /Start free if life feels scattered/);
     assert.match(html, /3 clear needs/);
-    assert.match(html, /Start where you actually are/);
-    assert.match(html, /Pick the sentence that sounds most like your situation/);
+    assert.match(html, /Start where you are/);
+    assert.match(html, /Pick the sentence that feels true/);
     assert.match(html, /Start free/);
     assert.match(html, /Get direct help/);
     assert.match(html, /Manage billing/);
     assert.match(html, /Pick your path/);
     assert.match(html, /Three ways to begin/);
-    assert.match(html, /I am getting organized/);
+    assert.match(html, /I feel scattered/);
     assert.match(html, /I want help launching something/);
     assert.match(html, /I already pay for 3dvr/);
     assert.doesNotMatch(html, /The job of this page is simple/);
     assert.doesNotMatch(html, /Do not make every customer start on the same screen/);
-    assert.match(html, /I need to get organized/);
-    assert.match(html, /Find one next step without a card/);
+    assert.match(html, /Get clear for free/);
     assert.match(html, /I need help building something/);
     assert.match(html, /Get direct help on a real project/);
     assert.match(html, /I already pay for 3DVR/);
@@ -173,7 +173,7 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Open Messenger/);
     assert.match(html, /Open Finance/);
     assert.match(html, /One portal account/);
-    assert.match(html, /Switch plans later in Stripe/);
+    assert.match(html, /You are meant for more/);
     assert.match(html, /Open sign-in/);
     assert.match(html, /Browse apps/);
     assert.match(html, /Returning customers should not have to wade back through plan education\./);

--- a/tests/life.test.js
+++ b/tests/life.test.js
@@ -40,8 +40,8 @@ describe('life app', () => {
     assert.match(portalIndex, /<span class="app-card__title">Life<\/span>/);
     assert.match(portalIndex, /Track daily check-ins, weekly reflection, and the five parts of your life/);
 
-    assert.match(freeTrial, /continue in the portal start flow/);
-    assert.match(freeTrial, /Start with daily direction/);
+    assert.match(freeTrial, /Free link sent\. Check your email, then open the portal\./);
+    assert.match(freeTrial, /Pick one move/);
     assert.match(freeTrial, /href="\/start\/"/);
 
     assert.match(readme, /\[Life\]\(https:\/\/3dvr-portal\.vercel\.app\/life\/\)/);

--- a/tests/start-router.test.js
+++ b/tests/start-router.test.js
@@ -12,7 +12,7 @@ test('start router sends clarity-first answers to Life', () => {
   assert.equal(key, 'life');
   assert.equal(
     getRecommendation({ project: 'personal', stage: 'idea', support: 'free' }).title,
-    'Start free in the portal'
+    'Start free with Daily Direction'
   );
   assert.equal(
     getRecommendation({ project: 'personal', stage: 'idea', support: 'free' }).primaryLabel,


### PR DESCRIPTION
## What changed

- Repositioned the free plan around organizing life, finding the next step, and helping people see they are meant for more.
- Simplified the free trial page copy: shorter headline, no-card framing, simpler email form, and clearer three-step path.
- Updated the start page and router so the free lane points to Daily Direction and one small move today.
- Updated the portal plan pill and support lane copy to make free help feel useful first.
- Updated regression tests for the new free-plan framing.

## Why

The free plan should feel like the core doorway for people who feel scattered, not just a billing/account setup step.

## Validation

- `node --test tests/customer-journey-pages.test.js tests/start-router.test.js tests/life.test.js`
- `git diff --check`
- Mobile WebKit screenshots at 390px for `/free-trial.html`, `/start/`, and `/`: all had `scrollWidth === clientWidth` and no overflowing elements.
