### PR TITLE
[codex] Harden stale portal identity cookies

### DIFF
--- a/auth-identity.js
+++ b/auth-identity.js
@@ -251,13 +251,26 @@
     const nextUsername = identity.username || aliasToDisplay(nextAlias) || 'User';
     const nextVerifiedEmail = normalizeText(identity.verifiedEmail).toLowerCase();
     const hasStoredPassword = normalizeText(storage.getItem('password')).length > 0;
-    const nextSignedIn = hasStoredPassword || identity.authMethod === 'oauth' || identity.authMethod === 'sea';
     const currentSignedIn = storage.getItem('signedIn') === 'true';
     const currentAlias = normalizeText(storage.getItem('alias'));
     const currentUsername = normalizeText(storage.getItem('username'));
     const currentAuthMethod = normalizeText(storage.getItem('authMethod'));
     const currentAuthProvider = normalizeText(storage.getItem('authProvider'));
     const currentVerifiedEmail = normalizeText(storage.getItem('verifiedEmail')).toLowerCase();
+    const currentOauthAccountId = normalizeText(storage.getItem('oauthAccountId'));
+    const aliasMatches = currentAlias === nextAlias;
+    const hasMatchingGunCredential = (!currentAlias || aliasMatches) && hasStoredPassword;
+    const hasMatchingOauthSession = (
+      aliasMatches
+      && currentSignedIn
+      && currentAuthMethod === 'oauth'
+      && identity.authMethod === 'oauth'
+      && currentOauthAccountId.length > 0
+    );
+    const nextSignedIn = hasMatchingGunCredential || hasMatchingOauthSession;
+    const nextAuthMethod = nextSignedIn ? identity.authMethod : '';
+    const nextAuthProvider = nextSignedIn ? identity.authProvider : '';
+    const nextStoredVerifiedEmail = nextSignedIn ? nextVerifiedEmail : '';
     const hasGuestMarkers = Boolean(
       storage.getItem('guest')
       || storage.getItem('guestId')
@@ -267,9 +280,9 @@
       currentSignedIn !== nextSignedIn
       || currentAlias !== nextAlias
       || currentUsername !== nextUsername
-      || currentAuthMethod !== identity.authMethod
-      || currentAuthProvider !== identity.authProvider
-      || currentVerifiedEmail !== nextVerifiedEmail
+      || currentAuthMethod !== nextAuthMethod
+      || currentAuthProvider !== nextAuthProvider
+      || currentVerifiedEmail !== nextStoredVerifiedEmail
       || hasGuestMarkers
     );
 
@@ -284,20 +297,23 @@
     }
     storage.setItem('alias', nextAlias);
     storage.setItem('username', nextUsername);
