### PR TITLE
[codex] Add AI-backed portal guide

### DIFF
--- a/api/openai-site.js
+++ b/api/openai-site.js
@@ -1,4 +1,5 @@
 import { createForgeHandler } from '../src/forge/api.js';
+import { createGuideHandler } from '../src/guide/api.js';
 
 export const DEFAULT_MODEL = 'gpt-4.1-mini';
 export const SUPPORTED_SITE_MODELS = Object.freeze([
@@ -459,10 +460,15 @@ export function createSiteGeneratorHandler(options = {}) {
 export function createOpenAiSiteRouter(options = {}) {
   const siteHandler = createSiteGeneratorHandler(options);
   const forgeHandler = createForgeHandler(options.forge || options);
+  const guideHandler = createGuideHandler(options.guide || options);
 
   return async function handler(req, res) {
     if (req?.body?.forge === true || req?.query?.provider === 'forge') {
       return forgeHandler(req, res);
+    }
+
+    if (req?.body?.guide === true || req?.query?.provider === 'guide') {
+      return guideHandler(req, res);
     }
 
     return siteHandler(req, res);

--- a/index-style.css
+++ b/index-style.css
@@ -918,6 +918,20 @@ body[data-view-mode="human-os"]:not([data-active-room=""]) .human-os-map {
   outline: none;
 }
 
+.portal-guide__chips button:disabled,
+.portal-guide__form .cta:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.portal-guide__status {
+  min-height: 1.25rem;
+  margin: -0.15rem 0 0;
+  color: rgba(148, 163, 184, 0.9);
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
 .portal-guide__steps {
   display: grid;
   gap: 0.55rem;

--- a/index.html
+++ b/index.html
@@ -319,7 +319,8 @@
               <button type="button" data-guide-chip="I need money, work, or a better follow-up system.">Money</button>
               <button type="button" data-guide-chip="I want to build a page, app, or project.">Build</button>
             </div>
-            <button class="cta primary" type="submit">Guide me</button>
+            <button class="cta primary" type="submit" data-guide-submit>Guide me</button>
+            <p class="portal-guide__status" data-guide-status aria-live="polite"></p>
           </form>
         </div>
 
@@ -1605,7 +1606,10 @@
     const guideCopy = document.querySelector('[data-guide-copy]');
     const guideSteps = document.querySelector('[data-guide-steps]');
     const guidePrimary = document.querySelector('[data-guide-primary]');
+    const guideSubmit = document.querySelector('[data-guide-submit]');
+    const guideStatus = document.querySelector('[data-guide-status]');
     const guideShowDock = document.querySelector('[data-guide-show-dock]');
+    const GUIDE_API_TIMEOUT_MS = 14000;
     let activeAppLane = 'all';
     const roomMeta = {
       purpose: {
@@ -2056,6 +2060,7 @@
     };
 
     let lastGuideRoute = portalGuideRoutes.find((route) => route.id === 'life') || portalGuideRoutes[0];
+    let isGuideBusy = false;
 
     const scoreGuideRoute = (route, query) =>
       route.keywords.reduce((score, keyword) => {
@@ -2083,6 +2088,102 @@
       return bestRoute;
     };
 
+    const getGuideRouteSummaries = () =>
+      portalGuideRoutes.map((route) => ({
+        id: route.id,
+        room: route.room,
+        title: route.title,
+        label: route.label,
+        copy: route.copy,
+        search: route.search,
+        keywords: route.keywords,
+      }));
+
+    const normalizeGuideSteps = (steps, fallbackSteps) => {
+      const normalized = Array.isArray(steps)
+        ? steps.map((step) => String(step || '').trim()).filter(Boolean).slice(0, 3)
+        : [];
+
+      fallbackSteps.forEach((step) => {
+        if (normalized.length < 3) {
+          normalized.push(step);
+        }
+      });
+
+      return normalized.slice(0, 3);
+    };
+
+    const parseGuideApiError = async (response) => {
+      const errorText = await response.text();
+      if (!errorText) {
+        return 'The AI guide is not available.';
+      }
+
+      try {
+        const parsed = JSON.parse(errorText);
+        return parsed?.error || parsed?.message || errorText;
+      } catch {
+        return errorText;
+      }
+    };
+
+    const setGuideBusy = (isBusy) => {
+      isGuideBusy = isBusy;
+      if (guideSubmit) {
+        guideSubmit.disabled = isBusy;
+        guideSubmit.textContent = isBusy ? 'Thinking...' : 'Guide me';
+      }
+      guideChipButtons.forEach((button) => {
+        button.disabled = isBusy;
+      });
+    };
+
+    const mergeGuideResult = (guide = {}, fallbackRoute) => {
+      const route = portalGuideRoutes.find((item) => item.id === guide.routeId) || fallbackRoute;
+
+      return {
+        ...route,
+        label: String(guide.label || route.label || '').trim() || route.label,
+        title: String(guide.title || route.title || '').trim() || route.title,
+        copy: String(guide.copy || route.copy || '').trim() || route.copy,
+        steps: normalizeGuideSteps(guide.steps, route.steps),
+        source: 'ai',
+      };
+    };
+
+    const requestGuideRoute = async (prompt, fallbackRoute) => {
+      const controller = new AbortController();
+      const timeout = window.setTimeout(() => controller.abort(), GUIDE_API_TIMEOUT_MS);
+
+      try {
+        const response = await fetch('/api/openai-site', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          signal: controller.signal,
+          body: JSON.stringify({
+            guide: true,
+            prompt,
+            routes: getGuideRouteSummaries(),
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(await parseGuideApiError(response));
+        }
+
+        const result = await response.json();
+        return mergeGuideResult(result?.guide, fallbackRoute);
+      } catch (error) {
+        if (error?.name === 'AbortError') {
+          throw new Error('The AI guide timed out.');
+        }
+
+        throw error;
+      } finally {
+        window.clearTimeout(timeout);
+      }
+    };
+
     const renderGuideRoute = (route) => {
       if (!route || !guideResult) return;
 
@@ -2105,14 +2206,33 @@
       guideResult.hidden = false;
     };
 
-    const submitGuidePrompt = (value = '') => {
+    const submitGuidePrompt = async (value = '') => {
+      if (isGuideBusy) return;
       const prompt = value.trim();
-      const route = chooseGuideRoute(prompt);
-      renderGuideRoute(route);
-      guideResult?.scrollIntoView({
-        behavior: prefersReducedMotionQuery?.matches ? 'auto' : 'smooth',
-        block: 'nearest',
-      });
+      if (!prompt) {
+        if (guideStatus) guideStatus.textContent = 'Type one sentence first.';
+        guidePrompt?.focus();
+        return;
+      }
+
+      const fallbackRoute = chooseGuideRoute(prompt);
+      setGuideBusy(true);
+      if (guideStatus) guideStatus.textContent = 'AI guide is thinking...';
+
+      try {
+        const route = await requestGuideRoute(prompt, fallbackRoute);
+        renderGuideRoute(route);
+        if (guideStatus) guideStatus.textContent = 'AI guide ready.';
+      } catch (error) {
+        renderGuideRoute({ ...fallbackRoute, source: 'local-fallback' });
+        if (guideStatus) guideStatus.textContent = 'Local guide ready. AI is unavailable.';
+      } finally {
+        setGuideBusy(false);
+        guideResult?.scrollIntoView({
+          behavior: prefersReducedMotionQuery?.matches ? 'auto' : 'smooth',
+          block: 'nearest',
+        });
+      }
     };
 
     const showGuideMatches = () => {

--- a/src/guide/api.js
+++ b/src/guide/api.js
@@ -1,0 +1,300 @@
+export const DEFAULT_GUIDE_MODEL = 'gpt-4.1-mini';
+export const SUPPORTED_GUIDE_MODELS = Object.freeze([
+  'gpt-4o-mini',
+  'gpt-4.1-mini',
+  'gpt-5.4-mini',
+  'gpt-5.4'
+]);
+
+const GUIDE_SCHEMA = {
+  name: 'portal_guide_response',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['routeId', 'label', 'title', 'copy', 'steps'],
+    properties: {
+      routeId: { type: 'string' },
+      label: { type: 'string' },
+      title: { type: 'string' },
+      copy: { type: 'string' },
+      steps: {
+        type: 'array',
+        items: { type: 'string' }
+      }
+    }
+  }
+};
+
+const FALLBACK_ROUTE = Object.freeze({
+  id: 'life',
+  label: 'Life path',
+  title: 'Daily Direction',
+  copy: 'Start by sorting life, attention, and the one next step for today.',
+  steps: [
+    'Do a 3-minute check-in.',
+    'Name what needs attention.',
+    'Pick one small move for today.'
+  ]
+});
+
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function resolveDate(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+function formatIsoDate(value) {
+  return resolveDate(value).toISOString().slice(0, 10);
+}
+
+function isGpt5FamilyModel(model) {
+  return /^gpt-5([.-]|$)/.test(String(model || '').trim());
+}
+
+function normalizeRequestedModel(value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    return DEFAULT_GUIDE_MODEL;
+  }
+
+  return SUPPORTED_GUIDE_MODELS.includes(normalized) ? normalized : '';
+}
+
+function clean(value, maxLength = 2000) {
+  return String(value || '').trim().replace(/\s+/g, ' ').slice(0, maxLength);
+}
+
+function normalizeRoutes(value) {
+  const source = Array.isArray(value) ? value : [];
+  const routes = source
+    .map(route => ({
+      id: clean(route?.id, 40),
+      room: clean(route?.room, 40),
+      title: clean(route?.title, 120),
+      label: clean(route?.label, 80),
+      copy: clean(route?.copy, 220),
+      search: clean(route?.search, 160),
+      keywords: Array.isArray(route?.keywords)
+        ? route.keywords.map(keyword => clean(keyword, 80)).filter(Boolean).slice(0, 12)
+        : []
+    }))
+    .filter(route => route.id && route.title)
+    .slice(0, 12);
+
+  return routes.length ? routes : [FALLBACK_ROUTE];
+}
+
+function findRouteById(routes, routeId) {
+  const normalized = clean(routeId, 40).toLowerCase();
+  return routes.find(route => route.id.toLowerCase() === normalized)
+    || routes.find(route => route.id === FALLBACK_ROUTE.id)
+    || routes[0]
+    || FALLBACK_ROUTE;
+}
+
+function normalizeStringList(value, fallback, { min = 3, max = 3 } = {}) {
+  const source = Array.isArray(value) ? value : [];
+  const normalized = source
+    .map(item => clean(item, 120))
+    .filter(Boolean)
+    .slice(0, max);
+
+  fallback.forEach((item) => {
+    if (normalized.length < min) {
+      normalized.push(item);
+    }
+  });
+
+  return normalized.slice(0, max);
+}
+
+function extractResponseText(responseData) {
+  const outputItems = Array.isArray(responseData?.output) ? responseData.output : [];
+
+  for (const item of outputItems) {
+    if (item?.type !== 'message') continue;
+    const contentItems = Array.isArray(item.content) ? item.content : [];
+    for (const content of contentItems) {
+      if (content?.type !== 'output_text') continue;
+      const text = typeof content.text === 'string' ? content.text.trim() : '';
+      if (text) {
+        return text;
+      }
+    }
+  }
+
+  return '';
+}
+
+function parseJsonResponse(responseData) {
+  const raw = extractResponseText(responseData);
+  if (!raw) {
+    throw new Error('No content returned from OpenAI.');
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse OpenAI response: ${error.message}`);
+  }
+}
+
+export function buildGuideInstructions(now = new Date()) {
+  const currentDate = resolveDate(now);
+
+  return [
+    'You are the 3DVR Portal guide.',
+    `Today is ${formatIsoDate(currentDate)}.`,
+    'Your job is to read one messy user prompt and choose the best existing portal destination.',
+    'Choose only one routeId from the provided routes. Never invent a route.',
+    'Give direct, practical guidance. No hype, no sales copy, no long explanation.',
+    'Write at about a third-grade reading level. Short words. Short sentences.',
+    'The user may feel overwhelmed. Make the next step feel easy.',
+    'If the user asks for money, income, clients, sales, bills, or work, usually choose money or work.',
+    'If the user asks for purpose, meaning, life direction, or being meant for more, usually choose purpose or life.',
+    'If the user has a messy idea or frustration, usually choose idea.',
+    'If the user wants to build a page, app, or project, usually choose build.',
+    'The copy field must be one short sentence. Each step must be one short action.',
+    'Return only the JSON object requested by the schema.'
+  ].join(' ');
+}
+
+function buildGuideInput({ prompt, routes }) {
+  return JSON.stringify({
+    prompt: clean(prompt, 800),
+    routes: normalizeRoutes(routes)
+  }, null, 2);
+}
+
+export function buildGuideOpenAiRequest({
+  prompt,
+  routes,
+  model = DEFAULT_GUIDE_MODEL,
+  now = new Date()
+}) {
+  const requestBody = {
+    model,
+    instructions: buildGuideInstructions(now),
+    input: buildGuideInput({ prompt, routes }),
+    store: false,
+    text: {
+      format: {
+        type: 'json_schema',
+        ...GUIDE_SCHEMA
+      }
+    }
+  };
+
+  if (!isGpt5FamilyModel(model)) {
+    requestBody.temperature = 0.25;
+  }
+
+  return requestBody;
+}
+
+export function normalizeGuideResult(value = {}, routes = []) {
+  const normalizedRoutes = normalizeRoutes(routes);
+  const route = findRouteById(normalizedRoutes, value?.routeId);
+
+  return {
+    routeId: route.id,
+    label: clean(value?.label, 80) || route.label || FALLBACK_ROUTE.label,
+    title: clean(value?.title, 120) || route.title || FALLBACK_ROUTE.title,
+    copy: clean(value?.copy, 220) || route.copy || FALLBACK_ROUTE.copy,
+    steps: normalizeStringList(value?.steps, route.steps || FALLBACK_ROUTE.steps, { min: 3, max: 3 })
+  };
+}
+
+export function createGuideHandler(options = {}) {
+  const {
+    apiKey = process.env.OPENAI_API_KEY,
+    model = normalizeRequestedModel(options.model || process.env.OPENAI_GUIDE_MODEL || DEFAULT_GUIDE_MODEL) || DEFAULT_GUIDE_MODEL,
+    fetchImpl = globalThis.fetch,
+    now = () => new Date()
+  } = options;
+
+  return async function handler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method !== 'POST') {
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    const {
+      prompt,
+      routes,
+      apiKey: requestApiKey,
+      model: requestedModel
+    } = req.body || {};
+    const effectiveApiKey = typeof requestApiKey === 'string' && requestApiKey.trim()
+      ? requestApiKey.trim()
+      : apiKey;
+    const effectiveModel = requestedModel === undefined
+      ? model
+      : normalizeRequestedModel(requestedModel);
+
+    if (!effectiveApiKey) {
+      return res.status(500).json({ error: 'OpenAI API key is not configured.' });
+    }
+
+    if (!effectiveModel) {
+      return res.status(400).json({
+        error: `Unsupported model. Choose one of: ${SUPPORTED_GUIDE_MODELS.join(', ')}.`
+      });
+    }
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      return res.status(400).json({ error: 'A guide prompt is required.' });
+    }
+
+    try {
+      const currentDate = resolveDate(now());
+      const routeList = normalizeRoutes(routes);
+      const requestBody = buildGuideOpenAiRequest({
+        prompt,
+        routes: routeList,
+        model: effectiveModel,
+        now: currentDate
+      });
+
+      const response = await fetchImpl('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${effectiveApiKey}`
+        },
+        body: JSON.stringify(requestBody)
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return res.status(response.status).json({ error: errorText || 'OpenAI error' });
+      }
+
+      const data = await response.json();
+      const parsed = parseJsonResponse(data);
+
+      return res.status(200).json({
+        mode: 'guide',
+        guide: normalizeGuideResult(parsed, routeList),
+        model: effectiveModel,
+        createdAt: currentDate.getTime()
+      });
+    } catch (error) {
+      return res.status(500).json({ error: error.message || 'Unexpected error during Guide routing.' });
+    }
+  };
+}
+
+const handler = createGuideHandler();
+export default handler;

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -15,11 +15,18 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Tell the portal what you need\./);
     assert.match(html, /data-guide-form/);
     assert.match(html, /data-guide-prompt/);
+    assert.match(html, /data-guide-submit/);
+    assert.match(html, /data-guide-status/);
     assert.match(html, /data-guide-chip="I feel scattered and need to organize my life\."/);
     assert.match(html, /data-guide-result hidden/);
     assert.match(html, /data-guide-show-dock/);
     assert.match(html, /const portalGuideRoutes =/);
     assert.match(html, /const chooseGuideRoute =/);
+    assert.match(html, /const requestGuideRoute =/);
+    assert.match(html, /fetch\('\/api\/openai-site'/);
+    assert.match(html, /guide:\s*true/);
+    assert.match(html, /AI guide is thinking/);
+    assert.match(html, /Local guide ready\. AI is unavailable\./);
     assert.match(html, /const showGuideMatches =/);
     assert.match(html, /Nine doors into the portal/);
     assert.match(html, /🧭 My Purpose/);
@@ -120,6 +127,7 @@ describe('portal customer journey pages', () => {
     assert.match(css, /\.portal-guide\s*\{/);
     assert.match(css, /\.portal-guide__chips/);
     assert.match(css, /\.portal-guide__actions/);
+    assert.match(css, /\.portal-guide__status/);
     assert.match(css, /@media \(min-width: 721px\) \{[\s\S]*?\.hero-actions \{[\s\S]*?grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(9rem,\s*1fr\)\);[\s\S]*?\.hero-actions \.cta \{[\s\S]*?padding:\s*0\.58rem 1rem;/);
     assert.match(css, /font-size:\s*clamp\(2rem,\s*8\.8vw,\s*2\.35rem\)/);
     assert.doesNotMatch(css, /botanical-border/);

--- a/tests/guide-api.test.js
+++ b/tests/guide-api.test.js
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildGuideInstructions,
+  buildGuideOpenAiRequest,
+  createGuideHandler,
+  DEFAULT_GUIDE_MODEL,
+  normalizeGuideResult,
+  SUPPORTED_GUIDE_MODELS
+} from '../src/guide/api.js';
+import { createOpenAiSiteRouter } from '../api/openai-site.js';
+
+const guideRoutes = [
+  {
+    id: 'life',
+    room: 'life',
+    title: 'Daily Direction',
+    label: 'Life path',
+    copy: 'Start by sorting life, attention, and the one next step for today.',
+    search: 'life daily direction organize',
+    keywords: ['life', 'scattered', 'organize'],
+    steps: ['Check in.', 'Name the stuck point.', 'Pick one move.']
+  },
+  {
+    id: 'money',
+    room: 'money',
+    title: 'Revenue Desk',
+    label: 'Money path',
+    copy: 'Start with one money move, one follow-up, and one clear next action.',
+    search: 'revenue money follow up',
+    keywords: ['money', 'income', 'clients'],
+    steps: ['Name the pressure.', 'Pick one lead.', 'Choose one money move.']
+  }
+];
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    ended: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end(payload) {
+      this.ended = true;
+      this.body = payload ?? this.body;
+      return this;
+    },
+    setHeader(key, value) {
+      this.headers[key] = value;
+    }
+  };
+}
+
+function createOpenAiResponse(payload, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return payload;
+    },
+    async text() {
+      return JSON.stringify(payload);
+    }
+  };
+}
+
+function createOutputText(payload) {
+  return {
+    output: [
+      {
+        type: 'message',
+        content: [
+          {
+            type: 'output_text',
+            text: JSON.stringify(payload)
+          }
+        ]
+      }
+    ]
+  };
+}
+
+test('buildGuideInstructions keeps the guide short and route-bound', () => {
+  const instructions = buildGuideInstructions(new Date('2026-06-30T12:00:00.000Z'));
+
+  assert.match(instructions, /Today is 2026-06-30\./);
+  assert.match(instructions, /choose the best existing portal destination/i);
+  assert.match(instructions, /Never invent a route/i);
+  assert.match(instructions, /third-grade reading level/i);
+  assert.match(instructions, /one short sentence/i);
+});
+
+test('buildGuideOpenAiRequest creates a structured guide route request', () => {
+  const request = buildGuideOpenAiRequest({
+    prompt: 'I need money and do not know what to do first.',
+    routes: guideRoutes,
+    model: DEFAULT_GUIDE_MODEL,
+    now: new Date('2026-06-30T12:00:00.000Z')
+  });
+
+  assert.equal(request.model, DEFAULT_GUIDE_MODEL);
+  assert.equal(request.store, false);
+  assert.equal(request.temperature, 0.25);
+  assert.equal(request.text.format.type, 'json_schema');
+  assert.equal(request.text.format.name, 'portal_guide_response');
+  assert.match(request.input, /Revenue Desk/);
+  assert.match(request.input, /I need money/);
+});
+
+test('buildGuideOpenAiRequest omits temperature for gpt-5 family models', () => {
+  const request = buildGuideOpenAiRequest({
+    prompt: 'I want to organize my life.',
+    routes: guideRoutes,
+    model: 'gpt-5.4',
+    now: new Date('2026-06-30T12:00:00.000Z')
+  });
+
+  assert.equal('temperature' in request, false);
+});
+
+test('supported guide models mirror the portal model options', () => {
+  assert.equal(DEFAULT_GUIDE_MODEL, 'gpt-4.1-mini');
+  assert.deepEqual(SUPPORTED_GUIDE_MODELS, [
+    'gpt-4o-mini',
+    'gpt-4.1-mini',
+    'gpt-5.4-mini',
+    'gpt-5.4'
+  ]);
+});
+
+test('normalizeGuideResult keeps model output attached to a real route', () => {
+  const result = normalizeGuideResult({
+    routeId: 'money',
+    label: 'Money first',
+    title: 'Start with cash',
+    copy: 'Pick one way to get a reply today.',
+    steps: ['Name the offer.', 'Text one person.', 'Track the reply.']
+  }, guideRoutes);
+
+  assert.equal(result.routeId, 'money');
+  assert.equal(result.label, 'Money first');
+  assert.equal(result.steps.length, 3);
+
+  const fallback = normalizeGuideResult({
+    routeId: 'made-up-room',
+    steps: ['Too short.']
+  }, guideRoutes);
+
+  assert.equal(fallback.routeId, 'life');
+  assert.equal(fallback.title, 'Daily Direction');
+  assert.equal(fallback.steps.length, 3);
+});
+
+test('Guide handler returns normalized AI-backed portal direction', async () => {
+  let requestUrl = '';
+  let requestBody = null;
+  const handler = createGuideHandler({
+    apiKey: 'sk-test',
+    now: () => new Date('2026-06-30T12:00:00.000Z'),
+    fetchImpl: async (url, options = {}) => {
+      requestUrl = String(url);
+      requestBody = JSON.parse(options.body || '{}');
+      return createOpenAiResponse(createOutputText({
+        routeId: 'money',
+        label: 'Money first',
+        title: 'Revenue Desk',
+        copy: 'Start with one person and one offer.',
+        steps: [
+          'Name the offer.',
+          'Text one person.',
+          'Track the reply.'
+        ]
+      }));
+    }
+  });
+  const res = createMockRes();
+
+  await handler({
+    method: 'POST',
+    headers: {},
+    body: {
+      prompt: 'I need money this week.',
+      routes: guideRoutes
+    }
+  }, res);
+
+  assert.equal(requestUrl, 'https://api.openai.com/v1/responses');
+  assert.equal(requestBody.text.format.name, 'portal_guide_response');
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.mode, 'guide');
+  assert.equal(res.body.model, DEFAULT_GUIDE_MODEL);
+  assert.equal(res.body.guide.routeId, 'money');
+  assert.equal(res.body.guide.steps.length, 3);
+});
+
+test('OpenAI site route dispatches Guide requests without another API function', async () => {
+  let requestBody = null;
+  const handler = createOpenAiSiteRouter({
+    apiKey: 'sk-test',
+    now: () => new Date('2026-06-30T12:00:00.000Z'),
+    fetchImpl: async (_url, options = {}) => {
+      requestBody = JSON.parse(options.body || '{}');
+      return createOpenAiResponse(createOutputText({
+        routeId: 'life',
+        label: 'Life first',
+        title: 'Daily Direction',
+        copy: 'Start with what is right in front of you.',
+        steps: ['Check in.', 'Pick one need.', 'Do one move.']
+      }));
+    }
+  });
+  const res = createMockRes();
+
+  await handler({
+    method: 'POST',
+    headers: {},
+    query: {},
+    body: {
+      guide: true,
+      prompt: 'I feel scattered.',
+      routes: guideRoutes
+    }
+  }, res);
+
+  assert.equal(requestBody.text.format.name, 'portal_guide_response');
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.mode, 'guide');
+  assert.equal(res.body.guide.routeId, 'life');
+});
+
+test('Guide handler validates key, model, and prompt', async () => {
+  const noKey = createGuideHandler({ apiKey: '' });
+  const noKeyRes = createMockRes();
+  await noKey({ method: 'POST', headers: {}, body: { prompt: 'help', routes: guideRoutes } }, noKeyRes);
+  assert.equal(noKeyRes.statusCode, 500);
+  assert.match(noKeyRes.body.error, /OpenAI API key/);
+
+  const unsupported = createGuideHandler({ apiKey: 'sk-test' });
+  const unsupportedRes = createMockRes();
+  await unsupported({
+    method: 'POST',
+    headers: {},
+    body: {
+      prompt: 'help',
+      routes: guideRoutes,
+      model: 'gpt-5-mini'
+    }
+  }, unsupportedRes);
+  assert.equal(unsupportedRes.statusCode, 400);
+  assert.match(unsupportedRes.body.error, /Unsupported model/);
+
+  const missingPrompt = createGuideHandler({ apiKey: 'sk-test' });
+  const missingPromptRes = createMockRes();
+  await missingPrompt({ method: 'POST', headers: {}, body: { routes: guideRoutes } }, missingPromptRes);
+  assert.equal(missingPromptRes.statusCode, 400);
+  assert.match(missingPromptRes.body.error, /guide prompt/i);
+});


### PR DESCRIPTION
## Summary
- Add a structured AI-backed Guide mode handler behind the existing `/api/openai-site` router.
- Send the portal's known guide routes to the model and normalize the response back to real route IDs.
- Update the Guide UI to call the backend, show a small thinking/status state, and fall back to local keyword routing when AI is unavailable.

## Validation
- `node --test tests/guide-api.test.js tests/customer-journey-pages.test.js tests/openai-site.test.js tests/forge-api.test.js`
- `git diff --check`
- Mobile Chromium browser pass at 390px with mocked `/api/openai-site` Guide response: request included `guide: true`, rendered AI guidance, linked to `revenue-desk/`, and reported `scrollWidth === clientWidth`.
