### PR TITLE
Add Money Printer experiment learning loop

### DIFF
--- a/.github/workflows/money-printer-self-improve.yml
+++ b/.github/workflows/money-printer-self-improve.yml
@@ -57,7 +57,7 @@ jobs:
             $auto_merge_flag \
             --wait-checks \
             --check-interval 10 \
-            --title "Money Printer autonomous operator report" \
+            --title "Money Printer autonomous learning update" \
             --json | tee artifacts/money-printer-self-improve/latest.json
 
       - name: Collect operator reports

--- a/docs/money-printer-learning-ledger.json
+++ b/docs/money-printer-learning-ledger.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "primary_metric": "revenue_cents",
+  "current_signals": {
+    "visits": 0,
+    "signups": 0,
+    "qualified_leads": 0,
+    "outreach_sent": 0,
+    "qualified_replies": 0,
+    "calls_booked": 0,
+    "customers": 0,
+    "revenue_cents": 0
+  },
+  "backlog": [
+    {
+      "id": "free-page-conversion-baseline",
+      "title": "Measure the Free Page visit-to-lead conversion rate",
+      "hypothesis": "A visible baseline will expose the highest-leverage funnel bottleneck.",
+      "metric": "qualified_leads",
+      "confidence": 0.9,
+      "effort": 1,
+      "risk": "GREEN",
+      "status": "ready",
+      "score": 0.9
+    },
+    {
+      "id": "buyer-language-research",
+      "title": "Research recurring buyer language for one narrow service niche",
+      "hypothesis": "Using the buyer’s own pain language will improve qualified replies.",
+      "metric": "qualified_replies",
+      "confidence": 0.75,
+      "effort": 2,
+      "risk": "GREEN",
+      "status": "research",
+      "score": 0.375
+    },
+    {
+      "id": "free-page-proof-test",
+      "title": "Test one proof-focused Free Page message",
+      "hypothesis": "Concrete proof will convert more qualified visitors than broad claims.",
+      "metric": "qualified_leads",
+      "confidence": 0.65,
+      "effort": 2,
+      "risk": "YELLOW",
+      "status": "blocked-on-baseline",
+      "score": 0.125
+    }
+  ],
+  "outcomes": [],
+  "decision": {
+    "experiment_id": "free-page-conversion-baseline",
+    "reason": "Establish a real funnel baseline before automatically changing copy or outreach."
+  },
+  "guardrails": {
+    "auto_execute": [
+      "research artifacts",
+      "measurement updates",
+      "internal documentation"
+    ],
+    "approval_required": [
+      "prospect outreach",
+      "pricing",
+      "billing",
+      "credentials",
+      "deployment",
+      "auth"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "money-printer:ai-status": "node scripts/money-printer-cli.mjs ai-status",
     "money-printer:codex": "node scripts/money-printer-cli.mjs codex",
     "money-printer:operator": "node scripts/money-printer-operator.mjs",
+    "money-printer:learning": "node scripts/money-printer-learning.mjs",
     "money-printer:supervisor": "node scripts/money-printer-supervisor.mjs",
     "money-printer:auto-business": "node scripts/money-printer-auto-business.mjs",
     "money:loop": "node scripts/money/run-loop.mjs",

--- a/scripts/money-printer-learning.mjs
+++ b/scripts/money-printer-learning.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { applyMeasurement, createLearningLedger } from '../src/money-printer/learningLedger.js';
+
+export const DEFAULT_LEDGER_PATH = 'docs/money-printer-learning-ledger.json';
+
+async function readJson(filePath, fallback) {
+  try { return JSON.parse(await readFile(filePath, 'utf8')); }
+  catch (error) { if (error.code === 'ENOENT') return fallback; throw error; }
+}
+
+export async function updateLearningLedger({ rootDir = process.cwd(), measurementPath = '' } = {}) {
+  const ledgerPath = path.join(rootDir, DEFAULT_LEDGER_PATH);
+  const existing = await readJson(ledgerPath, null);
+  const ledger = existing || createLearningLedger();
+  const measurement = measurementPath ? await readJson(path.resolve(rootDir, measurementPath), {}) : {};
+  const result = applyMeasurement(ledger, measurement);
+  const changed = !existing || result.changed;
+  if (changed) await writeFile(ledgerPath, `${JSON.stringify(result.ledger, null, 2)}\n`, 'utf8');
+  return { changed, reason: !existing ? 'initialized experiment memory' : result.changed ? 'recorded new measured signals' : 'no new measured signal', ledgerPath, ledger: result.ledger, outcome: result.outcome || null };
+}
+
+async function main() {
+  const index = process.argv.indexOf('--measurement-file');
+  const result = await updateLearningLedger({ measurementPath: index >= 0 ? process.argv[index + 1] : '' });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main().catch(error => { console.error(`money-printer-learning: ${error.message}`); process.exitCode = 1; });

--- a/scripts/money-printer-operator.mjs
+++ b/scripts/money-printer-operator.mjs
@@ -10,6 +10,7 @@ import {
   runSelfReview
 } from './money-printer-self-review.mjs';
 import { sendOperatorReportEmail } from '../src/money-printer/operatorEmailReport.js';
+import { DEFAULT_LEDGER_PATH, updateLearningLedger } from './money-printer-learning.mjs';
 
 function parseArgs(argv = process.argv.slice(2)) {
   const args = { _: [] };
@@ -174,7 +175,8 @@ async function runVerification(rootDir) {
   const commands = [
     ['node', ['--check', 'scripts/money-printer-self-review.mjs']],
     ['node', ['--check', 'scripts/money-printer-operator.mjs']],
-    ['node', ['--test', 'tests/money-printer-self-review.test.js']]
+    ['node', ['--check', 'scripts/money-printer-learning.mjs']],
+    ['node', ['--test', 'tests/money-printer-self-review.test.js', 'tests/money-printer-learning.test.js']]
   ];
   const results = commands.map(([command, args]) => runCommand(command, args, { cwd: rootDir }));
   return {
@@ -185,30 +187,6 @@ async function runVerification(rootDir) {
       result: commandOutputSummary(result)
     }))
   };
-}
-
-async function writeSafeImprovement(rootDir) {
-  const filePath = path.join(rootDir, 'docs', 'money-printer-operator-report.md');
-  const generatedAt = new Date().toISOString();
-  const content = `# Money Printer Operator Report
-
-Generated: ${generatedAt}
-
-## Current Safe Improvement
-
-This report is the v1 safe improvement target for the Money Printer operator.
-
-The operator may update this document during a dry run or proposal cycle because it is documentation-only and does not touch users, billing, sending, deployment, secrets, auth, or schedulers.
-
-## Guardrail Reminder
-
-- GREEN changes may be eligible for auto-merge after tests pass.
-- YELLOW changes may open a PR but need Thomas to merge.
-- RED changes stop before opening a mergeable PR.
-- Real email, SMS, Stripe, billing, auth, deployment, scheduler, secrets, and destructive cleanup remain blocked.
-`;
-  await writeFile(filePath, content, 'utf8');
-  return filePath;
 }
 
 async function buildReport(rootDir, command) {
@@ -298,12 +276,24 @@ async function runPropose(rootDir, options = {}) {
   const branchContext = ensureProposalBranch(rootDir, options);
   const report = await buildReport(rootDir, 'propose');
   report.branchContext = branchContext;
-  report.impact = {
-    intent: 'Keep the autonomous Money Printer loop auditable by refreshing its operator report document.',
-    whatChanged: 'Updated docs/money-printer-operator-report.md with a new generated timestamp and the current safe-improvement guardrail reminder.',
-    whyItMatters: 'Thomas can see that the scheduled loop is alive while the change stays limited to documentation and avoids billing, outreach, secrets, auth, deployment, and schedulers.'
+  const learning = await updateLearningLedger({
+    rootDir,
+    measurementPath: options.measurementFile || process.env.MONEY_PRINTER_MEASUREMENT_FILE || ''
+  });
+  report.learning = {
+    changed: learning.changed,
+    reason: learning.reason,
+    ledgerPath: path.relative(rootDir, learning.ledgerPath),
+    decision: learning.ledger.decision,
+    signals: learning.ledger.current_signals,
+    outcomesRecorded: learning.ledger.outcomes.length
   };
-  report.safeImprovementPath = await writeSafeImprovement(rootDir);
+  report.impact = {
+    intent: 'Turn the scheduled Money Printer job into a persistent experiment-learning loop.',
+    whatChanged: learning.changed ? `Updated ${DEFAULT_LEDGER_PATH} with ranked experiments and durable measured outcomes.` : 'No repository change: the loop found no new measured signal to learn from.',
+    whyItMatters: 'The loop now compounds verified learning and stops opening timestamp-only PRs when nothing meaningful changed.'
+  };
+  report.safeImprovementPath = learning.ledgerPath;
   report.verification = await runVerification(rootDir);
   const operatorDir = await ensureOperatorDir(rootDir);
   const selfReviewPath = path.join(operatorDir, 'self-review-latest.md');
@@ -313,12 +303,12 @@ async function runPropose(rootDir, options = {}) {
     testsPassed: report.verification.passed,
     commands: verificationCommands,
     out: selfReviewPath,
-    summary: 'Money Printer proposed a documentation-only operator report update.',
+    summary: learning.changed ? 'Money Printer updated its experiment learning ledger.' : 'Money Printer found no new learning and made no change.',
     intent: report.impact.intent,
     whatChanged: report.impact.whatChanged,
     whyItMatters: report.impact.whyItMatters,
-    rollbackPlan: 'Revert the PR commit or restore docs/money-printer-operator-report.md from main.',
-    nextSuggestedAction: 'If GREEN, open a PR for the documentation-only report update. If not GREEN, ask Thomas to review.'
+    rollbackPlan: `Revert the PR commit or restore ${DEFAULT_LEDGER_PATH} from main.`,
+    nextSuggestedAction: learning.changed ? 'If GREEN, persist the new learning. Otherwise, wait for a new measurement.' : 'Wait for a new measured signal; do not open a PR.'
   });
   report.selfReview = {
     risk: review.risk,
@@ -332,13 +322,13 @@ async function runPropose(rootDir, options = {}) {
     reasons: review.reasons
   };
 
-  if (parseBool(options.createPr) && review.risk !== 'RED') {
-    git(rootDir, ['add', 'docs/money-printer-operator-report.md']);
-    git(rootDir, ['commit', '-m', options.commitMessage || 'Add Money Printer operator report']);
+  if (parseBool(options.createPr) && learning.changed && review.risk !== 'RED') {
+    git(rootDir, ['add', DEFAULT_LEDGER_PATH]);
+    git(rootDir, ['commit', '-m', options.commitMessage || 'Update Money Printer learning ledger']);
     git(rootDir, ['push', '-u', 'origin', git(rootDir, ['branch', '--show-current'])]);
     report.pr = await openPullRequest(rootDir, {
       base: options.base || 'main',
-      title: options.title || 'Money Printer autonomous operator report',
+      title: options.title || 'Money Printer autonomous learning update',
       bodyPath: selfReviewPath
     });
     report.merge = await mergePullRequestIfGreen(rootDir, review, report.pr, {
@@ -346,7 +336,7 @@ async function runPropose(rootDir, options = {}) {
       waitChecks: options.waitChecks,
       checkInterval: options.checkInterval
     });
-  } else if (parseBool(options.createPr) && review.risk === 'RED') {
+  } else if (parseBool(options.createPr) && learning.changed && review.risk === 'RED') {
     report.pr = {
       url: '',
       blocked: true,
@@ -378,7 +368,7 @@ Usage:
 
 Commands:
   report      Inspect repo state and write an email-ready local report.
-  propose     Create a documentation-only safe improvement and self-review it.
+  propose     Update durable experiment learning when new measurements exist.
 
 Flags:
   --root <dir>             Repo root, defaults to cwd.
@@ -390,6 +380,7 @@ Flags:
   --branch-name <name>     Branch to create when proposal starts from main/master.
   --title <text>           PR title.
   --commit-message <text>  Commit message for proposal mode.
+  --measurement-file <file> Import a JSON signal snapshot into outcome history.
   --email                  Alias for --email-report.
   --email-report           Send the internal Thomas report after the run.
   --email-dry-run          Verify email config and log without sending.
@@ -423,6 +414,7 @@ async function main() {
       branchName: args.branchName,
       title: args.title,
       commitMessage: args.commitMessage,
+      measurementFile: args.measurementFile,
       emailReport: args.emailReport || args.email,
       emailDryRun: args.emailDryRun || args.dryRun
     });
@@ -460,5 +452,5 @@ export {
   autonomousBranchName,
   ensureProposalBranch,
   sendOperatorReportEmail,
-  writeSafeImprovement
+  updateLearningLedger
 };

--- a/src/money-printer/learningLedger.js
+++ b/src/money-printer/learningLedger.js
@@ -1,0 +1,65 @@
+const DEFAULT_BACKLOG = [
+  { id: 'free-page-conversion-baseline', title: 'Measure the Free Page visit-to-lead conversion rate', hypothesis: 'A visible baseline will expose the highest-leverage funnel bottleneck.', metric: 'qualified_leads', confidence: 0.9, effort: 1, risk: 'GREEN', status: 'ready' },
+  { id: 'buyer-language-research', title: 'Research recurring buyer language for one narrow service niche', hypothesis: 'Using the buyer’s own pain language will improve qualified replies.', metric: 'qualified_replies', confidence: 0.75, effort: 2, risk: 'GREEN', status: 'research' },
+  { id: 'free-page-proof-test', title: 'Test one proof-focused Free Page message', hypothesis: 'Concrete proof will convert more qualified visitors than broad claims.', metric: 'qualified_leads', confidence: 0.65, effort: 2, risk: 'YELLOW', status: 'blocked-on-baseline' }
+];
+
+export const SIGNAL_KEYS = ['visits', 'signups', 'qualified_leads', 'outreach_sent', 'qualified_replies', 'calls_booked', 'customers', 'revenue_cents'];
+
+function numberOrZero(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : 0;
+}
+
+export function normalizeSignals(signals = {}) {
+  return Object.fromEntries(SIGNAL_KEYS.map(key => [key, numberOrZero(signals[key])]));
+}
+
+export function experimentScore(experiment = {}) {
+  const effort = Math.max(1, numberOrZero(experiment.effort));
+  const riskPenalty = experiment.risk === 'GREEN' ? 0 : experiment.risk === 'YELLOW' ? 0.2 : 1;
+  return Number(Math.max(0, numberOrZero(experiment.confidence) / effort - riskPenalty).toFixed(3));
+}
+
+export function rankBacklog(backlog = []) {
+  return backlog.map(item => ({ ...item, score: experimentScore(item) }))
+    .sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+}
+
+export function createLearningLedger() {
+  return {
+    schema_version: 1,
+    primary_metric: 'revenue_cents',
+    current_signals: normalizeSignals(),
+    backlog: rankBacklog(DEFAULT_BACKLOG),
+    outcomes: [],
+    decision: { experiment_id: 'free-page-conversion-baseline', reason: 'Establish a real funnel baseline before automatically changing copy or outreach.' },
+    guardrails: {
+      auto_execute: ['research artifacts', 'measurement updates', 'internal documentation'],
+      approval_required: ['prospect outreach', 'pricing', 'billing', 'credentials', 'deployment', 'auth']
+    }
+  };
+}
+
+export function applyMeasurement(ledger = createLearningLedger(), measurement = {}) {
+  const previous = normalizeSignals(ledger.current_signals);
+  const current = normalizeSignals({ ...previous, ...(measurement.signals || measurement) });
+  const changed = SIGNAL_KEYS.some(key => current[key] !== previous[key]);
+  if (!changed) return { changed: false, ledger };
+
+  const outcome = {
+    observed_at: String(measurement.observed_at || measurement.observedAt || new Date().toISOString()),
+    experiment_id: measurement.experiment_id || measurement.experimentId || ledger.decision?.experiment_id || 'unattributed',
+    source: measurement.source || 'manual-import',
+    signals: current,
+    delta: Object.fromEntries(SIGNAL_KEYS.map(key => [key, current[key] - previous[key]])),
+    note: String(measurement.note || '').slice(0, 500)
+  };
+  return {
+    changed: true,
+    ledger: { ...ledger, current_signals: current, backlog: rankBacklog(ledger.backlog || []), outcomes: [...(ledger.outcomes || []), outcome].slice(-90) },
+    outcome
+  };
+}
+
+export { DEFAULT_BACKLOG };

--- a/tests/money-printer-learning.test.js
+++ b/tests/money-printer-learning.test.js
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { applyMeasurement, createLearningLedger, rankBacklog } from '../src/money-printer/learningLedger.js';
+import { updateLearningLedger } from '../scripts/money-printer-learning.mjs';
+
+test('ranks low-risk, high-confidence experiments first', () => {
+  const ranked = rankBacklog([{ id: 'slow', confidence: 0.9, effort: 4, risk: 'GREEN' }, { id: 'fast', confidence: 0.8, effort: 1, risk: 'GREEN' }, { id: 'risky', confidence: 1, effort: 1, risk: 'RED' }]);
+  assert.deepEqual(ranked.map(item => item.id), ['fast', 'slow', 'risky']);
+});
+
+test('records only material signal changes as outcomes', () => {
+  const ledger = createLearningLedger();
+  assert.equal(applyMeasurement(ledger, {}).changed, false);
+  const result = applyMeasurement(ledger, { observed_at: '2026-07-12T00:00:00.000Z', source: 'analytics-import', signals: { visits: 20, qualified_leads: 2 } });
+  assert.equal(result.changed, true);
+  assert.equal(result.ledger.outcomes.length, 1);
+  assert.equal(result.outcome.delta.visits, 20);
+});
+
+test('initializes once and becomes a no-op without new measurements', async () => {
+  const rootDir = await mkdtemp(path.join(tmpdir(), 'money-learning-'));
+  await mkdir(path.join(rootDir, 'docs'));
+  const first = await updateLearningLedger({ rootDir });
+  const firstBody = await readFile(first.ledgerPath, 'utf8');
+  const second = await updateLearningLedger({ rootDir });
+  assert.equal(first.changed, true);
+  assert.equal(second.changed, false);
+  assert.equal(await readFile(second.ledgerPath, 'utf8'), firstBody);
+});
+
+test('imports a measurement file into persistent outcome history', async () => {
+  const rootDir = await mkdtemp(path.join(tmpdir(), 'money-learning-'));
+  await mkdir(path.join(rootDir, 'docs'));
+  await updateLearningLedger({ rootDir });
+  await writeFile(path.join(rootDir, 'measurement.json'), JSON.stringify({ observed_at: '2026-07-12T01:00:00.000Z', source: 'test', signals: { visits: 10, signups: 1 } }));
+  const result = await updateLearningLedger({ rootDir, measurementPath: 'measurement.json' });
+  assert.equal(result.changed, true);
+  assert.equal(result.ledger.outcomes[0].signals.signups, 1);
+});

--- a/tests/money-printer-self-review.test.js
+++ b/tests/money-printer-self-review.test.js
@@ -128,8 +128,11 @@ test('operator proposal commits only the reviewed safe improvement', () => {
   assert.match(source, /whatChanged: report\.impact\.whatChanged/);
   assert.match(source, /whyItMatters: report\.impact\.whyItMatters/);
   assert.doesNotMatch(source, /outPath: selfReviewPath/);
-  assert.match(source, /\['add', 'docs\/money-printer-operator-report\.md'\]/);
-  assert.doesNotMatch(source, /\['add', 'docs\/money-printer-operator-report\.md', 'SELF_REVIEW\.md'\]/);
+  assert.match(source, /updateLearningLedger/);
+  assert.match(source, /learning\.changed/);
+  assert.match(source, /\['add', DEFAULT_LEDGER_PATH\]/);
+  assert.doesNotMatch(source, /\['add', DEFAULT_LEDGER_PATH, 'SELF_REVIEW\.md'\]/);
+  assert.match(source, /no new measured signal/i);
   assert.match(source, /waitChecks: options\.waitChecks/);
   assert.match(source, /\['pr', 'checks', pr\.url, '--watch', '--interval', interval\]/);
   assert.match(source, /pull request checks did not pass/);


### PR DESCRIPTION
## Summary

- replace timestamp-only operator-report churn with a durable experiment learning ledger
- rank a guarded research/experiment backlog by confidence, effort, and risk
- record material funnel-signal changes as bounded outcome history
- make scheduled runs no-op when no measured signal changed
- retain approval gates for outreach, pricing, billing, credentials, deployment, and auth

## Verification

- `node --check scripts/money-printer-learning.mjs`
- `node --check scripts/money-printer-operator.mjs`
- `node --test tests/money-printer-learning.test.js tests/money-printer-self-review.test.js`
- related operator-email suite (20 total tests passed)
- repeated ledger run confirmed the second run makes no file change
- `git diff --check`

## Rollback

Revert this PR to restore the documentation-only nightly proposal target.
