### PR TITLE
[codex] Fix normal sign in links

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
           <span class="top-nav__toggle-text">Menu</span>
         </button>
         <button type="button" class="top-nav__search" data-app-search-trigger>Search apps</button>
-        <a class="top-nav__sign-in" href="sign-in.html?upgrade=guest&amp;redirect=%2Findex.html" data-auth-entry>Sign in</a>
+        <a class="top-nav__sign-in" href="sign-in.html?redirect=%2Findex.html" data-auth-entry>Sign in</a>
       </div>
       <div class="view-toggle-container" aria-label="Portal view mode">
         <button class="toggle-btn" type="button" data-view-mode-button="guide" data-active="false">Guide</button>
@@ -158,7 +158,7 @@
         <a href="#app-hub-title" data-app-search-trigger>Apps</a>
         <a href="games.html">Games</a>
         <a href="share.html">Share</a>
-        <a href="sign-in.html?upgrade=guest&amp;redirect=%2Findex.html" data-auth-entry>Sign in</a>
+        <a href="sign-in.html?redirect=%2Findex.html" data-auth-entry>Sign in</a>
         <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">GitHub</a>
       </nav>
     </div>
@@ -1543,7 +1543,7 @@
       const currentPath = `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`;
       const href = signedIn
         ? 'profile.html'
