### PR TITLE
Schedule guarded Money Printer self-improvement

### DIFF
--- a/.github/workflows/money-printer-self-improve.yml
+++ b/.github/workflows/money-printer-self-improve.yml
@@ -1,0 +1,74 @@
+name: Money Printer Self Improvement
+
+on:
+  schedule:
+    # 11:45 PM Pacific during daylight time.
+    - cron: '45 06 * * *'
+  workflow_dispatch:
+    inputs:
+      auto_merge:
+        description: 'Auto-merge GREEN self-reviewed improvements after checks pass'
+        required: false
+        default: 'true'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  self-improve:
+    name: Propose guarded self-improvement
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Git author
+        run: |
+          git config user.name "3DVR Money Printer"
+          git config user.email "actions@github.com"
+
+      - name: Run guarded self-improvement
+        env:
+          AUTO_MERGE_INPUT: ${{ inputs.auto_merge || 'true' }}
+        run: |
+          mkdir -p artifacts/money-printer-self-improve
+          auto_merge_flag=""
+          if [ "$AUTO_MERGE_INPUT" = "true" ]; then
+            auto_merge_flag="--auto-merge"
+          fi
+
+          npm run --silent money-printer:operator -- propose \
+            --create-pr \
+            $auto_merge_flag \
+            --wait-checks \
+            --check-interval 10 \
+            --title "Money Printer autonomous operator report" \
+            --json | tee artifacts/money-printer-self-improve/latest.json
+
+      - name: Collect operator reports
+        if: always()
+        run: |
+          mkdir -p artifacts/money-printer-self-improve/operator
+          cp -R .money-printer/operator/. artifacts/money-printer-self-improve/operator/ 2>/dev/null || true
+
+      - name: Upload self-improvement artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: money-printer-self-improve-${{ github.run_id }}
+          path: artifacts/money-printer-self-improve/

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "money-printer:daemon": "node scripts/money-printer-cli.mjs daemon --once",
     "money-printer:ai-status": "node scripts/money-printer-cli.mjs ai-status",
     "money-printer:codex": "node scripts/money-printer-cli.mjs codex",
+    "money-printer:operator": "node scripts/money-printer-operator.mjs",
     "money-printer:supervisor": "node scripts/money-printer-supervisor.mjs",
     "money-printer:auto-business": "node scripts/money-printer-auto-business.mjs",
     "money:loop": "node scripts/money/run-loop.mjs",

--- a/scripts/money-printer-operator.mjs
+++ b/scripts/money-printer-operator.mjs
@@ -248,10 +248,28 @@ async function mergePullRequestIfGreen(rootDir, review, pr, options = {}) {
       reason: 'auto-merge flag not enabled'
     };
   }
+  let checks = null;
+  if (parseBool(options.waitChecks)) {
+    const interval = String(Number(options.checkInterval || 10) || 10);
+    const result = runCommand('gh', ['pr', 'checks', pr.url, '--watch', '--interval', interval], { cwd: rootDir });
+    checks = {
+      waited: true,
+      ok: result.ok,
+      output: commandOutputSummary(result)
+    };
+    if (!result.ok) {
+      return {
+        merged: false,
+        reason: 'pull request checks did not pass',
+        checks
+      };
+    }
+  }
   gh(rootDir, ['pr', 'merge', pr.url, '--squash', '--delete-branch']);
   return {
     merged: true,
-    reason: 'GREEN self-review and checks passed'
+    reason: checks ? 'GREEN self-review and pull request checks passed' : 'GREEN self-review and local checks passed',
+    checks
   };
 }
 
@@ -324,7 +342,9 @@ async function runPropose(rootDir, options = {}) {
       bodyPath: selfReviewPath
     });
     report.merge = await mergePullRequestIfGreen(rootDir, review, report.pr, {
-      autoMerge: options.autoMerge
+      autoMerge: options.autoMerge,
+      waitChecks: options.waitChecks,
+      checkInterval: options.checkInterval
     });
   } else if (parseBool(options.createPr) && review.risk === 'RED') {
     report.pr = {
@@ -364,6 +384,8 @@ Flags:
   --root <dir>             Repo root, defaults to cwd.
   --create-pr              Commit, push, and open a PR when the self-review is not RED.
   --auto-merge             Merge the PR only if self-review is GREEN and checks passed.
+  --wait-checks            Wait for GitHub PR checks before auto-merge.
+  --check-interval <sec>   Poll interval for --wait-checks, default 10.
   --base <branch>          PR base, default main.
   --branch-name <name>     Branch to create when proposal starts from main/master.
   --title <text>           PR title.
@@ -395,6 +417,8 @@ async function main() {
     result = await runPropose(rootDir, {
       createPr: args.createPr,
       autoMerge: args.autoMerge,
+      waitChecks: args.waitChecks,
+      checkInterval: args.checkInterval,
       base: args.base,
       branchName: args.branchName,
       title: args.title,

--- a/tests/money-printer-self-review.test.js
+++ b/tests/money-printer-self-review.test.js
@@ -130,4 +130,21 @@ test('operator proposal commits only the reviewed safe improvement', () => {
   assert.doesNotMatch(source, /outPath: selfReviewPath/);
   assert.match(source, /\['add', 'docs\/money-printer-operator-report\.md'\]/);
   assert.doesNotMatch(source, /\['add', 'docs\/money-printer-operator-report\.md', 'SELF_REVIEW\.md'\]/);
+  assert.match(source, /waitChecks: options\.waitChecks/);
+  assert.match(source, /\['pr', 'checks', pr\.url, '--watch', '--interval', interval\]/);
+  assert.match(source, /pull request checks did not pass/);
+});
+
+test('nightly self-improvement workflow uses guarded operator proposal', () => {
+  const workflow = readFileSync(new URL('../.github/workflows/money-printer-self-improve.yml', import.meta.url), 'utf8');
+
+  assert.match(workflow, /Money Printer Self Improvement/);
+  assert.match(workflow, /cron: '45 06 \* \* \*'/);
+  assert.match(workflow, /contents: write/);
+  assert.match(workflow, /pull-requests: write/);
+  assert.match(workflow, /money-printer:operator -- propose/);
+  assert.match(workflow, /--create-pr/);
+  assert.match(workflow, /--wait-checks/);
+  assert.match(workflow, /--auto-merge/);
+  assert.match(workflow, /upload-artifact/);
 });


### PR DESCRIPTION
## Summary

- add a nightly Money Printer Self Improvement GitHub Action
- expose `money-printer:operator` as an npm script for the guarded proposal command
- add `--wait-checks` so GREEN auto-merge waits for PR checks before merging
- test the workflow and merge gate source expectations

## Guardrails

- the scheduled command only runs `money-printer-operator propose`
- the current proposal target is documentation-only: `docs/money-printer-operator-report.md`
- self-review blocks secrets, billing, sending, auth, deployment config, scheduler edits, deletes, and large changes from GREEN auto-merge
- this PR itself is human-merged because it touches workflow and approval logic

## Verification

- `node --check scripts/money-printer-operator.mjs`
- `npm test -- tests/money-printer-self-review.test.js tests/money-printer-operator-email.test.js`
- `git diff --check`
