### PR TITLE
Complete guarded Money Printer execution loop

### DIFF
--- a/.github/workflows/money-printer-self-improve.yml
+++ b/.github/workflows/money-printer-self-improve.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   self-improve:
-    name: Propose guarded self-improvement
+    name: Execute one guarded improvement
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -69,7 +69,7 @@ jobs:
             --wait-checks \
             --check-interval 10 \
             --evidence-dir .money-printer/evidence \
-            --title "Money Printer autonomous learning update" \
+            --title "Money Printer guarded experiment execution" \
             --json | tee artifacts/money-printer-self-improve/latest.json
 
       - name: Collect operator reports

--- a/docs/money-printer-experiments/market-customer-intake-automation-for-owner-led-service-busin.md
+++ b/docs/money-printer-experiments/market-customer-intake-automation-for-owner-led-service-busin.md
@@ -1,0 +1,22 @@
+# Customer Intake automation for owner-led service businesses that need clearer lead follow-up
+
+## Hypothesis
+
+owner-led service businesses that need clearer lead follow-up teams repeatedly lose time on customer intake and need a faster process.
+
+## Evidence
+
+- Market: owner-led service businesses that need clearer lead follow-up
+- Signals analyzed: 11
+- Fit score: 82/100
+- Verdict: strong signal
+- Strongest channel: Hacker News
+- Evidence run: market-pulse-20260712172802
+
+## Bounded next experiment
+
+Create one internal offer prototype that addresses this problem: owner-led service businesses that need clearer lead follow-up teams repeatedly lose time on customer intake and need a faster process. Validate the language with reaction snapshots before any prospect outreach, pricing, deployment, or billing change.
+
+## Success metric
+
+Primary metric: qualified_replies. Keep this artifact internal until a human approves any external probe.

--- a/docs/money-printer-learning-ledger.json
+++ b/docs/money-printer-learning-ledger.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "primary_metric": "revenue_cents",
   "current_signals": {
     "visits": 0,
@@ -31,7 +31,7 @@
       "confidence": 0.82,
       "effort": 2,
       "risk": "GREEN",
-      "status": "research",
+      "status": "prepared",
       "evidence_run_id": "market-pulse-20260712172802",
       "score": 0.41
     },
@@ -60,8 +60,8 @@
   ],
   "outcomes": [],
   "decision": {
-    "experiment_id": "free-page-conversion-baseline",
-    "reason": "Establish a real funnel baseline before automatically changing copy or outreach."
+    "experiment_id": "market-customer-intake-automation-for-owner-led-service-busin",
+    "reason": "Executed one bounded GREEN action: prepare-validation-brief."
   },
   "guardrails": {
     "auto_execute": [
@@ -118,5 +118,14 @@
       "run_id": "market-pulse-20260712172802",
       "signals_analyzed": 11
     }
-  }
+  },
+  "executions": [
+    {
+      "execution_key": "market-customer-intake-automation-for-owner-led-service-busin:fnv1a-ae33b7d5",
+      "experiment_id": "market-customer-intake-automation-for-owner-led-service-busin",
+      "action": "prepare-validation-brief",
+      "artifact_path": "docs/money-printer-experiments/market-customer-intake-automation-for-owner-led-service-busin.md",
+      "executed_at": "2026-07-12T17:28:02.917Z"
+    }
+  ]
 }

--- a/scripts/money-printer-operator.mjs
+++ b/scripts/money-printer-operator.mjs
@@ -11,6 +11,7 @@ import {
 } from './money-printer-self-review.mjs';
 import { sendOperatorReportEmail } from '../src/money-printer/operatorEmailReport.js';
 import { DEFAULT_LEDGER_PATH, updateLearningLedger } from './money-printer-learning.mjs';
