### PR TITLE
Use Gmail for money operator updates

### DIFF
--- a/.github/workflows/money-autopilot.yml
+++ b/.github/workflows/money-autopilot.yml
@@ -49,9 +49,10 @@ jobs:
       MONEY_AUTOPILOT_DEFAULT_DESTINATION_URL: ${{ vars.MONEY_AUTOPILOT_DEFAULT_DESTINATION_URL }}
       MONEY_AUTOPILOT_GA_PROPERTY_ID: ${{ vars.MONEY_AUTOPILOT_GA_PROPERTY_ID }}
       MONEY_AUTOPILOT_GA_ACCESS_TOKEN: ${{ secrets.MONEY_AUTOPILOT_GA_ACCESS_TOKEN }}
-      MONEY_OPERATOR_TELEGRAM_BOT_TOKEN: ${{ secrets.MONEY_OPERATOR_TELEGRAM_BOT_TOKEN }}
-      MONEY_OPERATOR_TELEGRAM_CHAT_ID: ${{ secrets.MONEY_OPERATOR_TELEGRAM_CHAT_ID }}
-      MONEY_OPERATOR_TELEGRAM_DRY_RUN: ${{ vars.MONEY_OPERATOR_TELEGRAM_DRY_RUN }}
+      GMAIL_USER: ${{ secrets.GMAIL_USER }}
+      GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+      MONEY_OPERATOR_EMAIL_TO: ${{ vars.MONEY_OPERATOR_EMAIL_TO }}
+      MONEY_OPERATOR_EMAIL_DRY_RUN: ${{ vars.MONEY_OPERATOR_EMAIL_DRY_RUN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -83,21 +84,21 @@ jobs:
             npm run money:operator-brief -- \
               --dryRun true \
               --mode "$mode" \
-              --sendTelegram true \
+              --sendEmail true \
               --out artifacts/money-autopilot/latest.json \
               --briefOut artifacts/money-autopilot/operator-brief.md \
               --queueOut artifacts/money-autopilot/lead-queue.csv \
-              --telegramOut artifacts/money-autopilot/telegram-message.txt \
-              --deliveryOut artifacts/money-autopilot/telegram-delivery.json
+              --emailOut artifacts/money-autopilot/email-message.txt \
+              --deliveryOut artifacts/money-autopilot/email-delivery.json
           else
             npm run money:operator-brief -- \
               --mode "$mode" \
-              --sendTelegram true \
+              --sendEmail true \
               --out artifacts/money-autopilot/latest.json \
               --briefOut artifacts/money-autopilot/operator-brief.md \
               --queueOut artifacts/money-autopilot/lead-queue.csv \
-              --telegramOut artifacts/money-autopilot/telegram-message.txt \
-              --deliveryOut artifacts/money-autopilot/telegram-delivery.json
+              --emailOut artifacts/money-autopilot/email-message.txt \
+              --deliveryOut artifacts/money-autopilot/email-delivery.json
           fi
 
       - name: Upload autopilot artifact

--- a/.github/workflows/outbound-autopilot.yml
+++ b/.github/workflows/outbound-autopilot.yml
@@ -31,9 +31,10 @@ jobs:
       MONEY_OUTBOUND_DAILY_CAP: ${{ vars.MONEY_OUTBOUND_DAILY_CAP }}
       MONEY_OUTBOUND_SENDER_WEBHOOK_URL: ${{ secrets.MONEY_OUTBOUND_SENDER_WEBHOOK_URL }}
       MONEY_OUTBOUND_SENDER_WEBHOOK_TOKEN: ${{ secrets.MONEY_OUTBOUND_SENDER_WEBHOOK_TOKEN }}
-      MONEY_OPERATOR_TELEGRAM_BOT_TOKEN: ${{ secrets.MONEY_OPERATOR_TELEGRAM_BOT_TOKEN }}
-      MONEY_OPERATOR_TELEGRAM_CHAT_ID: ${{ secrets.MONEY_OPERATOR_TELEGRAM_CHAT_ID }}
-      MONEY_OPERATOR_TELEGRAM_DRY_RUN: ${{ vars.MONEY_OPERATOR_TELEGRAM_DRY_RUN }}
+      GMAIL_USER: ${{ secrets.GMAIL_USER }}
+      GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+      MONEY_OPERATOR_EMAIL_TO: ${{ vars.MONEY_OPERATOR_EMAIL_TO }}
+      MONEY_OPERATOR_EMAIL_DRY_RUN: ${{ vars.MONEY_OPERATOR_EMAIL_DRY_RUN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,14 +57,14 @@ jobs:
           npm run money:outbound -- \
             --mode "$INPUT_MODE" \
             --dailyCap "$INPUT_DAILY_CAP" \
-            --sendTelegram true \
+            --sendEmail true \
             --out artifacts/outbound-autopilot/latest.json \
             --queueOut artifacts/outbound-autopilot/outbound-queue.csv \
             --outcomesOut artifacts/outbound-autopilot/outcome-tracker.csv \
             --summaryOut artifacts/outbound-autopilot/outbound-summary.md \
-            --telegramOut artifacts/outbound-autopilot/telegram-message.txt \
+            --emailOut artifacts/outbound-autopilot/email-message.txt \
             --dispatchOut artifacts/outbound-autopilot/dispatch.json \
-            --deliveryOut artifacts/outbound-autopilot/telegram-delivery.json
+            --deliveryOut artifacts/outbound-autopilot/email-delivery.json
 
       - name: Upload outbound artifact
         uses: actions/upload-artifact@v4

--- a/api/_lib/gmail-transport.js
+++ b/api/_lib/gmail-transport.js
@@ -1,0 +1,57 @@
+import nodemailer from 'nodemailer';
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function normalizeEmail(value) {
+  const email = normalizeText(value).toLowerCase();
+  if (!email) return '';
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : '';
+}
+
+function parseInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseBoolean(value, fallback = false) {
+  if (value === undefined || value === null || value === '') return fallback;
+  return /^(1|true|yes|on)$/i.test(String(value).trim());
+}
+
+export function buildGmailTransportOptions(config = process.env, authOverride = null) {
+  const user = normalizeEmail(config.GMAIL_USER) || '3dvr.tech@gmail.com';
+  const pass = normalizeText(config.GMAIL_APP_PASSWORD);
+  const host = normalizeText(config.THREEDVR_GMAIL_SMTP_HOST || 'smtp.gmail.com');
+  const port = parseInteger(config.THREEDVR_GMAIL_SMTP_PORT, 587);
+  const secure = parseBoolean(config.THREEDVR_GMAIL_SMTP_SECURE, port === 465);
+  const requireTLS = parseBoolean(config.THREEDVR_GMAIL_SMTP_REQUIRE_TLS, port === 587);
+  const rejectUnauthorized = parseBoolean(config.THREEDVR_GMAIL_SMTP_REJECT_UNAUTHORIZED, true);
+
+  const auth = authOverride || ((user && pass) ? { user, pass } : null);
+  if (!auth) {
+    throw new Error('Gmail auth is not configured.');
+  }
+
+  const options = {
+    host,
+    port,
+    secure,
+    auth
+  };
+
+  if (requireTLS) {
+    options.requireTLS = true;
+  }
+
+  if (port === 587) {
+    options.tls = { rejectUnauthorized };
+  }
+
+  return options;
+}
+
+export function createGmailTransport(config = process.env, authOverride = null) {
+  return nodemailer.createTransport(buildGmailTransportOptions(config, authOverride));
+}

--- a/scripts/money/operator-brief.mjs
+++ b/scripts/money/operator-brief.mjs
@@ -4,6 +4,7 @@ import { runAutopilotCycle } from '../../src/money/autopilot.js';
 import {
   buildMoneyOperatorBrief,
   leadQueueToCsv,
+  sendEmailBrief,
   sendTelegramBrief
 } from '../../src/money/operatorBrief.js';
 
@@ -12,10 +13,12 @@ function parseArgs(argv = []) {
     out: '',
     briefOut: '',
     queueOut: '',
+    emailOut: '',
     telegramOut: '',
     deliveryOut: '',
     dryRun: '',
     mode: 'auto',
+    sendEmail: '',
     sendTelegram: ''
   };
 
@@ -65,6 +68,7 @@ async function main() {
   if (args.out) outputs.autopilot = await writeOutput(args.out, autopilot);
   if (args.briefOut) outputs.brief = await writeOutput(args.briefOut, brief.markdown, { json: false });
   if (args.queueOut) outputs.queue = await writeOutput(args.queueOut, leadQueueToCsv(brief.leadQueue), { json: false });
+  if (args.emailOut) outputs.email = await writeOutput(args.emailOut, `${brief.markdown}\n`, { json: false });
   if (args.telegramOut) outputs.telegram = await writeOutput(args.telegramOut, `${brief.telegramText}\n`, { json: false });
 
   let delivery = {
@@ -72,8 +76,16 @@ async function main() {
     sent: false,
     skipped: true,
     failed: false,
-    reason: 'telegram delivery not requested'
+    reason: 'operator delivery not requested'
   };
+
+  if (parseBool(args.sendEmail, false)) {
+    delivery = await sendEmailBrief({
+      subject: `3DVR ${brief.title}`,
+      text: brief.markdown,
+      dryRun: parseBool(process.env.MONEY_OPERATOR_EMAIL_DRY_RUN, false)
+    });
+  }
 
   if (parseBool(args.sendTelegram, false)) {
     delivery = await sendTelegramBrief({
@@ -88,7 +100,7 @@ async function main() {
   console.log(`Autopilot run: ${autopilot.runId}`);
   console.log(`Top opportunity: ${autopilot.topOpportunity?.title || 'none'}`);
   console.log(`One thing: ${brief.oneThing}`);
-  console.log(`Telegram: ${delivery.sent ? 'sent' : delivery.reason}`);
+  console.log(`Delivery: ${delivery.sent ? 'sent' : delivery.reason}`);
 
   Object.entries(outputs).forEach(([label, filePath]) => {
     console.log(`${label}: ${filePath}`);

--- a/scripts/money/outbound-autopilot.mjs
+++ b/scripts/money/outbound-autopilot.mjs
@@ -10,7 +10,10 @@ import {
   parseProspectsCsv,
   queueToCsv
 } from '../../src/money/outboundAutopilot.js';
-import { sendTelegramBrief } from '../../src/money/operatorBrief.js';
+import {
+  sendEmailBrief,
+  sendTelegramBrief
+} from '../../src/money/operatorBrief.js';
 
 function parseArgs(argv = []) {
   const args = {
@@ -21,9 +24,11 @@ function parseArgs(argv = []) {
     queueOut: '',
     outcomesOut: '',
     summaryOut: '',
+    emailOut: '',
     telegramOut: '',
     deliveryOut: '',
     dispatchOut: '',
+    sendEmail: '',
     sendTelegram: '',
     dryRun: ''
   };
@@ -109,32 +114,41 @@ async function main() {
   if (args.queueOut) outputs.queue = await writeOutput(args.queueOut, queueToCsv(queue), { json: false });
   if (args.outcomesOut) outputs.outcomes = await writeOutput(args.outcomesOut, outcomeTrackerToCsv(queue), { json: false });
   if (args.summaryOut) outputs.summary = await writeOutput(args.summaryOut, summary, { json: false });
+  if (args.emailOut) outputs.email = await writeOutput(args.emailOut, `${summary}\n`, { json: false });
   if (args.telegramOut) outputs.telegram = await writeOutput(args.telegramOut, `${summary}\n`, { json: false });
   if (args.dispatchOut) outputs.dispatch = await writeOutput(args.dispatchOut, dispatch);
 
-  let telegram = {
+  let delivery = {
     attempted: false,
     sent: false,
     skipped: true,
     failed: false,
-    reason: 'telegram delivery not requested'
+    reason: 'operator delivery not requested'
   };
 
+  if (parseBool(args.sendEmail, false)) {
+    delivery = await sendEmailBrief({
+      subject: '3DVR Outbound Autopilot',
+      text: summary,
+      dryRun: parseBool(process.env.MONEY_OPERATOR_EMAIL_DRY_RUN, false)
+    });
+  }
+
   if (parseBool(args.sendTelegram, false)) {
-    telegram = await sendTelegramBrief({
+    delivery = await sendTelegramBrief({
       text: summary,
       dryRun: parseBool(process.env.MONEY_OPERATOR_TELEGRAM_DRY_RUN, false)
     });
   }
 
-  if (args.deliveryOut) outputs.delivery = await writeOutput(args.deliveryOut, telegram);
+  if (args.deliveryOut) outputs.delivery = await writeOutput(args.deliveryOut, delivery);
 
   console.log('Outbound Autopilot');
   console.log(`Mode: ${args.mode}`);
   console.log(`Prospects scored: ${queue.length}`);
   console.log(`Top prospect: ${queue[0]?.name || queue[0]?.segment || 'none'}`);
   console.log(`Dispatch: ${dispatch.reason}`);
-  console.log(`Telegram: ${telegram.sent ? 'sent' : telegram.reason}`);
+  console.log(`Delivery: ${delivery.sent ? 'sent' : delivery.reason}`);
   Object.entries(outputs).forEach(([label, filePath]) => console.log(`${label}: ${filePath}`));
 }
 

--- a/src/money/operatorBrief.js
+++ b/src/money/operatorBrief.js
@@ -1,3 +1,5 @@
+import { createGmailTransport } from '../../api/_lib/gmail-transport.js';
+
 function clean(value) {
   return String(value || '').trim();
 }
@@ -27,6 +29,19 @@ function bulletList(items = [], fallback = 'None recorded.') {
   const usable = items.map(clean).filter(Boolean);
   if (!usable.length) return `- ${fallback}`;
   return usable.map(item => `- ${item}`).join('\n');
+}
+
+function escapeHtml(value = '') {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function markdownToHtml(markdown = '') {
+  return `<pre style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; line-height: 1.5;">${escapeHtml(markdown)}</pre>`;
 }
 
 function inferBriefMode({ mode = 'auto', now = new Date() } = {}) {
@@ -267,6 +282,80 @@ export async function sendTelegramBrief({ text, env = process.env, fetchImpl = f
     }
     result.sent = true;
     result.reason = 'sent';
+    return result;
+  } catch (error) {
+    result.failed = true;
+    result.reason = `send failed: ${error.message}`;
+    return result;
+  }
+}
+
+export async function sendEmailBrief({
+  subject = '3DVR Operator Brief',
+  text,
+  html,
+  env = process.env,
+  dryRun,
+  transport
+} = {}) {
+  const to = clean(
+    env.MONEY_OPERATOR_EMAIL_TO
+    || env.OPERATOR_EMAIL_TO
+    || env.MONEY_PRINTER_OPERATOR_EMAIL_TO
+    || env.MONEY_PRINTER_OWNER_EMAIL
+    || env.GMAIL_USER
+  );
+  const fromAddress = clean(env.GMAIL_USER);
+  const from = clean(env.MONEY_OPERATOR_EMAIL_FROM || env.OPERATOR_EMAIL_FROM)
+    || (fromAddress ? `3DVR Operator <${fromAddress}>` : '');
+  const result = {
+    attempted: false,
+    sent: false,
+    skipped: false,
+    failed: false,
+    dryRun: parseBool(dryRun ?? env.MONEY_OPERATOR_EMAIL_DRY_RUN, false),
+    reason: '',
+    to,
+    messageId: ''
+  };
+
+  if (!clean(text) && !clean(html)) {
+    result.skipped = true;
+    result.reason = 'email body missing';
+    return result;
+  }
+
+  if (!to) {
+    result.skipped = true;
+    result.reason = 'email recipient missing: set MONEY_OPERATOR_EMAIL_TO or OPERATOR_EMAIL_TO';
+    return result;
+  }
+
+  if (!fromAddress || !clean(env.GMAIL_APP_PASSWORD)) {
+    result.skipped = true;
+    result.reason = 'gmail config missing: GMAIL_USER and GMAIL_APP_PASSWORD';
+    return result;
+  }
+
+  if (result.dryRun) {
+    result.skipped = true;
+    result.reason = 'dry-run';
+    return result;
+  }
+
+  result.attempted = true;
+  try {
+    const mailer = transport || createGmailTransport(env);
+    const info = await mailer.sendMail({
+      from,
+      to,
+      subject,
+      text,
+      html: html || markdownToHtml(text)
+    });
+    result.sent = true;
+    result.reason = 'sent';
+    result.messageId = clean(info?.messageId);
     return result;
   } catch (error) {
     result.failed = true;

--- a/tests/gmail-transport.test.js
+++ b/tests/gmail-transport.test.js
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGmailTransportOptions } from '../api/_lib/gmail-transport.js';
+
+describe('gmail transport', () => {
+  it('defaults to Gmail SMTP 587 with STARTTLS', () => {
+    const options = buildGmailTransportOptions({
+      GMAIL_USER: 'bot@example.com',
+      GMAIL_APP_PASSWORD: 'secret'
+    });
+
+    assert.equal(options.host, 'smtp.gmail.com');
+    assert.equal(options.port, 587);
+    assert.equal(options.secure, false);
+    assert.equal(options.requireTLS, true);
+    assert.deepEqual(options.tls, { rejectUnauthorized: true });
+  });
+
+  it('can be forced to legacy SSL mode', () => {
+    const options = buildGmailTransportOptions({
+      GMAIL_USER: 'bot@example.com',
+      GMAIL_APP_PASSWORD: 'secret',
+      THREEDVR_GMAIL_SMTP_PORT: '465',
+      THREEDVR_GMAIL_SMTP_SECURE: 'true'
+    });
+
+    assert.equal(options.port, 465);
+    assert.equal(options.secure, true);
+    assert.equal(options.requireTLS, undefined);
+    assert.equal(options.tls, undefined);
+  });
+});

--- a/tests/money-operator-brief.test.js
+++ b/tests/money-operator-brief.test.js
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   buildMoneyOperatorBrief,
   leadQueueToCsv,
+  sendEmailBrief,
   sendTelegramBrief
 } from '../src/money/operatorBrief.js';
 
@@ -151,4 +152,70 @@ test('sendTelegramBrief posts to Telegram when configured', async () => {
   assert.equal(body.chat_id, '123');
   assert.equal(body.disable_web_page_preview, true);
   assert.equal(body.text, 'Day Money Brief');
+});
+
+test('sendEmailBrief skips cleanly when Gmail config is missing', async () => {
+  const result = await sendEmailBrief({
+    subject: '3DVR Day Money Brief',
+    text: 'Day Money Brief',
+    env: {
+      MONEY_OPERATOR_EMAIL_TO: 'thomas@example.com'
+    }
+  });
+
+  assert.equal(result.sent, false);
+  assert.equal(result.skipped, true);
+  assert.match(result.reason, /gmail config missing/);
+});
+
+test('sendEmailBrief supports dry-run without calling Gmail', async () => {
+  let called = false;
+  const result = await sendEmailBrief({
+    subject: '3DVR Day Money Brief',
+    text: 'Day Money Brief',
+    dryRun: true,
+    env: {
+      GMAIL_USER: 'bot@example.com',
+      GMAIL_APP_PASSWORD: 'secret',
+      MONEY_OPERATOR_EMAIL_TO: 'thomas@example.com'
+    },
+    transport: {
+      async sendMail() {
+        called = true;
+      }
+    }
+  });
+
+  assert.equal(called, false);
+  assert.equal(result.sent, false);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, 'dry-run');
+});
+
+test('sendEmailBrief sends through configured transport', async () => {
+  const messages = [];
+  const result = await sendEmailBrief({
+    subject: '3DVR Day Money Brief',
+    text: 'Day Money Brief',
+    env: {
+      GMAIL_USER: 'bot@example.com',
+      GMAIL_APP_PASSWORD: 'secret',
+      MONEY_OPERATOR_EMAIL_TO: 'thomas@example.com'
+    },
+    transport: {
+      async sendMail(message) {
+        messages.push(message);
+        return { messageId: 'email-1' };
+      }
+    }
+  });
+
+  assert.equal(result.sent, true);
+  assert.equal(result.reason, 'sent');
+  assert.equal(result.messageId, 'email-1');
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].to, 'thomas@example.com');
+  assert.equal(messages[0].from, '3DVR Operator <bot@example.com>');
+  assert.equal(messages[0].subject, '3DVR Day Money Brief');
+  assert.match(messages[0].html, /Day Money Brief/);
 });

--- a/tests/money-outbound-autopilot.test.js
+++ b/tests/money-outbound-autopilot.test.js
@@ -190,5 +190,8 @@ test('outbound workflow runs scheduled approval-first queue generation', async (
   assert.match(workflow, /MONEY_OUTBOUND_SENDER_WEBHOOK_URL/);
   assert.match(workflow, /outbound-queue\.csv/);
   assert.match(workflow, /outcome-tracker\.csv/);
-  assert.match(workflow, /telegram-delivery\.json/);
+  assert.match(workflow, /sendEmail true/);
+  assert.match(workflow, /email-message\.txt/);
+  assert.match(workflow, /email-delivery\.json/);
+  assert.doesNotMatch(workflow, /sendTelegram true/);
 });


### PR DESCRIPTION
## Summary
- add shared Gmail SMTP transport and operator email delivery helper
- switch Money Autopilot and Outbound Autopilot operator delivery from Telegram to Gmail artifacts/delivery
- add tests for Gmail transport, email delivery, and Gmail-only outbound workflow wiring

## Verification
- npm test -- tests/money-operator-brief.test.js tests/money-outbound-autopilot.test.js tests/gmail-transport.test.js
- local Gmail operator brief smoke run sent to 3dvr.tech@gmail.com