### PR TITLE
Add Microbusiness Launch Sprint campaign

### DIFF
--- a/microbusiness-sprint/app.js
+++ b/microbusiness-sprint/app.js
@@ -1,0 +1,54 @@
+const builder = document.querySelector('#briefBuilder');
+const outputs = {
+  title: document.querySelector('[data-output="title"]'),
+  summary: document.querySelector('[data-output="summary"]'),
+  steps: document.querySelector('[data-output="steps"]'),
+  mailto: document.querySelector('[data-output="mailto"]')
+};
+
+function clean(value, fallback) {
+  const normalized = String(value || '').trim().replace(/\s+/g, ' ');
+  return normalized || fallback;
+}
+
+function buildMailto(payload) {
+  const body = [
+    'I want to start a 3DVR Microbusiness Launch Sprint.',
+    '',
+    `Calling: ${payload.calling}`,
+    `Audience: ${payload.audience}`,
+    `Pain: ${payload.pain}`,
+    `Paid result: ${payload.paidResult}`,
+    '',
+    'Please help me turn this into the first paid offer.'
+  ].join('\n');
+
+  return `mailto:tmsteph1290@gmail.com?subject=${encodeURIComponent('3DVR Microbusiness Launch Sprint')}&body=${encodeURIComponent(body)}`;
+}
+
+builder?.addEventListener('submit', event => {
+  event.preventDefault();
+  const form = new FormData(builder);
+  const payload = {
+    calling: clean(form.get('calling'), 'a skill or calling that keeps returning'),
+    audience: clean(form.get('audience'), 'one reachable audience'),
+    pain: clean(form.get('pain'), 'one painful moment they already feel'),
+    paidResult: clean(form.get('paidResult'), 'one useful result delivered within 7 days')
+  };
+
+  outputs.title.textContent = `${payload.audience}: ${payload.paidResult}`;
+  outputs.summary.textContent = `The sprint starts with ${payload.calling}. The first offer should help ${payload.audience} move through "${payload.pain}" and pay for "${payload.paidResult}".`;
+  outputs.steps.innerHTML = '';
+
+  [
+    `Interview 3 people in ${payload.audience}.`,
+    `Write one promise around "${payload.paidResult}".`,
+    'Launch a short page and ask for a paid yes before expanding the build.'
+  ].forEach(step => {
+    const item = document.createElement('li');
+    item.textContent = step;
+    outputs.steps.append(item);
+  });
+
+  outputs.mailto.href = buildMailto(payload);
+});

