### PR TITLE
Add outbound autopilot queue

### DIFF
--- a/.github/workflows/outbound-autopilot.yml
+++ b/.github/workflows/outbound-autopilot.yml
@@ -1,0 +1,72 @@
+name: Outbound Autopilot
+
+on:
+  schedule:
+    # 9:45 AM Pacific during daylight time, after the morning money brief.
+    - cron: '45 16 * * *'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'draft-only, approval-required, or allowlisted-auto-send'
+        required: false
+        default: 'approval-required'
+      daily_cap:
+        description: 'Maximum allowlisted auto-sends per run'
+        required: false
+        default: '3'
+
+jobs:
+  outbound:
+    name: Build outbound queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+      MONEY_AUTOPILOT_MARKET: ${{ vars.MONEY_AUTOPILOT_MARKET }}
+      MONEY_AUTOPILOT_KEYWORDS: ${{ vars.MONEY_AUTOPILOT_KEYWORDS }}
+      MONEY_AUTOPILOT_CHANNELS: ${{ vars.MONEY_AUTOPILOT_CHANNELS }}
+      MONEY_AUTOPILOT_DEFAULT_DESTINATION_URL: ${{ vars.MONEY_AUTOPILOT_DEFAULT_DESTINATION_URL }}
+      MONEY_OUTBOUND_MODE: ${{ vars.MONEY_OUTBOUND_MODE }}
+      MONEY_OUTBOUND_DAILY_CAP: ${{ vars.MONEY_OUTBOUND_DAILY_CAP }}
+      MONEY_OUTBOUND_SENDER_WEBHOOK_URL: ${{ secrets.MONEY_OUTBOUND_SENDER_WEBHOOK_URL }}
+      MONEY_OUTBOUND_SENDER_WEBHOOK_TOKEN: ${{ secrets.MONEY_OUTBOUND_SENDER_WEBHOOK_TOKEN }}
+      MONEY_OPERATOR_TELEGRAM_BOT_TOKEN: ${{ secrets.MONEY_OPERATOR_TELEGRAM_BOT_TOKEN }}
+      MONEY_OPERATOR_TELEGRAM_CHAT_ID: ${{ secrets.MONEY_OPERATOR_TELEGRAM_CHAT_ID }}
+      MONEY_OPERATOR_TELEGRAM_DRY_RUN: ${{ vars.MONEY_OPERATOR_TELEGRAM_DRY_RUN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run outbound autopilot
+        env:
+          INPUT_MODE: ${{ inputs.mode || vars.MONEY_OUTBOUND_MODE || 'approval-required' }}
+          INPUT_DAILY_CAP: ${{ inputs.daily_cap || vars.MONEY_OUTBOUND_DAILY_CAP || '3' }}
+        run: |
+          mkdir -p artifacts/outbound-autopilot
+          npm run money:outbound -- \
+            --mode "$INPUT_MODE" \
+            --dailyCap "$INPUT_DAILY_CAP" \
+            --sendTelegram true \
+            --out artifacts/outbound-autopilot/latest.json \
+            --queueOut artifacts/outbound-autopilot/outbound-queue.csv \
+            --outcomesOut artifacts/outbound-autopilot/outcome-tracker.csv \
+            --summaryOut artifacts/outbound-autopilot/outbound-summary.md \
+            --telegramOut artifacts/outbound-autopilot/telegram-message.txt \
+            --dispatchOut artifacts/outbound-autopilot/dispatch.json \
+            --deliveryOut artifacts/outbound-autopilot/telegram-delivery.json
+
+      - name: Upload outbound artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: outbound-autopilot-${{ github.run_id }}
+          path: artifacts/outbound-autopilot/

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "money:loop": "node scripts/money/run-loop.mjs",
     "money:autopilot": "node scripts/money/run-autopilot.mjs",
     "money:operator-brief": "node scripts/money/operator-brief.mjs",
+    "money:outbound": "node scripts/money/outbound-autopilot.mjs",
     "market:pulse": "node scripts/growth/run-market-pulse.mjs",
     "market:meta-worker": "node scripts/growth/run-meta-market-worker.mjs",
     "playwright:install:linux": "node scripts/playwright/install-runtime.mjs",

--- a/scripts/money/outbound-autopilot.mjs
+++ b/scripts/money/outbound-autopilot.mjs
@@ -1,0 +1,144 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { runAutopilotCycle } from '../../src/money/autopilot.js';
+import {
+  DEFAULT_OUTBOUND_PROSPECTS,
+  buildOutboundQueue,
+  buildOutboundSummary,
+  dispatchOutboundWebhook,
+  outcomeTrackerToCsv,
+  parseProspectsCsv,
+  queueToCsv
+} from '../../src/money/outboundAutopilot.js';
+import { sendTelegramBrief } from '../../src/money/operatorBrief.js';
+
+function parseArgs(argv = []) {
+  const args = {
+    prospects: '',
+    mode: process.env.MONEY_OUTBOUND_MODE || 'approval-required',
+    dailyCap: process.env.MONEY_OUTBOUND_DAILY_CAP || '3',
+    out: '',
+    queueOut: '',
+    outcomesOut: '',
+    summaryOut: '',
+    telegramOut: '',
+    deliveryOut: '',
+    dispatchOut: '',
+    sendTelegram: '',
+    dryRun: ''
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    const hasValue = argv[index + 1] && !argv[index + 1].startsWith('--');
+    args[key] = hasValue ? argv[index + 1] : 'true';
+    if (hasValue) index += 1;
+  }
+
+  return args;
+}
+
+function parseBool(value, fallback = false) {
+  if (typeof value === 'boolean') return value;
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+async function writeOutput(pathname, payload, { json = true } = {}) {
+  const absolute = resolve(pathname);
+  await mkdir(dirname(absolute), { recursive: true });
+  const body = json ? `${JSON.stringify(payload, null, 2)}\n` : payload;
+  await writeFile(absolute, body, 'utf8');
+  return absolute;
+}
+
+async function loadProspects(pathname) {
+  if (!pathname) return DEFAULT_OUTBOUND_PROSPECTS.slice();
+  const content = await readFile(resolve(pathname), 'utf8');
+  if (pathname.endsWith('.json')) {
+    const parsed = JSON.parse(content);
+    return Array.isArray(parsed) ? parsed : parsed.prospects || [];
+  }
+  return parseProspectsCsv(content);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = args.dryRun ? parseBool(args.dryRun) : undefined;
+  const now = new Date();
+  const [autopilot, prospects] = await Promise.all([
+    runAutopilotCycle({ dryRun }),
+    loadProspects(args.prospects)
+  ]);
+
+  const queue = buildOutboundQueue({
+    prospects,
+    autopilot,
+    mode: args.mode,
+    dailyCap: args.dailyCap,
+    now
+  });
+  const dispatch = await dispatchOutboundWebhook({
+    queue,
+    webhookUrl: process.env.MONEY_OUTBOUND_SENDER_WEBHOOK_URL || '',
+    token: process.env.MONEY_OUTBOUND_SENDER_WEBHOOK_TOKEN || ''
+  });
+  const summary = buildOutboundSummary({
+    queue,
+    mode: args.mode,
+    dispatch,
+    now
+  });
+
+  const outputs = {};
+  const payload = {
+    generatedAt: now.toISOString(),
+    mode: args.mode,
+    dailyCap: Number(args.dailyCap) || 3,
+    autopilotRunId: autopilot.runId,
+    dispatch,
+    queue
+  };
+
+  if (args.out) outputs.out = await writeOutput(args.out, payload);
+  if (args.queueOut) outputs.queue = await writeOutput(args.queueOut, queueToCsv(queue), { json: false });
+  if (args.outcomesOut) outputs.outcomes = await writeOutput(args.outcomesOut, outcomeTrackerToCsv(queue), { json: false });
+  if (args.summaryOut) outputs.summary = await writeOutput(args.summaryOut, summary, { json: false });
+  if (args.telegramOut) outputs.telegram = await writeOutput(args.telegramOut, `${summary}\n`, { json: false });
+  if (args.dispatchOut) outputs.dispatch = await writeOutput(args.dispatchOut, dispatch);
+
+  let telegram = {
+    attempted: false,
+    sent: false,
+    skipped: true,
+    failed: false,
+    reason: 'telegram delivery not requested'
+  };
+
+  if (parseBool(args.sendTelegram, false)) {
+    telegram = await sendTelegramBrief({
+      text: summary,
+      dryRun: parseBool(process.env.MONEY_OPERATOR_TELEGRAM_DRY_RUN, false)
+    });
+  }
+
+  if (args.deliveryOut) outputs.delivery = await writeOutput(args.deliveryOut, telegram);
+
+  console.log('Outbound Autopilot');
+  console.log(`Mode: ${args.mode}`);
+  console.log(`Prospects scored: ${queue.length}`);
+  console.log(`Top prospect: ${queue[0]?.name || queue[0]?.segment || 'none'}`);
+  console.log(`Dispatch: ${dispatch.reason}`);
+  console.log(`Telegram: ${telegram.sent ? 'sent' : telegram.reason}`);
+  Object.entries(outputs).forEach(([label, filePath]) => console.log(`${label}: ${filePath}`));
+}
+
+main().catch(error => {
+  console.error(error?.message || error);
+  process.exit(1);
+});

--- a/src/money/outboundAutopilot.js
+++ b/src/money/outboundAutopilot.js
@@ -1,0 +1,438 @@
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function compact(value, max = 260) {
+  const text = clean(value).replace(/\s+/g, ' ');
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1)).trim()}...`;
+}
+
+function parseBool(value, fallback = false) {
+  if (typeof value === 'boolean') return value;
+  const normalized = clean(value).toLowerCase();
+  if (!normalized) return fallback;
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function toNumber(value, fallback) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function escapeCsv(value = '') {
+  const text = String(value ?? '');
+  if (!/[",\n\r]/.test(text)) return text;
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+function slugify(value = '') {
+  return clean(value)
+    .toLowerCase()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'prospect';
+}
+
+function splitCsvLine(line = '') {
+  const cells = [];
+  let cell = '';
+  let quoted = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    const next = line[index + 1];
+    if (char === '"' && quoted && next === '"') {
+      cell += '"';
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (char === ',' && !quoted) {
+      cells.push(cell);
+      cell = '';
+      continue;
+    }
+    cell += char;
+  }
+
+  cells.push(cell);
+  return cells.map(clean);
+}
+
+export function parseProspectsCsv(csv = '') {
+  const lines = String(csv || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean);
+  if (lines.length < 2) return [];
+
+  const headers = splitCsvLine(lines[0]).map(header => slugify(header).replace(/-/g, '_'));
+  return lines.slice(1).map((line, index) => {
+    const cells = splitCsvLine(line);
+    const row = {};
+    headers.forEach((header, cellIndex) => {
+      row[header] = cells[cellIndex] || '';
+    });
+    return normalizeProspect(row, index);
+  }).filter(prospect => prospect.name || prospect.company || prospect.email || prospect.segment);
+}
+
+function normalizeProspect(input = {}, index = 0) {
+  const name = clean(input.name || input.contact || input.lead || input.person);
+  const company = clean(input.company || input.business || input.organization);
+  const segment = clean(input.segment || input.niche || input.type);
+  const email = clean(input.email || input.mail);
+  const channel = clean(input.channel || (email ? 'email' : 'text'));
+  const relationship = clean(input.relationship || input.source || input.context || 'warm/local');
+  const problemHint = clean(input.problem || input.problem_hint || input.need || input.notes);
+  const website = clean(input.website || input.url || input.link);
+  const allowAutoSend = parseBool(input.allow_auto_send ?? input.allowAutoSend, false);
+  const status = clean(input.status || 'new');
+
+  return {
+    id: clean(input.id) || slugify(`${name || company || segment || 'prospect'}-${index + 1}`),
+    name,
+    company,
+    segment: segment || 'person who could use a simple first website',
+    email,
+    channel,
+    relationship,
+    problemHint,
+    website,
+    allowAutoSend,
+    status,
+    lastContactedAt: clean(input.last_contacted_at || input.lastContactedAt),
+    replyStatus: clean(input.reply_status || input.replyStatus),
+    pageStatus: clean(input.page_status || input.pageStatus),
+    subscriptionStatus: clean(input.subscription_status || input.subscriptionStatus),
+    notes: clean(input.notes)
+  };
+}
+
+export const DEFAULT_OUTBOUND_PROSPECTS = Object.freeze([
+  {
+    id: 'warm-side-project',
+    name: 'Warm contact with a side project',
+    segment: 'friend, freelancer, or creator with a project they mention often',
+    channel: 'text',
+    relationship: 'warm network',
+    problemHint: 'They need one clean link that explains the thing without turning it into a big brand project.',
+    allowAutoSend: false
+  },
+  {
+    id: 'local-service-pro',
+    name: 'Local service pro',
+    segment: 'solo contractor, technician, coach, vendor, or service provider',
+    channel: 'email',
+    relationship: 'local business',
+    problemHint: 'They may be relying on referrals, screenshots, or social profiles instead of a simple page.',
+    allowAutoSend: false
+  },
+  {
+    id: 'event-industry-contact',
+    name: 'Event industry contact',
+    segment: 'AV, event, production, or freelance operator contact',
+    channel: 'text',
+    relationship: 'industry network',
+    problemHint: 'They could use a simple page to show services, credits, availability, and contact info.',
+    allowAutoSend: false
+  },
+  {
+    id: 'creator-or-teacher',
+    name: 'Creator or teacher',
+    segment: 'person with a useful skill, class, offer, or lesson',
+    channel: 'email',
+    relationship: 'warm/community',
+    problemHint: 'They need a first public page for the idea before they need a course platform or full site.',
+    allowAutoSend: false
+  }
+]);
+
+function prospectLabel(prospect = {}) {
+  return clean(prospect.name)
+    || clean(prospect.company)
+    || clean(prospect.segment)
+    || 'there';
+}
+
+function firstName(label = '') {
+  const first = clean(label).split(/\s+/)[0] || '';
+  if (!first || /^(warm|local|event|creator|person)$/i.test(first)) return 'there';
+  return first;
+}
+
+function scoreProspect(prospect = {}) {
+  let score = 40;
+  if (/warm|friend|industry|local/i.test(prospect.relationship)) score += 18;
+  if (/service|freelance|creator|teacher|contractor|event|av|production/i.test(`${prospect.segment} ${prospect.problemHint}`)) score += 18;
+  if (prospect.email || prospect.channel === 'text') score += 8;
+  if (prospect.website) score += 4;
+  if (prospect.status === 'new') score += 6;
+  if (prospect.lastContactedAt) score -= 20;
+  if (/replied|interested/i.test(prospect.replyStatus)) score += 20;
+  if (/converted|subscribed/i.test(prospect.subscriptionStatus)) score -= 40;
+  return Math.max(0, Math.min(100, score));
+}
+
+function buildSubject(prospect = {}, offer = {}) {
+  if (prospect.channel === 'text') return '';
+  const label = prospect.company || prospect.name || 'your project';
+  if (/service|contractor|local/i.test(`${prospect.segment} ${prospect.relationship}`)) {
+    return `Simple page for ${label}`;
+  }
+  return 'I can make you a simple one-page website';
+}
+
+function buildMessage(prospect = {}, offer = {}) {
+  const label = prospectLabel(prospect);
+  const greeting = firstName(label);
+  const destinationUrl = clean(offer.destinationUrl) || 'https://portal.3dvr.tech/free-page/';
+  const problem = clean(prospect.problemHint)
+    || 'it helps to have one clean link that explains what you do';
+  const relationship = clean(prospect.relationship);
+  const contextLine = relationship && !/warm\/local/i.test(relationship)
+    ? `I thought of you because of your ${relationship} context.`
+    : 'I thought of you because this is easiest to test with real people, not abstract audiences.';
+
+  return [
+    `Hey ${greeting},`,
+    '',
+    "I'm testing a small 3DVR offer: I make a clean one-page website draft for free.",
+    contextLine,
+    `The angle is simple: ${problem}`,
+    '',
+    'If you send me the basics, I can make a first draft page. If it is useful, keeping it live is optional at $5/month. If not, no pressure.',
+    '',
+    `Details: ${destinationUrl}`
+  ].join('\n');
+}
+
+function buildApprovalReason(prospect = {}, mode = 'approval-required') {
+  if (mode === 'draft-only') return 'Draft only. No send decision requested.';
+  if (!prospect.allowAutoSend) return 'Needs approval because this prospect is not allowlisted for auto-send.';
+  if (!prospect.email && prospect.channel === 'email') return 'Needs approval because no email is available.';
+  return 'Allowlisted for auto-send if sender is configured and daily cap allows it.';
+}
+
+export function buildOutboundQueue({
+  prospects = DEFAULT_OUTBOUND_PROSPECTS,
+  autopilot = {},
+  mode = 'approval-required',
+  dailyCap = 3,
+  now = new Date()
+} = {}) {
+  const allowedModes = new Set(['draft-only', 'approval-required', 'allowlisted-auto-send']);
+  const safeMode = allowedModes.has(clean(mode)) ? clean(mode) : 'approval-required';
+  const offer = {
+    title: clean(autopilot.topOpportunity?.title) || '3DVR Free Page',
+    destinationUrl: clean(autopilot.publish?.destinationUrl)
+      || clean(autopilot.promotion?.destinationUrl)
+      || 'https://portal.3dvr.tech/free-page/'
+  };
+  const cap = Math.max(0, Math.floor(toNumber(dailyCap, 3)));
+  let autoSendSlots = cap;
+
+  return prospects
+    .map((item, index) => normalizeProspect(item, index))
+    .map(prospect => {
+      const score = scoreProspect(prospect);
+      const eligibleForAutoSend = safeMode === 'allowlisted-auto-send'
+        && prospect.allowAutoSend
+        && !prospect.lastContactedAt
+        && (prospect.email || prospect.channel !== 'email');
+      const autoSendPlanned = eligibleForAutoSend && autoSendSlots > 0;
+      if (autoSendPlanned) autoSendSlots -= 1;
+      const status = safeMode === 'draft-only'
+        ? 'drafted'
+        : autoSendPlanned
+          ? 'ready-to-send'
+          : 'needs-approval';
+
+      return {
+        ...prospect,
+        score,
+        offer: offer.title,
+        destinationUrl: offer.destinationUrl,
+        subject: buildSubject(prospect, offer),
+        messageDraft: buildMessage(prospect, offer),
+        approvalStatus: status,
+        approvalReason: buildApprovalReason(prospect, safeMode),
+        eligibleForAutoSend,
+        autoSendPlanned,
+        generatedAt: now.toISOString()
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+}
+
+export function queueToCsv(queue = []) {
+  const columns = [
+    'id',
+    'score',
+    'name',
+    'company',
+    'segment',
+    'channel',
+    'email',
+    'relationship',
+    'approvalStatus',
+    'approvalReason',
+    'subject',
+    'messageDraft',
+    'destinationUrl',
+    'allowAutoSend',
+    'lastContactedAt',
+    'replyStatus',
+    'pageStatus',
+    'subscriptionStatus',
+    'notes'
+  ];
+  return [
+    columns.join(','),
+    ...queue.map(row => columns.map(column => escapeCsv(row[column])).join(','))
+  ].join('\n') + '\n';
+}
+
+export function outcomeTrackerToCsv(queue = []) {
+  const columns = [
+    'id',
+    'name',
+    'channel',
+    'contactedAt',
+    'replyStatus',
+    'pageRequestedAt',
+    'pageDeliveredAt',
+    'keepLiveDecision',
+    'subscriptionStatus',
+    'revenue',
+    'nextFollowUpAt',
+    'notes'
+  ];
+  return [
+    columns.join(','),
+    ...queue.map(row => columns.map(column => escapeCsv(row[column])).join(','))
+  ].join('\n') + '\n';
+}
+
+export async function dispatchOutboundWebhook({
+  queue = [],
+  webhookUrl = '',
+  token = '',
+  fetchImpl = fetch
+} = {}) {
+  const ready = queue.filter(item => item.autoSendPlanned);
+  const result = {
+    attempted: false,
+    sent: false,
+    skipped: false,
+    failed: false,
+    sentCount: 0,
+    reason: ''
+  };
+
+  if (!ready.length) {
+    result.skipped = true;
+    result.reason = 'no allowlisted prospects planned for auto-send';
+    return result;
+  }
+  if (!clean(webhookUrl)) {
+    result.skipped = true;
+    result.reason = 'sender webhook not configured';
+    return result;
+  }
+
+  result.attempted = true;
+  try {
+    const response = await fetchImpl(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {})
+      },
+      body: JSON.stringify({
+        mode: 'outbound-autopilot',
+        messages: ready.map(item => ({
+          id: item.id,
+          channel: item.channel,
+          to: item.email,
+          subject: item.subject,
+          body: item.messageDraft,
+          metadata: {
+            score: item.score,
+            segment: item.segment,
+            offer: item.offer
+          }
+        }))
+      })
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(text || `sender webhook returned ${response.status}`);
+    }
+    result.sent = true;
+    result.sentCount = ready.length;
+    result.reason = 'sent via sender webhook';
+    return result;
+  } catch (error) {
+    result.failed = true;
+    result.reason = `send failed: ${error.message}`;
+    return result;
+  }
+}
+
+export function buildOutboundSummary({
+  queue = [],
+  mode = 'approval-required',
+  dispatch = null,
+  now = new Date()
+} = {}) {
+  const top = queue.slice(0, 5);
+  const ready = queue.filter(item => item.autoSendPlanned);
+  const approval = queue.filter(item => item.approvalStatus === 'needs-approval');
+  const drafted = queue.filter(item => item.approvalStatus === 'drafted');
+  const lines = top.map((item, index) => (
+    `${index + 1}. ${prospectLabel(item)} (${item.channel}, score ${item.score}) - ${item.approvalStatus}`
+  ));
+  const firstDraft = top[0];
+
+  return `# Outbound Autopilot
+
+Generated: ${now.toISOString()}
+Mode: ${mode}
+
+## Money Action
+
+Approve or contact the highest-score prospect, deliver a free page draft, and ask whether it is useful enough to keep live for $5/month.
+
+## Queue Status
+
+- prospects scored: ${queue.length}
+- needs approval: ${approval.length}
+- drafted only: ${drafted.length}
+- planned auto-send: ${ready.length}
+- dispatch: ${dispatch ? dispatch.reason : 'not attempted'}
+
+## Top Prospects
+
+${lines.length ? lines.map(line => `- ${line}`).join('\n') : '- No prospects available.'}
+
+## First Draft
+
+${firstDraft ? [
+    `To: ${prospectLabel(firstDraft)}`,
+    firstDraft.subject ? `Subject: ${firstDraft.subject}` : '',
+    '',
+    compact(firstDraft.messageDraft, 900)
+  ].filter(Boolean).join('\n') : 'No draft generated.'}
+
+## Guardrail
+
+Auto-send requires mode \`allowlisted-auto-send\`, an allowlisted prospect, daily cap room, and a configured sender webhook.
+`;
+}

