### PR TITLE
Add twice-daily money operator brief

### DIFF
--- a/.github/workflows/money-autopilot.yml
+++ b/.github/workflows/money-autopilot.yml
@@ -2,13 +2,20 @@ name: Money Autopilot
 
 on:
   schedule:
-    - cron: '17 */6 * * *'
+    # 8:15 PM Pacific during daylight time.
+    - cron: '15 03 * * *'
+    # 9:15 AM Pacific during daylight time.
+    - cron: '15 16 * * *'
   workflow_dispatch:
     inputs:
       dry_run:
         description: 'Skip GitHub publish even when publish is enabled'
         required: false
         default: 'false'
+      mode:
+        description: 'Brief mode: auto, day, or night'
+        required: false
+        default: 'auto'
 
 jobs:
   autopilot:
@@ -42,6 +49,9 @@ jobs:
       MONEY_AUTOPILOT_DEFAULT_DESTINATION_URL: ${{ vars.MONEY_AUTOPILOT_DEFAULT_DESTINATION_URL }}
       MONEY_AUTOPILOT_GA_PROPERTY_ID: ${{ vars.MONEY_AUTOPILOT_GA_PROPERTY_ID }}
       MONEY_AUTOPILOT_GA_ACCESS_TOKEN: ${{ secrets.MONEY_AUTOPILOT_GA_ACCESS_TOKEN }}
