### PR TITLE
Add Money Printer operator report email

### DIFF
--- a/docs/money-printer-automerge.md
+++ b/docs/money-printer-automerge.md
@@ -12,6 +12,8 @@ This first version is intentionally local/manual. It does not install a cron, sy
 
 ```bash
 node scripts/money-printer-operator.mjs report
+node scripts/money-printer-operator.mjs report --email-report --email-dry-run
+node scripts/money-printer-operator.mjs report --email
 node scripts/money-printer-operator.mjs propose
 node scripts/money-printer-self-review.mjs
 ```
@@ -19,6 +21,8 @@ node scripts/money-printer-self-review.mjs
 `report` inspects the repo and writes a local email-ready report under `.money-printer/operator/`.
 
 `propose` creates one documentation-only safe improvement, runs focused checks, generates an ignored self-review report under `.money-printer/operator/`, and classifies the change.
+
+`--email-report` sends the internal Thomas operator report after the run. `--email-dry-run` verifies the report path and email configuration without sending.
 
 PR creation and auto-merge are opt-in:
 
@@ -103,11 +107,52 @@ The PR body should include the self-review summary when the operator opens a PR.
 
 ## Notification
 
-Real email sending is not implemented in v1. The operator writes an email-ready report for Thomas at:
+The operator writes an email-ready report for Thomas at:
 
 `.money-printer/operator/thomas-email-latest.md`
 
-That keeps the reporting path testable without adding Gmail, SMTP, SMS, or outreach risk.
+Internal report email can use Gmail or SMTP when configured. This path is not outreach and does not load lead/contact sending.
+
+Suggested configuration:
+
+```bash
+OPERATOR_EMAIL_TO=thomas@example.com
+OPERATOR_EMAIL_FROM="3DVR Money Printer <3dvr.tech@gmail.com>"
+GMAIL_USER=3dvr.tech@gmail.com
+GMAIL_APP_PASSWORD=...
+```
+
+SMTP is also supported:
+
+```bash
+OPERATOR_EMAIL_TO=thomas@example.com
+OPERATOR_EMAIL_FROM="3DVR Money Printer <operator@example.com>"
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=operator@example.com
+SMTP_PASS=...
+```
+
+Dry run:
+
+```bash
+node scripts/money-printer-operator.mjs report --email-report --email-dry-run
+```
+
+Real internal report email:
+
+```bash
+node scripts/money-printer-operator.mjs report --email
+```
+
+Intentionally not allowed through this path:
+
+- cold outreach
+- lead/contact sending
+- SMS
+- Stripe or billing actions
+- deployment changes
+- scheduler changes
 
 ## Current Status
 

--- a/scripts/money-printer-operator.mjs
+++ b/scripts/money-printer-operator.mjs
@@ -9,6 +9,7 @@ import {
   buildSelfReviewMarkdown,
   runSelfReview
 } from './money-printer-self-review.mjs';
