### PR TITLE
Simplify portal homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,16 +150,11 @@
         <button class="toggle-btn" type="button" data-view-mode-button="workshop" data-active="true">Workshop</button>
       </div>
       <nav class="top-buttons" id="landingQuickLinks" aria-label="3DVR quick links">
-        <a href="https://3dvr.tech">Home</a>
+        <a href="free-page/">Free Website</a>
         <a href="start/">Start</a>
         <a href="life/index.html">Daily Direction</a>
-        <a href="friends-family/">Support</a>
         <a href="start/#paid-lanes">Plans</a>
-        <a href="#app-hub-title" data-app-search-trigger>Apps</a>
-        <a href="games.html">Games</a>
-        <a href="share.html">Share</a>
         <a href="sign-in.html?redirect=%2Findex.html" data-auth-entry>Sign in</a>
-        <a href="https://github.com/tmsteph/3dvr-portal" target="_blank" rel="noopener">GitHub</a>
       </nav>
     </div>
 

--- a/tests/friends-family-pass.test.js
+++ b/tests/friends-family-pass.test.js
@@ -51,10 +51,13 @@ test('friends and family page uses defensive mobile sizing', async () => {
   assert.match(html, /@media \(max-width: 760px\)\s*\{[\s\S]*?\.offer-grid\s*\{[\s\S]*?grid-template-columns:\s*1fr;/);
 });
 
-test('portal home links the pass in navigation, support lanes, app dock, and rooms', async () => {
+test('portal home keeps the pass discoverable in support lanes, app dock, and rooms', async () => {
   const html = await readFile(portalUrl, 'utf8');
 
-  assert.match(html, /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="friends-family\/">Support<\/a>/);
+  assert.doesNotMatch(
+    html,
+    /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="friends-family\/">Support<\/a>/
+  );
   assert.match(
     html,
     /<a href="friends-family\/" class="shortcut-card">[\s\S]*?<span class="shortcut-card__title">Friends &amp; Family Pass<\/span>/

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -124,13 +124,20 @@ test('homepage app search can find the manifestation practice', async () => {
   assert.match(html, /wish, outcome, obstacle, and if\/then plan/);
 });
 
-test('homepage top navigation keeps Games one click away', async () => {
+test('homepage top navigation stays focused after Search apps', async () => {
   const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
 
   assert.match(
     html,
-    /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="games\.html">Games<\/a>/
+    /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="free-page\/">Free Website<\/a>/
   );
+  assert.match(html, /<a href="start\/">Start<\/a>/);
+  assert.match(html, /<a href="life\/index\.html">Daily Direction<\/a>/);
+  assert.match(html, /<a href="start\/#paid-lanes">Plans<\/a>/);
+  assert.match(html, /data-auth-entry>Sign in<\/a>/);
+  assert.doesNotMatch(html, /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="games\.html">Games<\/a>/);
+  assert.doesNotMatch(html, /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="share\.html">Share<\/a>/);
+  assert.doesNotMatch(html, /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?>[\s\S]*GitHub[\s\S]*?<\/nav>/);
 });
 
 test('homepage top navigation keeps Daily Direction one click away', async () => {


### PR DESCRIPTION
## Summary
- reduce the always-visible portal homepage nav after Search apps
- make Free Website the first business-facing link
- keep Start, Daily Direction, Plans, and Profile/Sign in visible while moving Games/Share/GitHub/Support back into search/app dock discovery

## Tests
- npm test -- tests/homepage-search-ux.test.js tests/friends-family-pass.test.js tests/customer-journey-pages.test.js tests/portal-home-mobile-layout.test.js
- local static checks: /, /free-page/, /start/, /life/index.html return 200

Note: Playwright Chromium is not installed here, so the mobile layout browser subtest skipped after import succeeded.