### PR TITLE
Center larger portal logo on desktop

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -2112,6 +2112,16 @@ footer a {
 }
 
 @media (min-width: 960px) {
+  .portal-swirl-brand {
+    width: 100%;
+    justify-content: center;
+    margin-bottom: 0.35rem;
+  }
+
+  .portal-swirl-logo {
+    width: clamp(12rem, 18vw, 15.5rem);
+  }
+
   .shortcut-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -118,6 +118,8 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /state\.wobbleVelocityY \+= dx \* DRAG_WOBBLE_FACTOR \* wobbleMultiplier/);
     assert.match(swirlScript, /state\.wobbleX = clamp\(state\.wobbleX \+ state\.wobbleVelocityX \* frames/);
     assert.match(css, /width: clamp\(7\.4rem, 19vw, 10rem\)/);
+    assert.match(css, /@media \(min-width: 960px\) \{[\s\S]*?\.portal-swirl-brand \{[\s\S]*?width: 100%;[\s\S]*?justify-content: center;/);
+    assert.match(css, /@media \(min-width: 960px\) \{[\s\S]*?\.portal-swirl-logo \{[\s\S]*?width: clamp\(12rem, 18vw, 15\.5rem\)/);
     assert.match(css, /width: clamp\(8\.4rem, 38vw, 10\.2rem\)/);
     assert.match(swirlScript, /window\.__portalSwirlLogo/);
   });


### PR DESCRIPTION
## Summary\n- Center the spinning portal logo inside the desktop hero\n- Increase desktop-only logo size while leaving mobile sizing unchanged\n- Cover the desktop sizing rule in the portal logo branding test\n\n## Tests\n- npm test -- tests/portal-logo-branding.test.js tests/homepage-search-ux.test.js\n- Playwright Chromium screenshot check at 1440x1100 and 390x844 against local dev server