### PR TITLE
[codex] Add native cache clear header to reset page

### DIFF
--- a/tests/mobile-browser-resilience.test.js
+++ b/tests/mobile-browser-resilience.test.js
@@ -29,6 +29,7 @@ test('portal root and unversioned styles/scripts revalidate on mobile browsers',
   assert.equal(findHeaderValue(rootRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
   assert.equal(findHeaderValue(indexRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
   assert.equal(findHeaderValue(cacheResetRule.headers, 'Cache-Control'), 'no-store');
+  assert.equal(findHeaderValue(cacheResetRule.headers, 'Clear-Site-Data'), '"cache"');
   assert.equal(findHeaderValue(codeAssetRule.headers, 'Cache-Control'), 'public, max-age=0, must-revalidate');
   assert.equal(findHeaderValue(mediaAssetRule.headers, 'Cache-Control'), 'public, max-age=31536000, immutable');
 });

--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,10 @@
         {
           "key": "Cache-Control",
           "value": "no-store"
+        },
+        {
+          "key": "Clear-Site-Data",
+          "value": "\"cache\""
         }
       ]
     },


### PR DESCRIPTION
## What changed

Adds `Clear-Site-Data: "cache"` to `/cache-reset.html` while keeping `Cache-Control: no-store`.

## Why

The reset page already clears Cache Storage and unregisters portal service workers with JavaScript. This adds Chrome's native cache-clearing response header for the same special repair URL, which can clear the browser cache layer without touching cookies, localStorage, or IndexedDB.

## Validation

- `node --test tests/mobile-browser-resilience.test.js tests/auth-identity.test.js`
- Inline syntax/JSON check for `cache-reset.html`, `auth-identity.js`, `pwa-install.js`, and `vercel.json`
- `git diff --check`