### PR TITLE
[codex] Self-heal portal auth cache

### DIFF
--- a/auth-identity.js
+++ b/auth-identity.js
@@ -1,6 +1,10 @@
 (function initAuthIdentity(global) {
   const SHARED_COOKIE_NAME = 'portalIdentity';
   const SHARED_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
+  const AUTH_CACHE_RECOVERY_VERSION = '2026-06-30-auth-cache-v1';
+  const AUTH_CACHE_RECOVERY_KEY = '3dvr-auth-cache-recovery-version';
+  const AUTH_CACHE_RECOVERY_RELOAD_KEY = `3dvr-auth-cache-recovery-reload:${AUTH_CACHE_RECOVERY_VERSION}`;
+  const AUTH_CRITICAL_PATHS = new Set(['/', '/index.html', '/profile.html', '/sign-in.html']);
 
   function normalizeText(value) {
     return typeof value === 'string' ? value.trim() : '';
@@ -19,6 +23,123 @@
       return '.3dvr.tech';
     }
     return '';
+  }
+
+  function isAuthCriticalPath(locationObj = global.location) {
+    const pathname = locationObj && typeof locationObj.pathname === 'string'
+      ? locationObj.pathname
+      : '';
+    return AUTH_CRITICAL_PATHS.has(pathname || '/');
+  }
+
+  function shouldRunAuthCacheRecovery(storage = global.localStorage) {
+    try {
+      return !storage || storage.getItem(AUTH_CACHE_RECOVERY_KEY) !== AUTH_CACHE_RECOVERY_VERSION;
+    } catch (_err) {
+      return true;
+    }
+  }
+
+  function markAuthCacheRecovery(storage = global.localStorage) {
+    if (!storage || typeof storage.setItem !== 'function') return;
+    try {
+      storage.setItem(AUTH_CACHE_RECOVERY_KEY, AUTH_CACHE_RECOVERY_VERSION);
+    } catch (_err) {
+      // Ignore storage failures; cache recovery is best-effort.
+    }
+  }
+
+  function clearPortalShellCaches(cacheApi = global.caches) {
+    if (!cacheApi || typeof cacheApi.keys !== 'function' || typeof cacheApi.delete !== 'function') {
+      return Promise.resolve(false);
+    }
+
+    return cacheApi.keys()
+      .then(keys => Promise.all(
+        keys
+          .filter(key => /^3dvr-(html|static)-/.test(String(key || '')))
+          .map(key => cacheApi.delete(key))
+      ))
+      .then(results => results.some(Boolean));
+  }
+
+  function requestWaitingActivation(registration) {
+    if (!registration || !registration.waiting || typeof registration.waiting.postMessage !== 'function') {
+      return false;
+    }
+    registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+    return true;
+  }
+
+  function updateRootServiceWorker(navigatorObj = global.navigator) {
+    if (
+      !navigatorObj
+      || !navigatorObj.serviceWorker
+      || typeof navigatorObj.serviceWorker.getRegistration !== 'function'
+    ) {
+      return Promise.resolve(false);
+    }
+
+    return navigatorObj.serviceWorker.getRegistration('/')
+      .then(registration => {
+        if (!registration) return false;
+        const updatePromise = typeof registration.update === 'function'
+          ? registration.update().catch(() => registration)
+          : Promise.resolve(registration);
+        return updatePromise.then(nextRegistration => {
+          requestWaitingActivation(nextRegistration || registration);
+          return true;
+        });
+      });
+  }
+
+  function reloadAuthCriticalPageOnce({
+    locationObj = global.location,
+    sessionStorageObj = global.sessionStorage,
+  } = {}) {
+    if (!isAuthCriticalPath(locationObj) || !locationObj || typeof locationObj.reload !== 'function') {
+      return false;
+    }
+
+    try {
+      if (
+        sessionStorageObj
+        && typeof sessionStorageObj.getItem === 'function'
+        && sessionStorageObj.getItem(AUTH_CACHE_RECOVERY_RELOAD_KEY) === 'true'
+      ) {
+        return false;
+      }
+      if (sessionStorageObj && typeof sessionStorageObj.setItem === 'function') {
+        sessionStorageObj.setItem(AUTH_CACHE_RECOVERY_RELOAD_KEY, 'true');
+      }
+    } catch (_err) {
+      // Reload anyway if sessionStorage is unavailable.
+    }
+
+    locationObj.reload();
+    return true;
+  }
+
+  function refreshPortalAuthCache({
+    storage = global.localStorage,
+    reload = false,
+  } = {}) {
+    if (!shouldRunAuthCacheRecovery(storage)) {
+      return Promise.resolve(false);
+    }
+
+    return Promise.all([
+      clearPortalShellCaches(),
+      updateRootServiceWorker(),
+    ])
+      .then(results => {
+        markAuthCacheRecovery(storage);
+        if (reload) {
+          reloadAuthCriticalPageOnce();
+        }
+        return results.some(Boolean);
+      })
+      .catch(() => false);
   }
 
   function sanitizeIdentityPayload(payload = {}) {
@@ -176,6 +297,9 @@
     writeSharedIdentity,
     clearSharedIdentity,
     syncStorageFromSharedIdentity,
+    refreshPortalAuthCache,
     resolveSharedCookieDomain,
   };
+
+  refreshPortalAuthCache({ reload: true });
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/pwa-install.js
+++ b/pwa-install.js
@@ -10,6 +10,10 @@
   const scopeHref = new URL(scopePath, window.location.origin).href;
   const reloadGuardKey = `3dvr-service-worker-reload:${scopePath}`;
   const reloadCooldownMs = 30000;
+  const authCacheRecoveryVersion = '2026-06-30-auth-cache-v1';
+  const authCacheRecoveryKey = '3dvr-auth-cache-recovery-version';
+  const authCacheRecoveryReloadKey = `3dvr-auth-cache-recovery-reload:${authCacheRecoveryVersion}`;
+  const authCriticalPaths = new Set(['/', '/index.html', '/profile.html', '/sign-in.html']);
   let restoredFromPageCache = false;
 
   window.addEventListener('pageshow', (event) => {
@@ -70,6 +74,89 @@
     return true;
   };
 
+  const isAuthCriticalPath = () => {
+    const pathname = window.location.pathname || '/';
+    return authCriticalPaths.has(pathname);
+  };
+
+  const shouldRunAuthCacheRecovery = () => {
+    try {
+      return localStorage.getItem(authCacheRecoveryKey) !== authCacheRecoveryVersion;
+    } catch (error) {
+      return true;
+    }
+  };
+
+  const markAuthCacheRecovery = () => {
+    try {
+      localStorage.setItem(authCacheRecoveryKey, authCacheRecoveryVersion);
+    } catch (error) {
+      console.warn('Unable to mark auth cache recovery', error);
+    }
+  };
+
+  const clearPortalShellCaches = async () => {
+    if (!window.caches || typeof window.caches.keys !== 'function') {
+      return false;
+    }
+
+    const keys = await window.caches.keys();
+    const portalCacheKeys = keys.filter((key) => /^3dvr-(html|static)-/.test(key));
+    const results = await Promise.all(portalCacheKeys.map((key) => window.caches.delete(key)));
+    return results.some(Boolean);
+  };
+
+  const updateRootServiceWorker = async () => {
+    if (!navigator.serviceWorker || typeof navigator.serviceWorker.getRegistration !== 'function') {
+      return false;
+    }
+
+    const registration = await navigator.serviceWorker.getRegistration('/');
+    if (!registration) {
+      return false;
+    }
+
+    if (typeof registration.update === 'function') {
+      await registration.update();
+    }
+    requestWaitingActivation(registration);
+    return true;
+  };
+
+  const maybeReloadAfterAuthCacheRecovery = () => {
+    if (!isAuthCriticalPath()) {
+      return;
+    }
+
+    try {
+      if (sessionStorage.getItem(authCacheRecoveryReloadKey) === 'true') {
+        return;
+      }
+      sessionStorage.setItem(authCacheRecoveryReloadKey, 'true');
+    } catch (error) {
+      console.warn('Unable to guard auth cache recovery reload', error);
+    }
+
+    window.location.reload();
+  };
+
+  const recoverPortalAuthCache = async () => {
+    if (!shouldRunAuthCacheRecovery()) {
+      return;
+    }
+
+    try {
+      await Promise.all([
+        clearPortalShellCaches(),
+        updateRootServiceWorker(),
+      ]);
+      markAuthCacheRecovery();
+      maybeReloadAfterAuthCacheRecovery();
+    } catch (error) {
+      console.warn('Portal auth cache recovery skipped', error);
+    }
+  };
+
   const wireServiceWorkerUpdates = (registration) => {
     if (!registration) return;
 
@@ -120,6 +207,7 @@
     }
   };
 
+  recoverPortalAuthCache();
   registerServiceWorker();
 
   const installBanner = document.querySelector('[data-install-banner]');

--- a/tests/auth-identity.test.js
+++ b/tests/auth-identity.test.js
@@ -51,14 +51,25 @@ function createStorage() {
   };
 }
 
