### PR TITLE
Focus Next Move questions by topic

### DIFF
--- a/next-move-lab/app.js
+++ b/next-move-lab/app.js
@@ -1,6 +1,7 @@
 import {
   createClaritySnapshot,
   createFallbackGuidance,
+  getNextMoveQuestions,
   snapshotToText
 } from './snapshot.js';
 
@@ -14,12 +15,30 @@ const aiStatus = document.querySelector('[data-ai-status]');
 const followUpStatus = document.querySelector('[data-follow-up-status]');
 const submitButton = document.querySelector('[data-submit-button]');
 const followUpButton = document.querySelector('[data-follow-up-button]');
+const detailQuestions = document.querySelector('[data-detail-questions]');
 
 let latestSnapshot = null;
 let latestGuidance = null;
 
 function selectedMode() {
   return form.querySelector('input[name="mode"]:checked')?.value || '';
+}
+
+function showQuestions(mode) {
+  const questions = getNextMoveQuestions(mode);
+  if (!questions) {
+    detailQuestions.hidden = true;
+    return;
+  }
+
+  Object.entries(questions).forEach(([name, question]) => {
+    document.querySelector(`[data-question-label="${name}"]`).textContent = question.label;
+    document.querySelector(`[data-question-help="${name}"]`).textContent = question.help;
+    document.querySelector(`[data-answer-label="${name}"]`).textContent = question.label.replace(/^\d+\.\s*/, '');
+    form.elements[name].placeholder = question.placeholder;
+  });
+
+  detailQuestions.hidden = false;
 }
 
 function createPathCard(path, index) {
@@ -200,6 +219,12 @@ async function copySnapshot() {
 
 form.addEventListener('submit', generateInitialGuidance);
 followUpForm.addEventListener('submit', refineGuidance);
+form.querySelectorAll('input[name="mode"]').forEach(input => {
+  input.addEventListener('change', () => {
+    showQuestions(input.value);
+    form.elements.situation.focus();
+  });
+});
 
 document.querySelector('[data-action="edit"]').addEventListener('click', () => {
   resultView.hidden = true;
@@ -218,6 +243,7 @@ document.querySelector('[data-action="reset"]').addEventListener('click', () => 
   status.textContent = '';
   aiStatus.textContent = '';
   followUpStatus.textContent = '';
+  detailQuestions.hidden = true;
   form.querySelector('input[name="mode"]').focus();
 });
 

--- a/next-move-lab/index.html
+++ b/next-move-lab/index.html
@@ -24,7 +24,7 @@
     <section class="hero" aria-labelledby="pageTitle">
       <p class="eyebrow">Small experiment · no account required</p>
       <h1 id="pageTitle">What feels stuck?</h1>
-      <p>Answer three short questions. Get one clear next step.</p>
+      <p>Pick one topic. Answer three clear questions.</p>
     </section>
 
     <section class="panel" data-form-view aria-labelledby="formTitle">
@@ -51,44 +51,25 @@
           </label>
         </fieldset>
 
-        <label class="question" for="situation">
-          <span>2. What feels stuck?</span>
-          <small>Tell us the main problem.</small>
-          <textarea
-            id="situation"
-            name="situation"
-            rows="4"
-            maxlength="600"
-            placeholder="I have a few choices. I do not know which one to try."
-            required
-          ></textarea>
-        </label>
+        <div class="detail-questions" data-detail-questions hidden>
+          <label class="question" for="situation">
+            <span data-question-label="situation"></span>
+            <small data-question-help="situation"></small>
+            <textarea id="situation" name="situation" rows="3" maxlength="600" required></textarea>
+          </label>
 
-        <label class="question" for="desired">
-          <span>3. What do you want?</span>
-          <small>Name one result you can see.</small>
-          <textarea
-            id="desired"
-            name="desired"
-            rows="3"
-            maxlength="600"
-            placeholder="I want one choice I can test this month."
-            required
-          ></textarea>
-        </label>
+          <label class="question" for="desired">
+            <span data-question-label="desired"></span>
+            <small data-question-help="desired"></small>
+            <textarea id="desired" name="desired" rows="3" maxlength="600" required></textarea>
+          </label>
 
-        <label class="question" for="constraint">
-          <span>4. What limit should we know?</span>
-          <small>Think about time, money, family, or health.</small>
-          <textarea
-            id="constraint"
-            name="constraint"
-            rows="3"
-            maxlength="600"
-            placeholder="I have three hours a week and no money to spend."
-            required
-          ></textarea>
-        </label>
+          <label class="question" for="constraint">
+            <span data-question-label="constraint"></span>
+            <small data-question-help="constraint"></small>
+            <textarea id="constraint" name="constraint" rows="3" maxlength="600" required></textarea>
+          </label>
+        </div>
 
         <p class="form-error" data-error role="alert"></p>
         <button class="button button--primary" type="submit" data-submit-button>Show my next step</button>
@@ -134,9 +115,9 @@
         <details class="answers-card">
           <summary>See my answers</summary>
           <dl class="snapshot-grid">
-            <div><dt>What feels stuck</dt><dd data-result-situation></dd></div>
-            <div><dt>What I want</dt><dd data-result-desired></dd></div>
-            <div><dt>My limit</dt><dd data-result-constraint></dd></div>
+            <div><dt data-answer-label="situation"></dt><dd data-result-situation></dd></div>
+            <div><dt data-answer-label="desired"></dt><dd data-result-desired></dd></div>
+            <div><dt data-answer-label="constraint"></dt><dd data-result-constraint></dd></div>
           </dl>
         </details>
       </details>

--- a/next-move-lab/snapshot.js
+++ b/next-move-lab/snapshot.js
@@ -28,6 +28,60 @@ const MODES = Object.freeze({
   })
 });
 
+const QUESTION_SETS = Object.freeze({
+  career: Object.freeze({
+    situation: Object.freeze({
+      label: '2. What choice are you making?',
+      help: 'Name the paths you are choosing between.',
+      placeholder: 'Stay in this job or look for a new one.'
+    }),
+    desired: Object.freeze({
+      label: '3. What would make it a win?',
+      help: 'Name one change you want soon.',
+      placeholder: 'More time with my family each week.'
+    }),
+    constraint: Object.freeze({
+      label: '4. What must not get worse?',
+      help: 'Pick your biggest limit.',
+      placeholder: 'I cannot take a pay cut.'
+    })
+  }),
+  startup: Object.freeze({
+    situation: Object.freeze({
+      label: '2. Who do you want to help?',
+      help: 'Name one kind of person.',
+      placeholder: 'Small event teams that miss new leads.'
+    }),
+    desired: Object.freeze({
+      label: '3. What will you offer first?',
+      help: 'Name one small thing they can try.',
+      placeholder: 'I will set up one simple lead form.'
+    }),
+    constraint: Object.freeze({
+      label: '4. What can you spend on a test?',
+      help: 'Name your time and money limit.',
+      placeholder: 'Three hours and no money this week.'
+    })
+  }),
+  build: Object.freeze({
+    situation: Object.freeze({
+      label: '2. Who will use it?',
+      help: 'Name one kind of person.',
+      placeholder: 'A parent who wants a simple meal plan.'
+    }),
+    desired: Object.freeze({
+      label: '3. What one job should it do?',
+      help: 'Name the first useful result.',
+      placeholder: 'Make a meal plan in five minutes.'
+    }),
+    constraint: Object.freeze({
+      label: '4. What must wait until later?',
+      help: 'Cut one part from the first try.',
+      placeholder: 'Accounts and phone apps can wait.'
+    })
+  })
+});
+
 export function normalizeSnapshotText(value = '', maxLength = 600) {
   return String(value)
     .trim()
@@ -37,6 +91,10 @@ export function normalizeSnapshotText(value = '', maxLength = 600) {
 
 export function getNextMoveMode(mode = '') {
   return MODES[normalizeSnapshotText(mode, 40)] || null;
+}
+
+export function getNextMoveQuestions(mode = '') {
+  return QUESTION_SETS[normalizeSnapshotText(mode, 40)] || null;
 }
 
 export function createClaritySnapshot(input = {}) {

--- a/next-move-lab/styles.css
+++ b/next-move-lab/styles.css
@@ -175,6 +175,11 @@ form {
   margin-top: 1.75rem;
 }
 
+.detail-questions {
+  display: grid;
+  gap: 1.35rem;
+}
+
 .mode-grid {
   display: grid;
   gap: 0.7rem;

--- a/tests/next-move-lab.test.js
+++ b/tests/next-move-lab.test.js
@@ -5,6 +5,7 @@ import {
   createClaritySnapshot,
   createFallbackGuidance,
   getNextMoveMode,
+  getNextMoveQuestions,
   normalizeSnapshotText,
   snapshotToText
 } from '../next-move-lab/snapshot.js';
@@ -21,6 +22,22 @@ test('Next Move modes route into existing portal tools', () => {
   assert.equal(getNextMoveMode('startup').route, '../launch-room/?mode=test-service');
   assert.equal(getNextMoveMode('build').route, '../free-page/');
   assert.equal(getNextMoveMode('unknown'), null);
+});
+
+test('each mode asks three focused questions with separate jobs', () => {
+  const career = getNextMoveQuestions('career');
+  const startup = getNextMoveQuestions('startup');
+  const build = getNextMoveQuestions('build');
+
+  assert.match(career.situation.label, /choice/i);
+  assert.match(career.constraint.label, /must not get worse/i);
+  assert.match(startup.situation.label, /who/i);
+  assert.match(startup.desired.label, /offer/i);
+  assert.match(startup.constraint.label, /spend/i);
+  assert.match(build.situation.label, /who/i);
+  assert.match(build.desired.label, /one job/i);
+  assert.match(build.constraint.label, /wait until later/i);
+  assert.equal(getNextMoveQuestions('unknown'), null);
 });
 
 test('Clarity Snapshot preserves context and returns one bounded next action', () => {
@@ -69,13 +86,14 @@ test('Next Move Lab sends answers only to its isolated AI endpoint', async () =>
   const app = await readFile(new URL('../next-move-lab/app.js', import.meta.url), 'utf8');
   const css = await readFile(new URL('../next-move-lab/styles.css', import.meta.url), 'utf8');
 
-  assert.match(html, /What feels stuck\?/);
+  assert.match(html, /Pick one topic\. Answer three clear questions\./);
   assert.match(html, /My life or job/);
   assert.match(html, /A business idea/);
   assert.match(html, /Something to build/);
   assert.match(html, /We do not save them/i);
   assert.match(html, /See more ideas/);
   assert.match(app, /fetch\('\/api\/openai-site\?provider=next-move'/);
+  assert.match(app, /getNextMoveQuestions/);
   assert.doesNotMatch(app, /localStorage|sessionStorage|Gun\(/);
   assert.match(app, /textContent/);
   assert.match(css, /@media \(max-width: 360px\)/);


### PR DESCRIPTION
## What changed
- show questions only after a topic is picked
- ask a different, non-overlapping set for job, business, and build choices
- keep every prompt short and at the existing plain-language level
- carry the matching labels into the saved answer view

## Checks
- 30 focused Next Move/OpenAI tests pass
- Chromium verified all three question sets at 280px
- viewport, document, and body widths all stay at 280px

## Scope
No account, billing, storage, API contract, or portal handoff changes.