### PR TITLE
[codex] Bust portal auth cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -3,10 +3,16 @@
 importScripts('/chat/notification-routing.js');
 
 // Increment this to bust old caches when you deploy
-const CACHE_VERSION = 'v17';
+const CACHE_VERSION = 'v18';
 const STATIC_CACHE = `3dvr-static-${CACHE_VERSION}`;
 const HTML_CACHE = `3dvr-html-${CACHE_VERSION}`;
 const chatNotificationRouting = self.ChatNotificationRouting || null;
+const AUTH_CRITICAL_HTML_PATHS = new Set([
+  '/',
+  '/index.html',
+  '/profile.html',
+  '/sign-in.html'
+]);
 
 // What to cache at install (add your CSS/JS/assets here). Keep HTML out of the
 // install cache so stale app shells cannot survive a deploy.
@@ -102,8 +108,18 @@ const shouldCacheHtmlResponse = (response) => {
   return contentType.includes('text/html');
 };
 
+const isAuthCriticalHtmlRequest = (request) => {
+  try {
+    const url = new URL(request.url);
+    return url.origin === self.location.origin && AUTH_CRITICAL_HTML_PATHS.has(url.pathname);
+  } catch (error) {
+    return false;
+  }
+};
+
 const cacheHtmlResponse = async (request, response) => {
   if (!shouldCacheHtmlResponse(response)) return;
+  if (isAuthCriticalHtmlRequest(request)) return;
 
   const responseForCache = response.clone();
   const responseForInspection = response.clone();
@@ -123,6 +139,7 @@ const getCachedHtmlFallback = async (request) => {
 };
 
 const networkFirstHtml = async (request) => {
+  const isAuthCritical = isAuthCriticalHtmlRequest(request);
   const fresh = await fetch(request, { cache: 'reload' });
   const contentType = fresh.headers.get('content-type') || '';
 
@@ -131,10 +148,13 @@ const networkFirstHtml = async (request) => {
     const text = await responseForInspection.text();
 
     if (SECURITY_CHECKPOINT_PATTERN.test(text)) {
+      if (isAuthCritical) {
+        return fresh;
+      }
       return getCachedHtmlFallback(request);
     }
 
-    if (fresh.ok) {
+    if (fresh.ok && !isAuthCritical) {
       const cache = await caches.open(HTML_CACHE);
       await cache.put(request, fresh.clone());
     }

--- a/tests/mobile-browser-resilience.test.js
+++ b/tests/mobile-browser-resilience.test.js
@@ -48,7 +48,12 @@ test('root service worker does not cache stale portal HTML or Vercel checkpoints
   const source = await readProjectFile('service-worker.js');
   const staticAssetsBlock = source.match(/const STATIC_ASSETS = \[[\s\S]*?\];/)?.[0] || '';
 
-  assert.match(source, /const CACHE_VERSION = 'v17';/);
+  assert.match(source, /const CACHE_VERSION = 'v18';/);
+  assert.match(source, /const AUTH_CRITICAL_HTML_PATHS = new Set\(\[/);
+  assert.match(source, /'\/index\.html'/);
+  assert.match(source, /'\/profile\.html'/);
+  assert.match(source, /'\/sign-in\.html'/);
+  assert.match(source, /const isAuthCriticalHtmlRequest = \(request\) =>/);
   assert.doesNotMatch(staticAssetsBlock, /'\/'/);
   assert.match(source, /SECURITY_CHECKPOINT_PATTERN/);
   assert.match(source, /Vercel Security Checkpoint/);
@@ -57,8 +62,11 @@ test('root service worker does not cache stale portal HTML or Vercel checkpoints
   assert.match(source, /705\|805/);
   assert.match(source, /networkFirstHtml/);
   assert.match(source, /SECURITY_CHECKPOINT_PATTERN\.test\(text\)/);
+  assert.match(source, /if \(isAuthCritical\) \{[\s\S]*?return fresh;[\s\S]*?\}/);
   assert.match(source, /return getCachedHtmlFallback\(request\)/);
   assert.match(source, /shouldCacheHtmlResponse/);
+  assert.match(source, /if \(isAuthCriticalHtmlRequest\(request\)\) return;/);
+  assert.match(source, /fresh\.ok && !isAuthCritical/);
   assert.match(source, /fetch\(request,\s*\{\s*cache:\s*'reload'\s*\}\)/);
   assert.match(source, /caches\.match\(request,\s*\{\s*ignoreSearch:\s*true\s*\}\)/);
   assert.match(source, /createOfflinePortalFallbackResponse/);


### PR DESCRIPTION
## Summary
- Bump the root service worker cache from `v17` to `v18` so installed browsers replace old portal caches.
- Treat `/`, `/index.html`, `/profile.html`, and `/sign-in.html` as auth-critical HTML that is never cached by the service worker.
- Avoid serving cached fallback HTML for those auth-critical pages when a Vercel checkpoint response is detected.

## Why
Normal Android Chrome can keep an installed service worker/cache while Incognito works with a clean browser state. The prior auth fix was live, but a stale installed browser could still be served old Profile/Sign-in HTML from the worker cache.

## Validation
- `node --test tests/mobile-browser-resilience.test.js tests/profile-page.test.js tests/customer-journey-pages.test.js tests/sign-in-page.test.js`
- Script parse check for `service-worker.js`, `pwa-install.js`, `index.html`, `profile.html`
- `git diff --check`