### PR TITLE
Connect Money Printer evidence and market research

### DIFF
--- a/.github/workflows/money-printer-self-improve.yml
+++ b/.github/workflows/money-printer-self-improve.yml
@@ -12,6 +12,7 @@ on:
         default: 'true'
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 
@@ -42,6 +43,16 @@ jobs:
           git config user.name "3DVR Money Printer"
           git config user.email "actions@github.com"
 
+      - name: Collect latest operating evidence
+        run: |
+          mkdir -p .money-printer/evidence
+          for workflow in money-autopilot.yml outbound-autopilot.yml market-pulse.yml; do
+            run_id="$(gh run list --workflow "$workflow" --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+            if [ -n "$run_id" ]; then
+              gh run download "$run_id" --dir ".money-printer/evidence/$workflow" || true
+            fi
+          done
+
       - name: Run guarded self-improvement
         env:
           AUTO_MERGE_INPUT: ${{ inputs.auto_merge || 'true' }}
@@ -57,6 +68,7 @@ jobs:
             $auto_merge_flag \
             --wait-checks \
             --check-interval 10 \
+            --evidence-dir .money-printer/evidence \
             --title "Money Printer autonomous learning update" \
             --json | tee artifacts/money-printer-self-improve/latest.json
 

--- a/docs/money-printer-learning-ledger.json
+++ b/docs/money-printer-learning-ledger.json
@@ -24,6 +24,18 @@
       "score": 0.9
     },
     {
+      "id": "market-customer-intake-automation-for-owner-led-service-busin",
+      "title": "Customer Intake automation for owner-led service businesses that need clearer lead follow-up",
+      "hypothesis": "owner-led service businesses that need clearer lead follow-up teams repeatedly lose time on customer intake and need a faster process.",
+      "metric": "qualified_replies",
+      "confidence": 0.82,
+      "effort": 2,
+      "risk": "GREEN",
+      "status": "research",
+      "evidence_run_id": "market-pulse-20260712172802",
+      "score": 0.41
+    },
+    {
       "id": "buyer-language-research",
       "title": "Research recurring buyer language for one narrow service niche",
       "hypothesis": "Using the buyer’s own pain language will improve qualified replies.",
@@ -65,5 +77,46 @@
       "deployment",
       "auth"
     ]
+  },
+  "research": {
+    "latest_run_id": "market-pulse-20260712172802",
+    "observed_at": "2026-07-12T17:28:02.917Z",
+    "fingerprint": "fnv1a-ae33b7d5",
+    "market": "owner-led service businesses that need clearer lead follow-up",
+    "signals_analyzed": 11,
+    "fit_score": 82,
+    "verdict": "strong signal",
+    "strongest_channel": "Hacker News",
+    "opportunity": {
+      "title": "Customer Intake automation for owner-led service businesses that need clearer lead follow-up",
+      "problem": "owner-led service businesses that need clearer lead follow-up teams repeatedly lose time on customer intake and need a faster process.",
+      "score": 80.9
+    },
+    "next_action": "Run the top social probe and collect reaction snapshots before packaging the offer.",
+    "warnings": [
+      "Reddit r/freelance unavailable (HTTP 403)"
+    ]
+  },
+  "sources": {
+    "analytics": {
+      "available": false,
+      "run_id": "money-20260712171841-v58z41",
+      "reason": "GA4 credentials or session count unavailable"
+    },
+    "outbound": {
+      "available": true,
+      "run_id": "money-20260712174048-m51r2m",
+      "queue_size": 4
+    },
+    "revenue": {
+      "available": true,
+      "rows": 4,
+      "reason": "outbound outcome tracker imported"
+    },
+    "research": {
+      "available": true,
+      "run_id": "market-pulse-20260712172802",
+      "signals_analyzed": 11
+    }
   }
 }