+import { executeGuardedImprovement } from '../src/money-printer/guardedExecutor.js';
 
 function parseArgs(argv = process.argv.slice(2)) {
   const args = { _: [] };
@@ -176,7 +177,8 @@ async function runVerification(rootDir) {
     ['node', ['--check', 'scripts/money-printer-self-review.mjs']],
     ['node', ['--check', 'scripts/money-printer-operator.mjs']],
     ['node', ['--check', 'scripts/money-printer-learning.mjs']],
-    ['node', ['--test', 'tests/money-printer-self-review.test.js', 'tests/money-printer-learning.test.js']]
+    ['node', ['--check', 'src/money-printer/guardedExecutor.js']],
+    ['node', ['--test', 'tests/money-printer-self-review.test.js', 'tests/money-printer-learning.test.js', 'tests/money-printer-guarded-executor.test.js']]
   ];
   const results = commands.map(([command, args]) => runCommand(command, args, { cwd: rootDir }));
   return {
@@ -281,22 +283,41 @@ async function runPropose(rootDir, options = {}) {
     measurementPath: options.measurementFile || process.env.MONEY_PRINTER_MEASUREMENT_FILE || '',
     evidenceDir: options.evidenceDir || process.env.MONEY_PRINTER_EVIDENCE_DIR || ''
   });
+  const execution = await executeGuardedImprovement({
+    rootDir,
+    ledgerPath: learning.ledgerPath,
+    ledger: learning.ledger
+  });
+  const ledger = execution.ledger;
+  const changed = learning.changed || execution.changed;
   report.learning = {
     changed: learning.changed,
     reason: learning.reason,
     ledgerPath: path.relative(rootDir, learning.ledgerPath),
-    decision: learning.ledger.decision,
-    signals: learning.ledger.current_signals,
-    outcomesRecorded: learning.ledger.outcomes.length,
-    research: learning.ledger.research || null,
-    sources: learning.ledger.sources || {}
+    decision: ledger.decision,
+    signals: ledger.current_signals,
+    outcomesRecorded: ledger.outcomes.length,
+    research: ledger.research || null,
+    sources: ledger.sources || {}
+  };
+  report.execution = {
+    changed: execution.changed,
+    reason: execution.reason,
+    artifactPath: execution.artifactPath || '',
+    execution: execution.execution || null,
+    skipped: execution.skipped || []
   };
   report.impact = {
-    intent: 'Turn the scheduled Money Printer job into a persistent experiment-learning loop.',
-    whatChanged: learning.changed ? `Updated ${DEFAULT_LEDGER_PATH} with ranked experiments and durable measured outcomes.` : 'No repository change: the loop found no new measured signal to learn from.',
-    whyItMatters: 'The loop now compounds verified learning and stops opening timestamp-only PRs when nothing meaningful changed.'
+    intent: 'Turn ranked evidence into one bounded improvement while preserving approval gates.',
+    whatChanged: execution.changed
+      ? `Executed one GREEN experiment and prepared ${execution.artifactPath}.`
+      : learning.changed
+        ? `Updated ${DEFAULT_LEDGER_PATH} with ranked experiments and durable measured outcomes.`
+        : 'No repository change: the loop found no new evidence-backed GREEN action.',
+    whyItMatters: 'The loop now converts research into a concrete validation asset without touching outreach, pricing, billing, credentials, deployment, or auth.'
   };
-  report.safeImprovementPath = learning.ledgerPath;
+  const changedPaths = execution.changedPaths || (learning.changed ? [DEFAULT_LEDGER_PATH] : []);
+  report.safeImprovementPaths = changedPaths;
   report.verification = await runVerification(rootDir);
   const operatorDir = await ensureOperatorDir(rootDir);
   const selfReviewPath = path.join(operatorDir, 'self-review-latest.md');
@@ -306,12 +327,16 @@ async function runPropose(rootDir, options = {}) {
     testsPassed: report.verification.passed,
     commands: verificationCommands,
     out: selfReviewPath,
-    summary: learning.changed ? 'Money Printer updated its experiment learning ledger.' : 'Money Printer found no new learning and made no change.',
+    summary: execution.changed
+      ? 'Money Printer executed one bounded GREEN improvement.'
+      : learning.changed
+        ? 'Money Printer updated its experiment learning ledger.'
+        : 'Money Printer found no new executable learning and made no change.',
     intent: report.impact.intent,
     whatChanged: report.impact.whatChanged,
     whyItMatters: report.impact.whyItMatters,
-    rollbackPlan: `Revert the PR commit or restore ${DEFAULT_LEDGER_PATH} from main.`,
-    nextSuggestedAction: learning.changed ? 'If GREEN, persist the new learning. Otherwise, wait for a new measurement.' : 'Wait for a new measured signal; do not open a PR.'
+    rollbackPlan: `Revert the PR commit or restore ${changedPaths.join(' and ') || DEFAULT_LEDGER_PATH} from main.`,
+    nextSuggestedAction: changed ? 'If GREEN, persist the bounded action. Otherwise, wait for new evidence.' : 'Wait for new evidence; do not open a PR.'
   });
   report.selfReview = {
     risk: review.risk,
@@ -325,13 +350,13 @@ async function runPropose(rootDir, options = {}) {
     reasons: review.reasons
   };
 
-  if (parseBool(options.createPr) && learning.changed && review.risk !== 'RED') {
-    git(rootDir, ['add', DEFAULT_LEDGER_PATH]);
-    git(rootDir, ['commit', '-m', options.commitMessage || 'Update Money Printer learning ledger']);
+  if (parseBool(options.createPr) && changed && review.risk !== 'RED') {
+    git(rootDir, ['add', ...changedPaths]);
+    git(rootDir, ['commit', '-m', options.commitMessage || 'Execute guarded Money Printer improvement']);
     git(rootDir, ['push', '-u', 'origin', git(rootDir, ['branch', '--show-current'])]);
     report.pr = await openPullRequest(rootDir, {
       base: options.base || 'main',
-      title: options.title || 'Money Printer autonomous learning update',
+      title: options.title || 'Money Printer guarded experiment execution',
       bodyPath: selfReviewPath
     });
     report.merge = await mergePullRequestIfGreen(rootDir, review, report.pr, {
@@ -339,7 +364,7 @@ async function runPropose(rootDir, options = {}) {
       waitChecks: options.waitChecks,
       checkInterval: options.checkInterval
     });
-  } else if (parseBool(options.createPr) && learning.changed && review.risk === 'RED') {
+  } else if (parseBool(options.createPr) && changed && review.risk === 'RED') {
     report.pr = {
       url: '',
       blocked: true,
@@ -371,7 +396,7 @@ Usage:
 
 Commands:
   report      Inspect repo state and write an email-ready local report.
-  propose     Update durable experiment learning when new measurements exist.
+  propose     Learn from evidence and execute at most one bounded GREEN action.
 
 Flags:
   --root <dir>             Repo root, defaults to cwd.
@@ -390,7 +415,7 @@ Flags:
   --email-dry-run          Verify email config and log without sending.
   --json                   Print JSON.
 
-Report email is internal-only. Outreach, billing, deployment changes, schedulers, and secrets are not connected to this command.
+Report email is internal-only. GREEN execution is limited to measurement and internal validation artifacts. Outreach, pricing, billing, deployment changes, schedulers, auth, and secrets are not connected to this command.
 `);
 }
 
@@ -457,5 +482,6 @@ export {
   autonomousBranchName,
   ensureProposalBranch,
   sendOperatorReportEmail,
-  updateLearningLedger
+  updateLearningLedger,
+  executeGuardedImprovement
 };

--- a/src/money-printer/guardedExecutor.js
+++ b/src/money-printer/guardedExecutor.js
@@ -1,0 +1,162 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const EXECUTABLE_STATUSES = new Set(['ready', 'research']);
+const MAX_EXECUTIONS = 50;
+
+function cleanText(value = '', fallback = '') {
+  return String(value || fallback).replace(/\s+/g, ' ').trim().slice(0, 500);
+}
+
+function safeId(value = '') {
+  return String(value).toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 96);
+}
+
+function percent(numerator, denominator) {
+  if (!denominator) return '0.0%';
+  return `${((numerator / denominator) * 100).toFixed(1)}%`;
+}
+
+function executionKey(experiment, ledger) {
+  if (experiment.id === 'free-page-conversion-baseline') {
+    const signals = ledger.current_signals || {};
+    return `${experiment.id}:${signals.visits || 0}:${signals.qualified_leads || 0}`;
+  }
+  return `${experiment.id}:${ledger.research?.fingerprint || experiment.evidence_run_id || 'no-evidence'}`;
+}
+
+function baselineCandidate(experiment, ledger) {
+  const visits = Number(ledger.current_signals?.visits || 0);
+  if (!ledger.sources?.analytics?.available || visits <= 0) {
+    return { blocked: 'analytics baseline unavailable' };
+  }
+  const leads = Number(ledger.current_signals?.qualified_leads || 0);
+  return {
+    action: 'record-conversion-baseline',
+    observedAt: ledger.outcomes?.at(-1)?.observed_at || new Date().toISOString(),
+    markdown: `# ${cleanText(experiment.title)}
+
+## Measured baseline
+
+- Visits: ${visits}
+- Qualified leads: ${leads}
+- Visit-to-qualified-lead rate: ${percent(leads, visits)}
+- Source: ${cleanText(ledger.sources.analytics.run_id, 'analytics import')}
+
+## Decision rule
+
+Use this as the control for the next proof-focused Free Page test. Do not ship a copy variant unless it names the same primary metric and can be rolled back independently.
+`
+  };
+}
+
+function researchCandidate(experiment, ledger) {
+  const research = ledger.research || {};
+  const matchesEvidence = experiment.evidence_run_id
+    && experiment.evidence_run_id === research.latest_run_id;
+  if (!matchesEvidence) return { blocked: 'matching research evidence unavailable' };
+  return {
+    action: 'prepare-validation-brief',
+    observedAt: research.observed_at || new Date().toISOString(),
+    markdown: `# ${cleanText(experiment.title)}
+
+## Hypothesis
+
+${cleanText(experiment.hypothesis, 'The market evidence supports a narrow validation test.')}
+
+## Evidence
+
+- Market: ${cleanText(research.market, 'not specified')}
+- Signals analyzed: ${Number(research.signals_analyzed || 0)}
+- Fit score: ${Number(research.fit_score || 0)}/100
+- Verdict: ${cleanText(research.verdict, 'unrated')}
+- Strongest channel: ${cleanText(research.strongest_channel, 'not specified')}
+- Evidence run: ${cleanText(research.latest_run_id, 'not specified')}
+
+## Bounded next experiment
+
+Create one internal offer prototype that addresses this problem: ${cleanText(research.opportunity?.problem, experiment.hypothesis)} Validate the language with reaction snapshots before any prospect outreach, pricing, deployment, or billing change.
+
+## Success metric
+
+Primary metric: ${cleanText(experiment.metric, 'qualified_replies')}. Keep this artifact internal until a human approves any external probe.
+`
+  };
+}
+
+function buildCandidate(experiment, ledger) {
+  if (experiment.id === 'free-page-conversion-baseline') {
+    return baselineCandidate(experiment, ledger);
+  }
+  if (experiment.status === 'research') {
+    return researchCandidate(experiment, ledger);
+  }
+  return { blocked: 'no bounded executor is registered for this experiment' };
+}
+
+export function selectGuardedImprovement(ledger = {}) {
+  const completed = new Set((ledger.executions || []).map(item => item.execution_key));
+  const skipped = [];
+  for (const experiment of ledger.backlog || []) {
+    if (experiment.risk !== 'GREEN') {
+      skipped.push({ experiment_id: experiment.id, reason: 'approval required for non-GREEN experiment' });
+      continue;
+    }
+    if (!EXECUTABLE_STATUSES.has(experiment.status)) continue;
+    const execution_key = executionKey(experiment, ledger);
+    if (completed.has(execution_key)) continue;
+    const candidate = buildCandidate(experiment, ledger);
+    if (candidate.blocked) {
+      skipped.push({ experiment_id: experiment.id, reason: candidate.blocked });
+      continue;
+    }
+    return { experiment, execution_key, skipped, ...candidate };
+  }
+  return { experiment: null, skipped };
+}
+
+export async function executeGuardedImprovement({ rootDir, ledger, ledgerPath, write = true } = {}) {
+  const selected = selectGuardedImprovement(ledger);
+  if (!selected.experiment) {
+    return { changed: false, reason: 'no executable GREEN improvement', skipped: selected.skipped, ledger };
+  }
+
+  const experimentId = safeId(selected.experiment.id);
+  const artifactPath = `docs/money-printer-experiments/${experimentId}.md`;
+  const execution = {
+    execution_key: selected.execution_key,
+    experiment_id: selected.experiment.id,
+    action: selected.action,
+    artifact_path: artifactPath,
+    executed_at: selected.observedAt
+  };
+  const nextLedger = {
+    ...ledger,
+    schema_version: Math.max(2, Number(ledger.schema_version || 1)),
+    backlog: (ledger.backlog || []).map(item => item.id === selected.experiment.id
+      ? { ...item, status: 'prepared' }
+      : item),
+    executions: [...(ledger.executions || []), execution].slice(-MAX_EXECUTIONS),
+    decision: {
+      experiment_id: selected.experiment.id,
+      reason: `Executed one bounded GREEN action: ${selected.action}.`
+    }
+  };
+
+  if (write) {
+    const absoluteArtifactPath = path.join(rootDir, artifactPath);
+    await mkdir(path.dirname(absoluteArtifactPath), { recursive: true });
+    await writeFile(absoluteArtifactPath, selected.markdown, 'utf8');
+    await writeFile(ledgerPath, `${JSON.stringify(nextLedger, null, 2)}\n`, 'utf8');
+  }
+
+  return {
+    changed: true,
+    reason: `prepared ${selected.action} for ${selected.experiment.id}`,
+    artifactPath,
+    changedPaths: [path.relative(rootDir, ledgerPath), artifactPath],
+    execution,
+    skipped: selected.skipped,
+    ledger: nextLedger
+  };
+}

--- a/src/money-printer/learningLedger.js
+++ b/src/money-printer/learningLedger.js
@@ -68,7 +68,11 @@ export function applyEvidence(ledger = createLearningLedger(), evidence = {}) {
   const researchChanged = Boolean(evidence.research?.fingerprint && evidence.research.fingerprint !== ledger.research?.fingerprint);
   if (researchChanged) {
     const backlog = [...(next.backlog || [])];
-    if (evidence.experiment && !backlog.some(item => item.id === evidence.experiment.id)) backlog.push(evidence.experiment);
+    if (evidence.experiment) {
+      const existingIndex = backlog.findIndex(item => item.id === evidence.experiment.id);
+      if (existingIndex >= 0) backlog[existingIndex] = evidence.experiment;
+      else backlog.push(evidence.experiment);
+    }
     next = { ...next, research: evidence.research, backlog: rankBacklog(backlog) };
   }
   const comparableSources = sources => Object.fromEntries(Object.entries(sources || {}).map(([key, value]) => {

--- a/tests/money-printer-guarded-executor.test.js
+++ b/tests/money-printer-guarded-executor.test.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { executeGuardedImprovement, selectGuardedImprovement } from '../src/money-printer/guardedExecutor.js';
+import { createLearningLedger } from '../src/money-printer/learningLedger.js';
+
+function ledgerWithResearch() {
+  const ledger = createLearningLedger();
+  return {
+    ...ledger,
+    sources: { analytics: { available: false } },
+    research: {
+      latest_run_id: 'pulse-1',
+      observed_at: '2026-07-12T17:28:02.917Z',
+      fingerprint: 'finding-1',
+      market: 'owner-led service businesses',
+      signals_analyzed: 11,
+      fit_score: 82,
+      verdict: 'strong signal',
+      strongest_channel: 'Hacker News'
+    },
+    backlog: [
+      ...ledger.backlog,
+      {
+        id: 'market-intake-automation',
+        title: 'Customer intake automation',
+        hypothesis: 'Faster follow-up will rescue qualified leads.',
+        metric: 'qualified_replies',
+        confidence: 0.82,
+        effort: 2,
+        risk: 'GREEN',
+        status: 'research',
+        evidence_run_id: 'pulse-1',
+        score: 0.41
+      }
+    ]
+  };
+}
+
+test('skips a blocked baseline and selects one evidence-backed GREEN experiment', () => {
+  const selected = selectGuardedImprovement(ledgerWithResearch());
+  assert.equal(selected.experiment.id, 'market-intake-automation');
+  assert.equal(selected.action, 'prepare-validation-brief');
+  assert.deepEqual(selected.skipped[0], {
+    experiment_id: 'free-page-conversion-baseline',
+    reason: 'analytics baseline unavailable'
+  });
+});
+
+test('writes one bounded artifact and records the execution durably', async () => {
+  const rootDir = await mkdtemp(path.join(tmpdir(), 'guarded-executor-'));
+  const ledgerPath = path.join(rootDir, 'docs', 'money-printer-learning-ledger.json');
+  const result = await executeGuardedImprovement({ rootDir, ledgerPath, ledger: ledgerWithResearch() });
+  const artifact = await readFile(path.join(rootDir, result.artifactPath), 'utf8');
+
+  assert.equal(result.changed, true);
+  assert.match(artifact, /Customer intake automation/);
+  assert.match(artifact, /Keep this artifact internal/);
+  assert.equal(result.ledger.executions.length, 1);
+  assert.equal(result.ledger.backlog.find(item => item.id === 'market-intake-automation').status, 'prepared');
+  assert.equal(selectGuardedImprovement(result.ledger).experiment, null);
+});
+
+test('records a Free Page baseline only when analytics has real visits', () => {
+  const ledger = createLearningLedger();
+  ledger.sources = { analytics: { available: true, run_id: 'analytics-1' } };
+  ledger.current_signals = { ...ledger.current_signals, visits: 20, qualified_leads: 2 };
+  const selected = selectGuardedImprovement(ledger);
+
+  assert.equal(selected.experiment.id, 'free-page-conversion-baseline');
+  assert.equal(selected.action, 'record-conversion-baseline');
+  assert.match(selected.markdown, /10\.0%/);
+});
+
+test('never executes YELLOW findings', () => {
+  const ledger = createLearningLedger();
+  ledger.backlog = [{ id: 'copy-change', risk: 'YELLOW', status: 'ready', score: 1 }];
+  const selected = selectGuardedImprovement(ledger);
+  assert.equal(selected.experiment, null);
+  assert.match(selected.skipped[0].reason, /approval required/);
+});

--- a/tests/money-printer-learning.test.js
+++ b/tests/money-printer-learning.test.js
@@ -62,3 +62,26 @@ test('persists each research run once and promotes its opportunity into the back
   assert.equal(second.changed, false);
   assert.equal(newRunSameFinding.changed, false);
 });
+
+test('refreshes an existing research experiment when its evidence changes', () => {
+  const first = applyEvidence(createLearningLedger(), {
+    signals: {},
+    research: { latest_run_id: 'pulse-1', fingerprint: 'finding-1' },
+    experiment: { id: 'market-lead-rescue', title: 'Lead rescue', confidence: 0.7, effort: 2, risk: 'GREEN', status: 'research', evidence_run_id: 'pulse-1' }
+  });
+  const prepared = {
+    ...first.ledger,
+    backlog: first.ledger.backlog.map(item => item.id === 'market-lead-rescue' ? { ...item, status: 'prepared' } : item)
+  };
+  const refreshed = applyEvidence(prepared, {
+    signals: {},
+    research: { latest_run_id: 'pulse-2', fingerprint: 'finding-2' },
+    experiment: { id: 'market-lead-rescue', title: 'Lead rescue v2', confidence: 0.85, effort: 2, risk: 'GREEN', status: 'research', evidence_run_id: 'pulse-2' }
+  });
+  const experiment = refreshed.ledger.backlog.find(item => item.id === 'market-lead-rescue');
+
+  assert.equal(refreshed.changed, true);
+  assert.equal(experiment.status, 'research');
+  assert.equal(experiment.evidence_run_id, 'pulse-2');
+  assert.equal(experiment.title, 'Lead rescue v2');
+});

--- a/tests/money-printer-self-review.test.js
+++ b/tests/money-printer-self-review.test.js
@@ -129,10 +129,11 @@ test('operator proposal commits only the reviewed safe improvement', () => {
   assert.match(source, /whyItMatters: report\.impact\.whyItMatters/);
   assert.doesNotMatch(source, /outPath: selfReviewPath/);
   assert.match(source, /updateLearningLedger/);
-  assert.match(source, /learning\.changed/);
-  assert.match(source, /\['add', DEFAULT_LEDGER_PATH\]/);
+  assert.match(source, /executeGuardedImprovement/);
+  assert.match(source, /execution\.changed/);
+  assert.match(source, /\['add', \.\.\.changedPaths\]/);
   assert.doesNotMatch(source, /\['add', DEFAULT_LEDGER_PATH, 'SELF_REVIEW\.md'\]/);
-  assert.match(source, /no new measured signal/i);
+  assert.match(source, /no new evidence-backed GREEN action/i);
   assert.match(source, /waitChecks: options\.waitChecks/);
   assert.match(source, /\['pr', 'checks', pr\.url, '--watch', '--interval', interval\]/);
   assert.match(source, /pull request checks did not pass/);
@@ -149,6 +150,7 @@ test('nightly self-improvement workflow uses guarded operator proposal', () => {
   assert.match(workflow, /Collect latest operating evidence/);
   assert.match(workflow, /--evidence-dir \.money-printer\/evidence/);
   assert.match(workflow, /money-printer:operator -- propose/);
+  assert.match(workflow, /Execute one guarded improvement/);
   assert.match(workflow, /--create-pr/);
   assert.match(workflow, /--wait-checks/);
   assert.match(workflow, /--auto-merge/);


### PR DESCRIPTION
## Outcome

Completes the guarded-execution phase of the Money Printer learning loop.

The nightly job now:

- selects at most one evidence-backed GREEN experiment
- skips blocked baselines instead of inventing work
- prepares a bounded internal validation artifact
- records executions durably and prevents duplicate PRs
- refreshes an existing opportunity when later research changes its evidence
- keeps prospect outreach, pricing, billing, credentials, deployment, auth, and non-GREEN product changes behind approval

## First execution

The current Free Page baseline was correctly skipped because analytics is unavailable. The executor then selected the 82/100 customer-intake automation finding and generated one internal validation brief. A second run was a clean no-op.

## Verification

- `git diff --check`
- 66/66 focused Money Printer tests passed
- operator dry run passed and produced exactly one bounded artifact
- repeat operator run passed with no repository change
- full repository suite: 729 passed, 2 skipped, 13 failed in unrelated pre-existing areas (Connect copy, calendar/OAuth environment assumptions, community ordering, CRM/Forge fixtures, shared launcher/insights coverage, Playwright installer expectations, and sales research markup)

## Risk and rollback

This installation PR changes the nightly workflow and operator code, so it requires normal human/CI review. Once installed, autonomous PRs remain limited to green-listed internal docs/ledger artifacts and normal checks. Roll back by reverting this PR.

Stripe mode, portal origin, account linking, and outbound sending are unchanged.
