### PR TITLE
Track Free Page conversions with GA4

### DIFF
--- a/free-page/app.js
+++ b/free-page/app.js
@@ -32,11 +32,20 @@ function buildMailto(formData) {
   return `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 }
 
+function trackLeadIntent() {
+  if (typeof window.gtag !== 'function') return;
+
+  window.gtag('event', 'generate_lead', {
+    method: 'mailto_brief'
+  });
+}
+
 if (form && mailtoLink && handoffCopy) {
   form.addEventListener('submit', event => {
     event.preventDefault();
     const formData = new FormData(form);
     const href = buildMailto(formData);
+    trackLeadIntent();
     mailtoLink.href = href;
     handoffCopy.textContent = 'Your email is ready. Review it, add any links or photos, and send.';
     window.location.href = href;

--- a/free-page/index.html
+++ b/free-page/index.html
@@ -6,6 +6,13 @@
   <title>Free One-Page Website | 3DVR</title>
   <meta name="description" content="3DVR will make a clean one-page website for free. Keep it live with small edits for $5/month if you like it.">
   <link rel="canonical" href="https://portal.3dvr.tech/free-page/">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-96XRKQ5L65"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-96XRKQ5L65');
+  </script>
   <link rel="stylesheet" href="./styles.css">
   <script defer src="/_vercel/insights/script.js"></script>
 </head>

--- a/tests/free-page-offer.test.js
+++ b/tests/free-page-offer.test.js
@@ -15,6 +15,8 @@ test('free page offer presents the tiny website starter offer', () => {
   assert.match(html, /\.\.\/billing\/\?plan=starter/);
   assert.match(html, /\.\.\/launch-site\//);
   assert.match(html, /<script defer src="\/_vercel\/insights\/script\.js"><\/script>/);
+  assert.match(html, /googletagmanager\.com\/gtag\/js\?id=G-96XRKQ5L65/);
+  assert.match(html, /gtag\('config', 'G-96XRKQ5L65'\)/);
 });
 
 test('free page brief builds an email handoff without backend dependencies', () => {
@@ -22,4 +24,6 @@ test('free page brief builds an email handoff without backend dependencies', () 
   assert.match(script, /Free 3DVR one-page website/);
   assert.match(script, /3dvr\.tech@gmail\.com/);
   assert.match(script, /\$5\/month/);
+  assert.match(script, /gtag\('event', 'generate_lead'/);
+  assert.match(script, /method: 'mailto_brief'/);
 });


### PR DESCRIPTION
## Summary

- install the Google tag for GA4 stream `G-96XRKQ5L65` on `/free-page/`
- record a GA4 `generate_lead` event when the brief is submitted
- keep form contents out of analytics event parameters
- preserve existing Vercel Web Analytics tracking

## Verification

- `node --test tests/free-page-offer.test.js`
- `git diff --check`
- local `/free-page/` response contains the GA4 and Vercel tags
- Google-hosted `gtag.js` endpoint returns HTTP 200 for the Measurement ID

## Known baseline issue

`tests/vercel-insights-tag.test.js` currently fails unchanged on `main` because multiple pre-existing tracked HTML files do not contain the Vercel Insights tag. This PR does not broaden scope to modify those unrelated pages.

## Follow-up required for nightly reporting

The browser tag starts collection. Automated GA4 Data API reads still require the numeric GA4 Property ID and read-only service-account access; no secret is included here.