--- a/scripts/money-printer-learning.mjs
+++ b/scripts/money-printer-learning.mjs
@@ -4,7 +4,8 @@ import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
-import { applyMeasurement, createLearningLedger } from '../src/money-printer/learningLedger.js';
+import { applyEvidence, applyMeasurement, createLearningLedger } from '../src/money-printer/learningLedger.js';
+import { collectLearningEvidence } from '../src/money-printer/learningSources.js';
 
 export const DEFAULT_LEDGER_PATH = 'docs/money-printer-learning-ledger.json';
 
@@ -13,20 +14,26 @@ async function readJson(filePath, fallback) {
   catch (error) { if (error.code === 'ENOENT') return fallback; throw error; }
 }
 
-export async function updateLearningLedger({ rootDir = process.cwd(), measurementPath = '' } = {}) {
+export async function updateLearningLedger({ rootDir = process.cwd(), measurementPath = '', evidenceDir = '' } = {}) {
   const ledgerPath = path.join(rootDir, DEFAULT_LEDGER_PATH);
   const existing = await readJson(ledgerPath, null);
   const ledger = existing || createLearningLedger();
-  const measurement = measurementPath ? await readJson(path.resolve(rootDir, measurementPath), {}) : {};
-  const result = applyMeasurement(ledger, measurement);
+  const importedEvidence = evidenceDir ? await collectLearningEvidence(path.resolve(rootDir, evidenceDir)) : null;
+  const measurement = measurementPath ? await readJson(path.resolve(rootDir, measurementPath), {}) : null;
+  const result = importedEvidence ? applyEvidence(ledger, importedEvidence) : applyMeasurement(ledger, measurement || {});
   const changed = !existing || result.changed;
   if (changed) await writeFile(ledgerPath, `${JSON.stringify(result.ledger, null, 2)}\n`, 'utf8');
-  return { changed, reason: !existing ? 'initialized experiment memory' : result.changed ? 'recorded new measured signals' : 'no new measured signal', ledgerPath, ledger: result.ledger, outcome: result.outcome || null };
+  const reason = !existing
+    ? 'initialized experiment memory'
+    : result.researchChanged ? 'recorded new market research'
+      : result.changed ? 'recorded new operating evidence' : 'no new measured signal';
+  return { changed, reason, ledgerPath, ledger: result.ledger, outcome: result.outcome || null, researchChanged: Boolean(result.researchChanged), evidence: importedEvidence };
 }
 
 async function main() {
   const index = process.argv.indexOf('--measurement-file');
-  const result = await updateLearningLedger({ measurementPath: index >= 0 ? process.argv[index + 1] : '' });
+  const evidenceIndex = process.argv.indexOf('--evidence-dir');
+  const result = await updateLearningLedger({ measurementPath: index >= 0 ? process.argv[index + 1] : '', evidenceDir: evidenceIndex >= 0 ? process.argv[evidenceIndex + 1] : '' });
   console.log(JSON.stringify(result, null, 2));
 }
 

--- a/scripts/money-printer-operator.mjs
+++ b/scripts/money-printer-operator.mjs
@@ -278,7 +278,8 @@ async function runPropose(rootDir, options = {}) {
   report.branchContext = branchContext;
   const learning = await updateLearningLedger({
     rootDir,
-    measurementPath: options.measurementFile || process.env.MONEY_PRINTER_MEASUREMENT_FILE || ''
+    measurementPath: options.measurementFile || process.env.MONEY_PRINTER_MEASUREMENT_FILE || '',
+    evidenceDir: options.evidenceDir || process.env.MONEY_PRINTER_EVIDENCE_DIR || ''
   });
   report.learning = {
     changed: learning.changed,
@@ -286,7 +287,9 @@ async function runPropose(rootDir, options = {}) {
     ledgerPath: path.relative(rootDir, learning.ledgerPath),
     decision: learning.ledger.decision,
     signals: learning.ledger.current_signals,
-    outcomesRecorded: learning.ledger.outcomes.length
+    outcomesRecorded: learning.ledger.outcomes.length,
+    research: learning.ledger.research || null,
+    sources: learning.ledger.sources || {}
   };
   report.impact = {
     intent: 'Turn the scheduled Money Printer job into a persistent experiment-learning loop.',
@@ -381,6 +384,7 @@ Flags:
   --title <text>           PR title.
   --commit-message <text>  Commit message for proposal mode.
   --measurement-file <file> Import a JSON signal snapshot into outcome history.
+  --evidence-dir <dir>      Import latest analytics, outbound, and research artifacts.
   --email                  Alias for --email-report.
   --email-report           Send the internal Thomas report after the run.
   --email-dry-run          Verify email config and log without sending.
@@ -415,6 +419,7 @@ async function main() {
       title: args.title,
       commitMessage: args.commitMessage,
       measurementFile: args.measurementFile,
+      evidenceDir: args.evidenceDir,
       emailReport: args.emailReport || args.email,
       emailDryRun: args.emailDryRun || args.dryRun
     });

--- a/src/money-printer/learningLedger.js
+++ b/src/money-printer/learningLedger.js
@@ -62,4 +62,22 @@ export function applyMeasurement(ledger = createLearningLedger(), measurement = 
   };
 }
 
+export function applyEvidence(ledger = createLearningLedger(), evidence = {}) {
+  const measurement = applyMeasurement(ledger, evidence);
+  let next = measurement.ledger;
+  const researchChanged = Boolean(evidence.research?.fingerprint && evidence.research.fingerprint !== ledger.research?.fingerprint);
+  if (researchChanged) {
+    const backlog = [...(next.backlog || [])];
+    if (evidence.experiment && !backlog.some(item => item.id === evidence.experiment.id)) backlog.push(evidence.experiment);
+    next = { ...next, research: evidence.research, backlog: rankBacklog(backlog) };
+  }
+  const comparableSources = sources => Object.fromEntries(Object.entries(sources || {}).map(([key, value]) => {
+    const { run_id: ignoredRunId, ...stable } = value || {};
+    return [key, stable];
+  }));
+  const sourcesChanged = Boolean(evidence.sources && JSON.stringify(comparableSources(evidence.sources)) !== JSON.stringify(comparableSources(ledger.sources)));
+  if (measurement.changed || researchChanged || sourcesChanged) next = { ...next, sources: evidence.sources || {} };
+  return { changed: measurement.changed || researchChanged || sourcesChanged, ledger: next, outcome: measurement.outcome, researchChanged, sourcesChanged };
+}
+
 export { DEFAULT_BACKLOG };

--- a/src/money-printer/learningSources.js
+++ b/src/money-printer/learningSources.js
@@ -1,0 +1,148 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+async function walk(directory) {
+  const files = [];
+  let entries = [];
+  try { entries = await readdir(directory, { withFileTypes: true }); }
+  catch (error) { if (error.code === 'ENOENT') return files; throw error; }
+  for (const entry of entries) {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await walk(target));
+    else files.push(target);
+  }
+  return files;
+}
+
+export function parseEmbeddedJson(text = '') {
+  const source = String(text);
+  for (let index = source.indexOf('{'); index >= 0; index = source.indexOf('{', index + 1)) {
+    try { return JSON.parse(source.slice(index)); } catch { /* skip command chatter */ }
+  }
+  return null;
+}
+
+export function parseCsv(text = '') {
+  const rows = [];
+  let row = [];
+  let field = '';
+  let quoted = false;
+  const source = String(text).replace(/\r\n/g, '\n');
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '"' && quoted && source[index + 1] === '"') { field += '"'; index += 1; }
+    else if (char === '"') quoted = !quoted;
+    else if (char === ',' && !quoted) { row.push(field); field = ''; }
+    else if (char === '\n' && !quoted) { row.push(field); rows.push(row); row = []; field = ''; }
+    else field += char;
+  }
+  if (field || row.length) { row.push(field); rows.push(row); }
+  const [headers = [], ...body] = rows.filter(item => item.some(value => value !== ''));
+  return body.map(values => Object.fromEntries(headers.map((header, index) => [header, values[index] || ''])));
+}
+
+function cents(value) {
+  const normalized = String(value || '').replace(/[^\d.-]/g, '');
+  const amount = Number(normalized);
+  return Number.isFinite(amount) ? Math.max(0, Math.round(amount * 100)) : 0;
+}
+
+function positive(value) {
+  return /^(1|true|yes|positive|qualified|interested|replied|booked|active|paid)$/i.test(String(value || '').trim());
+}
+
+function slug(value = '') {
+  return String(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 54) || 'market-opportunity';
+}
+
+function fingerprint(value = '') {
+  let hash = 2166136261;
+  for (const char of String(value)) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `fnv1a-${(hash >>> 0).toString(16).padStart(8, '0')}`;
+}
+
+export function deriveEvidence({ autopilot = null, outbound = null, outcomes = [], marketPulse = null } = {}) {
+  const queue = Array.isArray(outbound?.queue) ? outbound.queue : [];
+  const sentFromQueue = queue.filter(item => item.lastContactedAt || item.contactedAt || /sent|contacted/i.test(item.status || '')).length;
+  const sentFromDispatch = Number(outbound?.dispatch?.sentCount || 0);
+  const replies = outcomes.filter(item => positive(item.replyStatus)).length;
+  const calls = outcomes.filter(item => /booked|scheduled/i.test(item.replyStatus || item.notes || '')).length;
+  const customers = outcomes.filter(item => positive(item.subscriptionStatus) || /customer|paid/i.test(item.keepLiveDecision || '')).length;
+  const revenueCents = outcomes.reduce((sum, item) => sum + cents(item.revenue), 0);
+  const analyticsAvailable = Boolean(autopilot?.analytics?.enabled && Number.isFinite(Number(autopilot?.analytics?.sessions)));
+  const researchAvailable = Boolean(marketPulse?.runId);
+
+  const signals = {
+    ...(analyticsAvailable ? { visits: Number(autopilot.analytics.sessions) } : {}),
+    outreach_sent: Math.max(sentFromQueue, sentFromDispatch),
+    qualified_replies: replies,
+    calls_booked: calls,
+    customers,
+    revenue_cents: revenueCents
+  };
+  const researchCore = researchAvailable ? {
+    market: marketPulse.market || '',
+    signals_analyzed: Number(marketPulse.signalsAnalyzed || 0),
+    fit_score: Number(marketPulse.marketFit?.score || 0),
+    verdict: marketPulse.marketFit?.verdict || '',
+    strongest_channel: marketPulse.marketFit?.strongestChannel || '',
+    opportunity: marketPulse.topOpportunity || {},
+    next_action: marketPulse.marketFit?.nextAction || '',
+    warnings: Array.isArray(marketPulse.warnings) ? marketPulse.warnings.slice(0, 8) : []
+  } : null;
+  const research = researchCore ? {
+    latest_run_id: marketPulse.runId,
+    observed_at: marketPulse.generatedAt || '',
+    fingerprint: fingerprint(JSON.stringify(researchCore)),
+    ...researchCore
+  } : null;
+  const experiment = research?.opportunity?.title ? {
+    id: `market-${slug(research.opportunity.title)}`,
+    title: research.opportunity.title,
+    hypothesis: research.opportunity.problem || `Market Pulse found a ${research.verdict || 'promising'} demand signal.`,
+    metric: 'qualified_replies',
+    confidence: Math.min(1, Math.max(0, research.fit_score / 100)),
+    effort: 2,
+    risk: 'GREEN',
+    status: 'research',
+    evidence_run_id: research.latest_run_id
+  } : null;
+
+  return {
+    source: 'github-actions-evidence',
+    observed_at: marketPulse?.generatedAt || outbound?.generatedAt || autopilot?.generatedAt || new Date().toISOString(),
+    signals,
+    research,
+    experiment,
+    sources: {
+      analytics: { available: analyticsAvailable, run_id: autopilot?.runId || '', reason: analyticsAvailable ? 'GA4 session count imported' : 'GA4 credentials or session count unavailable' },
+      outbound: { available: Boolean(outbound), run_id: outbound?.autopilotRunId || '', queue_size: queue.length },
+      revenue: { available: outcomes.length > 0, rows: outcomes.length, reason: outcomes.length ? 'outbound outcome tracker imported' : 'outcome tracker unavailable' },
+      research: { available: researchAvailable, run_id: marketPulse?.runId || '', signals_analyzed: Number(marketPulse?.signalsAnalyzed || 0) }
+    }
+  };
+}
+
+export async function collectLearningEvidence(evidenceDir) {
+  if (!evidenceDir) return null;
+  const files = await walk(evidenceDir);
+  let autopilot = null;
+  let outbound = null;
+  let marketPulse = null;
+  let outcomes = [];
+  for (const file of files) {
+    const basename = path.basename(file);
+    const content = await readFile(file, 'utf8');
+    if (basename === 'outcome-tracker.csv') outcomes = parseCsv(content);
+    if (basename !== 'latest.json') continue;
+    const parsed = parseEmbeddedJson(content);
+    if (!parsed) continue;
+    if (parsed.runId?.startsWith('market-pulse-')) marketPulse = parsed;
+    else if (Array.isArray(parsed.queue) && parsed.dispatch) outbound = parsed;
+    else if (parsed.runId?.startsWith('money-')) autopilot = parsed;
+  }
+  return deriveEvidence({ autopilot, outbound, outcomes, marketPulse });
+}

