### PR TITLE
[codex] Make Forge feel more app-like

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -60,6 +60,7 @@ const refs = {
   form: document.querySelector('[data-forge-form]'),
   answer: document.querySelector('[data-forge-answer]'),
   inputLabel: document.querySelector('[data-input-label]'),
+  inputMode: document.querySelector('[data-forge-input-mode]'),
   submit: document.querySelector('[data-submit-answer]'),
   spark: document.querySelector('[data-spark-idea]'),
   easyAnswer: document.querySelector('[data-easy-answer]'),
@@ -70,6 +71,8 @@ const refs = {
   progress: document.querySelector('[data-forge-progress]'),
   progressLabel: document.querySelector('[data-forge-progress-label]'),
   progressBar: document.querySelector('[data-forge-progress-bar]'),
+  appStatus: document.querySelector('[data-forge-app-status]'),
+  stageSteps: Array.from(document.querySelectorAll('[data-forge-step]')),
   guidancePanel: document.querySelector('[data-guidance-panel]'),
   guidanceDiagnosis: document.querySelector('[data-guidance-diagnosis]'),
   guidancePaths: document.querySelector('[data-guidance-paths]'),
@@ -851,6 +854,45 @@ function renderProgress() {
   refs.progressBar.style.width = `${percent}%`;
 }
 
+function resolveAppStep() {
+  if (session.stage === stage.BRIEF || session.stage === stage.GENERATING) {
+    return 'brief';
+  }
+
+  if (session.stage === stage.FOLLOWUPS) {
+    return 'followups';
+  }
+
+  return 'initial';
+}
+
+function renderAppChrome(statusText) {
+  const activeStep = resolveAppStep();
+
+  if (refs.appStatus) {
+    refs.appStatus.textContent = statusText.replace(/\.$/, '');
+  }
+
+  if (refs.inputMode) {
+    const labels = {
+      initial: 'Sort',
+      followups: 'Shape',
+      brief: 'Plan',
+    };
+    refs.inputMode.textContent = labels[activeStep] || 'Sort';
+  }
+
+  refs.stageSteps.forEach((step) => {
+    const isActive = step.dataset.forgeStep === activeStep;
+    step.dataset.active = isActive ? 'true' : 'false';
+    if (isActive) {
+      step.setAttribute('aria-current', 'step');
+    } else {
+      step.removeAttribute('aria-current');
+    }
+  });
+}
+
 function currentPrompt() {
   if (session.stage === stage.GENERATING) {
     return {
@@ -1045,6 +1087,7 @@ function render() {
   refs.briefPanel.hidden = session.stage !== stage.BRIEF;
   refs.status.textContent = statusText;
   if (refs.briefStatus) refs.briefStatus.textContent = statusText;
+  renderAppChrome(statusText);
 
   renderProgress();
   renderTranscript();

--- a/forge/index.html
+++ b/forge/index.html
@@ -19,18 +19,32 @@
 <body class="landing theme-dark forge-page">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <div class="landing-shell forge-shell">
-    <header class="top-nav">
-      <nav class="top-buttons" aria-label="Forge navigation">
+    <header class="forge-appbar">
+      <a class="forge-appbar__brand" href="../index.html" aria-label="Back to portal">
+        <span class="forge-appbar__mark" aria-hidden="true">3F</span>
+        <span>
+          <strong>Forge</strong>
+          <small>3DVR</small>
+        </span>
+      </a>
+      <nav class="forge-appbar__nav" aria-label="Forge navigation">
         <a href="../index.html">Portal</a>
-        <a href="../launch-room/">Launch Room</a>
-        <a href="../web-builder-app/">Codex Bench</a>
+        <a href="../launch-room/">Launch</a>
+        <a href="../web-builder-app/">Bench</a>
       </nav>
+      <span class="forge-appbar__status" data-forge-app-status>Ready</span>
     </header>
 
     <main id="mainContent" class="landing-content">
       <section class="forge-workspace" aria-labelledby="forgeRoomTitle">
+        <div class="forge-stage-rail" data-forge-stage-rail aria-label="Forge steps">
+          <span data-forge-step="initial">Sort</span>
+          <span data-forge-step="followups">Shape</span>
+          <span data-forge-step="brief">Plan</span>
+        </div>
+
         <div class="forge-panel forge-conversation" data-forge-panel="conversation">
-          <div class="forge-panel__header">
+          <div class="forge-panel__header forge-screen-header">
             <span class="eyebrow">3DVR Forge</span>
             <h1 id="forgeRoomTitle">What feels stuck?</h1>
           </div>
@@ -63,6 +77,10 @@
           </article>
 
           <form class="forge-input" data-forge-form>
+            <div class="forge-input__topline">
+              <span>Today</span>
+              <span data-forge-input-mode>Sort</span>
+            </div>
             <label for="forgeAnswer" class="forge-input__label" data-input-label>
               One sentence is enough.
             </label>
@@ -94,7 +112,7 @@
         </div>
 
         <aside class="forge-panel forge-brief" data-forge-panel="brief" hidden aria-labelledby="movementBriefTitle">
-          <div class="forge-panel__header">
+          <div class="forge-panel__header forge-screen-header">
             <span class="eyebrow">Plan</span>
             <h2 id="movementBriefTitle">Your next step plan</h2>
           </div>

--- a/forge/styles.css
+++ b/forge/styles.css
@@ -23,39 +23,121 @@ body {
 }
 
 .forge-page {
+  min-height: 100vh;
   background:
-    radial-gradient(circle at 16% 10%, rgba(245, 158, 11, 0.18), transparent 30rem),
-    radial-gradient(circle at 82% 18%, rgba(56, 189, 248, 0.14), transparent 34rem),
-    linear-gradient(180deg, #0b111c 0%, #111827 52%, #090d15 100%);
+    linear-gradient(135deg, rgba(245, 158, 11, 0.12), transparent 24rem),
+    linear-gradient(180deg, #07111f 0%, #111827 48%, #070b13 100%);
   color: var(--forge-text);
 }
 
 .forge-shell {
-  width: min(100%, 1180px);
+  width: min(100%, 1100px);
+  padding-top: 1rem;
+  padding-bottom: 1.5rem;
 }
 
-.forge-page .top-nav {
-  margin-bottom: 1.1rem;
+.forge-appbar {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  width: min(100%, 920px);
+  margin: 0 auto 1rem;
+  padding: 0.55rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 1.35rem;
+  background: rgba(7, 12, 22, 0.88);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(18px);
 }
 
-.forge-page .top-buttons {
-  width: fit-content;
-  max-width: min(100%, 620px);
-  margin-bottom: 0;
-  padding: 0.5rem;
-  border-radius: 1.25rem;
+.forge-appbar__brand,
+.forge-appbar__nav,
+.forge-appbar__status {
+  min-width: 0;
 }
 
-.forge-page .top-buttons a {
-  min-height: 2.45rem;
-  padding: 0.52rem 1.05rem;
-  font-size: 0.92rem;
+.forge-appbar__brand {
+  display: inline-grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--forge-text);
+  text-decoration: none;
+}
+
+.forge-appbar__brand strong,
+.forge-appbar__brand small {
+  display: block;
+  line-height: 1;
+}
+
+.forge-appbar__brand strong {
+  font-size: 0.98rem;
+}
+
+.forge-appbar__brand small {
+  margin-top: 0.16rem;
+  color: var(--forge-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.forge-appbar__mark {
+  display: grid;
+  width: 2.25rem;
+  aspect-ratio: 1;
+  place-items: center;
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  border-radius: 0.78rem;
+  background: rgba(56, 189, 248, 0.15);
+  color: #e0f2fe;
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.forge-appbar__nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.forge-appbar__nav a,
+.forge-appbar__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.15rem;
+  padding: 0.48rem 0.72rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+  color: rgba(226, 232, 240, 0.94);
+  font-size: 0.82rem;
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.forge-appbar__nav a:hover,
+.forge-appbar__nav a:focus-visible {
+  border-color: rgba(56, 189, 248, 0.5);
+  outline: none;
+}
+
+.forge-appbar__status {
+  background: rgba(52, 211, 153, 0.1);
+  color: rgba(209, 250, 229, 0.96);
+  white-space: nowrap;
 }
 
 .forge-workspace {
   display: grid;
-  gap: 1rem;
-  width: min(100%, 760px);
+  gap: 0.85rem;
+  width: min(100%, 860px);
   margin: 0 auto;
 }
 
@@ -67,11 +149,13 @@ body[data-forge-stage="brief"] .forge-workspace {
   display: grid;
   gap: 1rem;
   min-width: 0;
-  padding: clamp(1rem, 2vw, 1.35rem);
+  padding: clamp(1rem, 2vw, 1.5rem);
   border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: var(--radius-lg);
-  background: var(--forge-panel);
-  box-shadow: 0 24px 70px rgba(3, 7, 18, 0.38);
+  border-radius: 1.55rem;
+  background:
+    linear-gradient(180deg, rgba(17, 24, 39, 0.92), rgba(8, 13, 23, 0.94)),
+    var(--forge-panel);
+  box-shadow: 0 30px 90px rgba(3, 7, 18, 0.42);
 }
 
 .forge-panel[hidden] {
@@ -85,6 +169,13 @@ body[data-forge-stage="brief"] .forge-workspace {
 .forge-panel__header {
   display: grid;
   gap: 0.6rem;
+}
+
+.forge-screen-header {
+  padding: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 1.1rem;
+  background: rgba(148, 163, 184, 0.07);
 }
 
 .forge-panel__header h1,
@@ -105,6 +196,7 @@ body[data-forge-stage="brief"] .forge-workspace {
   display: grid;
   gap: 0.75rem;
   min-height: 5rem;
+  padding: 0.15rem;
 }
 
 .forge-transcript:empty {
@@ -148,7 +240,7 @@ body[data-forge-stage="brief"] .forge-workspace {
   gap: 0.35rem;
   max-width: 92%;
   padding: 0.85rem 0.95rem;
-  border-radius: 1rem;
+  border-radius: 1.1rem;
   border: 1px solid rgba(148, 163, 184, 0.16);
   background: rgba(11, 15, 24, 0.7);
 }
@@ -179,7 +271,7 @@ body[data-forge-stage="brief"] .forge-workspace {
   gap: 1rem;
   padding: 1rem;
   border: 1px solid rgba(245, 158, 11, 0.28);
-  border-radius: var(--radius-md);
+  border-radius: 1.15rem;
   background:
     linear-gradient(145deg, rgba(120, 53, 15, 0.2), rgba(8, 13, 23, 0.9)),
     rgba(8, 13, 23, 0.86);
@@ -242,6 +334,26 @@ body[data-forge-stage="brief"] .forge-workspace {
 .forge-input {
   display: grid;
   gap: 0.8rem;
+  position: sticky;
+  bottom: 1rem;
+  z-index: 8;
+  padding: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.25rem;
+  background: rgba(7, 12, 22, 0.92);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.34);
+  backdrop-filter: blur(18px);
+}
+
+.forge-input__topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .forge-input__label {
@@ -251,10 +363,10 @@ body[data-forge-stage="brief"] .forge-workspace {
 
 .forge-input textarea {
   width: 100%;
-  min-height: 11rem;
+  min-height: 8.5rem;
   padding: 1rem;
   border: 1px solid rgba(148, 163, 184, 0.24);
-  border-radius: var(--radius-md);
+  border-radius: 1rem;
   background: rgba(8, 13, 23, 0.96);
   color: var(--forge-text);
   font: inherit;
@@ -317,9 +429,46 @@ body[data-forge-stage="brief"] .forge-workspace {
 }
 
 .forge-status {
+  width: fit-content;
+  max-width: 100%;
   margin: 0;
+  padding: 0.38rem 0.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.08);
   color: var(--forge-muted);
-  font-size: 0.92rem;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.forge-stage-rail {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+  padding: 0.45rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 1.15rem;
+  background: rgba(7, 12, 22, 0.72);
+}
+
+.forge-stage-rail span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 2.15rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 0.85rem;
+  color: rgba(226, 232, 240, 0.68);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.forge-stage-rail span[data-active="true"] {
+  border-color: rgba(245, 158, 11, 0.46);
+  background: rgba(245, 158, 11, 0.14);
+  color: var(--forge-text);
 }
 
 .movement-brief-grid {
@@ -332,7 +481,7 @@ body[data-forge-stage="brief"] .forge-workspace {
   gap: 0.45rem;
   padding: 1rem;
   border: 1px solid rgba(148, 163, 184, 0.16);
-  border-radius: var(--radius-md);
+  border-radius: 1.15rem;
   background: rgba(9, 13, 21, 0.82);
 }
 
@@ -461,17 +610,26 @@ body[data-forge-stage="brief"] .forge-workspace {
     padding-right: 1rem;
   }
 
-  .forge-page .top-buttons {
+  .forge-appbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.45rem;
+    top: 0.5rem;
+    border-radius: 1.05rem;
+  }
+
+  .forge-appbar__brand {
+    overflow: hidden;
+  }
+
+  .forge-appbar__nav {
+    grid-column: 1 / -1;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     width: 100%;
-    max-width: 100%;
-    gap: 0.45rem;
-    padding: 0.45rem;
-    border-radius: 1rem;
   }
 
-  .forge-page .top-buttons a {
+  .forge-appbar__nav a {
     width: 100%;
     min-width: 0;
     min-height: 2.25rem;
@@ -479,6 +637,20 @@ body[data-forge-stage="brief"] .forge-workspace {
     font-size: 0.78rem;
     line-height: 1.12;
     text-align: center;
+  }
+
+  .forge-appbar__status {
+    display: none;
+  }
+
+  .forge-input {
+    bottom: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 1.1rem;
+  }
+
+  .forge-input textarea {
+    min-height: 7.25rem;
   }
 
   .forge-panel,
@@ -498,6 +670,10 @@ body[data-forge-stage="brief"] .forge-workspace {
     min-width: 0;
     padding-left: 0.5rem;
     padding-right: 0.5rem;
+  }
+
+  .forge-input__actions .cta.primary {
+    grid-column: 1 / -1;
   }
 
   .forge-input__actions .cta.ghost {

--- a/tests/forge.test.js
+++ b/tests/forge.test.js
@@ -7,14 +7,23 @@ describe('3DVR Forge product route', () => {
     const html = await readFile(new URL('../forge/index.html', import.meta.url), 'utf8');
 
     assert.match(html, /<title>3DVR Forge \| Turn frustration into a project<\/title>/);
+    assert.match(html, /class="forge-appbar"/);
+    assert.match(html, /class="forge-appbar__brand" href="\.\.\/index\.html"/);
+    assert.match(html, /data-forge-app-status>Ready<\/span>/);
     assert.match(html, /href="\.\.\/index\.html">Portal<\/a>/);
-    assert.match(html, /href="\.\.\/launch-room\/">Launch Room<\/a>/);
+    assert.match(html, /href="\.\.\/launch-room\/">Launch<\/a>/);
+    assert.match(html, /href="\.\.\/web-builder-app\/">Bench<\/a>/);
+    assert.match(html, /class="forge-stage-rail" data-forge-stage-rail/);
+    assert.match(html, /data-forge-step="initial">Sort<\/span>/);
+    assert.match(html, /data-forge-step="followups">Shape<\/span>/);
+    assert.match(html, /data-forge-step="brief">Plan<\/span>/);
     assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
     assert.match(html, /src="\/gun-init\.js"/);
     assert.match(html, /3DVR Forge/);
     assert.match(html, /What feels stuck\?/);
     assert.match(html, /data-forge-form/);
     assert.match(html, /data-forge-answer/);
+    assert.match(html, /data-forge-input-mode>Sort<\/span>/);
     assert.match(html, /data-forge-presets/);
     assert.match(html, /data-preset-idea="I need money and I do not know what to do first\."/);
     assert.match(html, /Need money<\/button>/);
@@ -97,6 +106,8 @@ describe('3DVR Forge product route', () => {
     assert.match(app, /function formatGuidanceMessage\(guidance\)/);
     assert.match(app, /function renderGuidance\(\)/);
     assert.match(app, /function renderProgress\(\)/);
+    assert.match(app, /function renderAppChrome\(statusText\)/);
+    assert.match(app, /function resolveAppStep\(\)/);
     assert.match(app, /function sparkIdea\(\)/);
     assert.match(app, /function usePresetIdea\(event\)/);
     assert.match(app, /function useSimpleAnswer\(\)/);
@@ -147,13 +158,16 @@ describe('3DVR Forge product route', () => {
     const css = await readFile(new URL('../forge/styles.css', import.meta.url), 'utf8');
 
     assert.match(css, /html,\s*body\s*\{\s*overflow-x:\s*hidden;/);
-    assert.match(css, /\.forge-shell\s*\{\s*width:\s*min\(100%,\s*1180px\);/);
+    assert.match(css, /\.forge-shell\s*\{\s*width:\s*min\(100%,\s*1100px\);/);
     assert.match(css, /\.forge-workspace\s*\{\s*display:\s*grid;/);
-    assert.match(css, /width:\s*min\(100%,\s*760px\);/);
+    assert.match(css, /width:\s*min\(100%,\s*860px\);/);
     assert.match(css, /body\[data-forge-stage="brief"\]\s+\.forge-workspace/);
     assert.match(css, /\.forge-transcript:empty/);
     assert.match(css, /\.forge-page\s+\[hidden\]\s*\{[\s\S]*?display:\s*none !important;/);
     assert.match(css, /\.forge-progress\s*\{/);
+    assert.match(css, /\.forge-appbar\s*\{/);
+    assert.match(css, /\.forge-stage-rail\s*\{/);
+    assert.match(css, /\.forge-input__topline\s*\{/);
     assert.match(css, /\.forge-guidance\s*\{/);
     assert.match(css, /\.forge-spark\s*\{/);
     assert.match(css, /\.forge-easy-answer\s*\{/);


### PR DESCRIPTION
## What changed

- Reworked Forge into a more self-contained app shell with a sticky app bar, compact brand mark, nav actions, and status chip.
- Added a three-step app rail for Sort, Shape, and Plan that follows Forge state.
- Turned the prompt area into an app-like input dock with a tighter textarea, preset chips, and stronger primary action styling.
- Restyled panels, guidance, and brief cards so the experience feels more like one focused tool than a portal page.
- Added render wiring and tests for the app chrome.

## Why

Forge was functionally better but still felt like a web page. This makes the interaction feel more like a dedicated product surface, especially on mobile.

## Validation

- `node --test tests/forge.test.js tests/forge-api.test.js tests/homepage-search-ux.test.js`
- `git diff --check`
- Mobile WebKit walkthrough at 390px across initial and guided states: no horizontal overflow, app status hidden on phone, stage rail updates correctly.
- Desktop WebKit screenshot at 1366px: no horizontal overflow, app bar and stage rail render correctly.
