### PR TITLE
Use sign-in action for guest identity

### DIFF
--- a/navbar.js
+++ b/navbar.js
@@ -20,6 +20,11 @@ function clearSharedIdentityCookie() {
   }
 }
 
+function currentSignInHref() {
+  const currentPath = `${window.location.pathname || '/'}${window.location.search || ''}${window.location.hash || ''}`;
+  return `/sign-in.html?redirect=${encodeURIComponent(currentPath || '/index.html')}`;
+}
+
 function hideUnreadyHomepageSections() {
   const systemLayers = document.getElementById('systemLayers');
   if (systemLayers) {
@@ -88,6 +93,11 @@ function createNavbar() {
   button.innerText = 'Sign Out';
 
   button.addEventListener('click', () => {
+    if (isGuest) {
+      window.location.href = currentSignInHref();
+      return;
+    }
+
     if (!isGuest) {
       try {
         user.leave();
@@ -137,8 +147,8 @@ function createNavbar() {
     stats.href = 'profile.html#profile';
     stats.setAttribute('aria-label', 'View your guest profile details');
     stats.title = 'View your guest profile';
-    button.innerText = 'Sign Out';
-    button.setAttribute('aria-label', 'Sign out of guest mode');
+    button.innerText = 'Sign in';
+    button.setAttribute('aria-label', 'Sign in or create an account');
   }
 
   function updateNameDisplay() {

--- a/tests/guest-upgrade-entrypoints.test.js
+++ b/tests/guest-upgrade-entrypoints.test.js
@@ -6,13 +6,16 @@ const navbarUrl = new URL('../navbar.js', import.meta.url);
 const indexUrl = new URL('../index.html', import.meta.url);
 
 describe('guest account entrypoints', () => {
-  it('keeps the floating guest identity action as sign out instead of account creation', async () => {
+  it('turns the floating guest identity action into a normal sign-in link', async () => {
     const source = await readFile(navbarUrl, 'utf8');
     assert.doesNotMatch(source, /function guestUpgradeHref\(\)/);
     assert.doesNotMatch(source, /upgrade=guest/);
     assert.doesNotMatch(source, /Create an account and keep guest progress/);
-    assert.match(source, /button\.innerText = 'Sign Out'/);
-    assert.match(source, /button\.setAttribute\('aria-label', 'Sign out of guest mode'\)/);
+    assert.match(source, /function currentSignInHref\(\)/);
+    assert.match(source, /window\.location\.href = currentSignInHref\(\)/);
+    assert.match(source, /button\.innerText = 'Sign in'/);
+    assert.match(source, /button\.setAttribute\('aria-label', 'Sign in or create an account'\)/);
+    assert.doesNotMatch(source, /button\.setAttribute\('aria-label', 'Sign out of guest mode'\)/);
   });
 
   it('sends the homepage auth modal to normal sign-in without the guest upgrade flag', async () => {


### PR DESCRIPTION
## Summary\n- Change the floating identity button to say Sign in for guest users\n- Send guests to the canonical sign-in page with a redirect back to the current page\n- Preserve guest local progress markers when opening sign-in\n\n## Tests\n- npm test -- tests/guest-upgrade-entrypoints.test.js tests/homepage-search-ux.test.js\n- Playwright Chromium guest-button check against local dev server