--- a/src/money/autopilot.js
+++ b/src/money/autopilot.js
@@ -530,6 +530,10 @@ async function fetchGoogleAnalyticsHints(config = {}, fetchImpl = globalThis.fet
 
   const topPaths = [];
   const topSources = [];
+  const sessions = rows.reduce((total, row) => {
+    const value = Number(row?.metricValues?.[0]?.value || 0);
+    return total + (Number.isFinite(value) ? value : 0);
+  }, 0);
 
   rows.slice(0, 15).forEach(row => {
     const dimensions = Array.isArray(row?.dimensionValues) ? row.dimensionValues : [];
@@ -543,6 +547,7 @@ async function fetchGoogleAnalyticsHints(config = {}, fetchImpl = globalThis.fet
     enabled: true,
     source: 'ga4',
     warnings: [],
+    sessions,
     keywords: parseGaKeywordHints(topPaths),
     topPaths: uniqueStrings(topPaths).slice(0, 8),
     topSources: uniqueStrings(topSources).slice(0, 8)

--- a/tests/money-autopilot.test.js
+++ b/tests/money-autopilot.test.js
@@ -206,7 +206,7 @@ test('runAutopilotCycle executes loop and returns publish/promotion summaries', 
       ok: true,
       status: 200,
       async json() {
-        return { rows: [] };
+        return { rows: [{ dimensionValues: [{ value: 'google / organic' }, { value: '/free-page/' }], metricValues: [{ value: '17' }] }] };
       },
       async text() {
         return '';
@@ -252,6 +252,7 @@ test('runAutopilotCycle executes loop and returns publish/promotion summaries', 
 
   assert.equal(result.runId, 'money-run-1');
   assert.equal(result.publish.github.published, false);
+  assert.equal(result.analytics.sessions, 17);
   assert.equal(result.publish.github.reason, 'github publish disabled');
   assert.equal(result.publish.vercel.reason, 'vercel deploy disabled');
   assert.equal(result.promotion.reason, 'promotion dispatch disabled');

--- a/tests/money-printer-learning-sources.test.js
+++ b/tests/money-printer-learning-sources.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { collectLearningEvidence, deriveEvidence, parseCsv, parseEmbeddedJson } from '../src/money-printer/learningSources.js';
+
+test('parses JSON after npm and runtime chatter', () => {
+  const parsed = parseEmbeddedJson('> npm run research\nhello\n{"runId":"market-pulse-1","signalsAnalyzed":4}\n');
+  assert.equal(parsed.runId, 'market-pulse-1');
+});
+
+test('parses quoted CSV including embedded commas and newlines', () => {
+  const rows = parseCsv('id,replyStatus,notes\na,qualified,"useful, specific"\nb,,"two\nlines"\n');
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].notes, 'useful, specific');
+  assert.equal(rows[1].notes, 'two\nlines');
+});
+
+test('derives measured signals and a guarded research experiment', () => {
+  const evidence = deriveEvidence({
+    autopilot: { runId: 'money-1', generatedAt: '2026-07-13T00:00:00Z', analytics: { enabled: true, sessions: 42 } },
+    outbound: { generatedAt: '2026-07-13T01:00:00Z', autopilotRunId: 'money-2', dispatch: { sentCount: 1 }, queue: [] },
+    outcomes: [{ replyStatus: 'qualified', subscriptionStatus: 'active', revenue: '$5.00' }],
+    marketPulse: { runId: 'market-pulse-1', generatedAt: '2026-07-13T02:00:00Z', market: 'local services', signalsAnalyzed: 11, marketFit: { score: 82, verdict: 'strong signal', strongestChannel: 'Hacker News', nextAction: 'Interview three buyers.' }, topOpportunity: { title: 'Lead follow-up rescue', problem: 'Leads go cold.' } }
+  });
+  assert.equal(evidence.signals.visits, 42);
+  assert.equal(evidence.signals.outreach_sent, 1);
+  assert.equal(evidence.signals.qualified_replies, 1);
+  assert.equal(evidence.signals.customers, 1);
+  assert.equal(evidence.signals.revenue_cents, 500);
+  assert.equal(evidence.experiment.risk, 'GREEN');
+  assert.equal(evidence.research.fit_score, 82);
+  assert.match(evidence.research.fingerprint, /^fnv1a-/);
+});
+
+test('collects the latest workflow evidence from artifact directories', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'money-evidence-'));
+  await mkdir(path.join(root, 'autopilot'), { recursive: true });
+  await mkdir(path.join(root, 'outbound'), { recursive: true });
+  await mkdir(path.join(root, 'pulse'), { recursive: true });
+  await writeFile(path.join(root, 'autopilot', 'latest.json'), JSON.stringify({ runId: 'money-1', analytics: { enabled: false } }));
+  await writeFile(path.join(root, 'outbound', 'latest.json'), JSON.stringify({ generatedAt: '2026-07-13T01:00:00Z', autopilotRunId: 'money-2', dispatch: { sentCount: 0 }, queue: [] }));
+  await writeFile(path.join(root, 'outbound', 'outcome-tracker.csv'), 'id,replyStatus,revenue\na,qualified,5\n');
+  await writeFile(path.join(root, 'pulse', 'latest.json'), `npm chatter\n${JSON.stringify({ runId: 'market-pulse-2', signalsAnalyzed: 3, marketFit: { score: 70 }, topOpportunity: { title: 'Fast intake' } })}`);
+  const evidence = await collectLearningEvidence(root);
+  assert.equal(evidence.research.latest_run_id, 'market-pulse-2');
+  assert.equal(evidence.signals.qualified_replies, 1);
+  assert.equal(evidence.signals.revenue_cents, 500);
+  assert.equal(evidence.sources.analytics.available, false);
+});

--- a/tests/money-printer-learning.test.js
+++ b/tests/money-printer-learning.test.js
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { applyMeasurement, createLearningLedger, rankBacklog } from '../src/money-printer/learningLedger.js';
+import { applyEvidence, applyMeasurement, createLearningLedger, rankBacklog } from '../src/money-printer/learningLedger.js';
 import { updateLearningLedger } from '../scripts/money-printer-learning.mjs';
 
 test('ranks low-risk, high-confidence experiments first', () => {
@@ -39,4 +39,26 @@ test('imports a measurement file into persistent outcome history', async () => {
   const result = await updateLearningLedger({ rootDir, measurementPath: 'measurement.json' });
   assert.equal(result.changed, true);
   assert.equal(result.ledger.outcomes[0].signals.signups, 1);
+});
+
+test('persists each research run once and promotes its opportunity into the backlog', () => {
+  const ledger = createLearningLedger();
+  const evidence = {
+    signals: {},
+    sources: { research: { available: true, run_id: 'pulse-1' } },
+    research: { latest_run_id: 'pulse-1', fingerprint: 'same-finding', fit_score: 82 },
+    experiment: { id: 'market-lead-rescue', title: 'Lead rescue', confidence: 0.82, effort: 2, risk: 'GREEN', status: 'research' }
+  };
+  const first = applyEvidence(ledger, evidence);
+  const second = applyEvidence(first.ledger, evidence);
+  const newRunSameFinding = applyEvidence(first.ledger, {
+    ...evidence,
+    research: { ...evidence.research, latest_run_id: 'pulse-2' },
+    sources: { research: { available: true, run_id: 'pulse-2' } }
+  });
+  assert.equal(first.changed, true);
+  assert.equal(first.researchChanged, true);
+  assert.equal(first.ledger.backlog.some(item => item.id === 'market-lead-rescue'), true);
+  assert.equal(second.changed, false);
+  assert.equal(newRunSameFinding.changed, false);
 });

--- a/tests/money-printer-self-review.test.js
+++ b/tests/money-printer-self-review.test.js
@@ -145,6 +145,9 @@ test('nightly self-improvement workflow uses guarded operator proposal', () => {
   assert.match(workflow, /cron: '45 06 \* \* \*'/);
   assert.match(workflow, /contents: write/);
   assert.match(workflow, /pull-requests: write/);
+  assert.match(workflow, /actions: read/);
+  assert.match(workflow, /Collect latest operating evidence/);
+  assert.match(workflow, /--evidence-dir \.money-printer\/evidence/);
   assert.match(workflow, /money-printer:operator -- propose/);
   assert.match(workflow, /--create-pr/);
   assert.match(workflow, /--wait-checks/);


### PR DESCRIPTION
## Summary

- download the latest successful Money Autopilot, Outbound Autopilot, and Market Pulse artifacts before the nightly learning decision
- derive actual operating signals from GA session data (when configured), outbound outcomes, customers, and tracked revenue
- persist the latest material market finding and promote it into the ranked experiment backlog
- deduplicate research by content fingerprint so a new run ID alone cannot create PR churn
- expose source availability explicitly; unavailable analytics is not mistaken for measured zero traffic
- keep all outreach, pricing, billing, credential, deployment, and auth approval gates unchanged

## First imported finding

Market Pulse found an 82/100 signal around customer-intake automation for owner-led service businesses with weak lead follow-up. The Free Page conversion baseline remains the top-ranked experiment until analytics is connected.

## Verification

- 52 focused analytics, Market Pulse, outbound, learning, self-review, and operator-email tests passed
- artifact parsing handles npm/runtime chatter and quoted multiline CSV
- repeated import of identical artifacts is a no-op
- a new workflow run ID with identical research content is also a no-op
- `git diff --check`

## Known source gap

The repo currently has no GA4 property/access token or Stripe secret available to GitHub Actions. The connector reports this honestly and will begin importing GA sessions when those existing variables are configured. Moving billing credentials is intentionally outside this PR.
