### PR TITLE
[codex] Add Money Printer trust review queue

### DIFF
--- a/money-printer/app.js
+++ b/money-printer/app.js
@@ -21,12 +21,17 @@ import {
 } from '../src/money-printer/moneyPrinterCore.js';
 import { readConnectorStatuses } from '../src/money-printer/moneyPrinterConnectors.js';
 import { createMoneyPrinterStorage } from '../src/money-printer/moneyPrinterStorage.js';
+import {
+  createMessageReviewItem,
+  seedTrustReviewQueue
+} from '../src/money-printer/messageReview.js';
 
 const elements = {
   form: document.getElementById('missionForm'),
   missionInput: document.getElementById('missionInput'),
   missionStatus: document.getElementById('missionStatus'),
   metricsGrid: document.getElementById('metricsGrid'),
+  messageReviewQueue: document.getElementById('messageReviewQueue'),
   runtimeStatusGrid: document.getElementById('runtimeStatusGrid'),
   nextBestMoneyAction: document.getElementById('nextBestMoneyAction'),
   businessConfigPreview: document.getElementById('businessConfigPreview'),
@@ -43,12 +48,35 @@ const elements = {
 };
 
 const moneyPrinterStorage = createMoneyPrinterStorage();
+const MESSAGE_REVIEW_STORAGE_KEY = '3dvr.moneyPrinter.messageReviewQueue.v1';
 let connectorStatuses = [];
 let state = moneyPrinterStorage.hydrate();
+let messageReviewQueue = loadMessageReviewQueue();
 
 function saveState() {
   if (!moneyPrinterStorage.write(state)) {
     setStatus('Local browser storage is unavailable, so this session will not persist after refresh.');
+  }
+}
+
+function loadMessageReviewQueue() {
+  try {
+    const raw = window.localStorage.getItem(MESSAGE_REVIEW_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (Array.isArray(parsed) && parsed.length) {
+      return parsed.map(item => createMessageReviewItem(item));
+    }
+  } catch (_error) {
+    // Fall back to seeded review examples.
+  }
+  return seedTrustReviewQueue();
+}
+
+function saveMessageReviewQueue() {
+  try {
+    window.localStorage.setItem(MESSAGE_REVIEW_STORAGE_KEY, JSON.stringify(messageReviewQueue));
+  } catch (_error) {
+    setStatus('Message review queue could not be saved locally.');
   }
 }
 
@@ -114,6 +142,14 @@ function titleFromKey(value = '') {
     .trim();
 }
 
+function safeText(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 function money(value) {
   const numeric = Number(value || 0);
   return new Intl.NumberFormat('en-US', {
@@ -146,6 +182,87 @@ function renderMetrics() {
 
   replaceChildren(elements.metricsGrid, metricCards);
   elements.nextBestMoneyAction.textContent = metrics.nextBestMoneyAction;
+}
+
+function riskTone(riskLevel = '') {
+  if (riskLevel === 'GREEN') return 'green';
+  if (riskLevel === 'RED') return 'red';
+  return 'yellow';
+}
+
+function actionLabel(action) {
+  return {
+    'approve-send': 'Approve & Send',
+    edit: 'Edit',
+    skip: 'Skip',
+    'ban-lead': 'Ban Lead',
+    'save-later': 'Save for Later'
+  }[action] || action;
+}
+
+function renderMessageReviewQueue() {
+  if (!elements.messageReviewQueue) return;
+  const items = [...messageReviewQueue].sort((left, right) => {
+    const order = { RED: 0, YELLOW: 1, GREEN: 2 };
+    const byRisk = (order[left.riskLevel] ?? 3) - (order[right.riskLevel] ?? 3);
+    if (byRisk) return byRisk;
+    return String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''));
+  });
+
+  if (!items.length) {
+    elements.messageReviewQueue.innerHTML = '<p class="empty-state">No messages are queued for review.</p>';
+    return;
+  }
+
+  elements.messageReviewQueue.innerHTML = items.map(item => `
+    <article class="message-review-card" data-risk="${safeText(riskTone(item.riskLevel))}">
+      <div class="message-review-card__top">
+        <div>
+          <span class="mp-card-label">${safeText(item.status)}</span>
+          <h3>${safeText(item.leadName)}</h3>
+        </div>
+        <strong class="risk-badge" data-risk="${safeText(riskTone(item.riskLevel))}">${safeText(item.riskLevel)}</strong>
+      </div>
+      <dl class="review-explainer">
+        <div>
+          <dt>Why generated</dt>
+          <dd>${safeText(item.whyGenerated)}</dd>
+        </div>
+        <div>
+          <dt>Why relevant</dt>
+          <dd>${safeText(item.whyLeadRelevant)}</dd>
+        </div>
+        <div>
+          <dt>Offer</dt>
+          <dd>${safeText(item.offerConnection || item.offer)}</dd>
+        </div>
+        <div>
+          <dt>Risk score</dt>
+          <dd>${safeText(item.riskExplanation)}</dd>
+        </div>
+      </dl>
+      <div class="message-draft">
+        <label>
+          <span>Subject</span>
+          <input data-review-field="subject" data-review-id="${safeText(item.id)}" value="${safeText(item.subject)}" />
+        </label>
+        <label>
+          <span>Message</span>
+          <textarea data-review-field="body" data-review-id="${safeText(item.id)}" rows="8">${safeText(item.body)}</textarea>
+        </label>
+      </div>
+      <ul class="safeguard-list">
+        ${(item.safeguards || []).map(note => `<li>${safeText(note)}</li>`).join('')}
+      </ul>
+      <div class="review-actions">
+        ${item.actions.map(action => `
+          <button class="mp-button ${action === 'approve-send' ? 'mp-button--primary' : ''}" type="button" data-review-action="${safeText(action)}" data-review-id="${safeText(item.id)}">
+            ${safeText(actionLabel(action))}
+          </button>
+        `).join('')}
+      </div>
+    </article>
+  `).join('');
 }
 
 function renderRuntimeStatus() {
@@ -509,6 +626,7 @@ function renderTools() {
 
 function render() {
   renderMetrics();
+  renderMessageReviewQueue();
   renderRuntimeStatus();
   renderBusinessConfig();
   renderFounderBrief();
@@ -518,6 +636,50 @@ function render() {
   renderBots();
   renderAutonomyZones();
   renderTools();
+}
+
+function updateReviewItem(id, patch) {
+  messageReviewQueue = messageReviewQueue.map(item => (
+    item.id === id
+      ? createMessageReviewItem({ ...item, ...patch, updatedAt: new Date().toISOString() })
+      : item
+  ));
+  saveMessageReviewQueue();
+  renderMessageReviewQueue();
+}
+
+function handleReviewAction(action, id) {
+  const item = messageReviewQueue.find(entry => entry.id === id);
+  if (!item) return;
+  if (action === 'approve-send') {
+    updateReviewItem(id, {
+      status: item.canAutoSend ? 'approved-auto-send-ready' : 'approved-human-send-required',
+      whyGenerated: `${item.whyGenerated} Human approved this draft.`
+    });
+    setStatus(item.canAutoSend
+      ? 'GREEN message approved. It can use the pre-approved send path.'
+      : 'Message approved. Human send remains required for this risk level.');
+    return;
+  }
+  if (action === 'edit') {
+    updateReviewItem(id, { status: 'editing' });
+    setStatus('Draft opened for editing. Risk will be recalculated as you change it.');
+    return;
+  }
+  if (action === 'skip') {
+    updateReviewItem(id, { status: 'skipped' });
+    setStatus('Message skipped. Lead is preserved for later context.');
+    return;
+  }
+  if (action === 'ban-lead') {
+    updateReviewItem(id, { status: 'banned', riskLevel: 'RED' });
+    setStatus('Lead banned from this review queue.');
+    return;
+  }
+  if (action === 'save-later') {
+    updateReviewItem(id, { status: 'saved-later' });
+    setStatus('Message saved for later review.');
+  }
 }
 
 function commit(message) {
@@ -658,10 +820,25 @@ document.addEventListener('click', event => {
       [botId]: createPromptOutput(botId)
     };
     commit('Prompt template shown for the selected bot.');
+    return;
+  }
+
+  const reviewButton = event.target.closest('[data-review-action]');
+  if (reviewButton) {
+    handleReviewAction(reviewButton.dataset.reviewAction, reviewButton.dataset.reviewId);
   }
 });
 
 document.addEventListener('change', event => {
+  const reviewField = event.target.closest('[data-review-field]');
+  if (reviewField) {
+    updateReviewItem(reviewField.dataset.reviewId, {
+      [reviewField.dataset.reviewField]: reviewField.value,
+      status: 'edited-review-required'
+    });
+    return;
+  }
+
   const select = event.target.closest('[data-experiment-status]');
   if (!select) {
     return;

--- a/money-printer/index.html
+++ b/money-printer/index.html
@@ -86,6 +86,38 @@
         </article>
       </section>
 
+      <section class="mp-band" aria-labelledby="reviewQueueTitle">
+        <div class="mp-section-heading mp-section-heading--wide">
+          <span class="eyebrow">Trust-preserving operator</span>
+          <h2 id="reviewQueueTitle">Message review queue</h2>
+          <p>
+            Codex can research, draft, update CRM, and recommend next actions. Messages that risk trust wait here
+            until a human approves, edits, skips, bans the lead, or saves the draft for later.
+          </p>
+        </div>
+        <div class="trust-loop" aria-label="Money Printer trust loop">
+          <span>Market</span>
+          <span>Offer</span>
+          <span>Lead</span>
+          <span>Trust</span>
+          <span>Payment</span>
+          <span>Fulfillment</span>
+          <span>Follow-up</span>
+        </div>
+        <div class="review-policy">
+          <strong>The human remains the trust layer.</strong>
+          <p>
+            GREEN can be auto-sent only when it matches a pre-approved low-risk relationship template.
+            YELLOW and RED stay queued. Cold outreach, pricing, promises, billing, legal language, and sensitive
+            personal details require review.
+          </p>
+          <p>
+            Review actions: Approve &amp; Send, Edit, Skip, Ban Lead, or Save for Later.
+          </p>
+        </div>
+        <div id="messageReviewQueue" class="message-review-grid" aria-live="polite"></div>
+      </section>
+
       <section class="mp-band" aria-labelledby="runtimeStatusTitle">
         <div class="mp-section-heading">
           <span class="eyebrow">AI / Runtime Status</span>

--- a/money-printer/styles.css
+++ b/money-printer/styles.css
@@ -678,6 +678,145 @@ body.money-printer-page {
   padding: 0.08rem 0.25rem;
 }
 
+.trust-loop {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 1rem 0;
+}
+
+.trust-loop span,
+.risk-badge {
+  border: 1px solid rgba(160, 174, 192, 0.22);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.78);
+  color: #d7fbe8;
+  padding: 0.35rem 0.62rem;
+  font-weight: 800;
+  font-size: 0.76rem;
+}
+
+.review-policy {
+  border: 1px solid rgba(45, 212, 191, 0.24);
+  border-radius: 8px;
+  background: rgba(45, 212, 191, 0.08);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.review-policy p {
+  margin-bottom: 0;
+  color: var(--mp-muted);
+}
+
+.message-review-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.message-review-card {
+  border: 1px solid rgba(160, 174, 192, 0.18);
+  border-radius: 8px;
+  background: rgba(3, 8, 13, 0.72);
+  padding: 1rem;
+}
+
+.message-review-card[data-risk="green"] {
+  border-color: rgba(134, 239, 172, 0.42);
+}
+
+.message-review-card[data-risk="yellow"] {
+  border-color: rgba(251, 191, 36, 0.44);
+}
+
+.message-review-card[data-risk="red"] {
+  border-color: rgba(251, 113, 133, 0.48);
+}
+
+.message-review-card__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.message-review-card h3 {
+  margin: 0.15rem 0 0;
+}
+
+.risk-badge[data-risk="green"] {
+  background: rgba(134, 239, 172, 0.12);
+  color: #bbf7d0;
+}
+
+.risk-badge[data-risk="yellow"] {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fde68a;
+}
+
+.risk-badge[data-risk="red"] {
+  background: rgba(251, 113, 133, 0.12);
+  color: #fecdd3;
+}
+
+.review-explainer {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.review-explainer div {
+  border: 1px solid rgba(160, 174, 192, 0.14);
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+
+.review-explainer dt,
+.message-draft span {
+  color: #d5fffa;
+  font-weight: 800;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+.review-explainer dd {
+  margin: 0.25rem 0 0;
+  color: var(--mp-muted);
+}
+
+.message-draft {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.message-draft label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.message-draft input,
+.message-draft textarea {
+  width: 100%;
+  border: 1px solid rgba(160, 174, 192, 0.22);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.86);
+  color: var(--mp-text);
+  padding: 0.7rem;
+  font: inherit;
+}
+
+.safeguard-list {
+  color: var(--mp-muted);
+  margin: 0.9rem 0;
+}
+
+.review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
 @media (min-width: 760px) {
   .mp-hero {
     grid-template-columns: minmax(0, 0.94fr) minmax(340px, 0.72fr);
@@ -756,5 +895,11 @@ body.money-printer-page {
   .idea-score-grid,
   .traction-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .review-explainer {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/money-printer/messageReview.js
+++ b/src/money-printer/messageReview.js
@@ -1,0 +1,280 @@
+export const MESSAGE_RISK_LEVELS = Object.freeze({
+  GREEN: 'GREEN',
+  YELLOW: 'YELLOW',
+  RED: 'RED'
+});
+
+export const REVIEW_ACTIONS = Object.freeze([
+  'approve-send',
+  'edit',
+  'skip',
+  'ban-lead',
+  'save-later'
+]);
+
+const LOW_RISK_MESSAGE_TYPES = new Set([
+  'thank-you',
+  'reminder',
+  'opt-in-confirmation',
+  'existing-contact-follow-up'
+]);
+
+const LOW_RISK_RELATIONSHIPS = new Set([
+  'existing-contact',
+  'customer',
+  'subscriber',
+  'warm',
+  'inbound',
+  'referral',
+  'opted-in'
+]);
+
+const PRICE_PATTERN = /\$\s?\d+|\b\d+\s?(?:usd|dollars?)\b|\/mo\b|per month|pricing|price|cost|checkout|billing|stripe/i;
+const PROMISE_PATTERN = /\b(guarantee|guaranteed|promise|will make you|make you money|double your|triple your|rank #?1|risk-free|no risk|results guaranteed)\b/i;
+const LEGAL_PATTERN = /\b(legal|lawyer|attorney|contract|liability|compliance|tax advice|investment advice|financial advice|medical advice)\b/i;
+const SENSITIVE_PATTERN = /\b(health condition|diagnosis|therapy|trauma|debt|bankruptcy|ssn|social security|password|private|confidential|adult|sexual)\b/i;
+const OPT_OUT_PATTERN = /\b(unsubscribe|opt out|stop receiving|reply stop|no more emails)\b/i;
+const DECEPTIVE_SUBJECT_PATTERN = /\b(re:|fwd:|urgent account|invoice due|payment failed|final notice)\b/i;
+
+function cleanText(value) {
+  return String(value || '').trim();
+}
+
+function includesPattern(value, pattern) {
+  return pattern.test(cleanText(value));
+}
+
+function unique(items) {
+  return [...new Set(items.filter(Boolean))];
+}
+
+function normalizeRelationship(value = '') {
+  return cleanText(value).toLowerCase();
+}
+
+function normalizeMessageType(value = '') {
+  return cleanText(value).toLowerCase();
+}
+
+function normalizeLeadTemperature(value = '') {
+  const normalized = cleanText(value).toLowerCase();
+  if (['cold', 'warm', 'hot', 'existing', 'inbound', 'customer', 'subscriber'].includes(normalized)) {
+    return normalized;
+  }
+  return 'cold';
+}
+
+export function assessMessageRisk(input = {}) {
+  const subject = cleanText(input.subject);
+  const body = cleanText(input.body || input.message);
+  const leadTemperature = normalizeLeadTemperature(input.leadTemperature || input.temperature);
+  const relationship = normalizeRelationship(input.relationship || input.source);
+  const messageType = normalizeMessageType(input.messageType || input.type);
+  const commercial = Boolean(input.commercial ?? true);
+  const preApprovedTemplate = Boolean(input.preApprovedTemplate);
+  const hasOptOut = Boolean(input.hasOptOut) || includesPattern(body, OPT_OUT_PATTERN);
+  const claimsUncertain = Boolean(input.claimsUncertain || input.uncertainClaim);
+
+  const signals = [];
+  const safeguards = [];
+  let score = 0;
+
+  if (!subject) {
+    score += 1;
+    signals.push('Missing subject line.');
+  } else if (includesPattern(subject, DECEPTIVE_SUBJECT_PATTERN)) {
+    score += 4;
+    signals.push('Subject may look deceptive or pressure-based.');
+  } else {
+    safeguards.push('Subject line is present and can be reviewed for accuracy.');
+  }
+
+  if (leadTemperature === 'cold') {
+    score += 2;
+    signals.push('Lead is cold, so human review is required before first contact.');
+  }
+
+  if (claimsUncertain) {
+    score += 2;
+    signals.push('Message includes an uncertain claim or unverified context.');
+  }
+
+  if (includesPattern(`${subject}\n${body}`, PRICE_PATTERN)) {
+    score += 2;
+    signals.push('Message references pricing, checkout, billing, or money.');
+  }
+
+  if (includesPattern(body, PROMISE_PATTERN)) {
+    score += 4;
+    signals.push('Message includes a strong promise or outcome claim.');
+  }
+
+  if (includesPattern(body, LEGAL_PATTERN)) {
+    score += 4;
+    signals.push('Message includes legal, tax, medical, financial, or compliance language.');
+  }
+
+  if (includesPattern(body, SENSITIVE_PATTERN)) {
+    score += 4;
+    signals.push('Message includes sensitive personal or private details.');
+  }
+
+  if (commercial && leadTemperature === 'cold' && !hasOptOut) {
+    score += 2;
+    signals.push('Cold commercial message needs a clear opt-out path before sending.');
+  }
+
+  if (commercial) {
+    safeguards.push('Commercial email should use accurate sender identity and a non-deceptive subject.');
+    if (hasOptOut) safeguards.push('Opt-out language is present.');
+    else safeguards.push('Opt-out language is missing or must be added before sending.');
+  }
+
+  const lowRiskContext = preApprovedTemplate
+    && LOW_RISK_MESSAGE_TYPES.has(messageType)
+    && (LOW_RISK_RELATIONSHIPS.has(relationship) || LOW_RISK_RELATIONSHIPS.has(leadTemperature))
+    && !claimsUncertain
+    && !includesPattern(`${subject}\n${body}`, PRICE_PATTERN)
+    && !includesPattern(body, PROMISE_PATTERN)
+    && !includesPattern(body, LEGAL_PATTERN)
+    && !includesPattern(body, SENSITIVE_PATTERN);
+
+  let riskLevel = MESSAGE_RISK_LEVELS.YELLOW;
+  if (score > 4) riskLevel = MESSAGE_RISK_LEVELS.RED;
+  else if (score <= 0 && lowRiskContext) riskLevel = MESSAGE_RISK_LEVELS.GREEN;
+
+  const requiresReview = riskLevel !== MESSAGE_RISK_LEVELS.GREEN;
+  const canAutoSend = riskLevel === MESSAGE_RISK_LEVELS.GREEN && lowRiskContext;
+
+  return {
+    riskLevel,
+    score,
+    requiresReview,
+    canAutoSend,
+    signals: unique(signals),
+    safeguards: unique(safeguards),
+    explanation: unique([
+      riskLevel === MESSAGE_RISK_LEVELS.GREEN
+        ? 'GREEN: pre-approved low-risk relationship message.'
+        : riskLevel === MESSAGE_RISK_LEVELS.RED
+          ? 'RED: trust-sensitive content needs human review and likely editing.'
+          : 'YELLOW: useful draft, but human review is required before sending.',
+      ...signals
+    ]).join(' '),
+    compliance: {
+      accurateSenderIdentity: Boolean(input.accurateSenderIdentity ?? true),
+      nonDeceptiveSubject: !includesPattern(subject, DECEPTIVE_SUBJECT_PATTERN),
+      optOutRequired: commercial && leadTemperature === 'cold',
+      optOutPresent: hasOptOut,
+      noMisleadingClaims: !includesPattern(body, PROMISE_PATTERN),
+      notes: unique(safeguards)
+    }
+  };
+}
+
+export function createMessageReviewItem(input = {}) {
+  const id = cleanText(input.id) || `review-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const assessment = assessMessageRisk(input);
+  const now = new Date().toISOString();
+  return {
+    id,
+    leadId: cleanText(input.leadId),
+    leadName: cleanText(input.leadName || input.name || 'Unknown lead'),
+    leadContact: cleanText(input.leadContact || input.email || input.contact),
+    leadTemperature: normalizeLeadTemperature(input.leadTemperature || input.temperature),
+    offer: cleanText(input.offer || '3DVR support'),
+    subject: cleanText(input.subject),
+    body: cleanText(input.body || input.message),
+    whyGenerated: cleanText(input.whyGenerated || 'Money Printer found a possible next business action.'),
+    whyLeadRelevant: cleanText(input.whyLeadRelevant || input.relevance || 'Lead appears connected to the selected market or sprint.'),
+    offerConnection: cleanText(input.offerConnection || `Connects to ${cleanText(input.offer || 'the current 3DVR offer')}.`),
+    riskLevel: assessment.riskLevel,
+    riskScore: assessment.score,
+    riskExplanation: assessment.explanation,
+    safeguards: assessment.safeguards,
+    compliance: assessment.compliance,
+    canAutoSend: assessment.canAutoSend,
+    requiresReview: assessment.requiresReview,
+    status: cleanText(input.status) || (assessment.canAutoSend && input.autoSendEligible ? 'auto-send-eligible' : 'queued'),
+    actions: REVIEW_ACTIONS,
+    createdAt: cleanText(input.createdAt) || now,
+    updatedAt: cleanText(input.updatedAt) || now
+  };
+}
+
+export function seedTrustReviewQueue() {
+  return [
+    createMessageReviewItem({
+      id: 'review-woolleys-gutter-experts',
+      leadId: 'follow-up-leak-woolleys-gutter-experts',
+      leadName: "Woolley's Gutter Experts",
+      leadContact: 'woolleysgutterexperts@hotmail.com',
+      leadTemperature: 'cold',
+      offer: 'Simple page + intake + follow-up desk',
+      subject: 'Quick idea for gutter estimate follow-up',
+      body: `Hi Josh,
+
+I saw Woolley's focuses on seamless rain gutter installs, cleaning, guards, and free estimates around San Diego County.
+
+Quick question: do estimate requests ever get hard to track once they come in from calls, the site, Facebook, or referrals?
+
+I am testing a simple 3DVR setup for local service businesses: one clean intake path and a small follow-up desk so quote requests do not disappear in texts, emails, or notes.
+
+If you send one service you want more estimates for, I can sketch the first simple follow-up path.
+
+Thomas
+3dvr.tech
+
+If this is not useful, reply and I will not follow up.`,
+      whyGenerated: 'Follow-Up Leak Sprint selected quote-driven local services as the current money path.',
+      whyLeadRelevant: 'Gutter work is estimate-driven, local, and likely depends on fast quote follow-up.',
+      offerConnection: 'Connects to the Follow-Up Leak Sprint offer: simple page, intake path, and follow-up desk.',
+      hasOptOut: true,
+      accurateSenderIdentity: true
+    }),
+    createMessageReviewItem({
+      id: 'review-rkc-construction',
+      leadId: 'follow-up-leak-rkc-construction',
+      leadName: 'RKC Construction',
+      leadContact: 'info@rkcconstruction.com',
+      leadTemperature: 'cold',
+      offer: 'Simple page + intake + follow-up desk',
+      subject: 'Quick idea for patio project follow-up',
+      body: `Hi RKC team,
+
+I saw RKC handles patio covers, pergolas, sunrooms, enclosures, and outdoor living projects across San Diego County.
+
+Quick question: when someone clicks Get a Quote, where does follow-up usually get hardest: first response, choosing the right service, financing questions, or keeping the project moving?
+
+I am testing a simple 3DVR setup for contractors: a clear intake path plus a small follow-up desk so quote requests and project next steps do not get buried.
+
+Thomas
+3dvr.tech
+
+If this is not useful, reply and I will not follow up.`,
+      whyGenerated: 'Market Pulse scored owner-led services with quote follow-up leaks as a strong signal.',
+      whyLeadRelevant: 'Construction projects have quote, financing, scheduling, and follow-up steps.',
+      offerConnection: 'Connects to a contractor follow-up desk that keeps requests visible.',
+      hasOptOut: true,
+      accurateSenderIdentity: true
+    }),
+    createMessageReviewItem({
+      id: 'review-existing-thank-you',
+      leadId: 'existing-customer-demo',
+      leadName: 'Existing 3DVR contact',
+      leadTemperature: 'warm',
+      relationship: 'existing-contact',
+      messageType: 'thank-you',
+      preApprovedTemplate: true,
+      commercial: false,
+      offer: 'Customer follow-up',
+      subject: 'Thanks for the update',
+      body: 'Thanks for the update. I saved this and will follow up with the next clear step.',
+      whyGenerated: 'Existing contact sent an update that needs a short acknowledgement.',
+      whyLeadRelevant: 'Existing relationship and no commercial claim.',
+      offerConnection: 'Keeps fulfillment and follow-up moving without a sales pitch.',
+      accurateSenderIdentity: true,
+      autoSendEligible: true
+    })
+  ];
+}

--- a/tests/money-printer-message-review.test.js
+++ b/tests/money-printer-message-review.test.js
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  assessMessageRisk,
+  createMessageReviewItem,
+  seedTrustReviewQueue
+} from '../src/money-printer/messageReview.js';
+
+test('message review gates cold commercial outreach for human review', () => {
+  const item = createMessageReviewItem({
+    leadName: 'Local Contractor',
+    leadTemperature: 'cold',
+    offer: '$50/mo follow-up desk',
+    subject: 'Quick idea for quote follow-up',
+    body: 'I can help set up a simple follow-up desk for $50/mo.',
+    whyGenerated: 'Market Pulse found quote follow-up pain.',
+    whyLeadRelevant: 'Local service business with quote flow.',
+    offerConnection: 'Connects to the follow-up desk offer.',
+    hasOptOut: true
+  });
+
+  assert.equal(item.riskLevel, 'YELLOW');
+  assert.equal(item.requiresReview, true);
+  assert.equal(item.canAutoSend, false);
+  assert.match(item.riskExplanation, /Lead is cold/);
+  assert.match(item.riskExplanation, /pricing|checkout|billing|money/i);
+  assert.equal(item.compliance.optOutRequired, true);
+});
+
+test('message review marks sensitive promises as red', () => {
+  const assessment = assessMessageRisk({
+    leadTemperature: 'cold',
+    subject: 'Guaranteed results',
+    body: 'We guarantee you will make money and can advise on legal compliance.',
+    hasOptOut: true
+  });
+
+  assert.equal(assessment.riskLevel, 'RED');
+  assert.equal(assessment.requiresReview, true);
+  assert.equal(assessment.canAutoSend, false);
+  assert.match(assessment.explanation, /strong promise/i);
+  assert.match(assessment.explanation, /legal/i);
+});
+
+test('message review allows only pre-approved low-risk relationship templates to be green', () => {
+  const assessment = assessMessageRisk({
+    leadTemperature: 'warm',
+    relationship: 'existing-contact',
+    messageType: 'thank-you',
+    preApprovedTemplate: true,
+    commercial: false,
+    subject: 'Thanks for the update',
+    body: 'Thanks for the update. I saved this and will follow up with the next clear step.'
+  });
+
+  assert.equal(assessment.riskLevel, 'GREEN');
+  assert.equal(assessment.requiresReview, false);
+  assert.equal(assessment.canAutoSend, true);
+});
+
+test('seed queue includes explained review actions and risk levels', () => {
+  const queue = seedTrustReviewQueue();
+  assert.equal(queue.length >= 3, true);
+  assert.equal(queue.every(item => item.actions.includes('approve-send')), true);
+  assert.equal(queue.every(item => item.actions.includes('ban-lead')), true);
+  assert.equal(queue.some(item => item.riskLevel === 'GREEN'), true);
+  assert.equal(queue.some(item => item.riskLevel === 'YELLOW'), true);
+  assert.equal(queue.every(item => item.whyGenerated && item.whyLeadRelevant && item.offerConnection), true);
+});

--- a/tests/money-printer-page.test.js
+++ b/tests/money-printer-page.test.js
@@ -32,6 +32,9 @@ describe('money-printer MVP', () => {
     assert.match(html, /id="missionInput"/);
     assert.match(html, /Generate Money Machine/);
     assert.match(html, /Money Printer Dashboard/);
+    assert.match(html, /Message review queue/);
+    assert.match(html, /The human remains the trust layer\./);
+    assert.match(html, /Approve &amp; Send|Approve & Send/);
     assert.match(html, /AI \/ Runtime Status/);
     assert.match(html, /npm run money-printer -- ai-status/);
     assert.match(html, /Opportunity Engine/);
@@ -101,6 +104,7 @@ describe('money-printer MVP', () => {
 
   it('exposes a browser-free core API for future CLI and daemon reuse', async () => {
     const core = await import(new URL('moneyPrinterCore.js', srcDir));
+    const review = await import(new URL('messageReview.js', srcDir));
     const required = [
       'createDefaultBusinessConfig',
       'updateBusinessConfigFromMission',
@@ -120,6 +124,8 @@ describe('money-printer MVP', () => {
     assert.equal(state.ideas.length, 5);
     assert.match(state.businessConfig.mission, /local service businesses/);
     assert.match(core.runBotLoop('executive-agent', state).title, /Executive Agent/);
+    assert.equal(typeof review.assessMessageRisk, 'function');
+    assert.equal(typeof review.createMessageReviewItem, 'function');
   });
 
   it('documents mock connector environment variables without secrets', async () => {


### PR DESCRIPTION
## Summary
- Adds a browser-free Money Printer message risk engine with GREEN/YELLOW/RED scoring
- Adds a Money Printer message review queue for trust-sensitive outreach drafts
- Adds review actions: Approve & Send, Edit, Skip, Ban Lead, Save for Later
- Explains why each draft was generated, why the lead is relevant, offer connection, safeguards, and risk score
- Keeps v1 conservative: YELLOW/RED remain human-reviewed; GREEN is only for pre-approved low-risk relationship templates

## Trust rules covered
- Cold leads, pricing, billing, promises, legal/compliance language, and sensitive details trigger review
- Commercial cold outreach checks for opt-out handling
- Subjects are checked for deceptive pressure patterns
- Human remains the trust layer; Money Printer prepares and explains the action

## Validation
- `node --test tests/money-printer-message-review.test.js tests/money-printer-page.test.js`
- `node --check money-printer/app.js && node --check src/money-printer/messageReview.js`

## Current delivery blocker

GitHub currently reports this PR as **not mergeable** against `main` (re-checked 2026-08-14). Keep it in draft until the branch is refreshed/rebased and the focused validation above is rerun on the refreshed head. Do not treat the older local validation as sufficient after conflict resolution.