### PR TITLE
Harden Money Printer self-review artifacts

### DIFF
--- a/docs/money-printer-automerge.md
+++ b/docs/money-printer-automerge.md
@@ -18,7 +18,7 @@ node scripts/money-printer-self-review.mjs
 
 `report` inspects the repo and writes a local email-ready report under `.money-printer/operator/`.
 
-`propose` creates one documentation-only safe improvement, runs focused checks, generates `SELF_REVIEW.md`, and classifies the change.
+`propose` creates one documentation-only safe improvement, runs focused checks, generates an ignored self-review report under `.money-printer/operator/`, and classifies the change.
 
 PR creation and auto-merge are opt-in:
 
@@ -86,7 +86,9 @@ Examples:
 
 ## Self Review
 
-Every run can generate `SELF_REVIEW.md` with:
+The standalone self-review command can generate `SELF_REVIEW.md`. Operator proposal runs write the same report shape to `.money-printer/operator/self-review-latest.md` and use that file as the PR body, without committing the generated artifact.
+
+Every self-review includes:
 
 - summary
 - files changed

--- a/scripts/money-printer-operator.mjs
+++ b/scripts/money-printer-operator.mjs
@@ -177,7 +177,7 @@ async function buildReport(rootDir, command) {
 async function openPullRequest(rootDir, options = {}) {
   const branch = git(rootDir, ['branch', '--show-current']);
   const title = options.title || 'Money Printer autonomous safe improvement';
-  const bodyPath = path.join(rootDir, 'SELF_REVIEW.md');
+  const bodyPath = options.bodyPath || path.join(rootDir, 'SELF_REVIEW.md');
   const body = await readFile(bodyPath, 'utf8').catch(() => 'Money Printer self-review unavailable.');
   gh(rootDir, ['pr', 'create', '--base', options.base || 'main', '--head', branch, '--title', title, '--body', body]);
   const url = gh(rootDir, ['pr', 'view', '--json', 'url', '--jq', '.url']);
@@ -227,11 +227,14 @@ async function runPropose(rootDir, options = {}) {
   const report = await buildReport(rootDir, 'propose');
   report.safeImprovementPath = await writeSafeImprovement(rootDir);
   report.verification = await runVerification(rootDir);
+  const operatorDir = await ensureOperatorDir(rootDir);
+  const selfReviewPath = path.join(operatorDir, 'self-review-latest.md');
   const verificationCommands = report.verification.commands.map(item => `${item.command}: ${item.ok ? 'pass' : 'fail'}`);
   const review = await runSelfReview({
     rootDir,
     testsPassed: report.verification.passed,
     commands: verificationCommands,
+    outPath: selfReviewPath,
     summary: 'Money Printer proposed a documentation-only operator report update.',
     rollbackPlan: 'Revert the PR commit or restore docs/money-printer-operator-report.md from main.',
     nextSuggestedAction: 'If GREEN, open a PR for the documentation-only report update. If not GREEN, ask Thomas to review.'
@@ -246,12 +249,13 @@ async function runPropose(rootDir, options = {}) {
   };
 
   if (parseBool(options.createPr) && review.risk !== 'RED') {
-    git(rootDir, ['add', 'docs/money-printer-operator-report.md', 'SELF_REVIEW.md']);
+    git(rootDir, ['add', 'docs/money-printer-operator-report.md']);
     git(rootDir, ['commit', '-m', options.commitMessage || 'Add Money Printer operator report']);
     git(rootDir, ['push', '-u', 'origin', git(rootDir, ['branch', '--show-current'])]);
     report.pr = await openPullRequest(rootDir, {
       base: options.base || 'main',
-      title: options.title || 'Money Printer autonomous operator report'
+      title: options.title || 'Money Printer autonomous operator report',
+      bodyPath: selfReviewPath
     });
     report.merge = await mergePullRequestIfGreen(rootDir, review, report.pr, {
       autoMerge: options.autoMerge

--- a/tests/money-printer-self-review.test.js
+++ b/tests/money-printer-self-review.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import {
   RISK_LEVELS,
@@ -93,4 +94,12 @@ test('detects secret-like paths and renders the required self-review sections', 
   assert.match(markdown, /Safety Checks/);
   assert.match(markdown, /Rollback Plan/);
   assert.match(markdown, /Next Suggested Action/);
+});
+
+test('operator proposal commits only the reviewed safe improvement', () => {
+  const source = readFileSync(new URL('../scripts/money-printer-operator.mjs', import.meta.url), 'utf8');
+
+  assert.match(source, /self-review-latest\.md/);
+  assert.match(source, /\['add', 'docs\/money-printer-operator-report\.md'\]/);
+  assert.doesNotMatch(source, /\['add', 'docs\/money-printer-operator-report\.md', 'SELF_REVIEW\.md'\]/);
 });


### PR DESCRIPTION
Hardens the Money Printer operator after the first successful GREEN auto-merge run.

Changes:

- Writes proposal self-review output to the ignored .money-printer/operator runtime folder.
- Uses that self-review file as the PR body.
- Stops staging SELF_REVIEW.md as part of autonomous docs/report PRs.
- Adds a regression check for the proposal staging behavior.


Safety:
- No sending, billing, auth, deployment, scheduler, or secrets changes.
- Self-review classifies this PR as YELLOW because it touches automation code.


Verification:
- node --check scripts/money-printer-operator.mjs
- node --check scripts/money-printer-self-review.mjs
- node --test tests/money-printer-self-review.test.js tests/money-printer-message-review.test.js tests/money-printer-page.test.js

# Money Printer Self Review

## Summary

Money Printer autonomous self-review.

## Files Changed

- `M` `docs/money-printer-automerge.md` (4+/2-) - Path is documentation, tests, local Money Printer UI, or a bounded Money Printer internal file.
- `M` `scripts/money-printer-operator.mjs` (7+/3-) - Path is product, automation, API, CRM, package, or approval logic and needs human review.
- `M` `tests/money-printer-self-review.test.js` (9+/0-) - Path is documentation, tests, local Money Printer UI, or a bounded Money Printer internal file.

## Risk Classification

YELLOW

Reasons:

- scripts/money-printer-operator.mjs: Path is product, automation, API, CRM, package, or approval logic and needs human review.

## Auto-Merge Decision

Blocked

## Safety Checks

- tests passed: pass
- no secrets touched: pass
- no billing touched: pass
- no real sending touched: pass
- no deployment config touched: pass
- no destructive changes: pass
- changed file count within limit: pass
- additions within limit: pass
- deletions within limit: pass

## Verification

- node --check scripts/money-printer-operator.mjs
- node --check scripts/money-printer-self-review.mjs
- node --test tests/money-printer-self-review.test.js tests/money-printer-message-review.test.js tests/money-printer-page.test.js

## Rollback Plan

Revert the PR commit or run `git revert <merge-commit>` after merge.

## Next Suggested Action

Ask Thomas to review the blocked or non-green change before merge.
