### PR TITLE
Make portal logo pause only while pressed

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,8 +178,7 @@
                 data-portal-swirl-logo
                 role="button"
                 tabindex="0"
-                aria-pressed="false"
-                aria-label="Interactive 3dvr portal 3D swirl logo. Press to pause or resume. Drag or touch to tilt and flip it."
+                aria-label="Interactive 3dvr portal 3D swirl logo. Press and hold to pause. Drag or touch to tilt and flip it."
               >
                 <canvas class="portal-swirl-logo__canvas" data-portal-swirl-canvas></canvas>
                 <span class="portal-swirl-logo__fallback" aria-hidden="true">

--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -361,11 +361,6 @@
         state.extraFaceSpin = 0;
       }
       root.dataset.logoPaused = String(state.paused);
-      root.setAttribute('aria-pressed', String(state.paused));
-    };
-
-    const togglePaused = () => {
-      setPaused(!state.paused);
     };
 
     const getGesture = () => {
@@ -502,6 +497,7 @@
     const startDrag = (event) => {
       const point = getPointer(event);
       state.dragging = true;
+      setPaused(true);
       state.pointerMoved = false;
       state.lastX = point.x;
       state.lastY = point.y;
@@ -553,7 +549,7 @@
 
       const wasTap = !state.pointerMoved && Math.hypot(state.gestureDX, state.gestureDY) < 6;
       if (wasTap) {
-        togglePaused();
+        setPaused(false);
         return;
       }
 
@@ -566,6 +562,7 @@
         -MAX_EXTRA_SPIN,
         MAX_EXTRA_SPIN,
       );
+      setPaused(false);
     };
 
     const setupInteraction = () => {
@@ -580,7 +577,7 @@
 
       root.addEventListener('keydown', (event) => {
         if (event.key === ' ') {
-          togglePaused();
+          if (!event.repeat) setPaused(true);
           event.preventDefault();
         } else if (event.key === 'ArrowRight') {
           setPaused(false);
@@ -595,6 +592,12 @@
         } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
           setPaused(false);
           registerFlipGesture('x', event.key === 'ArrowUp' ? -1 : 1, FLIP_DISTANCE_FULL_CHARGE);
+          event.preventDefault();
+        }
+      });
+      root.addEventListener('keyup', (event) => {
+        if (event.key === ' ') {
+          setPaused(false);
           event.preventDefault();
         }
       });

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -8,6 +8,7 @@ describe('portal logo branding', () => {
     const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
     const css = await readFile(new URL('../index-style.css', import.meta.url), 'utf8');
     const swirlScript = await readFile(new URL('../portal-swirl-logo.js', import.meta.url), 'utf8');
+    const swirlHtml = html.match(/<div\s+class="portal-swirl-logo"[\s\S]*?<\/div>\s*<\/div>\s*<span class="hero-eyebrow">/)?.[0] || '';
 
     assert.match(logo, /3dvr portal logo/);
     assert.match(logo, />3dvr</);
@@ -22,8 +23,8 @@ describe('portal logo branding', () => {
     assert.match(html, /data-portal-swirl-logo/);
     assert.match(html, /3dvr portal 3D swirl logo/);
     assert.match(html, /role="button"/);
-    assert.match(html, /aria-pressed="false"/);
-    assert.match(html, /Press to pause or resume/);
+    assert.doesNotMatch(swirlHtml, /aria-pressed=/);
+    assert.match(html, /Press and hold to pause/);
     assert.match(css, /\.portal-swirl-logo/);
     assert.match(css, /\.portal-swirl-logo\[data-logo-paused="true"\]/);
     assert.match(swirlScript, /THREE_CDN_URL/);
@@ -36,8 +37,8 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /paused: false/);
     assert.match(swirlScript, /const setPaused = \(paused\) =>/);
     assert.match(swirlScript, /root\.dataset\.logoPaused = String\(state\.paused\)/);
-    assert.match(swirlScript, /root\.setAttribute\('aria-pressed', String\(state\.paused\)\)/);
-    assert.match(swirlScript, /const togglePaused = \(\) =>/);
+    assert.doesNotMatch(swirlScript, /root\.setAttribute\('aria-pressed'/);
+    assert.doesNotMatch(swirlScript, /const togglePaused = \(\) =>/);
     assert.match(swirlScript, /MAX_EXTRA_SPIN = 0\.105/);
     assert.match(swirlScript, /makeTextTexture/);
     assert.match(
@@ -92,8 +93,10 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /state\.extraFaceSpin \+\s*Math\.hypot\(state\.dragDX, state\.dragDY\) \* 0\.0018 \* getSpinBoost\(\) \* getTouchSpinScale\(\)/);
     assert.match(swirlScript, /const baseSpin = state\.paused \? 0 : reducedMotion \? BASE_FACE_SPIN \* 0\.28 : BASE_FACE_SPIN/);
     assert.match(swirlScript, /const extraSpin = state\.paused \? 0 : state\.extraFaceSpin/);
-    assert.match(swirlScript, /if \(wasTap\) \{\s*togglePaused\(\);/);
-    assert.match(swirlScript, /if \(event\.key === ' '\) \{\s*togglePaused\(\);/);
+    assert.match(swirlScript, /state\.dragging = true;\s*setPaused\(true\);/);
+    assert.match(swirlScript, /if \(wasTap\) \{\s*setPaused\(false\);/);
+    assert.match(swirlScript, /if \(event\.key === ' '\) \{\s*if \(!event\.repeat\) setPaused\(true\);/);
+    assert.match(swirlScript, /root\.addEventListener\('keyup', \(event\) => \{\s*if \(event\.key === ' '\) \{\s*setPaused\(false\);/);
     assert.match(swirlScript, /paused: state\.paused/);
     assert.match(swirlScript, /touchRampCount: state\.touchRampCount/);
     assert.match(swirlScript, /touchInstability: state\.touchInstability/);


### PR DESCRIPTION
## Summary
- Change the portal swirl logo from pause/resume toggle to hold-to-pause.
- Pointer/touch press pauses the spin; release resumes it.
- Space key pauses while held and resumes on keyup.
- Remove aria-pressed from the logo because it is no longer a toggle button.

## Verification
- node --check portal-swirl-logo.js
- node --test tests/portal-logo-branding.test.js
- Firefox smoke: pointerdown sets data-logo-paused=true, pointerup sets false; Space down sets true, Space up sets false.