### PR TITLE
[codex] Add Growth Desk portal surface

### DIFF
--- a/growth-desk/app.js
+++ b/growth-desk/app.js
@@ -1,0 +1,144 @@
+const SPRINT_TAG = 'follow-up-leak-sprint';
+const RECORD_PREFIX = 'follow-up-leak-';
+const gun = window.Gun
+  ? window.Gun({ peers: window.__GUN_PEERS__ || ['wss://gun-relay-3dvr.fly.dev/gun'] })
+  : null;
+
+const elements = {
+  status: document.getElementById('syncStatus'),
+  total: document.getElementById('totalCount'),
+  ready: document.getElementById('readyCount'),
+  manual: document.getElementById('manualCount'),
+  hold: document.getElementById('holdCount'),
+  list: document.getElementById('leadList'),
+  refresh: document.getElementById('refreshButton'),
+};
+
+const state = {
+  records: {},
+  drafts: {},
+};
+
+function safe(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function isSprintRecord(record, id) {
+  const recordId = String(record?.id || id || '');
+  const tags = String(record?.tags || '');
+  return recordId.startsWith(RECORD_PREFIX) || tags.includes(SPRINT_TAG);
+}
+
+function classify(record = {}) {
+  const status = String(record.status || '').toLowerCase();
+  const tags = String(record.tags || '').toLowerCase();
+  if (status === 'lost' || tags.includes('do_not_send')) return 'hold';
+  if (tags.includes('manual_verify') || tags.includes('contact_form_or_manual')) return 'manual';
+  if (status.includes('invited') || tags.includes('ready_for_review')) return 'ready';
+  return 'manual';
+}
+
+function statusLabel(record = {}) {
+  const status = String(record.status || 'Lead').trim();
+  const type = classify(record);
+  const className = type === 'ready' ? 'status-ready' : type === 'hold' ? 'status-hold' : 'status-manual';
+  return `<span class="${className}">${safe(status)}</span>`;
+}
+
+function crmUrl(record = {}) {
+  const filter = encodeURIComponent(record.id || record.name || SPRINT_TAG);
+  return `../crm/?filter=${filter}`;
+}
+
+function draftPreview(record = {}) {
+  const draft = state.drafts[record.id] || {};
+  return draft.subject || record.nextBestAction || 'Open CRM to review this record.';
+}
+
+function render() {
+  const records = Object.values(state.records)
+    .filter(Boolean)
+    .sort((left, right) => {
+      const order = { ready: 0, manual: 1, hold: 2 };
+      const byClass = order[classify(left)] - order[classify(right)];
+      if (byClass) return byClass;
+      return String(left.name || '').localeCompare(String(right.name || ''));
+    });
+
+  const counts = records.reduce((acc, record) => {
+    acc[classify(record)] += 1;
+    return acc;
+  }, { ready: 0, manual: 0, hold: 0 });
+
+  elements.total.textContent = String(records.length);
+  elements.ready.textContent = String(counts.ready);
+  elements.manual.textContent = String(counts.manual);
+  elements.hold.textContent = String(counts.hold);
+
+  if (!records.length) {
+    elements.list.innerHTML = '<p class="empty">No Follow-Up Leak Sprint records found yet. Run the command-center CRM sync first.</p>';
+    return;
+  }
+
+  elements.list.innerHTML = records.map((record) => `
+    <article class="lead-card">
+      <div>
+        <h3>${safe(record.name || 'Unnamed record')}</h3>
+        <p>${safe(record.lastSignal || record.primaryPain || 'No signal recorded yet.')}</p>
+        <div class="lead-card__meta">
+          ${statusLabel(record)}
+          <span>${safe(record.nextFollowUp ? `Follow up ${record.nextFollowUp}` : 'No follow-up date')}</span>
+          <span>${safe(record.offerAmount || '$20-$50/mo')}</span>
+        </div>
+      </div>
+      <div class="lead-card__actions">
+        <a class="button primary" href="${safe(crmUrl(record))}">Open CRM record</a>
+        <a class="button" href="../crm/flow.html">Flow view</a>
+        <span>${safe(draftPreview(record))}</span>
+      </div>
+    </article>
+  `).join('');
+}
+
+function setStatus(message) {
+  if (elements.status) elements.status.textContent = message;
+}
+
+function connect() {
+  if (!gun) {
+    setStatus('Gun is unavailable. Open CRM directly.');
+    render();
+    return;
+  }
+
+  setStatus('Listening to 3dvr-crm and outreach drafts.');
+  gun.get('3dvr-crm').map().on((data, id) => {
+    if (!id) return;
+    if (!data) {
+      delete state.records[id];
+      render();
+      return;
+    }
+    if (!isSprintRecord(data, id)) return;
+    state.records[id] = { ...data, id: data.id || id };
+    render();
+  });
+
+  gun.get('3dvr-portal').get('crm-outreach-drafts').map().on((data, id) => {
+    if (!id || !data) return;
+    state.drafts[id] = data;
+    render();
+  });
+}
+
+elements.refresh?.addEventListener('click', () => {
+  setStatus('Refreshing live CRM data.');
+  render();
+});
+
+connect();

--- a/growth-desk/index.html
+++ b/growth-desk/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>Growth Desk | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="Internal 3DVR growth desk for reviewing CRM leads, outreach drafts, market signals, and the current follow-up sprint."
+  />
+  <meta name="theme-color" content="#101820" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../gun-init.js"></script>
+</head>
+<body>
+  <div class="shell">
+    <header class="hero">
+      <nav class="topbar" aria-label="Growth desk navigation">
+        <a href="../">Portal</a>
+        <a href="../crm/">CRM</a>
+        <a href="../crm/flow.html">CRM Flow</a>
+        <a href="../revenue-desk/">Revenue Desk</a>
+        <a href="../sales/market-pulse.html">Market Pulse</a>
+        <a href="../growth-operator/">Growth Operator</a>
+      </nav>
+
+      <div class="hero-grid">
+        <div>
+          <p class="eyebrow">Operator workspace</p>
+          <h1>Growth Desk</h1>
+          <p class="lead">
+            Review the current market sprint, open each CRM record, approve the next message, and keep the money loop from becoming scattered notes.
+          </p>
+          <div class="hero-actions">
+            <a class="button primary" href="../crm/?filter=follow-up-leak-sprint">Open sprint in CRM</a>
+            <a class="button" href="../sales/market-pulse.html">Market Pulse</a>
+            <a class="button" href="https://github.com/tmsteph/3dvr-command-center" rel="noreferrer">Command Center repo</a>
+          </div>
+        </div>
+        <aside class="status-card">
+          <span>Current sprint</span>
+          <strong>Follow-Up Leak Sprint</strong>
+          <p id="syncStatus" role="status" aria-live="polite">Connecting to portal CRM records.</p>
+        </aside>
+      </div>
+    </header>
+
+    <main>
+      <section class="metric-grid" aria-label="Sprint metrics">
+        <article>
+          <span>Total records</span>
+          <strong id="totalCount">0</strong>
+        </article>
+        <article>
+          <span>Ready</span>
+          <strong id="readyCount">0</strong>
+        </article>
+        <article>
+          <span>Manual review</span>
+          <strong id="manualCount">0</strong>
+        </article>
+        <article>
+          <span>Hold</span>
+          <strong id="holdCount">0</strong>
+        </article>
+      </section>
+
+      <section class="panel sprint-panel" aria-labelledby="sprint-title">
+        <div class="section-head row">
+          <div>
+            <p class="eyebrow">Money path</p>
+            <h2 id="sprint-title">Simple page + intake + follow-up desk.</h2>
+            <p>
+              The offer is intentionally small: help owner-led services stop losing quote requests and next steps.
+            </p>
+          </div>
+          <div class="action-stack">
+            <a class="button primary" href="../crm/?filter=Warm%20-%20Invited">Review ready records</a>
+            <a class="button" href="../crm/?filter=follow-up-leak-sprint">View all sprint records</a>
+          </div>
+        </div>
+        <div class="offer-box">
+          <span>Tiny ask</span>
+          <p>
+            Where do new leads or project ideas usually get lost right now? I am testing a simple 3DVR setup: a page, contact path, and follow-up desk so things do not disappear in texts, DMs, or notes.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="review-title">
+        <div class="section-head row">
+          <div>
+            <p class="eyebrow">CRM review</p>
+            <h2 id="review-title">Approve nothing blindly.</h2>
+            <p>These records are mirrored from the private command-center repo into portal CRM. Open the CRM record before sending.</p>
+          </div>
+          <button class="button" id="refreshButton" type="button">Refresh</button>
+        </div>
+        <div id="leadList" class="lead-list">
+          <p class="empty">Loading sprint records...</p>
+        </div>
+      </section>
+
+      <section class="workflow-grid" aria-label="Workflow">
+        <article>
+          <span>1</span>
+          <strong>Research</strong>
+          <p>Market Pulse picks the segment and top opportunity.</p>
+        </article>
+        <article>
+          <span>2</span>
+          <strong>Draft</strong>
+          <p>Command Center creates reviewed, custom messages.</p>
+        </article>
+        <article>
+          <span>3</span>
+          <strong>Approve</strong>
+          <p>CRM shows the record, draft, follow-up date, and status.</p>
+        </article>
+        <article>
+          <span>4</span>
+          <strong>Track</strong>
+          <p>Replies, holds, and follow-ups stay in CRM instead of chat history.</p>
+        </article>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/growth-desk/style.css
+++ b/growth-desk/style.css
@@ -1,0 +1,306 @@
+:root {
+  color-scheme: dark;
+  --bg: #101820;
+  --panel: rgba(255, 255, 255, 0.075);
+  --panel-strong: rgba(255, 255, 255, 0.11);
+  --border: rgba(255, 255, 255, 0.15);
+  --text: #f5f7f8;
+  --muted: #aeb9c2;
+  --accent: #38d9a9;
+  --accent-strong: #8ce99a;
+  --warn: #ffd166;
+  --danger: #ff7b7b;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(56, 217, 169, 0.18), transparent 30rem),
+    radial-gradient(circle at 82% 0%, rgba(255, 209, 102, 0.12), transparent 28rem),
+    linear-gradient(135deg, #101820 0%, #18232d 55%, #101820 100%);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+}
+
+.shell {
+  width: min(100%, 1180px);
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.hero {
+  padding: 18px 0 26px;
+}
+
+.topbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 28px;
+}
+
+.topbar a,
+.button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.button.primary {
+  border-color: rgba(56, 217, 169, 0.5);
+  background: var(--accent);
+  color: #07110d;
+}
+
+.hero-grid,
+.section-head.row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 360px);
+  gap: 22px;
+  align-items: start;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent-strong);
+  font-size: 0.77rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 760px;
+  margin-bottom: 14px;
+  font-size: clamp(2.35rem, 8vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 10px;
+  font-size: clamp(1.55rem, 4vw, 2.35rem);
+  line-height: 1.08;
+}
+
+.lead {
+  max-width: 760px;
+  color: var(--muted);
+  font-size: clamp(1.05rem, 2vw, 1.35rem);
+}
+
+.hero-actions,
+.action-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.status-card,
+.panel,
+.metric-grid article,
+.workflow-grid article,
+.lead-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.status-card {
+  padding: 20px;
+}
+
+.status-card span,
+.metric-grid span,
+.offer-box span,
+.lead-card__meta span,
+.workflow-grid span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.status-card strong {
+  display: block;
+  margin: 8px 0;
+  font-size: 1.3rem;
+}
+
+.metric-grid,
+.workflow-grid,
+.lead-list {
+  display: grid;
+  gap: 14px;
+}
+
+.metric-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-bottom: 16px;
+}
+
+.metric-grid article,
+.workflow-grid article {
+  padding: 18px;
+}
+
+.metric-grid strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 2rem;
+}
+
+.panel {
+  margin: 16px 0;
+  padding: 20px;
+}
+
+.offer-box {
+  border-left: 4px solid var(--accent);
+  border-radius: 8px;
+  margin-top: 18px;
+  padding: 16px;
+  background: rgba(56, 217, 169, 0.08);
+}
+
+.offer-box p {
+  margin: 8px 0 0;
+  color: #dce8e2;
+}
+
+.lead-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  padding: 16px;
+  background: var(--panel-strong);
+}
+
+.lead-card h3 {
+  margin-bottom: 6px;
+  font-size: 1.15rem;
+}
+
+.lead-card p {
+  margin-bottom: 10px;
+  color: var(--muted);
+}
+
+.lead-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.lead-card__meta span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 5px 8px;
+  background: rgba(0, 0, 0, 0.16);
+  color: #d7e0e5;
+  text-transform: none;
+}
+
+.lead-card__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 170px;
+}
+
+.status-ready {
+  color: var(--accent-strong);
+}
+
+.status-manual {
+  color: var(--warn);
+}
+
+.status-hold {
+  color: var(--danger);
+}
+
+.empty {
+  margin: 0;
+  color: var(--muted);
+}
+
+.workflow-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 18px 0 40px;
+}
+
+.workflow-grid strong {
+  display: block;
+  margin: 8px 0;
+  font-size: 1.1rem;
+}
+
+.workflow-grid p {
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+@media (max-width: 820px) {
+  .shell {
+    padding: 14px;
+  }
+
+  .hero-grid,
+  .section-head.row,
+  .lead-card {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-grid,
+  .workflow-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lead-card__actions {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .metric-grid,
+  .workflow-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar a,
+  .button {
+    width: 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -562,6 +562,11 @@
             <span class="app-card__title">Revenue Desk</span>
             <span class="app-card__meta">Run the daily founder loop: follow-ups, proposals, billing, and one revenue move.</span>
           </a>
+          <a href="growth-desk/" class="app-card" data-app-keywords="growth desk command center crm outreach follow up leak sprint leads market pulse money">
+            <span class="app-card__icon" aria-hidden="true">GD</span>
+            <span class="app-card__title">Growth Desk</span>
+            <span class="app-card__meta">Review the current sprint, CRM leads, custom drafts, and next approved money move.</span>
+          </a>
           <a href="growth-operator/" class="app-card">
             <span class="app-card__icon" aria-hidden="true">GO</span>
             <span class="app-card__title">Growth Operator</span>

--- a/tests/growth-desk.test.js
+++ b/tests/growth-desk.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('Growth Desk ships as a CRM-backed operator surface', async () => {
+  const html = await readFile(new URL('../growth-desk/index.html', import.meta.url), 'utf8');
+  const script = await readFile(new URL('../growth-desk/app.js', import.meta.url), 'utf8');
+  const portal = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const vercel = await readFile(new URL('../vercel.json', import.meta.url), 'utf8');
+
+  assert.match(html, /<title>Growth Desk \| 3DVR Portal<\/title>/);
+  assert.match(html, /noindex, nofollow/);
+  assert.match(html, /Follow-Up Leak Sprint/);
+  assert.match(html, /Open sprint in CRM/);
+  assert.match(html, /Command Center repo/);
+  assert.match(script, /const SPRINT_TAG = 'follow-up-leak-sprint';/);
+  assert.match(script, /gun\.get\('3dvr-crm'\)/);
+  assert.match(script, /crm-outreach-drafts/);
+  assert.match(portal, /href="growth-desk\/"/);
+  assert.match(portal, /<span class="app-card__title">Growth Desk<\/span>/);
+  assert.match(vercel, /growth\.3dvr\.tech/);
+  assert.match(vercel, /\/growth-desk\/index\.html/);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -273,6 +273,16 @@
       "destination": "/purpose/index.html"
     },
     {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "growth.3dvr.tech"
+        }
+      ],
+      "destination": "/growth-desk/index.html"
+    },
+    {
       "source": "/webhooks/stripe",
       "destination": "/api/webhooks/stripe"
     },


### PR DESCRIPTION
## Summary
- Adds a `/growth-desk/` operator page for the Follow-Up Leak Sprint
- Links Growth Desk from the portal app dock
- Adds `growth.3dvr.tech` rewrite to the Growth Desk page
- Adds a focused regression test for the page, CRM hooks, portal card, and rewrite

## Validation
- `node --test tests/growth-desk.test.js`
- `node --check growth-desk/app.js`

## Notes
- The Growth Desk page is marked `noindex, nofollow` and links into CRM instead of making the private command-center repo the public source of truth.
- A full `npm test` run still hits an unrelated pre-existing assertion in `tests/3dvr-connect-and-fascia-release.test.js` around `consent-based` vs `consent-centered` copy.
