### PR TITLE
Add Offer Garden portal app

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,6 +499,16 @@
             <span class="app-card__cta">Open small offer</span>
           </a>
           <a
+            href="offer-garden/"
+            class="app-card"
+            data-app-keywords="offer garden start free launch free success fee payments earn creator service lessons sales"
+          >
+            <span class="app-card__icon" aria-hidden="true">$0</span>
+            <span class="app-card__title">Start an Offer</span>
+            <span class="app-card__meta">Start free, make a small offer, and pay 3DVR only when money comes through your page.</span>
+            <span class="app-card__cta">Make offer</span>
+          </a>
+          <a
             href="ideas/forge-revenue-sprint.html"
             class="app-card"
             data-app-keywords="forge sprint paid launch offer revenue deposit money validation test message landing page builder"

--- a/offer-garden/app.js
+++ b/offer-garden/app.js
@@ -1,0 +1,144 @@
+(function () {
+  const storageKey = '3dvr:offer-garden:v1';
+
+  const form = document.querySelector('#offer-form');
+  const skillInput = document.querySelector('#skill');
+  const personInput = document.querySelector('#person');
+  const resultInput = document.querySelector('#result');
+  const priceInput = document.querySelector('#price');
+  const resetButton = document.querySelector('#reset-offer');
+  const saveButton = document.querySelector('#save-offer');
+  const copyButton = document.querySelector('#copy-message');
+  const status = document.querySelector('#status');
+
+  const cardTitle = document.querySelector('#card-title');
+  const cardLine = document.querySelector('#card-line');
+  const cardPerson = document.querySelector('#card-person');
+  const cardResult = document.querySelector('#card-result');
+  const cardPrice = document.querySelector('#card-price');
+  const shareMessage = document.querySelector('#share-message');
+
+  function clean(value) {
+    return String(value || '').trim().replace(/\s+/g, ' ');
+  }
+
+  function readDraft() {
+    return {
+      skill: clean(skillInput.value),
+      person: clean(personInput.value),
+      result: clean(resultInput.value),
+      price: clean(priceInput.value),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  function setStatus(message, tone) {
+    status.textContent = message;
+    if (tone) {
+      status.dataset.tone = tone;
+    } else {
+      delete status.dataset.tone;
+    }
+  }
+
+  function buildShareMessage(draft) {
+    const skill = draft.skill || 'a small offer';
+    const person = draft.person || 'people who may need this';
+    const result = draft.result || 'a small win';
+    const price = draft.price || 'a starter price';
+
+    return [
+      `I am testing a simple offer: ${skill}.`,
+      `It is for ${person}.`,
+      `You get ${result}.`,
+      `It starts at ${price}.`,
+      'Want to take a quick look?'
+    ].join('\n');
+  }
+
+  function render(draft) {
+    const skill = draft.skill || 'Your simple offer';
+    const person = draft.person || 'Someone who needs this';
+    const result = draft.result || 'A small win';
+    const price = draft.price || 'Pick a fair starter price';
+
+    cardTitle.textContent = skill;
+    cardLine.textContent = draft.skill
+      ? 'A clear first offer you can test with one person.'
+      : 'Tell us what you can help with. We will turn it into a clear first offer.';
+    cardPerson.textContent = person;
+    cardResult.textContent = result;
+    cardPrice.textContent = price;
+    shareMessage.value = buildShareMessage(draft);
+  }
+
+  function saveDraft(draft) {
+    localStorage.setItem(storageKey, JSON.stringify(draft));
+  }
+
+  function loadDraft() {
+    try {
+      return JSON.parse(localStorage.getItem(storageKey) || 'null');
+    } catch {
+      return null;
+    }
+  }
+
+  function fillForm(draft) {
+    if (!draft) return;
+    skillInput.value = draft.skill || '';
+    personInput.value = draft.person || '';
+    resultInput.value = draft.result || '';
+    priceInput.value = draft.price || '';
+  }
+
+  async function copyText(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+
+    shareMessage.focus();
+    shareMessage.select();
+    document.execCommand('copy');
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const draft = readDraft();
+    render(draft);
+    saveDraft(draft);
+    setStatus('Launch Card made. Share it with one person.', 'good');
+  });
+
+  [skillInput, personInput, resultInput, priceInput].forEach((input) => {
+    input.addEventListener('input', () => {
+      render(readDraft());
+    });
+  });
+
+  saveButton.addEventListener('click', () => {
+    saveDraft(readDraft());
+    setStatus('Draft saved on this device.', 'good');
+  });
+
+  resetButton.addEventListener('click', () => {
+    form.reset();
+    localStorage.removeItem(storageKey);
+    render({});
+    setStatus('Cleared.', 'warn');
+  });
+
+  copyButton.addEventListener('click', async () => {
+    try {
+      await copyText(shareMessage.value);
+      setStatus('Message copied.', 'good');
+    } catch {
+      setStatus('Copy did not work. Select the message and copy it.', 'warn');
+    }
+  });
+
+  const saved = loadDraft();
+  fillForm(saved);
+  render(saved || {});
+})();

--- a/offer-garden/index.html
+++ b/offer-garden/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Start an Offer | 3DVR Portal</title>
+  <meta
+    name="description"
+    content="Start free, make a simple offer, and only pay 3DVR when money comes through your page."
+  >
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <div class="page">
+    <header class="topbar">
+      <a class="brand" href="../index.html">3DVR Portal</a>
+      <nav aria-label="Offer links">
+        <a href="../life/">Daily Direction</a>
+        <a href="../launch-room/">Launch Room</a>
+      </nav>
+    </header>
+
+    <main class="shell">
+      <section class="hero" aria-labelledby="offer-title">
+        <p class="kicker">Free to start</p>
+        <h1 id="offer-title">Start free. Launch free. Pay only when you earn.</h1>
+        <p class="lead">Make one small offer. Share it. If people pay through 3DVR later, 3DVR takes a small fee.</p>
+      </section>
+
+      <section class="builder" aria-labelledby="builder-title">
+        <div class="panel form-panel">
+          <div class="panel-head">
+            <p class="step">Step 1</p>
+            <h2 id="builder-title">Make your offer</h2>
+          </div>
+
+          <form id="offer-form" class="offer-form">
+            <label for="skill">What can you help with?</label>
+            <input id="skill" name="skill" type="text" autocomplete="off" placeholder="Guitar lessons" required>
+
+            <label for="person">Who is it for?</label>
+            <input id="person" name="person" type="text" autocomplete="off" placeholder="New players">
+
+            <label for="result">What do they get?</label>
+            <textarea id="result" name="result" rows="3" placeholder="A first song, simple practice plan, and help staying on track"></textarea>
+
+            <label for="price">Starter price</label>
+            <input id="price" name="price" type="text" autocomplete="off" placeholder="$40/session">
+
+            <div class="actions">
+              <button class="button primary" type="submit">Make Launch Card</button>
+              <button class="button ghost" type="button" id="reset-offer">Clear</button>
+            </div>
+          </form>
+        </div>
+
+        <aside class="panel promise-panel" aria-labelledby="promise-title">
+          <p class="step">How it works</p>
+          <h2 id="promise-title">No money needed today.</h2>
+          <ol class="plain-list">
+            <li>Make a simple offer.</li>
+            <li>Share it with a few people.</li>
+            <li>Turn on payments when ready.</li>
+            <li>3DVR earns a small fee only when you get paid.</li>
+          </ol>
+          <p class="note">Payment setup is not live in this app yet. This is the offer draft.</p>
+        </aside>
+      </section>
+
+      <section class="launch-card" aria-labelledby="card-title">
+        <div class="card-preview" id="launch-card-preview">
+          <p class="mini">Launch Card</p>
+          <h2 id="card-title">Your simple offer</h2>
+          <p id="card-line">Tell us what you can help with. We will turn it into a clear first offer.</p>
+          <div class="card-row">
+            <span>For</span>
+            <strong id="card-person">Someone who needs this</strong>
+          </div>
+          <div class="card-row">
+            <span>Gets</span>
+            <strong id="card-result">A small win</strong>
+          </div>
+          <div class="card-row">
+            <span>Starts at</span>
+            <strong id="card-price">Pick a fair starter price</strong>
+          </div>
+        </div>
+
+        <div class="panel next-panel">
+          <p class="step">Step 2</p>
+          <h2>Share it</h2>
+          <p class="small">Start with one person. Keep it normal.</p>
+          <textarea id="share-message" rows="5" readonly>I am testing a simple offer with 3DVR. Want to take a quick look?</textarea>
+          <div class="actions">
+            <button class="button primary" type="button" id="copy-message">Copy Message</button>
+            <button class="button ghost" type="button" id="save-offer">Save Draft</button>
+          </div>
+          <p id="status" class="status" role="status" aria-live="polite">Ready.</p>
+        </div>
+      </section>
+
+      <section class="terms-strip" aria-label="Simple terms">
+        <div>
+          <strong>Free Builder</strong>
+          <span>$0 today</span>
+        </div>
+        <div>
+          <strong>Success fee</strong>
+          <span>Only on payments through 3DVR</span>
+        </div>
+        <div>
+          <strong>You keep most</strong>
+          <span>Fees come after refunds and payment costs</span>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/offer-garden/styles.css
+++ b/offer-garden/styles.css
@@ -1,0 +1,407 @@
+:root {
+  --bg: #0d1117;
+  --panel: #151b23;
+  --panel-2: #1d2633;
+  --text: #f7fafc;
+  --muted: #cbd5e1;
+  --soft: #94a3b8;
+  --line: rgba(226, 232, 240, 0.16);
+  --green: #8ee6a8;
+  --blue: #8dd8ff;
+  --gold: #ffe08a;
+  --danger: #ffb4a8;
+  --shadow: 0 22px 70px rgba(0, 0, 0, 0.34);
+}
+
+html,
+body {
+  width: 100%;
+  max-width: 100%;
+  min-height: 100%;
+  margin: 0;
+  overflow-x: hidden;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  color: var(--text);
+  background:
+    radial-gradient(circle at top left, rgba(142, 230, 168, 0.14), transparent 32rem),
+    radial-gradient(circle at top right, rgba(141, 216, 255, 0.12), transparent 30rem),
+    var(--bg);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+.page {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  max-width: 100%;
+  padding: 18px;
+}
+
+.shell,
+.topbar {
+  width: min(100%, 1120px);
+  max-width: 100%;
+}
+
+.topbar {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  transform: translateX(-50%);
+  backdrop-filter: blur(16px);
+}
+
+.brand,
+.topbar nav a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(13, 17, 23, 0.72);
+  font-weight: 850;
+}
+
+.brand {
+  padding: 8px 13px;
+}
+
+.topbar nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.topbar nav a {
+  padding: 8px 12px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.shell {
+  display: grid;
+  gap: 18px;
+  padding-top: 78px;
+}
+
+.hero {
+  display: grid;
+  gap: 14px;
+  padding: 24px 0 10px;
+}
+
+.kicker,
+.step,
+.mini {
+  width: fit-content;
+  max-width: 100%;
+  margin: 0;
+  border: 1px solid rgba(142, 230, 168, 0.32);
+  border-radius: 999px;
+  padding: 5px 9px;
+  color: var(--green);
+  background: rgba(142, 230, 168, 0.08);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 820px;
+  margin-bottom: 0;
+  font-size: clamp(2.45rem, 11vw, 5.6rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: clamp(1.35rem, 4vw, 2rem);
+  line-height: 1.08;
+}
+
+.lead {
+  max-width: 660px;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: clamp(1.08rem, 3vw, 1.4rem);
+}
+
+.builder,
+.launch-card,
+.terms-strip {
+  display: grid;
+  gap: 14px;
+}
+
+.builder,
+.launch-card {
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  align-items: stretch;
+}
+
+.panel,
+.card-preview,
+.terms-strip {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(21, 27, 35, 0.9);
+  box-shadow: var(--shadow);
+}
+
+.panel {
+  padding: 18px;
+}
+
+.panel-head,
+.offer-form,
+.next-panel {
+  display: grid;
+  gap: 12px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-weight: 800;
+}
+
+input,
+textarea {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 13px 14px;
+  color: var(--text);
+  background: rgba(13, 17, 23, 0.8);
+  outline: none;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:focus,
+textarea:focus {
+  border-color: rgba(141, 216, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(141, 216, 255, 0.12);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  max-width: 100%;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 11px 17px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.button.primary {
+  color: #07110b;
+  background: var(--green);
+}
+
+.button.ghost {
+  border-color: var(--line);
+  color: var(--text);
+  background: rgba(13, 17, 23, 0.72);
+}
+
+.promise-panel {
+  align-content: start;
+  background:
+    linear-gradient(150deg, rgba(255, 224, 138, 0.11), transparent),
+    rgba(21, 27, 35, 0.9);
+}
+
+.plain-list {
+  display: grid;
+  gap: 10px;
+  margin: 12px 0;
+  padding-left: 22px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  font-weight: 750;
+}
+
+.note,
+.small,
+.status {
+  margin-bottom: 0;
+  color: var(--soft);
+}
+
+.note {
+  border-left: 3px solid var(--gold);
+  padding-left: 12px;
+}
+
+.card-preview {
+  display: grid;
+  gap: 14px;
+  padding: 20px;
+  background:
+    linear-gradient(145deg, rgba(142, 230, 168, 0.14), rgba(141, 216, 255, 0.08)),
+    var(--panel-2);
+}
+
+.card-preview h2 {
+  font-size: clamp(1.8rem, 6vw, 3rem);
+}
+
+#card-line {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.08rem;
+}
+
+.card-row {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 10px;
+  align-items: baseline;
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+}
+
+.card-row span {
+  color: var(--soft);
+  font-weight: 850;
+}
+
+.card-row strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+}
+
+.next-panel textarea {
+  min-height: 128px;
+}
+
+.status[data-tone="good"] {
+  color: var(--green);
+}
+
+.status[data-tone="warn"] {
+  color: var(--danger);
+}
+
+.terms-strip {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 14px;
+}
+
+.terms-strip div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  border-right: 1px solid var(--line);
+  padding: 8px 12px;
+}
+
+.terms-strip div:last-child {
+  border-right: 0;
+}
+
+.terms-strip strong {
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.terms-strip span {
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 760px) {
+  .page {
+    padding: 12px;
+  }
+
+  .topbar {
+    position: static;
+    transform: none;
+    padding: 0;
+  }
+
+  .shell {
+    padding-top: 14px;
+  }
+
+  .builder,
+  .launch-card,
+  .terms-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar,
+  .topbar nav,
+  .actions {
+    align-items: stretch;
+  }
+
+  .topbar nav a,
+  .button {
+    flex: 1 1 auto;
+  }
+
+  .terms-strip div {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .terms-strip div:last-child {
+    border-bottom: 0;
+  }
+}

--- a/tests/offer-garden.test.js
+++ b/tests/offer-garden.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const pageUrl = new URL('../offer-garden/index.html', import.meta.url);
+const stylesUrl = new URL('../offer-garden/styles.css', import.meta.url);
+const appUrl = new URL('../offer-garden/app.js', import.meta.url);
+const portalUrl = new URL('../index.html', import.meta.url);
+
+test('offer garden keeps the success-share offer simple and safe', async () => {
+  const html = await readFile(pageUrl, 'utf8');
+  const css = await readFile(stylesUrl, 'utf8');
+  const app = await readFile(appUrl, 'utf8');
+
+  assert.match(html, /Start free\. Launch free\. Pay only when you earn\./);
+  assert.match(html, /Make one small offer\. Share it\./);
+  assert.match(html, /3DVR earns a small fee only when you get paid\./);
+  assert.match(html, /Payment setup is not live in this app yet\./);
+  assert.match(html, /id="skill"/);
+  assert.match(html, /id="share-message"/);
+  assert.match(html, /Copy Message/);
+  assert.doesNotMatch(html, /profit/i);
+  assert.doesNotMatch(html, /Stripe/i);
+  assert.doesNotMatch(app, /fetch\(/);
+  assert.doesNotMatch(app, /stripe/i);
+  assert.match(app, /localStorage\.setItem\(storageKey/);
+  assert.match(app, /navigator\.clipboard\.writeText/);
+  assert.match(css, /overflow-x:\s*hidden/);
+  assert.match(css, /width:\s*min\(100%, 1120px\)/);
+  assert.match(css, /@media \(max-width: 760px\)[\s\S]*?grid-template-columns:\s*1fr/);
+});
+
+test('portal home links to the offer garden app', async () => {
+  const html = await readFile(portalUrl, 'utf8');
+
+  assert.match(html, /href="offer-garden\/"/);
+  assert.match(html, /<span class="app-card__title">Start an Offer<\/span>/);
+  assert.match(html, /Start free, make a small offer, and pay 3DVR only when money comes through your page\./);
+});


### PR DESCRIPTION
## Summary
- Add a new portal app at /offer-garden/ for creating a simple first offer.
- Keep the copy short: start free, launch free, pay only when money comes through the 3DVR page.
- Save drafts locally and generate a plain share message.
- Add the app to the portal home app dock.

## Safety
- No Stripe wiring.
- No real payment processing.
- No outreach sending.
- The app states payment setup is not live yet.

## Verification
- node --check offer-garden/app.js
- node --test tests/offer-garden.test.js
- node --test tests/offer-garden.test.js tests/friends-family-pass.test.js tests/site-launcher-page.test.js
- curl -fsS http://127.0.0.1:3000/offer-garden/ | rg -n "Start free|Make Launch Card|Payment setup is not live|share-message"

Note: Playwright Chromium could not render screenshots in this host because the local browser runtime exits on GPU process failure before opening a page.