### PR TITLE
Fix folded-phone overflow and polish outreach email

### DIFF
--- a/api/calendar/reminder-email.js
+++ b/api/calendar/reminder-email.js
@@ -52,6 +52,19 @@ function formatMessage(value = '') {
   return escaped.replace(/\n/g, '<br>');
 }
 
+function formatLeadOutreachMessage(value = '') {
+  return normalizeText(value)
+    .split('\n')
+    .map((line) => {
+      const escaped = escapeHtml(line);
+      if (/^Postal address:/i.test(line.trim())) {
+        return `<span style="font-size: 11px; line-height: 1.45; color: #667085;">${escaped}</span>`;
+      }
+      return escaped;
+    })
+    .join('<br>');
+}
+
 function normalizeRecipientList(value) {
   const list = Array.isArray(value)
     ? value
@@ -356,14 +369,15 @@ function confirmRecoveryVerification({ email, code, verificationId, config = pro
 }
 
 function buildLeadOutreachHtml({ headline, message, senderName, senderEmail }) {
-  const fromLabel = normalizeText(senderName) || 'Thomas @ 3DVR';
+  const fromLabel = normalizeText(senderName) || 'Thomas at 3dvr.tech';
   const replyLabel = normalizeEmail(senderEmail);
+  const includesSender = /\bThomas\b[\s\S]*\b3dvr(?:\.tech)?\b/i.test(message);
 
   return `
     <div style="font-family: Arial, sans-serif; line-height: 1.6;">
-      <p>${formatMessage(headline || 'Quick note from 3DVR')}</p>
-      <p>${formatMessage(message)}</p>
-      <p style="margin-top: 20px;">${escapeHtml(fromLabel)}${replyLabel ? `<br><a href="mailto:${replyLabel}">${escapeHtml(replyLabel)}</a>` : ''}</p>
+      <p>${formatMessage(headline || 'Quick note from 3dvr.tech')}</p>
+      <p>${formatLeadOutreachMessage(message)}</p>
+      ${includesSender ? '' : `<p style="margin-top: 20px;">${escapeHtml(fromLabel)}${replyLabel ? `<br><a href="mailto:${replyLabel}">${escapeHtml(replyLabel)}</a>` : ''}</p>`}
     </div>
   `;
 }
@@ -816,7 +830,7 @@ export function createLeadOutreachEmailHandler(options = {}) {
     const subject = normalizeText(req.body?.subject);
     const text = normalizeText(req.body?.text);
     const headline = normalizeText(req.body?.headline);
-    const senderName = normalizeText(req.body?.senderName || 'Thomas @ 3DVR');
+    const senderName = normalizeText(req.body?.senderName || 'Thomas at 3dvr.tech');
     const senderEmail = normalizeEmail(req.body?.senderEmail || resolveMailCredentials(config).user);
     const inReplyTo = normalizeText(req.body?.inReplyTo);
     const references = normalizeText(req.body?.references);
@@ -843,7 +857,7 @@ export function createLeadOutreachEmailHandler(options = {}) {
     }
 
     const sender = resolveMailCredentials(config).user || 'no-reply@3dvr.tech';
-    const from = `"${senderName || 'Thomas @ 3DVR'}" <${sender}>`;
+    const from = `"${senderName || 'Thomas at 3dvr.tech'}" <${sender}>`;
     const replyTo = senderEmail || undefined;
 
     try {

--- a/free-page/preview/index.html
+++ b/free-page/preview/index.html
@@ -52,7 +52,7 @@
     </section>
   </main>
 
-  <footer>Advertisement from 3DVR · <a href="https://3dvr.tech">3dvr.tech</a></footer>
+  <footer>Business offer from <a href="https://3dvr.tech">3dvr.tech</a></footer>
   <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/free-page/preview/styles.css
+++ b/free-page/preview/styles.css
@@ -8,7 +8,9 @@
 }
 
 * { box-sizing: border-box; }
+html { overflow-x: clip; }
 body {
+  overflow-x: clip;
   margin: 0;
   min-height: 100vh;
   color: var(--ink);
@@ -17,6 +19,8 @@ body {
 }
 a { color: inherit; }
 .site-header, main, footer { width: min(1120px, calc(100% - 32px)); margin-inline: auto; }
+.site-header > *, .intro, .browser, .mock-site, .claim-card > * { min-width: 0; }
+h1, h2, p, a, strong, span { overflow-wrap: anywhere; }
 .site-header { display: flex; justify-content: space-between; align-items: center; padding: 24px 0; color: var(--muted); }
 .site-header p { margin: 0; }
 .brand { text-decoration: none; font-weight: 800; letter-spacing: .08em; }
@@ -50,4 +54,12 @@ footer { padding: 28px 0 48px; color: var(--muted); font-size: .85rem; }
   .mock-proof { grid-template-columns: 1fr; }
   .claim-card { align-items: stretch; flex-direction: column; }
   .claim-button { text-align: center; }
+}
+@media (max-width: 360px) {
+  .site-header, main, footer { width: min(100% - 24px, 1120px); }
+  .browser { margin: 32px 0; border-radius: 18px; }
+  .browser-bar { padding-inline: 12px; }
+  .mock-site { padding: 18px; }
+  .mock-hero { padding: 48px 0 56px; }
+  .claim-card { padding: 22px 18px; }
 }

--- a/free-page/styles.css
+++ b/free-page/styles.css
@@ -17,9 +17,11 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: clip;
 }
 
 body {
+  overflow-x: clip;
   min-height: 100vh;
   margin: 0;
   color: var(--free-ink);
@@ -74,6 +76,22 @@ main,
 footer {
   width: min(1120px, calc(100% - 32px));
   margin: 0 auto;
+}
+
+.site-header > *,
+.hero > *,
+.brief-section > *,
+.handoff > *,
+.keep-live > * {
+  min-width: 0;
+}
+
+h1,
+h2,
+p,
+a,
+label {
+  overflow-wrap: anywhere;
 }
 
 .site-header {
@@ -433,5 +451,41 @@ footer {
 
   .hero {
     padding-top: 28px;
+  }
+}
+
+@media (max-width: 360px) {
+  .site-header,
+  main,
+  footer {
+    width: min(100% - 24px, 1120px);
+  }
+
+  .site-header {
+    padding-top: 16px;
+  }
+
+  .hero-copy,
+  .proof-card,
+  .brief-card,
+  .handoff,
+  .keep-live,
+  .operator-note {
+    padding: 1.1rem;
+    border-radius: 24px;
+  }
+
+  h1 {
+    font-size: clamp(2.55rem, 16vw, 3.4rem);
+  }
+
+  h2 {
+    font-size: clamp(2rem, 12vw, 2.6rem);
+  }
+
+  .hero-actions .button,
+  .handoff > .button,
+  .keep-live > .button {
+    width: 100%;
   }
 }

--- a/tests/account-recovery-email.test.js
+++ b/tests/account-recovery-email.test.js
@@ -432,9 +432,9 @@ describe('account recovery email api', () => {
         mode: 'lead-outreach',
         to: ['tmsteph1290@gmail.com'],
         subject: 'Re: Quick idea for your site',
-        headline: 'Quick note from 3DVR',
-        text: 'I noticed one small customer-flow issue worth tightening.',
-        senderName: 'Thomas @ 3DVR',
+        headline: 'Quick note from 3dvr.tech',
+        text: 'I noticed one small customer-flow issue worth tightening.\n\nThomas\n3dvr.tech\n\nBusiness offer from 3dvr.tech.\nPostal address: 123 Main St, San Diego, CA 92101\nTo opt out, reply stop.',
+        senderName: 'Thomas at 3dvr.tech',
         senderEmail: '3dvr.tech@gmail.com',
         inReplyTo: '<reply-message@example.com>',
         references: '<thread-root@example.com> <reply-message@example.com>'
@@ -453,7 +453,9 @@ describe('account recovery email api', () => {
     assert.equal(sent.replyTo, '3dvr.tech@gmail.com');
     assert.equal(sent.inReplyTo, '<reply-message@example.com>');
     assert.equal(sent.references, '<thread-root@example.com> <reply-message@example.com>');
-    assert.match(sent.html, /Quick note from 3DVR/i);
+    assert.match(sent.html, /Quick note from 3dvr\.tech/i);
+    assert.match(sent.html, /font-size: 11px[^>]*>Postal address:/i);
+    assert.equal((sent.html.match(/Thomas at 3dvr\.tech/gi) || []).length, 0);
     assert.match(sent.text, /customer-flow issue/i);
   });
 });

--- a/tests/free-page-offer.test.js
+++ b/tests/free-page-offer.test.js
@@ -6,6 +6,8 @@ const html = await readFile(new URL('../free-page/index.html', import.meta.url),
 const script = await readFile(new URL('../free-page/app.js', import.meta.url), 'utf8');
 const previewHtml = await readFile(new URL('../free-page/preview/index.html', import.meta.url), 'utf8');
 const previewScript = await readFile(new URL('../free-page/preview/app.js', import.meta.url), 'utf8');
+const styles = await readFile(new URL('../free-page/styles.css', import.meta.url), 'utf8');
+const previewStyles = await readFile(new URL('../free-page/preview/styles.css', import.meta.url), 'utf8');
 
 test('free page offer presents the tiny website starter offer', () => {
   assert.match(html, /I.ll make you a clean one-page website for free/);
@@ -31,6 +33,17 @@ test('personalized preview is noindex, safely client-rendered, and tracks explic
   assert.match(previewScript, /track\('preview_view'\)/);
   assert.match(previewScript, /track\('claim_intent'\)/);
   assert.doesNotMatch(previewScript, /innerHTML/);
+  assert.match(previewHtml, /Business offer from/);
+  assert.doesNotMatch(previewHtml, /Advertisement from/);
+});
+
+test('free page layouts contain folded-phone overflow guards', () => {
+  for (const css of [styles, previewStyles]) {
+    assert.match(css, /overflow-x:\s*clip/);
+    assert.match(css, /@media \(max-width: 360px\)/);
+    assert.match(css, /overflow-wrap:\s*anywhere/);
+    assert.match(css, /min-width:\s*0/);
+  }
 });
 
 test('free page brief builds an email handoff without backend dependencies', () => {


### PR DESCRIPTION
## Summary
- eliminate horizontal overflow on the free-page offer and personalized preview at folded-phone widths
- render the required postal address at a compact 11px in outreach HTML
- avoid duplicate sender signatures and use the 3dvr.tech sender identity
- replace the preview's literal Advertisement label with Business offer

## Verification
- focused portal tests: 18/18 passing
- Playwright at 280px: document and body scroll widths remain exactly 280px on both routes