-function loadAuthIdentity({ hostname = 'portal.3dvr.tech', documentObj, localStorage } = {}) {
+function loadAuthIdentity({
+  hostname = 'portal.3dvr.tech',
+  documentObj,
+  localStorage,
+  sessionStorage,
+  locationObj,
+  caches,
+  navigator,
+} = {}) {
   const documentRef = documentObj || createCookieDocument();
   const storageRef = localStorage || createStorage();
   const sandbox = {
     window: {
       document: documentRef,
-      location: { hostname },
+      location: locationObj || { hostname },
       localStorage: storageRef,
+      sessionStorage: sessionStorage || createStorage(),
+      caches,
+      navigator,
     },
   };
   vm.runInNewContext(authIdentitySource, sandbox, { filename: 'auth-identity.js' });
@@ -66,6 +77,21 @@ function loadAuthIdentity({ hostname = 'portal.3dvr.tech', documentObj, localSto
     api: sandbox.window.AuthIdentity,
     document: documentRef,
     localStorage: storageRef,
+  };
+}
+
+function createCacheApi(keys = []) {
+  const cacheKeys = new Set(keys);
+  const deleted = [];
+  return {
+    deleted,
+    async keys() {
+      return Array.from(cacheKeys);
+    },
+    async delete(key) {
+      deleted.push(key);
+      return cacheKeys.delete(key);
+    },
   };
 }
 
@@ -183,5 +209,73 @@ describe('auth identity helper', () => {
     const cleared = api.clearSharedIdentity();
     assert.equal(cleared, true);
     assert.equal(api.readSharedIdentity(), null);
+  });
+
+  it('refreshes stale portal auth caches without clearing identity storage', async () => {
+    const localStorage = createStorage();
+    const sessionStorage = createStorage();
+    const cacheApi = createCacheApi([
+      '3dvr-html-v17',
+      '3dvr-static-v17',
+      'contacts-static-v4',
+      'calendar-html-v2',
+    ]);
+    const waitingMessages = [];
+    let updateCalled = false;
+    let registrationScope = '';
+    let reloadCount = 0;
+    const registration = {
+      waiting: {
+        postMessage(message) {
+          waitingMessages.push(message);
+        },
+      },
+      async update() {
+        updateCalled = true;
+        return registration;
+      },
+    };
+
+    localStorage.setItem('signedIn', 'true');
+    localStorage.setItem('alias', 'pilot@3dvr');
+    localStorage.setItem('username', 'Pilot');
+    localStorage.setItem('password', 'secret');
+    localStorage.setItem('3dvr-auth-cache-recovery-version', '2026-06-30-auth-cache-v1');
+
+    const { api } = loadAuthIdentity({
+      localStorage,
+      sessionStorage,
+      caches: cacheApi,
+      navigator: {
+        serviceWorker: {
+          async getRegistration(scope) {
+            registrationScope = scope;
+            return registration;
+          },
+        },
+      },
+      locationObj: {
+        hostname: 'portal.3dvr.tech',
+        pathname: '/profile.html',
+        reload() {
+          reloadCount += 1;
+        },
+      },
+    });
+
+    localStorage.removeItem('3dvr-auth-cache-recovery-version');
+    const changed = await api.refreshPortalAuthCache({ storage: localStorage, reload: true });
+
+    assert.equal(changed, true);
+    assert.deepEqual(cacheApi.deleted.sort(), ['3dvr-html-v17', '3dvr-static-v17']);
+    assert.equal(updateCalled, true);
+    assert.equal(registrationScope, '/');
+    assert.equal(waitingMessages.length, 1);
+    assert.equal(waitingMessages[0].type, 'SKIP_WAITING');
+    assert.equal(reloadCount, 1);
+    assert.equal(localStorage.getItem('3dvr-auth-cache-recovery-version'), '2026-06-30-auth-cache-v1');
+    assert.equal(localStorage.getItem('signedIn'), 'true');
+    assert.equal(localStorage.getItem('alias'), 'pilot@3dvr');
+    assert.equal(localStorage.getItem('password'), 'secret');
   });
 });

