### PR TITLE
[codex] Aggressively reset portal auth cache

### DIFF
--- a/auth-identity.js
+++ b/auth-identity.js
@@ -1,7 +1,7 @@
 (function initAuthIdentity(global) {
   const SHARED_COOKIE_NAME = 'portalIdentity';
   const SHARED_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
-  const AUTH_CACHE_RECOVERY_VERSION = '2026-06-30-auth-cache-v1';
+  const AUTH_CACHE_RECOVERY_VERSION = '2026-06-30-auth-cache-v2';
   const AUTH_CACHE_RECOVERY_KEY = '3dvr-auth-cache-recovery-version';
   const AUTH_CACHE_RECOVERY_RELOAD_KEY = `3dvr-auth-cache-recovery-reload:${AUTH_CACHE_RECOVERY_VERSION}`;
   const AUTH_CRITICAL_PATHS = new Set(['/', '/index.html', '/profile.html', '/sign-in.html']);
@@ -49,16 +49,14 @@
     }
   }
 
-  function clearPortalShellCaches(cacheApi = global.caches) {
+  function clearPortalOriginCaches(cacheApi = global.caches) {
     if (!cacheApi || typeof cacheApi.keys !== 'function' || typeof cacheApi.delete !== 'function') {
       return Promise.resolve(false);
     }
 
     return cacheApi.keys()
       .then(keys => Promise.all(
-        keys
-          .filter(key => /^3dvr-(html|static)-/.test(String(key || '')))
-          .map(key => cacheApi.delete(key))
+        keys.map(key => cacheApi.delete(key))
       ))
       .then(results => results.some(Boolean));
   }
@@ -71,26 +69,42 @@
     return true;
   }
 