+import { sendOperatorReportEmail } from '../src/money-printer/operatorEmailReport.js';
 
 function parseArgs(argv = process.argv.slice(2)) {
   const args = { _: [] };
@@ -91,7 +92,7 @@ async function writeThomasReport(rootDir, report) {
   const filePath = path.join(dir, 'thomas-email-latest.md');
   const body = `# Money Printer Operator Report
 
-This is an email-ready report. Real email sending is disabled in v1.
+This is an internal operator report. Real outreach sending is not connected to this report path.
 
 ## Summary
 
@@ -111,6 +112,19 @@ ${report.next || 'Review the operator output.'}
 `;
   await writeFile(filePath, body, 'utf8');
   return filePath;
+}
+
+async function maybeSendOperatorReport(rootDir, report, options = {}) {
+  if (!parseBool(options.emailReport)) {
+    return null;
+  }
+  const email = await sendOperatorReportEmail({
+    rootDir,
+    reportPath: report.thomasReportPath,
+    dryRun: parseBool(options.emailDryRun)
+  });
+  report.emailReport = email;
+  return email;
 }
 
 function commandOutputSummary(result) {
@@ -204,7 +218,7 @@ async function mergePullRequestIfGreen(rootDir, review, pr, options = {}) {
   };
 }
 
-async function runReport(rootDir) {
+async function runReport(rootDir, options = {}) {
   const report = await buildReport(rootDir, 'report');
   const review = await runSelfReview({
     rootDir,
@@ -220,6 +234,8 @@ async function runReport(rootDir) {
   const dir = await ensureOperatorDir(rootDir);
   report.reportPath = await writeJson(path.join(dir, 'latest-report.json'), report);
   report.thomasReportPath = await writeThomasReport(rootDir, report);
+  await maybeSendOperatorReport(rootDir, report, options);
+  report.reportPath = await writeJson(path.join(dir, 'latest-report.json'), report);
   return report;
 }
 
@@ -271,6 +287,11 @@ async function runPropose(rootDir, options = {}) {
   const dir = await ensureOperatorDir(rootDir);
   report.reportPath = await writeJson(path.join(dir, 'latest-proposal.json'), report);
   report.thomasReportPath = await writeThomasReport(rootDir, report);
+  await maybeSendOperatorReport(rootDir, report, {
+    emailReport: options.emailReport,
+    emailDryRun: options.emailDryRun
+  });
+  report.reportPath = await writeJson(path.join(dir, 'latest-proposal.json'), report);
   return report;
 }
 
@@ -279,8 +300,11 @@ function printHelp() {
 
 Usage:
   node scripts/money-printer-operator.mjs report
+  node scripts/money-printer-operator.mjs report --email-report --email-dry-run
+  node scripts/money-printer-operator.mjs report --email
   node scripts/money-printer-operator.mjs propose
   node scripts/money-printer-operator.mjs propose --create-pr --auto-merge
+  node scripts/money-printer-operator.mjs propose --create-pr --auto-merge --email-report
 
 Commands:
   report      Inspect repo state and write an email-ready local report.
@@ -293,9 +317,12 @@ Flags:
   --base <branch>          PR base, default main.
   --title <text>           PR title.
   --commit-message <text>  Commit message for proposal mode.
+  --email                  Alias for --email-report.
+  --email-report           Send the internal Thomas report after the run.
+  --email-dry-run          Verify email config and log without sending.
   --json                   Print JSON.
 
-Real email sending, outreach, billing, deployment changes, schedulers, and secrets are not implemented in v1.
+Report email is internal-only. Outreach, billing, deployment changes, schedulers, and secrets are not connected to this command.
 `);
 }
 
@@ -309,14 +336,19 @@ async function main() {
   const command = args._[0] || 'report';
   let result;
   if (command === 'report') {
-    result = await runReport(rootDir);
+    result = await runReport(rootDir, {
+      emailReport: args.emailReport || args.email,
+      emailDryRun: args.emailDryRun || args.dryRun
+    });
   } else if (command === 'propose') {
     result = await runPropose(rootDir, {
       createPr: args.createPr,
       autoMerge: args.autoMerge,
       base: args.base,
       title: args.title,
-      commitMessage: args.commitMessage
+      commitMessage: args.commitMessage,
+      emailReport: args.emailReport || args.email,
+      emailDryRun: args.emailDryRun || args.dryRun
     });
   } else {
     throw new Error(`Unknown command: ${command}`);
@@ -331,6 +363,9 @@ async function main() {
   console.log(`Auto-merge: ${result.selfReview?.autoMergeAllowed ? 'allowed' : 'blocked'}`);
   console.log(`Report: ${path.relative(rootDir, result.reportPath || '')}`);
   console.log(`Thomas report: ${path.relative(rootDir, result.thomasReportPath || '')}`);
+  if (result.emailReport) {
+    console.log(`Email report: ${result.emailReport.sent ? 'sent' : result.emailReport.skipped ? `skipped (${result.emailReport.reason})` : result.emailReport.failed ? `failed (${result.emailReport.reason})` : result.emailReport.reason}`);
+  }
   if (result.pr?.url) console.log(`PR: ${result.pr.url}`);
   if (result.merge) console.log(`Merge: ${result.merge.merged ? 'merged' : `not merged (${result.merge.reason})`}`);
 }
@@ -346,5 +381,6 @@ export {
   runReport,
   runPropose,
   runVerification,
+  sendOperatorReportEmail,
   writeSafeImprovement
 };

--- a/src/money-printer/operatorEmailReport.js
+++ b/src/money-printer/operatorEmailReport.js
@@ -1,0 +1,207 @@
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { loadMoneyPrinterEnv } from './moneyPrinterEnv.js';
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function parseBool(value) {
+  if (typeof value === 'boolean') return value;
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+function redactConfig(config = {}) {
+  return {
+    to: config.to || '',
+    from: config.from || '',
+    transport: config.transport || '',
+    missing: config.missing || []
+  };
+}
+
+function resolveFrom(env = {}) {
+  const explicit = clean(env.OPERATOR_EMAIL_FROM || env.MONEY_PRINTER_OPERATOR_EMAIL_FROM);
+  if (explicit) return explicit;
+  const gmailUser = clean(env.GMAIL_USER);
+  if (gmailUser) return `"3DVR Money Printer" <${gmailUser}>`;
+  const smtpUser = clean(env.SMTP_USER);
+  if (smtpUser) return `"3DVR Money Printer" <${smtpUser}>`;
+  return clean(env.MAIL_FROM || env.AUTO_BUSINESS_FROM_EMAIL);
+}
+
+export function resolveOperatorEmailConfig(env = {}) {
+  const to = clean(
+    env.OPERATOR_EMAIL_TO
+    || env.MONEY_PRINTER_OPERATOR_EMAIL_TO
+    || env.MONEY_PRINTER_OWNER_EMAIL
+    || env.AUTO_BUSINESS_OWNER_EMAIL
+    || env.STRIPE_LOG_EMAIL
+    || env.GMAIL_USER
+  );
+  const from = resolveFrom(env);
+  const gmailUser = clean(env.GMAIL_USER);
+  const gmailPass = clean(env.GMAIL_APP_PASSWORD);
+  const smtpHost = clean(env.SMTP_HOST);
+  const smtpUser = clean(env.SMTP_USER);
+  const smtpPass = clean(env.SMTP_PASS || env.SMTP_PASSWORD);
+  const smtpPort = Number(env.SMTP_PORT || 587);
+  const smtpSecure = parseBool(env.SMTP_SECURE, false);
+  const missing = [];
+
+  if (!to) missing.push('OPERATOR_EMAIL_TO or MONEY_PRINTER_OWNER_EMAIL');
+  if (!from) missing.push('OPERATOR_EMAIL_FROM or GMAIL_USER/SMTP_USER');
+
+  if (gmailUser && gmailPass) {
+    return {
+      ok: Boolean(to && from),
+      to,
+      from,
+      transport: 'gmail',
+      missing,
+      nodemailerOptions: {
+        service: 'gmail',
+        auth: {
+          user: gmailUser,
+          pass: gmailPass
+        }
+      }
+    };
+  }
+
+  if (smtpHost && smtpUser && smtpPass) {
+    return {
+      ok: Boolean(to && from),
+      to,
+      from,
+      transport: 'smtp',
+      missing,
+      nodemailerOptions: {
+        host: smtpHost,
+        port: Number.isFinite(smtpPort) ? smtpPort : 587,
+        secure: smtpSecure,
+        auth: {
+          user: smtpUser,
+          pass: smtpPass
+        }
+      }
+    };
+  }
+
+  missing.push('GMAIL_USER + GMAIL_APP_PASSWORD or SMTP_HOST + SMTP_USER + SMTP_PASS');
+  return {
+    ok: false,
+    to,
+    from,
+    transport: '',
+    missing,
+    nodemailerOptions: null
+  };
+}
+
+async function defaultNodemailerImporter() {
+  return import('nodemailer');
+}
+
+async function appendEmailLog(rootDir, entry = {}) {
+  const dir = path.join(rootDir, '.money-printer', 'operator');
+  await mkdir(dir, { recursive: true });
+  const logPath = path.join(dir, 'email-report-log.jsonl');
+  await appendFile(logPath, `${JSON.stringify({
+    timestamp: new Date().toISOString(),
+    ...entry
+  })}\n`, 'utf8');
+  return logPath;
+}
+
+export async function sendOperatorReportEmail(options = {}) {
+  const rootDir = path.resolve(options.rootDir || process.cwd());
+  const reportPath = path.resolve(rootDir, options.reportPath || '.money-printer/operator/thomas-email-latest.md');
+  const env = options.env || process.env;
+  await loadMoneyPrinterEnv(rootDir, env);
+
+  const result = {
+    attempted: false,
+    sent: false,
+    skipped: false,
+    failed: false,
+    dryRun: parseBool(options.dryRun ?? env.OPERATOR_EMAIL_DRY_RUN, false),
+    reportPath,
+    logPath: '',
+    reason: '',
+    config: null
+  };
+
+  let body = '';
+  try {
+    body = await readFile(reportPath, 'utf8');
+  } catch (error) {
+    result.skipped = true;
+    result.reason = `report file unavailable: ${error.code || error.message}`;
+    result.logPath = await appendEmailLog(rootDir, {
+      status: 'skipped',
+      reason: result.reason,
+      reportPath
+    });
+    return result;
+  }
+
+  const config = resolveOperatorEmailConfig(env);
+  result.config = redactConfig(config);
+
+  if (!config.ok) {
+    result.skipped = true;
+    result.reason = `email config missing: ${config.missing.join(', ')}`;
+    result.logPath = await appendEmailLog(rootDir, {
+      status: 'skipped',
+      reason: result.reason,
+      reportPath,
+      config: result.config
+    });
+    return result;
+  }
+
+  if (result.dryRun) {
+    result.skipped = true;
+    result.reason = 'dry-run';
+    result.logPath = await appendEmailLog(rootDir, {
+      status: 'dry-run',
+      reason: result.reason,
+      reportPath,
+      config: result.config
+    });
+    return result;
+  }
+
+  result.attempted = true;
+  try {
+    const imported = await (options.nodemailerImporter || defaultNodemailerImporter)();
+    const nodemailer = imported.default || imported;
+    const transport = options.transport || nodemailer.createTransport(config.nodemailerOptions);
+    await transport.sendMail({
+      from: config.from,
+      to: config.to,
+      subject: options.subject || '[3DVR Money Printer] Operator report',
+      text: body
+    });
+    result.sent = true;
+    result.reason = 'sent';
+    result.logPath = await appendEmailLog(rootDir, {
+      status: 'sent',
+      reason: result.reason,
+      reportPath,
+      config: result.config
+    });
+    return result;
+  } catch (error) {
+    result.failed = true;
+    result.reason = `send failed: ${error.message}`;
+    result.logPath = await appendEmailLog(rootDir, {
+      status: 'failed',
+      reason: result.reason,
+      reportPath,
+      config: result.config
+    });
+    return result;
+  }
+}

--- a/tests/money-printer-operator-email.test.js
+++ b/tests/money-printer-operator-email.test.js
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  resolveOperatorEmailConfig,
+  sendOperatorReportEmail
+} from '../src/money-printer/operatorEmailReport.js';
+
+async function withTempRoot(fn) {
+  const root = await mkdtemp(path.join(tmpdir(), '3dvr-operator-email-'));
+  try {
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function writeReport(root) {
+  const reportPath = path.join(root, '.money-printer', 'operator', 'thomas-email-latest.md');
+  await mkdir(path.dirname(reportPath), { recursive: true });
+  await writeFile(reportPath, '# Money Printer Operator Report\n\nNo secrets here.\n', 'utf8');
+  return reportPath;
+}
+
+test('operator report email skips cleanly when config is missing', async () => {
+  await withTempRoot(async root => {
+    const reportPath = await writeReport(root);
+    const result = await sendOperatorReportEmail({
+      rootDir: root,
+      reportPath,
+      env: {
+        HOME: root
+      }
+    });
+
+    assert.equal(result.sent, false);
+    assert.equal(result.skipped, true);
+    assert.match(result.reason, /email config missing/);
+    assert.match(result.reason, /OPERATOR_EMAIL_TO/);
+    const log = await readFile(result.logPath, 'utf8');
+    assert.match(log, /"status":"skipped"/);
+  });
+});
+
+test('operator report email supports dry-run without sending', async () => {
+  await withTempRoot(async root => {
+    const reportPath = await writeReport(root);
+    let sendCalled = false;
+    const result = await sendOperatorReportEmail({
+      rootDir: root,
+      reportPath,
+      dryRun: true,
+      env: {
+        HOME: root,
+        OPERATOR_EMAIL_TO: 'thomas@example.com',
+        OPERATOR_EMAIL_FROM: 'operator@example.com',
+        SMTP_HOST: 'smtp.example.com',
+        SMTP_USER: 'operator@example.com',
+        SMTP_PASS: 'secret-value'
+      },
+      transport: {
+        async sendMail() {
+          sendCalled = true;
+        }
+      }
+    });
+
+    assert.equal(sendCalled, false);
+    assert.equal(result.sent, false);
+    assert.equal(result.skipped, true);
+    assert.equal(result.reason, 'dry-run');
+    assert.equal(result.config.to, 'thomas@example.com');
+    assert.equal(result.config.from, 'operator@example.com');
+    assert.equal(result.config.transport, 'smtp');
+    assert.deepEqual(result.config.missing, []);
+  });
+});
+
+test('operator report email sends report body through provided transport', async () => {
+  await withTempRoot(async root => {
+    const reportPath = await writeReport(root);
+    const sent = [];
+    const result = await sendOperatorReportEmail({
+      rootDir: root,
+      reportPath,
+      env: {
+        HOME: root,
+        OPERATOR_EMAIL_TO: 'thomas@example.com',
+        GMAIL_USER: '3dvr.tech@gmail.com',
+        GMAIL_APP_PASSWORD: 'gmail-secret-value'
+      },
+      nodemailerImporter: async () => ({
+        createTransport() {
+          return {
+            async sendMail(message) {
+              sent.push(message);
+            }
+          };
+        }
+      })
+    });
+
+    assert.equal(result.sent, true);
+    assert.equal(result.reason, 'sent');
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].to, 'thomas@example.com');
+    assert.match(sent[0].from, /3DVR Money Printer/);
+    assert.match(sent[0].text, /Money Printer Operator Report/);
+  });
+});
+
+test('operator email config and logs never expose secret values', async () => {
+  const config = resolveOperatorEmailConfig({
+    OPERATOR_EMAIL_TO: 'thomas@example.com',
+    SMTP_HOST: 'smtp.example.com',
+    SMTP_USER: 'operator@example.com',
+    SMTP_PASS: 'do-not-print-this-secret'
+  });
+
+  assert.equal(JSON.stringify(config.missing).includes('do-not-print-this-secret'), false);
+
+  await withTempRoot(async root => {
+    const reportPath = await writeReport(root);
+    const result = await sendOperatorReportEmail({
+      rootDir: root,
+      reportPath,
+      dryRun: true,
+      env: {
+        HOME: root,
+        OPERATOR_EMAIL_TO: 'thomas@example.com',
+        SMTP_HOST: 'smtp.example.com',
+        SMTP_USER: 'operator@example.com',
+        SMTP_PASS: 'do-not-print-this-secret'
+      }
+    });
+    const log = await readFile(result.logPath, 'utf8');
+    assert.equal(log.includes('do-not-print-this-secret'), false);
+  });
+});


### PR DESCRIPTION
Adds internal email delivery for Money Printer operator reports.

What changed:

- Adds a report-only email sender for .money-printer/operator/thomas-email-latest.md.
- Supports Gmail or SMTP via env vars without hardcoded secrets.
- Adds report/propose flags: --email, --email-report, and --email-dry-run.
- Logs sent/skipped/failed report email status to .money-printer/operator/email-report-log.jsonl.
- Documents dry-run, real internal report email, and disallowed actions.
Safety:

- Internal operator report email only.
- No outreach or lead/contact sending.
- No SMS, Stripe, billing, deployment config, scheduler, auth, or secret changes.
- Missing config skips cleanly and prints/logs missing env var names only.
- Self-review is YELLOW because this handles email delivery and operator automation; do not auto-merge.
Verification:

- node --check src/money-printer/operatorEmailReport.js
- node --check scripts/money-printer-operator.mjs
- node --test tests/money-printer-operator-email.test.js tests/money-printer-self-review.test.js
- node scripts/money-printer-operator.mjs report --email-report --email-dry-run --json

# Money Printer Self Review

## Summary

Money Printer autonomous self-review.

## Files Changed

- `M` `docs/money-printer-automerge.md` (47+/2-) - Path is documentation, tests, local Money Printer UI, or a bounded Money Printer internal file.
- `M` `scripts/money-printer-operator.mjs` (41+/5-) - Path is product, automation, API, CRM, package, or approval logic and needs human review.
- `A` `src/money-printer/operatorEmailReport.js` (207+/0-) - Path is product, automation, API, CRM, package, or approval logic and needs human review.
- `A` `tests/money-printer-operator-email.test.js` (141+/0-) - Path is documentation, tests, local Money Printer UI, or a bounded Money Printer internal file.

## Risk Classification

YELLOW

Reasons:

- scripts/money-printer-operator.mjs: Path is product, automation, API, CRM, package, or approval logic and needs human review.
- src/money-printer/operatorEmailReport.js: Path is product, automation, API, CRM, package, or approval logic and needs human review.

## Auto-Merge Decision

Blocked

## Safety Checks

- tests passed: pass
- no secrets touched: pass
- no billing touched: pass
- no real sending touched: pass
- no deployment config touched: pass
- no destructive changes: pass
- changed file count within limit: pass
- additions within limit: pass
- deletions within limit: pass

## Verification

- node --check src/money-printer/operatorEmailReport.js
- node --check scripts/money-printer-operator.mjs
- node --test tests/money-printer-operator-email.test.js tests/money-printer-self-review.test.js
- node scripts/money-printer-operator.mjs report --email-report --email-dry-run --json

## Rollback Plan

Revert the PR commit or run `git revert <merge-commit>` after merge.

## Next Suggested Action

Ask Thomas to review the blocked or non-green change before merge.
