### PR TITLE
Create safe branches for scheduled Money Printer proposals

### DIFF
--- a/docs/money-printer-automerge.md
+++ b/docs/money-printer-automerge.md
@@ -22,6 +22,8 @@ node scripts/money-printer-self-review.mjs
 
 `propose` creates one documentation-only safe improvement, runs focused checks, generates an ignored self-review report under `.money-printer/operator/`, and classifies the change.
 
+When `propose --create-pr` starts from `main` or `master`, the operator creates a timestamped branch before writing the safe improvement. Scheduled runs should not commit directly to `main`.
+
 `--email-report` sends the internal Thomas operator report after the run. `--email-dry-run` verifies the report path and email configuration without sending.
 
 PR creation and auto-merge are opt-in:

--- a/scripts/money-printer-operator.mjs
+++ b/scripts/money-printer-operator.mjs
@@ -133,6 +133,29 @@ function commandOutputSummary(result) {
   return text.slice(0, 500);
 }
 
+function autonomousBranchName(date = new Date()) {
+  const stamp = date.toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+  return `codex/money-printer-autonomous-${stamp}`;
+}
+
+function ensureProposalBranch(rootDir, options = {}) {
+  const branch = git(rootDir, ['branch', '--show-current']);
+  if (!['main', 'master'].includes(branch)) {
+    return {
+      originalBranch: branch,
+      branch,
+      created: false
+    };
+  }
+  const nextBranch = options.branchName || autonomousBranchName();
+  git(rootDir, ['switch', '-c', nextBranch]);
+  return {
+    originalBranch: branch,
+    branch: nextBranch,
+    created: true
+  };
+}
+
 async function runVerification(rootDir) {
   const commands = [
     ['node', ['--check', 'scripts/money-printer-self-review.mjs']],
@@ -240,7 +263,9 @@ async function runReport(rootDir, options = {}) {
 }
 
 async function runPropose(rootDir, options = {}) {
+  const branchContext = ensureProposalBranch(rootDir, options);
   const report = await buildReport(rootDir, 'propose');
+  report.branchContext = branchContext;
   report.safeImprovementPath = await writeSafeImprovement(rootDir);
   report.verification = await runVerification(rootDir);
   const operatorDir = await ensureOperatorDir(rootDir);
@@ -315,6 +340,7 @@ Flags:
   --create-pr              Commit, push, and open a PR when the self-review is not RED.
   --auto-merge             Merge the PR only if self-review is GREEN and checks passed.
   --base <branch>          PR base, default main.
+  --branch-name <name>     Branch to create when proposal starts from main/master.
   --title <text>           PR title.
   --commit-message <text>  Commit message for proposal mode.
   --email                  Alias for --email-report.
@@ -345,6 +371,7 @@ async function main() {
       createPr: args.createPr,
       autoMerge: args.autoMerge,
       base: args.base,
+      branchName: args.branchName,
       title: args.title,
       commitMessage: args.commitMessage,
       emailReport: args.emailReport || args.email,
@@ -381,6 +408,8 @@ export {
   runReport,
   runPropose,
   runVerification,
+  autonomousBranchName,
+  ensureProposalBranch,
   sendOperatorReportEmail,
   writeSafeImprovement
 };

--- a/tests/money-printer-self-review.test.js
+++ b/tests/money-printer-self-review.test.js
@@ -100,6 +100,8 @@ test('operator proposal commits only the reviewed safe improvement', () => {
   const source = readFileSync(new URL('../scripts/money-printer-operator.mjs', import.meta.url), 'utf8');
 
   assert.match(source, /self-review-latest\.md/);
+  assert.match(source, /ensureProposalBranch\(rootDir, options\)/);
+  assert.match(source, /git\(rootDir, \['switch', '-c', nextBranch\]\)/);
   assert.match(source, /out: selfReviewPath/);
   assert.doesNotMatch(source, /outPath: selfReviewPath/);
   assert.match(source, /\['add', 'docs\/money-printer-operator-report\.md'\]/);


### PR DESCRIPTION
Hardens scheduled Money Printer proposal runs so the operator does not commit directly on main.

Changes:

- If propose starts from main/master, create a timestamped codex/money-printer-autonomous-* branch first.
- Preserve existing behavior when already on a feature branch.
- Document scheduled propose branch behavior.
- Add a regression check for branch creation before safe improvement writes.
Safety:

- No outreach, billing, deployment, scheduler, auth, secret, or destructive changes.
- Self-review is YELLOW because it changes operator automation.
Verification:

- node --check scripts/money-printer-operator.mjs
- node --test tests/money-printer-self-review.test.js tests/money-printer-operator-email.test.js

# Money Printer Self Review

## Summary

Money Printer autonomous self-review.

## Files Changed

- `M` `docs/money-printer-automerge.md` (2+/0-) - Path is documentation, tests, local Money Printer UI, or a bounded Money Printer internal file.
- `M` `scripts/money-printer-operator.mjs` (29+/0-) - Path is product, automation, API, CRM, package, or approval logic and needs human review.
- `M` `tests/money-printer-self-review.test.js` (2+/0-) - Path is documentation, tests, local Money Printer UI, or a bounded Money Printer internal file.

## Risk Classification

YELLOW

Reasons:

- scripts/money-printer-operator.mjs: Path is product, automation, API, CRM, package, or approval logic and needs human review.

## Auto-Merge Decision

Blocked

## Safety Checks

- tests passed: pass
- no secrets touched: pass
- no billing touched: pass
- no real sending touched: pass
- no deployment config touched: pass
- no destructive changes: pass
- changed file count within limit: pass
- additions within limit: pass
- deletions within limit: pass

## Verification

- node --check scripts/money-printer-operator.mjs
- node --test tests/money-printer-self-review.test.js tests/money-printer-operator-email.test.js

## Rollback Plan

Revert the PR commit or run `git revert <merge-commit>` after merge.

## Next Suggested Action

Ask Thomas to review the blocked or non-green change before merge.
