### PR TITLE
[codex] Restore visible sign in links

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -255,6 +255,35 @@ body.landing {
   box-shadow: var(--top-button-shadow-hover);
 }
 
+.top-nav__sign-in {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.05rem;
+  padding: 0.72rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(186, 230, 253, 0.32);
+  background: rgba(8, 15, 31, 0.68);
+  color: rgba(226, 232, 240, 0.92);
+  font-weight: 850;
+  text-decoration: none;
+  box-shadow: 0 16px 36px rgba(4, 9, 20, 0.22);
+  backdrop-filter: blur(14px);
+  transition: transform var(--transition-base),
+    background var(--transition-base),
+    border-color var(--transition-base),
+    color var(--transition-base);
+}
+
+.top-nav__sign-in:hover,
+.top-nav__sign-in:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(125, 211, 252, 0.62);
+  background: rgba(14, 165, 233, 0.18);
+  color: var(--color-text);
+  outline: none;
+}
+
 .top-nav__search {
   position: relative;
   display: inline-flex;
@@ -2017,10 +2046,12 @@ footer a {
 
   .top-nav__primary {
     display: grid;
-    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+    grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr) minmax(0, 0.85fr);
+    gap: 0.5rem;
   }
 
-  .top-nav__toggle {
+  .top-nav__toggle,
+  .top-nav__sign-in {
     display: inline-flex;
   }
 
@@ -2112,6 +2143,22 @@ footer a {
 
   .top-nav__toggle {
     width: 100%;
+  }
+
+  .top-nav__toggle,
+  .top-nav__search,
+  .top-nav__sign-in {
+    min-height: 2.75rem;
+    padding: 0.58rem 0.72rem;
+    font-size: 0.88rem;
+  }
+
+  .top-nav__search {
+    gap: 0.35rem;
+  }
+
+  .top-nav__search::after {
+    left: 1.05rem;
   }
 
   .hero-eyebrow {

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     }
     .top-nav__toggle,
     .top-nav__search,
+    .top-nav__sign-in,
     .cta,
     .top-buttons a {
       border: 1px solid rgba(88, 166, 255, 0.45);
@@ -141,6 +142,7 @@
           <span class="top-nav__toggle-text">Menu</span>
         </button>
         <button type="button" class="top-nav__search" data-app-search-trigger>Search apps</button>
+        <a class="top-nav__sign-in" href="sign-in.html?upgrade=guest&amp;redirect=%2Findex.html" data-auth-entry>Sign in</a>
       </div>
       <div class="view-toggle-container" aria-label="Portal view mode">
         <button class="toggle-btn" type="button" data-view-mode-button="guide" data-active="false">Guide</button>
@@ -156,6 +158,7 @@
         <a href="#app-hub-title" data-app-search-trigger>Apps</a>
         <a href="games.html">Games</a>
         <a href="share.html">Share</a>
+        <a href="sign-in.html?upgrade=guest&amp;redirect=%2Findex.html" data-auth-entry>Sign in</a>
         <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">GitHub</a>
       </nav>
     </div>
@@ -1533,6 +1536,19 @@
     function startAccountFromHere() {
       const currentPath = `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`;
       window.location.href = `/sign-in.html?redirect=${encodeURIComponent(currentPath || '/index.html')}`;
+    }
+
+    function updatePortalAuthEntryLinks() {
+      const signedIn = localStorage.getItem('signedIn') === 'true';
+      const currentPath = `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`;
+      const href = signedIn
+        ? 'profile.html'
+        : `sign-in.html?upgrade=guest&redirect=${encodeURIComponent(currentPath || '/index.html')}`;
+      const label = signedIn ? 'Profile' : 'Sign in';
+      document.querySelectorAll('[data-auth-entry]').forEach((link) => {
+        link.setAttribute('href', href);
+        link.textContent = label;
+      });
     }
   </script>
 
@@ -3232,6 +3248,7 @@
     updateAppFilter(initialSearchValue);
     renderOwnedAppList();
     applyAutoIdentityHints();
+    updatePortalAuthEntryLinks();
   </script>
   <script defer src="/issue-launcher.js"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -328,6 +328,48 @@
       box-shadow: none;
     }
 
+    .profile-signin-callout {
+      display: grid;
+      gap: 0.75rem;
+      margin: 1rem 0;
+      padding: 1rem;
+      border-radius: var(--radius-md);
+      background: rgba(37, 99, 235, 0.08);
+      border: 1px solid rgba(37, 99, 235, 0.2);
+    }
+
+    .profile-signin-callout[hidden] {
+      display: none;
+    }
+
+    .profile-signin-callout p {
+      margin: 0;
+      color: var(--color-text-muted);
+    }
+
+    .profile-signin-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 2.65rem;
+      width: fit-content;
+      padding: 0.72rem 1rem;
+      border-radius: var(--radius-md);
+      background: linear-gradient(135deg, #2563eb, #1d4ed8);
+      color: #fff;
+      border: 1px solid rgba(37, 99, 235, 0.4);
+      box-shadow: 0 14px 28px rgba(37, 99, 235, 0.24);
+      font-weight: 800;
+    }
+
+    .profile-signin-link:hover,
+    .profile-signin-link:focus-visible {
+      color: #fff;
+      transform: translateY(-1px);
+      outline: 2px solid rgba(37, 99, 235, 0.28);
+      outline-offset: 2px;
+    }
+
     .danger {
       background: rgba(220, 38, 38, 0.08);
       color: #b91c1c;
@@ -520,6 +562,7 @@
   <a href="notes/">📝 Shared Notes</a>
   <a href="/tasks/">✅ Task Board</a>
   <a href="games.html">🎮 Mini Games</a>
+  <a href="sign-in.html?upgrade=guest&amp;redirect=%2Fprofile.html" data-profile-auth-entry>🔑 Sign in</a>
   <a href="https://3dvr.tech/#subscribe" target="_blank">⭐ Subscribe</a>
   <a href="https://github.com/tmsteph/3dvr-portal" target="_blank">🚀 GitHub</a>
 </div>
@@ -565,6 +608,11 @@
 
       <div class="unlock-hints">
         📚 Education unlocks at 500 • 🛠️ Creator tools at 1500 • 🚀 Builder status at 3000
+      </div>
+
+      <div class="profile-signin-callout" id="profile-sign-in-callout">
+        <p>You are using this browser as a guest. Sign in when you want sync, billing, and saved work across devices.</p>
+        <a class="profile-signin-link" href="sign-in.html?upgrade=guest&amp;redirect=%2Fprofile.html">Sign in or create account</a>
       </div>
 
       <form class="name-form" onsubmit="event.preventDefault(); saveUsername();">
@@ -748,6 +796,8 @@ const usernameEl = document.getElementById('username');
 const scoreEl = document.getElementById('score');
 const levelEl = document.getElementById('level');
 const progressEl = document.getElementById('progress');
+const profileSignInCallout = document.getElementById('profile-sign-in-callout');
+const profileAuthEntryLinks = Array.from(document.querySelectorAll('[data-profile-auth-entry]'));
 const adminStatusEl = document.getElementById('admin-status');
 const adminActionsEl = document.getElementById('admin-actions');
 const adminBadgeEl = document.getElementById('admin-badge');
@@ -1306,6 +1356,15 @@ function applyDisplayName() {
   usernameEl.innerText = computeDisplayName();
 }
 
+function updateProfileSignInCallout() {
+  if (!profileSignInCallout) return;
+  profileSignInCallout.hidden = isSignedIn;
+  profileAuthEntryLinks.forEach((link) => {
+    link.setAttribute('href', isSignedIn ? 'profile.html' : 'sign-in.html?upgrade=guest&redirect=%2Fprofile.html');
+    link.textContent = isSignedIn ? '👤 Profile' : '🔑 Sign in';
+  });
+}
+
 function updateAdminCard() {
   if (!adminStatusEl || !adminActionsEl || !adminBadgeEl) return;
 
@@ -1614,6 +1673,7 @@ function initializeSignedInProfile({ oauthOnly = false } = {}) {
   subscribeToGrantLog();
   renderUserResults();
   updateAdminCard();
+  updateProfileSignInCallout();
 }
 
 function initializeGuestProfile() {
@@ -1628,6 +1688,7 @@ function initializeGuestProfile() {
   applyDisplayName();
   subscribeToScore();
   updateAdminCard();
+  updateProfileSignInCallout();
 }
 
 const signedInAlias = (localStorage.getItem('alias') || '').trim();

--- a/tests/contacts-score.e2e.test.js
+++ b/tests/contacts-score.e2e.test.js
@@ -25,7 +25,187 @@ const MIME_TYPES = {
   '.webmanifest': 'application/manifest+json',
 };
 
+const GUN_STUB_SOURCE = `
+(() => {
+  const store = new Map();
+  const listeners = new Map();
+  const authListeners = new Set();
+
+  function clone(value) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function keyFor(path) {
+    return path.join('/');
+  }
+
+  function snapshotFor(path) {
+    const key = keyFor(path);
+    if (store.has(key)) {
+      return clone(store.get(key));
+    }
+
+    const prefix = key ? key + '/' : '';
+    const output = {};
+    let found = false;
+
+    for (const [storedKey, value] of store.entries()) {
+      if (!storedKey.startsWith(prefix)) continue;
+      const remainder = storedKey.slice(prefix.length);
+      if (!remainder || remainder.includes('/')) continue;
+      output[remainder] = clone(value);
+      found = true;
+    }
+
+    return found ? output : undefined;
+  }
+
+  function notify(path) {
+    const key = keyFor(path);
+    const bucket = listeners.get(key) || [];
+    const snapshot = snapshotFor(path);
+    bucket.forEach((callback) => callback(snapshot));
+  }
+
+  function makeNode(path = []) {
+    const node = {
+      get(next) {
+        return makeNode([...path, String(next)]);
+      },
+      put(value, callback) {
+        store.set(keyFor(path), clone(value));
+        notify(path);
+        callback && callback({ ok: true });
+        return node;
+      },
+      set(value, callback) {
+        return node.put(value, callback);
+      },
+      once(callback) {
+        callback && setTimeout(() => callback(snapshotFor(path)), 0);
+        return node;
+      },
+      on(callback) {
+        const key = keyFor(path);
+        const bucket = listeners.get(key) || [];
+        bucket.push(callback);
+        listeners.set(key, bucket);
+        callback && setTimeout(() => callback(snapshotFor(path)), 0);
+        return { off() {} };
+      },
+      off() {},
+      map() {
+        return {
+          on(callback) {
+            const prefix = keyFor(path);
+            for (const [storedKey, value] of store.entries()) {
+              if (!storedKey.startsWith(prefix + '/')) continue;
+              const remainder = storedKey.slice(prefix.length + 1);
+              if (!remainder || remainder.includes('/')) continue;
+              callback(clone(value), remainder);
+            }
+            return { off() {} };
+          }
+        };
+      }
+    };
+    return node;
+  }
+
+  function createUser() {
+    const userNode = makeNode(['~user']);
+    const user = {
+      ...userNode,
+      is: null,
+      _: { sea: null },
+      recall() {
+        const signedIn = window.localStorage.getItem('signedIn') === 'true';
+        const storedAlias = String(window.localStorage.getItem('alias') || '').trim();
+        const storedPub = String(window.localStorage.getItem('userPubKey') || '').trim();
+        if (signedIn && storedPub) {
+          user.is = { pub: storedPub, alias: storedAlias };
+          user._ = { sea: { pub: storedPub } };
+        }
+      },
+      auth(alias, _password, callback) {
+        const normalizedAlias = String(alias || '').trim();
+        const pub = 'pub_' + normalizedAlias.replace(/[^a-z0-9]+/gi, '_');
+        user.is = { pub, alias: normalizedAlias };
+        user._ = { sea: { pub } };
+        window.setTimeout(() => {
+          authListeners.forEach((listener) => listener());
+          callback && callback({ ok: true, pub });
+        }, 0);
+      },
+      create(alias, _password, callback) {
+        const normalizedAlias = String(alias || '').trim();
+        const pub = 'pub_' + normalizedAlias.replace(/[^a-z0-9]+/gi, '_');
+        user.is = { pub, alias: normalizedAlias };
+        user._ = { sea: { pub } };
+        window.setTimeout(() => {
+          callback && callback({ ok: true, pub });
+        }, 0);
+      },
+      leave() {
+        user.is = null;
+        user._ = { sea: null };
+      },
+      on(eventName, callback) {
+        if (eventName === 'auth' && typeof callback === 'function') {
+          authListeners.add(callback);
+        }
+      }
+    };
+    return user;
+  }
+
+  window.Gun = function Gun() {
+    const user = createUser();
+    return {
+      user() {
+        return user;
+      },
+      get(key) {
+        return makeNode([String(key)]);
+      }
+    };
+  };
+
+  window.Gun.SEA = {
+    async sign(payload) {
+      return JSON.stringify(payload);
+    }
+  };
+  window.SEA = window.Gun.SEA;
+})();
+`;
+
 async function installExternalRoutes(context) {
+  await context.route('https://cdn.jsdelivr.net/npm/gun/gun.js', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript; charset=utf-8',
+      body: GUN_STUB_SOURCE
+    });
+  });
+
+  await context.route('https://cdn.jsdelivr.net/npm/gun/sea.js', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript; charset=utf-8',
+      body: 'window.SEA = window.Gun && window.Gun.SEA ? window.Gun.SEA : {};'
+    });
+  });
+
+  await context.route('https://cdn.jsdelivr.net/npm/gun/axe.js', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript; charset=utf-8',
+      body: ''
+    });
+  });
+
   await context.route('https://cdn.tailwindcss.com', async route => {
     await route.fulfill({
       status: 200,
@@ -39,6 +219,14 @@ async function installExternalRoutes(context) {
       status: 200,
       contentType: 'application/javascript; charset=utf-8',
       body: '',
+    });
+  });
+
+  await context.route('https://fav.farm/**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml; charset=utf-8',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"></svg>'
     });
   });
 }