--- a/microbusiness-sprint/app.js
+++ b/microbusiness-sprint/app.js
@@ -13,17 +13,19 @@ function clean(value, fallback) {
 
 function buildMailto(payload) {
   const body = [
-    'I want to start a 3DVR Microbusiness Launch Sprint.',
+    'I want to start the 3DVR Microbusiness Launch Sprint.',
+    '',
+    'Price anchor: $500 launch sprint',
     '',
     `Calling: ${payload.calling}`,
     `Audience: ${payload.audience}`,
     `Pain: ${payload.pain}`,
     `Paid result: ${payload.paidResult}`,
     '',
-    'Please help me turn this into the first paid offer.'
+    'Please help me turn this into one paid offer, landing page, lead/payment path, outreach script, and validation list.'
   ].join('\n');
 
-  return `mailto:tmsteph1290@gmail.com?subject=${encodeURIComponent('3DVR Microbusiness Launch Sprint')}&body=${encodeURIComponent(body)}`;
+  return `mailto:3dvr.tech@gmail.com?subject=${encodeURIComponent('3DVR Microbusiness Launch Sprint')}&body=${encodeURIComponent(body)}`;
 }
 
 builder?.addEventListener('submit', event => {
@@ -33,17 +35,17 @@ builder?.addEventListener('submit', event => {
     calling: clean(form.get('calling'), 'a skill or calling that keeps returning'),
     audience: clean(form.get('audience'), 'one reachable audience'),
     pain: clean(form.get('pain'), 'one painful moment they already feel'),
-    paidResult: clean(form.get('paidResult'), 'one useful result delivered within 7 days')
+    paidResult: clean(form.get('paidResult'), 'one paid offer, landing page, lead/payment path, outreach script, and validation list')
   };
 
   outputs.title.textContent = `${payload.audience}: ${payload.paidResult}`;
-  outputs.summary.textContent = `The sprint starts with ${payload.calling}. The first offer should help ${payload.audience} move through "${payload.pain}" and pay for "${payload.paidResult}".`;
+  outputs.summary.textContent = `The $500 sprint starts with ${payload.calling}. The first offer should help ${payload.audience} move through "${payload.pain}" and pay for "${payload.paidResult}".`;
   outputs.steps.innerHTML = '';
 
   [
     `Interview 3 people in ${payload.audience}.`,
-    `Write one promise around "${payload.paidResult}".`,
-    'Launch a short page and ask for a paid yes before expanding the build.'
+    `Write one $500 launch-sprint promise around "${payload.paidResult}".`,
+    'Launch a short page, lead/payment path, and outreach script before expanding the build.'
   ].forEach(step => {
     const item = document.createElement('li');
     item.textContent = step;

--- a/microbusiness-sprint/index.html
+++ b/microbusiness-sprint/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta
     name="description"
-    content="3DVR Microbusiness Launch Sprint helps people turn a calling, skill, or rough idea into a paid microbusiness offer and launch plan."
+    content="3DVR Microbusiness Launch Sprint helps people turn a calling, skill, or rough idea into one paid offer, landing page, lead path, outreach script, and validation list."
   >
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://portal.3dvr.tech/microbusiness-sprint/">
@@ -26,22 +26,22 @@
     <nav aria-label="Campaign navigation">
       <a href="#sprint-tool">Shape it</a>
       <a href="#offer">Offer</a>
-      <a href="../billing/?plan=founder">Start</a>
+      <a href="../billing/?plan=pro">Start</a>
     </nav>
   </header>
 
   <main>
     <section class="sprint-hero" aria-labelledby="campaign-title">
       <div class="hero-copy">
-        <p class="eyebrow">Calling -> offer -> first sale</p>
+        <p class="eyebrow">3DVR Microbusiness Launch Sprint</p>
         <h1 id="campaign-title">Turn the thing you keep thinking about into a tiny business people can buy.</h1>
         <p class="lede">
-          A focused 3DVR sprint for builders, operators, artists, parents, technicians, and restless people who
-          know they are meant to do more than trade every hour for someone else's roadmap.
+          A $500 launch sprint for builders, operators, artists, parents, technicians, and restless people who want
+          one paid offer, one landing page, one lead or payment path, one outreach script, and one first validation list.
         </p>
         <div class="hero-actions">
           <a class="button button-primary" href="#sprint-tool">Draft your sprint</a>
-          <a class="button button-secondary" href="../billing/?plan=builder">Choose Builder</a>
+          <a class="button button-secondary" href="#offer">See the offer</a>
         </div>
       </div>
 
@@ -54,11 +54,11 @@
           </div>
           <div>
             <dt>Day 2</dt>
-            <dd>Package one paid offer with a simple promise and price.</dd>
+            <dd>Package one paid offer with a simple promise and a $500 launch-sprint anchor.</dd>
           </div>
           <div>
             <dt>Day 3</dt>
-            <dd>Launch the page, outreach list, and first validation loop.</dd>
+            <dd>Launch the page, lead or payment path, outreach script, and first validation list.</dd>
           </div>
         </dl>
       </aside>
@@ -90,13 +90,15 @@
         </label>
 
         <label>
-          What could someone pay for within 7 days?
-          <input name="paidResult" type="text" placeholder="A live offer page, customer script, and first outreach list">
+          What paid result could you deliver within 7 days?
+          <input name="paidResult" type="text" placeholder="A live offer page, payment path, outreach script, and first validation list">
         </label>
 
         <div class="builder-actions">
           <button class="button button-primary" type="submit">Build sprint brief</button>
-          <a class="button button-secondary" href="../billing/?plan=founder">Start at $20/mo</a>
+          <a class="button button-secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Microbusiness%20Launch%20Sprint">
+            Contact 3DVR
+          </a>
         </div>
       </form>
 
@@ -112,7 +114,7 @@
         <a
           class="button button-primary"
           data-output="mailto"
-          href="mailto:tmsteph1290@gmail.com?subject=3DVR%20Microbusiness%20Sprint"
+          href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Microbusiness%20Launch%20Sprint"
         >
           Send this to 3DVR
         </a>
@@ -122,27 +124,29 @@
     <section id="offer" class="offer-strip" aria-labelledby="offer-title">
       <div>
         <p class="eyebrow">Campaign offer</p>
-        <h2 id="offer-title">The first offer is the sprint itself.</h2>
+        <h2 id="offer-title">The first offer is the sprint itself: $500 to launch the proof.</h2>
         <p>
-          We sell direct help turning a person's calling into one live microbusiness experiment. The portal becomes
-          the workspace, and each sprint creates proof, pages, leads, and future product requirements.
+          We sell direct help turning a skill, calling, or service idea into one paid offer, landing page, lead or
+          payment path, outreach script, and first validation list. If billing is not ready, email
+          <a href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Microbusiness%20Launch%20Sprint">3dvr.tech@gmail.com</a>
+          and we will handle intake manually.
         </p>
       </div>
       <div class="price-grid">
-        <a class="price-tile" href="../billing/?plan=founder">
+        <a class="price-tile featured" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20%24500%20Microbusiness%20Launch%20Sprint">
+          <span>Launch Sprint</span>
+          <strong>$500</strong>
+          <small>One offer, page, lead/payment path, script, and validation list.</small>
+        </a>
+        <a class="price-tile" href="../billing/?plan=pro">
           <span>Founder</span>
           <strong>$20/mo</strong>
-          <small>For first pages and fuzzy ideas.</small>
+          <small>For ongoing first pages, fuzzy ideas, and light execution support.</small>
         </a>
-        <a class="price-tile featured" href="../billing/?plan=builder">
+        <a class="price-tile" href="../billing/?plan=builder">
           <span>Builder</span>
           <strong>$50/mo</strong>
-          <small>For operators ready to launch and validate.</small>
-        </a>
-        <a class="price-tile" href="mailto:tmsteph1290@gmail.com?subject=3DVR%20Embedded%20Sprint">
-          <span>Embedded</span>
-          <strong>$200/mo</strong>
-          <small>For recurring workflow pain and teams.</small>
+          <small>For operators who want the sprint workspace to keep moving.</small>
         </a>
       </div>
     </section>

--- a/microbusiness-sprint/index.html
+++ b/microbusiness-sprint/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta
+    name="description"
+    content="3DVR Microbusiness Launch Sprint helps people turn a calling, skill, or rough idea into a paid microbusiness offer and launch plan."
+  >
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://portal.3dvr.tech/microbusiness-sprint/">
+  <title>Microbusiness Launch Sprint | 3DVR Portal</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="./styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="sprint-page">
+  <header class="campaign-topbar">
+    <a class="brand-lockup" href="../index.html" aria-label="3DVR Portal home">
+      <img src="../icons/icon-192.png" width="40" height="40" alt="">
+      <span>
+        <strong>3DVR</strong>
+        <small>Microbusiness Sprint</small>
+      </span>
+    </a>
+    <nav aria-label="Campaign navigation">
+      <a href="#sprint-tool">Shape it</a>
+      <a href="#offer">Offer</a>
+      <a href="../billing/?plan=founder">Start</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="sprint-hero" aria-labelledby="campaign-title">
+      <div class="hero-copy">
+        <p class="eyebrow">Calling -> offer -> first sale</p>
+        <h1 id="campaign-title">Turn the thing you keep thinking about into a tiny business people can buy.</h1>
+        <p class="lede">
+          A focused 3DVR sprint for builders, operators, artists, parents, technicians, and restless people who
+          know they are meant to do more than trade every hour for someone else's roadmap.
+        </p>
+        <div class="hero-actions">
+          <a class="button button-primary" href="#sprint-tool">Draft your sprint</a>
+          <a class="button button-secondary" href="../billing/?plan=builder">Choose Builder</a>
+        </div>
+      </div>
+
+      <aside class="hero-proof" aria-label="Sprint deliverables">
+        <img src="../icons/icon-512.png" width="88" height="88" alt="">
+        <dl>
+          <div>
+            <dt>Day 1</dt>
+            <dd>Find the practical business angle inside your calling.</dd>
+          </div>
+          <div>
+            <dt>Day 2</dt>
+            <dd>Package one paid offer with a simple promise and price.</dd>
+          </div>
+          <div>
+            <dt>Day 3</dt>
+            <dd>Launch the page, outreach list, and first validation loop.</dd>
+          </div>
+        </dl>
+      </aside>
+    </section>
+
+    <section id="sprint-tool" class="sprint-tool" aria-labelledby="tool-title">
+      <div class="tool-intro">
+        <p class="eyebrow">Start here</p>
+        <h2 id="tool-title">Draft the first useful version.</h2>
+        <p>
+          Keep it honest. A small clear offer can start moving today; a giant perfect plan usually waits.
+        </p>
+      </div>
+
+      <form class="brief-builder" id="briefBuilder">
+        <label>
+          What skill, frustration, or calling keeps coming back?
+          <textarea name="calling" rows="4" placeholder="I keep helping people organize messy event tech, workflows, or launch ideas."></textarea>
+        </label>
+
+        <label>
+          Who would you help first?
+          <input name="audience" type="text" placeholder="Freelancers, local service owners, overwhelmed creators">
+        </label>
+
+        <label>
+          What painful moment can you make easier?
+          <input name="pain" type="text" placeholder="They have an idea but no clear offer, page, or next action">
+        </label>
+
+        <label>
+          What could someone pay for within 7 days?
+          <input name="paidResult" type="text" placeholder="A live offer page, customer script, and first outreach list">
+        </label>
+
+        <div class="builder-actions">
+          <button class="button button-primary" type="submit">Build sprint brief</button>
+          <a class="button button-secondary" href="../billing/?plan=founder">Start at $20/mo</a>
+        </div>
+      </form>
+
+      <aside class="sprint-brief" aria-live="polite">
+        <p class="brief-label">Sprint Brief</p>
+        <h3 data-output="title">Your microbusiness sprint</h3>
+        <p data-output="summary">Answer the prompts to create a first offer, first audience, and next actions.</p>
+        <ol data-output="steps">
+          <li>Pick one audience.</li>
+          <li>Name one painful moment.</li>
+          <li>Sell one result before building the empire.</li>
+        </ol>
+        <a
+          class="button button-primary"
+          data-output="mailto"
+          href="mailto:tmsteph1290@gmail.com?subject=3DVR%20Microbusiness%20Sprint"
+        >
+          Send this to 3DVR
+        </a>
+      </aside>
+    </section>
+
+    <section id="offer" class="offer-strip" aria-labelledby="offer-title">
+      <div>
+        <p class="eyebrow">Campaign offer</p>
+        <h2 id="offer-title">The first offer is the sprint itself.</h2>
+        <p>
+          We sell direct help turning a person's calling into one live microbusiness experiment. The portal becomes
+          the workspace, and each sprint creates proof, pages, leads, and future product requirements.
+        </p>
+      </div>
+      <div class="price-grid">
+        <a class="price-tile" href="../billing/?plan=founder">
+          <span>Founder</span>
+          <strong>$20/mo</strong>
+          <small>For first pages and fuzzy ideas.</small>
+        </a>
+        <a class="price-tile featured" href="../billing/?plan=builder">
+          <span>Builder</span>
+          <strong>$50/mo</strong>
+          <small>For operators ready to launch and validate.</small>
+        </a>
+        <a class="price-tile" href="mailto:tmsteph1290@gmail.com?subject=3DVR%20Embedded%20Sprint">
+          <span>Embedded</span>
+          <strong>$200/mo</strong>
+          <small>For recurring workflow pain and teams.</small>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/microbusiness-sprint/styles.css
+++ b/microbusiness-sprint/styles.css
@@ -1,0 +1,377 @@
+:root {
+  --sprint-ink: #17201a;
+  --sprint-muted: #536157;
+  --sprint-paper: #f8f4ea;
+  --sprint-surface: #fffdf6;
+  --sprint-line: rgba(23, 32, 26, 0.14);
+  --sprint-moss: #28614a;
+  --sprint-moss-dark: #174632;
+  --sprint-clay: #b65239;
+  --sprint-sun: #f1bd4b;
+  --sprint-blue: #2d6f9f;
+  --sprint-shadow: 0 24px 70px rgba(54, 42, 25, 0.16);
+}
+
+.sprint-page {
+  min-height: 100vh;
+  background:
+    linear-gradient(90deg, rgba(23, 32, 26, 0.04) 1px, transparent 1px),
+    linear-gradient(rgba(23, 32, 26, 0.04) 1px, transparent 1px),
+    radial-gradient(circle at 12% 18%, rgba(241, 189, 75, 0.24), transparent 30%),
+    radial-gradient(circle at 90% 8%, rgba(45, 111, 159, 0.18), transparent 28%),
+    var(--sprint-paper);
+  background-size: 28px 28px, 28px 28px, auto, auto, auto;
+  color: var(--sprint-ink);
+}
+
+.campaign-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem clamp(1rem, 4vw, 3rem);
+  background: rgba(248, 244, 234, 0.88);
+  border-bottom: 1px solid var(--sprint-line);
+  backdrop-filter: blur(16px);
+}
+
+.brand-lockup,
+.campaign-topbar nav,
+.hero-actions,
+.builder-actions,
+.price-grid {
+  display: flex;
+  align-items: center;
+}
+
+.brand-lockup {
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.brand-lockup img {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+}
+
+.brand-lockup span {
+  display: grid;
+  line-height: 1.1;
+}
+
+.brand-lockup strong {
+  font-size: 1rem;
+}
+
+.brand-lockup small {
+  color: var(--sprint-muted);
+  font-weight: 700;
+}
+
+.campaign-topbar nav {
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.campaign-topbar nav a {
+  padding: 0.55rem 0.8rem;
+  border: 1px solid transparent;
+  border-radius: 0.55rem;
+  color: var(--sprint-muted);
+  font-weight: 800;
+}
+
+.campaign-topbar nav a:hover {
+  color: var(--sprint-ink);
+  border-color: var(--sprint-line);
+  background: rgba(255, 253, 246, 0.72);
+}
+
+.sprint-page main {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 4.75rem) 0 5rem;
+}
+
+.sprint-hero,
+.sprint-tool,
+.offer-strip {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+}
+
+.sprint-hero {
+  grid-template-columns: minmax(0, 1.16fr) minmax(280px, 0.84fr);
+  align-items: stretch;
+  min-height: calc(100vh - 8rem);
+}
+
+.hero-copy,
+.hero-proof,
+.brief-builder,
+.sprint-brief,
+.offer-strip,
+.price-tile {
+  border: 1px solid var(--sprint-line);
+  background: rgba(255, 253, 246, 0.82);
+  box-shadow: var(--sprint-shadow);
+}
+
+.hero-copy {
+  display: grid;
+  align-content: center;
+  padding: clamp(2rem, 5vw, 4.5rem);
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--sprint-clay);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero-copy h1 {
+  max-width: 11ch;
+  margin: 0;
+  font-size: clamp(3.1rem, 7vw, 6.2rem);
+  line-height: 0.96;
+}
+
+.lede,
+.tool-intro p,
+.offer-strip p,
+.sprint-brief p,
+.price-tile small {
+  color: var(--sprint-muted);
+}
+
+.lede {
+  max-width: 62ch;
+  margin: 1.4rem 0 0;
+  font-size: 1.13rem;
+}
+
+.hero-actions,
+.builder-actions {
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1.6rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.8rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--sprint-line);
+  border-radius: 0.55rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.button-primary {
+  color: #fffdf6;
+  background: var(--sprint-moss);
+  border-color: var(--sprint-moss-dark);
+}
+
+.button-primary:hover {
+  color: #fff;
+  background: var(--sprint-moss-dark);
+}
+
+.button-secondary {
+  color: var(--sprint-ink);
+  background: rgba(241, 189, 75, 0.24);
+}
+
+.hero-proof {
+  display: grid;
+  align-content: end;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 4vw, 2.4rem);
+  background:
+    linear-gradient(160deg, rgba(40, 97, 74, 0.94), rgba(23, 70, 50, 0.9)),
+    var(--sprint-moss);
+  color: #fffdf6;
+}
+
+.hero-proof img {
+  width: 5.5rem;
+  height: 5.5rem;
+  border: 1px solid rgba(255, 253, 246, 0.35);
+  border-radius: 1rem;
+}
+
+.hero-proof dl {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+}
+
+.hero-proof div {
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 253, 246, 0.26);
+}
+
+.hero-proof dt {
+  color: var(--sprint-sun);
+  font-weight: 900;
+}
+
+.hero-proof dd {
+  margin: 0.2rem 0 0;
+  color: rgba(255, 253, 246, 0.82);
+}
+
+.sprint-tool {
+  grid-template-columns: minmax(220px, 0.55fr) minmax(300px, 1fr) minmax(280px, 0.7fr);
+  align-items: start;
+  padding-top: 2rem;
+}
+
+.tool-intro h2,
+.offer-strip h2 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1;
+}
+
+.brief-builder,
+.sprint-brief {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.brief-builder label {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--sprint-ink);
+  font-weight: 900;
+}
+
+.brief-builder input,
+.brief-builder textarea {
+  width: 100%;
+  border: 1px solid var(--sprint-line);
+  border-radius: 0.5rem;
+  padding: 0.8rem 0.9rem;
+  background: #fffdf6;
+  color: var(--sprint-ink);
+  font: inherit;
+}
+
+.brief-builder textarea {
+  resize: vertical;
+}
+
+.brief-builder input:focus,
+.brief-builder textarea:focus {
+  outline: 3px solid rgba(45, 111, 159, 0.22);
+  border-color: var(--sprint-blue);
+}
+
+.brief-label {
+  margin: 0;
+  color: var(--sprint-clay);
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.sprint-brief h3 {
+  margin: 0;
+  font-size: 1.65rem;
+  line-height: 1.08;
+}
+
+.sprint-brief ol {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.sprint-brief li {
+  color: var(--sprint-muted);
+}
+
+.offer-strip {
+  grid-template-columns: minmax(260px, 0.7fr) minmax(300px, 1fr);
+  align-items: start;
+  margin-top: 2rem;
+  padding: clamp(1.4rem, 4vw, 2.2rem);
+}
+
+.price-grid {
+  gap: 0.9rem;
+  align-items: stretch;
+}
+
+.price-tile {
+  display: grid;
+  flex: 1 1 0;
+  min-width: 0;
+  gap: 0.4rem;
+  padding: 1rem;
+}
+
+.price-tile span {
+  color: var(--sprint-clay);
+  font-weight: 900;
+}
+
+.price-tile strong {
+  font-size: 1.8rem;
+}
+
+.price-tile.featured {
+  background: rgba(241, 189, 75, 0.22);
+  border-color: rgba(182, 82, 57, 0.3);
+}
+
+@media (max-width: 980px) {
+  .sprint-hero,
+  .sprint-tool,
+  .offer-strip {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .hero-copy h1 {
+    max-width: 12ch;
+  }
+}
+
+@media (max-width: 720px) {
+  .campaign-topbar {
+    position: static;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .campaign-topbar nav {
+    justify-content: flex-start;
+  }
+
+  .hero-copy {
+    padding: 1.35rem;
+  }
+
+  .hero-copy h1 {
+    font-size: clamp(2.6rem, 14vw, 4rem);
+  }
+
+  .price-grid {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a fresh `/microbusiness-sprint/` campaign route for the 3DVR Microbusiness Launch Sprint
- include an interactive brief builder that turns a calling, audience, pain, and paid result into a sprint brief
- align public copy with the autopilot offer: $500 launch sprint, one paid offer, landing page, lead/payment path, outreach script, and validation list
- route Founder/Builder follow-up to existing billing pages and provide a `3dvr.tech@gmail.com` fallback CTA

## Verification
- `node --check microbusiness-sprint/app.js`
- local static check: `/microbusiness-sprint/` returned 200
- local static check: `/billing/?plan=pro` returned 200
- local static check: `/billing/?plan=builder` returned 200

## Notes
- this PR only adds the new campaign route files and does not modify existing portal pages
- live payment acceptance depends on the server/Vercel Stripe configuration now being connected separately