-        : `sign-in.html?upgrade=guest&redirect=${encodeURIComponent(currentPath || '/index.html')}`;
+        : `sign-in.html?redirect=${encodeURIComponent(currentPath || '/index.html')}`;
       const label = signedIn ? 'Profile' : 'Sign in';
       document.querySelectorAll('[data-auth-entry]').forEach((link) => {
         link.setAttribute('href', href);

--- a/profile.html
+++ b/profile.html
@@ -562,7 +562,7 @@
   <a href="notes/">📝 Shared Notes</a>
   <a href="/tasks/">✅ Task Board</a>
   <a href="games.html">🎮 Mini Games</a>
-  <a href="sign-in.html?upgrade=guest&amp;redirect=%2Fprofile.html" data-profile-auth-entry>🔑 Sign in</a>
+  <a href="sign-in.html?redirect=%2Fprofile.html" data-profile-auth-entry>🔑 Sign in</a>
   <a href="https://3dvr.tech/#subscribe" target="_blank">⭐ Subscribe</a>
   <a href="https://github.com/tmsteph/3dvr-portal" target="_blank">🚀 GitHub</a>
 </div>
@@ -612,7 +612,7 @@
 
       <div class="profile-signin-callout" id="profile-sign-in-callout">
         <p>You are using this browser as a guest. Sign in when you want sync, billing, and saved work across devices.</p>
-        <a class="profile-signin-link" href="sign-in.html?upgrade=guest&amp;redirect=%2Fprofile.html">Sign in or create account</a>
+        <a class="profile-signin-link" href="sign-in.html?redirect=%2Fprofile.html">Sign in or create account</a>
       </div>
 
       <form class="name-form" onsubmit="event.preventDefault(); saveUsername();">
@@ -1360,7 +1360,7 @@ function updateProfileSignInCallout() {
   if (!profileSignInCallout) return;
   profileSignInCallout.hidden = isSignedIn;
   profileAuthEntryLinks.forEach((link) => {
-    link.setAttribute('href', isSignedIn ? 'profile.html' : 'sign-in.html?upgrade=guest&redirect=%2Fprofile.html');
+    link.setAttribute('href', isSignedIn ? 'profile.html' : 'sign-in.html?redirect=%2Fprofile.html');
     link.textContent = isSignedIn ? '👤 Profile' : '🔑 Sign in';
   });
 }

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -102,10 +102,11 @@ describe('portal customer journey pages', () => {
     assert.match(html, /Start Your Thing/);
     assert.match(html, /Start Here: organize life, ideas, work, and what wants to grow\./);
     assert.match(html, /Search the dock/);
-    assert.match(html, /class="top-nav__sign-in" href="sign-in\.html\?upgrade=guest&amp;redirect=%2Findex\.html" data-auth-entry>Sign in<\/a>/);
-    assert.match(html, /href="sign-in\.html\?upgrade=guest&amp;redirect=%2Findex\.html" data-auth-entry>Sign in<\/a>/);
+    assert.match(html, /class="top-nav__sign-in" href="sign-in\.html\?redirect=%2Findex\.html" data-auth-entry>Sign in<\/a>/);
+    assert.match(html, /href="sign-in\.html\?redirect=%2Findex\.html" data-auth-entry>Sign in<\/a>/);
     assert.match(html, /function updatePortalAuthEntryLinks\(\)/);
     assert.match(html, /const label = signedIn \? 'Profile' : 'Sign in'/);
+    assert.doesNotMatch(html, /sign-in\.html\?upgrade=guest/);
     assert.match(html, /You are already in\./);
     assert.match(html, /The portal remembers this browser\./);
     assert.doesNotMatch(html, /Sign in to save your progress/);

--- a/tests/guest-upgrade-entrypoints.test.js
+++ b/tests/guest-upgrade-entrypoints.test.js
@@ -23,6 +23,7 @@ describe('guest account entrypoints', () => {
     assert.match(html, /authModal\.style\.display = 'none'/);
     assert.doesNotMatch(html, /authModal\.style\.display = 'flex'/);
     assert.doesNotMatch(html, /upgradeParam/);
+    assert.doesNotMatch(html, /sign-in\.html\?upgrade=guest/);
     assert.doesNotMatch(html, /&upgrade=guest/);
     assert.match(html, /\/sign-in\.html\?redirect=/);
   });

--- a/tests/profile-page.test.js
+++ b/tests/profile-page.test.js
@@ -35,7 +35,7 @@ test('profile section exposes a sign-out action that clears stored auth state', 
 test('profile page exposes clear sign-in paths for guest users', async () => {
   const html = await readFile(new URL('../profile.html', import.meta.url), 'utf8');
 
-  assert.match(html, /href="sign-in\.html\?upgrade=guest&amp;redirect=%2Fprofile\.html" data-profile-auth-entry>🔑 Sign in<\/a>/);
+  assert.match(html, /href="sign-in\.html\?redirect=%2Fprofile\.html" data-profile-auth-entry>🔑 Sign in<\/a>/);
   assert.match(html, /id="profile-sign-in-callout"/);
   assert.match(html, /You are using this browser as a guest/);
   assert.match(html, /Sign in or create account/);
@@ -44,4 +44,5 @@ test('profile page exposes clear sign-in paths for guest users', async () => {
   assert.match(html, /function updateProfileSignInCallout\(\)/);
   assert.match(html, /profileSignInCallout\.hidden = isSignedIn/);
   assert.match(html, /link\.textContent = isSignedIn \? '👤 Profile' : '🔑 Sign in'/);
+  assert.doesNotMatch(html, /sign-in\.html\?upgrade=guest/);
 });


### PR DESCRIPTION
## Summary
- remove the guest-upgrade flag from normal homepage and profile sign-in links
- keep redirect targets intact so users return to the page they came from
- update auth regression tests so normal sign-in cannot accidentally become guest-upgrade sign-in again

## Root cause
The visible Sign in links added for the guest-first portal were pointing at `sign-in.html?upgrade=guest...`. Since the portal automatically enters guest mode, regular users could land on the sign-in page with guest-upgrade copy instead of a normal sign-in flow.

## Validation
- `node --test tests/sign-in-page.test.js tests/guest-upgrade-entrypoints.test.js tests/customer-journey-pages.test.js tests/profile-page.test.js tests/auth-entrypoints.test.js`
- inline script syntax check for `index.html`, `profile.html`, and `sign-in.html`
- `git diff --check`
- browser-level live sign-in relay check against `https://portal.3dvr.tech/sign-in.html?redirect=%2Findex.html`
- repo Playwright smoke check passed