### PR TITLE
Keep Money Printer reports out of self-review

### DIFF
--- a/.github/workflows/money-printer-self-improve.yml
+++ b/.github/workflows/money-printer-self-improve.yml
@@ -62,6 +62,7 @@ jobs:
           if [ "$AUTO_MERGE_INPUT" = "true" ]; then
             auto_merge_flag="--auto-merge"
           fi
+          operator_output="$RUNNER_TEMP/money-printer-self-improve-latest.json"
 
           npm run --silent money-printer:operator -- propose \
             --create-pr \
@@ -70,7 +71,8 @@ jobs:
             --check-interval 10 \
             --evidence-dir .money-printer/evidence \
             --title "Money Printer guarded experiment execution" \
-            --json | tee artifacts/money-printer-self-improve/latest.json
+            --json | tee "$operator_output"
+          cp "$operator_output" artifacts/money-printer-self-improve/latest.json
 
       - name: Collect operator reports
         if: always()

--- a/tests/money-printer-self-review.test.js
+++ b/tests/money-printer-self-review.test.js
@@ -154,5 +154,8 @@ test('nightly self-improvement workflow uses guarded operator proposal', () => {
   assert.match(workflow, /--create-pr/);
   assert.match(workflow, /--wait-checks/);
   assert.match(workflow, /--auto-merge/);
+  assert.match(workflow, /operator_output="\$RUNNER_TEMP\/money-printer-self-improve-latest\.json"/);
+  assert.match(workflow, /--json \| tee "\$operator_output"/);
+  assert.match(workflow, /cp "\$operator_output" artifacts\/money-printer-self-improve\/latest\.json/);
   assert.match(workflow, /upload-artifact/);
 });


### PR DESCRIPTION
## Outcome

Keeps the workflow's generated JSON report outside the Git checkout until Money Printer finishes self-review.

The production-like run after #1147 showed that `tee` created `artifacts/money-printer-self-improve/latest.json` before self-review. That untracked report was correctly classified as non-GREEN, but it would also block a genuinely GREEN docs/ledger execution from auto-merging.

This change writes the report to `$RUNNER_TEMP`, then copies it into the artifact upload directory after the guarded operator exits. Autonomous self-review now sees only the intended repository improvement.

## Verification

- 18/18 focused execution, learning, and workflow guardrail tests passed
- `git diff --check`

No billing, outreach, auth, credential, deployment, or product behavior changes.
