### PR TITLE
[codex] Add prompt guide mode to portal

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -695,7 +695,15 @@ body.landing {
 }
 
 body[data-view-mode="workshop"] .human-os-container,
+body[data-view-mode="guide"] .human-os-container,
+body[data-view-mode="guide"] .app-hub,
+body[data-view-mode="guide"] .gamified-dashboard,
+body[data-view-mode="guide"] .info-panels,
 body[data-view-mode="human-os"][data-active-room=""] .app-hub {
+  display: none;
+}
+
+body:not([data-view-mode="guide"]) .portal-guide {
   display: none;
 }
 
@@ -812,6 +820,115 @@ body[data-view-mode="human-os"]:not([data-active-room=""]) .human-os-map {
   max-width: 640px;
   margin: 0.75rem 0 0;
   color: var(--color-text-muted);
+}
+
+.portal-guide {
+  display: grid;
+  gap: 1rem;
+  width: min(100%, 960px);
+  margin: 0 auto;
+}
+
+.portal-guide__panel,
+.portal-guide__result {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  padding: clamp(1.15rem, 2.5vw, 1.8rem);
+  border: 1px solid rgba(34, 211, 238, 0.18);
+  border-radius: calc(var(--radius-lg) + 0.1rem);
+  background:
+    linear-gradient(150deg, rgba(8, 15, 31, 0.92), rgba(13, 24, 45, 0.78)),
+    rgba(8, 15, 31, 0.72);
+  box-shadow: 0 30px 80px rgba(4, 9, 20, 0.42);
+}
+
+.portal-guide__intro,
+.portal-guide__form,
+.portal-guide__result > div:first-child {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.portal-guide__intro h2,
+.portal-guide__result h3 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2vw + 1rem, 2.9rem);
+  line-height: 1.08;
+}
+
+.portal-guide__intro p,
+.portal-guide__result p {
+  margin: 0;
+  max-width: 680px;
+  color: var(--color-text-muted);
+  line-height: 1.55;
+}
+
+.portal-guide__label {
+  color: rgba(226, 232, 240, 0.9);
+  font-weight: 800;
+}
+
+.portal-guide__form textarea {
+  width: 100%;
+  min-height: 8.5rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 1.05rem;
+  background: rgba(3, 7, 18, 0.62);
+  color: var(--color-text);
+  font: inherit;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.portal-guide__form textarea:focus-visible {
+  border-color: rgba(34, 211, 238, 0.58);
+  outline: 2px solid rgba(34, 211, 238, 0.32);
+  outline-offset: 2px;
+}
+
+.portal-guide__chips,
+.portal-guide__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.portal-guide__chips button {
+  min-width: 0;
+  min-height: 2.4rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid rgba(56, 189, 248, 0.26);
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.portal-guide__chips button:hover,
+.portal-guide__chips button:focus-visible {
+  border-color: rgba(56, 189, 248, 0.58);
+  outline: none;
+}
+
+.portal-guide__steps {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.portal-guide__result[hidden] {
+  display: none;
 }
 
 
@@ -1100,7 +1217,11 @@ body[data-view-mode="human-os"]:not([data-active-room=""]) .human-os-map {
 body[data-view-mode="human-os"] .hero-actions,
 body[data-view-mode="human-os"] .workspace-strip,
 body[data-view-mode="human-os"] .plan-strip,
-body[data-view-mode="human-os"] .hero-shortcuts {
+body[data-view-mode="human-os"] .hero-shortcuts,
+body[data-view-mode="guide"] .hero-actions,
+body[data-view-mode="guide"] .workspace-strip,
+body[data-view-mode="guide"] .plan-strip,
+body[data-view-mode="guide"] .hero-shortcuts {
   display: none;
 }
 
@@ -1901,6 +2022,24 @@ footer a {
 
   .shortcut-grid {
     grid-template-columns: 1fr;
+  }
+
+  .portal-guide__chips,
+  .portal-guide__actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portal-guide__chips button,
+  .portal-guide__actions .cta {
+    width: 100%;
+    min-width: 0;
+    padding-left: 0.55rem;
+    padding-right: 0.55rem;
+  }
+
+  .portal-guide__actions .cta {
+    grid-column: 1 / -1;
   }
 
   .app-hub--filtering .app-toolbar {

--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
         <button type="button" class="top-nav__search" data-app-search-trigger>Search apps</button>
       </div>
       <div class="view-toggle-container" aria-label="Portal view mode">
+        <button class="toggle-btn" type="button" data-view-mode-button="guide" data-active="false">Guide</button>
         <button class="toggle-btn" type="button" data-view-mode-button="human-os" data-active="false">Human O.S.</button>
         <button class="toggle-btn" type="button" data-view-mode-button="workshop" data-active="true">Workshop</button>
       </div>
@@ -294,6 +295,46 @@
             </div>
           </div>
         </div>
+      </section>
+
+      <section class="portal-guide" aria-labelledby="portal-guide-title" data-portal-guide>
+        <div class="portal-guide__panel">
+          <div class="portal-guide__intro">
+            <span class="eyebrow">One prompt</span>
+            <h2 id="portal-guide-title">Tell the portal what you need.</h2>
+            <p>Write one sentence. The portal will pick a place to start and give you the next few moves.</p>
+          </div>
+          <form class="portal-guide__form" data-guide-form>
+            <label class="portal-guide__label" for="portalGuidePrompt">What are you trying to sort out?</label>
+            <textarea
+              id="portalGuidePrompt"
+              rows="4"
+              maxlength="800"
+              placeholder="Example: I feel scattered and need to organize my life."
+              data-guide-prompt
+            ></textarea>
+            <div class="portal-guide__chips" aria-label="Guide starter prompts">
+              <button type="button" data-guide-chip="I feel scattered and need to organize my life.">Life</button>
+              <button type="button" data-guide-chip="I have an idea and do not know what to do next.">Idea</button>
+              <button type="button" data-guide-chip="I need money, work, or a better follow-up system.">Money</button>
+              <button type="button" data-guide-chip="I want to build a page, app, or project.">Build</button>
+            </div>
+            <button class="cta primary" type="submit">Guide me</button>
+          </form>
+        </div>
+
+        <article class="portal-guide__result" data-guide-result hidden>
+          <div>
+            <span class="eyebrow" data-guide-label>Best place</span>
+            <h3 data-guide-title>Daily Direction</h3>
+            <p data-guide-copy>Start with a quick life check-in and one clear next step.</p>
+          </div>
+          <ol class="portal-guide__steps" data-guide-steps></ol>
+          <div class="portal-guide__actions">
+            <a class="cta primary" href="life/index.html" data-guide-primary>Open Daily Direction</a>
+            <button class="cta ghost" type="button" data-guide-show-dock>Show matching apps</button>
+          </div>
+        </article>
       </section>
 
       <section class="human-os-container" aria-labelledby="human-os-title">
@@ -1555,6 +1596,16 @@
     const roomReveal = document.querySelector('[data-room-reveal]');
     const roomTitle = document.querySelector('[data-room-title]');
     const roomSubtitle = document.querySelector('[data-room-subtitle]');
+    const guideForm = document.querySelector('[data-guide-form]');
+    const guidePrompt = document.querySelector('[data-guide-prompt]');
+    const guideChipButtons = Array.from(document.querySelectorAll('[data-guide-chip]'));
+    const guideResult = document.querySelector('[data-guide-result]');
+    const guideLabel = document.querySelector('[data-guide-label]');
+    const guideTitle = document.querySelector('[data-guide-title]');
+    const guideCopy = document.querySelector('[data-guide-copy]');
+    const guideSteps = document.querySelector('[data-guide-steps]');
+    const guidePrimary = document.querySelector('[data-guide-primary]');
+    const guideShowDock = document.querySelector('[data-guide-show-dock]');
     let activeAppLane = 'all';
     const roomMeta = {
       purpose: {
@@ -1605,6 +1656,152 @@
       money: 'money finance billing revenue cashflow offers rewards income',
       play: 'games play 3d spatial physics xr arcade engine',
     };
+    const portalGuideRoutes = [
+      {
+        id: 'money',
+        room: 'money',
+        href: 'revenue-desk/',
+        cta: 'Open Revenue Desk',
+        label: 'Money path',
+        title: 'Revenue Desk',
+        copy: 'Start with one money move, one follow-up, and one clear next action.',
+        search: 'revenue money follow up',
+        keywords: ['money', 'cash', 'income', 'revenue', 'bill', 'rent', 'sell', 'client', 'paid'],
+        steps: [
+          'Name the money pressure in one sentence.',
+          'Pick one person or lead to follow up with.',
+          'Use the desk to choose the next revenue move.',
+        ],
+      },
+      {
+        id: 'work',
+        room: 'work',
+        href: 'job-tracker/index.html',
+        cta: 'Open Job Tracker',
+        label: 'Work path',
+        title: 'Job Tracker',
+        copy: 'Turn work pressure into a small search, proof, or outreach step.',
+        search: 'job work crm contacts',
+        keywords: ['job', 'work', 'career', 'hire', 'hired', 'resume', 'freelance', 'client work'],
+        steps: [
+          'Name the kind of work you want next.',
+          'List one person, place, or role to contact.',
+          'Use the tracker to keep the next step visible.',
+        ],
+      },
+      {
+        id: 'build',
+        room: 'projects',
+        href: 'launch-room/',
+        cta: 'Open Launch Room',
+        label: 'Build path',
+        title: 'Launch Room',
+        copy: 'Turn the thing you want to build into a page, plan, and first test.',
+        search: 'launch builder project page app',
+        keywords: ['build', 'app', 'page', 'website', 'site', 'launch', 'project', 'tool', 'software'],
+        steps: [
+          'Write the smallest useful version.',
+          'Choose the first screen or page.',
+          'Open Launch Room and make the first draft.',
+        ],
+      },
+      {
+        id: 'idea',
+        room: 'projects',
+        href: 'forge/',
+        cta: 'Open Forge',
+        label: 'Idea path',
+        title: '3DVR Forge',
+        copy: 'Turn a messy thought into a simple plan, message, and 7-day test.',
+        search: 'forge idea plan message',
+        keywords: ['idea', 'stuck idea', 'frustration', 'rant', 'dream', 'dont know', "don't know", 'what next'],
+        steps: [
+          'Say the messy version first.',
+          'Answer two easy shaping prompts.',
+          'Leave with one plan you can copy.',
+        ],
+      },
+      {
+        id: 'purpose',
+        room: 'purpose',
+        href: 'purpose/',
+        cta: 'Open Purpose',
+        label: 'Purpose path',
+        title: 'Purpose',
+        copy: 'Start with meaning, values, and the bigger direction behind the next move.',
+        search: 'purpose meaning direction values',
+        keywords: ['purpose', 'meaning', 'values', 'mission', 'vision', 'meant for more', 'direction'],
+        steps: [
+          'Name what keeps pulling at you.',
+          'Pick one value that matters now.',
+          'Open Purpose and turn that into a direction.',
+        ],
+      },
+      {
+        id: 'community',
+        room: 'community',
+        href: 'cell/index.html',
+        cta: 'Open Cell',
+        label: 'People path',
+        title: 'Cell',
+        copy: 'Use a small support cell when the next step needs people around it.',
+        search: 'community support cell people',
+        keywords: ['friend', 'family', 'community', 'support', 'group', 'people', 'accountability'],
+        steps: [
+          'Name who should be around this.',
+          'Pick one check-in or support rhythm.',
+          'Open Cell to organize the people side.',
+        ],
+      },
+      {
+        id: 'learning',
+        room: 'learning',
+        href: 'education-suite/',
+        cta: 'Open Learning',
+        label: 'Learning path',
+        title: 'Education Suite',
+        copy: 'Use a learning lane when the block is skill, practice, or understanding.',
+        search: 'learn education skill',
+        keywords: ['learn', 'study', 'practice', 'skill', 'teach', 'school', 'course'],
+        steps: [
+          'Name the skill you need.',
+          'Choose one tiny lesson or practice.',
+          'Open Learning and keep it small.',
+        ],
+      },
+      {
+        id: 'play',
+        room: 'play',
+        href: 'games.html',
+        cta: 'Open Games',
+        label: 'Play path',
+        title: 'Games',
+        copy: 'Use play when you need motion, reset, or a quick energy shift.',
+        search: 'games play jetpack stellar',
+        keywords: ['game', 'games', 'play', 'bored', 'fun', 'reset', 'energy'],
+        steps: [
+          'Pick a quick game or motion room.',
+          'Play for a short reset.',
+          'Come back and choose one next move.',
+        ],
+      },
+      {
+        id: 'life',
+        room: 'life',
+        href: 'life/index.html',
+        cta: 'Open Daily Direction',
+        label: 'Life path',
+        title: 'Daily Direction',
+        copy: 'Start by sorting life, attention, and the one next step for today.',
+        search: 'life daily direction organize',
+        keywords: ['life', 'scattered', 'organize', 'clear', 'overwhelmed', 'stuck', 'habit', 'health', 'next step'],
+        steps: [
+          'Do a 3-minute check-in.',
+          'Name what needs attention.',
+          'Pick one small move for today.',
+        ],
+      },
+    ];
     const humanRoomTitles = {
       purpose: [
         'Purpose',
@@ -1843,10 +2040,10 @@
       roomReveal.hidden = false;
     };
     const setViewMode = (nextMode, nextRoom = '') => {
-      const mode = nextMode === 'workshop' ? 'workshop' : 'human-os';
+      const mode = ['workshop', 'guide'].includes(nextMode) ? nextMode : 'human-os';
       document.body.dataset.viewMode = mode;
       document.body.dataset.activeRoom = mode === 'human-os' ? nextRoom : '';
-      if (mode === 'human-os' && activeAppLane !== 'all') {
+      if (mode !== 'workshop' && activeAppLane !== 'all') {
         setActiveAppLane('all');
       }
       viewModeButtons.forEach((button) => {
@@ -1856,6 +2053,87 @@
       });
       syncRoomReveal();
       updateAppFilter(searchInput?.value ?? '');
+    };
+
+    let lastGuideRoute = portalGuideRoutes.find((route) => route.id === 'life') || portalGuideRoutes[0];
+
+    const scoreGuideRoute = (route, query) =>
+      route.keywords.reduce((score, keyword) => {
+        if (!query.includes(keyword)) return score;
+        return score + Math.max(1, keyword.split(/\s+/).length);
+      }, 0);
+
+    const chooseGuideRoute = (value = '') => {
+      const query = value.trim().toLowerCase();
+      if (!query) {
+        return lastGuideRoute;
+      }
+
+      let bestRoute = portalGuideRoutes.find((route) => route.id === 'life') || portalGuideRoutes[0];
+      let bestScore = 0;
+
+      portalGuideRoutes.forEach((route) => {
+        const score = scoreGuideRoute(route, query);
+        if (score > bestScore) {
+          bestRoute = route;
+          bestScore = score;
+        }
+      });
+
+      return bestRoute;
+    };
+
+    const renderGuideRoute = (route) => {
+      if (!route || !guideResult) return;
+
+      lastGuideRoute = route;
+      if (guideLabel) guideLabel.textContent = route.label;
+      if (guideTitle) guideTitle.textContent = route.title;
+      if (guideCopy) guideCopy.textContent = route.copy;
+      if (guidePrimary) {
+        guidePrimary.href = route.href;
+        guidePrimary.textContent = route.cta;
+      }
+      if (guideSteps) {
+        guideSteps.replaceChildren();
+        route.steps.forEach((step) => {
+          const item = document.createElement('li');
+          item.textContent = step;
+          guideSteps.appendChild(item);
+        });
+      }
+      guideResult.hidden = false;
+    };
+
+    const submitGuidePrompt = (value = '') => {
+      const prompt = value.trim();
+      const route = chooseGuideRoute(prompt);
+      renderGuideRoute(route);
+      guideResult?.scrollIntoView({
+        behavior: prefersReducedMotionQuery?.matches ? 'auto' : 'smooth',
+        block: 'nearest',
+      });
+    };
+
+    const showGuideMatches = () => {
+      if (!lastGuideRoute) return;
+
+      if (lastGuideRoute.room) {
+        if (searchInput) {
+          searchInput.value = '';
+        }
+        setViewMode('human-os', lastGuideRoute.room);
+      } else {
+        setViewMode('workshop');
+        if (searchInput) {
+          searchInput.value = lastGuideRoute.search || '';
+        }
+        updateAppFilter(searchInput?.value ?? '');
+      }
+
+      window.requestAnimationFrame(() => {
+        scrollAppsIntoView({ alignSearch: false });
+      });
     };
 
     const updateAppFilter = (value = '') => {
@@ -2044,6 +2322,23 @@
       }
     };
 
+    guideForm?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      submitGuidePrompt(guidePrompt?.value ?? '');
+    });
+
+    guideChipButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const prompt = button.dataset.guideChip || '';
+        if (guidePrompt) {
+          guidePrompt.value = prompt;
+        }
+        submitGuidePrompt(prompt);
+      });
+    });
+
+    guideShowDock?.addEventListener('click', showGuideMatches);
+
     const getAuthModal = () => document.getElementById('auth-modal');
 
     const isAuthModalVisible = () => {
@@ -2062,7 +2357,7 @@
     const focusSearch = ({ scroll = false, alignSearch = false } = {}) => {
       if (!searchInput || isAuthModalVisible()) return;
 
-      if (getViewMode() === 'human-os' && !getActiveRoom()) {
+      if (getViewMode() === 'guide' || (getViewMode() === 'human-os' && !getActiveRoom())) {
         setViewMode('workshop');
       }
 

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -9,7 +9,18 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Find your purpose\. Organize your life\. Launch your world\./);
     assert.match(html, /What are you trying to organize today\?/);
     assert.match(html, /Human O\.S\./);
+    assert.match(html, /data-view-mode-button="guide"/);
+    assert.match(html, />Guide<\/button>/);
     assert.match(html, /Workshop/);
+    assert.match(html, /Tell the portal what you need\./);
+    assert.match(html, /data-guide-form/);
+    assert.match(html, /data-guide-prompt/);
+    assert.match(html, /data-guide-chip="I feel scattered and need to organize my life\."/);
+    assert.match(html, /data-guide-result hidden/);
+    assert.match(html, /data-guide-show-dock/);
+    assert.match(html, /const portalGuideRoutes =/);
+    assert.match(html, /const chooseGuideRoute =/);
+    assert.match(html, /const showGuideMatches =/);
     assert.match(html, /Nine doors into the portal/);
     assert.match(html, /🧭 My Purpose/);
     assert.match(html, /🌱 My Life/);
@@ -83,6 +94,7 @@ describe('portal customer journey pages', () => {
     assert.match(html, /A 72-hour paid setup that turns a yes into intake, checklist, and first-week follow-up\./);
     assert.match(html, /ideas\/client-onboarding-sprint\.html/);
     assert.match(html, /data-active-room=""/);
+    assert.match(html, /data-view-mode-button="guide"/);
     assert.match(html, /data-view-mode-button="workshop"/);
     assert.doesNotMatch(html, /Suggested launcher lanes/);
     assert.doesNotMatch(html, /Run the business workspace/);
@@ -104,6 +116,10 @@ describe('portal customer journey pages', () => {
     assert.match(globalCss, /text-size-adjust:\s*100%/);
     assert.match(css, /@media \(max-width: 380px\)/);
     assert.match(css, /\.hero-actions \.cta\s*\{/);
+    assert.match(css, /body\[data-view-mode="guide"\] \.app-hub/);
+    assert.match(css, /\.portal-guide\s*\{/);
+    assert.match(css, /\.portal-guide__chips/);
+    assert.match(css, /\.portal-guide__actions/);
     assert.match(css, /@media \(min-width: 721px\) \{[\s\S]*?\.hero-actions \{[\s\S]*?grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(9rem,\s*1fr\)\);[\s\S]*?\.hero-actions \.cta \{[\s\S]*?padding:\s*0\.58rem 1rem;/);
     assert.match(css, /font-size:\s*clamp\(2rem,\s*8\.8vw,\s*2\.35rem\)/);
     assert.doesNotMatch(css, /botanical-border/);


### PR DESCRIPTION
## What changed

- Added a third portal view switch: `Guide` alongside Human O.S. and Workshop.
- Added a one-prompt Guide mode that recommends where to go next based on the user’s sentence.
- Added starter chips for Life, Idea, Money, and Build.
- Added local routing for life, money, work, build, ideas, purpose, community, learning, and play paths.
- Added guided result output with a primary destination and a `Show matching apps` action.
- Kept Workshop as the default view.
- Hid lower dashboard/info sections in Guide mode so the screen stays focused.

## Why

The portal direction is moving toward one prompt that takes the user where they need to go and guides them, instead of making them browse a large app dock first.

## Validation

- `node --test tests/customer-journey-pages.test.js tests/homepage-search-ux.test.js tests/forge.test.js`
- `git diff --check`
- Mobile WebKit at 390px: Guide prompt and result had `scrollWidth === clientWidth`, no overflowing elements, and the Life prompt routed to Daily Direction.
- Browser flow: `Show matching apps` switched to Human O.S. Life room and showed matching Life apps.