-  function updateRootServiceWorker(navigatorObj = global.navigator) {
+  function isSameOriginServiceWorkerScope(scope = '', currentOrigin = '') {
+    if (!currentOrigin) return true;
+    const normalizedScope = String(scope || '');
+    const UrlConstructor = global && typeof global.URL === 'function' ? global.URL : null;
+    if (UrlConstructor) {
+      try {
+        return new UrlConstructor(normalizedScope).origin === currentOrigin;
+      } catch (_err) {
+        // Fall back to a prefix check for test environments without a browser URL implementation.
+      }
+    }
+    return normalizedScope === currentOrigin || normalizedScope.startsWith(`${currentOrigin}/`);
+  }
+
+  function unregisterPortalServiceWorkers(navigatorObj = global.navigator, locationObj = global.location) {
     if (
       !navigatorObj
       || !navigatorObj.serviceWorker
-      || typeof navigatorObj.serviceWorker.getRegistration !== 'function'
+      || typeof navigatorObj.serviceWorker.getRegistrations !== 'function'
     ) {
       return Promise.resolve(false);
     }
 
-    return navigatorObj.serviceWorker.getRegistration('/')
-      .then(registration => {
-        if (!registration) return false;
-        const updatePromise = typeof registration.update === 'function'
-          ? registration.update().catch(() => registration)
-          : Promise.resolve(registration);
-        return updatePromise.then(nextRegistration => {
-          requestWaitingActivation(nextRegistration || registration);
-          return true;
-        });
-      });
+    const currentOrigin = locationObj && locationObj.origin ? locationObj.origin : '';
+    return navigatorObj.serviceWorker.getRegistrations()
+      .then(registrations => Promise.all(
+        registrations
+          .filter(registration => isSameOriginServiceWorkerScope(registration && registration.scope, currentOrigin))
+          .map(registration => {
+            requestWaitingActivation(registration);
+            return typeof registration.unregister === 'function'
+              ? registration.unregister()
+              : Promise.resolve(false);
+          })
+      ))
+      .then(results => results.some(Boolean));
   }
 
   function reloadAuthCriticalPageOnce({
@@ -129,8 +143,8 @@
     }
 
     return Promise.all([
-      clearPortalShellCaches(),
-      updateRootServiceWorker(),
+      clearPortalOriginCaches(),
+      unregisterPortalServiceWorkers(),
     ])
       .then(results => {
         markAuthCacheRecovery(storage);

--- a/cache-reset.html
+++ b/cache-reset.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Cache-Control" content="no-store">
+  <title>Reset 3DVR Portal Cache</title>
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100dvh;
+      display: grid;
+      place-items: center;
+      background: #0d1117;
+      color: #e6edf3;
+      font-family: Arial, Helvetica, sans-serif;
+      line-height: 1.5;
+      padding: 24px;
+    }
+    main {
+      width: min(100%, 460px);
+      border: 1px solid #30363d;
+      border-radius: 12px;
+      background: #161b22;
+      padding: 24px;
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 1.35rem;
+    }
+    p {
+      margin: 0 0 14px;
+      color: #9ba3b4;
+    }
+    a {
+      color: #8cc8ff;
+      font-weight: 700;
+    }
+    .status {
+      min-height: 1.5em;
+      color: #b8f1c5;
+      font-weight: 700;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Refreshing Portal</h1>
+    <p>This clears cached portal files and service workers only. Saved app data and sign-in data stay in this browser.</p>
+    <p class="status" id="status">Starting reset...</p>
+    <p><a href="/">Return to portal</a></p>
+  </main>
+  <script>
+    (async () => {
+      const status = document.getElementById('status');
+      const recoveryVersion = '2026-06-30-auth-cache-v2';
+      const setStatus = (message) => {
+        if (status) status.textContent = message;
+      };
+
+      try {
+        setStatus('Clearing cached portal files...');
+        if (window.caches && typeof window.caches.keys === 'function') {
+          const keys = await window.caches.keys();
+          await Promise.all(keys.map((key) => window.caches.delete(key)));
+        }
+
+        setStatus('Removing old portal service workers...');
+        if (navigator.serviceWorker && typeof navigator.serviceWorker.getRegistrations === 'function') {
+          const registrations = await navigator.serviceWorker.getRegistrations();
+          await Promise.all(registrations.map((registration) => registration.unregister()));
+        }
+
+        try {
+          localStorage.setItem('3dvr-auth-cache-recovery-version', recoveryVersion);
+        } catch (error) {
+          console.warn('Could not store portal cache reset marker', error);
+        }
+
+        setStatus('Opening a fresh portal...');
+        const nextUrl = `/?portalCacheReset=${encodeURIComponent(recoveryVersion)}&t=${Date.now()}`;
+        window.setTimeout(() => {
+          window.location.replace(nextUrl);
+        }, 400);
+      } catch (error) {
+        console.error('Portal cache reset failed', error);
+        setStatus('Reset hit a browser error. Use the link below to return.');
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/pwa-install.js
+++ b/pwa-install.js
@@ -10,7 +10,7 @@
   const scopeHref = new URL(scopePath, window.location.origin).href;
   const reloadGuardKey = `3dvr-service-worker-reload:${scopePath}`;
   const reloadCooldownMs = 30000;
-  const authCacheRecoveryVersion = '2026-06-30-auth-cache-v1';
+  const authCacheRecoveryVersion = '2026-06-30-auth-cache-v2';
   const authCacheRecoveryKey = '3dvr-auth-cache-recovery-version';
   const authCacheRecoveryReloadKey = `3dvr-auth-cache-recovery-reload:${authCacheRecoveryVersion}`;
   const authCriticalPaths = new Set(['/', '/index.html', '/profile.html', '/sign-in.html']);
@@ -95,32 +95,31 @@
     }
   };
 
-  const clearPortalShellCaches = async () => {
+  const clearPortalOriginCaches = async () => {
     if (!window.caches || typeof window.caches.keys !== 'function') {
       return false;
     }
 
     const keys = await window.caches.keys();
-    const portalCacheKeys = keys.filter((key) => /^3dvr-(html|static)-/.test(key));
-    const results = await Promise.all(portalCacheKeys.map((key) => window.caches.delete(key)));
+    const results = await Promise.all(keys.map((key) => window.caches.delete(key)));
     return results.some(Boolean);
   };
 
-  const updateRootServiceWorker = async () => {
-    if (!navigator.serviceWorker || typeof navigator.serviceWorker.getRegistration !== 'function') {
+  const unregisterPortalServiceWorkers = async () => {
+    if (!navigator.serviceWorker || typeof navigator.serviceWorker.getRegistrations !== 'function') {
       return false;
     }
 
-    const registration = await navigator.serviceWorker.getRegistration('/');
-    if (!registration) {
-      return false;
-    }
-
-    if (typeof registration.update === 'function') {
-      await registration.update();
-    }
-    requestWaitingActivation(registration);
-    return true;
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    const sameOriginRegistrations = registrations.filter((registration) => {
+      try {
+        return new URL(registration.scope).origin === window.location.origin;
+      } catch (error) {
+        return false;
+      }
+    });
+    const results = await Promise.all(sameOriginRegistrations.map((registration) => registration.unregister()));
+    return results.some(Boolean);
   };
 
   const maybeReloadAfterAuthCacheRecovery = () => {
@@ -147,8 +146,8 @@
 
     try {
       await Promise.all([
-        clearPortalShellCaches(),
-        updateRootServiceWorker(),
+        clearPortalOriginCaches(),
+        unregisterPortalServiceWorkers(),
       ]);
       markAuthCacheRecovery();
       maybeReloadAfterAuthCacheRecovery();
@@ -207,8 +206,9 @@
     }
   };
 
-  recoverPortalAuthCache();
-  registerServiceWorker();
+  recoverPortalAuthCache().finally(() => {
+    registerServiceWorker();
+  });
 
   const installBanner = document.querySelector('[data-install-banner]');
   const installButton = installBanner?.querySelector('[data-install-button]');

--- a/tests/auth-identity.test.js
+++ b/tests/auth-identity.test.js
@@ -221,18 +221,18 @@ describe('auth identity helper', () => {
       'calendar-html-v2',
     ]);
     const waitingMessages = [];
-    let updateCalled = false;
-    let registrationScope = '';
+    let unregisterCount = 0;
     let reloadCount = 0;
     const registration = {
+      scope: 'https://portal.3dvr.tech/',
       waiting: {
         postMessage(message) {
           waitingMessages.push(message);
         },
       },
-      async update() {
-        updateCalled = true;
-        return registration;
+      async unregister() {
+        unregisterCount += 1;
+        return true;
       },
     };
 
@@ -240,7 +240,7 @@ describe('auth identity helper', () => {
     localStorage.setItem('alias', 'pilot@3dvr');
     localStorage.setItem('username', 'Pilot');
     localStorage.setItem('password', 'secret');
-    localStorage.setItem('3dvr-auth-cache-recovery-version', '2026-06-30-auth-cache-v1');
+    localStorage.setItem('3dvr-auth-cache-recovery-version', '2026-06-30-auth-cache-v2');
 
     const { api } = loadAuthIdentity({
       localStorage,
@@ -248,14 +248,22 @@ describe('auth identity helper', () => {
       caches: cacheApi,
       navigator: {
         serviceWorker: {
-          async getRegistration(scope) {
-            registrationScope = scope;
-            return registration;
+          async getRegistrations() {
+            return [
+              registration,
+              {
+                scope: 'https://other.example/',
+                async unregister() {
+                  throw new Error('wrong registration');
+                },
+              },
+            ];
           },
         },
       },
       locationObj: {
         hostname: 'portal.3dvr.tech',
+        origin: 'https://portal.3dvr.tech',
         pathname: '/profile.html',
         reload() {
           reloadCount += 1;
@@ -267,13 +275,17 @@ describe('auth identity helper', () => {
     const changed = await api.refreshPortalAuthCache({ storage: localStorage, reload: true });
 
     assert.equal(changed, true);
-    assert.deepEqual(cacheApi.deleted.sort(), ['3dvr-html-v17', '3dvr-static-v17']);
-    assert.equal(updateCalled, true);
-    assert.equal(registrationScope, '/');
+    assert.deepEqual(cacheApi.deleted.sort(), [
+      '3dvr-html-v17',
+      '3dvr-static-v17',
+      'calendar-html-v2',
+      'contacts-static-v4',
+    ]);
+    assert.equal(unregisterCount, 1);
     assert.equal(waitingMessages.length, 1);
     assert.equal(waitingMessages[0].type, 'SKIP_WAITING');
     assert.equal(reloadCount, 1);
-    assert.equal(localStorage.getItem('3dvr-auth-cache-recovery-version'), '2026-06-30-auth-cache-v1');
+    assert.equal(localStorage.getItem('3dvr-auth-cache-recovery-version'), '2026-06-30-auth-cache-v2');
     assert.equal(localStorage.getItem('signedIn'), 'true');
     assert.equal(localStorage.getItem('alias'), 'pilot@3dvr');
     assert.equal(localStorage.getItem('password'), 'secret');

--- a/tests/mobile-browser-resilience.test.js
+++ b/tests/mobile-browser-resilience.test.js
@@ -17,15 +17,18 @@ test('portal root and unversioned styles/scripts revalidate on mobile browsers',
 
   const rootRule = rules.find((rule) => rule.source === '/');
   const indexRule = rules.find((rule) => rule.source === '/index.html');
+  const cacheResetRule = rules.find((rule) => rule.source === '/cache-reset.html');
   const codeAssetRule = rules.find((rule) => rule.source === '/(.*)\\.(css|js)');
   const mediaAssetRule = rules.find((rule) => rule.source === '/(.*)\\.(png|jpg|jpeg|gif|svg|webp|woff2?)');
 
   assert.ok(rootRule);
   assert.ok(indexRule);
+  assert.ok(cacheResetRule);
   assert.ok(codeAssetRule);
   assert.ok(mediaAssetRule);
   assert.equal(findHeaderValue(rootRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
   assert.equal(findHeaderValue(indexRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
+  assert.equal(findHeaderValue(cacheResetRule.headers, 'Cache-Control'), 'no-store');
   assert.equal(findHeaderValue(codeAssetRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
   assert.equal(findHeaderValue(mediaAssetRule.headers, 'Cache-Control'), 'public, max-age=31536000, immutable');
 });
@@ -77,11 +80,14 @@ test('root PWA installer prevents controllerchange reload loops', async () => {
 
   assert.match(source, /reloadGuardKey/);
   assert.match(source, /reloadCooldownMs = 30000/);
-  assert.match(source, /authCacheRecoveryVersion = '2026-06-30-auth-cache-v1'/);
+  assert.match(source, /authCacheRecoveryVersion = '2026-06-30-auth-cache-v2'/);
   assert.match(source, /authCriticalPaths = new Set\(\['\/', '\/index\.html', '\/profile\.html', '\/sign-in\.html'\]\)/);
-  assert.match(source, /const clearPortalShellCaches = async \(\) =>/);
-  assert.match(source, /\^3dvr-\(html\|static\)-/);
-  assert.match(source, /updateRootServiceWorker/);
+  assert.match(source, /const clearPortalOriginCaches = async \(\) =>/);
+  assert.match(source, /window\.caches\.keys\(\)/);
+  assert.match(source, /keys\.map\(\(key\) => window\.caches\.delete\(key\)\)/);
+  assert.match(source, /unregisterPortalServiceWorkers/);
+  assert.match(source, /navigator\.serviceWorker\.getRegistrations\(\)/);
+  assert.match(source, /registration\.unregister\(\)/);
   assert.match(source, /recoverPortalAuthCache\(\)/);
   assert.match(source, /window\.addEventListener\('pageshow'/);
   assert.match(source, /event\.persisted/);
@@ -89,4 +95,21 @@ test('root PWA installer prevents controllerchange reload loops', async () => {
   assert.match(source, /document\.visibilityState === 'hidden'/);
   assert.match(source, /shouldReloadForControllerChange\(\)/);
   assert.match(source, /window\.location\.reload\(\)/);
+});
+
+test('cache reset page aggressively clears only browser cache infrastructure', async () => {
+  const html = await readProjectFile('cache-reset.html');
+
+  assert.match(html, /Reset 3DVR Portal Cache/);
+  assert.match(html, /Saved app data and sign-in data stay in this browser/);
+  assert.match(html, /window\.caches\.keys\(\)/);
+  assert.match(html, /window\.caches\.delete\(key\)/);
+  assert.match(html, /navigator\.serviceWorker\.getRegistrations\(\)/);
+  assert.match(html, /registration\.unregister\(\)/);
+  assert.match(html, /3dvr-auth-cache-recovery-version/);
+  assert.match(html, /2026-06-30-auth-cache-v2/);
+  assert.match(html, /window\.location\.replace\(nextUrl\)/);
+  assert.doesNotMatch(html, /localStorage\.clear\(\)/);
+  assert.doesNotMatch(html, /indexedDB\.deleteDatabase/);
+  assert.doesNotMatch(html, /document\.cookie\s*=/);
 });

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,15 @@
       ]
     },
     {
+      "source": "/cache-reset.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    },
+    {
       "source": "/(.*)\\.(css|js)",
       "headers": [
         {


### PR DESCRIPTION
## What changed

This escalates the portal auth cache recovery for browsers that stayed stuck after the v18 service worker and first self-heal pass.

- Bumps the portal auth cache recovery marker to `2026-06-30-auth-cache-v2`.
- Clears all Cache Storage entries for the portal origin instead of only `3dvr-html-*` and `3dvr-static-*` entries.
- Unregisters same-origin service workers before re-registering the root worker.
- Adds `/cache-reset.html`, a no-store standalone repair page that clears Cache Storage and service workers without touching localStorage, cookies, or IndexedDB.
- Extends regression coverage for the aggressive reset behavior and the no-store reset page.

## Why

A normal Android Chrome session can keep stale service worker/cache state even when incognito sees the fixed auth flow. Users should not need to clear all browser data or close many tabs. This gives the portal a stronger self-repair path while preserving saved app/sign-in data.

## Validation

- `node --test tests/auth-identity.test.js tests/mobile-browser-resilience.test.js tests/profile-page.test.js tests/sign-in-page.test.js tests/customer-journey-pages.test.js`
- Inline script syntax check for `auth-identity.js`, `pwa-install.js`, `service-worker.js`, `cache-reset.html`, `index.html`, `profile.html`, and `sign-in.html`
- `git diff --check`