### PR TITLE
Make portal coin pause on press

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -611,6 +611,14 @@ body.landing {
   cursor: grabbing;
 }
 
+.portal-swirl-logo[data-logo-paused="true"] {
+  cursor: pointer;
+}
+
+.portal-swirl-logo[data-logo-paused="true"]::after {
+  opacity: 0.32;
+}
+
 .portal-swirl-logo:focus-visible {
   outline: 3px solid rgba(56, 189, 248, 0.45);
   outline-offset: 5px;

--- a/index.html
+++ b/index.html
@@ -176,9 +176,10 @@
               <div
                 class="portal-swirl-logo"
                 data-portal-swirl-logo
-                role="img"
+                role="button"
                 tabindex="0"
-                aria-label="Interactive 3dvr portal 3D swirl logo. Drag or touch to tilt it, flip it, and wind up the spin."
+                aria-pressed="false"
+                aria-label="Interactive 3dvr portal 3D swirl logo. Press to pause or resume. Drag or touch to tilt and flip it."
               >
                 <canvas class="portal-swirl-logo__canvas" data-portal-swirl-canvas></canvas>
                 <span class="portal-swirl-logo__fallback" aria-hidden="true">

--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -1,7 +1,7 @@
 (() => {
   const THREE_CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
   const TAU = Math.PI * 2;
-  const BASE_FACE_SPIN = -TAU / 5200;
+  const BASE_FACE_SPIN = TAU / 5200;
   const DRAG_WIND_FACTOR = 0.00065;
   const MAX_EXTRA_SPIN = 0.105;
   const SPIN_DECAY = 0.99;
@@ -258,6 +258,8 @@
       ready: false,
       mode: 'initializing',
       dragging: false,
+      paused: false,
+      pointerMoved: false,
       lastX: 0,
       lastY: 0,
       dragDX: 0,
@@ -351,6 +353,19 @@
       } catch {
         // Pointer capture is optional; release behavior should never block settling.
       }
+    };
+
+    const setPaused = (paused) => {
+      state.paused = Boolean(paused);
+      if (state.paused) {
+        state.extraFaceSpin = 0;
+      }
+      root.dataset.logoPaused = String(state.paused);
+      root.setAttribute('aria-pressed', String(state.paused));
+    };
+
+    const togglePaused = () => {
+      setPaused(!state.paused);
     };
 
     const getGesture = () => {
@@ -487,6 +502,7 @@
     const startDrag = (event) => {
       const point = getPointer(event);
       state.dragging = true;
+      state.pointerMoved = false;
       state.lastX = point.x;
       state.lastY = point.y;
       state.dragDX = 0;
@@ -504,6 +520,9 @@
       const dx = point.x - state.lastX;
       const dy = point.y - state.lastY;
       const distance = Math.hypot(dx, dy);
+      if (distance > 3) {
+        state.pointerMoved = true;
+      }
       state.lastX = point.x;
       state.lastY = point.y;
       state.dragDX = dx;
@@ -532,6 +551,12 @@
       state.dragging = false;
       releasePointer(event);
 
+      const wasTap = !state.pointerMoved && Math.hypot(state.gestureDX, state.gestureDY) < 6;
+      if (wasTap) {
+        togglePaused();
+        return;
+      }
+
       const gesture = getGesture();
       updateSwipeStreak(gesture);
       addDirectionalFlipImpulse(gesture);
@@ -554,15 +579,21 @@
       window.addEventListener('pointercancel', endDrag);
 
       root.addEventListener('keydown', (event) => {
-        if (event.key === 'ArrowRight' || event.key === ' ') {
-          state.extraFaceSpin = clamp(state.extraFaceSpin - 0.012, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
+        if (event.key === ' ') {
+          togglePaused();
+          event.preventDefault();
+        } else if (event.key === 'ArrowRight') {
+          setPaused(false);
+          state.extraFaceSpin = clamp(state.extraFaceSpin + 0.012, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
           registerFlipGesture('y', 1, FLIP_DISTANCE_FULL_CHARGE);
           event.preventDefault();
         } else if (event.key === 'ArrowLeft') {
-          state.extraFaceSpin = clamp(state.extraFaceSpin - 0.008, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
+          setPaused(false);
+          state.extraFaceSpin = clamp(state.extraFaceSpin + 0.008, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
           registerFlipGesture('y', -1, FLIP_DISTANCE_FULL_CHARGE);
           event.preventDefault();
         } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+          setPaused(false);
           registerFlipGesture('x', event.key === 'ArrowUp' ? -1 : 1, FLIP_DISTANCE_FULL_CHARGE);
           event.preventDefault();
         }
@@ -710,8 +741,9 @@
         state.flipY = lerp(state.flipY, nearestGoodFaceAngle(state.flipY), FLIP_HOME_EASE);
       }
 
-      const baseSpin = reducedMotion ? BASE_FACE_SPIN * 0.28 : BASE_FACE_SPIN;
-      state.faceSpin += (baseSpin + state.extraFaceSpin) * spinElapsed;
+      const baseSpin = state.paused ? 0 : reducedMotion ? BASE_FACE_SPIN * 0.28 : BASE_FACE_SPIN;
+      const extraSpin = state.paused ? 0 : state.extraFaceSpin;
+      state.faceSpin += (baseSpin + extraSpin) * spinElapsed;
       render();
     };
 
@@ -725,6 +757,7 @@
         getState: () => ({
           mode: state.mode,
           dragging: state.dragging,
+          paused: state.paused,
           faceSpin: state.faceSpin,
           extraFaceSpin: state.extraFaceSpin,
           targetX: state.targetX,

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -21,14 +21,23 @@ describe('portal logo branding', () => {
     assert.match(html, /portal-swirl-logo\.js/);
     assert.match(html, /data-portal-swirl-logo/);
     assert.match(html, /3dvr portal 3D swirl logo/);
+    assert.match(html, /role="button"/);
+    assert.match(html, /aria-pressed="false"/);
+    assert.match(html, /Press to pause or resume/);
     assert.match(css, /\.portal-swirl-logo/);
+    assert.match(css, /\.portal-swirl-logo\[data-logo-paused="true"\]/);
     assert.match(swirlScript, /THREE_CDN_URL/);
     assert.match(swirlScript, /three\.js\/r128\/three\.min\.js/);
     assert.match(swirlScript, /CylinderGeometry/);
     assert.match(swirlScript, /TorusGeometry/);
     assert.match(swirlScript, /CanvasTexture/);
-    assert.match(swirlScript, /BASE_FACE_SPIN/);
+    assert.match(swirlScript, /const BASE_FACE_SPIN = TAU \/ 5200/);
     assert.match(swirlScript, /extraFaceSpin/);
+    assert.match(swirlScript, /paused: false/);
+    assert.match(swirlScript, /const setPaused = \(paused\) =>/);
+    assert.match(swirlScript, /root\.dataset\.logoPaused = String\(state\.paused\)/);
+    assert.match(swirlScript, /root\.setAttribute\('aria-pressed', String\(state\.paused\)\)/);
+    assert.match(swirlScript, /const togglePaused = \(\) =>/);
     assert.match(swirlScript, /MAX_EXTRA_SPIN = 0\.105/);
     assert.match(swirlScript, /makeTextTexture/);
     assert.match(
@@ -79,6 +88,11 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /getTouchFlipScale/);
     assert.match(swirlScript, /updateTouchRamp/);
     assert.match(swirlScript, /state\.extraFaceSpin - distance \* DRAG_WIND_FACTOR \* getSpinBoost\(\) \* touchSpinScale/);
+    assert.match(swirlScript, /const baseSpin = state\.paused \? 0 : reducedMotion \? BASE_FACE_SPIN \* 0\.28 : BASE_FACE_SPIN/);
+    assert.match(swirlScript, /const extraSpin = state\.paused \? 0 : state\.extraFaceSpin/);
+    assert.match(swirlScript, /if \(wasTap\) \{\s*togglePaused\(\);/);
+    assert.match(swirlScript, /if \(event\.key === ' '\) \{\s*togglePaused\(\);/);
+    assert.match(swirlScript, /paused: state\.paused/);
     assert.match(swirlScript, /touchRampCount: state\.touchRampCount/);
     assert.match(swirlScript, /touchInstability: state\.touchInstability/);
     assert.match(swirlScript, /const axis = absX >= absY \? 'y' : 'x'/);


### PR DESCRIPTION
This updates the 3DVR portal coin interaction.

Included:
- Reverses the portal coin base spin direction.
- Makes the coin an accessible pause/resume control.
- Tap/click toggles pause.
- Space toggles pause.
- Arrow-key tilt/flip controls still work and resume motion.
- Adds a subtle paused visual state.

Verification:
- node --check portal-swirl-logo.js
- node --test tests/portal-logo-branding.test.js

Note:
- Local Playwright launched Chromium but crashed at browser.newPage in this shell before loading the page. GitHub Playwright checks should provide browser validation.