### PR TITLE
Fix desktop username recovery

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script src="auth-identity.js"></script>
   <script src="score.js"></script>
   <script src="/pwa-install.js" defer></script>
   <style>
@@ -1276,6 +1277,13 @@
     ]);
     const user = gun.user();
     const portalRoot = gun.get('3dvr-portal');
+    if (window.AuthIdentity && typeof window.AuthIdentity.syncStorageFromSharedIdentity === 'function') {
+      try {
+        window.AuthIdentity.syncStorageFromSharedIdentity(localStorage);
+      } catch (err) {
+        console.warn('Unable to sync portal identity from shared cookie', err);
+      }
+    }
     if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'function') {
       window.ScoreSystem.recallUserSession(user);
     } else {
@@ -1507,10 +1515,15 @@
       const signedIn = localStorage.getItem('signedIn') === 'true';
       const alias = localStorage.getItem('alias');
       const password = localStorage.getItem('password');
+      const authMethod = (localStorage.getItem('authMethod') || '').trim().toLowerCase();
 
       if (signedIn && alias && password) {
         localStorage.removeItem('guest');
         restoreStoredGunSession(alias, password);
+      } else if (signedIn && alias && authMethod === 'oauth') {
+        localStorage.removeItem('guest');
+        localStorage.removeItem('guestId');
+        localStorage.removeItem('guestDisplayName');
       } else if (signedIn) {
         clearStoredAuthSession();
       }

--- a/profile.html
+++ b/profile.html
@@ -760,6 +760,14 @@ if (window.ScoreSystem && typeof window.ScoreSystem.recallUserSession === 'funct
   }
 }
 
+if (window.AuthIdentity && typeof window.AuthIdentity.syncStorageFromSharedIdentity === 'function') {
+  try {
+    window.AuthIdentity.syncStorageFromSharedIdentity(localStorage);
+  } catch (err) {
+    console.warn('Unable to sync profile identity from shared cookie', err);
+  }
+}
+
 let isSignedIn = localStorage.getItem('signedIn') === 'true';
 if (!isSignedIn && window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function') {
   window.ScoreSystem.ensureGuestIdentity();
@@ -1383,7 +1391,8 @@ function computeDisplayName() {
   if (isSignedIn) {
     if (portalStoredName) return portalStoredName;
     if (aliasName) return aliasName;
-    return 'Guest';
+    const storedAliasName = aliasToDisplay(readStoredAlias());
+    return storedAliasName || 'User';
   }
   if (isGuest) {
     if (guestStoredName) return guestStoredName;
@@ -1650,7 +1659,7 @@ function watchUsername(node) {
       return;
     }
     const fallback = isSignedIn
-      ? (portalStoredName || aliasName || 'Guest')
+      ? (portalStoredName || aliasName || aliasToDisplay(readStoredAlias()) || 'User')
       : (guestStoredName || 'Guest');
     node.get('username').put(fallback);
     handleProfileName(fallback);

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -148,3 +148,13 @@ test('homepage top navigation keeps Daily Direction one click away', async () =>
     /<nav class="top-buttons" id="landingQuickLinks"[\s\S]*?<a href="life\/index\.html">Daily Direction<\/a>/
   );
 });
+
+test('homepage syncs shared identity before falling back to guest mode', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /<script src="auth-identity\.js"><\/script>/);
+  assert.match(html, /AuthIdentity\.syncStorageFromSharedIdentity\(localStorage\)/);
+  assert.match(html, /const authMethod = \(localStorage\.getItem\('authMethod'\) \|\| ''\)\.trim\(\)\.toLowerCase\(\)/);
+  assert.match(html, /signedIn && alias && authMethod === 'oauth'/);
+  assert.match(html, /localStorage\.removeItem\('guestDisplayName'\)/);
+});

--- a/tests/profile-page.test.js
+++ b/tests/profile-page.test.js
@@ -51,3 +51,14 @@ test('profile page exposes clear sign-in paths for guest users', async () => {
   assert.match(html, /link\.textContent = isSignedIn \? '👤 Profile' : '🔑 Sign in'/);
   assert.doesNotMatch(html, /sign-in\.html\?upgrade=guest/);
 });
+
+test('profile page recovers signed-in display names from shared identity and alias fallbacks', async () => {
+  const html = await readFile(new URL('../profile.html', import.meta.url), 'utf8');
+
+  assert.match(html, /<script src="auth-identity\.js"><\/script>/);
+  assert.match(html, /AuthIdentity\.syncStorageFromSharedIdentity\(localStorage\)/);
+  assert.match(html, /const storedAliasName = aliasToDisplay\(readStoredAlias\(\)\)/);
+  assert.match(html, /return storedAliasName \|\| 'User'/);
+  assert.match(html, /portalStoredName \|\| aliasName \|\| aliasToDisplay\(readStoredAlias\(\)\) \|\| 'User'/);
+  assert.doesNotMatch(html, /portalStoredName \|\| aliasName \|\| 'Guest'/);
+});


### PR DESCRIPTION
## Summary\n- Load the shared auth identity helper on the homepage before auth state falls back to guest mode\n- Sync profile storage from the shared identity cookie before computing signed-in/guest state\n- Use alias-derived signed-in fallbacks instead of persisting/displaying Guest for signed-in profiles\n\n## Tests\n- npm test -- tests/profile-page.test.js tests/homepage-search-ux.test.js tests/auth-identity.test.js