--- a/tests/money-outbound-autopilot.test.js
+++ b/tests/money-outbound-autopilot.test.js
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+  buildOutboundQueue,
+  buildOutboundSummary,
+  dispatchOutboundWebhook,
+  outcomeTrackerToCsv,
+  parseProspectsCsv,
+  queueToCsv
+} from '../src/money/outboundAutopilot.js';
+
+const autopilot = {
+  runId: 'money-1',
+  topOpportunity: {
+    title: '3DVR Free Page'
+  },
+  publish: {
+    destinationUrl: 'https://portal.3dvr.tech/free-page/'
+  }
+};
+
+test('parseProspectsCsv reads allowlist and prospect fields', () => {
+  const prospects = parseProspectsCsv([
+    'name,email,segment,relationship,allow_auto_send,problem_hint',
+    'Dana,dana@example.com,local service pro,warm referral,true,Needs one clean link',
+    'Lee,,creator,friend,false,Needs a project page'
+  ].join('\n'));
+
+  assert.equal(prospects.length, 2);
+  assert.equal(prospects[0].name, 'Dana');
+  assert.equal(prospects[0].allowAutoSend, true);
+  assert.equal(prospects[1].channel, 'text');
+});
+
+test('buildOutboundQueue defaults to approval-required and drafts personal messages', () => {
+  const queue = buildOutboundQueue({
+    autopilot,
+    mode: 'approval-required',
+    prospects: [{
+      name: 'Dana',
+      email: 'dana@example.com',
+      segment: 'local service pro',
+      relationship: 'warm referral',
+      problemHint: 'Needs one clean link',
+      allowAutoSend: true
+    }]
+  });
+
+  assert.equal(queue.length, 1);
+  assert.equal(queue[0].approvalStatus, 'needs-approval');
+  assert.equal(queue[0].eligibleForAutoSend, false);
+  assert.match(queue[0].messageDraft, /Hey Dana/);
+  assert.match(queue[0].messageDraft, /free/);
+  assert.match(queue[0].destinationUrl, /free-page/);
+});
+
+test('buildOutboundQueue plans auto-send only for allowlisted prospects inside cap', () => {
+  const queue = buildOutboundQueue({
+    autopilot,
+    mode: 'allowlisted-auto-send',
+    dailyCap: 1,
+    prospects: [
+      {
+        name: 'Dana',
+        email: 'dana@example.com',
+        segment: 'local service pro',
+        relationship: 'warm referral',
+        allowAutoSend: true
+      },
+      {
+        name: 'Lee',
+        email: 'lee@example.com',
+        segment: 'creator',
+        relationship: 'friend',
+        allowAutoSend: true
+      },
+      {
+        name: 'Morgan',
+        email: 'morgan@example.com',
+        segment: 'contractor',
+        relationship: 'cold',
+        allowAutoSend: false
+      }
+    ]
+  });
+
+  assert.equal(queue.filter(item => item.autoSendPlanned).length, 1);
+  assert.equal(queue.find(item => item.name === 'Morgan').approvalStatus, 'needs-approval');
+});
+
+test('queue and outcome CSV files include money-loop tracking columns', () => {
+  const queue = buildOutboundQueue({
+    autopilot,
+    mode: 'draft-only',
+    prospects: [{ name: 'Dana', segment: 'creator' }]
+  });
+
+  const queueCsv = queueToCsv(queue);
+  const outcomeCsv = outcomeTrackerToCsv(queue);
+
+  assert.match(queueCsv, /^id,score,name,company,segment,channel,email,relationship,approvalStatus/);
+  assert.match(queueCsv, /messageDraft/);
+  assert.match(outcomeCsv, /^id,name,channel,contactedAt,replyStatus,pageRequestedAt,pageDeliveredAt/);
+  assert.match(outcomeCsv, /subscriptionStatus,revenue,nextFollowUpAt/);
+});
+
+test('dispatchOutboundWebhook skips unless allowlisted messages and webhook are present', async () => {
+  const noMessages = await dispatchOutboundWebhook({ queue: [] });
+  assert.equal(noMessages.skipped, true);
+  assert.match(noMessages.reason, /no allowlisted/);
+
+  const queue = buildOutboundQueue({
+    autopilot,
+    mode: 'allowlisted-auto-send',
+    prospects: [{
+      name: 'Dana',
+      email: 'dana@example.com',
+      segment: 'local service pro',
+      allowAutoSend: true
+    }]
+  });
+  const noWebhook = await dispatchOutboundWebhook({ queue });
+  assert.equal(noWebhook.skipped, true);
+  assert.match(noWebhook.reason, /sender webhook not configured/);
+});
+
+test('dispatchOutboundWebhook posts allowlisted messages to configured sender', async () => {
+  const queue = buildOutboundQueue({
+    autopilot,
+    mode: 'allowlisted-auto-send',
+    prospects: [{
+      name: 'Dana',
+      email: 'dana@example.com',
+      segment: 'local service pro',
+      allowAutoSend: true
+    }]
+  });
+  const requests = [];
+  const result = await dispatchOutboundWebhook({
+    queue,
+    webhookUrl: 'https://sender.example.com/send',
+    token: 'secret-token',
+    async fetchImpl(url, options) {
+      requests.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ ok: true });
+        }
+      };
+    }
+  });
+
+  assert.equal(result.sent, true);
+  assert.equal(result.sentCount, 1);
+  assert.equal(requests[0].url, 'https://sender.example.com/send');
+  assert.equal(requests[0].options.headers.Authorization, 'Bearer secret-token');
+  const payload = JSON.parse(requests[0].options.body);
+  assert.equal(payload.mode, 'outbound-autopilot');
+  assert.equal(payload.messages[0].to, 'dana@example.com');
+});
+
+test('buildOutboundSummary includes guardrail and first draft', () => {
+  const queue = buildOutboundQueue({
+    autopilot,
+    prospects: [{ name: 'Dana', segment: 'creator' }]
+  });
+  const summary = buildOutboundSummary({
+    queue,
+    mode: 'approval-required',
+    dispatch: { reason: 'sender webhook not configured' },
+    now: new Date('2026-07-10T17:00:00.000Z')
+  });
+
+  assert.match(summary, /Outbound Autopilot/);
+  assert.match(summary, /Money Action/);
+  assert.match(summary, /Dana/);
+  assert.match(summary, /Auto-send requires mode/);
+});
+
+test('outbound workflow runs scheduled approval-first queue generation', async () => {
+  const workflow = await readFile(new URL('../.github/workflows/outbound-autopilot.yml', import.meta.url), 'utf8');
+
+  assert.match(workflow, /Outbound Autopilot/);
+  assert.match(workflow, /cron: '45 16 \* \* \*'/);
+  assert.match(workflow, /money:outbound/);
+  assert.match(workflow, /approval-required/);
+  assert.match(workflow, /MONEY_OUTBOUND_SENDER_WEBHOOK_URL/);
+  assert.match(workflow, /outbound-queue\.csv/);
+  assert.match(workflow, /outcome-tracker\.csv/);
+  assert.match(workflow, /telegram-delivery\.json/);
+});


### PR DESCRIPTION
## Summary

- add Outbound Autopilot v1 for prospect scoring, message drafting, approval queues, and outcome tracking
- add `money:outbound` CLI that writes queue, outcome tracker, summary, dispatch status, and Telegram artifacts
- add a scheduled Outbound Autopilot workflow after the morning money brief
- configure repo variables for approval-first mode and a small daily cap

## Guardrails

- default mode is `approval-required`
- external sending requires `allowlisted-auto-send`, an allowlisted prospect, cap room, and configured sender webhook secrets
- without sender webhook config, dispatch skips cleanly
- no prospect outreach is sent by this PR by default

## Existing-solutions preflight

I checked open-source outreach/CRM options first. They are either too broad or add platform surface area before this offer is validated. This keeps the first loop in the existing 3DVR portal and can later connect to a sender/CRM once the rules are explicit.

## Verification

- `node --check src/money/outboundAutopilot.js && node --check scripts/money/outbound-autopilot.mjs`
- `npm test -- tests/money-outbound-autopilot.test.js tests/money-operator-brief.test.js`
- local `npm run money:outbound -- --mode approval-required ...` artifact generation
- `git diff --check`
