### PR TITLE
Update portal releases through v0.0.54

### DIFF
--- a/docs/future-portal-agent-monorepo.md
+++ b/docs/future-portal-agent-monorepo.md
@@ -1,0 +1,64 @@
+# Future Portal + Agent Monorepo Design
+
+Status: future design; no migration is currently scheduled.
+
+## Decision
+
+If `3dvr-agent` is consolidated into `3dvr-portal`, use an incremental monorepo layout. Keep the existing portal at the repository root and import the agent intact under `apps/agent`.
+
+```text
+3dvr-portal/
+├── app/                     # existing portal code
+├── public/                  # existing portal assets
+├── package.json             # existing portal package and scripts
+├── ...                      # other existing portal files
+├── apps/
+│   └── agent/               # imported 3dvr-agent repository
+│       ├── package.json
+│       ├── thomas-agent/
+│       ├── test/
+│       ├── install.sh
+│       └── README.md
+└── .github/workflows/
+    ├── portal.yml
+    └── agent.yml
+```
+
+The asymmetric shape is intentional. A monorepo does not require moving every application at once, and keeping the portal at the root avoids changing its current Vercel project root, imports, scripts, and deployment assumptions.
+
+## Runtime boundaries
+
+- The portal remains a Vercel deployment built from the repository root.
+- The agent remains a separate Hetzner runtime whose commands run from `apps/agent`.
+- The agent keeps its own package manifest, tests, install script, environment, and process commands.
+- Portal and agent secrets remain separate and never move into shared source-controlled configuration.
+- CI uses path filters: portal changes run portal checks, agent changes run agent checks, and cross-cutting changes run both.
+
+## Migration outline
+
+1. Start from a fresh `origin/main` checkout and leave existing dirty worktrees untouched.
+2. Import the agent with Git history preserved under `apps/agent`.
+3. Add agent-only CI paths and root convenience commands without changing portal deployment behavior.
+4. Verify the complete agent and portal test suites from the combined repository.
+5. Prove the monorepo checkout on Hetzner before switching the active worker path.
+6. Archive the standalone `3dvr-agent` repository as read-only for a transition period; do not delete it.
+
+## Deferred work
+
+Do not create shared packages during the initial migration. Extract a package only after real duplication establishes a stable boundary—for example preview schemas, attribution rules, or outreach branding used by both runtimes.
+
+A possible later shape is:
+
+```text
+apps/
+├── portal/
+└── agent/
+packages/
+└── outreach-contracts/
+```
+
+Moving the portal into `apps/portal` is explicitly deferred because it would change Vercel roots, imports, scripts, CI paths, and other established assumptions. The agent can also be separated later by extracting the history of `apps/agent`.
+
+## Trigger to revisit
+
+Revisit this design when atomic portal-and-agent changes are common enough that coordinating two repositories creates material release friction. Until then, keep both repositories operationally independent.

--- a/releases/index.html
+++ b/releases/index.html
@@ -99,20 +99,36 @@
   <div class="section">
     <h2>Latest Release</h2>
     <article class="release-card">
-      <a class="release-link" href="v0.0.52.html">v0.0.52</a>
-      <span class="release-meta">Week of June 29, 2026</span>
+      <a class="release-link" href="v0.0.54.html">v0.0.54</a>
+      <span class="release-meta">Week of July 13, 2026</span>
       <p class="release-summary">
-        Free-first portal routing through <a href="../life/index.html">Daily Direction</a>,
-        <a href="../friends-family/">Friends &amp; Family Pass</a>, app-like <a href="../forge/">3DVR Forge</a>,
-        automatic identity recovery, sign-in/cache hardening, the
-        <a href="../docs/3dvr-long-term-plan-roadmap.md">long-term roadmap</a>, and the
-        <a href="../docs/no-account-stripe-payment-plan.md">no-account Stripe payment plan</a>.
+        A measurable <a href="../free-page/">Free Page</a> outreach funnel with personalized previews, explicit
+        engagement and claim events, folded-phone polish, guarded Money Printer execution, and a deeper
+        <a href="../research/">OpenClaw research library</a>.
       </p>
     </article>
   </div>
   <div class="section">
     <h2>Release History</h2>
     <ul class="release-grid">
