### PR TITLE
Add personalized outreach preview funnel

### DIFF
--- a/free-page/preview/app.js
+++ b/free-page/preview/app.js
@@ -1,0 +1,56 @@
+import {
+  createAnalyticsSessionId,
+  createFreePageAnalyticsClient
+} from '../../src/analytics/freePage.js';
+
+const params = new URLSearchParams(window.location.search);
+const recipientId = clean(params.get('r'), 80);
+const business = clean(params.get('name'), 80) || 'your business';
+const focus = clean(params.get('focus'), 180)
+  || 'A focused page can make your main service and best contact path obvious.';
+const action = clean(params.get('action'), 40) || 'Get in touch';
+const analyticsClient = createFreePageAnalyticsClient();
+
+function clean(value, limit) {
+  return String(value || '').replace(/[\u0000-\u001f<>]/g, '').trim().slice(0, limit);
+}
+
+function slug(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
+}
+
+function sessionId() {
+  const key = '3dvr-free-page-preview-session';
+  try {
+    const existing = sessionStorage.getItem(key);
+    if (existing) return existing;
+    const created = createAnalyticsSessionId();
+    sessionStorage.setItem(key, created);
+    return created;
+  } catch (_error) {
+    return createAnalyticsSessionId();
+  }
+}
+
+function track(eventType) {
+  if (!analyticsClient || !recipientId) return Promise.resolve();
+  return analyticsClient.track(eventType, {
+    recipientId,
+    sessionId: sessionId()
+  }).catch(error => console.info('Preview analytics unavailable.', error.message));
+}
+
+document.querySelectorAll('[data-business]').forEach(node => { node.textContent = business; });
+document.querySelector('[data-host]').textContent = `${slug(business) || 'your-business'}.com`;
+document.querySelector('[data-headline]').textContent = `${business}, made easier to understand and contact.`;
+document.querySelector('[data-focus]').textContent = focus;
+document.querySelector('[data-action]').textContent = action;
+document.title = `${business} website preview | 3DVR`;
+
+const claimButton = document.querySelector('#claimButton');
+const subject = `Claiming the free one-page draft for ${business}`;
+const body = `Hi Thomas,\n\nI'd like to claim the free one-page draft for ${business}.\n\nPreview reference: ${recipientId || 'not provided'}`;
+claimButton.href = `mailto:3dvr.tech@gmail.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+claimButton.addEventListener('click', () => track('claim_intent'));
+
+track('preview_view');

--- a/free-page/preview/index.html
+++ b/free-page/preview/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Your one-page website preview | 3DVR</title>
+  <meta name="robots" content="noindex,nofollow">
+  <meta name="description" content="A private one-page website direction prepared by 3DVR.">
+  <link rel="stylesheet" href="./styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="../../gun-init.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="../"><span>3D</span> 3DVR</a>
+    <p>Prepared for <strong data-business>your business</strong></p>
+  </header>
+
+  <main>
+    <section class="intro">
+      <p class="eyebrow">A first direction—not a finished site</p>
+      <h1>Here’s how a clearer one-page site could introduce <span data-business>your business</span>.</h1>
+      <p>This preview uses a simple structure: what you do, why someone should trust you, and one obvious next step.</p>
+    </section>
+
+    <section class="browser" aria-label="Website direction preview">
+      <div class="browser-bar" aria-hidden="true"><i></i><i></i><i></i><span data-host>your-business.com</span></div>
+      <div class="mock-site">
+        <nav><strong data-business>Your business</strong><span>Services&nbsp;&nbsp; About&nbsp;&nbsp; Contact</span></nav>
+        <div class="mock-hero">
+          <p class="mock-kicker">Local, straightforward, easy to reach</p>
+          <h2 data-headline>A clearer way to understand what you offer.</h2>
+          <p data-focus>A focused page can make your main service and best contact path obvious.</p>
+          <span class="mock-button" data-action>Get in touch</span>
+        </div>
+        <div class="mock-proof">
+          <article><b>What you do</b><span>Your core services in plain language.</span></article>
+          <article><b>Why choose you</b><span>Proof, experience, and local trust.</span></article>
+          <article><b>Next step</b><span>One clear way to call, book, or ask.</span></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="claim-card">
+      <div>
+        <p class="eyebrow">Want the real first draft?</p>
+        <h2>I’ll build it at no cost. There’s no obligation to keep it.</h2>
+        <p>Reply to Thomas or use this button. We’ll confirm the facts before anything goes public.</p>
+      </div>
+      <a class="claim-button" id="claimButton" href="mailto:3dvr.tech@gmail.com">Claim my free draft</a>
+    </section>
+  </main>
+
+  <footer>Advertisement from 3DVR · <a href="https://3dvr.tech">3dvr.tech</a></footer>
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/free-page/preview/styles.css
+++ b/free-page/preview/styles.css
@@ -1,0 +1,53 @@
+:root {
+  color-scheme: dark;
+  --ink: #f8fafc;
+  --muted: #a9b6c9;
+  --panel: rgba(13, 23, 40, 0.82);
+  --line: rgba(148, 163, 184, 0.22);
+  --accent: #79f2c0;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--ink);
+  background: radial-gradient(circle at 15% 0%, #173f4f 0, transparent 35%), #07101d;
+  font: 16px/1.6 Inter, ui-sans-serif, system-ui, sans-serif;
+}
+a { color: inherit; }
+.site-header, main, footer { width: min(1120px, calc(100% - 32px)); margin-inline: auto; }
+.site-header { display: flex; justify-content: space-between; align-items: center; padding: 24px 0; color: var(--muted); }
+.site-header p { margin: 0; }
+.brand { text-decoration: none; font-weight: 800; letter-spacing: .08em; }
+.brand span { color: var(--accent); }
+main { padding: 6vh 0 64px; }
+.intro { max-width: 800px; }
+.eyebrow { color: var(--accent); font-size: .78rem; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+h1 { margin: 12px 0 20px; font-size: clamp(2.25rem, 6vw, 5rem); line-height: 1.02; letter-spacing: -.045em; }
+.intro > p:last-child { max-width: 680px; color: var(--muted); font-size: 1.1rem; }
+.browser { margin: 52px 0; overflow: hidden; border: 1px solid var(--line); border-radius: 24px; background: #f5efe4; color: #17202a; box-shadow: 0 30px 90px rgba(0,0,0,.35); }
+.browser-bar { display: flex; gap: 7px; align-items: center; padding: 14px 18px; background: #dfe6e8; color: #64748b; font-size: .78rem; }
+.browser-bar i { width: 10px; height: 10px; border-radius: 50%; background: #9ba9ae; }
+.browser-bar span { margin-left: 8px; }
+.mock-site { padding: clamp(24px, 5vw, 72px); }
+.mock-site nav { display: flex; justify-content: space-between; gap: 16px; color: #4b5563; }
+.mock-hero { max-width: 760px; padding: clamp(64px, 11vw, 130px) 0 80px; }
+.mock-kicker { color: #247c65; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; font-size: .75rem; }
+.mock-hero h2 { margin: 12px 0; font: 700 clamp(2.2rem, 7vw, 5.5rem)/.98 Georgia, serif; letter-spacing: -.04em; }
+.mock-hero > p:not(.mock-kicker) { max-width: 600px; color: #52606d; font-size: 1.1rem; }
+.mock-button { display: inline-block; margin-top: 18px; padding: 12px 20px; border-radius: 999px; background: #173f4f; color: white; font-weight: 800; }
+.mock-proof { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.mock-proof article { display: grid; gap: 6px; padding-top: 18px; border-top: 1px solid #cbd5d1; }
+.mock-proof span { color: #68747d; }
+.claim-card { display: flex; justify-content: space-between; align-items: center; gap: 32px; padding: clamp(28px, 5vw, 52px); border: 1px solid var(--line); border-radius: 24px; background: var(--panel); }
+.claim-card h2 { margin: 8px 0; font-size: clamp(1.6rem, 4vw, 2.6rem); line-height: 1.15; }
+.claim-card p:last-child { color: var(--muted); }
+.claim-button { flex: 0 0 auto; padding: 15px 22px; border-radius: 999px; background: var(--accent); color: #07101d; font-weight: 900; text-decoration: none; }
+footer { padding: 28px 0 48px; color: var(--muted); font-size: .85rem; }
+@media (max-width: 700px) {
+  .site-header p, .mock-site nav span { display: none; }
+  .mock-proof { grid-template-columns: 1fr; }
+  .claim-card { align-items: stretch; flex-direction: column; }
+  .claim-button { text-align: center; }
+}

--- a/src/analytics/freePage.js
+++ b/src/analytics/freePage.js
@@ -8,10 +8,13 @@ export const FREE_PAGE_ANALYTICS_PATH = Object.freeze([
 
 export const FREE_PAGE_ANALYTICS_EVENT_TYPES = Object.freeze([
   'page_view',
-  'generate_lead'
+  'generate_lead',
+  'preview_view',
+  'claim_intent'
 ]);
 
 const FREE_PAGE_PATH = '/free-page/';
+const FREE_PAGE_PREVIEW_PATH = '/free-page/preview/';
 
 function safeRandomId() {
   if (globalThis.crypto?.randomUUID) {
@@ -45,16 +48,25 @@ export function createFreePageAnalyticsEvent(eventType, options = {}) {
   const timestamp = (options.now instanceof Date ? options.now : new Date(options.now || Date.now())).toISOString();
   const id = cleanId(options.id || `${Date.now().toString(36)}-${safeRandomId()}`);
   const sessionId = cleanId(options.sessionId);
+  const recipientId = cleanId(options.recipientId);
+  const page = eventType === 'preview_view' || eventType === 'claim_intent'
+    ? FREE_PAGE_PREVIEW_PATH
+    : FREE_PAGE_PATH;
 
   if (!id || !sessionId) {
     throw new Error('Free Page analytics events require event and session IDs.');
   }
 
+  if (page === FREE_PAGE_PREVIEW_PATH && !recipientId) {
+    throw new Error('Personalized preview events require an opaque recipient ID.');
+  }
+
   return {
     id,
     eventType,
-    page: FREE_PAGE_PATH,
+    page,
     sessionId,
+    ...(recipientId ? { recipientId } : {}),
     timestamp,
     day: utcDay(timestamp),
     source: 'first-party-gun'
@@ -126,6 +138,7 @@ export function normalizeFreePageAnalyticsEvent(data = {}, id = '') {
   const eventType = String(data.eventType || '').trim();
   const page = String(data.page || '').trim();
   const sessionId = cleanId(data.sessionId);
+  const recipientId = cleanId(data.recipientId);
   const timestamp = String(data.timestamp || '').trim();
   const normalizedId = cleanId(id || data.id);
 
@@ -133,7 +146,8 @@ export function normalizeFreePageAnalyticsEvent(data = {}, id = '') {
     !normalizedId
     || !sessionId
     || !FREE_PAGE_ANALYTICS_EVENT_TYPES.includes(eventType)
-    || page !== FREE_PAGE_PATH
+    || ![FREE_PAGE_PATH, FREE_PAGE_PREVIEW_PATH].includes(page)
+    || (page === FREE_PAGE_PREVIEW_PATH && !recipientId)
     || Number.isNaN(Date.parse(timestamp))
   ) {
     return null;
@@ -144,6 +158,7 @@ export function normalizeFreePageAnalyticsEvent(data = {}, id = '') {
     eventType,
     page,
     sessionId,
+    ...(recipientId ? { recipientId } : {}),
     timestamp,
     day: utcDay(timestamp),
     source: String(data.source || '').trim()
@@ -165,12 +180,21 @@ export function summarizeFreePageAnalytics(events = [], options = {}) {
   const values = [...uniqueEvents.values()];
   const pageViews = values.filter(event => event.eventType === 'page_view');
   const leads = values.filter(event => event.eventType === 'generate_lead');
+  const previewViews = values.filter(event => event.eventType === 'preview_view');
+  const claimIntents = values.filter(event => event.eventType === 'claim_intent');
   const sessions = new Set(pageViews.map(event => event.sessionId));
+  const previewVisitors = new Set(previewViews.map(event => event.recipientId));
+  const claimedRecipients = new Set(claimIntents.map(event => event.recipientId));
 
   return {
     sessions: sessions.size,
     pageViews: pageViews.length,
     leads: leads.length,
+    previewViews: previewViews.length,
+    previewVisitors: previewVisitors.size,
+    qualifiedPreviewVisits: previewVisitors.size,
+    claimIntents: claimIntents.length,
+    claimedRecipients: claimedRecipients.size,
     eventCount: values.length
   };
 }

--- a/tests/free-page-analytics.test.js
+++ b/tests/free-page-analytics.test.js
@@ -63,8 +63,40 @@ test('summarizes unique sessions, views, and leads while ignoring malformed even
     sessions: 1,
     pageViews: 2,
     leads: 1,
+    previewViews: 0,
+    previewVisitors: 0,
+    qualifiedPreviewVisits: 0,
+    claimIntents: 0,
+    claimedRecipients: 0,
     eventCount: 3
   });
+});
+
+test('summarizes personalized preview visits and claim intent without recipient contact data', () => {
+  const events = [
+    createFreePageAnalyticsEvent('preview_view', {
+      id: 'preview-1', sessionId: 'session-1', recipientId: 'recipient-a', now: '2026-07-14T04:00:00.000Z'
+    }),
+    createFreePageAnalyticsEvent('preview_view', {
+      id: 'preview-2', sessionId: 'session-2', recipientId: 'recipient-a', now: '2026-07-14T04:05:00.000Z'
+    }),
+    createFreePageAnalyticsEvent('claim_intent', {
+      id: 'claim-1', sessionId: 'session-2', recipientId: 'recipient-a', now: '2026-07-14T04:06:00.000Z'
+    })
+  ];
+
+  assert.deepEqual(summarizeFreePageAnalytics(events), {
+    sessions: 0,
+    pageViews: 0,
+    leads: 0,
+    previewViews: 2,
+    previewVisitors: 1,
+    qualifiedPreviewVisits: 1,
+    claimIntents: 1,
+    claimedRecipients: 1,
+    eventCount: 3
+  });
+  assert.equal('email' in events[0], false);
 });
 
 test('returns Money Printer compatible analytics from a Gun reader', async () => {

--- a/tests/free-page-offer.test.js
+++ b/tests/free-page-offer.test.js
@@ -4,6 +4,8 @@ import test from 'node:test';
 
 const html = await readFile(new URL('../free-page/index.html', import.meta.url), 'utf8');
 const script = await readFile(new URL('../free-page/app.js', import.meta.url), 'utf8');
+const previewHtml = await readFile(new URL('../free-page/preview/index.html', import.meta.url), 'utf8');
+const previewScript = await readFile(new URL('../free-page/preview/app.js', import.meta.url), 'utf8');
 
 test('free page offer presents the tiny website starter offer', () => {
   assert.match(html, /I.ll make you a clean one-page website for free/);
@@ -19,6 +21,16 @@ test('free page offer presents the tiny website starter offer', () => {
   assert.match(html, /gtag\('config', 'G-96XRKQ5L65'\)/);
   assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
   assert.match(html, /\.\.\/gun-init\.js/);
+});
+
+test('personalized preview is noindex, safely client-rendered, and tracks explicit funnel events', () => {
+  assert.match(previewHtml, /noindex,nofollow/);
+  assert.match(previewHtml, /Claim my free draft/);
+  assert.match(previewHtml, /data-business/);
+  assert.match(previewScript, /textContent = business/);
+  assert.match(previewScript, /track\('preview_view'\)/);
+  assert.match(previewScript, /track\('claim_intent'\)/);
+  assert.doesNotMatch(previewScript, /innerHTML/);
 });
 
 test('free page brief builds an email handoff without backend dependencies', () => {


### PR DESCRIPTION
Adds a noindex personalized Free Page preview with safe query-param rendering and an explicit claim CTA. Extends first-party Gun analytics with opaque recipient IDs, preview views, unique qualified preview visits, and claim intent. No email addresses, IP collection, or tracking pixels.\n\nVerification:\n- node --test tests/free-page-analytics.test.js tests/free-page-offer.test.js (7/7)\n- local dev route returned 200 and rendered correctly at a 390px mobile viewport\n- full main suite currently has 13 unrelated baseline failures