--- a/tests/mobile-browser-resilience.test.js
+++ b/tests/mobile-browser-resilience.test.js
@@ -77,6 +77,12 @@ test('root PWA installer prevents controllerchange reload loops', async () => {
 
   assert.match(source, /reloadGuardKey/);
   assert.match(source, /reloadCooldownMs = 30000/);
+  assert.match(source, /authCacheRecoveryVersion = '2026-06-30-auth-cache-v1'/);
+  assert.match(source, /authCriticalPaths = new Set\(\['\/', '\/index\.html', '\/profile\.html', '\/sign-in\.html'\]\)/);
+  assert.match(source, /const clearPortalShellCaches = async \(\) =>/);
+  assert.match(source, /\^3dvr-\(html\|static\)-/);
+  assert.match(source, /updateRootServiceWorker/);
+  assert.match(source, /recoverPortalAuthCache\(\)/);
   assert.match(source, /window\.addEventListener\('pageshow'/);
   assert.match(source, /event\.persisted/);
   assert.match(source, /sessionStorage\.getItem\(reloadGuardKey\)/);


### PR DESCRIPTION
## Summary
- Add a self-healing portal cache repair to `pwa-install.js` so the portal home can clear stale root shell caches and update the service worker without users closing tabs or clearing site data.
- Add the same repair path to `auth-identity.js`, which stale `profile.html` and `sign-in.html` pages already load, so old cached auth pages can recover themselves.
- The repair deletes only Cache Storage entries named like `3dvr-html-*` and `3dvr-static-*`, asks the root worker to update/skip waiting, and reloads auth-critical pages once.

## Why
Incognito works because it has clean Cache Storage and no old service worker. Normal Android Chrome can keep old controlled tabs and stale cached auth HTML. Users should not have to clear all site data or close every tab.

## Validation
- `node --test tests/auth-identity.test.js tests/mobile-browser-resilience.test.js tests/profile-page.test.js tests/sign-in-page.test.js tests/customer-journey-pages.test.js`
- Script parse check for `auth-identity.js`, `pwa-install.js`, `service-worker.js`, `index.html`, `profile.html`, `sign-in.html`
- `git diff --check`