+      <li class="release-card">
+        <a class="release-link" href="v0.0.54.html">v0.0.54</a>
+        <span class="release-meta">Week of July 13, 2026</span>
+        <p class="release-summary">
+          A measurable <a href="../free-page/">Free Page</a> outreach funnel with personalized previews, explicit
+          engagement and claim events, folded-phone polish, guarded Money Printer execution, and a deeper
+          <a href="../research/">OpenClaw research library</a>.
+        </p>
+      </li>
+      <li class="release-card">
+        <a class="release-link" href="v0.0.53.html">v0.0.53</a>
+        <span class="release-meta">Week of July 6, 2026</span>
+        <p class="release-summary">
+          The <a href="../free-page/">Free Page</a> starter offer, a guarded
+          <a href="../money-printer/">Money Printer</a> operating loop, a calmer homepage, opportunity onboarding,
+          <a href="../signal-garden/">Signal Garden</a>, and focused portal-game improvements.
+        </p>
+      </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.52.html">v0.0.52</a>
         <span class="release-meta">Week of June 29, 2026</span>

--- a/releases/v0.0.52.html
+++ b/releases/v0.0.52.html
@@ -24,7 +24,7 @@
   <p><a class="back-link" href="index.html">Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
     <a class="release-nav-link" href="v0.0.51.html">Previous release</a>
-    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+    <a class="release-nav-link" href="v0.0.53.html">Next release</a>
   </nav>
   <h1>Release v0.0.52</h1>
   <div class="tag">Week of June 29, 2026</div>

