### PR TITLE
Add Signal Garden portal game

### DIFF
--- a/games.html
+++ b/games.html
@@ -150,6 +150,11 @@ h1 {
   --card-glow: linear-gradient(135deg, rgba(56, 189, 248, 0.38), rgba(99, 102, 241, 0.4));
   --icon-bg: linear-gradient(135deg, #020617, #4f46e5);
 }
+
+.game-card.signal {
+  --card-glow: linear-gradient(135deg, rgba(214, 243, 109, 0.38), rgba(242, 166, 90, 0.38));
+  --icon-bg: linear-gradient(135deg, #0f2f2a, #d6f36d);
+}
 </style>
 
   <script defer src="/_vercel/insights/script.js"></script>
@@ -168,6 +173,19 @@ h1 {
 <p class="hub-intro">Pick a launch tile and jump into one of the portal's quick-play experiments.</p>
 
 <div class="game-grid" aria-label="3DVR mini games">
+  <a class="game-card signal" href="signal-garden/">
+    <span class="game-icon" aria-hidden="true">
+      <svg viewBox="0 0 96 96" role="img">
+        <path d="M48 12c8 14 20 24 36 30-16 6-28 16-36 30-8-14-20-24-36-30 16-6 28-16 36-30z" fill="currentColor"/>
+        <circle cx="28" cy="30" r="6" fill="#fff" opacity="0.78"/>
+        <circle cx="68" cy="34" r="5" fill="#fff" opacity="0.58"/>
+        <circle cx="56" cy="68" r="7" fill="#fff" opacity="0.66"/>
+        <path d="M28 30c14 7 27 20 28 38M28 30c13-2 27 0 40 4" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" opacity="0.52"/>
+      </svg>
+    </span>
+    <span class="game-title">Signal Garden</span>
+    <p class="game-blurb">A calm arcade field where sparks turn into a living constellation.</p>
+  </a>
   <a class="game-card pong" href="pong.html">
     <span class="game-icon" aria-hidden="true">
       <svg viewBox="0 0 96 96" role="img">

--- a/index.html
+++ b/index.html
@@ -198,6 +198,10 @@
             <div class="workspace-strip" aria-label="Featured games">
               <span class="workspace-strip__label">Featured games</span>
               <div class="workspace-ribbon">
+                <a class="workspace-pill" href="signal-garden/">
+                  <strong>Game: Signal Garden</strong>
+                  <span>Collect sparks and wake a living constellation.</span>
+                </a>
                 <a class="workspace-pill" href="stellar-flight.html">
                   <strong>Game: Stellar Drift</strong>
                   <span>Fly a starfighter through deep-space drift lanes.</span>
@@ -682,6 +686,11 @@
             <span class="app-card__icon" aria-hidden="true">🎮</span>
             <span class="app-card__title">Games</span>
             <span class="app-card__meta">Compete, sharpen skills, and earn bonus points.</span>
+          </a>
+          <a href="signal-garden/" class="app-card" data-app-keywords="signal garden game calm arcade constellation spark focus play">
+            <span class="app-card__icon" aria-hidden="true">SG</span>
+            <span class="app-card__title">Signal Garden</span>
+            <span class="app-card__meta">Game: collect sparks, keep a streak alive, and wake the field.</span>
           </a>
           <a href="stellar-flight.html" class="app-card" data-app-keywords="stellar drift game flight starfighter space arcade play">
             <span class="app-card__icon" aria-hidden="true">🚀</span>
@@ -2091,7 +2100,7 @@
         label: 'Play path',
         title: 'Games',
         copy: 'Use play when you need motion, reset, or a quick energy shift.',
-        search: 'games play jetpack stellar',
+        search: 'games play signal garden jetpack stellar',
         keywords: ['game', 'games', 'play', 'bored', 'fun', 'reset', 'energy'],
         steps: [
           'Pick a quick game or motion room.',
@@ -2222,6 +2231,7 @@
       ],
       play: [
         'Games',
+        'Signal Garden',
         'Stellar Drift',
         'Jetpack Corridor',
         '3DVR Girl',
@@ -2253,6 +2263,7 @@
       'Projects',
       'Cell',
       'Games',
+      'Signal Garden',
       'Stellar Drift',
       'Jetpack Corridor',
     ]);

--- a/signal-garden/app.js
+++ b/signal-garden/app.js
@@ -1,0 +1,389 @@
+import {
+  advancePlayer,
+  collectNearbyNodes,
+  computeGardenGrade,
+  createGardenNodes,
+} from './game-state.js';
+
+const canvas = document.querySelector('#gardenCanvas');
+const context = canvas.getContext('2d');
+const overlay = document.querySelector('[data-overlay]');
+const startButton = document.querySelector('[data-start]');
+const overlayCopy = document.querySelector('[data-overlay-copy]');
+const scoreElement = document.querySelector('[data-score]');
+const sparksElement = document.querySelector('[data-sparks]');
+const timeElement = document.querySelector('[data-time]');
+const gradeElement = document.querySelector('[data-grade]');
+const controlButtons = [...document.querySelectorAll('.signal-controls button')];
+
+const input = {
+  up: false,
+  right: false,
+  down: false,
+  left: false,
+  boost: false,
+};
+
+const game = {
+  status: 'idle',
+  width: 1,
+  height: 1,
+  startedAt: 0,
+  elapsed: 0,
+  score: 0,
+  collected: 0,
+  combo: 0,
+  lastCollectTime: -Infinity,
+  nodes: [],
+  trails: [],
+  player: {
+    x: 0,
+    y: 0,
+    radius: 14,
+    speed: 235,
+  },
+  pointerTarget: null,
+};
+
+const duration = 60;
+let lastFrame = performance.now();
+
+function resizeCanvas() {
+  const pixelRatio = window.devicePixelRatio || 1;
+  game.width = window.innerWidth;
+  game.height = window.innerHeight;
+  canvas.width = Math.round(game.width * pixelRatio);
+  canvas.height = Math.round(game.height * pixelRatio);
+  canvas.style.width = `${game.width}px`;
+  canvas.style.height = `${game.height}px`;
+  context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+
+  if (game.status === 'idle') {
+    resetGame();
+  } else {
+    game.player.x = Math.min(game.player.x, game.width - game.player.radius);
+    game.player.y = Math.min(game.player.y, game.height - game.player.radius);
+  }
+}
+
+function resetGame() {
+  const seed = Math.floor(Date.now() / 1000) % 100000;
+  game.elapsed = 0;
+  game.score = 0;
+  game.collected = 0;
+  game.combo = 0;
+  game.lastCollectTime = -Infinity;
+  game.trails = [];
+  game.pointerTarget = null;
+  game.player = {
+    x: game.width / 2,
+    y: game.height / 2,
+    radius: 14,
+    speed: Math.min(275, Math.max(210, game.width * 0.16)),
+  };
+  game.nodes = createGardenNodes({
+    count: game.width < 680 ? 15 : 22,
+    width: game.width,
+    height: game.height,
+    margin: game.width < 680 ? 68 : 96,
+    seed,
+  });
+  updateHud();
+}
+
+function startGame() {
+  resetGame();
+  game.status = 'running';
+  game.startedAt = performance.now();
+  overlay.hidden = true;
+  lastFrame = performance.now();
+}
+
+function finishGame() {
+  game.status = 'complete';
+  overlay.hidden = false;
+  const grade = computeGardenGrade(game.score, game.collected, game.nodes.length);
+  overlayCopy.textContent = `${grade} field. Score ${game.score}. ${game.collected}/${game.nodes.length} sparks.`;
+  startButton.textContent = 'Again';
+}
+
+function updateHud() {
+  scoreElement.textContent = String(game.score);
+  sparksElement.textContent = `${game.collected}/${game.nodes.length}`;
+  timeElement.textContent = String(Math.max(0, Math.ceil(duration - game.elapsed)));
+  gradeElement.textContent = computeGardenGrade(game.score, game.collected, game.nodes.length);
+}
+
+function updatePointerInput(deltaSeconds) {
+  if (!game.pointerTarget) return;
+
+  const dx = game.pointerTarget.x - game.player.x;
+  const dy = game.pointerTarget.y - game.player.y;
+  const distance = Math.hypot(dx, dy);
+  if (distance < 4) return;
+
+  const speed = game.player.speed * (input.boost ? 1.55 : 1) * deltaSeconds;
+  const step = Math.min(distance, speed);
+  game.player.x += (dx / distance) * step;
+  game.player.y += (dy / distance) * step;
+}
+
+function updateGame(deltaSeconds, now) {
+  if (game.status !== 'running') return;
+
+  game.elapsed = (now - game.startedAt) / 1000;
+  if (game.pointerTarget) {
+    updatePointerInput(deltaSeconds);
+  } else {
+    game.player = advancePlayer(game.player, input, deltaSeconds, {
+      width: game.width,
+      height: game.height,
+    });
+  }
+
+  const collection = collectNearbyNodes(game.player, game.nodes, {
+    collectionRadius: input.boost ? 34 : 27,
+    time: game.elapsed,
+    comboWindow: 1.35,
+    lastCollectTime: game.lastCollectTime,
+    combo: game.combo,
+  });
+
+  if (collection.collected > 0) {
+    const collectedNodes = collection.nodes.filter((node, index) => !node.active && game.nodes[index].active);
+    collectedNodes.forEach((node) => {
+      game.trails.push({
+        x: node.x,
+        y: node.y,
+        age: 0,
+        life: 1.2,
+      });
+    });
+    game.nodes = collection.nodes;
+    game.score += collection.score;
+    game.collected += collection.collected;
+    game.combo = collection.combo;
+    game.lastCollectTime = collection.lastCollectTime;
+  }
+
+  game.trails = game.trails
+    .map((trail) => ({ ...trail, age: trail.age + deltaSeconds }))
+    .filter((trail) => trail.age < trail.life);
+
+  updateHud();
+
+  if (game.elapsed >= duration || game.collected >= game.nodes.length) {
+    finishGame();
+  }
+}
+
+function drawBackground(now) {
+  const pulse = Math.sin(now * 0.0004) * 0.5 + 0.5;
+  const gradient = context.createLinearGradient(0, 0, game.width, game.height);
+  gradient.addColorStop(0, '#07101a');
+  gradient.addColorStop(0.46, '#102a2f');
+  gradient.addColorStop(1, '#281a2a');
+  context.fillStyle = gradient;
+  context.fillRect(0, 0, game.width, game.height);
+
+  context.save();
+  context.globalAlpha = 0.14 + pulse * 0.05;
+  context.strokeStyle = '#b7f0d0';
+  context.lineWidth = 1;
+  const spacing = game.width < 680 ? 44 : 58;
+  const offset = (now * 0.012) % spacing;
+  for (let x = -spacing + offset; x < game.width + spacing; x += spacing) {
+    context.beginPath();
+    context.moveTo(x, 0);
+    context.lineTo(x + game.height * 0.24, game.height);
+    context.stroke();
+  }
+  for (let y = -spacing + offset; y < game.height + spacing; y += spacing) {
+    context.beginPath();
+    context.moveTo(0, y);
+    context.lineTo(game.width, y - game.width * 0.16);
+    context.stroke();
+  }
+  context.restore();
+}
+
+function drawConnections() {
+  const collected = game.nodes.filter((node) => !node.active);
+  if (collected.length < 2) return;
+
+  context.save();
+  context.strokeStyle = 'rgba(214, 243, 109, 0.42)';
+  context.lineWidth = 2;
+  context.beginPath();
+  collected.forEach((node, index) => {
+    if (index === 0) {
+      context.moveTo(node.x, node.y);
+    } else {
+      context.lineTo(node.x, node.y);
+    }
+  });
+  context.stroke();
+  context.restore();
+}
+
+function drawNodes(now) {
+  game.nodes.forEach((node) => {
+    const wave = Math.sin(now * 0.003 * node.pulse + node.x * 0.02) * 0.5 + 0.5;
+    const radius = node.radius + wave * 4;
+
+    context.save();
+    context.globalAlpha = node.active ? 1 : 0.24;
+    context.beginPath();
+    context.fillStyle = node.active ? '#d6f36d' : '#a6c7ba';
+    context.shadowBlur = node.active ? 24 : 8;
+    context.shadowColor = node.active ? '#d6f36d' : '#8bb6ad';
+    context.arc(node.x, node.y, radius, 0, Math.PI * 2);
+    context.fill();
+
+    context.globalAlpha = node.active ? 0.22 : 0.08;
+    context.beginPath();
+    context.arc(node.x, node.y, radius * 2.2, 0, Math.PI * 2);
+    context.fill();
+    context.restore();
+  });
+}
+
+function drawTrails() {
+  game.trails.forEach((trail) => {
+    const progress = trail.age / trail.life;
+    context.save();
+    context.globalAlpha = 1 - progress;
+    context.strokeStyle = '#ffffff';
+    context.lineWidth = 2;
+    context.beginPath();
+    context.arc(trail.x, trail.y, 18 + progress * 52, 0, Math.PI * 2);
+    context.stroke();
+    context.restore();
+  });
+}
+
+function drawPlayer(now) {
+  const pulse = Math.sin(now * 0.008) * 0.5 + 0.5;
+  context.save();
+  context.translate(game.player.x, game.player.y);
+  context.rotate(now * 0.002);
+  context.shadowBlur = input.boost ? 34 : 22;
+  context.shadowColor = input.boost ? '#f2a65a' : '#68e8ff';
+  context.fillStyle = input.boost ? '#f2a65a' : '#68e8ff';
+  context.beginPath();
+  for (let i = 0; i < 6; i += 1) {
+    const angle = (Math.PI * 2 * i) / 6;
+    const radius = i % 2 === 0 ? game.player.radius + 7 + pulse * 3 : game.player.radius - 2;
+    const x = Math.cos(angle) * radius;
+    const y = Math.sin(angle) * radius;
+    if (i === 0) context.moveTo(x, y);
+    else context.lineTo(x, y);
+  }
+  context.closePath();
+  context.fill();
+  context.restore();
+}
+
+function draw(now) {
+  drawBackground(now);
+  drawConnections();
+  drawNodes(now);
+  drawTrails();
+  drawPlayer(now);
+}
+
+function frame(now) {
+  const deltaSeconds = Math.min(0.04, (now - lastFrame) / 1000);
+  lastFrame = now;
+  updateGame(deltaSeconds, now);
+  draw(now);
+  requestAnimationFrame(frame);
+}
+
+function setDirection(direction, active) {
+  input[direction] = active;
+  document.querySelector(`[data-dir="${direction}"]`)?.setAttribute('data-active', String(active));
+}
+
+function bindControls() {
+  const keyMap = {
+    ArrowUp: 'up',
+    KeyW: 'up',
+    ArrowRight: 'right',
+    KeyD: 'right',
+    ArrowDown: 'down',
+    KeyS: 'down',
+    ArrowLeft: 'left',
+    KeyA: 'left',
+  };
+
+  window.addEventListener('keydown', (event) => {
+    if (event.code === 'Space') {
+      input.boost = true;
+      document.querySelector('[data-boost]')?.setAttribute('data-active', 'true');
+      event.preventDefault();
+      return;
+    }
+    const direction = keyMap[event.code];
+    if (direction) {
+      game.pointerTarget = null;
+      setDirection(direction, true);
+      event.preventDefault();
+    }
+  });
+
+  window.addEventListener('keyup', (event) => {
+    if (event.code === 'Space') {
+      input.boost = false;
+      document.querySelector('[data-boost]')?.setAttribute('data-active', 'false');
+      return;
+    }
+    const direction = keyMap[event.code];
+    if (direction) {
+      setDirection(direction, false);
+    }
+  });
+
+  canvas.addEventListener('pointerdown', (event) => {
+    if (game.status !== 'running') return;
+    canvas.setPointerCapture(event.pointerId);
+    game.pointerTarget = { x: event.clientX, y: event.clientY };
+  });
+
+  canvas.addEventListener('pointermove', (event) => {
+    if (game.status !== 'running' || !game.pointerTarget) return;
+    game.pointerTarget = { x: event.clientX, y: event.clientY };
+  });
+
+  canvas.addEventListener('pointerup', () => {
+    game.pointerTarget = null;
+  });
+
+  controlButtons.forEach((button) => {
+    const direction = button.dataset.dir;
+    const isBoost = Object.hasOwn(button.dataset, 'boost');
+    const setActive = (active) => {
+      if (direction) setDirection(direction, active);
+      if (isBoost) {
+        input.boost = active;
+        button.setAttribute('data-active', String(active));
+      }
+    };
+    button.addEventListener('pointerdown', (event) => {
+      event.preventDefault();
+      game.pointerTarget = null;
+      setActive(true);
+      button.setPointerCapture(event.pointerId);
+    });
+    button.addEventListener('pointerup', () => setActive(false));
+    button.addEventListener('pointercancel', () => setActive(false));
+    button.addEventListener('pointerleave', () => setActive(false));
+  });
+
+  startButton.addEventListener('click', startGame);
+  window.addEventListener('resize', resizeCanvas);
+}
+
+resizeCanvas();
+bindControls();
+requestAnimationFrame(frame);

--- a/signal-garden/game-state.js
+++ b/signal-garden/game-state.js
@@ -1,0 +1,114 @@
+export function clamp(value, min, max) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+export function createSeededRng(seed = 1) {
+  let state = Math.floor(seed) % 2147483647;
+  if (state <= 0) {
+    state += 2147483646;
+  }
+
+  return () => {
+    state = (state * 16807) % 2147483647;
+    return (state - 1) / 2147483646;
+  };
+}
+
+export function createGardenNodes(options = {}) {
+  const {
+    count = 18,
+    width = 100,
+    height = 100,
+    margin = 10,
+    seed = 1,
+  } = options;
+  const rng = createSeededRng(seed);
+  const nodes = [];
+  const safeWidth = Math.max(1, width);
+  const safeHeight = Math.max(1, height);
+  const safeMargin = Math.max(0, Math.min(margin, safeWidth / 3, safeHeight / 3));
+
+  for (let index = 0; index < count; index += 1) {
+    const ring = index % 3;
+    const pulse = 0.7 + rng() * 0.8;
+    nodes.push({
+      id: `spark-${index}`,
+      x: safeMargin + rng() * (safeWidth - safeMargin * 2),
+      y: safeMargin + rng() * (safeHeight - safeMargin * 2),
+      radius: 8 + ring * 2 + rng() * 5,
+      pulse,
+      value: 10 + ring * 5,
+      active: true,
+      collectedAt: null,
+    });
+  }
+
+  return nodes;
+}
+
+export function distanceBetween(a, b) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.hypot(dx, dy);
+}
+
+export function collectNearbyNodes(player, nodes, options = {}) {
+  const {
+    collectionRadius = 28,
+    time = 0,
+    comboWindow = 1.25,
+    lastCollectTime = -Infinity,
+    combo = 0,
+  } = options;
+  let score = 0;
+  let collected = 0;
+  let nextCombo = combo;
+  const nextNodes = nodes.map((node) => {
+    if (!node.active || distanceBetween(player, node) > collectionRadius + node.radius) {
+      return node;
+    }
+
+    collected += 1;
+    nextCombo = time - lastCollectTime <= comboWindow ? nextCombo + 1 : 1;
+    score += node.value + Math.max(0, nextCombo - 1) * 4;
+
+    return {
+      ...node,
+      active: false,
+      collectedAt: time,
+    };
+  });
+
+  return {
+    nodes: nextNodes,
+    collected,
+    combo: collected > 0 ? nextCombo : combo,
+    score,
+    lastCollectTime: collected > 0 ? time : lastCollectTime,
+  };
+}
+
+export function advancePlayer(player, input, deltaSeconds, bounds) {
+  const speed = player.speed ?? 220;
+  const dx = (input.right ? 1 : 0) - (input.left ? 1 : 0);
+  const dy = (input.down ? 1 : 0) - (input.up ? 1 : 0);
+  const length = Math.hypot(dx, dy) || 1;
+  const boost = input.boost ? 1.55 : 1;
+  const nextX = player.x + (dx / length) * speed * boost * deltaSeconds;
+  const nextY = player.y + (dy / length) * speed * boost * deltaSeconds;
+
+  return {
+    ...player,
+    x: clamp(nextX, player.radius, bounds.width - player.radius),
+    y: clamp(nextY, player.radius, bounds.height - player.radius),
+  };
+}
+
+export function computeGardenGrade(score, collected, totalNodes) {
+  const completion = totalNodes <= 0 ? 1 : collected / totalNodes;
+  if (completion >= 1 && score >= totalNodes * 16) return 'Bloom';
+  if (completion >= 0.7) return 'Awake';
+  if (completion >= 0.4) return 'Gathering';
+  return 'Seed';
+}

--- a/signal-garden/index.html
+++ b/signal-garden/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Signal Garden - 3DVR Portal</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="signal-page">
+  <a class="skip-link" href="#signalGarden">Skip to game</a>
+  <nav class="top-buttons signal-nav" aria-label="Signal Garden links">
+    <a href="../index.html">Portal</a>
+    <a href="../games.html">Games</a>
+    <a href="../life/index.html">Daily Direction</a>
+  </nav>
+
+  <main id="signalGarden" class="signal-shell">
+    <section class="signal-stage" aria-label="Signal Garden game">
+      <canvas id="gardenCanvas" class="garden-canvas"></canvas>
+      <div class="signal-hud" aria-live="polite">
+        <div>
+          <span>Score</span>
+          <strong data-score>0</strong>
+        </div>
+        <div>
+          <span>Sparks</span>
+          <strong data-sparks>0/0</strong>
+        </div>
+        <div>
+          <span>Time</span>
+          <strong data-time>60</strong>
+        </div>
+        <div>
+          <span>State</span>
+          <strong data-grade>Seed</strong>
+        </div>
+      </div>
+      <div class="signal-overlay" data-overlay>
+        <div class="signal-dialog" role="dialog" aria-modal="true" aria-labelledby="signalTitle">
+          <span class="signal-kicker">3DVR quick play</span>
+          <h1 id="signalTitle">Signal Garden</h1>
+          <p data-overlay-copy>Collect sparks, keep a streak alive, and wake the field.</p>
+          <button class="signal-action" type="button" data-start>Start</button>
+        </div>
+      </div>
+      <div class="signal-controls" aria-label="Touch controls">
+        <button type="button" data-dir="left" aria-label="Move left" title="Move left">←</button>
+        <button type="button" data-dir="up" aria-label="Move up" title="Move up">↑</button>
+        <button type="button" data-dir="down" aria-label="Move down" title="Move down">↓</button>
+        <button type="button" data-dir="right" aria-label="Move right" title="Move right">→</button>
+        <button type="button" data-boost aria-label="Boost" title="Boost">↯</button>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/signal-garden/styles.css
+++ b/signal-garden/styles.css
@@ -1,0 +1,231 @@
+:root {
+  color-scheme: dark;
+}
+
+body.signal-page {
+  background:
+    linear-gradient(140deg, rgba(7, 12, 20, 0.98), rgba(13, 33, 39, 0.98) 48%, rgba(31, 23, 34, 0.98)),
+    #080c12;
+  color: #eef7f2;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.signal-nav {
+  background: rgba(7, 12, 20, 0.78);
+  border-color: rgba(214, 243, 109, 0.28);
+  left: 50%;
+  margin: 0;
+  max-width: calc(100% - 24px);
+  position: fixed;
+  top: 12px;
+  transform: translateX(-50%);
+  z-index: 20;
+}
+
+.signal-nav a {
+  background: rgba(214, 243, 109, 0.16);
+  border-color: rgba(214, 243, 109, 0.34);
+  color: #eef7f2;
+  min-width: 88px;
+}
+
+.signal-nav a:hover,
+.signal-nav a:focus-visible {
+  background: rgba(214, 243, 109, 0.26);
+  color: #ffffff;
+}
+
+.signal-page .skip-link:not(:focus) {
+  height: 1px;
+  left: -999px;
+  overflow: hidden;
+  position: absolute;
+  top: auto;
+  width: 1px;
+}
+
+.signal-shell {
+  height: 100vh;
+  width: 100vw;
+}
+
+.signal-stage {
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.garden-canvas {
+  display: block;
+  height: 100%;
+  touch-action: none;
+  width: 100%;
+}
+
+.signal-hud {
+  bottom: 18px;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(78px, 1fr));
+  left: 50%;
+  max-width: min(760px, calc(100% - 24px));
+  position: fixed;
+  transform: translateX(-50%);
+  width: 100%;
+  z-index: 15;
+}
+
+.signal-hud div {
+  background: rgba(7, 12, 20, 0.72);
+  border: 1px solid rgba(179, 220, 205, 0.26);
+  border-radius: 8px;
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
+  min-width: 0;
+  padding: 8px 10px;
+}
+
+.signal-hud span,
+.signal-kicker {
+  color: #b4c9c4;
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.signal-hud strong {
+  color: #ffffff;
+  display: block;
+  font-size: clamp(1rem, 2.6vw, 1.45rem);
+  line-height: 1.1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.signal-overlay {
+  align-items: center;
+  background: rgba(4, 8, 14, 0.38);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 24px;
+  position: fixed;
+  z-index: 30;
+}
+
+.signal-overlay[hidden] {
+  display: none;
+}
+
+.signal-dialog {
+  background: rgba(10, 16, 24, 0.84);
+  border: 1px solid rgba(179, 220, 205, 0.28);
+  border-radius: 8px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.46);
+  max-width: 440px;
+  padding: 22px;
+  text-align: left;
+  width: min(100%, 440px);
+}
+
+.signal-dialog h1 {
+  color: #ffffff;
+  font-size: clamp(2.2rem, 10vw, 4.75rem);
+  line-height: 0.95;
+  margin: 8px 0 14px;
+}
+
+.signal-dialog p {
+  color: #d2dfda;
+  font-size: 1rem;
+  line-height: 1.55;
+  margin: 0 0 18px;
+}
+
+.signal-action {
+  background: #d6f36d;
+  border: 0;
+  border-radius: 8px;
+  color: #14200d;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 900;
+  min-height: 46px;
+  padding: 0 18px;
+}
+
+.signal-action:focus-visible,
+.signal-controls button:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 3px;
+}
+
+.signal-controls {
+  bottom: 104px;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(5, 46px);
+  justify-content: center;
+  left: 50%;
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 16;
+}
+
+.signal-controls button {
+  align-items: center;
+  background: rgba(238, 247, 242, 0.14);
+  border: 1px solid rgba(238, 247, 242, 0.24);
+  border-radius: 8px;
+  color: #ffffff;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 1.3rem;
+  font-weight: 900;
+  height: 46px;
+  justify-content: center;
+  line-height: 1;
+  touch-action: none;
+  width: 46px;
+}
+
+.signal-controls button[data-active="true"] {
+  background: rgba(214, 243, 109, 0.28);
+  border-color: rgba(214, 243, 109, 0.72);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .signal-controls {
+    opacity: 0.72;
+  }
+}
+
+@media (max-width: 620px) {
+  body.signal-page {
+    overflow: hidden;
+  }
+
+  .signal-nav {
+    top: 8px;
+  }
+
+  .signal-hud {
+    bottom: 10px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .signal-controls {
+    bottom: 126px;
+    grid-template-columns: repeat(5, 42px);
+  }
+
+  .signal-controls button {
+    height: 42px;
+    width: 42px;
+  }
+}

--- a/tests/signal-garden-page.test.js
+++ b/tests/signal-garden-page.test.js
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('Signal Garden portal app', () => {
+  it('ships the game page, script, and canvas surface', async () => {
+    const html = await readFile(new URL('../signal-garden/index.html', import.meta.url), 'utf8');
+    assert.match(html, /<title>Signal Garden - 3DVR Portal<\/title>/);
+    assert.match(html, /id="gardenCanvas"/);
+    assert.match(html, /type="module" src="app\.js"/);
+    assert.match(html, /data-start>Start<\/button>/);
+  });
+
+  it('is linked from the game hub and homepage app dock', async () => {
+    const [gamesHub, homepage] = await Promise.all([
+      readFile(new URL('../games.html', import.meta.url), 'utf8'),
+      readFile(new URL('../index.html', import.meta.url), 'utf8'),
+    ]);
+
+    assert.match(gamesHub, /href="signal-garden\/"/);
+    assert.match(gamesHub, /Signal Garden/);
+    assert.match(homepage, /href="signal-garden\/"/);
+    assert.match(homepage, /data-app-keywords="signal garden game calm arcade constellation spark focus play"/);
+  });
+});

--- a/tests/signal-garden-state.test.js
+++ b/tests/signal-garden-state.test.js
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  advancePlayer,
+  clamp,
+  collectNearbyNodes,
+  computeGardenGrade,
+  createGardenNodes,
+} from '../signal-garden/game-state.js';
+
+function assertNear(actual, expected, epsilon = 1e-9) {
+  assert.ok(Math.abs(actual - expected) <= epsilon, `${actual} is not within ${epsilon} of ${expected}`);
+}
+
+describe('signal garden helpers', () => {
+  it('clamps invalid and out-of-range values', () => {
+    assert.equal(clamp(12, 0, 10), 10);
+    assert.equal(clamp(-4, 0, 10), 0);
+    assert.equal(clamp(Number.NaN, 2, 10), 2);
+  });
+
+  it('creates deterministic sparks inside the playable area', () => {
+    const nodes = createGardenNodes({
+      count: 3,
+      width: 300,
+      height: 180,
+      margin: 20,
+      seed: 11,
+    });
+
+    assert.equal(nodes.length, 3);
+    assertNear(nodes[0].x, 136.19807402249245);
+    assertNear(nodes[1].y, 92.4487089388526);
+    assert.ok(nodes.every((node) => node.x >= 20 && node.x <= 280));
+    assert.ok(nodes.every((node) => node.y >= 20 && node.y <= 160));
+  });
+
+  it('collects nearby active sparks and awards combo score', () => {
+    const nodes = [
+      { id: 'a', x: 50, y: 50, radius: 8, value: 10, active: true },
+      { id: 'b', x: 70, y: 50, radius: 8, value: 15, active: true },
+      { id: 'c', x: 140, y: 50, radius: 8, value: 20, active: true },
+    ];
+
+    const result = collectNearbyNodes({ x: 55, y: 50 }, nodes, {
+      collectionRadius: 12,
+      time: 2,
+      lastCollectTime: 1,
+      combo: 1,
+    });
+
+    assert.equal(result.collected, 2);
+    assert.equal(result.combo, 3);
+    assert.equal(result.score, 37);
+    assert.equal(result.nodes[0].active, false);
+    assert.equal(result.nodes[1].active, false);
+    assert.equal(result.nodes[2].active, true);
+  });
+
+  it('advances the player with normalized movement and bounds', () => {
+    const player = { x: 10, y: 10, radius: 5, speed: 100 };
+    const moved = advancePlayer(
+      player,
+      { up: false, right: true, down: true, left: false, boost: false },
+      1,
+      { width: 80, height: 80 },
+    );
+
+    assertNear(moved.x, 75);
+    assertNear(moved.y, 75);
+  });
+
+  it('grades the garden by completion and score', () => {
+    assert.equal(computeGardenGrade(0, 0, 10), 'Seed');
+    assert.equal(computeGardenGrade(80, 4, 10), 'Gathering');
+    assert.equal(computeGardenGrade(120, 7, 10), 'Awake');
+    assert.equal(computeGardenGrade(180, 10, 10), 'Bloom');
+  });
+});


### PR DESCRIPTION
## Summary
- add Signal Garden as a self-contained canvas portal game
- link it from the homepage, app dock/search data, play lane, and games hub
- add focused tests for Signal Garden helpers and portal links

## Verification
- node --test tests/signal-garden-state.test.js tests/signal-garden-page.test.js tests/jetpack-game-state.test.js
- git diff --check origin/main..HEAD
- curl -I http://127.0.0.1:3000/signal-garden/

Note: full npm test has known unrelated failures/missing deps in this fresh worktree, matching the earlier local caveat.