### PR TITLE
Make preview contact button functional

### DIFF
--- a/free-page/preview/app.js
+++ b/free-page/preview/app.js
@@ -9,10 +9,17 @@ const business = clean(params.get('name'), 80) || 'your business';
 const focus = clean(params.get('focus'), 180)
   || 'A focused page can make your main service and best contact path obvious.';
 const action = clean(params.get('action'), 40) || 'Get in touch';
+const fragment = new URLSearchParams(window.location.hash.slice(1));
+const contactEmail = validEmail(fragment.get('email'));
 const analyticsClient = createFreePageAnalyticsClient();
 
 function clean(value, limit) {
   return String(value || '').replace(/[\u0000-\u001f<>]/g, '').trim().slice(0, limit);
+}
+
+function validEmail(value) {
+  const email = clean(value, 254).toLowerCase();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : '';
 }
 
 function slug(value) {
@@ -46,6 +53,19 @@ document.querySelector('[data-headline]').textContent = `${business}, made easie
 document.querySelector('[data-focus]').textContent = focus;
 document.querySelector('[data-action]').textContent = action;
 document.title = `${business} website preview | 3DVR`;
+
+const contactButton = document.querySelector('#contactButton');
+if (contactEmail) {
+  const contactSubject = `Website inquiry for ${business}`;
+  const contactBody = `Hi,\n\nI'm interested in learning more about ${business}.`;
+  contactButton.href = `mailto:${contactEmail}?subject=${encodeURIComponent(contactSubject)}&body=${encodeURIComponent(contactBody)}`;
+  contactButton.setAttribute('aria-label', `${action} by email`);
+  document.querySelector('#contactNote').textContent = 'The contact button above opens an email to you. Reply to Thomas to adjust the copy, colors, or next step before anything goes public.';
+} else {
+  contactButton.classList.add('is-preview-only');
+  contactButton.setAttribute('aria-disabled', 'true');
+  contactButton.setAttribute('title', 'Preview button');
+}
 
 const claimButton = document.querySelector('#claimButton');
 const subject = `Claiming the free one-page draft for ${business}`;

--- a/free-page/preview/index.html
+++ b/free-page/preview/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <header class="site-header">
-    <a class="brand" href="../"><span>3D</span> 3DVR</a>
+    <a class="brand" href="../"><span>3dvr</span>.tech</a>
     <p>Prepared for <strong data-business>your business</strong></p>
   </header>
 
@@ -32,7 +32,7 @@
           <p class="mock-kicker">Local, straightforward, easy to reach</p>
           <h2 data-headline>A clearer way to understand what you offer.</h2>
           <p data-focus>A focused page can make your main service and best contact path obvious.</p>
-          <span class="mock-button" data-action>Get in touch</span>
+          <a class="mock-button" data-action id="contactButton">Get in touch</a>
         </div>
         <div class="mock-proof">
           <article><b>What you do</b><span>Your core services in plain language.</span></article>
@@ -46,7 +46,7 @@
       <div>
         <p class="eyebrow">Want the real first draft?</p>
         <h2>I’ll build it at no cost. There’s no obligation to keep it.</h2>
-        <p>Reply to Thomas or use this button. We’ll confirm the facts before anything goes public.</p>
+        <p id="contactNote">Reply to Thomas to adjust the copy, colors, or next step before anything goes public.</p>
       </div>
       <a class="claim-button" id="claimButton" href="mailto:3dvr.tech@gmail.com">Claim my free draft</a>
     </section>

--- a/free-page/preview/styles.css
+++ b/free-page/preview/styles.css
@@ -40,7 +40,9 @@ h1 { margin: 12px 0 20px; font-size: clamp(2.25rem, 6vw, 5rem); line-height: 1.0
 .mock-kicker { color: #247c65; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; font-size: .75rem; }
 .mock-hero h2 { margin: 12px 0; font: 700 clamp(2.2rem, 7vw, 5.5rem)/.98 Georgia, serif; letter-spacing: -.04em; }
 .mock-hero > p:not(.mock-kicker) { max-width: 600px; color: #52606d; font-size: 1.1rem; }
-.mock-button { display: inline-block; margin-top: 18px; padding: 12px 20px; border-radius: 999px; background: #173f4f; color: white; font-weight: 800; }
+.mock-button { display: inline-block; margin-top: 18px; padding: 12px 20px; border-radius: 999px; background: #173f4f; color: white; font-weight: 800; text-decoration: none; }
+.mock-button[href]:hover, .mock-button[href]:focus-visible { background: #247c65; }
+.mock-button.is-preview-only { cursor: default; }
 .mock-proof { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
 .mock-proof article { display: grid; gap: 6px; padding-top: 18px; border-top: 1px solid #cbd5d1; }
 .mock-proof span { color: #68747d; }

--- a/tests/free-page-offer.test.js
+++ b/tests/free-page-offer.test.js
@@ -28,10 +28,14 @@ test('free page offer presents the tiny website starter offer', () => {
 test('personalized preview is noindex, safely client-rendered, and tracks explicit funnel events', () => {
   assert.match(previewHtml, /noindex,nofollow/);
   assert.match(previewHtml, /Claim my free draft/);
+  assert.match(previewHtml, /id="contactButton"/);
   assert.match(previewHtml, /data-business/);
   assert.match(previewScript, /textContent = business/);
   assert.match(previewScript, /track\('preview_view'\)/);
   assert.match(previewScript, /track\('claim_intent'\)/);
+  assert.match(previewScript, /window\.location\.hash/);
+  assert.match(previewScript, /mailto:\$\{contactEmail\}/);
+  assert.doesNotMatch(previewScript, /searchParams\.get\('email'\)/);
   assert.doesNotMatch(previewScript, /innerHTML/);
   assert.match(previewHtml, /Business offer from/);
   assert.doesNotMatch(previewHtml, /Advertisement from/);


### PR DESCRIPTION
## Summary\n- turn the mock-site CTA into a real prefilled mailto link for inbound requesters\n- read the requester address from the privacy-safer URL fragment and never send it to analytics\n- polish the preview's 3dvr.tech branding, interaction states, and explanatory copy\n\n## Verification\n- focused Free Page + analytics tests: 8/8 passed\n- Chromium at 280px: functional requester mailto and no horizontal overflow\n- full portal suite still has 19 unrelated baseline failures; focused changed-area tests are green