--- a/releases/v0.0.53.html
+++ b/releases/v0.0.53.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.53 (Week of July 6, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.52.html">Previous release</a>
+    <a class="release-nav-link" href="v0.0.54.html">Next release</a>
+  </nav>
+  <h1>Release v0.0.53</h1>
+  <div class="tag">Week of July 6, 2026</div>
+  <div class="release-summary">
+    <p>
+      This week turned the portal into a more focused operating surface: a clear free-page offer, a guarded
+      Money Printer workflow, a calmer homepage, and a stronger set of small games and opportunity tools.
+    </p>
+    <ul class="release-summary-list">
+      <li>
+        <strong>Money Printer becomes an operating loop:</strong>
+        <a href="../growth-desk/">Growth Desk</a>, <a href="../money-printer/">Money Printer</a>, and
+        <a href="../offer-garden/">Offer Garden</a> gained review queues, self-review, evidence-rich reports,
+        safe proposal branches, operator email actions, scheduled improvement, and an outbound queue across
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1029">PR #1029</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1035">#1035</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1036">#1036</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1038">#1038</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1042">#1042</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1043">#1043</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1044">#1044</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1046">#1046</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1052">#1052</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1055">#1055</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1056">#1056</a>, and
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1117">#1117</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1120">#1120</a>.
+      </li>
+      <li>
+        <strong>A direct microbusiness offer:</strong>
+        the Microbusiness Launch Sprint and <a href="../free-page/">Free Page</a> starter offer landed in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1096">PR #1096</a> and
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1099">PR #1099</a>, backed by a practical outreach
+        script in <a href="https://github.com/tmsteph/3dvr-portal/pull/1081">PR #1081</a>.
+      </li>
+      <li>
+        <strong>A quieter, clearer portal shell:</strong>
+        navigation, guest identity, desktop recovery, logo scale, and the interactive portal spinner were refined
+        in <a href="https://github.com/tmsteph/3dvr-portal/pull/1105">PR #1105</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1112">PR #1112</a>. Core laptop workspaces were
+        compacted in <a href="https://github.com/tmsteph/3dvr-portal/pull/1122">PR #1122</a>, and the homepage
+        now asks people to start small and pick one next step.
+      </li>
+      <li>
+        <strong>Games gained depth and variety:</strong>
+        <a href="../signal-garden/">Signal Garden</a> joined the portal, while
+        <a href="../games.html">Game Hub</a>, Zero-G Ski Range, <a href="../pong.html">Pong</a>, and
+        <a href="../orbital-courier/">Orbital Courier</a> received focused control, layout, and world-building
+        passes in <a href="https://github.com/tmsteph/3dvr-portal/pull/1123">PR #1123</a> and
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1127">PR #1127</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1131">PR #1131</a>.
+      </li>
+      <li>
+        <strong>Opportunity onboarding:</strong>
+        <a href="../career-launch/">Career Launch</a> gained career and opportunity onboarding in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1132">PR #1132</a>. A misplaced pilot document was
+        deliberately reverted in <a href="https://github.com/tmsteph/3dvr-portal/pull/1137">PR #1137</a> without
+        removing the product flow.
+      </li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Operational notes</h2>
+    <p>
+      Recurring autonomous operator reports were published throughout the week, making the Money Printer's work
+      inspectable without presenting every scheduled report as a separate product feature. This release covers
+      product work merged from <a href="https://github.com/tmsteph/3dvr-portal/pull/1025">PR #1025</a> through
+      <a href="https://github.com/tmsteph/3dvr-portal/pull/1143">PR #1143</a>.
+    </p>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">&copy; 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/releases/v0.0.54.html
+++ b/releases/v0.0.54.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.54 (Week of July 13, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+    .release-nav-link.is-disabled { opacity: 0.4; pointer-events: none; cursor: default; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.53.html">Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+  </nav>
+  <h1>Release v0.0.54</h1>
+  <div class="tag">Week of July 13, 2026</div>
+  <div class="release-summary">
+    <p>
+      This week connected the free-page offer to measurable outreach. The portal can now serve a personalized
+      preview, record explicit engagement, and support a guarded path from prospect research to a claimed page.
+    </p>
+    <ul class="release-summary-list">
+      <li>
+        <strong>Evidence-led Money Printer:</strong>
+        the learning loop now connects experiments to evidence and market research, keeps generated reports out of
+        self-review, and executes only through a guarded path in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1144">PR #1144</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1145">PR #1145</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1147">PR #1147</a>, and
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1148">PR #1148</a>.
+      </li>
+      <li>
+        <strong>Free Page measurement without hidden tracking:</strong>
+        <a href="../free-page/">Free Page</a> added Vercel Analytics, GA4 conversion events, and Gun-backed
+        first-party analytics in <a href="https://github.com/tmsteph/3dvr-portal/pull/1149">PR #1149</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1151">PR #1151</a>.
+      </li>
+      <li>
+        <strong>OpenClaw research library:</strong>
+        the <a href="../research/">research desk</a> now includes notes on distributed-agent orchestration,
+        supervised hierarchies, agent orchestration patterns, and readable live narration from
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1146">PR #1146</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1152">PR #1152</a>, and
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1153">PR #1153</a>.
+      </li>
+      <li>
+        <strong>Personalized preview funnel:</strong>
+        <a href="../free-page/preview/">personalized Free Page previews</a> can carry opaque recipient attribution,
+        record explicit views and claims, and hand interested owners into the next step. The funnel shipped in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1154">PR #1154</a>.
+      </li>
+      <li>
+        <strong>Folded-phone and email polish:</strong>
+        narrow layouts no longer drift horizontally on folded-phone widths, outreach identifies the business as
+        3dvr.tech, and the required address is visually quieter in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1155">PR #1155</a>.
+      </li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Release cadence</h2>
+    <p>
+      v0.0.54 is the current weekly release and covers work merged from
+      <a href="https://github.com/tmsteph/3dvr-portal/pull/1144">PR #1144</a> through
+      <a href="https://github.com/tmsteph/3dvr-portal/pull/1155">PR #1155</a>. The product story is now one
+      connected loop: find a qualified business, show a useful preview, measure explicit interest, and make claiming
+      the page simple.
+    </p>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">&copy; 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -15,12 +15,18 @@ async function fileExists(path) {
 }
 
 describe('release hub backfill', () => {
-  it('updates the release index with the weekly milestones through v0.0.52', async () => {
+  it('updates the release index with the weekly milestones through v0.0.54', async () => {
     const indexUrl = new URL('index.html', baseDir);
     assert.equal(await fileExists(indexUrl), true, 'releases/index.html should exist');
 
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /Latest Release/);
+    assert.match(html, /href="v0\.0\.54\.html">v0\.0\.54</);
+    assert.match(html, /Week of July 13, 2026/);
+    assert.match(html, /personalized previews/);
+    assert.match(html, /href="v0\.0\.53\.html">v0\.0\.53</);
+    assert.match(html, /Week of July 6, 2026/);
+    assert.match(html, /Free Page<\/a> starter offer/);
     assert.match(html, /href="v0\.0\.52\.html">v0\.0\.52</);
     assert.match(html, /Week of June 29, 2026/);
     assert.match(html, /href="\.\.\/life\/index\.html">Daily Direction</);
@@ -89,6 +95,8 @@ describe('release hub backfill', () => {
 
   it('ships the new milestone pages with coherent navigation, summaries, and source links', async () => {
     const releases = [
+      ['v0.0.54.html', /Week of July 13, 2026/, /Personalized preview funnel/i, /aria-disabled="true"/],
+      ['v0.0.53.html', /Week of July 6, 2026/, /Money Printer becomes an operating loop/i, /href="v0\.0\.54\.html"/],
       ['v0.0.52.html', /Week of June 29, 2026/, /Free-first portal and Monday release path/i, /pull\/977/],
       ['v0.0.51.html', /Week of June 22, 2026/, /Money Printer and paid sprint paths/i, /href="v0\.0\.52\.html"/],
       ['v0.0.50.html', /Week of June 15, 2026/, /Launch Site publishing/i, /href="v0\.0\.51\.html"/],
@@ -120,12 +128,28 @@ describe('release hub backfill', () => {
   });
 
   it('links shipped apps and docs inline where the release summaries mention them', async () => {
+    const release54 = await readFile(new URL('v0.0.54.html', baseDir), 'utf8');
+    const release53 = await readFile(new URL('v0.0.53.html', baseDir), 'utf8');
     const release52 = await readFile(new URL('v0.0.52.html', baseDir), 'utf8');
     const release51 = await readFile(new URL('v0.0.51.html', baseDir), 'utf8');
     const release50 = await readFile(new URL('v0.0.50.html', baseDir), 'utf8');
     const release49 = await readFile(new URL('v0.0.49.html', baseDir), 'utf8');
     const release47 = await readFile(new URL('v0.0.47.html', baseDir), 'utf8');
     const release48 = await readFile(new URL('v0.0.48.html', baseDir), 'utf8');
+
+    assert.match(release54, /href="\.\.\/free-page\/">Free Page</);
+    assert.match(release54, /href="\.\.\/free-page\/preview\/">personalized Free Page previews</);
+    assert.match(release54, /href="\.\.\/research\/">research desk</);
+    assert.match(release54, /pull\/1144/);
+    assert.match(release54, /pull\/1155/);
+
+    assert.match(release53, /href="\.\.\/growth-desk\/">Growth Desk</);
+    assert.match(release53, /href="\.\.\/money-printer\/">Money Printer</);
+    assert.match(release53, /href="\.\.\/offer-garden\/">Offer Garden</);
+    assert.match(release53, /href="\.\.\/signal-garden\/">Signal Garden</);
+    assert.match(release53, /href="\.\.\/career-launch\/">Career Launch</);
+    assert.match(release53, /pull\/1025/);
+    assert.match(release53, /pull\/1143/);
 
     assert.match(release52, /href="\.\.\/friends-family\/">Friends &amp; Family Pass</);
     assert.match(release52, /href="\.\.\/life\/index\.html">Daily Direction</);


### PR DESCRIPTION
## Summary

- add weekly portal releases v0.0.53 and v0.0.54
- update the release hub and previous/next navigation
- preserve the incremental portal + agent monorepo proposal as a future design document
- extend release tests through v0.0.54

## Verification

- `node --test tests/releases-hub.test.js`
- `git diff --check`
