### PR TITLE
[codex] Repair auto-business market loop

### DIFF
--- a/sales/market-pulse.js
+++ b/sales/market-pulse.js
@@ -439,6 +439,18 @@ function render() {
 }
 
 function normalizeListing(data = {}, id = '') {
+  let evidence = [];
+  if (Array.isArray(data.evidence)) {
+    evidence = data.evidence;
+  } else if (data.evidenceJson) {
+    try {
+      const parsed = JSON.parse(String(data.evidenceJson || ''));
+      evidence = Array.isArray(parsed) ? parsed : [];
+    } catch (_error) {
+      evidence = [];
+    }
+  }
+
   return {
     id: String(data.id || id || '').trim(),
     title: String(data.title || '').trim(),
@@ -450,7 +462,7 @@ function normalizeListing(data = {}, id = '') {
     confidenceScore: Number(data.confidenceScore || 0),
     approved: Boolean(data.approved || data.approvalStatus === 'approved'),
     approvalStatus: String(data.approvalStatus || '').trim(),
-    evidence: Array.isArray(data.evidence) ? data.evidence : [],
+    evidence,
     updatedAt: String(data.updatedAt || '').trim(),
     source: String(data.source || '').trim(),
   };

--- a/scripts/growth/run-market-pulse.mjs
+++ b/scripts/growth/run-market-pulse.mjs
@@ -3,3 +3,4 @@ import { runMarketPulseCli } from '../../src/growth/market-pulse-runner.js';
 
 const { exitCode } = await runMarketPulseCli();
 process.exitCode = exitCode;
+process.exit(exitCode);

--- a/src/growth/market-pulse.js
+++ b/src/growth/market-pulse.js
@@ -586,6 +586,24 @@ export function serializeMarketPulseForGun(pulse = {}) {
   };
 }
 
+export function serializeDirectoryListingForGun(listing = {}) {
+  return {
+    id: normalizeText(listing.id),
+    title: normalizeText(listing.title),
+    market: normalizeText(listing.market),
+    pain: normalizeText(listing.pain),
+    recommendedOffer: normalizeText(listing.recommendedOffer),
+    suggestedPrice: normalizeText(listing.suggestedPrice),
+    confidence: normalizeText(listing.confidence),
+    confidenceScore: Number(listing.confidenceScore || 0),
+    approvalStatus: normalizeText(listing.approvalStatus),
+    approved: Boolean(listing.approved),
+    evidenceJson: JSON.stringify(Array.isArray(listing.evidence) ? listing.evidence : []),
+    updatedAt: normalizeText(listing.updatedAt),
+    source: normalizeText(listing.source),
+  };
+}
+
 export function deserializeMarketPulseFromGun(record = {}) {
   return {
     runId: normalizeText(record.runId),
@@ -639,7 +657,7 @@ export async function createMarketPulseClient(options = {}) {
       await putNode(runsNode.get(pulse.runId), latestRecord);
       const approvedListings = (pulse.directoryListings || []).filter((item) => item.approved);
       for (const listing of approvedListings) {
-        await putNode(directoryNode.get(listing.id), listing);
+        await putNode(directoryNode.get(listing.id), serializeDirectoryListingForGun(listing));
       }
       return {
         runId: pulse.runId,

--- a/src/money/autopilot.js
+++ b/src/money/autopilot.js
@@ -11,7 +11,8 @@ const DEFAULT_AUTOPILOT_PROFILE = {
   autoDiscover: true,
   discoverySeeds: ['freelance', 'small business', 'automation', 'client onboarding', 'lead follow up'],
   publishPathPrefix: 'money-ai/offers',
-  checkoutCtaLabel: 'Start Paid Plan'
+  checkoutCtaLabel: 'Start Paid Plan',
+  defaultDestinationUrl: 'https://portal.3dvr.tech/friends-family/'
 };
 
 const MARKET_PROFILES = [
@@ -545,7 +546,7 @@ export function resolveAutopilotConfig(options = {}) {
       defaultDestinationUrl: String(
         options.defaultDestinationUrl
         || env.MONEY_AUTOPILOT_DEFAULT_DESTINATION_URL
-        || ''
+        || DEFAULT_AUTOPILOT_PROFILE.defaultDestinationUrl
       ).trim()
     },
     monetization: {
@@ -932,13 +933,15 @@ export async function runAutopilotCycle(options = {}) {
     ...report,
     monetization: {
       ...(report.monetization || {}),
-      checkoutUrl: config.monetization.checkoutUrl,
-      checkoutCtaLabel: config.monetization.checkoutCtaLabel
+      checkoutUrl: config.monetization.checkoutUrl || config.promotion.defaultDestinationUrl,
+      checkoutCtaLabel: config.monetization.checkoutUrl
+        ? config.monetization.checkoutCtaLabel
+        : 'Start Free'
     }
   };
 
   if (!config.monetization.checkoutUrl) {
-    warnings.push('Checkout URL not configured. Offer CTA will use /free-trial.html.');
+    warnings.push(`Checkout URL not configured. Campaign traffic will use ${config.promotion.defaultDestinationUrl}.`);
   }
 
   const offerHtml = buildOfferHtml({
@@ -1026,8 +1029,8 @@ export async function runAutopilotCycle(options = {}) {
 
   publish.destinationUrl = publish.vercel.url
     || publish.github.htmlUrl
-    || config.promotion.defaultDestinationUrl
     || config.monetization.checkoutUrl
+    || config.promotion.defaultDestinationUrl
     || '';
 
   const promotionTasks = buildPromotionTasks(

--- a/tests/market-pulse-runner.test.js
+++ b/tests/market-pulse-runner.test.js
@@ -136,4 +136,6 @@ test('market pulse automation is wired to npm and scheduled GitHub Actions', asy
   assert.match(workflow, /workflow_dispatch/);
   assert.match(workflow, /npm run market:pulse -- --json/);
   assert.match(workflow, /MARKET_PULSE_MARKET/);
+  const script = await readFile(new URL('../scripts/growth/run-market-pulse.mjs', import.meta.url), 'utf8');
+  assert.match(script, /process\.exit\(exitCode\)/);
 });

--- a/tests/market-pulse.test.js
+++ b/tests/market-pulse.test.js
@@ -4,6 +4,7 @@ import {
   buildMarketPulse,
   deserializeMarketPulseFromGun,
   runMarketPulseCycle,
+  serializeDirectoryListingForGun,
   serializeMarketPulseForGun,
 } from '../src/growth/market-pulse.js';
 
@@ -69,6 +70,20 @@ test('market pulse gun serialization keeps dashboard arrays recoverable', () => 
   assert.equal(restored.marketFit.verdict.length > 0, true);
   assert.equal(restored.tests.length, 2);
   assert.match(restored.automationPolicy.marketResearch, /runner|scheduler/i);
+});
+
+test('directory listing serialization avoids raw arrays in Gun directory writes', () => {
+  const pulse = buildMarketPulse(demand, {
+    generatedAt: '2026-05-14T10:00:00.000Z',
+    runId: 'market-pulse-test',
+  });
+  const listing = pulse.directoryListings[0];
+  const serialized = serializeDirectoryListingForGun(listing);
+
+  assert.equal(Array.isArray(serialized.evidence), false);
+  assert.equal(typeof serialized.evidenceJson, 'string');
+  assert.deepEqual(JSON.parse(serialized.evidenceJson), listing.evidence);
+  assert.equal(serialized.approved, true);
 });
 
 test('runMarketPulseCycle writes approved listings through the injected client', async () => {

--- a/tests/money-autopilot.test.js
+++ b/tests/money-autopilot.test.js
@@ -363,3 +363,45 @@ test('runAutopilotCycle uses checkout URL as destination fallback', async () => 
   assert.equal(result.monetization.checkoutConfigured, true);
   assert.equal(result.monetization.checkoutCtaLabel, 'Start Paid Plan');
 });
+
+test('runAutopilotCycle uses public friends-family page when checkout is missing', async () => {
+  const result = await runAutopilotCycle({
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return { rows: [] };
+      },
+      async text() {
+        return '';
+      }
+    }),
+    env: {
+      MONEY_AUTOPILOT_PUBLISH: 'false',
+      MONEY_AUTOPILOT_PROMOTION: 'false'
+    },
+    autoDiscover: false,
+    runLoopImpl: async payload => ({
+      runId: 'money-default-destination',
+      generatedAt: '2026-02-13T00:00:00.000Z',
+      input: payload,
+      topOpportunity: {
+        id: 'op-1',
+        title: 'Default destination opportunity',
+        problem: 'Traffic needs somewhere useful to land.',
+        solution: 'Send traffic to the public free/support path.',
+        suggestedPrice: '$5/mo'
+      },
+      warnings: [],
+      signals: [],
+      opportunities: [],
+      adDrafts: [{ channel: 'email', headline: 'Try a small next step', body: 'Start free.', cta: 'Start free' }],
+      executionChecklist: []
+    })
+  });
+
+  assert.equal(result.publish.destinationUrl, 'https://portal.3dvr.tech/friends-family/');
+  assert.equal(result.promotion.destinationUrl, 'https://portal.3dvr.tech/friends-family/');
+  assert.equal(result.monetization.checkoutConfigured, false);
+  assert.match(result.warnings.join('\n'), /friends-family/);
+});


### PR DESCRIPTION
## Summary
- fix Market Pulse Gun directory writes by serializing listing evidence instead of writing raw arrays
- force the Market Pulse CLI script to exit after printing results so scheduled jobs do not hang on open Gun handles
- give Money Autopilot a useful public CTA fallback at the Friends & Family page while preserving Stripe checkout priority when configured
- update dashboard/test coverage for the serialized directory listing shape and default Autopilot destination

## Validation
- node --test tests/market-pulse.test.js tests/market-pulse-runner.test.js tests/sales-market-pulse.test.js tests/money-autopilot.test.js
- npm run market:pulse -- --dry-run --json
- npm run market:pulse -- --json
- npm run money:autopilot -- --dryRun true --out /tmp/money-autopilot-check.json

## Runtime notes
- Live Market Pulse completed locally and published 1 directory listing.
- GitHub variable MONEY_AUTOPILOT_DEFAULT_DESTINATION_URL is set to https://portal.3dvr.tech/friends-family/.