+      MONEY_OPERATOR_TELEGRAM_BOT_TOKEN: ${{ secrets.MONEY_OPERATOR_TELEGRAM_BOT_TOKEN }}
+      MONEY_OPERATOR_TELEGRAM_CHAT_ID: ${{ secrets.MONEY_OPERATOR_TELEGRAM_CHAT_ID }}
+      MONEY_OPERATOR_TELEGRAM_DRY_RUN: ${{ vars.MONEY_OPERATOR_TELEGRAM_DRY_RUN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -55,17 +65,43 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run autopilot cycle
+      - name: Run operator brief
+        env:
+          INPUT_MODE: ${{ inputs.mode || 'auto' }}
+          EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
           mkdir -p artifacts/money-autopilot
+          mode="${INPUT_MODE:-auto}"
+          if [ "$mode" = "auto" ]; then
+            if [ "$EVENT_SCHEDULE" = "15 03 * * *" ]; then
+              mode="night"
+            else
+              mode="day"
+            fi
+          fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
-            npm run money:autopilot -- --dryRun true --out artifacts/money-autopilot/latest.json
+            npm run money:operator-brief -- \
+              --dryRun true \
+              --mode "$mode" \
+              --sendTelegram true \
+              --out artifacts/money-autopilot/latest.json \
+              --briefOut artifacts/money-autopilot/operator-brief.md \
+              --queueOut artifacts/money-autopilot/lead-queue.csv \
+              --telegramOut artifacts/money-autopilot/telegram-message.txt \
+              --deliveryOut artifacts/money-autopilot/telegram-delivery.json
           else
-            npm run money:autopilot -- --out artifacts/money-autopilot/latest.json
+            npm run money:operator-brief -- \
+              --mode "$mode" \
+              --sendTelegram true \
+              --out artifacts/money-autopilot/latest.json \
+              --briefOut artifacts/money-autopilot/operator-brief.md \
+              --queueOut artifacts/money-autopilot/lead-queue.csv \
+              --telegramOut artifacts/money-autopilot/telegram-message.txt \
+              --deliveryOut artifacts/money-autopilot/telegram-delivery.json
           fi
 
       - name: Upload autopilot artifact
         uses: actions/upload-artifact@v4
         with:
           name: money-autopilot-${{ github.run_id }}
-          path: artifacts/money-autopilot/latest.json
+          path: artifacts/money-autopilot/

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "money-printer:auto-business": "node scripts/money-printer-auto-business.mjs",
     "money:loop": "node scripts/money/run-loop.mjs",
     "money:autopilot": "node scripts/money/run-autopilot.mjs",
+    "money:operator-brief": "node scripts/money/operator-brief.mjs",
     "market:pulse": "node scripts/growth/run-market-pulse.mjs",
     "market:meta-worker": "node scripts/growth/run-meta-market-worker.mjs",
     "playwright:install:linux": "node scripts/playwright/install-runtime.mjs",

--- a/scripts/money/operator-brief.mjs
+++ b/scripts/money/operator-brief.mjs
@@ -1,0 +1,101 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { runAutopilotCycle } from '../../src/money/autopilot.js';
+import {
+  buildMoneyOperatorBrief,
+  leadQueueToCsv,
+  sendTelegramBrief
+} from '../../src/money/operatorBrief.js';
+
+function parseArgs(argv = []) {
+  const args = {
+    out: '',
+    briefOut: '',
+    queueOut: '',
+    telegramOut: '',
+    deliveryOut: '',
+    dryRun: '',
+    mode: 'auto',
+    sendTelegram: ''
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) continue;
+
+    const key = token.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    const hasValue = argv[index + 1] && !argv[index + 1].startsWith('--');
+    args[key] = hasValue ? argv[index + 1] : 'true';
+    if (hasValue) index += 1;
+  }
+
+  return args;
+}
+
+function parseBool(value, fallback = false) {
+  if (typeof value === 'boolean') return value;
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+async function writeOutput(pathname, payload, { json = true } = {}) {
+  const absolute = resolve(pathname);
+  await mkdir(dirname(absolute), { recursive: true });
+  const body = json ? `${JSON.stringify(payload, null, 2)}\n` : payload;
+  await writeFile(absolute, body, 'utf8');
+  return absolute;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = args.dryRun
+    ? parseBool(args.dryRun)
+    : undefined;
+
+  const autopilot = await runAutopilotCycle({ dryRun });
+  const brief = buildMoneyOperatorBrief({
+    autopilot,
+    mode: args.mode || process.env.MONEY_OPERATOR_BRIEF_MODE || 'auto'
+  });
+
+  const outputs = {};
+  if (args.out) outputs.autopilot = await writeOutput(args.out, autopilot);
+  if (args.briefOut) outputs.brief = await writeOutput(args.briefOut, brief.markdown, { json: false });
+  if (args.queueOut) outputs.queue = await writeOutput(args.queueOut, leadQueueToCsv(brief.leadQueue), { json: false });
+  if (args.telegramOut) outputs.telegram = await writeOutput(args.telegramOut, `${brief.telegramText}\n`, { json: false });
+
+  let delivery = {
+    attempted: false,
+    sent: false,
+    skipped: true,
+    failed: false,
+    reason: 'telegram delivery not requested'
+  };
+
+  if (parseBool(args.sendTelegram, false)) {
+    delivery = await sendTelegramBrief({
+      text: brief.telegramText,
+      dryRun: parseBool(process.env.MONEY_OPERATOR_TELEGRAM_DRY_RUN, false)
+    });
+  }
+
+  if (args.deliveryOut) outputs.delivery = await writeOutput(args.deliveryOut, delivery);
+
+  console.log(`Money operator brief: ${brief.title}`);
+  console.log(`Autopilot run: ${autopilot.runId}`);
+  console.log(`Top opportunity: ${autopilot.topOpportunity?.title || 'none'}`);
+  console.log(`One thing: ${brief.oneThing}`);
+  console.log(`Telegram: ${delivery.sent ? 'sent' : delivery.reason}`);
+
+  Object.entries(outputs).forEach(([label, filePath]) => {
+    console.log(`${label}: ${filePath}`);
+  });
+}
+
+main().catch(error => {
+  console.error(error?.message || error);
+  process.exit(1);
+});

--- a/src/money/operatorBrief.js
+++ b/src/money/operatorBrief.js
@@ -1,0 +1,276 @@
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function compact(value, max = 260) {
+  const text = clean(value).replace(/\s+/g, ' ');
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1)).trim()}...`;
+}
+
+function parseBool(value, fallback = false) {
+  if (typeof value === 'boolean') return value;
+  const normalized = clean(value).toLowerCase();
+  if (!normalized) return fallback;
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function escapeCsv(value = '') {
+  const text = String(value ?? '');
+  if (!/[",\n\r]/.test(text)) return text;
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+function bulletList(items = [], fallback = 'None recorded.') {
+  const usable = items.map(clean).filter(Boolean);
+  if (!usable.length) return `- ${fallback}`;
+  return usable.map(item => `- ${item}`).join('\n');
+}
+
+function inferBriefMode({ mode = 'auto', now = new Date() } = {}) {
+  const requested = clean(mode).toLowerCase();
+  if (['day', 'morning'].includes(requested)) return 'day';
+  if (['night', 'evening'].includes(requested)) return 'night';
+  const utcHour = now.getUTCHours();
+  return utcHour >= 0 && utcHour < 12 ? 'night' : 'day';
+}
+
+function modeTitle(mode) {
+  return mode === 'night' ? 'Night Money Brief' : 'Day Money Brief';
+}
+
+function modeAction(mode) {
+  if (mode === 'night') {
+    return 'Pick one person for tomorrow and leave the message ready to send.';
+  }
+  return 'Send or edit one message to one likely person today.';
+}
+
+function selectDrafts(autopilot = {}, limit = 3) {
+  const drafts = Array.isArray(autopilot.adDrafts) ? autopilot.adDrafts : [];
+  return drafts
+    .filter(item => clean(item?.body))
+    .slice(0, limit)
+    .map((item, index) => ({
+      id: clean(item.id) || `draft-${index + 1}`,
+      channel: clean(item.channel) || 'text',
+      headline: clean(item.headline) || 'Personal outreach',
+      body: clean(item.body),
+      cta: clean(item.cta) || 'Send the basics'
+    }));
+}
+
+function buildLeadQueue(autopilot = {}, { mode = 'day' } = {}) {
+  const drafts = selectDrafts(autopilot, 3);
+  const opportunity = autopilot.topOpportunity || {};
+  const audience = clean(opportunity.audience) || clean(autopilot.market) || 'a warm local contact';
+  const runId = clean(autopilot.runId) || 'money-run';
+
+  return drafts.map((draft, index) => ({
+    id: `${runId}-lead-${index + 1}`,
+    priority: index + 1,
+    segment: index === 0 ? audience : `${draft.channel} contact: ${audience}`,
+    channel: draft.channel,
+    status: 'suggested',
+    nextStep: modeAction(mode),
+    messageDraft: draft.body,
+    cta: draft.cta,
+    contactedAt: '',
+    replyStatus: '',
+    pageStatus: '',
+    subscriptionStatus: '',
+    notes: ''
+  }));
+}
+
+export function leadQueueToCsv(queue = []) {
+  const columns = [
+    'id',
+    'priority',
+    'segment',
+    'channel',
+    'status',
+    'nextStep',
+    'messageDraft',
+    'cta',
+    'contactedAt',
+    'replyStatus',
+    'pageStatus',
+    'subscriptionStatus',
+    'notes'
+  ];
+
+  return [
+    columns.join(','),
+    ...queue.map(row => columns.map(column => escapeCsv(row[column])).join(','))
+  ].join('\n') + '\n';
+}
+
+export function buildMoneyOperatorBrief({ autopilot = {}, mode = 'auto', now = new Date() } = {}) {
+  const resolvedMode = inferBriefMode({ mode, now });
+  const title = modeTitle(resolvedMode);
+  const opportunity = autopilot.topOpportunity || {};
+  const destinationUrl = clean(autopilot.publish?.destinationUrl)
+    || clean(autopilot.promotion?.destinationUrl)
+    || clean(autopilot.monetization?.checkoutUrl)
+    || 'https://portal.3dvr.tech/free-page/';
+  const drafts = selectDrafts(autopilot, 3);
+  const leadQueue = buildLeadQueue(autopilot, { mode: resolvedMode });
+  const warnings = Array.isArray(autopilot.warnings) ? autopilot.warnings : [];
+  const checklist = Array.isArray(autopilot.executionChecklist) ? autopilot.executionChecklist.slice(0, 5) : [];
+  const generatedAt = clean(autopilot.generatedAt) || now.toISOString();
+  const price = clean(opportunity.suggestedPrice) || 'Free draft, then $5/month to keep it live';
+  const score = Number.isFinite(Number(opportunity.score)) ? Number(opportunity.score) : null;
+
+  const draftLines = drafts.map((draft, index) => [
+    `${index + 1}. ${draft.channel}: ${draft.headline}`,
+    `   ${compact(draft.body, 360)}`,
+    `   CTA: ${draft.cta}`
+  ].join('\n'));
+
+  const leadLines = leadQueue.map(item => (
+    `${item.priority}. ${compact(item.segment, 140)} — ${item.channel} — ${item.status}`
+  ));
+
+  const markdown = `# ${title}
+
+Generated: ${generatedAt}
+Run: ${clean(autopilot.runId) || 'unknown'}
+
+## One Thing
+
+${modeAction(resolvedMode)}
+
+## Offer Angle
+
+- Offer: ${clean(opportunity.title) || '3DVR Free Page'}
+- Audience: ${clean(opportunity.audience) || clean(autopilot.market) || 'warm contacts who need a simple first website'}
+- Price path: ${price}
+- Score: ${score === null ? 'not scored' : score}
+- Destination: ${destinationUrl}
+
+## Why This Should Work
+
+${compact(clean(opportunity.problem) || 'Most people need one clear page before they need a full site.', 420)}
+
+${compact(clean(opportunity.solution) || 'Offer a free one-page draft, then ask whether it is useful enough to keep live for $5/month.', 420)}
+
+## Suggested Lead Queue
+
+${bulletList(leadLines, 'Pick one warm person manually.')}
+
+## Ready Messages
+
+${draftLines.join('\n\n') || '- No draft messages generated.'}
+
+## Checklist
+
+${bulletList(checklist)}
+
+## Guardrail
+
+No automatic outreach was sent. Thomas approves or sends the message manually.
+
+## Warnings
+
+${bulletList(warnings, 'No warnings.')}
+`;
+
+  const telegramText = [
+    `${title}`,
+    '',
+    `One thing: ${modeAction(resolvedMode)}`,
+    '',
+    `Offer: ${clean(opportunity.title) || '3DVR Free Page'}`,
+    `Audience: ${compact(clean(opportunity.audience) || clean(autopilot.market) || 'warm contacts', 170)}`,
+    `Price: ${price}`,
+    `Destination: ${destinationUrl}`,
+    '',
+    'Message to use:',
+    drafts[0]?.body ? compact(drafts[0].body, 700) : 'No draft generated.',
+    '',
+    'Lead queue:',
+    ...(leadLines.length ? leadLines.map(item => `- ${item}`) : ['- Pick one warm person manually.']),
+    '',
+    'No automatic outreach was sent.'
+  ].join('\n');
+
+  return {
+    mode: resolvedMode,
+    title,
+    generatedAt,
+    runId: clean(autopilot.runId),
+    destinationUrl,
+    oneThing: modeAction(resolvedMode),
+    leadQueue,
+    markdown,
+    telegramText
+  };
+}
+
+export async function sendTelegramBrief({ text, env = process.env, fetchImpl = fetch, dryRun } = {}) {
+  const token = clean(
+    env.MONEY_OPERATOR_TELEGRAM_BOT_TOKEN
+    || env.TELEGRAM_BOT_TOKEN
+    || env.OPENCLAW_TELEGRAM_BOT_TOKEN
+  );
+  const chatId = clean(
+    env.MONEY_OPERATOR_TELEGRAM_CHAT_ID
+    || env.TELEGRAM_CHAT_ID
+    || env.OPENCLAW_TELEGRAM_CHAT_ID
+  );
+  const result = {
+    attempted: false,
+    sent: false,
+    skipped: false,
+    failed: false,
+    dryRun: parseBool(dryRun ?? env.MONEY_OPERATOR_TELEGRAM_DRY_RUN, false),
+    reason: ''
+  };
+
+  if (!clean(text)) {
+    result.skipped = true;
+    result.reason = 'message text missing';
+    return result;
+  }
+
+  if (!token || !chatId) {
+    result.skipped = true;
+    result.reason = 'telegram config missing: MONEY_OPERATOR_TELEGRAM_BOT_TOKEN and MONEY_OPERATOR_TELEGRAM_CHAT_ID';
+    return result;
+  }
+
+  if (result.dryRun) {
+    result.skipped = true;
+    result.reason = 'dry-run';
+    return result;
+  }
+
+  result.attempted = true;
+  try {
+    const response = await fetchImpl(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: compact(text, 3900),
+        disable_web_page_preview: true
+      })
+    });
+    const responseText = await response.text();
+    if (!response.ok) {
+      throw new Error(responseText || `Telegram returned ${response.status}`);
+    }
+    result.sent = true;
+    result.reason = 'sent';
+    return result;
+  } catch (error) {
+    result.failed = true;
+    result.reason = `send failed: ${error.message}`;
+    return result;
+  }
+}

--- a/tests/money-operator-brief.test.js
+++ b/tests/money-operator-brief.test.js
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildMoneyOperatorBrief,
+  leadQueueToCsv,
+  sendTelegramBrief
+} from '../src/money/operatorBrief.js';
+
+function sampleAutopilot() {
+  return {
+    runId: 'money-1',
+    generatedAt: '2026-07-10T16:15:00.000Z',
+    market: 'people who need a simple first website',
+    warnings: ['Checkout URL not configured. Campaign traffic will use https://portal.3dvr.tech/free-page/.'],
+    topOpportunity: {
+      title: '3DVR Free Page',
+      audience: 'friends, freelancers, creators, local service people, and small businesses',
+      problem: 'Most people need one clean page they can send before they need a full site.',
+      solution: 'Make a free one-page draft, then ask whether it is useful enough to keep live for $5/month.',
+      suggestedPrice: 'Free draft, then $5/month to keep it live',
+      score: 86
+    },
+    adDrafts: [
+      {
+        id: 'free-page-text-1',
+        channel: 'text',
+        headline: 'Want a simple page for what you do?',
+        body: 'I am testing a tiny 3DVR offer: I will make you a clean one-page website for free.',
+        cta: 'Send the basics'
+      },
+      {
+        id: 'free-page-email-1',
+        channel: 'email',
+        headline: 'I can make you a simple one-page website',
+        body: 'I am making free one-page websites for people with a service or creative project.',
+        cta: 'Send the basics'
+      }
+    ],
+    executionChecklist: [
+      'Send the free page offer to 10 people.',
+      'Collect their name, offer, audience, main CTA, and best contact link.'
+    ],
+    publish: {
+      destinationUrl: 'https://portal.3dvr.tech/free-page/'
+    },
+    monetization: {
+      checkoutConfigured: false,
+      checkoutUrl: '',
+      checkoutCtaLabel: 'Keep It Live'
+    }
+  };
+}
+
+test('buildMoneyOperatorBrief creates a day brief and lead queue without auto-sending', () => {
+  const brief = buildMoneyOperatorBrief({
+    autopilot: sampleAutopilot(),
+    mode: 'day'
+  });
+
+  assert.equal(brief.mode, 'day');
+  assert.equal(brief.title, 'Day Money Brief');
+  assert.match(brief.markdown, /Send or edit one message to one likely person today/);
+  assert.match(brief.markdown, /3DVR Free Page/);
+  assert.match(brief.markdown, /No automatic outreach was sent/);
+  assert.match(brief.telegramText, /Message to use:/);
+  assert.equal(brief.leadQueue.length, 2);
+  assert.equal(brief.leadQueue[0].status, 'suggested');
+  assert.equal(brief.leadQueue[0].subscriptionStatus, '');
+});
+
+test('buildMoneyOperatorBrief creates a night brief for tomorrow prep', () => {
+  const brief = buildMoneyOperatorBrief({
+    autopilot: sampleAutopilot(),
+    mode: 'night'
+  });
+
+  assert.equal(brief.mode, 'night');
+  assert.equal(brief.title, 'Night Money Brief');
+  assert.match(brief.telegramText, /Pick one person for tomorrow/);
+});
+
+test('leadQueueToCsv writes tracker columns and escapes message drafts', () => {
+  const brief = buildMoneyOperatorBrief({
+    autopilot: sampleAutopilot(),
+    mode: 'day'
+  });
+  const csv = leadQueueToCsv(brief.leadQueue);
+
+  assert.match(csv, /^id,priority,segment,channel,status,nextStep,messageDraft,cta,contactedAt/);
+  assert.match(csv, /replyStatus,pageStatus,subscriptionStatus,notes/);
+  assert.match(csv, /money-1-lead-1/);
+  assert.match(csv, /I am testing a tiny 3DVR offer: I will make you a clean one-page website for free\./);
+});
+
+test('sendTelegramBrief skips cleanly when config is missing', async () => {
+  const result = await sendTelegramBrief({
+    text: 'Day Money Brief',
+    env: {}
+  });
+
+  assert.equal(result.sent, false);
+  assert.equal(result.skipped, true);
+  assert.match(result.reason, /telegram config missing/);
+});
+
+test('sendTelegramBrief supports dry-run without calling Telegram', async () => {
+  let called = false;
+  const result = await sendTelegramBrief({
+    text: 'Day Money Brief',
+    dryRun: true,
+    env: {
+      MONEY_OPERATOR_TELEGRAM_BOT_TOKEN: 'token',
+      MONEY_OPERATOR_TELEGRAM_CHAT_ID: '123'
+    },
+    async fetchImpl() {
+      called = true;
+    }
+  });
+
+  assert.equal(called, false);
+  assert.equal(result.sent, false);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, 'dry-run');
+});
+
+test('sendTelegramBrief posts to Telegram when configured', async () => {
+  const requests = [];
+  const result = await sendTelegramBrief({
+    text: 'Day Money Brief',
+    env: {
+      MONEY_OPERATOR_TELEGRAM_BOT_TOKEN: 'token',
+      MONEY_OPERATOR_TELEGRAM_CHAT_ID: '123'
+    },
+    async fetchImpl(url, options) {
+      requests.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ ok: true });
+        }
+      };
+    }
+  });
+
+  assert.equal(result.sent, true);
+  assert.equal(result.reason, 'sent');
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, 'https://api.telegram.org/bottoken/sendMessage');
+  const body = JSON.parse(requests[0].options.body);
+  assert.equal(body.chat_id, '123');
+  assert.equal(body.disable_web_page_preview, true);
+  assert.equal(body.text, 'Day Money Brief');
+});


### PR DESCRIPTION
## Summary

- change Money Autopilot from every 6 hours to twice daily day/night operator briefs
- add a money operator brief CLI that writes the autopilot JSON, readable brief, Telegram message, delivery status, and CSV lead queue
- add optional Telegram delivery via `MONEY_OPERATOR_TELEGRAM_BOT_TOKEN` and `MONEY_OPERATOR_TELEGRAM_CHAT_ID`, with safe skip behavior when config is missing

## Verification

- `node --check scripts/money/operator-brief.mjs && node --check src/money/operatorBrief.js`
- `npm test -- tests/money-operator-brief.test.js tests/money-autopilot.test.js`
- local dry-run of `npm run money:operator-brief -- --dryRun true --mode day --sendTelegram true ...`

## Notes

- GitHub Actions secrets `MONEY_OPERATOR_TELEGRAM_BOT_TOKEN` and `MONEY_OPERATOR_TELEGRAM_CHAT_ID` are configured.
- `MONEY_OPERATOR_TELEGRAM_DRY_RUN=false` is configured as a repo variable.
- No automatic outreach is sent; the Telegram brief is for Thomas to approve/send manually.