@@ -86,7 +274,7 @@ describe('contacts score integration', () => {
       const context = await createPlaywrightContext(browser);
       await installExternalRoutes(context);
       const page = await context.newPage();
-      await page.goto(`${baseUrl}/contacts/index.html`, { waitUntil: 'networkidle' });
+      await page.goto(`${baseUrl}/contacts/index.html`, { waitUntil: 'domcontentloaded' });
       await page.waitForSelector('#floatingIdentityScore');
 
       const initialScore = await page.textContent('#floatingIdentityScore');
@@ -121,7 +309,7 @@ describe('contacts score integration', () => {
       const context = await createPlaywrightContext(browser);
       await installExternalRoutes(context);
       const page = await context.newPage();
-      await page.goto(`${baseUrl}/contacts/index.html`, { waitUntil: 'networkidle' });
+      await page.goto(`${baseUrl}/contacts/index.html`, { waitUntil: 'domcontentloaded' });
       await page.waitForSelector('#floatingIdentityScore');
       await page.waitForFunction(() => {
         const manager = window.ScoreSystem && window.ScoreSystem.getManager
@@ -168,7 +356,7 @@ describe('contacts score integration', () => {
       });
       assert.equal(scoreAfterCreate > scoreBeforeCreate, true);
 
-      await page.reload({ waitUntil: 'networkidle' });
+      await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForTimeout(500);
 
       const managerScore = await page.evaluate(() => {

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -102,6 +102,10 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Start Your Thing/);
     assert.match(html, /Start Here: organize life, ideas, work, and what wants to grow\./);
     assert.match(html, /Search the dock/);
+    assert.match(html, /class="top-nav__sign-in" href="sign-in\.html\?upgrade=guest&amp;redirect=%2Findex\.html" data-auth-entry>Sign in<\/a>/);
+    assert.match(html, /href="sign-in\.html\?upgrade=guest&amp;redirect=%2Findex\.html" data-auth-entry>Sign in<\/a>/);
+    assert.match(html, /function updatePortalAuthEntryLinks\(\)/);
+    assert.match(html, /const label = signedIn \? 'Profile' : 'Sign in'/);
     assert.match(html, /You are already in\./);
     assert.match(html, /The portal remembers this browser\./);
     assert.doesNotMatch(html, /Sign in to save your progress/);

--- a/tests/profile-page.test.js
+++ b/tests/profile-page.test.js
@@ -31,3 +31,17 @@ test('profile section exposes a sign-out action that clears stored auth state', 
   assert.match(html, /'verifiedEmail'/);
   assert.match(html, /window\.location\.href = 'index\.html'/);
 });
+
+test('profile page exposes clear sign-in paths for guest users', async () => {
+  const html = await readFile(new URL('../profile.html', import.meta.url), 'utf8');
+
+  assert.match(html, /href="sign-in\.html\?upgrade=guest&amp;redirect=%2Fprofile\.html" data-profile-auth-entry>🔑 Sign in<\/a>/);
+  assert.match(html, /id="profile-sign-in-callout"/);
+  assert.match(html, /You are using this browser as a guest/);
+  assert.match(html, /Sign in or create account/);
+  assert.match(html, /const profileSignInCallout = document\.getElementById\('profile-sign-in-callout'\)/);
+  assert.match(html, /const profileAuthEntryLinks = Array\.from\(document\.querySelectorAll\('\[data-profile-auth-entry\]'\)\)/);
+  assert.match(html, /function updateProfileSignInCallout\(\)/);
+  assert.match(html, /profileSignInCallout\.hidden = isSignedIn/);
+  assert.match(html, /link\.textContent = isSignedIn \? '👤 Profile' : '🔑 Sign in'/);
+});


### PR DESCRIPTION
## Summary
- Add a visible Sign in button to the portal top controls and quick links
- Add Profile-page sign-in paths for guest users
- Keep the guest-first flow by linking with `upgrade=guest` and make links switch to Profile when already signed in

## Validation
- `node --test tests/customer-journey-pages.test.js tests/profile-page.test.js tests/auth-entrypoints.test.js tests/sign-in-page.test.js`
- inline script syntax check for `index.html` and `profile.html`
- `git diff --check`