### PR TITLE
Add isolated Next Move Lab

### DIFF
--- a/next-move-lab/app.js
+++ b/next-move-lab/app.js
@@ -1,0 +1,91 @@
+import { createClaritySnapshot, snapshotToText } from './snapshot.js';
+
+const form = document.querySelector('[data-next-move-form]');
+const formView = document.querySelector('[data-form-view]');
+const resultView = document.querySelector('[data-result-view]');
+const error = document.querySelector('[data-error]');
+const status = document.querySelector('[data-status]');
+
+function selectedMode() {
+  return form.querySelector('input[name="mode"]:checked')?.value || '';
+}
+
+function renderSnapshot(snapshot) {
+  document.querySelector('[data-result-title]').textContent = snapshot.title;
+  document.querySelector('[data-result-situation]').textContent = snapshot.situation;
+  document.querySelector('[data-result-desired]').textContent = snapshot.desired;
+  document.querySelector('[data-result-constraint]').textContent = snapshot.constraint;
+  document.querySelector('[data-result-lens]').textContent = snapshot.lens;
+  document.querySelector('[data-result-action]').textContent = snapshot.nextAction;
+  document.querySelector('[data-result-disclaimer]').textContent = snapshot.disclaimer;
+
+  const route = document.querySelector('[data-result-route]');
+  route.href = snapshot.route;
+  route.querySelector('strong').textContent = snapshot.routeLabel;
+  route.querySelector('span').textContent = snapshot.routeDetail;
+
+  formView.hidden = true;
+  resultView.hidden = false;
+  resultView.dataset.snapshot = JSON.stringify(snapshot);
+  document.querySelector('[data-result-title]').focus();
+}
+
+function currentSnapshot() {
+  const encoded = resultView.dataset.snapshot;
+  return encoded ? JSON.parse(encoded) : null;
+}
+
+async function copySnapshot() {
+  const snapshot = currentSnapshot();
+  if (!snapshot) return;
+  const text = snapshotToText(snapshot);
+
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    document.body.append(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    textarea.remove();
+  }
+
+  status.textContent = 'Snapshot copied.';
+}
+
+form.addEventListener('submit', event => {
+  event.preventDefault();
+  error.textContent = '';
+
+  try {
+    renderSnapshot(createClaritySnapshot({
+      mode: selectedMode(),
+      situation: form.elements.situation.value,
+      desired: form.elements.desired.value,
+      constraint: form.elements.constraint.value
+    }));
+  } catch (snapshotError) {
+    error.textContent = snapshotError.message;
+    form.querySelector(':invalid, textarea, input')?.focus();
+  }
+});
+
+document.querySelector('[data-action="edit"]').addEventListener('click', () => {
+  resultView.hidden = true;
+  formView.hidden = false;
+  form.elements.situation.focus();
+});
+
+document.querySelector('[data-action="reset"]').addEventListener('click', () => {
+  form.reset();
+  resultView.dataset.snapshot = '';
+  resultView.hidden = true;
+  formView.hidden = false;
+  error.textContent = '';
+  status.textContent = '';
+  form.querySelector('input[name="mode"]').focus();
+});
+
+document.querySelector('[data-action="copy"]').addEventListener('click', copySnapshot);

