### PR TITLE
Fix Money Printer self-review output path

### DIFF
--- a/scripts/money-printer-operator.mjs
+++ b/scripts/money-printer-operator.mjs
@@ -234,7 +234,7 @@ async function runPropose(rootDir, options = {}) {
     rootDir,
     testsPassed: report.verification.passed,
     commands: verificationCommands,
-    outPath: selfReviewPath,
+    out: selfReviewPath,
     summary: 'Money Printer proposed a documentation-only operator report update.',
     rollbackPlan: 'Revert the PR commit or restore docs/money-printer-operator-report.md from main.',
     nextSuggestedAction: 'If GREEN, open a PR for the documentation-only report update. If not GREEN, ask Thomas to review.'

--- a/tests/money-printer-self-review.test.js
+++ b/tests/money-printer-self-review.test.js
@@ -100,6 +100,8 @@ test('operator proposal commits only the reviewed safe improvement', () => {
   const source = readFileSync(new URL('../scripts/money-printer-operator.mjs', import.meta.url), 'utf8');
 
   assert.match(source, /self-review-latest\.md/);
+  assert.match(source, /out: selfReviewPath/);
+  assert.doesNotMatch(source, /outPath: selfReviewPath/);
   assert.match(source, /\['add', 'docs\/money-printer-operator-report\.md'\]/);
   assert.doesNotMatch(source, /\['add', 'docs\/money-printer-operator-report\.md', 'SELF_REVIEW\.md'\]/);
 });


### PR DESCRIPTION
Fixes the Money Printer operator self-review output path after the autonomous report loop exposed an option mismatch.

Changes:

- Uses the self-review engine supported out option instead of outPath.
- Keeps proposal self-review output in .money-printer/operator/self-review-latest.md.
- Adds a regression check for the exact option and staging behavior.
Safety:

- No sending, billing, auth, deployment, scheduler, or secrets changes.
- Self-review classifies this PR as YELLOW because it touches automation code.
Verification:

- node --check scripts/money-printer-operator.mjs
- node --check scripts/money-printer-self-review.mjs
- node --test tests/money-printer-self-review.test.js tests/money-printer-message-review.test.js tests/money-printer-page.test.js

# Money Printer Self Review

## Summary

Money Printer autonomous self-review.

## Files Changed

- `M` `scripts/money-printer-operator.mjs` (1+/1-) - Path is product, automation, API, CRM, package, or approval logic and needs human review.
- `M` `tests/money-printer-self-review.test.js` (2+/0-) - Path is documentation, tests, local Money Printer UI, or a bounded Money Printer internal file.

## Risk Classification

YELLOW

Reasons:

- scripts/money-printer-operator.mjs: Path is product, automation, API, CRM, package, or approval logic and needs human review.

## Auto-Merge Decision

Blocked

## Safety Checks

- tests passed: pass
- no secrets touched: pass
- no billing touched: pass
- no real sending touched: pass
- no deployment config touched: pass
- no destructive changes: pass
- changed file count within limit: pass
- additions within limit: pass
- deletions within limit: pass

## Verification

- node --check scripts/money-printer-operator.mjs
- node --check scripts/money-printer-self-review.mjs
- node --test tests/money-printer-self-review.test.js tests/money-printer-message-review.test.js tests/money-printer-page.test.js

## Rollback Plan

Revert the PR commit or run `git revert <merge-commit>` after merge.

## Next Suggested Action

Ask Thomas to review the blocked or non-green change before merge.
