### PR TITLE
[codex] Add string theory visualizer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1020,6 +1020,17 @@
             <span class="app-card__title">Fractal Explorer</span>
             <span class="app-card__meta">Explore raymarched fractals with shareable browser presets.</span>
           </a>
+          <a
+            href="string-theory/"
+            class="app-card"
+            data-app-tier="experimental"
+            data-app-keywords="string theory physics threejs visualizer quantum brane compact dimensions"
+          >
+            <span class="app-card__badge">Experimental</span>
+            <span class="app-card__icon" aria-hidden="true">∿</span>
+            <span class="app-card__title">String Theory Visualizer</span>
+            <span class="app-card__meta">Shape vibrating strings, branes, and compact dimensions in Three.js.</span>
+          </a>
           <a href="gun-explorer/index.html" class="app-card" data-app-tier="experimental">
             <span class="app-card__badge">Experimental</span>
             <span class="app-card__icon" aria-hidden="true">🗺️</span>
@@ -1998,6 +2009,22 @@
         ],
       },
       {
+        id: 'string-theory',
+        room: 'learning',
+        href: 'string-theory/',
+        cta: 'Open String Theory',
+        label: 'Physics path',
+        title: 'String Theory Visualizer',
+        copy: 'Explore vibrating strings, curled dimensions, and branes in Three.js.',
+        search: 'string theory physics threejs visualizer dimension brane quantum',
+        keywords: ['string theory', 'strings', 'physics', 'quantum', 'dimension', 'brane', 'visualize', 'visualizer', 'threejs'],
+        steps: [
+          'Open the visualizer.',
+          'Switch string modes.',
+          'Adjust energy and dimensions.',
+        ],
+      },
+      {
         id: 'play',
         room: 'play',
         href: 'games.html',
@@ -2100,6 +2127,7 @@
         'Open Source',
         'Human-Scale Tech',
         'Science Lab',
+        'String Theory Visualizer',
         'OpenAI Workbench',
         'Debian Browser Lab',
         'Personal Debian Server',

--- a/string-theory/app.js
+++ b/string-theory/app.js
@@ -1,0 +1,389 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+
+const canvas = document.getElementById('string-canvas');
+const statusEl = document.getElementById('status');
+const controls = {
+  mode: document.getElementById('mode'),
+  energy: document.getElementById('energy'),
+  tension: document.getElementById('tension'),
+  modes: document.getElementById('modes'),
+  curl: document.getElementById('curl')
+};
+const outputs = {
+  energy: document.getElementById('energy-value'),
+  tension: document.getElementById('tension-value'),
+  modes: document.getElementById('modes-value'),
+  curl: document.getElementById('curl-value')
+};
+
+const POINT_COUNT = 180;
+const STAR_COUNT = 360;
+const state = {
+  paused: false,
+  mode: 'open',
+  yaw: -0.45,
+  pitch: 0.18,
+  distance: 7.2,
+  dragging: false,
+  pointerX: 0,
+  pointerY: 0,
+  startYaw: 0,
+  startPitch: 0
+};
+
+const renderer = new THREE.WebGLRenderer({
+  canvas,
+  antialias: true,
+  alpha: false,
+  preserveDrawingBuffer: true,
+  powerPreference: 'high-performance'
+});
+renderer.setClearColor(0x05070d, 1);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.7));
+
+const scene = new THREE.Scene();
+scene.fog = new THREE.FogExp2(0x05070d, 0.055);
+
+const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 100);
+const root = new THREE.Group();
+scene.add(root);
+
+scene.add(new THREE.AmbientLight(0x8fb6ff, 0.8));
+const keyLight = new THREE.PointLight(0x50e6ff, 4.5, 24);
+keyLight.position.set(-3.5, 3.4, 4);
+scene.add(keyLight);
+const warmLight = new THREE.PointLight(0xf9d36a, 2.2, 18);
+warmLight.position.set(4, -2, -3);
+scene.add(warmLight);
+
+const stringGeometry = new THREE.BufferGeometry();
+const stringPositions = new Float32Array(POINT_COUNT * 3);
+stringGeometry.setAttribute('position', new THREE.BufferAttribute(stringPositions, 3));
+
+const stringMaterial = new THREE.LineBasicMaterial({
+  color: 0x50e6ff,
+  transparent: true,
+  opacity: 0.96
+});
+const stringLine = new THREE.Line(stringGeometry, stringMaterial);
+root.add(stringLine);
+
+const echoMaterial = new THREE.LineBasicMaterial({
+  color: 0xff6ad5,
+  transparent: true,
+  opacity: 0.28
+});
+const echoGeometry = new THREE.BufferGeometry();
+const echoPositions = new Float32Array(POINT_COUNT * 3);
+echoGeometry.setAttribute('position', new THREE.BufferAttribute(echoPositions, 3));
+const echoLine = new THREE.Line(echoGeometry, echoMaterial);
+root.add(echoLine);
+
+const particleGeometry = new THREE.BufferGeometry();
+const particlePositions = new Float32Array(POINT_COUNT * 3);
+particleGeometry.setAttribute('position', new THREE.BufferAttribute(particlePositions, 3));
+const particleMaterial = new THREE.PointsMaterial({
+  color: 0xf9d36a,
+  size: 0.045,
+  transparent: true,
+  opacity: 0.74,
+  depthWrite: false
+});
+const particles = new THREE.Points(particleGeometry, particleMaterial);
+root.add(particles);
+
+const brane = createBrane();
+root.add(brane.group);
+
+const compactDimension = createCompactDimension();
+root.add(compactDimension);
+
+const stars = createStars();
+scene.add(stars);
+
+hydrateControls();
+resize();
+updateCamera();
+animate(0);
+
+window.addEventListener('resize', resize);
+canvas.addEventListener('pointerdown', onPointerDown);
+window.addEventListener('pointermove', onPointerMove);
+window.addEventListener('pointerup', onPointerUp);
+canvas.addEventListener('wheel', onWheel, { passive: false });
+
+Object.entries(controls).forEach(([key, input]) => {
+  input.addEventListener('input', () => {
+    if (key === 'mode') {
+      state.mode = input.value;
+      updateModeVisibility();
+    }
+    syncOutputs();
+  });
+});
+
+document.getElementById('reset-view').addEventListener('click', () => {
+  state.yaw = -0.45;
+  state.pitch = 0.18;
+  state.distance = 7.2;
+  updateCamera();
+});
+
+document.getElementById('pause').addEventListener('click', (event) => {
+  state.paused = !state.paused;
+  event.currentTarget.textContent = state.paused ? 'Resume' : 'Pause';
+  event.currentTarget.setAttribute('aria-pressed', String(state.paused));
+});
+
+function hydrateControls() {
+  const params = new URLSearchParams(window.location.search);
+  const mode = params.get('mode');
+  if (mode && controls.mode.querySelector(`option[value="${CSS.escape(mode)}"]`)) {
+    controls.mode.value = mode;
+    state.mode = mode;
+  }
+  ['energy', 'tension', 'modes', 'curl'].forEach((key) => {
+    const value = params.get(key);
+    if (value !== null) {
+      controls[key].value = value;
+    }
+  });
+  syncOutputs();
+  updateModeVisibility();
+}
+
+function syncOutputs() {
+  outputs.energy.textContent = Number(controls.energy.value).toFixed(1);
+  outputs.tension.textContent = Number(controls.tension.value).toFixed(1);
+  outputs.modes.textContent = controls.modes.value;
+  outputs.curl.textContent = controls.curl.value;
+  statusEl.textContent = statusForMode(state.mode);
+}
+
+function statusForMode(mode) {
+  if (mode === 'closed') return 'Closed string loop.';
+  if (mode === 'brane') return 'String moving on a brane.';
+  if (mode === 'compact') return 'Extra dimension curled small.';
+  return 'Open string vibration.';
+}
+
+function updateModeVisibility() {
+  brane.group.visible = state.mode === 'brane';
+  compactDimension.visible = state.mode === 'compact';
+  echoLine.visible = state.mode !== 'brane';
+}
+
+function createBrane() {
+  const group = new THREE.Group();
+  const grid = new THREE.GridHelper(7.5, 22, 0x35557c, 0x1a2d46);
+  grid.rotation.x = Math.PI / 2;
+  grid.position.z = -0.42;
+  grid.material.transparent = true;
+  grid.material.opacity = 0.28;
+  group.add(grid);
+
+  const geometry = new THREE.PlaneGeometry(7.5, 4.6, 28, 18);
+  const material = new THREE.MeshBasicMaterial({
+    color: 0x243a66,
+    transparent: true,
+    opacity: 0.17,
+    wireframe: true
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.z = -0.45;
+  group.add(mesh);
+
+  return { group, mesh };
+}
+
+function createCompactDimension() {
+  const group = new THREE.Group();
+  const material = new THREE.LineBasicMaterial({
+    color: 0xf9d36a,
+    transparent: true,
+    opacity: 0.5
+  });
+
+  for (let ringIndex = 0; ringIndex < 5; ringIndex += 1) {
+    const curve = new THREE.EllipseCurve(0, 0, 0.52 + ringIndex * 0.2, 0.52 + ringIndex * 0.2);
+    const points = curve.getPoints(96).map((point) => new THREE.Vector3(point.x, point.y, -0.85 - ringIndex * 0.06));
+    const geometry = new THREE.BufferGeometry().setFromPoints(points);
+    const ring = new THREE.LineLoop(geometry, material);
+    ring.rotation.x = Math.PI / 2;
+    ring.rotation.z = ringIndex * 0.26;
+    group.add(ring);
+  }
+
+  return group;
+}
+
+function createStars() {
+  const positions = new Float32Array(STAR_COUNT * 3);
+  for (let index = 0; index < STAR_COUNT; index += 1) {
+    const radius = 9 + Math.random() * 18;
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.acos(THREE.MathUtils.randFloatSpread(2));
+    positions[index * 3] = Math.sin(phi) * Math.cos(theta) * radius;
+    positions[index * 3 + 1] = Math.cos(phi) * radius;
+    positions[index * 3 + 2] = Math.sin(phi) * Math.sin(theta) * radius;
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  return new THREE.Points(geometry, new THREE.PointsMaterial({
+    color: 0x8ebfff,
+    size: 0.022,
+    transparent: true,
+    opacity: 0.62,
+    depthWrite: false
+  }));
+}
+
+function writePoint(target, index, x, y, z) {
+  target[index * 3] = x;
+  target[index * 3 + 1] = y;
+  target[index * 3 + 2] = z;
+}
+
+function updateString(time) {
+  const energy = Number(controls.energy.value);
+  const tension = Number(controls.tension.value);
+  const modes = Number(controls.modes.value);
+  const curl = Number(controls.curl.value);
+  const amp = 0.2 + energy * 0.22;
+  const speed = 0.75 + energy * 0.7 + tension * 0.2;
+  const length = state.mode === 'brane' ? 6.6 : 5.5;
+
+  for (let index = 0; index < POINT_COUNT; index += 1) {
+    const u = index / (POINT_COUNT - 1);
+    const centered = u - 0.5;
+    let x = centered * length;
+    let y = 0;
+    let z = 0;
+    let echoX = x;
+    let echoY = 0;
+    let echoZ = 0;
+
+    if (state.mode === 'closed') {
+      const angle = u * Math.PI * 2;
+      const wave = Math.sin(angle * modes + time * speed) * amp * 0.45;
+      const radius = 1.55 + wave;
+      x = Math.cos(angle) * radius;
+      y = Math.sin(angle * modes * 0.5 + time * 0.7) * amp;
+      z = Math.sin(angle) * radius;
+      echoX = Math.cos(angle) * (radius + 0.32);
+      echoY = Math.sin(angle * modes * 0.5 + time * 0.7 + 0.9) * amp * 0.55;
+      echoZ = Math.sin(angle) * (radius + 0.32);
+    } else if (state.mode === 'compact') {
+      const angle = u * Math.PI * 2 * curl;
+      const wave = Math.sin(u * Math.PI * modes + time * speed) * amp;
+      x = centered * length;
+      y = Math.sin(angle + time * speed) * (0.46 + amp * 0.25) + wave * 0.24;
+      z = Math.cos(angle + time * speed) * (0.46 + amp * 0.25);
+      echoX = x;
+      echoY = Math.sin(angle + time * speed + Math.PI) * 0.22;
+      echoZ = Math.cos(angle + time * speed + Math.PI) * 0.22 - 0.55;
+    } else {
+      const envelope = state.mode === 'brane' ? 1 : Math.sin(Math.PI * u);
+      const waveA = Math.sin(u * Math.PI * modes + time * speed);
+      const waveB = Math.sin(u * Math.PI * (modes + 1) - time * (speed * 0.72));
+      x = centered * length;
+      y = (waveA * 0.72 + waveB * 0.28) * amp * envelope;
+      z = Math.cos(u * Math.PI * modes - time * speed) * amp * 0.34 * envelope;
+      echoX = x;
+      echoY = Math.sin(u * Math.PI * (modes + 2) + time * speed * 0.82) * amp * 0.45 * envelope;
+      echoZ = z - 0.48;
+    }
+
+    writePoint(stringPositions, index, x, y, z);
+    writePoint(echoPositions, index, echoX, echoY, echoZ);
+    writePoint(particlePositions, index, x, y, z);
+  }
+
+  stringGeometry.attributes.position.needsUpdate = true;
+  stringGeometry.computeBoundingSphere();
+  echoGeometry.attributes.position.needsUpdate = true;
+  echoGeometry.computeBoundingSphere();
+  particleGeometry.attributes.position.needsUpdate = true;
+  particleGeometry.computeBoundingSphere();
+
+  stringMaterial.color.set(state.mode === 'closed' ? 0xff6ad5 : 0x50e6ff);
+  particleMaterial.color.set(state.mode === 'compact' ? 0xf9d36a : 0xffffff);
+}
+
+function updateBrane(time) {
+  const position = brane.mesh.geometry.attributes.position;
+  const energy = Number(controls.energy.value);
+  for (let index = 0; index < position.count; index += 1) {
+    const x = position.getX(index);
+    const y = position.getY(index);
+    const ripple = Math.sin(x * 2.2 + time * 1.6) * Math.cos(y * 1.9 - time) * energy * 0.05;
+    position.setZ(index, ripple);
+  }
+  position.needsUpdate = true;
+}
+
+function resize() {
+  const width = Math.max(canvas.clientWidth || window.innerWidth, 1);
+  const height = Math.max(canvas.clientHeight || window.innerHeight, 1);
+  renderer.setSize(width, height, false);
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+}
+
+function updateCamera() {
+  const x = Math.sin(state.yaw) * Math.cos(state.pitch) * state.distance;
+  const y = Math.sin(state.pitch) * state.distance;
+  const z = Math.cos(state.yaw) * Math.cos(state.pitch) * state.distance;
+  camera.position.set(x, y, z);
+  camera.lookAt(0, 0, 0);
+}
+
+function animate(now) {
+  requestAnimationFrame(animate);
+  const time = now * 0.001;
+  if (!state.paused) {
+    root.rotation.y += 0.0018;
+    compactDimension.rotation.z -= 0.006;
+    stars.rotation.y += 0.0004;
+    updateString(time);
+    updateBrane(time);
+  }
+  renderer.render(scene, camera);
+}
+
+function onPointerDown(event) {
+  state.dragging = true;
+  state.pointerX = event.clientX;
+  state.pointerY = event.clientY;
+  state.startYaw = state.yaw;
+  state.startPitch = state.pitch;
+  canvas.setPointerCapture?.(event.pointerId);
+}
+
+function onPointerMove(event) {
+  if (!state.dragging) return;
+  const dx = (event.clientX - state.pointerX) / Math.max(window.innerWidth, 1);
+  const dy = (event.clientY - state.pointerY) / Math.max(window.innerHeight, 1);
+  state.yaw = state.startYaw - dx * Math.PI * 1.6;
+  state.pitch = THREE.MathUtils.clamp(state.startPitch + dy * Math.PI, -1.1, 1.1);
+  updateCamera();
+}
+
+function onPointerUp(event) {
+  state.dragging = false;
+  canvas.releasePointerCapture?.(event.pointerId);
+}
+
+function onWheel(event) {
+  event.preventDefault();
+  state.distance = THREE.MathUtils.clamp(state.distance + Math.sign(event.deltaY) * 0.45, 4.2, 12);
+  updateCamera();
+}
+
+window.StringTheoryVisualizer = {
+  renderer,
+  scene,
+  camera,
+  updateString,
+  state
+};

--- a/string-theory/index.html
+++ b/string-theory/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>String Theory Visualizer | 3DVR Portal</title>
+  <meta name="theme-color" content="#05070d">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+  <script type="module" src="app.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#controls">Skip to controls</a>
+  <main class="string-shell">
+    <canvas id="string-canvas" aria-label="Interactive Three.js string theory visualizer"></canvas>
+
+    <header class="scene-head">
+      <p class="eyebrow">Three.js toy model</p>
+      <h1>String Theory</h1>
+      <nav aria-label="String theory links">
+        <a href="../index.html">Portal</a>
+        <a href="../science/">Science</a>
+        <button id="reset-view" type="button">Reset</button>
+        <button id="pause" type="button" aria-pressed="false">Pause</button>
+      </nav>
+    </header>
+
+    <section class="control-panel" id="controls" aria-labelledby="controls-title">
+      <div class="panel-title">
+        <p class="eyebrow">Controls</p>
+        <h2 id="controls-title">Shape the string</h2>
+      </div>
+
+      <label>
+        <span>Mode</span>
+        <select id="mode">
+          <option value="open">Open string</option>
+          <option value="closed">Closed loop</option>
+          <option value="brane">Brane wave</option>
+          <option value="compact">Compact dimension</option>
+        </select>
+      </label>
+
+      <label>
+        <span>Energy <output id="energy-value">1.2</output></span>
+        <input id="energy" type="range" min="0.2" max="3" step="0.1" value="1.2">
+      </label>
+
+      <label>
+        <span>Tension <output id="tension-value">1.0</output></span>
+        <input id="tension" type="range" min="0.3" max="2.4" step="0.1" value="1">
+      </label>
+
+      <label>
+        <span>Modes <output id="modes-value">3</output></span>
+        <input id="modes" type="range" min="1" max="7" step="1" value="3">
+      </label>
+
+      <label>
+        <span>Compact curl <output id="curl-value">4</output></span>
+        <input id="curl" type="range" min="1" max="9" step="1" value="4">
+      </label>
+
+      <p class="status" id="status" aria-live="polite">Rendering vibrating strings.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/string-theory/styles.css
+++ b/string-theory/styles.css
@@ -1,0 +1,228 @@
+:root {
+  --bg: #05070d;
+  --panel: rgba(8, 12, 22, 0.72);
+  --panel-strong: rgba(8, 12, 22, 0.88);
+  --line: rgba(214, 226, 255, 0.18);
+  --ink: #f7fbff;
+  --muted: #adbad3;
+  --cyan: #50e6ff;
+  --gold: #f9d36a;
+  --pink: #ff6ad5;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.46);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 8;
+  padding: 0.58rem 0.75rem;
+  border-radius: 8px;
+  background: var(--cyan);
+  color: #001318;
+  transform: translateY(-150%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.string-shell {
+  min-height: 100vh;
+  min-height: 100dvh;
+  position: relative;
+  isolation: isolate;
+}
+
+#string-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  background: radial-gradient(circle at 50% 45%, #111a31 0, var(--bg) 62%);
+  touch-action: none;
+}
+
+.scene-head,
+.control-panel {
+  position: fixed;
+  z-index: 2;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.scene-head {
+  top: clamp(0.8rem, 2vw, 1.35rem);
+  left: clamp(0.8rem, 2vw, 1.35rem);
+  width: min(28rem, calc(100% - 1.6rem));
+  padding: clamp(0.9rem, 2vw, 1.2rem);
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--cyan);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.scene-head h1,
+.panel-title h2 {
+  margin: 0;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.scene-head h1 {
+  font-size: clamp(2rem, 6vw, 4.6rem);
+}
+
+.scene-head nav,
+.control-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.95rem;
+}
+
+.scene-head a,
+.scene-head button,
+.control-panel button,
+.control-panel select {
+  min-height: 2.35rem;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.55rem 0.72rem;
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--ink);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.scene-head a:hover,
+.scene-head button:hover,
+.control-panel button:hover,
+.control-panel select:hover,
+.scene-head a:focus-visible,
+.scene-head button:focus-visible,
+.control-panel select:focus-visible,
+.control-panel input:focus-visible {
+  border-color: rgba(80, 230, 255, 0.7);
+  outline: 2px solid rgba(80, 230, 255, 0.24);
+  outline-offset: 2px;
+}
+
+.control-panel {
+  right: clamp(0.8rem, 2vw, 1.35rem);
+  bottom: clamp(0.8rem, 2vw, 1.35rem);
+  width: min(22rem, calc(100% - 1.6rem));
+  padding: 1rem;
+  display: grid;
+  gap: 0.82rem;
+}
+
+.panel-title {
+  display: grid;
+  gap: 0.28rem;
+}
+
+.panel-title h2 {
+  font-size: 1.12rem;
+}
+
+.control-panel label {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.control-panel label > span {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.7rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 760;
+}
+
+.control-panel input[type="range"] {
+  width: 100%;
+  accent-color: var(--cyan);
+}
+
+.control-panel select {
+  width: 100%;
+  background: var(--panel-strong);
+  color-scheme: dark;
+}
+
+.status {
+  min-height: 1.2rem;
+  margin: 0;
+  color: var(--gold);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 720px) {
+  body {
+    overflow: auto;
+  }
+
+  .string-shell {
+    min-height: 100dvh;
+    display: grid;
+    align-content: space-between;
+    gap: min(28vh, 12rem);
+    padding: 0.75rem;
+  }
+
+  #string-canvas {
+    position: fixed;
+  }
+
+  .scene-head,
+  .control-panel {
+    position: relative;
+    top: auto;
+    left: auto;
+    right: auto;
+    bottom: auto;
+    width: 100%;
+  }
+
+  .control-panel {
+    align-self: end;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #string-canvas {
+    touch-action: auto;
+  }
+}

--- a/tests/string-theory.test.js
+++ b/tests/string-theory.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import test from 'node:test';
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+test('string theory visualizer ships a Three.js learning route', async () => {
+  const appDir = new URL('../string-theory/', import.meta.url);
+  assert.equal(await fileExists(new URL('index.html', appDir)), true);
+  assert.equal(await fileExists(new URL('styles.css', appDir)), true);
+  assert.equal(await fileExists(new URL('app.js', appDir)), true);
+
+  const html = await readFile(new URL('index.html', appDir), 'utf8');
+  const css = await readFile(new URL('styles.css', appDir), 'utf8');
+  const app = await readFile(new URL('app.js', appDir), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /String Theory Visualizer \| 3DVR Portal/);
+  assert.match(html, /id="string-canvas"/);
+  assert.match(html, /id="mode"/);
+  assert.match(html, /Open string/);
+  assert.match(html, /Closed loop/);
+  assert.match(html, /Brane wave/);
+  assert.match(html, /Compact dimension/);
+
+  assert.match(css, /#string-canvas/);
+  assert.match(css, /position:\s*fixed/);
+  assert.match(css, /touch-action:\s*none/);
+  assert.match(css, /@media \(max-width: 720px\)/);
+
+  assert.match(app, /three@0\.165\.0\/build\/three\.module\.js/);
+  assert.match(app, /new THREE\.WebGLRenderer/);
+  assert.match(app, /createBrane/);
+  assert.match(app, /createCompactDimension/);
+  assert.match(app, /updateString/);
+  assert.match(app, /window\.StringTheoryVisualizer/);
+
+  assert.match(portal, /href="string-theory\/"/);
+  assert.match(portal, /String Theory Visualizer/);
+  assert.match(portal, /id: 'string-theory'/);
+  assert.match(portal, /String Theory Visualizer',/);
+});


### PR DESCRIPTION
## Summary
- Add `/string-theory/` as a Three.js toy model for vibrating strings, closed loops, brane waves, and compact dimensions
- Add compact controls for mode, energy, tension, vibration modes, and compact curl
- Add the visualizer to the portal app dock, Human O.S. learning room, and Guide routing

## Validation
- `node --check string-theory/app.js`
- `node --test tests/string-theory.test.js tests/customer-journey-pages.test.js tests/guide-api.test.js`
- `git diff --check`

## Browser note
- Attempted local Playwright desktop/mobile canvas pixel checks, but this container cannot launch Chromium/headless shell before page load. CI browser checks should cover the deploy environment.