### PR TITLE
[codex] Fix portal auth restore race

### DIFF
--- a/index.html
+++ b/index.html
@@ -1462,6 +1462,37 @@
 
     countAutoIdentityVisit();
 
+    function isGunAuthInProgressError(message = '') {
+      return /already being created or authenticated/i.test(String(message || ''));
+    }
+
+    function clearStoredAuthSession() {
+      localStorage.removeItem('signedIn');
+      localStorage.removeItem('alias');
+      localStorage.removeItem('username');
+      localStorage.removeItem('password');
+    }
+
+    function restoreStoredGunSession(alias, password, attempt = 0) {
+      if (!user || user.is || !alias || !password || typeof user.auth !== 'function') {
+        return;
+      }
+
+      user.auth(alias, password, ack => {
+        if (!ack || !ack.err) {
+          return;
+        }
+
+        if (isGunAuthInProgressError(ack.err) && attempt < 8) {
+          setTimeout(() => restoreStoredGunSession(alias, password, attempt + 1), 500);
+          return;
+        }
+
+        console.warn('Session restore failed', ack.err);
+        clearStoredAuthSession();
+      });
+    }
+
     function restoreAuthIfPossible() {
       const signedIn = localStorage.getItem('signedIn') === 'true';
       const alias = localStorage.getItem('alias');
@@ -1469,21 +1500,9 @@
 
       if (signedIn && alias && password) {
         localStorage.removeItem('guest');
-        if (!user.is) {
-          user.auth(alias, password, ack => {
-            if (ack && ack.err) {
-              console.warn('Session restore failed', ack.err);
-              localStorage.removeItem('signedIn');
-              localStorage.removeItem('alias');
-              localStorage.removeItem('username');
-              localStorage.removeItem('password');
-            }
-          });
-        }
+        restoreStoredGunSession(alias, password);
       } else if (signedIn) {
-        localStorage.removeItem('signedIn');
-        localStorage.removeItem('alias');
-        localStorage.removeItem('password');
+        clearStoredAuthSession();
       }
     }
 

--- a/profile.html
+++ b/profile.html
@@ -926,6 +926,46 @@ function clearLocalAuthState() {
   ].forEach(key => localStorage.removeItem(key));
 }
 
+function isGunAuthInProgressError(message = '') {
+  return /already being created or authenticated/i.test(String(message || ''));
+}
+
+function restoreSignedInGunSession(alias, password, attempt = 0) {
+  return new Promise(resolve => {
+    if (!alias || !password || !user || typeof user.auth !== 'function') {
+      resolve(false);
+      return;
+    }
+
+    if (user.is) {
+      resolve(true);
+      return;
+    }
+
+    try {
+      user.auth(alias, password, ack => {
+        if (!ack || !ack.err) {
+          resolve(true);
+          return;
+        }
+
+        if (isGunAuthInProgressError(ack.err) && attempt < 8) {
+          setTimeout(() => {
+            restoreSignedInGunSession(alias, password, attempt + 1)
+              .then(resolve);
+          }, 500);
+          return;
+        }
+
+        resolve(false);
+      });
+    } catch (err) {
+      console.warn('Unexpected profile auth restore error', err);
+      resolve(false);
+    }
+  });
+}
+
 function handleProfileSignOut() {
   if (!isGuest) {
     try {
@@ -1702,13 +1742,10 @@ if (isSignedIn && signedInAlias && (signedInPassword || signedInAuthMethod === '
   } else if (user.is) {
     initializeSignedInProfile();
   } else {
-    user.auth(signedInAlias, signedInPassword, ack => {
-      if (ack && ack.err) {
+    restoreSignedInGunSession(signedInAlias, signedInPassword).then(restored => {
+      if (!restored) {
         alert('Session expired. Please sign in again.');
-        localStorage.removeItem('signedIn');
-        localStorage.removeItem('alias');
-        localStorage.removeItem('username');
-        localStorage.removeItem('password');
+        clearLocalAuthState();
         clearSharedIdentity();
         initializeGuestProfile();
       } else {

--- a/tests/customer-journey-pages.test.js
+++ b/tests/customer-journey-pages.test.js
@@ -106,6 +106,11 @@ describe('portal customer journey pages', () => {
     assert.match(html, /href="sign-in\.html\?redirect=%2Findex\.html" data-auth-entry>Sign in<\/a>/);
     assert.match(html, /function updatePortalAuthEntryLinks\(\)/);
     assert.match(html, /const label = signedIn \? 'Profile' : 'Sign in'/);
+    assert.match(html, /function isGunAuthInProgressError\(message = ''\)/);
+    assert.match(html, /function restoreStoredGunSession\(alias, password, attempt = 0\)/);
+    assert.match(html, /attempt < 8/);
+    assert.match(html, /setTimeout\(\(\) => restoreStoredGunSession\(alias, password, attempt \+ 1\), 500\)/);
+    assert.match(html, /clearStoredAuthSession\(\)/);
     assert.doesNotMatch(html, /sign-in\.html\?upgrade=guest/);
     assert.match(html, /You are already in\./);
     assert.match(html, /The portal remembers this browser\./);

--- a/tests/profile-page.test.js
+++ b/tests/profile-page.test.js
@@ -26,6 +26,11 @@ test('profile section exposes a sign-out action that clears stored auth state', 
   assert.match(html, /user\.leave\(\)/);
   assert.match(html, /PortalOAuth\.clearAuthSessionMarkers/);
   assert.match(html, /function clearLocalAuthState\(\)/);
+  assert.match(html, /function isGunAuthInProgressError\(message = ''\)/);
+  assert.match(html, /function restoreSignedInGunSession\(alias, password, attempt = 0\)/);
+  assert.match(html, /attempt < 8/);
+  assert.match(html, /restoreSignedInGunSession\(signedInAlias, signedInPassword\)\.then\(restored =>/);
+  assert.match(html, /clearLocalAuthState\(\);/);
   assert.match(html, /'signedIn'/);
   assert.match(html, /'authMethod'/);
   assert.match(html, /'verifiedEmail'/);


### PR DESCRIPTION
## Summary
- Retry portal/profile Gun session restore when Gun reports auth is already in progress.
- Keep Profile from clearing a valid just-signed-in session during the second login race.
- Add regression assertions for the auth restore retry helpers.

## Root Cause
After signing out and signing back in, Profile called `user.auth` while Gun recall/auth was still in progress. Gun returned `User is already being created or authenticated!`, and Profile treated that as an expired session, cleared local auth, and fell back to guest mode.

## Validation
- `node --test tests/profile-page.test.js tests/customer-journey-pages.test.js tests/guest-upgrade-entrypoints.test.js tests/sign-in-page.test.js`
- Inline script parse check for `index.html`, `profile.html`, `sign-in.html`
- `git diff --check`
- Manual Playwright Firefox loop against patched local site with live Gun: create account, open profile, sign out, sign back in, confirm Profile remains signed in.