-    if (identity.authMethod) {
-      storage.setItem('authMethod', identity.authMethod);
+    if (nextAuthMethod) {
+      storage.setItem('authMethod', nextAuthMethod);
     } else {
       storage.removeItem('authMethod');
     }
-    if (identity.authProvider) {
-      storage.setItem('authProvider', identity.authProvider);
+    if (nextAuthProvider) {
+      storage.setItem('authProvider', nextAuthProvider);
     } else {
       storage.removeItem('authProvider');
     }
-    if (identity.verifiedEmail) {
-      storage.setItem('verifiedEmail', identity.verifiedEmail);
+    if (nextStoredVerifiedEmail) {
+      storage.setItem('verifiedEmail', nextStoredVerifiedEmail);
     } else {
       storage.removeItem('verifiedEmail');
+    }
+    if (!nextSignedIn && (identity.authMethod || identity.authProvider || identity.verifiedEmail)) {
+      clearSharedIdentity();
     }
     storage.removeItem('guest');
     storage.removeItem('guestId');

--- a/contacts/auth-identity.js
+++ b/contacts/auth-identity.js
@@ -116,13 +116,26 @@
     const nextUsername = identity.username || aliasToDisplay(nextAlias) || 'User';
     const nextVerifiedEmail = normalizeText(identity.verifiedEmail).toLowerCase();
     const hasStoredPassword = normalizeText(storage.getItem('password')).length > 0;
-    const nextSignedIn = hasStoredPassword || identity.authMethod === 'oauth';
     const currentSignedIn = storage.getItem('signedIn') === 'true';
     const currentAlias = normalizeText(storage.getItem('alias'));
     const currentUsername = normalizeText(storage.getItem('username'));
     const currentAuthMethod = normalizeText(storage.getItem('authMethod'));
     const currentAuthProvider = normalizeText(storage.getItem('authProvider'));
     const currentVerifiedEmail = normalizeText(storage.getItem('verifiedEmail')).toLowerCase();
+    const currentOauthAccountId = normalizeText(storage.getItem('oauthAccountId'));
+    const aliasMatches = currentAlias === nextAlias;
+    const hasMatchingGunCredential = (!currentAlias || aliasMatches) && hasStoredPassword;
+    const hasMatchingOauthSession = (
+      aliasMatches
+      && currentSignedIn
+      && currentAuthMethod === 'oauth'
+      && identity.authMethod === 'oauth'
+      && currentOauthAccountId.length > 0
+    );
+    const nextSignedIn = hasMatchingGunCredential || hasMatchingOauthSession;
+    const nextAuthMethod = nextSignedIn ? identity.authMethod : '';
+    const nextAuthProvider = nextSignedIn ? identity.authProvider : '';
+    const nextStoredVerifiedEmail = nextSignedIn ? nextVerifiedEmail : '';
     const hasGuestMarkers = Boolean(
       storage.getItem('guest')
       || storage.getItem('guestId')
@@ -132,9 +145,9 @@
       currentSignedIn !== nextSignedIn
       || currentAlias !== nextAlias
       || currentUsername !== nextUsername
-      || currentAuthMethod !== identity.authMethod
-      || currentAuthProvider !== identity.authProvider
-      || currentVerifiedEmail !== nextVerifiedEmail
+      || currentAuthMethod !== nextAuthMethod
+      || currentAuthProvider !== nextAuthProvider
+      || currentVerifiedEmail !== nextStoredVerifiedEmail
       || hasGuestMarkers
     );
 
@@ -149,20 +162,23 @@
     }
     storage.setItem('alias', nextAlias);
     storage.setItem('username', nextUsername);
-    if (identity.authMethod) {
-      storage.setItem('authMethod', identity.authMethod);
+    if (nextAuthMethod) {
+      storage.setItem('authMethod', nextAuthMethod);
     } else {
       storage.removeItem('authMethod');
     }
-    if (identity.authProvider) {
-      storage.setItem('authProvider', identity.authProvider);
+    if (nextAuthProvider) {
+      storage.setItem('authProvider', nextAuthProvider);
     } else {
       storage.removeItem('authProvider');
     }
-    if (identity.verifiedEmail) {
-      storage.setItem('verifiedEmail', identity.verifiedEmail);
+    if (nextStoredVerifiedEmail) {
+      storage.setItem('verifiedEmail', nextStoredVerifiedEmail);
     } else {
       storage.removeItem('verifiedEmail');
+    }
+    if (!nextSignedIn && (identity.authMethod || identity.authProvider || identity.verifiedEmail)) {
+      clearSharedIdentity();
     }
     storage.removeItem('guest');
     storage.removeItem('guestId');

--- a/tests/auth-identity.test.js
+++ b/tests/auth-identity.test.js
@@ -160,6 +160,10 @@ describe('auth identity helper', () => {
 
   it('preserves signed-in mode for OAuth identities without a stored password', () => {
     const { api, localStorage } = loadAuthIdentity();
+    localStorage.setItem('signedIn', 'true');
+    localStorage.setItem('alias', 'oauth@3dvr');
+    localStorage.setItem('authMethod', 'oauth');
+    localStorage.setItem('oauthAccountId', 'google-123');
 
     api.writeSharedIdentity({
       signedIn: true,
@@ -178,7 +182,7 @@ describe('auth identity helper', () => {
     assert.equal(localStorage.getItem('verifiedEmail'), 'oauth@example.com');
   });
 
-  it('preserves signed-in mode for SEA identities without a stored password', () => {
+  it('downgrades stale SEA identity cookies without a stored password', () => {
     const { api, localStorage } = loadAuthIdentity();
 
     api.writeSharedIdentity({
@@ -191,9 +195,33 @@ describe('auth identity helper', () => {
 
     const changed = api.syncStorageFromSharedIdentity(localStorage);
     assert.equal(changed, true);
-    assert.equal(localStorage.getItem('signedIn'), 'true');
-    assert.equal(localStorage.getItem('authMethod'), 'sea');
-    assert.equal(localStorage.getItem('authProvider'), 'gun');
+    assert.equal(localStorage.getItem('signedIn'), null);
+    assert.equal(localStorage.getItem('alias'), 'sea@3dvr');
+    assert.equal(localStorage.getItem('authMethod'), null);
+    assert.equal(localStorage.getItem('authProvider'), null);
+    assert.equal(api.readSharedIdentity(), null);
+  });
+
+  it('does not let a stale OAuth cookie create a signed-in session by itself', () => {
+    const { api, localStorage } = loadAuthIdentity();
+
+    api.writeSharedIdentity({
+      signedIn: true,
+      alias: 'oauth@3dvr',
+      username: 'OAuth User',
+      authMethod: 'oauth',
+      authProvider: 'google',
+      verifiedEmail: 'oauth@example.com',
+    });
+
+    const changed = api.syncStorageFromSharedIdentity(localStorage);
+    assert.equal(changed, true);
+    assert.equal(localStorage.getItem('signedIn'), null);
+    assert.equal(localStorage.getItem('alias'), 'oauth@3dvr');
+    assert.equal(localStorage.getItem('authMethod'), null);
+    assert.equal(localStorage.getItem('authProvider'), null);
+    assert.equal(localStorage.getItem('verifiedEmail'), null);
+    assert.equal(api.readSharedIdentity(), null);
   });
 
   it('clears shared identity cookies', () => {

--- a/tests/contacts-pwa-config.test.js
+++ b/tests/contacts-pwa-config.test.js
@@ -91,6 +91,10 @@ describe('contacts PWA configuration', () => {
 
     assert.match(authIdentitySource, /const SHARED_COOKIE_NAME = 'portalIdentity';/);
     assert.match(authIdentitySource, /syncStorageFromSharedIdentity/);
+    assert.match(authIdentitySource, /currentOauthAccountId/);
+    assert.match(authIdentitySource, /hasMatchingGunCredential/);
+    assert.match(authIdentitySource, /hasMatchingOauthSession/);
+    assert.match(authIdentitySource, /clearSharedIdentity\(\)/);
     assert.match(authIdentitySource, /global\.AuthIdentity =/);
   });
 


### PR DESCRIPTION
## What changed

Hardens the shared `portalIdentity` cookie sync in both root and contacts auth helpers.

- A shared identity cookie can no longer mark the browser signed in by itself.
- Gun/SEA sessions require a stored password for the same alias, or a missing alias that the cookie can safely restore.
- OAuth sessions require an existing matching local OAuth session marker and `oauthAccountId`.
- Stale OAuth/SEA cookies without matching local session material are downgraded, auth method/provider fields are removed, and the stale cookie is cleared.
- Contacts gets the same guard because it also syncs the shared portal cookie.

## Why

The user was only able to fix normal Android Chrome by clearing cookies, while incognito worked. That strongly points to stale `portalIdentity` cookies recreating a false signed-in state after cache/service-worker repair. The root bug was that `syncStorageFromSharedIdentity()` trusted `authMethod: oauth` or `authMethod: sea` from the cookie enough to set `localStorage.signedIn = true` even when the browser did not have usable local session material.

## Validation

- `node --test tests/auth-identity.test.js tests/contacts-pwa-config.test.js tests/profile-page.test.js tests/sign-in-page.test.js tests/mobile-browser-resilience.test.js`
- Inline script syntax check for `auth-identity.js`, `contacts/auth-identity.js`, `sign-in.html`, `profile.html`, and `index.html`
- `git diff --check`