### PR TITLE
Frame hero portal spinner

### DIFF
--- a/index-style.css
+++ b/index-style.css
@@ -566,15 +566,69 @@ body.landing {
   display: grid;
   gap: 1rem;
   align-content: start;
+  justify-items: start;
   min-width: 0;
   text-align: left;
 }
 
+.hero-main > .hero-eyebrow,
+.hero-main > h1,
+.hero-main > .hero-tagline {
+  justify-self: center;
+  text-align: center;
+}
+
+.hero-main > h1 {
+  max-width: 17ch;
+}
+
+.hero-main > .hero-tagline {
+  max-width: 42rem;
+}
+
+.hero-main > .hero-actions {
+  justify-content: center;
+  justify-self: center;
+}
+
 .portal-swirl-brand {
+  position: relative;
   display: grid;
   place-items: center;
   width: fit-content;
-  margin-bottom: 0.1rem;
+  padding: clamp(0.7rem, 1.4vw, 1.1rem);
+  margin: 0.2rem auto 0.25rem;
+  isolation: isolate;
+}
+
+.portal-swirl-frame {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border: 1px solid rgba(125, 211, 252, 0.34);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(34, 211, 238, 0.16), transparent 58%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.42), rgba(2, 6, 23, 0.12));
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.6),
+    0 0 80px rgba(34, 211, 238, 0.16),
+    inset 0 0 38px rgba(125, 211, 252, 0.1);
+  pointer-events: none;
+}
+
+.portal-swirl-frame::before,
+.portal-swirl-frame::after {
+  content: '';
+  position: absolute;
+  inset: 0.55rem;
+  border-radius: inherit;
+  border: 1px solid rgba(251, 191, 36, 0.18);
+}
+
+.portal-swirl-frame::after {
+  inset: 1.05rem;
+  border-color: rgba(45, 212, 191, 0.18);
 }
 
 .portal-swirl-logo {
@@ -2113,9 +2167,9 @@ footer a {
 
 @media (min-width: 960px) {
   .portal-swirl-brand {
-    width: 100%;
-    justify-content: center;
-    margin-bottom: 0.35rem;
+    width: fit-content;
+    justify-self: center;
+    margin-bottom: 0.45rem;
   }
 
   .portal-swirl-logo {
@@ -2151,8 +2205,8 @@ footer a {
   }
 
   .portal-swirl-brand {
-    width: 100%;
-    justify-content: center;
+    width: fit-content;
+    justify-self: center;
   }
 
   .portal-swirl-logo {

--- a/index.html
+++ b/index.html
@@ -168,7 +168,10 @@
         </div>
         <div class="hero-panel">
           <div class="hero-main">
+            <span class="hero-eyebrow">Human O.S.</span>
+            <h1 id="landing-title">Find your purpose. Organize your life. Launch your world.</h1>
             <div class="portal-swirl-brand">
+              <div class="portal-swirl-frame" aria-hidden="true"></div>
               <div
                 class="portal-swirl-logo"
                 data-portal-swirl-logo
@@ -183,8 +186,6 @@
                 </span>
               </div>
             </div>
-            <span class="hero-eyebrow">Human O.S.</span>
-            <h1 id="landing-title">Find your purpose. Organize your life. Launch your world.</h1>
             <p class="hero-tagline">
               Start small. Sort one messy thought and pick one next step for today.
             </p>

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -8,7 +8,8 @@ describe('portal logo branding', () => {
     const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
     const css = await readFile(new URL('../index-style.css', import.meta.url), 'utf8');
     const swirlScript = await readFile(new URL('../portal-swirl-logo.js', import.meta.url), 'utf8');
-    const swirlHtml = html.match(/<div\s+class="portal-swirl-logo"[\s\S]*?<\/div>\s*<\/div>\s*<span class="hero-eyebrow">/)?.[0] || '';
+    const heroLeadHtml = html.match(/<span class="hero-eyebrow">Human O\.S\.<\/span>[\s\S]*?<p class="hero-tagline">/)?.[0] || '';
+    const swirlHtml = html.match(/<div\s+class="portal-swirl-brand">[\s\S]*?<\/div>\s*<p class="hero-tagline">/)?.[0] || '';
 
     assert.match(logo, /3dvr portal logo/);
     assert.match(logo, />3dvr</);
@@ -21,6 +22,8 @@ describe('portal logo branding', () => {
     assert.match(css, /\.app-boot-enabled \.app-boot/);
     assert.match(html, /portal-swirl-logo\.js/);
     assert.match(html, /data-portal-swirl-logo/);
+    assert.match(heroLeadHtml, /<h1 id="landing-title">Find your purpose\. Organize your life\. Launch your world\.<\/h1>[\s\S]*?class="portal-swirl-brand"/);
+    assert.match(swirlHtml, /class="portal-swirl-frame"/);
     assert.match(html, /3dvr portal 3D swirl logo/);
     assert.match(html, /role="button"/);
     assert.doesNotMatch(swirlHtml, /aria-pressed=/);
@@ -117,9 +120,13 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /state\.extraFaceSpin = clamp\(/);
     assert.match(swirlScript, /state\.wobbleVelocityY \+= dx \* DRAG_WOBBLE_FACTOR \* wobbleMultiplier/);
     assert.match(swirlScript, /state\.wobbleX = clamp\(state\.wobbleX \+ state\.wobbleVelocityX \* frames/);
+    assert.match(css, /\.hero-main > h1 \{[\s\S]*?max-width: 17ch;/);
+    assert.match(css, /\.portal-swirl-frame \{/);
+    assert.match(css, /\.portal-swirl-frame::before,/);
     assert.match(css, /width: clamp\(7\.4rem, 19vw, 10rem\)/);
-    assert.match(css, /@media \(min-width: 960px\) \{[\s\S]*?\.portal-swirl-brand \{[\s\S]*?width: 100%;[\s\S]*?justify-content: center;/);
+    assert.match(css, /@media \(min-width: 960px\) \{[\s\S]*?\.portal-swirl-brand \{[\s\S]*?width: fit-content;[\s\S]*?justify-self: center;/);
     assert.match(css, /@media \(min-width: 960px\) \{[\s\S]*?\.portal-swirl-logo \{[\s\S]*?width: clamp\(12rem, 18vw, 15\.5rem\)/);
+    assert.match(css, /@media \(max-width: 640px\) \{[\s\S]*?\.portal-swirl-brand \{[\s\S]*?width: fit-content;[\s\S]*?justify-self: center;/);
     assert.match(css, /width: clamp\(8\.4rem, 38vw, 10\.2rem\)/);
     assert.match(swirlScript, /window\.__portalSwirlLogo/);
   });


### PR DESCRIPTION
## Summary\n- Move the main hero promise above the spinning portal\n- Add a subtle circular frame around the portal spinner\n- Keep desktop and mobile spinner centering verified\n\n## Tests\n- npm test -- tests/portal-logo-branding.test.js tests/customer-journey-pages.test.js tests/homepage-search-ux.test.js\n- Playwright Chromium screenshots at 1440x1100 and 390x844 against local dev server