--- a/next-move-lab/index.html
+++ b/next-move-lab/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta
+    name="description"
+    content="Turn a fuzzy career, startup, or build question into one practical next move."
+  >
+  <title>Next Move Lab | 3dvr Portal</title>
+  <link rel="icon" type="image/svg+xml" href="../brand/portal-logo.svg">
+  <link rel="stylesheet" href="./styles.css">
+  <script type="module" src="./app.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#mainContent">Skip to Next Move Lab</a>
+  <header class="lab-header">
+    <a class="brand" href="../index.html" aria-label="3dvr portal home">3dvr</a>
+    <span class="lab-label">Next Move Lab</span>
+  </header>
+
+  <main id="mainContent" class="lab-shell">
+    <section class="hero" aria-labelledby="pageTitle">
+      <p class="eyebrow">Small experiment · private by default</p>
+      <h1 id="pageTitle">What are you trying to figure out?</h1>
+      <p>
+        Give us three honest answers. This lab will turn them into one practical next move and point you to the
+        most relevant tool already inside the portal.
+      </p>
+    </section>
+
+    <section class="panel" data-form-view aria-labelledby="formTitle">
+      <div class="section-heading">
+        <p class="eyebrow">Clarity Snapshot</p>
+        <h2 id="formTitle">Start with what is true right now.</h2>
+        <p>Your answers stay in this tab and are not saved or sent. This first lab does not require an account.</p>
+      </div>
+
+      <form data-next-move-form>
+        <fieldset class="mode-grid">
+          <legend>1. What kind of next move is this?</legend>
+          <label class="mode-card">
+            <input type="radio" name="mode" value="career" required>
+            <span><strong>My life or career</strong><small>Direction, purpose, work, or a difficult choice</small></span>
+          </label>
+          <label class="mode-card">
+            <input type="radio" name="mode" value="startup" required>
+            <span><strong>A business idea</strong><small>An offer, customer, startup, or useful experiment</small></span>
+          </label>
+          <label class="mode-card">
+            <input type="radio" name="mode" value="build" required>
+            <span><strong>Something I want to build</strong><small>A website, product, project, or first version</small></span>
+          </label>
+        </fieldset>
+
+        <label class="question" for="situation">
+          <span>2. What feels unclear right now?</span>
+          <small>Share enough context to make the next step honest. Leave out private or sensitive information.</small>
+          <textarea
+            id="situation"
+            name="situation"
+            rows="4"
+            maxlength="600"
+            placeholder="I have several directions I could take, but I am not sure which one deserves my limited time."
+            required
+          ></textarea>
+        </label>
+
+        <label class="question" for="desired">
+          <span>3. What would meaningful progress look like?</span>
+          <small>Choose an observable result, not a perfect life.</small>
+          <textarea
+            id="desired"
+            name="desired"
+            rows="3"
+            maxlength="600"
+            placeholder="I want one direction I can test this month without risking my current income."
+            required
+          ></textarea>
+        </label>
+
+        <label class="question" for="constraint">
+          <span>4. What must the plan respect?</span>
+          <small>Time, money, family, health, energy, location, or another real constraint.</small>
+          <textarea
+            id="constraint"
+            name="constraint"
+            rows="3"
+            maxlength="600"
+            placeholder="I have three hours a week and cannot spend money yet."
+            required
+          ></textarea>
+        </label>
+
+        <p class="form-error" data-error role="alert"></p>
+        <button class="button button--primary" type="submit">Create my snapshot</button>
+      </form>
+    </section>
+
+    <section class="panel result" data-result-view hidden aria-labelledby="resultTitle">
+      <div class="section-heading">
+        <p class="eyebrow">Your Clarity Snapshot</p>
+        <h2 id="resultTitle" data-result-title tabindex="-1"></h2>
+        <p>This is a working hypothesis. Keep what helps and revise what does not.</p>
+      </div>
+
+      <dl class="snapshot-grid">
+        <div><dt>Where you are</dt><dd data-result-situation></dd></div>
+        <div><dt>What you want</dt><dd data-result-desired></dd></div>
+        <div><dt>What the plan must respect</dt><dd data-result-constraint></dd></div>
+      </dl>
+
+      <article class="move-card">
+        <p class="eyebrow">Working lens</p>
+        <p data-result-lens></p>
+        <h3>Your next 24-hour move</h3>
+        <p data-result-action></p>
+      </article>
+
+      <a class="route-card" data-result-route href="../start/">
+        <strong>Continue in the portal</strong>
+        <span></span>
+        <b aria-hidden="true">→</b>
+      </a>
+
+      <p class="disclaimer" data-result-disclaimer></p>
+      <div class="actions">
+        <button class="button" type="button" data-action="edit">Edit answers</button>
+        <button class="button button--primary" type="button" data-action="copy">Copy snapshot</button>
+        <button class="button button--quiet" type="button" data-action="reset">Start over</button>
+      </div>
+      <p class="status" data-status aria-live="polite"></p>
+    </section>
+
+    <aside class="scope-note" aria-label="Experiment scope">
+      <strong>Why this lab is intentionally small</strong>
+      <p>
+        It tests whether a short intake and a useful handoff help people move forward. Advice chat, email continuity,
+        saved plans, and paid guidance can be added only after this basic experience proves useful.
+      </p>
+    </aside>
+  </main>
+
+  <footer>
+    <a href="../index.html">Back to the portal</a>
+    <span>Experimental guidance from 3dvr.tech</span>
+  </footer>
+</body>
+</html>

