### PR TITLE
Add long-term 3DVR roadmap documentation

### DIFF
--- a/docs/3dvr-long-term-plan-roadmap.md
+++ b/docs/3dvr-long-term-plan-roadmap.md
@@ -1,0 +1,654 @@
+# 3DVR Long-Term Plan and Roadmap
+
+This document captures the current long-term direction for 3DVR without replacing older planning notes. It is meant to be a durable center of gravity for product, business, community, and open-source strategy.
+
+## 1. North Star
+
+3DVR is a long-term open-source technology company and builder community.
+
+The ambition is not only to make websites, apps, AI tools, or portals. Those are the starting points. The deeper goal is to build a community-run technology ecosystem that can eventually stand beside companies like Google, Microsoft, Apple, Tesla, and Meta in scope, but with a different moral foundation:
+
+- open-source
+- human-centered
+- community-owned
+- designed to create opportunity for normal people
+
+3DVR should help people:
+
+- organize their life
+- discover their calling
+- turn ideas into projects
+- turn projects into businesses
+- join a builder community
+- learn real technical skills
+- earn money
+- invest in the ecosystem
+- contribute to open-source technology
+- help build the next generation of computing
+
+Simple public promise:
+
+> 3DVR helps everyday people turn purpose into projects.
+
+More emotional promise:
+
+> Find your purpose. Visualize your movement. Launch your world.
+
+## 2. What 3DVR Is Becoming
+
+3DVR is not only a web design company. It is becoming a human-first technology operating system for people, projects, businesses, and communities.
+
+### Purpose Layer
+
+The Purpose Layer helps people clarify who they are, what they care about, what problems they see, and what kind of life or movement they want to build.
+
+Products here include:
+
+- Daily Direction
+- Purpose Finder
+- Launch Room
+- Movement Brief
+- life organization tools
+- personal dashboards
+- guided reflection tools
+
+This is the emotional doorway. A person may not know they need a website, CRM, AI agent, or business system yet. But they may know they feel scattered, stuck, underused, or called toward something.
+
+3DVR meets them there first.
+
+### Project Layer
+
+Once someone has a direction, 3DVR helps them turn it into a real project.
+
+This includes:
+
+- naming the project
+- defining the audience
+- writing the offer
+- creating a simple landing page
+- setting up contact forms
+- setting up booking
+- setting up payments
+- setting up basic follow-up
+- creating a public project page
+
+This is where purpose becomes visible.
+
+### Business Layer
+
+Once a project has real-world use, 3DVR helps it become a small business or organization.
+
+This includes:
+
+- websites
+- project desks
+- CRM
+- client intake
+- contact management
+- follow-up reminders
+- payments
+- invoices
+- proposals
+- email templates
+- basic analytics
+- customer pipelines
+
+This is the current practical money path.
+
+The first clean paid offer is still something like:
+
+> $20/month websites and simple project systems for people who need help being found, contacted, booked, and paid.
+
+The user should not have to understand DNS, Stripe, forms, calendars, GitHub, Vercel, or AI workflows. They should feel:
+
+> 3DVR gave me a simple desk for my project.
+
+### AI Operations Layer
+
+This is where Money Printer fits.
+
+Money Printer is the internal venture engine. It helps 3DVR research ideas, validate offers, generate landing pages, create outreach drafts, inspect projects, run business loops, and eventually help manage small ventures.
+
+It should remain approval-gated.
+
+Principle:
+
+> AI can suggest, draft, inspect, and operate, but humans approve important actions.
+
+Money Printer eventually becomes the engine behind:
+
+- lead research
+- offer testing
+- customer segmentation
+- website generation
+- business audits
+- project roadmaps
+- GitHub issue creation
+- Codex prompts
+- Vercel inspections
+- CRM suggestions
+- founder briefs
+- community opportunity matching
+
+This is how 3DVR can scale without needing a large traditional staff.
+
+### Open Computing Layer
+
+This is the deepest long-term layer.
+
+3DVR is ultimately about open computing for the masses.
+
+The dream includes:
+
+- open-source apps
+- open-source business tools
+- open-source AI workflows
+- open-source operating systems
+- Linux, Debian, Termux, and GNOME contribution pathways
+- open hardware
+- RISC-V
+- custom languages
+- distributed computing
+- 3D and VR interfaces
+- personal cloud systems
+- human-centered computing environments
+
+This is the "technology company like Google, Microsoft, Apple, Tesla, or Meta" horizon.
+
+Instead of closed platforms and shareholder extraction, 3DVR should move toward:
+
+- public code
+- community governance
+- contributor pathways
+- education
+- local ownership
+- transparent roadmaps
+- shared infrastructure
+- jobs and bounties
+- cooperative investment models
+
+## 3. Core Product Ladder
+
+The mistake would be trying to explain the whole vision to every new visitor. Most people need a small doorway.
+
+### Free
+
+Sort one messy thought. Pick one small next step. No card. No big plan.
+
+This can be Daily Direction, Launch Room, or a simplified Purpose tool. The goal is not to sell immediately. The goal is to create relief, clarity, and trust.
+
+### $5/month
+
+A basic supporter, identity, or light project plan.
+
+This could include:
+
+- simple profile
+- saved project brief
+- basic public page
+- community access
+- early builder updates
+
+### $20/month
+
+The current practical core offer: a simple website or project desk for people who need a public presence.
+
+Good fits include:
+
+- small businesses
+- creators
+- tutors
+- surf lessons
+- branding businesses
+- trading groups
+- local services
+- early startup ideas
+- community projects
+
+### $50/month
+
+Managed client flow.
+
+This includes more help with:
+
+- updates
+- follow-ups
+- CRM
+- contact forms
+- booking flow
+- payment flow
+- basic automation
+- monthly improvement
+
+### $200/month+
+
+Business OS or managed operations.
+
+This is for people who need a more serious system:
+
+- CRM
+- landing pages
+- campaigns
+- analytics
+- AI-assisted workflows
+- lead tracking
+- sales process
+- admin support
+- deeper consulting
+
+### Custom, Enterprise, and Community Projects
+
+Eventually this can include:
+
+- open-source infrastructure contracts
+- education programs
+- local business networks
+- founder cohorts
+- public-interest technology projects
+- hardware and software labs
+- community investment vehicles
+
+## 4. Website and Portal Split
+
+The main 3dvr.tech homepage should stay professional and focused for now. It should not try to explain the whole long-term roadmap.
+
+### 3dvr.tech
+
+Public business face.
+
+Message:
+
+> Websites, project systems, and AI-assisted tools for people building something real.
+
+Main offer:
+
+> $20/month websites and simple project support.
+
+### portal.3dvr.tech
+
+Internal lab, operating system, and builder portal.
+
+This is where the bigger vision lives:
+
+- Launch Room
+- CRM
+- Money Printer
+- Purpose tools
+- project dashboards
+- open-source pathways
+- experimental apps
+- community tools
+
+### apps.3dvr.tech or 3dvr.tech/apps
+
+Public app catalog.
+
+Eventually this becomes the clean customer-facing library:
+
+- Launch Room
+- Daily Direction
+- CRM
+- Project Desk
+- Purpose Finder
+- Open Source On-Ramp
+- Money Printer tools
+- Builder Log
+- Movement Page Generator
+
+This lets the homepage stay focused while the deeper ecosystem grows in parallel.
+
+## 5. Community Model
+
+3DVR should not only have customers. It should have layers of participation.
+
+### Customers
+
+People who pay for websites, project desks, business systems, or support.
+
+### Members
+
+People who use the free tools, join the portal, follow updates, and participate in the community.
+
+### Builders
+
+People who help make websites, apps, automations, documentation, designs, videos, and open-source contributions.
+
+### Contributors
+
+People who contribute code, docs, testing, bug reports, designs, templates, research, community support, or local projects.
+
+### Operators
+
+People who help run pieces of the business: sales, support, onboarding, project management, customer success, content, and technical delivery.
+
+### Investors and Supporters
+
+People who help fund the ecosystem through subscriptions, sponsorships, grants, donations, cooperative models, or eventually legal investment structures.
+
+Long-term dream:
+
+> Customers become members, members become builders, builders become contributors, contributors become operators, and operators become owners.
+
+## 6. Jobs and Economic Opportunity
+
+3DVR should eventually create work at many skill levels. Not everyone needs to be a senior programmer.
+
+Possible roles:
+
+- website setup assistant
+- customer onboarding helper
+- project interviewer
+- CRM organizer
+- support rep
+- documentation writer
+- template designer
+- open-source tester
+- local business scout
+- AI workflow reviewer
+- community moderator
+- junior developer
+- automation builder
+- 3D artist
+- hardware experimenter
+- Linux or open-source contributor
+- founder-in-residence
+
+3DVR should not only sell technology. It should help people enter the technology economy.
+
+Job promise:
+
+> Come with curiosity. Leave with skills, projects, income, and a place in the open-source future.
+
+## 7. Investment and Ownership
+
+The long-term structure should probably be hybrid.
+
+A pure startup may become too extractive. A pure nonprofit may struggle to move fast and sell real products.
+
+### For-Profit Arm
+
+Handles:
+
+- paid websites
+- apps
+- subscriptions
+- consulting
+- managed services
+- business operations
+- enterprise contracts
+
+### Nonprofit or Foundation Arm
+
+Handles:
+
+- education
+- open-source grants
+- community labs
+- public-interest software
+- contributor support
+- documentation
+- open hardware research
+- local training
+
+### Cooperative or Community Layer
+
+Longer term, this could allow:
+
+- member voting
+- contributor rewards
+- revenue sharing
+- bounty pools
+- community investment
+- project ownership models
+
+This must be handled carefully and legally, but the direction is right:
+
+> 3DVR should not just make users. It should create stakeholders.
+
+## 8. Product Roadmap
+
+### Phase 1: Clarity and Cash Flow
+
+Goal: make the current business understandable and sellable.
+
+Focus:
+
+- keep homepage professional
+- clarify the $20/month website offer
+- make billing easier
+- make onboarding simple
+- create one obvious free entry point
+- use Launch Room or Daily Direction as the free doorway
+- manually help real people
+- learn from Esai, Brenda, Mark, and other early customers
+- fix CRM enough to use internally
+- create a repeatable customer flow
+
+Success looks like:
+
+- people understand what 3DVR offers
+- friends and family can try the free tool
+- customers can subscribe easily
+- 3DVR can onboard someone without chaos
+- the $20/month offer feels real
+
+### Phase 2: Project Desk
+
+Goal: turn websites into a repeatable system.
+
+Build:
+
+- project profile
+- public project page
+- contact form
+- booking request
+- payment link
+- simple dashboard
+- project notes
+- follow-up reminders
+- basic CRM connection
+
+Position it as:
+
+> A simple desk for your project: website, contact, booking, payment, and follow-up in one place.
+
+Do not oversell the backend. Customers do not want "infrastructure." They want:
+
+> Can people find me, contact me, book me, and pay me?
+
+### Phase 3: CRM and Client Flow
+
+Goal: help customers manage relationships and opportunities.
+
+Build:
+
+- people
+- conversations
+- opportunities
+- projects
+- reminders
+- notes
+- tags
+- pipeline
+- templates
+- history
+
+3DVR's CRM angle:
+
+> People -> Conversations -> Opportunities -> Projects -> Movements
+
+This fits the larger 3DVR philosophy better than a generic sales CRM.
+
+### Phase 4: Money Printer Internal Engine
+
+Goal: make 3DVR itself smarter and more operational.
+
+Money Printer helps with:
+
+- market research
+- offer audits
+- customer analysis
+- landing page drafts
+- outreach drafts
+- GitHub issues
+- Codex prompts
+- Vercel checks
+- founder briefs
+- business experiments
+
+At first, it is internal. Later, pieces can become customer-facing.
+
+### Phase 5: Builder Community
+
+Goal: turn customers and users into collaborators.
+
+Build:
+
+- builder profiles
+- project rooms
+- open tasks
+- beginner-friendly issues
+- bounty boards
+- local project boards
+- contribution logs
+- public roadmaps
+- community calls
+- learning tracks
+
+This is where 3DVR starts becoming more than a service business.
+
+### Phase 6: Open Source On-Ramp
+
+Goal: help normal people contribute to open-source computing.
+
+Create pathways for:
+
+- documentation
+- bug reports
+- testing
+- tutorials
+- beginner code tasks
+- Termux
+- Debian
+- Linux
+- GNOME
+- open web tools
+- 3D and VR interfaces
+- RISC-V hardware
+- open business software
+
+This becomes one of 3DVR's most important differentiators.
+
+It is not only "learn to code." It is:
+
+> Join the open-source civilization project.
+
+### Phase 7: Full Open Technology Ecosystem
+
+Long term, 3DVR can expand into:
+
+- open-source productivity suite
+- community cloud
+- open CRM
+- open website builder
+- open AI business operator
+- open 3D/VR interface
+- open education platform
+- open hardware experiments
+- RISC-V devices
+- custom languages
+- local-first personal computing
+- distributed operating systems
+
+This is the Google, Microsoft, Apple, Tesla, and Meta-scale horizon. But the path starts with small useful tools for real people.
+
+## 9. Strategic Rule: Small Door, Giant World
+
+3DVR should always have a small, understandable front door.
+
+The giant vision is real, but it should not overwhelm people.
+
+Public entry points should sound simple:
+
+- Need a website?
+- Need help organizing your idea?
+- Want to launch a small project?
+- Want people to find, contact, book, and pay you?
+- Want to turn your purpose into something real?
+
+Then, once someone enters, they can discover the larger world:
+
+- project tools
+- AI systems
+- builder community
+- open-source pathways
+- jobs
+- investment
+- computing civilization
+
+The strategy:
+
+> Simple offer outside, deep ecosystem inside.
+
+## 10. Real Mission
+
+The real mission of 3DVR is to help people come alive as builders.
+
+Not everyone is ready to start a company. Not everyone knows they need open-source computing. Not everyone cares about Linux, RISC-V, AI agents, portals, or distributed systems.
+
+But many people feel something like:
+
+- I know I am meant for more.
+- I have ideas but no structure.
+- I need help turning this into something real.
+- I want to build but I do not know where to start.
+- I want work that matters.
+- I want to be part of the future.
+
+3DVR should be the doorway for those people.
+
+Long-term plan:
+
+> Help people organize their life, discover their calling, launch real projects, build useful technology, earn money, create community-owned infrastructure, and contribute to an open-source future.
+
+## 11. Immediate Next Roadmap
+
+The next practical steps are:
+
+1. Keep the main homepage focused on the simple paid website offer.
+2. Create one clear free entry point for friends and family.
+3. Fix billing so people like Esai can subscribe without friction.
+4. Turn the current customer list into real market research.
+5. Make CRM usable internally before trying to sell it broadly.
+6. Package Project Desk as the first repeatable product.
+7. Use Money Printer internally to improve offers, pages, and operations.
+8. Keep the portal as the experimental operating system.
+9. Slowly expose polished apps publicly.
+10. Build the community around real projects, not vague hype.
+
+The first milestone is not "build the next Google."
+
+The first milestone is:
+
+> Get real people from messy idea -> clear project -> working page -> contact/payment flow -> follow-up -> monthly relationship.
+
+If 3DVR can do that repeatedly, the larger ecosystem has a foundation.
+
+## 12. Final Summary
+
+3DVR is a long-term open-source technology company, community, and operating system for builders.
+
+It starts with simple websites, project desks, life organization, and launch tools.
+
+It grows into CRM, AI operations, business systems, education, jobs, and community investment.
+
+It eventually becomes an open-source computing ecosystem: apps, agents, portals, hardware, operating systems, languages, and community-run infrastructure.
+
+The seed is small:
+
+> Help one person organize their idea and launch one real project.
+
+The tree is enormous:
+
+> A community-owned open-source technology civilization.
+


### PR DESCRIPTION
## Summary
- Add a new standalone long-term 3DVR roadmap document under portal docs
- Capture the north star, product layers, product ladder, community model, ownership direction, roadmap phases, and immediate next steps
- Preserve older documentation without overwriting existing docs

## Tests
- test -s docs/3dvr-long-term-plan-roadmap.md
- rg key roadmap headings and final summary in the new document