### PR TITLE
[codex] Tighten friends family invite

### DIFF
--- a/friends-family/index.html
+++ b/friends-family/index.html
@@ -388,13 +388,13 @@
 
       <main>
         <section class="hero" aria-labelledby="friends-family-title">
-          <p class="kicker">Small first offer</p>
-          <h1 id="friends-family-title">Get clear. Take one step.</h1>
-          <p class="lead">Plan your ideas. See what to do next. Move without tech stress.</p>
+          <p class="kicker">Friends, family, and coworkers</p>
+          <h1 id="friends-family-title">Try 3DVR free. If it helps, join for $5.</h1>
+          <p class="lead">Sort one messy thought. Pick one next step. No card for free.</p>
           <div class="actions" aria-label="Friends and Family actions">
             <a class="button button--primary" href="../free-trial.html">Join free</a>
             <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
-              Help for $5/month
+              Join for $5/month
             </a>
           </div>
         </section>
@@ -402,11 +402,11 @@
         <section class="offer-grid" aria-label="Friends and Family choices">
           <article class="offer">
             <span class="offer__label">Early tester</span>
-            <h2>Free</h2>
+            <h2>Get clear</h2>
             <div class="price">$0</div>
-            <p>Try 3DVR and see if it helps.</p>
+            <p>Use the portal to sort life, ideas, money, or work into one small next step.</p>
             <ul>
-              <li>Sort ideas.</li>
+              <li>Check in.</li>
               <li>Pick one step.</li>
               <li>No card.</li>
             </ul>
@@ -417,32 +417,32 @@
             <span class="offer__label">Friends &amp; Family Pass</span>
             <h2>Help it grow</h2>
             <div class="price">$5<span>/month</span></div>
-            <p>Help build 3DVR while it is small.</p>
+            <p>Help fund the work and get the first look at new tools, experiments, and support paths.</p>
             <ul>
               <li>Free access.</li>
               <li>Early tools.</li>
               <li>Easy upgrade later.</li>
             </ul>
             <a class="button button--secondary" href="../sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">
-              Help for $5/month
+              Join for $5/month
             </a>
           </article>
         </section>
 
         <section class="fine-print" aria-label="Small print">
-          <p>Not money advice or custom work. Just early access, notes, and support.</p>
+          <p>Not money advice or custom work. Start free. Only pay if you want to help keep it growing.</p>
         </section>
 
         <section class="message-panel" aria-labelledby="copy-title">
           <div class="message-panel__top">
             <div>
-              <h2 id="copy-title">Share it</h2>
-              <p>Short enough to text.</p>
+              <h2 id="copy-title">Text this to one person</h2>
+              <p>Short, honest, and not awkward.</p>
             </div>
             <button class="button button--ghost" type="button" data-copy-message>Copy message</button>
           </div>
           <p class="invite-message" data-invite-message>
-            Try 3DVR free or help it grow for $5/month: https://portal.3dvr.tech/friends-family/
+            I am trying a simple 3DVR invite: use it free to sort one messy thought and pick a next step. If it helps, there is a $5/month friends and family pass too. Try it here: https://portal.3dvr.tech/friends-family/
           </p>
           <p class="copy-status" data-copy-status aria-live="polite"></p>
         </section>

--- a/tests/friends-family-pass.test.js
+++ b/tests/friends-family-pass.test.js
@@ -21,17 +21,20 @@ test('friends and family pass is a shareable small offer page', async () => {
   const html = await readFile(pageUrl, 'utf8');
 
   assert.match(html, /Friends &amp; Family Pass \| 3DVR Portal/);
-  assert.match(html, /Get clear\. Take one step\./);
-  assert.match(html, /Plan your ideas\. See what to do next\. Move without tech stress\./);
-  assert.match(html, /Help for \$5\/month/);
+  assert.match(html, /Try 3DVR free\. If it helps, join for \$5\./);
+  assert.match(html, /Sort one messy thought\. Pick one next step\. No card for free\./);
+  assert.match(html, /Join for \$5\/month/);
   assert.match(html, /href="\.\.\/free-trial\.html"/);
   assert.match(html, /href="\.\.\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dstarter"/);
-  assert.match(html, /Sort ideas\./);
+  assert.match(html, /Use the portal to sort life, ideas, money, or work into one small next step\./);
+  assert.match(html, /Check in\./);
   assert.match(html, /Pick one step\./);
-  assert.match(html, /Not money advice or custom work/);
-  assert.match(html, /Short enough to text\./);
+  assert.match(html, /Start free\. Only pay if you want to help keep it growing\./);
+  assert.match(html, /Text this to one person/);
+  assert.match(html, /Short, honest, and not awkward\./);
   assert.match(html, /data-copy-message/);
   assert.match(html, /data-invite-message/);
+  assert.match(html, /I am trying a simple 3DVR invite/);
   assert.match(html, /https:\/\/portal\.3dvr\.tech\/friends-family\//);
   assert.doesNotMatch(html, /What supporters get/);
   assert.doesNotMatch(html, /The bigger direction/);


### PR DESCRIPTION
## Summary
- align the portal Friends & Family invite with the sendable public offer
- make the page free-first with  as the simple supporter path
- replace the share copy with a short text-message invite
- update the dedicated Friends & Family regression test

## Validation
- `node --test tests/friends-family-pass.test.js tests/customer-journey-pages.test.js`
- inline script syntax check for `friends-family/index.html`
- `git diff --check`