### PR TITLE
Track Free Page visits in Vercel Analytics

### DIFF
--- a/free-page/index.html
+++ b/free-page/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="3DVR will make a clean one-page website for free. Keep it live with small edits for $5/month if you like it.">
   <link rel="canonical" href="https://portal.3dvr.tech/free-page/">
   <link rel="stylesheet" href="./styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
   <div class="ambient ambient-one"></div>

--- a/tests/free-page-offer.test.js
+++ b/tests/free-page-offer.test.js
@@ -14,6 +14,7 @@ test('free page offer presents the tiny website starter offer', () => {
   assert.match(html, /https:\/\/donovan\.3dvr\.tech\//);
   assert.match(html, /\.\.\/billing\/\?plan=starter/);
   assert.match(html, /\.\.\/launch-site\//);
+  assert.match(html, /<script defer src="\/_vercel\/insights\/script\.js"><\/script>/);
 });
 
 test('free page brief builds an email handoff without backend dependencies', () => {


### PR DESCRIPTION
## Outcome

Adds the repo-standard Vercel Web Analytics script to the Free Page offer so its page views appear in the already-enabled production Vercel Analytics dashboard.

## Why

The Money Printer needs a visit baseline for `/free-page/`, but this page was one of the tracked HTML files missing the Insights tag. This closes the collection gap without adding cookies, a new vendor, or credentials.

Vercel Hobby does not expose a documented Web Analytics read API or Analytics Drains, so this PR enables dashboard measurement but does not claim to automate nightly imports. GA4 remains the appropriate later source for read-only API automation.

## Verification

- `node --test tests/free-page-offer.test.js` (2/2)
- `git diff --check`

No Stripe, portal-origin, account-linking, auth, or outbound behavior changes.
