### PR TITLE
Route Money Printer report email through portal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ GMAIL_USER=replace_me@example.com
 GMAIL_APP_PASSWORD=replace_me
 STRIPE_LOG_EMAIL=replace_me@example.com
 AGENT_OPERATOR_EMAIL_TOKEN=replace_me
+OPERATOR_EMAIL_TO=replace_me@example.com
+OPERATOR_EMAIL_FROM=3dvr.tech@gmail.com
+OPERATOR_REPORT_EMAIL_ENDPOINT=https://portal.3dvr.tech/api/calendar/reminder-email
+OPERATOR_REPORT_EMAIL_TOKEN=replace_me
 
 # Optional integration settings
 STRIPE_CUSTOMER_PORTAL_LOGIN_URL=

--- a/docs/money-printer-automerge.md
+++ b/docs/money-printer-automerge.md
@@ -113,9 +113,18 @@ The operator writes an email-ready report for Thomas at:
 
 `.money-printer/operator/thomas-email-latest.md`
 
-Internal report email can use Gmail or SMTP when configured. This path is not outreach and does not load lead/contact sending.
+Internal report email can use the portal's Vercel API route, Gmail, or SMTP when configured. This path is not outreach and does not load lead/contact sending.
 
-Suggested configuration:
+Recommended DigitalOcean setup:
+
+```bash
+OPERATOR_REPORT_EMAIL_ENDPOINT=https://portal.3dvr.tech/api/calendar/reminder-email
+OPERATOR_REPORT_EMAIL_TOKEN=...
+```
+
+The Vercel route sends through the portal deployment's existing `nodemailer` Gmail configuration, so the DigitalOcean server only makes an HTTPS request and avoids cloud SMTP blocks.
+
+Direct Gmail configuration:
 
 ```bash
 OPERATOR_EMAIL_TO=thomas@example.com

--- a/src/money-printer/operatorEmailReport.js
+++ b/src/money-printer/operatorEmailReport.js
@@ -1,6 +1,9 @@
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { loadMoneyPrinterEnv } from './moneyPrinterEnv.js';
+import { buildOperatorReportEmailHtml } from './operatorReportEmailTemplate.js';
+
+export { buildOperatorReportEmailHtml } from './operatorReportEmailTemplate.js';
 
 function clean(value) {
   return String(value || '').trim();
@@ -20,123 +23,20 @@ function redactConfig(config = {}) {
   };
 }
 
-function escapeHtml(value = '') {
-  return String(value || '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+function resolvePortalEmailEndpoint(env = {}) {
+  return clean(
+    env.OPERATOR_REPORT_EMAIL_ENDPOINT
+    || env.MONEY_PRINTER_OPERATOR_EMAIL_ENDPOINT
+    || env.PORTAL_OPERATOR_REPORT_EMAIL_ENDPOINT
+  );
 }
 
-function button(label, href, color = '#0f766e') {
-  if (!href) return '';
-  return `<a href="${escapeHtml(href)}" style="display:inline-block;margin:8px 8px 0 0;padding:12px 16px;border-radius:8px;background:${color};color:#ffffff;text-decoration:none;font-weight:700;">${escapeHtml(label)}</a>`;
-}
-
-function mailtoUrl({ to, subject, body }) {
-  if (!to) return '';
-  const params = new URLSearchParams();
-  if (subject) params.set('subject', subject);
-  if (body) params.set('body', body);
-  return `mailto:${encodeURIComponent(to)}?${params.toString()}`;
-}
-
-function summarizeReport(report = {}) {
-  const risk = clean(report.selfReview?.risk || 'unknown');
-  const merged = Boolean(report.merge?.merged);
-  const prUrl = clean(report.pr?.url);
-  const failed = Boolean(report.emailReport?.failed);
-  const blocked = risk === 'RED' || (report.pr?.blocked) || failed;
-  const needsReview = risk === 'YELLOW' || (prUrl && !merged);
-  const actionRequired = blocked || needsReview;
-  return {
-    risk,
-    merged,
-    prUrl,
-    actionRequired,
-    headline: actionRequired ? 'Please review this' : 'Handled. No action needed.',
-    status: blocked ? 'Blocked' : needsReview ? 'Review needed' : 'Handled',
-    summary: blocked
-      ? 'Money Printer stopped or hit a failure. Check the buttons below.'
-      : needsReview
-        ? 'Money Printer prepared something, but it needs a human decision before it moves.'
-        : 'Money Printer completed the safe loop. A GREEN change was merged or handled.',
-    nextAction: blocked
-      ? 'Open the PR or server log and decide whether to fix, skip, or rerun.'
-      : needsReview
-        ? 'Open the PR, review the change, then merge or close it.'
-        : 'Nothing. You can ignore this email unless you want to inspect the run.',
-    color: blocked ? '#b91c1c' : needsReview ? '#b45309' : '#0f766e'
-  };
-}
-
-export function buildOperatorReportEmailHtml({ report = {}, text = '', to = '' } = {}) {
-  const summary = summarizeReport(report);
-  const repoUrl = 'https://github.com/tmsteph/3dvr-portal';
-  const actionsUrl = `${repoUrl}/actions`;
-  const portalUrl = 'https://portal.3dvr.tech/money-printer/';
-  const replyUrl = mailtoUrl({
-    to,
-    subject: `Money Printer report: ${summary.status}`,
-    body: [
-      `I reviewed the Money Printer report.`,
-      `Risk: ${summary.risk}`,
-      summary.prUrl ? `PR: ${summary.prUrl}` : '',
-      '',
-      'Decision / note:'
-    ].filter(Boolean).join('\n')
-  });
-
-  const primaryButtons = [
-    button(summary.prUrl && !summary.merged ? 'Review PR' : summary.prUrl ? 'Open PR' : '', summary.prUrl, summary.color),
-    button('Open Money Printer', portalUrl, '#1d4ed8'),
-    button('View GitHub Actions', actionsUrl, '#334155'),
-    button('Reply with decision', replyUrl, '#6d28d9')
-  ].join('');
-
-  const verification = Array.isArray(report.verification?.commands)
-    ? report.verification.commands.map(item => `<li>${escapeHtml(item.command)}: <strong>${item.ok ? 'pass' : 'fail'}</strong></li>`).join('')
-    : '<li>No verification commands recorded.</li>';
-
-  return `<!doctype html>
-<html>
-  <body style="margin:0;background:#f8fafc;color:#0f172a;font-family:Arial,sans-serif;">
-    <div style="max-width:680px;margin:0 auto;padding:24px;">
-      <div style="border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;padding:20px;">
-        <p style="margin:0 0 8px;color:#475569;font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;">3DVR Money Printer</p>
-        <h1 style="margin:0 0 12px;font-size:28px;line-height:1.1;">${escapeHtml(summary.headline)}</h1>
-        <div style="display:inline-block;margin:0 0 16px;padding:6px 10px;border-radius:999px;background:${summary.color};color:#ffffff;font-weight:700;">${escapeHtml(summary.status)} · ${escapeHtml(summary.risk)}</div>
-        <p style="margin:0 0 16px;font-size:16px;line-height:1.5;">${escapeHtml(summary.summary)}</p>
-        <div style="margin:0 0 16px;padding:14px;border-radius:10px;background:#f8fafc;border:1px solid #e2e8f0;">
-          <p style="margin:0 0 4px;color:#475569;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;">One thing to do</p>
-          <p style="margin:0;font-size:17px;line-height:1.45;font-weight:700;">${escapeHtml(summary.nextAction)}</p>
-        </div>
-        <div>${primaryButtons}</div>
-      </div>
-
-      <div style="margin-top:16px;border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;padding:20px;">
-        <h2 style="margin:0 0 12px;font-size:18px;">What happened</h2>
-        <ul style="margin:0;padding-left:20px;line-height:1.7;">
-          <li>Command: <strong>${escapeHtml(report.command || 'unknown')}</strong></li>
-          <li>Auto-merge allowed: <strong>${report.selfReview?.autoMergeAllowed ? 'yes' : 'no'}</strong></li>
-          <li>Merged: <strong>${summary.merged ? 'yes' : 'no'}</strong></li>
-          <li>Branch: <strong>${escapeHtml(report.branch || '')}</strong></li>
-        </ul>
-      </div>
-
-      <div style="margin-top:16px;border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;padding:20px;">
-        <h2 style="margin:0 0 12px;font-size:18px;">Checks</h2>
-        <ul style="margin:0;padding-left:20px;line-height:1.7;">${verification}</ul>
-      </div>
-
-      <details style="margin-top:16px;border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;padding:16px;">
-        <summary style="cursor:pointer;font-weight:700;">Plain report</summary>
-        <pre style="white-space:pre-wrap;font-size:13px;line-height:1.5;color:#334155;">${escapeHtml(text)}</pre>
-      </details>
-    </div>
-  </body>
-</html>`;
+function resolvePortalEmailToken(env = {}) {
+  return clean(
+    env.OPERATOR_REPORT_EMAIL_TOKEN
+    || env.AGENT_OPERATOR_EMAIL_TOKEN
+    || env.THREEDVR_AUTOPILOT_EMAIL_TOKEN
+  );
 }
 
 function resolveFrom(env = {}) {
@@ -222,6 +122,81 @@ async function defaultNodemailerImporter() {
   return import('nodemailer');
 }
 
+async function sendViaPortalEndpoint({
+  endpoint,
+  token,
+  report,
+  text,
+  subject,
+  to,
+  fetchImpl = fetch
+}) {
+  const response = await fetchImpl(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { 'X-Operator-Token': token } : {})
+    },
+    body: JSON.stringify({
+      mode: 'operator-alert',
+      to: [to].filter(Boolean),
+      subject,
+      summary: buildOperatorReportSummary(report),
+      text,
+      actionItems: buildOperatorReportActionItems(report),
+      commands: [
+        'systemctl status money-printer-operator.timer',
+        'journalctl -u money-printer-operator.service -n 100 -f',
+        'tail -f /var/log/3dvr/money-printer-operator.log'
+      ],
+      metadata: {
+        command: report.command || '',
+        risk: report.selfReview?.risk || '',
+        merged: report.merge?.merged ? 'yes' : 'no',
+        pr: report.pr?.url || ''
+      }
+    })
+  });
+
+  const responseText = await response.text();
+  let payload = null;
+  try {
+    payload = responseText ? JSON.parse(responseText) : null;
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    throw new Error(payload?.error || responseText || `portal endpoint returned ${response.status}`);
+  }
+
+  return payload || { ok: true };
+}
+
+function buildOperatorReportSummary(report = {}) {
+  const risk = clean(report.selfReview?.risk || 'unknown');
+  const pr = clean(report.pr?.url);
+  const merged = report.merge?.merged ? 'merged' : 'not merged';
+  if (pr) {
+    return `Money Printer finished a ${risk} run and ${merged}. PR: ${pr}`;
+  }
+  return `Money Printer finished a ${risk} run with no PR URL recorded.`;
+}
+
+function buildOperatorReportActionItems(report = {}) {
+  const risk = clean(report.selfReview?.risk || 'unknown');
+  if (risk === 'GREEN' && report.merge?.merged) {
+    return ['No action needed. The safe GREEN change was handled.'];
+  }
+  if (risk === 'YELLOW') {
+    return ['Review the PR before merging.', report.pr?.url ? `Open PR: ${report.pr.url}` : 'Check the latest operator report.'];
+  }
+  if (risk === 'RED') {
+    return ['Do not merge automatically.', 'Review the blocked change and decide whether to skip, rewrite, or rerun.'];
+  }
+  return ['Check the latest operator report.'];
+}
+
 async function appendEmailLog(rootDir, entry = {}) {
   const dir = path.join(rootDir, '.money-printer', 'operator');
   await mkdir(dir, { recursive: true });
@@ -267,8 +242,16 @@ export async function sendOperatorReportEmail(options = {}) {
 
   const config = resolveOperatorEmailConfig(env);
   result.config = redactConfig(config);
+  const portalEndpoint = resolvePortalEmailEndpoint(env);
+  const portalToken = resolvePortalEmailToken(env);
+  if (portalEndpoint) {
+    result.config = {
+      ...result.config,
+      transport: 'portal-endpoint'
+    };
+  }
 
-  if (!config.ok) {
+  if (!config.ok && !portalEndpoint) {
     result.skipped = true;
     result.reason = `email config missing: ${config.missing.join(', ')}`;
     result.logPath = await appendEmailLog(rootDir, {
@@ -282,18 +265,42 @@ export async function sendOperatorReportEmail(options = {}) {
 
   if (result.dryRun) {
     result.skipped = true;
-    result.reason = 'dry-run';
+    result.reason = portalEndpoint ? 'dry-run portal endpoint' : 'dry-run';
     result.logPath = await appendEmailLog(rootDir, {
       status: 'dry-run',
       reason: result.reason,
       reportPath,
-      config: result.config
+      config: {
+        ...result.config,
+        transport: portalEndpoint ? 'portal-endpoint' : result.config.transport
+      }
     });
     return result;
   }
 
   result.attempted = true;
   try {
+    if (portalEndpoint) {
+      await sendViaPortalEndpoint({
+        endpoint: portalEndpoint,
+        token: portalToken,
+        report: options.report || {},
+        text: body,
+        subject: options.subject || '[3DVR Money Printer] Operator report',
+        to: config.to || clean(env.OPERATOR_EMAIL_TO),
+        fetchImpl: options.fetchImpl
+      });
+      result.sent = true;
+      result.reason = 'sent via portal endpoint';
+      result.logPath = await appendEmailLog(rootDir, {
+        status: 'sent',
+        reason: result.reason,
+        reportPath,
+        config: result.config
+      });
+      return result;
+    }
+
     const imported = await (options.nodemailerImporter || defaultNodemailerImporter)();
     const nodemailer = imported.default || imported;
     const transport = options.transport || nodemailer.createTransport(config.nodemailerOptions);

--- a/src/money-printer/operatorReportEmailTemplate.js
+++ b/src/money-printer/operatorReportEmailTemplate.js
@@ -1,0 +1,122 @@
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function escapeHtml(value = '') {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function button(label, href, color = '#0f766e') {
+  if (!href) return '';
+  return `<a href="${escapeHtml(href)}" style="display:inline-block;margin:8px 8px 0 0;padding:12px 16px;border-radius:8px;background:${color};color:#ffffff;text-decoration:none;font-weight:700;">${escapeHtml(label)}</a>`;
+}
+
+function mailtoUrl({ to, subject, body }) {
+  if (!to) return '';
+  const params = new URLSearchParams();
+  if (subject) params.set('subject', subject);
+  if (body) params.set('body', body);
+  return `mailto:${encodeURIComponent(to)}?${params.toString()}`;
+}
+
+function summarizeReport(report = {}) {
+  const risk = clean(report.selfReview?.risk || 'unknown');
+  const merged = Boolean(report.merge?.merged);
+  const prUrl = clean(report.pr?.url);
+  const failed = Boolean(report.emailReport?.failed);
+  const blocked = risk === 'RED' || (report.pr?.blocked) || failed;
+  const needsReview = risk === 'YELLOW' || (prUrl && !merged);
+  const actionRequired = blocked || needsReview;
+  return {
+    risk,
+    merged,
+    prUrl,
+    actionRequired,
+    headline: actionRequired ? 'Please review this' : 'Handled. No action needed.',
+    status: blocked ? 'Blocked' : needsReview ? 'Review needed' : 'Handled',
+    summary: blocked
+      ? 'Money Printer stopped or hit a failure. Check the buttons below.'
+      : needsReview
+        ? 'Money Printer prepared something, but it needs a human decision before it moves.'
+        : 'Money Printer completed the safe loop. A GREEN change was merged or handled.',
+    nextAction: blocked
+      ? 'Open the PR or server log and decide whether to fix, skip, or rerun.'
+      : needsReview
+        ? 'Open the PR, review the change, then merge or close it.'
+        : 'Nothing. You can ignore this email unless you want to inspect the run.',
+    color: blocked ? '#b91c1c' : needsReview ? '#b45309' : '#0f766e'
+  };
+}
+
+export function buildOperatorReportEmailHtml({ report = {}, text = '', to = '' } = {}) {
+  const summary = summarizeReport(report);
+  const repoUrl = 'https://github.com/tmsteph/3dvr-portal';
+  const actionsUrl = `${repoUrl}/actions`;
+  const portalUrl = 'https://portal.3dvr.tech/money-printer/';
+  const replyUrl = mailtoUrl({
+    to,
+    subject: `Money Printer report: ${summary.status}`,
+    body: [
+      'I reviewed the Money Printer report.',
+      `Risk: ${summary.risk}`,
+      summary.prUrl ? `PR: ${summary.prUrl}` : '',
+      '',
+      'Decision / note:'
+    ].filter(Boolean).join('\n')
+  });
+
+  const primaryButtons = [
+    button(summary.prUrl && !summary.merged ? 'Review PR' : summary.prUrl ? 'Open PR' : '', summary.prUrl, summary.color),
+    button('Open Money Printer', portalUrl, '#1d4ed8'),
+    button('View GitHub Actions', actionsUrl, '#334155'),
+    button('Reply with decision', replyUrl, '#6d28d9')
+  ].join('');
+
+  const verification = Array.isArray(report.verification?.commands)
+    ? report.verification.commands.map(item => `<li>${escapeHtml(item.command)}: <strong>${item.ok ? 'pass' : 'fail'}</strong></li>`).join('')
+    : '<li>No verification commands recorded.</li>';
+
+  return `<!doctype html>
+<html>
+  <body style="margin:0;background:#f8fafc;color:#0f172a;font-family:Arial,sans-serif;">
+    <div style="max-width:680px;margin:0 auto;padding:24px;">
+      <div style="border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;padding:20px;">
+        <p style="margin:0 0 8px;color:#475569;font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;">3DVR Money Printer</p>
+        <h1 style="margin:0 0 12px;font-size:28px;line-height:1.1;">${escapeHtml(summary.headline)}</h1>
+        <div style="display:inline-block;margin:0 0 16px;padding:6px 10px;border-radius:999px;background:${summary.color};color:#ffffff;font-weight:700;">${escapeHtml(summary.status)} · ${escapeHtml(summary.risk)}</div>
+        <p style="margin:0 0 16px;font-size:16px;line-height:1.5;">${escapeHtml(summary.summary)}</p>
+        <div style="margin:0 0 16px;padding:14px;border-radius:10px;background:#f8fafc;border:1px solid #e2e8f0;">
+          <p style="margin:0 0 4px;color:#475569;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;">One thing to do</p>
+          <p style="margin:0;font-size:17px;line-height:1.45;font-weight:700;">${escapeHtml(summary.nextAction)}</p>
+        </div>
+        <div>${primaryButtons}</div>
+      </div>
+
+      <div style="margin-top:16px;border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;padding:20px;">
+        <h2 style="margin:0 0 12px;font-size:18px;">What happened</h2>
+        <ul style="margin:0;padding-left:20px;line-height:1.7;">
+          <li>Command: <strong>${escapeHtml(report.command || 'unknown')}</strong></li>
+          <li>Auto-merge allowed: <strong>${report.selfReview?.autoMergeAllowed ? 'yes' : 'no'}</strong></li>
+          <li>Merged: <strong>${summary.merged ? 'yes' : 'no'}</strong></li>
+          <li>Branch: <strong>${escapeHtml(report.branch || '')}</strong></li>
+        </ul>
+      </div>
+
+      <div style="margin-top:16px;border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;padding:20px;">
+        <h2 style="margin:0 0 12px;font-size:18px;">Checks</h2>
+        <ul style="margin:0;padding-left:20px;line-height:1.7;">${verification}</ul>
+      </div>
+
+      <details style="margin-top:16px;border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;padding:16px;">
+        <summary style="cursor:pointer;font-weight:700;">Plain report</summary>
+        <pre style="white-space:pre-wrap;font-size:13px;line-height:1.5;color:#334155;">${escapeHtml(text)}</pre>
+      </details>
+    </div>
+  </body>
+</html>`;
+}

--- a/tests/money-printer-operator-email.test.js
+++ b/tests/money-printer-operator-email.test.js
@@ -114,6 +114,81 @@ test('operator report email sends report body through provided transport', async
   });
 });
 
+test('operator report email can send through the portal endpoint instead of SMTP', async () => {
+  await withTempRoot(async root => {
+    const reportPath = await writeReport(root);
+    const requests = [];
+    const result = await sendOperatorReportEmail({
+      rootDir: root,
+      reportPath,
+      report: {
+        command: 'propose',
+        selfReview: { risk: 'GREEN', autoMergeAllowed: true }
+      },
+      env: {
+        HOME: root,
+        OPERATOR_EMAIL_TO: 'thomas@example.com',
+        OPERATOR_REPORT_EMAIL_ENDPOINT: 'https://portal.3dvr.tech/api/calendar/reminder-email',
+        OPERATOR_REPORT_EMAIL_TOKEN: 'operator-token'
+      },
+      async fetchImpl(url, options) {
+        requests.push({ url, options });
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ ok: true, sent: true });
+          }
+        };
+      }
+    });
+
+    assert.equal(result.sent, true);
+    assert.equal(result.reason, 'sent via portal endpoint');
+    assert.equal(result.config.transport, 'portal-endpoint');
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, 'https://portal.3dvr.tech/api/calendar/reminder-email');
+    assert.equal(requests[0].options.headers['X-Operator-Token'], 'operator-token');
+    const payload = JSON.parse(requests[0].options.body);
+    assert.equal(payload.mode, 'operator-alert');
+    assert.deepEqual(payload.to, ['thomas@example.com']);
+    assert.match(payload.text, /Money Printer Operator Report/);
+    assert.match(payload.summary, /GREEN/);
+    assert.equal(payload.metadata.command, 'propose');
+  });
+});
+
+test('operator report email logs portal endpoint failures without exposing token', async () => {
+  await withTempRoot(async root => {
+    const reportPath = await writeReport(root);
+    const result = await sendOperatorReportEmail({
+      rootDir: root,
+      reportPath,
+      env: {
+        HOME: root,
+        OPERATOR_REPORT_EMAIL_ENDPOINT: 'https://portal.3dvr.tech/api/calendar/reminder-email',
+        OPERATOR_REPORT_EMAIL_TOKEN: 'do-not-log-token'
+      },
+      async fetchImpl() {
+        return {
+          ok: false,
+          status: 401,
+          async text() {
+            return JSON.stringify({ error: 'Unauthorized.' });
+          }
+        };
+      }
+    });
+
+    assert.equal(result.sent, false);
+    assert.equal(result.failed, true);
+    assert.match(result.reason, /Unauthorized/);
+    const log = await readFile(result.logPath, 'utf8');
+    assert.equal(log.includes('do-not-log-token'), false);
+    assert.match(log, /portal-endpoint/);
+  });
+});
+
 test('operator email config and logs never expose secret values', async () => {
   const config = resolveOperatorEmailConfig({
     OPERATOR_EMAIL_TO: 'thomas@example.com',


### PR DESCRIPTION
This lets the DigitalOcean Money Printer operator send internal report emails through the portal's Vercel deployment instead of direct SMTP.

Included:
- Adds a protected Vercel API route at /api/money-printer/operator-report-email.
- Route uses existing portal nodemailer/Gmail env vars.
- Operator sender prefers OPERATOR_REPORT_EMAIL_ENDPOINT over direct SMTP when configured.
- Keeps this internal-report-only; no outreach sending is wired.
- Adds tests for portal endpoint sends, failures, route auth, and missing config.
- Documents DigitalOcean endpoint env vars.

Safety:
- Requires X-Operator-Token or Bearer token.
- Does not expose token values in logs.
- Does not touch Stripe, billing, outreach, SMS, cron, or deployment config.

Verification:
- node --check api/money-printer/operator-report-email.js
- node --check src/money-printer/operatorEmailReport.js
- node --test tests/money-printer-operator-email.test.js tests/operator-report-email-api.test.js