### PR TITLE
[codex] Tighten v0.0.52 release intro

### DIFF
--- a/releases/v0.0.52.html
+++ b/releases/v0.0.52.html
@@ -30,9 +30,9 @@
   <div class="tag">Week of June 29, 2026</div>
   <div class="release-summary">
     <p>
-      This release gets the portal current for the Friday, July 3, 2026 decision meeting and the Monday,
-      July 6, 2026 production release. The focus is narrower: make the free path obvious, keep sign-in from
-      trapping returning users, and document the next money path before building more billing machinery.
+      The portal is easier to start, easier to recover, and clearer about the next money path. The focus is simple:
+      make the free path obvious, keep sign-in from trapping returning users, and test direct Stripe links before
+      building more billing machinery.
     </p>
     <ul class="release-summary-list">
       <li>

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -134,7 +134,7 @@ describe('release hub backfill', () => {
     assert.match(release52, /href="\.\.\/string-theory\/">String Theory Visualizer</);
     assert.match(release52, /href="\.\.\/docs\/3dvr-long-term-plan-roadmap\.md">3DVR Long-Term Plan and Roadmap</);
     assert.match(release52, /href="\.\.\/docs\/no-account-stripe-payment-plan\.md">No-Account Stripe Payment Plan</);
-    assert.match(release52, /Friday, July 3, 2026/);
+    assert.match(release52, /The portal is easier to start, easier to recover, and clearer about the next money path/);
     assert.match(release52, /Monday,\s+July 6, 2026/);
     assert.match(release52, /pull\/906/);
     assert.match(release52, /pull\/977/);


### PR DESCRIPTION
## Summary
- replace the procedural v0.0.52 opening sentence with a shorter user-facing intro
- update the release hub test to preserve the clearer wording instead of the removed meeting phrase

## Validation
- node --test tests/releases-hub.test.js
