### PR TITLE
[codex] Add homepage owned app studio

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -949,6 +949,119 @@ body[data-view-mode="human-os"]:not([data-active-room=""]) .human-os-map {
   display: none;
 }
 
+.portal-app-studio {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  padding: 1.1rem;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  border-radius: 1.1rem;
+  background: rgba(3, 7, 18, 0.52);
+}
+
+.portal-app-studio[hidden] {
+  display: none;
+}
+
+.portal-app-studio__header {
+  display: grid;
+  gap: 0.85rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.portal-app-studio__header h3,
+.portal-app-studio__header p {
+  margin: 0;
+}
+
+.portal-app-studio__header h3 {
+  font-size: clamp(1.25rem, 1.2vw + 1rem, 1.8rem);
+}
+
+.portal-app-studio__header p {
+  color: var(--color-text-muted);
+}
+
+.portal-app-studio__grid {
+  display: grid;
+  gap: 0.8rem;
+  min-width: 0;
+}
+
+.portal-app-studio label {
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.portal-app-studio input,
+.portal-app-studio textarea {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 0.85rem;
+  background: rgba(3, 7, 18, 0.62);
+  color: var(--color-text);
+  font: inherit;
+  font-weight: 500;
+}
+
+.portal-app-studio input {
+  min-height: 2.75rem;
+  padding: 0.7rem 0.85rem;
+}
+
+.portal-app-studio textarea {
+  padding: 0.85rem;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.portal-app-studio__actions,
+.portal-app-studio__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.portal-app-studio__owned {
+  display: grid;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.portal-app-studio__list button {
+  min-width: 0;
+  min-height: 2.2rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.08);
+  color: rgba(226, 232, 240, 0.86);
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.portal-app-studio__list button[data-active="true"] {
+  border-color: rgba(34, 211, 238, 0.58);
+  background: rgba(34, 211, 238, 0.16);
+  color: var(--color-text);
+}
+
+@media (min-width: 721px) {
+  .portal-app-studio__header {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+}
+
 
 @keyframes breath {
   0%,

--- a/index.html
+++ b/index.html
@@ -337,6 +337,35 @@
             <button class="cta ghost" type="button" data-guide-show-dock>Show matching apps</button>
           </div>
         </article>
+
+        <section class="portal-app-studio" data-owned-app-studio hidden aria-labelledby="owned-app-title">
+          <div class="portal-app-studio__header">
+            <div>
+              <span class="eyebrow">Your app</span>
+              <h3 id="owned-app-title" data-owned-app-title>New app draft</h3>
+              <p data-owned-app-status>Only you can edit this draft.</p>
+            </div>
+            <a class="cta primary" href="web-builder-app/index.html" data-owned-app-builder>Open Builder</a>
+          </div>
+          <div class="portal-app-studio__grid">
+            <label>
+              App name
+              <input type="text" data-owned-app-name maxlength="80" autocomplete="off">
+            </label>
+            <label>
+              What should it do?
+              <textarea rows="4" data-owned-app-prompt maxlength="1200"></textarea>
+            </label>
+          </div>
+          <div class="portal-app-studio__actions">
+            <button class="cta primary" type="button" data-owned-app-save>Save draft</button>
+            <button class="cta ghost" type="button" data-owned-app-copy>Copy build prompt</button>
+          </div>
+          <div class="portal-app-studio__owned">
+            <strong>Your drafts</strong>
+            <div class="portal-app-studio__list" data-owned-app-list></div>
+          </div>
+        </section>
       </section>
 
       <section class="human-os-container" aria-labelledby="human-os-title">
@@ -1779,6 +1808,15 @@
     const guideStatus = document.querySelector('[data-guide-status]');
     const guideShowDock = document.querySelector('[data-guide-show-dock]');
     const autoIdentityStatus = document.querySelector('[data-auto-identity-status]');
+    const ownedAppStudio = document.querySelector('[data-owned-app-studio]');
+    const ownedAppTitle = document.querySelector('[data-owned-app-title]');
+    const ownedAppStatus = document.querySelector('[data-owned-app-status]');
+    const ownedAppBuilder = document.querySelector('[data-owned-app-builder]');
+    const ownedAppName = document.querySelector('[data-owned-app-name]');
+    const ownedAppPrompt = document.querySelector('[data-owned-app-prompt]');
+    const ownedAppSave = document.querySelector('[data-owned-app-save]');
+    const ownedAppCopy = document.querySelector('[data-owned-app-copy]');
+    const ownedAppList = document.querySelector('[data-owned-app-list]');
     const GUIDE_API_TIMEOUT_MS = 14000;
     let activeAppLane = 'all';
     const roomMeta = {
@@ -1861,6 +1899,22 @@
           'Name the kind of work you want next.',
           'List one person, place, or role to contact.',
           'Use the tracker to keep the next step visible.',
+        ],
+      },
+      {
+        id: 'app-admin',
+        room: 'projects',
+        href: 'web-builder-app/index.html',
+        cta: 'Open Builder',
+        label: 'App admin',
+        title: 'My App Studio',
+        copy: 'Make or edit an app draft that belongs to you.',
+        search: 'create edit app builder admin portal',
+        keywords: ['create app', 'make app', 'new app', 'edit app', 'my app', 'admin app', 'portal edit', 'own app', 'app builder'],
+        steps: [
+          'Say what the app should do.',
+          'Save the draft under your identity.',
+          'Open Builder when you are ready.',
         ],
       },
       {
@@ -2165,6 +2219,242 @@
     const trackPortalBehavior = (type, detail = {}) => {
       window.PortalAutoIdentity?.remember?.(type, detail);
     };
+    const OWNED_APPS_STORAGE_KEY = 'portal:owned-apps:v1';
+    const WEB_BUILDER_PREFILL_KEY = 'web-builder-prefill-request';
+    const APP_ADMIN_INTENT_RE = /\b(create|make|build|start|new|edit|update|change|fix|improve|admin|manage)\b[\s\S]{0,80}\b(app|tool|page|site|website|portal)\b|\b(app|tool|page|site|website|portal)\b[\s\S]{0,80}\b(create|make|build|edit|update|change|fix|improve|admin|manage)\b/i;
+    let currentOwnedAppId = '';
+
+    const parseStoredJson = (value, fallback) => {
+      if (!value) return fallback;
+      try {
+        return JSON.parse(value);
+      } catch (_error) {
+        return fallback;
+      }
+    };
+
+    const readOwnedApps = () => {
+      const stored = parseStoredJson(localStorage.getItem(OWNED_APPS_STORAGE_KEY), []);
+      return Array.isArray(stored) ? stored.filter((app) => app && typeof app === 'object') : [];
+    };
+
+    const writeOwnedApps = (apps) => {
+      localStorage.setItem(OWNED_APPS_STORAGE_KEY, JSON.stringify(apps));
+      return apps;
+    };
+
+    const getPortalOwnerId = () => {
+      const profile = window.PortalAutoIdentity?.ensure?.();
+      return String(
+        profile?.id
+        || localStorage.getItem('userPubKey')
+        || localStorage.getItem('guestId')
+        || ''
+      ).trim();
+    };
+
+    const canAdminOwnedApp = (app) => {
+      const ownerId = getPortalOwnerId();
+      return Boolean(ownerId && app?.ownerId === ownerId);
+    };
+
+    const getOwnedAppsForCurrentOwner = () => {
+      const ownerId = getPortalOwnerId();
+      return readOwnedApps()
+        .filter((app) => app.ownerId === ownerId)
+        .sort((a, b) => String(b.updatedAt || '').localeCompare(String(a.updatedAt || '')));
+    };
+
+    const makeOwnedAppId = () => {
+      if (window.crypto?.randomUUID) {
+        return `app_${window.crypto.randomUUID()}`;
+      }
+      return `app_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+    };
+
+    const toAppTitle = (value = '') => {
+      const cleaned = String(value)
+        .replace(/\b(can you|please|i want|i need|i would like|help me|for me)\b/gi, ' ')
+        .replace(/\b(create|make|build|start|new|edit|update|change|fix|improve|admin|manage)\b/gi, ' ')
+        .replace(/\b(app|tool|page|site|website|portal|that|where|with|for|about|into)\b/gi, ' ')
+        .replace(/[^a-z0-9\s-]/gi, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, 6)
+        .join(' ');
+
+      if (!cleaned) return 'New Portal App';
+      return cleaned.replace(/\b\w/g, (letter) => letter.toUpperCase());
+    };
+
+    const buildOwnedAppPrompt = (app) => [
+      `Build an owned 3DVR portal app named "${app.name}".`,
+      `Owner id: ${app.ownerId}.`,
+      `User request: ${app.prompt}`,
+      'Keep it mobile-first.',
+      'Make the first screen useful right away.',
+      'Store user data under this owner id.',
+      'Only show admin controls when the active owner id matches.',
+      'If code changes are needed in the shared portal, prepare them as a pull request.'
+    ].join('\n');
+
+    const mirrorOwnedAppToGun = (app) => {
+      try {
+        if (typeof portalRoot === 'undefined' || !portalRoot || !canAdminOwnedApp(app)) {
+          return;
+        }
+        portalRoot.get('owned-apps').get(app.ownerId).get(app.id).put({
+          id: app.id,
+          ownerId: app.ownerId,
+          name: app.name,
+          prompt: app.prompt,
+          buildPrompt: app.buildPrompt,
+          updatedAt: app.updatedAt,
+          createdAt: app.createdAt,
+          source: 'portal-home'
+        });
+      } catch (error) {
+        console.warn('Could not mirror owned app draft to Gun', error);
+      }
+    };
+
+    const saveOwnedAppDraft = (draft) => {
+      if (!canAdminOwnedApp(draft)) {
+        throw new Error('This draft belongs to another owner.');
+      }
+
+      const apps = readOwnedApps();
+      const existingIndex = apps.findIndex((app) => app.id === draft.id);
+      if (existingIndex >= 0 && apps[existingIndex].ownerId !== draft.ownerId) {
+        throw new Error('This draft belongs to another owner.');
+      }
+
+      if (existingIndex >= 0) {
+        apps[existingIndex] = draft;
+      } else {
+        apps.push(draft);
+      }
+
+      writeOwnedApps(apps);
+      mirrorOwnedAppToGun(draft);
+      return draft;
+    };
+
+    const makeOwnedAppDraft = (prompt, route) => {
+      const ownerId = getPortalOwnerId();
+      const now = new Date().toISOString();
+      const wantsEdit = /\b(edit|update|change|fix|improve|admin|manage)\b/i.test(prompt);
+      const latestOwnedDraft = getOwnedAppsForCurrentOwner()[0];
+      const existing = wantsEdit && latestOwnedDraft ? latestOwnedDraft : null;
+      const name = existing?.name || toAppTitle(prompt);
+      const draft = {
+        id: existing?.id || makeOwnedAppId(),
+        ownerId,
+        name,
+        prompt: String(prompt || '').trim(),
+        routeId: route?.id || 'app-admin',
+        status: 'draft',
+        createdAt: existing?.createdAt || now,
+        updatedAt: now,
+      };
+      draft.buildPrompt = buildOwnedAppPrompt(draft);
+      return saveOwnedAppDraft(draft);
+    };
+
+    const renderOwnedAppList = () => {
+      if (!ownedAppList) return;
+      const apps = getOwnedAppsForCurrentOwner();
+      ownedAppList.replaceChildren();
+
+      if (!apps.length) {
+        const empty = document.createElement('span');
+        empty.textContent = 'No drafts yet.';
+        ownedAppList.appendChild(empty);
+        return;
+      }
+
+      apps.forEach((app) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.dataset.ownedAppId = app.id;
+        button.dataset.active = app.id === currentOwnedAppId ? 'true' : 'false';
+        button.textContent = app.name || 'Untitled app';
+        ownedAppList.appendChild(button);
+      });
+    };
+
+    const getCurrentOwnedApp = () => {
+      const app = readOwnedApps().find((item) => item.id === currentOwnedAppId);
+      return app && canAdminOwnedApp(app) ? app : null;
+    };
+
+    const prepareBuilderHandoff = (app) => {
+      if (!canAdminOwnedApp(app)) {
+        if (ownedAppStatus) ownedAppStatus.textContent = 'This draft belongs to another owner.';
+        return false;
+      }
+
+      localStorage.setItem(WEB_BUILDER_PREFILL_KEY, JSON.stringify({
+        source: 'portal-home',
+        appId: app.id,
+        ownerId: app.ownerId,
+        request: app.buildPrompt,
+        siteTitle: app.name,
+        siteGoal: 'Create the first useful version.',
+        audience: 'The owner and the people they invite.',
+        createdAt: new Date().toISOString(),
+      }));
+      trackPortalBehavior('app', {
+        title: app.name,
+        href: 'web-builder-app/index.html',
+        room: 'projects',
+      });
+      return true;
+    };
+
+    const renderOwnedAppStudio = (app) => {
+      if (!ownedAppStudio || !app || !canAdminOwnedApp(app)) return;
+
+      currentOwnedAppId = app.id;
+      ownedAppStudio.hidden = false;
+      if (ownedAppTitle) ownedAppTitle.textContent = app.name || 'New app draft';
+      if (ownedAppName) ownedAppName.value = app.name || '';
+      if (ownedAppPrompt) ownedAppPrompt.value = app.prompt || '';
+      if (ownedAppStatus) {
+        ownedAppStatus.textContent = 'Only you can edit this draft.';
+      }
+      if (ownedAppBuilder) {
+        ownedAppBuilder.href = 'web-builder-app/index.html#builder-card';
+      }
+      renderOwnedAppList();
+    };
+
+    const hideOwnedAppStudio = () => {
+      if (ownedAppStudio) {
+        ownedAppStudio.hidden = true;
+      }
+    };
+
+    const handleOwnedAppIntent = (prompt, route) => {
+      if (!APP_ADMIN_INTENT_RE.test(prompt) && route?.id !== 'app-admin') {
+        hideOwnedAppStudio();
+        return null;
+      }
+
+      try {
+        const app = makeOwnedAppDraft(prompt, route);
+        renderOwnedAppStudio(app);
+        return app;
+      } catch (error) {
+        if (ownedAppStatus) {
+          ownedAppStatus.textContent = error?.message || 'Could not save this draft.';
+        }
+        return null;
+      }
+    };
+
     const setActiveAppLane = (lane = 'all') => {
       activeAppLane = lane || 'all';
       laneFilterButtons.forEach((button) => {
@@ -2422,10 +2712,12 @@
       const fallbackRoute = chooseGuideRoute(prompt);
       setGuideBusy(true);
       if (guideStatus) guideStatus.textContent = 'AI guide is thinking...';
+      hideOwnedAppStudio();
 
       try {
         const route = await requestGuideRoute(prompt, fallbackRoute);
         renderGuideRoute(route);
+        handleOwnedAppIntent(prompt, route);
         trackPortalBehavior('guide', {
           routeId: route.id,
           room: route.room,
@@ -2434,6 +2726,7 @@
         if (guideStatus) guideStatus.textContent = 'AI guide ready.';
       } catch (error) {
         renderGuideRoute({ ...fallbackRoute, source: 'local-fallback' });
+        handleOwnedAppIntent(prompt, fallbackRoute);
         trackPortalBehavior('guide', {
           routeId: fallbackRoute.id,
           room: fallbackRoute.room,
@@ -2662,6 +2955,63 @@
       }
     };
 
+    ownedAppSave?.addEventListener('click', () => {
+      const app = getCurrentOwnedApp();
+      if (!app) {
+        if (ownedAppStatus) ownedAppStatus.textContent = 'No app draft is selected.';
+        return;
+      }
+
+      const next = {
+        ...app,
+        name: (ownedAppName?.value || '').trim() || app.name || 'New Portal App',
+        prompt: (ownedAppPrompt?.value || '').trim() || app.prompt,
+        updatedAt: new Date().toISOString(),
+      };
+      next.buildPrompt = buildOwnedAppPrompt(next);
+
+      try {
+        saveOwnedAppDraft(next);
+        renderOwnedAppStudio(next);
+        if (ownedAppStatus) ownedAppStatus.textContent = 'Draft saved. Only you can edit it.';
+      } catch (error) {
+        if (ownedAppStatus) ownedAppStatus.textContent = error?.message || 'Could not save this draft.';
+      }
+    });
+
+    ownedAppCopy?.addEventListener('click', async () => {
+      const app = getCurrentOwnedApp();
+      if (!app) {
+        if (ownedAppStatus) ownedAppStatus.textContent = 'No app draft is selected.';
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(app.buildPrompt || buildOwnedAppPrompt(app));
+        if (ownedAppStatus) ownedAppStatus.textContent = 'Build prompt copied.';
+      } catch (_error) {
+        if (ownedAppStatus) ownedAppStatus.textContent = app.buildPrompt || buildOwnedAppPrompt(app);
+      }
+    });
+
+    ownedAppBuilder?.addEventListener('click', (event) => {
+      const app = getCurrentOwnedApp();
+      if (!app || !prepareBuilderHandoff(app)) {
+        event.preventDefault();
+      }
+    });
+
+    ownedAppList?.addEventListener('click', (event) => {
+      const button = event.target?.closest?.('[data-owned-app-id]');
+      if (!button) return;
+      const app = readOwnedApps().find((item) => item.id === button.dataset.ownedAppId);
+      if (!app || !canAdminOwnedApp(app)) {
+        if (ownedAppStatus) ownedAppStatus.textContent = 'This draft belongs to another owner.';
+        return;
+      }
+      renderOwnedAppStudio(app);
+    });
+
     guideForm?.addEventListener('submit', (event) => {
       event.preventDefault();
       submitGuidePrompt(guidePrompt?.value ?? '');
@@ -2852,6 +3202,7 @@
     setViewMode('workshop');
     setActiveAppLane('all');
     updateAppFilter(initialSearchValue);
+    renderOwnedAppList();
     applyAutoIdentityHints();
   </script>
   <script defer src="/issue-launcher.js"></script>

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -22,7 +22,13 @@ describe('portal customer journey pages', () => {
     assert.match(html, /data-guide-chip="I feel scattered and need to organize my life\."/);
     assert.match(html, /data-guide-result hidden/);
     assert.match(html, /data-guide-show-dock/);
+    assert.match(html, /data-owned-app-studio hidden/);
+    assert.match(html, /Only you can edit this draft\./);
+    assert.match(html, /data-owned-app-builder/);
+    assert.match(html, /Save draft/);
+    assert.match(html, /Copy build prompt/);
     assert.match(html, /const portalGuideRoutes =/);
+    assert.match(html, /id: 'app-admin'/);
     assert.match(html, /const chooseGuideRoute =/);
     assert.match(html, /const requestGuideRoute =/);
     assert.match(html, /fetch\('\/api\/openai-site'/);
@@ -35,6 +41,11 @@ describe('portal customer journey pages', () => {
     assert.match(html, /rememberPortalBehavior/);
     assert.match(html, /portal-auto-identity:updated/);
     assert.match(html, /lastGuideRoute/);
+    assert.match(html, /OWNED_APPS_STORAGE_KEY = 'portal:owned-apps:v1'/);
+    assert.match(html, /WEB_BUILDER_PREFILL_KEY = 'web-builder-prefill-request'/);
+    assert.match(html, /canAdminOwnedApp/);
+    assert.match(html, /handleOwnedAppIntent/);
+    assert.match(html, /Only show admin controls when the active owner id matches/);
     assert.match(html, /Nine doors into the portal/);
     assert.match(html, /🧭 My Purpose/);
     assert.match(html, /🌱 My Life/);
@@ -136,6 +147,8 @@ describe('portal customer journey pages', () => {
     assert.match(css, /\.portal-guide__actions/);
     assert.match(css, /\.portal-guide__status/);
     assert.match(css, /\.portal-guide__memory/);
+    assert.match(css, /\.portal-app-studio/);
+    assert.match(css, /\.portal-app-studio__list button\[data-active="true"\]/);
     assert.match(css, /@media \(min-width: 721px\) \{[\s\S]*?\.hero-actions \{[\s\S]*?grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(9rem,\s*1fr\)\);[\s\S]*?\.hero-actions \.cta \{[\s\S]*?padding:\s*0\.58rem 1rem;/);
     assert.match(css, /font-size:\s*clamp\(2rem,\s*8\.8vw,\s*2\.35rem\)/);
     assert.doesNotMatch(css, /botanical-border/);

--- a/tests/web-builder-defaults.test.js
+++ b/tests/web-builder-defaults.test.js
@@ -62,3 +62,14 @@ test('web builder waits for shared defaults before missing-key warning', async (
   assert.match(app, /hasDefaultRecord\(data\)/);
   assert.match(app, /await loadDefaultsWithOptions\(\{ force: false, silent: true, timeoutMs: DEFAULTS_LOAD_TIMEOUT_MS \}\)/);
 });
+
+test('web builder accepts homepage owned-app handoff', async () => {
+  const app = await readFile(new URL('../web-builder-app/app.js', import.meta.url), 'utf8');
+
+  assert.match(app, /builderPrefillStorageKey = 'web-builder-prefill-request'/);
+  assert.match(app, /hydrateBuilderPrefill\(\)/);
+  assert.match(app, /builderRequestInput\.value = request/);
+  assert.match(app, /siteTitleInput\.value = title/);
+  assert.match(app, /safeRemove\(localStorage, builderPrefillStorageKey\)/);
+  assert.match(app, /Loaded your app draft from Portal\./);
+});

--- a/web-builder-app/app.js
+++ b/web-builder-app/app.js
@@ -76,6 +76,7 @@ const openaiStorageKey = 'web-builder-openai';
 const vercelStorageKey = 'web-builder-vercel';
 const githubStorageKey = 'web-builder-github';
 const modelStorageKey = 'web-builder-model';
+const builderPrefillStorageKey = 'web-builder-prefill-request';
 
 const STATUS_TONE_CLASSES = ['status--info', 'status--success', 'status--warning', 'status--error'];
 const LOAD_DEFAULTS_LABEL = 'Reload shared defaults';
@@ -126,6 +127,7 @@ recallBillingSession();
 
 hydrateStoredKeys();
 hydrateCachedBillingStatus();
+hydrateBuilderPrefill();
 subscribeToDefaults();
 subscribeToBillingTier();
 subscribeToUsageCounters();
@@ -378,6 +380,39 @@ function safeParseJson(raw) {
   } catch (error) {
     return null;
   }
+}
+
+function hydrateBuilderPrefill() {
+  const raw = safeRead(localStorage, builderPrefillStorageKey) || safeRead(sessionStorage, builderPrefillStorageKey);
+  const prefill = safeParseJson(raw);
+  if (!prefill || typeof prefill !== 'object') {
+    return;
+  }
+
+  const request = String(prefill.request || '').trim();
+  if (request && builderRequestInput) {
+    builderRequestInput.value = request;
+  }
+
+  const title = String(prefill.siteTitle || '').trim();
+  if (title && siteTitleInput) {
+    siteTitleInput.value = title;
+  }
+
+  const goal = String(prefill.siteGoal || '').trim();
+  if (goal && siteGoalInput) {
+    siteGoalInput.value = goal;
+  }
+
+  const audience = String(prefill.audience || '').trim();
+  if (audience && siteAudienceInput) {
+    siteAudienceInput.value = audience;
+  }
+
+  safeRemove(localStorage, builderPrefillStorageKey);
+  safeRemove(sessionStorage, builderPrefillStorageKey);
+  setGenerateStatus('Loaded your app draft from Portal.', 'success');
+  logMessage(`Loaded app draft${title ? `: ${title}` : ''}.`);
 }
 
 function readSharedValue(key) {


### PR DESCRIPTION
## Summary
- Add a homepage App Studio result for prompts that ask to create or edit apps
- Store owned app drafts under the local portal identity and block admin actions when the owner id does not match
- Hand app drafts into Web Builder through a local prefill payload so the build prompt is already loaded

## Validation
- `node --test tests/customer-journey-pages.test.js tests/web-builder-defaults.test.js tests/guide-api.test.js`
- `node --check web-builder-app/app.js`
- inline homepage script syntax check with `new Function(...)`
- `git diff --check`