### PR TITLE
Add free page outreach sales script

### DIFF
--- a/sales/free-page-outreach.html
+++ b/sales/free-page-outreach.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Free Page Outreach | 3dvr Sales</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-100 font-sans">
+  <header class="bg-gradient-to-br from-blue-900 via-blue-800 to-purple-900 text-white">
+    <div class="max-w-5xl mx-auto px-6 py-8 space-y-4">
+      <nav class="text-xs uppercase tracking-[0.3em] text-blue-200 flex items-center gap-2">
+        <a href="index.html" class="text-blue-100 hover:text-white">Sales Directory</a>
+        <span aria-hidden="true">/</span>
+        <a href="scripts.html" class="text-blue-100 hover:text-white">Sales Scripts</a>
+        <span aria-hidden="true">/</span>
+        <span>Free Page Outreach</span>
+      </nav>
+      <div class="max-w-3xl">
+        <p class="text-xs uppercase tracking-[0.3em] text-blue-200">Warm network probe</p>
+        <h1 class="text-3xl font-bold mt-2">Free Page Outreach</h1>
+        <p class="text-sm text-blue-100 mt-3">
+          Texts for inviting people into a low-pressure 3DVR experiment: a simple free page for a project,
+          business, calling, or idea they care about.
+        </p>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-5xl mx-auto px-6 py-10 space-y-10">
+    <section class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 space-y-5">
+      <div>
+        <p class="text-xs uppercase tracking-[0.3em] text-blue-300">Primary text</p>
+        <h2 class="text-xl font-semibold mt-2">Best all-around version</h2>
+      </div>
+      <blockquote class="rounded-xl border border-blue-400/20 bg-slate-900 p-5 text-sm leading-7 text-slate-200 whitespace-pre-line">Hey, I'm working on a new 3DVR thing around helping people bring out what they're meant to build or share.
+
+A lot of people have some kind of purpose, calling, project, or gift in them, but it can be hard to turn that into something real.
+
+I'm making a few simple free web pages for people as a way to test the idea. Nothing fancy or salesy, just a first page for something you care about, offer, dream, project, or business.
+
+If you'd want one, send me the idea and I'll make you a first draft.</blockquote>
+    </section>
+
+    <section class="grid gap-5 md:grid-cols-2">
+      <article class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 space-y-4">
+        <div>
+          <p class="text-xs uppercase tracking-[0.3em] text-emerald-300">Short text</p>
+          <h2 class="text-lg font-semibold mt-2">For quick messages</h2>
+        </div>
+        <blockquote class="rounded-xl border border-white/5 bg-slate-900 p-5 text-sm leading-7 text-slate-200 whitespace-pre-line">Hey, I'm testing a 3DVR idea: helping people turn a purpose, project, business, or calling into a simple first web page.
+
+I'm making a few free pages for people while I figure it out. If there's something you've been wanting to build, share, or bring to life, send me the idea and I'll make you a first draft.</blockquote>
+      </article>
+
+      <article class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 space-y-4">
+        <div>
+          <p class="text-xs uppercase tracking-[0.3em] text-purple-300">Casual text</p>
+          <h2 class="text-lg font-semibold mt-2">For close friends</h2>
+        </div>
+        <blockquote class="rounded-xl border border-white/5 bg-slate-900 p-5 text-sm leading-7 text-slate-200 whitespace-pre-line">Hey, I'm making a few free simple websites/pages for people right now.
+
+The bigger idea is helping people bring out their potential - a project, calling, small business, creative thing, whatever feels real to them.
+
+If you have anything like that, send me the idea and I'll make you a first draft page.</blockquote>
+      </article>
+    </section>
+  </main>
+
+  <footer class="border-t border-white/10 bg-slate-950/80">
+    <div class="max-w-5xl mx-auto px-6 py-6 text-center text-xs tracking-[0.3em] uppercase text-slate-500">
+      2026 3dvr.tech
+    </div>
+  </footer>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/sales/scripts.html
+++ b/sales/scripts.html
@@ -28,6 +28,20 @@
 
   <main class="max-w-5xl mx-auto px-6 py-10 space-y-10">
     <section class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 space-y-5">
+      <div class="flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <p class="text-xs uppercase tracking-[0.3em] text-emerald-300">Warm network probe</p>
+          <h2 class="text-lg font-semibold mt-2">Free Page Outreach</h2>
+          <p class="text-sm text-slate-300 mt-2 max-w-2xl">
+            Text people you already know and offer a simple free page for a project, business, calling, or idea they
+            care about.
+          </p>
+        </div>
+        <a href="free-page-outreach.html" class="inline-flex items-center justify-center rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20">Open free page script</a>
+      </div>
+    </section>
+
+    <section class="rounded-2xl bg-slate-900/70 border border-white/5 p-6 space-y-5">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Discovery Call Flow</h2>
         <a href="training/#pitch" class="text-xs uppercase tracking-[0.3em] text-blue-300 hover:text-blue-200">Open pitch module</a>


### PR DESCRIPTION
## Summary
- Add a dedicated Sales page for warm-network free page outreach text variants
- Link the new page from `sales/scripts.html`
- Keep the page focused on usable outreach copy, without extra positioning notes

## Testing
- `node - <<'NODE' ... NODE` targeted check for the new outreach page: no `survival mode` text, includes Vercel Insights, includes issue launcher, and copy is ASCII
- `npm test` currently fails on the base branch for unrelated existing assertions, including `3dvr-connect/index.html` copy/include expectations and Playwright runtime installer expectations. The new page-specific checks pass.