--- a/next-move-lab/snapshot.js
+++ b/next-move-lab/snapshot.js
@@ -1,0 +1,83 @@
+const MODES = Object.freeze({
+  career: Object.freeze({
+    title: 'Find a direction worth testing',
+    lens: 'Treat this as a direction to test, not a permanent identity decision.',
+    nextAction: 'Name one person who understands this world and ask for a 20-minute reality-check conversation.',
+    route: '../career-launch/',
+    routeLabel: 'Build a Career Launch Brief',
+    routeDetail: 'Turn this direction into a small proof project and practical career evidence.'
+  }),
+  startup: Object.freeze({
+    title: 'Turn the idea into a small test',
+    lens: 'Do not build the whole business yet. Look for evidence that one real person wants the outcome.',
+    nextAction: 'Write a one-sentence offer and show it to one possible customer before building more.',
+    route: '../launch-room/?mode=test-service',
+    routeLabel: 'Plan a tiny service test',
+    routeDetail: 'Define the first audience, smallest useful offer, and a safe validation step.'
+  }),
+  build: Object.freeze({
+    title: 'Reduce the build to one useful result',
+    lens: 'The first version only needs to help one kind of person take one meaningful action.',
+    nextAction: 'Describe the smallest useful version in one sentence and choose the single action it should make easier.',
+    route: '../free-page/',
+    routeLabel: 'Create a free page concept',
+    routeDetail: 'Turn the idea into a focused one-page website or redesign preview.'
+  })
+});
+
+export function normalizeSnapshotText(value = '', maxLength = 600) {
+  return String(value)
+    .trim()
+    .replace(/\s+/g, ' ')
+    .slice(0, maxLength);
+}
+
+export function getNextMoveMode(mode = '') {
+  return MODES[normalizeSnapshotText(mode, 40)] || null;
+}
+
+export function createClaritySnapshot(input = {}) {
+  const modeId = normalizeSnapshotText(input.mode, 40);
+  const mode = getNextMoveMode(modeId);
+  const situation = normalizeSnapshotText(input.situation);
+  const desired = normalizeSnapshotText(input.desired);
+  const constraint = normalizeSnapshotText(input.constraint);
+
+  if (!mode) {
+    throw new Error('Choose what you are trying to figure out.');
+  }
+  if (!situation || !desired || !constraint) {
+    throw new Error('Answer all three questions to create a useful snapshot.');
+  }
+
+  return {
+    mode: modeId,
+    title: mode.title,
+    situation,
+    desired,
+    constraint,
+    lens: mode.lens,
+    nextAction: mode.nextAction,
+    route: mode.route,
+    routeLabel: mode.routeLabel,
+    routeDetail: mode.routeDetail,
+    disclaimer: 'This is a reflection tool, not medical, legal, financial, or crisis advice.'
+  };
+}
+
+export function snapshotToText(snapshot) {
+  return [
+    '3dvr Next Move — Clarity Snapshot',
+    '',
+    snapshot.title,
+    '',
+    `Where I am: ${snapshot.situation}`,
+    `What I want: ${snapshot.desired}`,
+    `What the plan must respect: ${snapshot.constraint}`,
+    '',
+    `Working lens: ${snapshot.lens}`,
+    `Next 24-hour move: ${snapshot.nextAction}`,
+    '',
+    snapshot.disclaimer
+  ].join('\n');
+}

