### PR TITLE
Align portal coin touch spin direction

### DIFF
--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -487,7 +487,7 @@
       }
       state.wobbleVelocityZ += wobbleSign * FLIP_WOBBLE_IMPULSE * 0.5 * impulseScale;
       state.extraFaceSpin = clamp(
-        state.extraFaceSpin - FLIP_SPIN_BOOST * impulseScale,
+        state.extraFaceSpin + FLIP_SPIN_BOOST * impulseScale,
         -MAX_EXTRA_SPIN,
         MAX_EXTRA_SPIN,
       );
@@ -531,7 +531,7 @@
       state.gestureDY += dy;
       const touchSpinScale = getTouchSpinScale();
       state.extraFaceSpin = clamp(
-        state.extraFaceSpin - distance * DRAG_WIND_FACTOR * getSpinBoost() * touchSpinScale,
+        state.extraFaceSpin + distance * DRAG_WIND_FACTOR * getSpinBoost() * touchSpinScale,
         -MAX_EXTRA_SPIN,
         MAX_EXTRA_SPIN,
       );
@@ -561,7 +561,7 @@
       updateSwipeStreak(gesture);
       addDirectionalFlipImpulse(gesture);
       state.extraFaceSpin = clamp(
-        state.extraFaceSpin -
+        state.extraFaceSpin +
           Math.hypot(state.dragDX, state.dragDY) * 0.0018 * getSpinBoost() * getTouchSpinScale(),
         -MAX_EXTRA_SPIN,
         MAX_EXTRA_SPIN,

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -87,7 +87,9 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /getTouchWobbleScale/);
     assert.match(swirlScript, /getTouchFlipScale/);
     assert.match(swirlScript, /updateTouchRamp/);
-    assert.match(swirlScript, /state\.extraFaceSpin - distance \* DRAG_WIND_FACTOR \* getSpinBoost\(\) \* touchSpinScale/);
+    assert.match(swirlScript, /state\.extraFaceSpin \+ distance \* DRAG_WIND_FACTOR \* getSpinBoost\(\) \* touchSpinScale/);
+    assert.match(swirlScript, /state\.extraFaceSpin \+ FLIP_SPIN_BOOST \* impulseScale/);
+    assert.match(swirlScript, /state\.extraFaceSpin \+\s*Math\.hypot\(state\.dragDX, state\.dragDY\) \* 0\.0018 \* getSpinBoost\(\) \* getTouchSpinScale\(\)/);
     assert.match(swirlScript, /const baseSpin = state\.paused \? 0 : reducedMotion \? BASE_FACE_SPIN \* 0\.28 : BASE_FACE_SPIN/);
     assert.match(swirlScript, /const extraSpin = state\.paused \? 0 : state\.extraFaceSpin/);
     assert.match(swirlScript, /if \(wasTap\) \{\s*togglePaused\(\);/);


### PR DESCRIPTION
This keeps the portal coin's touch/drag wind-up spinning in the same direction as the base rotation.

Included:
- Touch/drag extra spin now adds to the base spin direction.
- Flip spin boost now matches the base direction.
- Release wind-up now matches the base direction.
- Branding test locks the direction behavior.

Verification:
- node --check portal-swirl-logo.js
- node --test tests/portal-logo-branding.test.js