--- a/next-move-lab/styles.css
+++ b/next-move-lab/styles.css
@@ -1,0 +1,400 @@
+:root {
+  color-scheme: dark;
+  --background: #071019;
+  --surface: rgba(15, 27, 40, 0.9);
+  --surface-strong: #14283b;
+  --border: rgba(142, 205, 211, 0.24);
+  --text: #f3f7f7;
+  --muted: #aebfc5;
+  --accent: #7ce5d7;
+  --accent-dark: #071b1c;
+  --focus: #f2c66d;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--background);
+  color: var(--text);
+}
+
+body {
+  width: 100%;
+  max-width: 100%;
+  min-height: 100vh;
+  margin: 0;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(33, 113, 113, 0.32), transparent 34rem),
+    radial-gradient(circle at 100% 55%, rgba(45, 74, 128, 0.22), transparent 40rem),
+    var(--background);
+  line-height: 1.55;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+textarea,
+input {
+  font: inherit;
+}
+
+button,
+label,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.skip-link {
+  position: fixed;
+  top: -5rem;
+  left: 0.75rem;
+  z-index: 10;
+  padding: 0.7rem 1rem;
+  border-radius: 999px;
+  background: var(--text);
+  color: var(--background);
+}
+
+.skip-link:focus {
+  top: 0.75rem;
+}
+
+.lab-header,
+.lab-shell,
+footer {
+  width: min(100% - 2rem, 760px);
+  margin-inline: auto;
+}
+
+.lab-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-block: 1.25rem;
+}
+
+.brand {
+  color: var(--text);
+  font-size: 1.35rem;
+  font-weight: 850;
+  letter-spacing: -0.06em;
+  text-decoration: none;
+}
+
+.lab-label {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lab-shell {
+  display: grid;
+  gap: 1rem;
+  padding-block: 2.5rem 4rem;
+}
+
+.hero {
+  padding: clamp(1rem, 5vw, 2.25rem) 0 1.25rem;
+}
+
+.hero h1 {
+  max-width: 12ch;
+  margin: 0.35rem 0 1rem;
+  font-size: clamp(2.35rem, 10vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: -0.065em;
+}
+
+.hero > p:last-child {
+  max-width: 62ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 3vw, 1.18rem);
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.panel,
+.scope-note {
+  min-width: 0;
+  padding: clamp(1.1rem, 4vw, 2rem);
+  border: 1px solid var(--border);
+  border-radius: 1.4rem;
+  background: var(--surface);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.2);
+}
+
+.section-heading h2 {
+  margin: 0.35rem 0 0.5rem;
+  font-size: clamp(1.55rem, 6vw, 2.35rem);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+}
+
+.section-heading > p:last-child,
+.scope-note p,
+.disclaimer,
+.status {
+  margin: 0;
+  color: var(--muted);
+}
+
+form {
+  display: grid;
+  gap: 1.35rem;
+  margin-top: 1.75rem;
+}
+
+.mode-grid {
+  display: grid;
+  gap: 0.7rem;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.mode-grid legend,
+.question > span {
+  margin-bottom: 0.65rem;
+  color: var(--text);
+  font-weight: 750;
+}
+
+.mode-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8rem;
+  min-width: 0;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.025);
+  cursor: pointer;
+}
+
+.mode-card:has(input:checked) {
+  border-color: var(--accent);
+  background: rgba(124, 229, 215, 0.1);
+}
+
+.mode-card input {
+  flex: 0 0 auto;
+  margin-top: 0.3rem;
+  accent-color: var(--accent);
+}
+
+.mode-card span,
+.question {
+  display: grid;
+  min-width: 0;
+}
+
+.mode-card small,
+.question small {
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.question textarea {
+  width: 100%;
+  min-width: 0;
+  margin-top: 0.55rem;
+  padding: 0.9rem;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  background: #091621;
+  color: var(--text);
+}
+
+.question textarea::placeholder {
+  color: #788f98;
+}
+
+.form-error {
+  min-height: 1.5em;
+  margin: 0;
+  color: #ffbdad;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-strong);
+  color: var(--text);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.button--primary {
+  border-color: transparent;
+  background: var(--accent);
+  color: var(--accent-dark);
+}
+
+.button--quiet {
+  background: transparent;
+  color: var(--muted);
+}
+
+.snapshot-grid {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+.snapshot-grid div,
+.move-card {
+  min-width: 0;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.snapshot-grid dt {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.snapshot-grid dd {
+  margin: 0.35rem 0 0;
+  overflow-wrap: anywhere;
+}
+
+.move-card h3 {
+  margin: 1.25rem 0 0.25rem;
+  font-size: 1.15rem;
+}
+
+.move-card p {
+  overflow-wrap: anywhere;
+}
+
+.route-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.2rem 1rem;
+  align-items: center;
+  margin-block: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(124, 229, 215, 0.45);
+  border-radius: 1rem;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.route-card span {
+  grid-column: 1;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.route-card b {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  color: var(--accent);
+  font-size: 1.5rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+}
+
+.scope-note {
+  box-shadow: none;
+}
+
+.scope-note strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-block: 1.5rem 2.5rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (min-width: 640px) {
+  .mode-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .snapshot-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 360px) {
+  .lab-header,
+  .lab-shell,
+  footer {
+    width: min(100% - 1rem, 760px);
+  }
+
+  .panel,
+  .scope-note {
+    padding: 1rem;
+    border-radius: 1rem;
+  }
+
+  .actions .button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+}

--- a/tests/next-move-lab.test.js
+++ b/tests/next-move-lab.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+  createClaritySnapshot,
+  getNextMoveMode,
+  normalizeSnapshotText,
+  snapshotToText
+} from '../next-move-lab/snapshot.js';
+
+const input = {
+  mode: 'startup',
+  situation: 'I have several product ideas but no customers yet.',
+  desired: 'I want to learn which problem one person will pay to solve.',
+  constraint: 'I have three hours a week and no launch budget.'
+};
+
+test('Next Move modes route into existing portal tools', () => {
+  assert.equal(getNextMoveMode('career').route, '../career-launch/');
+  assert.equal(getNextMoveMode('startup').route, '../launch-room/?mode=test-service');
+  assert.equal(getNextMoveMode('build').route, '../free-page/');
+  assert.equal(getNextMoveMode('unknown'), null);
+});
+
+test('Clarity Snapshot preserves context and returns one bounded next action', () => {
+  const snapshot = createClaritySnapshot(input);
+
+  assert.equal(snapshot.mode, 'startup');
+  assert.equal(snapshot.situation, input.situation);
+  assert.equal(snapshot.desired, input.desired);
+  assert.equal(snapshot.constraint, input.constraint);
+  assert.match(snapshot.nextAction, /one possible customer/i);
+  assert.match(snapshot.disclaimer, /not medical, legal, financial, or crisis advice/i);
+  assert.doesNotMatch(JSON.stringify(snapshot), /guarantee/i);
+});
+
+test('Clarity Snapshot requires a mode and all three answers', () => {
+  assert.throws(() => createClaritySnapshot({ ...input, mode: '' }), /Choose what/);
+  assert.throws(() => createClaritySnapshot({ ...input, constraint: '' }), /all three questions/);
+});
+
+test('snapshot text is normalized, bounded, and exportable', () => {
+  assert.equal(normalizeSnapshotText('  one\n  useful   move  '), 'one useful move');
+  assert.equal(normalizeSnapshotText('x'.repeat(700)).length, 600);
+
+  const output = snapshotToText(createClaritySnapshot(input));
+  assert.match(output, /3dvr Next Move/);
+  assert.match(output, /What I want:/);
+  assert.match(output, /Next 24-hour move:/);
+});
+
+test('Next Move Lab is an isolated private browser experience', async () => {
+  const html = await readFile(new URL('../next-move-lab/index.html', import.meta.url), 'utf8');
+  const app = await readFile(new URL('../next-move-lab/app.js', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../next-move-lab/styles.css', import.meta.url), 'utf8');
+
+  assert.match(html, /What are you trying to figure out\?/);
+  assert.match(html, /answers stay in this tab and are not saved or sent/i);
+  assert.match(html, /My life or career/);
+  assert.match(html, /A business idea/);
+  assert.match(html, /Something I want to build/);
+  assert.doesNotMatch(app, /fetch\(|localStorage|sessionStorage|Gun\(/);
+  assert.match(app, /textContent/);
+  assert.match(css, /@media \(max-width: 360px\)/);
+  assert.match(css, /overflow-x: hidden/);
+});


### PR DESCRIPTION
## Outcome

Adds one isolated Next Move Lab route that turns three short answers into a private Clarity Snapshot and one 24-hour action.

## Scope

- Adds only the new `next-move-lab/` route and its focused test.
- Reuses existing Career Launch, Launch Room, and Free Page flows as handoffs.
- Does not change the portal home, existing apps, APIs, Gun data, accounts, billing, email, or the agent runtime.
- Keeps answers in the active browser tab; they are not persisted or sent.

## Verification

- Focused portal and compatibility tests: 12/12 passed.
- Interactive Chromium walkthrough passed at 280px with document and body widths equal to the viewport.
- Full portal suite: 742 passed, 2 skipped, 13 unrelated baseline failures on current main.
- Reviewed current 3dvr-web positioning and contact guidance; no conflicting or unsupported claims introduced.

## Follow-up boundary

AI advice, email continuity, saved plans, paid guidance, and homepage promotion remain intentionally out of scope until this intake proves useful.
