### PR TITLE
Make Next Move topic choice immediate

### DIFF
--- a/next-move-lab/app.js
+++ b/next-move-lab/app.js
@@ -5,6 +5,7 @@ import {
   getNextMoveQuestions,
   snapshotToText
 } from './snapshot.js';
+import { createCompassExperience } from './experience.js';
 
 const form = document.querySelector('[data-next-move-form]');
 const followUpForm = document.querySelector('[data-follow-up-form]');
@@ -18,13 +19,17 @@ const submitButton = document.querySelector('[data-submit-button]');
 const followUpButton = document.querySelector('[data-follow-up-button]');
 const detailQuestions = document.querySelector('[data-detail-questions]');
 const steps = [...form.querySelectorAll('[data-step]')];
+const compass = createCompassExperience({
+  form,
+  soundToggle: document.querySelector('[data-sound-toggle]')
+});
 
 let latestSnapshot = null;
 let latestGuidance = null;
 let stepIndex = 0;
 
 function selectedMode() {
-  return form.querySelector('input[name="mode"]:checked')?.value || '';
+  return form.elements.mode.value || '';
 }
 
 function showQuestions(mode) {
@@ -126,6 +131,7 @@ function renderGuidance(snapshot, guidance, message = '') {
 
   formView.hidden = true;
   resultView.hidden = false;
+  compass.reveal();
   status.textContent = message;
   document.querySelector('[data-result-title]').focus();
 }
@@ -177,6 +183,7 @@ async function generateInitialGuidance(event) {
   }
 
   setBusy(submitButton, aiStatus, true, 'Making a short plan…');
+  compass.setThinking(true);
 
   try {
     const guidance = await requestGuidance(snapshot);
@@ -194,6 +201,7 @@ async function generateInitialGuidance(event) {
       'AI is not ready, so here is a simple backup plan.'
     );
   } finally {
+    compass.setThinking(false);
     setBusy(submitButton, aiStatus, false);
   }
 }
@@ -209,6 +217,7 @@ async function refineGuidance(event) {
   }
 
   setBusy(followUpButton, followUpStatus, true, 'Updating your plan…');
+  compass.setThinking(true);
 
   try {
     const guidance = await requestGuidance({
@@ -222,6 +231,7 @@ async function refineGuidance(event) {
   } catch (requestError) {
     followUpStatus.textContent = requestError.message;
   } finally {
+    compass.setThinking(false);
     followUpButton.disabled = false;
     followUpButton.setAttribute('aria-busy', 'false');
   }
@@ -248,13 +258,19 @@ async function copySnapshot() {
 
 form.addEventListener('submit', generateInitialGuidance);
 followUpForm.addEventListener('submit', refineGuidance);
-form.querySelectorAll('input[name="mode"]').forEach(input => {
-  input.addEventListener('change', () => {
-    showQuestions(input.value);
-  });
-});
-
 form.addEventListener('click', event => {
+  const modeChoice = event.target.closest('[data-mode-choice]');
+  if (modeChoice) {
+    const mode = modeChoice.dataset.modeChoice;
+    form.elements.mode.value = mode;
+    form.querySelectorAll('[data-mode-choice]').forEach(button => {
+      button.dataset.selected = String(button === modeChoice);
+    });
+    showQuestions(mode);
+    showStep(1);
+    return;
+  }
+
   const answer = event.target.closest('[data-answer]');
   if (answer) {
     form.elements[answer.dataset.field].value = answer.dataset.answer;
@@ -301,7 +317,8 @@ document.querySelector('[data-action="reset"]').addEventListener('click', () => 
   followUpStatus.textContent = '';
   detailQuestions.hidden = true;
   showStep(0);
-  form.querySelector('input[name="mode"]').focus();
+  compass.reset();
+  form.querySelector('[data-mode-choice], input[name="mode"]')?.focus();
 });
 
 document.querySelector('[data-action="copy"]').addEventListener('click', copySnapshot);

--- a/next-move-lab/experience.js
+++ b/next-move-lab/experience.js
@@ -1,0 +1,166 @@
+const MODE_TONES = Object.freeze({
+  career: 196,
+  startup: 220,
+  build: 174.61
+});
+
+function audioConstructor() {
+  return window.AudioContext || window.webkitAudioContext || null;
+}
+
+export function createCompassExperience({ form, soundToggle }) {
+  let audio = null;
+  let soundOn = false;
+  let modeTone = MODE_TONES.career;
+  let completedFields = new WeakSet();
+
+  function makeAudio() {
+    if (audio) return audio;
+    const AudioContext = audioConstructor();
+    if (!AudioContext) return null;
+
+    const context = new AudioContext();
+    const master = context.createGain();
+    const filter = context.createBiquadFilter();
+    const warm = context.createOscillator();
+    const air = context.createOscillator();
+    const warmGain = context.createGain();
+    const airGain = context.createGain();
+
+    master.gain.value = 0.0001;
+    filter.type = 'lowpass';
+    filter.frequency.value = 900;
+    filter.Q.value = 0.7;
+    warm.type = 'sine';
+    warm.frequency.value = modeTone / 2;
+    warmGain.gain.value = 0.05;
+    air.type = 'triangle';
+    air.frequency.value = modeTone;
+    airGain.gain.value = 0.012;
+
+    warm.connect(warmGain);
+    warmGain.connect(filter);
+    air.connect(airGain);
+    airGain.connect(filter);
+    filter.connect(master);
+    master.connect(context.destination);
+    warm.start();
+    air.start();
+
+    audio = { context, master, filter, warm, air };
+    return audio;
+  }
+
+  function setPadTone(tone) {
+    modeTone = tone;
+    if (!audio) return;
+    const now = audio.context.currentTime;
+    audio.warm.frequency.setTargetAtTime(tone / 2, now, 0.35);
+    audio.air.frequency.setTargetAtTime(tone, now, 0.35);
+  }
+
+  function playTone(ratio = 1, delay = 0, length = 0.7) {
+    if (!soundOn || !audio) return;
+    const now = audio.context.currentTime + delay;
+    const oscillator = audio.context.createOscillator();
+    const gain = audio.context.createGain();
+
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(modeTone * ratio, now);
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.055, now + 0.025);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + length);
+    oscillator.connect(gain);
+    gain.connect(audio.filter);
+    oscillator.start(now);
+    oscillator.stop(now + length + 0.05);
+  }
+
+  function playStep(step) {
+    const notes = [1, 1.125, 1.25, 1.5];
+    playTone(notes[Math.max(0, Math.min(step - 1, notes.length - 1))], 0, 0.45);
+  }
+
+  function playReveal() {
+    [1, 1.25, 1.5, 2].forEach((ratio, index) => playTone(ratio, index * 0.11, 1.1));
+  }
+
+  async function setSound(enabled) {
+    if (enabled && !makeAudio()) {
+      soundToggle.disabled = true;
+      soundToggle.querySelector('b').textContent = 'No sound';
+      return;
+    }
+
+    soundOn = enabled;
+    if (enabled) await audio.context.resume();
+    const now = audio.context.currentTime;
+    audio.master.gain.cancelScheduledValues(now);
+    audio.master.gain.setTargetAtTime(enabled ? 0.16 : 0.0001, now, 0.08);
+    soundToggle.setAttribute('aria-pressed', String(enabled));
+    soundToggle.querySelector('b').textContent = enabled ? 'Sound on' : 'Sound off';
+    document.body.classList.toggle('has-sound', enabled);
+    if (enabled) playTone(1.5, 0.03, 0.6);
+  }
+
+  function progress() {
+    const hasMode = Boolean(form.querySelector('input[name="mode"]:checked'));
+    const answers = [...form.querySelectorAll('textarea')].filter(field => field.value.trim()).length;
+    return Number(hasMode) + answers;
+  }
+
+  function paintProgress() {
+    const value = progress();
+    document.body.dataset.progress = String(value);
+    document.documentElement.style.setProperty('--journey', String(value / 4));
+  }
+
+  form.querySelectorAll('input[name="mode"]').forEach((input, index) => {
+    input.addEventListener('change', () => {
+      document.body.dataset.mode = input.value;
+      setPadTone(MODE_TONES[input.value] || MODE_TONES.career);
+      paintProgress();
+      playStep(index + 1);
+    });
+  });
+
+  form.querySelectorAll('textarea').forEach(field => {
+    field.addEventListener('input', paintProgress);
+    field.addEventListener('change', () => {
+      if (!field.value.trim() || completedFields.has(field)) return;
+      completedFields.add(field);
+      playStep(progress());
+    });
+  });
+
+  soundToggle.addEventListener('click', () => setSound(!soundOn));
+  document.addEventListener('visibilitychange', () => {
+    if (!audio) return;
+    if (document.hidden) audio.context.suspend();
+    else if (soundOn) audio.context.resume();
+  });
+
+  paintProgress();
+
+  return {
+    setThinking(thinking) {
+      document.body.classList.toggle('is-thinking', thinking);
+      if (!audio) return;
+      const now = audio.context.currentTime;
+      audio.filter.frequency.setTargetAtTime(thinking ? 1700 : 900, now, 0.35);
+    },
+    reveal() {
+      document.body.classList.remove('is-thinking');
+      document.body.classList.add('has-result');
+      playReveal();
+    },
+    reset() {
+      completedFields = new WeakSet();
+      document.body.classList.remove('is-thinking', 'has-result');
+      document.body.dataset.mode = '';
+      document.body.dataset.progress = '0';
+      document.documentElement.style.setProperty('--journey', '0');
+      setPadTone(MODE_TONES.career);
+    }
+  };
+}

--- a/next-move-lab/index.html
+++ b/next-move-lab/index.html
@@ -17,14 +17,31 @@
   <a class="skip-link" href="#mainContent">Skip to Next Move Lab</a>
   <header class="lab-header">
     <a class="brand" href="../index.html" aria-label="3dvr portal home">3dvr</a>
-    <span class="lab-label">Next Move Lab</span>
+    <div class="header-tools">
+      <span class="lab-label">Next Move Lab</span>
+      <button class="sound-toggle" type="button" data-sound-toggle aria-pressed="false">
+        <span aria-hidden="true">♪</span>
+        <b>Sound off</b>
+      </button>
+    </div>
   </header>
 
   <main id="mainContent" class="lab-shell">
     <section class="hero" aria-labelledby="pageTitle">
-      <p class="eyebrow">Small experiment · no account required</p>
-      <h1 id="pageTitle">What feels stuck?</h1>
-      <p>Pick one topic. Answer three clear questions.</p>
+      <div class="hero-copy">
+        <p class="eyebrow">One small step</p>
+        <h1 id="pageTitle">What feels stuck?</h1>
+        <p>Pick one topic. Answer three clear questions.</p>
+      </div>
+      <div class="compass-scene" data-compass-scene aria-hidden="true">
+        <div class="star-field"></div>
+        <div class="compass-ring compass-ring--outer"></div>
+        <div class="compass-ring compass-ring--inner"></div>
+        <div class="compass-orb"><span></span></div>
+        <div class="journey-dots">
+          <i></i><i></i><i></i><i></i>
+        </div>
+      </div>
     </section>
 
     <section class="panel" data-form-view aria-labelledby="formTitle">
@@ -38,21 +55,17 @@
         <p class="step-note" data-step-note>Step 1 of 4</p>
         <fieldset class="mode-grid wizard-step" data-step="0">
           <legend>What is this about?</legend>
-          <label class="mode-card">
-            <input type="radio" name="mode" value="career" required>
+          <input type="hidden" name="mode" value="">
+          <button class="mode-card" type="button" data-mode-choice="career">
             <span><strong>My life or job</strong><small>A choice about life or work</small></span>
-          </label>
-          <label class="mode-card">
-            <input type="radio" name="mode" value="startup" required>
+          </button>
+          <button class="mode-card" type="button" data-mode-choice="startup">
             <span><strong>A business idea</strong><small>A customer, offer, or small test</small></span>
-          </label>
-          <label class="mode-card">
-            <input type="radio" name="mode" value="build" required>
+          </button>
+          <button class="mode-card" type="button" data-mode-choice="build">
             <span><strong>Something to build</strong><small>A site, product, or project</small></span>
-          </label>
+          </button>
         </fieldset>
-
-          <button class="button button--primary next-step" type="button" data-next>Next</button>
 
         <div class="detail-questions" data-detail-questions hidden>
           <div class="wizard-step" data-step="1">

--- a/next-move-lab/styles.css
+++ b/next-move-lab/styles.css
@@ -9,6 +9,9 @@
   --accent: #7ce5d7;
   --accent-dark: #071b1c;
   --focus: #f2c66d;
+  --journey: 0;
+  --scene-a: #7ce5d7;
+  --scene-b: #6995ff;
 }
 
 *,
@@ -33,10 +36,26 @@ body {
   margin: 0;
   overflow-x: hidden;
   background:
-    radial-gradient(circle at 12% 0%, rgba(33, 113, 113, 0.32), transparent 34rem),
-    radial-gradient(circle at 100% 55%, rgba(45, 74, 128, 0.22), transparent 40rem),
+    radial-gradient(circle at calc(12% + var(--journey) * 30%) 0%, color-mix(in srgb, var(--scene-a) 28%, transparent), transparent 34rem),
+    radial-gradient(circle at 100% 55%, color-mix(in srgb, var(--scene-b) 20%, transparent), transparent 40rem),
     var(--background);
   line-height: 1.55;
+  transition: background 1.2s ease;
+}
+
+body[data-mode="career"] {
+  --scene-a: #7ce5d7;
+  --scene-b: #6995ff;
+}
+
+body[data-mode="startup"] {
+  --scene-a: #f2c66d;
+  --scene-b: #f2768b;
+}
+
+body[data-mode="build"] {
+  --scene-a: #b79cff;
+  --scene-b: #6ee7ff;
 }
 
 a {
@@ -94,6 +113,12 @@ footer {
   padding-block: 1.25rem;
 }
 
+.header-tools {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
 .brand {
   color: var(--text);
   font-size: 1.35rem;
@@ -110,6 +135,42 @@ footer {
   text-transform: uppercase;
 }
 
+.sound-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(7, 16, 25, 0.68);
+  color: var(--muted);
+  font-size: 0.78rem;
+  cursor: pointer;
+  backdrop-filter: blur(12px);
+}
+
+.sound-toggle span {
+  display: grid;
+  width: 1.25rem;
+  height: 1.25rem;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(124, 229, 215, 0.12);
+  color: var(--accent);
+}
+
+.sound-toggle[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--scene-a) 65%, transparent);
+  color: var(--text);
+}
+
+.sound-toggle[aria-pressed="true"] span {
+  background: var(--scene-a);
+  color: var(--accent-dark);
+  animation: sound-pulse 1.8s ease-in-out infinite;
+}
+
 .lab-shell {
   display: grid;
   gap: 1rem;
@@ -117,6 +178,11 @@ footer {
 }
 
 .hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 250px);
+  gap: clamp(1rem, 5vw, 3rem);
+  align-items: center;
+  min-height: 330px;
   padding: clamp(1rem, 5vw, 2.25rem) 0 1.25rem;
 }
 
@@ -128,11 +194,191 @@ footer {
   letter-spacing: -0.065em;
 }
 
-.hero > p:last-child {
+.hero-copy > p:last-child {
   max-width: 62ch;
   margin: 0;
   color: var(--muted);
   font-size: clamp(1rem, 3vw, 1.18rem);
+}
+
+.compass-scene {
+  position: relative;
+  width: min(100%, 250px);
+  aspect-ratio: 1;
+  margin-inline: auto;
+  isolation: isolate;
+  filter: drop-shadow(0 1.75rem 3rem rgba(0, 0, 0, 0.3));
+}
+
+.compass-scene::before,
+.compass-scene::after {
+  position: absolute;
+  content: "";
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.compass-scene::before {
+  inset: 5%;
+  z-index: -2;
+  background:
+    radial-gradient(circle at 34% 28%, color-mix(in srgb, var(--scene-a) 48%, transparent), transparent 28%),
+    radial-gradient(circle at 68% 72%, color-mix(in srgb, var(--scene-b) 42%, transparent), transparent 34%),
+    radial-gradient(circle, rgba(16, 42, 57, 0.9), rgba(5, 12, 20, 0.2) 68%);
+  opacity: calc(0.58 + var(--journey) * 0.4);
+  filter: blur(5px);
+  animation: aura-breathe 5s ease-in-out infinite;
+}
+
+.compass-scene::after {
+  inset: 28%;
+  z-index: -1;
+  background: var(--scene-a);
+  opacity: calc(0.08 + var(--journey) * 0.16);
+  filter: blur(30px);
+  transition: opacity 0.8s ease, background 0.8s ease;
+}
+
+.star-field {
+  position: absolute;
+  inset: 8%;
+  border-radius: 50%;
+  background-image:
+    radial-gradient(circle at 18% 31%, rgba(255,255,255,.9) 0 1px, transparent 1.8px),
+    radial-gradient(circle at 77% 19%, rgba(255,255,255,.75) 0 1px, transparent 1.8px),
+    radial-gradient(circle at 83% 64%, rgba(255,255,255,.8) 0 1px, transparent 1.8px),
+    radial-gradient(circle at 29% 82%, rgba(255,255,255,.65) 0 1px, transparent 1.8px),
+    radial-gradient(circle at 54% 11%, var(--scene-a) 0 1.5px, transparent 2.2px),
+    radial-gradient(circle at 12% 62%, var(--scene-b) 0 1.5px, transparent 2.2px);
+  opacity: calc(0.24 + var(--journey) * 0.72);
+  transform: rotate(calc(var(--journey) * 14deg));
+  transition: opacity 0.8s ease, transform 1.2s ease;
+  animation: stars-turn 28s linear infinite;
+}
+
+.compass-ring {
+  position: absolute;
+  border: 1px solid color-mix(in srgb, var(--scene-a) 42%, transparent);
+  border-radius: 50%;
+  transition: border-color 0.8s ease, transform 1s ease;
+}
+
+.compass-ring::before,
+.compass-ring::after {
+  position: absolute;
+  content: "";
+  border-radius: 50%;
+  background: var(--scene-a);
+  box-shadow: 0 0 14px var(--scene-a);
+}
+
+.compass-ring--outer {
+  inset: 10%;
+  border-style: dashed;
+  opacity: 0.7;
+  animation: ring-turn 20s linear infinite;
+}
+
+.compass-ring--outer::before {
+  top: -3px;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+}
+
+.compass-ring--inner {
+  inset: 23%;
+  border-color: color-mix(in srgb, var(--scene-b) 48%, transparent);
+  animation: ring-turn-back 14s linear infinite;
+}
+
+.compass-ring--inner::after {
+  right: -3px;
+  top: 50%;
+  width: 5px;
+  height: 5px;
+  background: var(--scene-b);
+  box-shadow: 0 0 12px var(--scene-b);
+}
+
+.compass-orb {
+  position: absolute;
+  inset: 36%;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 38% 30%, rgba(255, 255, 255, 0.96), var(--scene-a) 12%, var(--scene-b) 45%, #0c1d2a 72%);
+  box-shadow:
+    0 0 25px color-mix(in srgb, var(--scene-a) 38%, transparent),
+    inset 0 0 16px rgba(255, 255, 255, 0.2);
+  transition: background 0.8s ease, transform 0.8s ease, box-shadow 0.8s ease;
+}
+
+.compass-orb span {
+  width: 2px;
+  height: 56%;
+  border-radius: 999px;
+  background: linear-gradient(to bottom, #fff 0 48%, rgba(255,255,255,.25) 48% 100%);
+  box-shadow: 0 0 8px #fff;
+  transform: rotate(calc(-32deg + var(--journey) * 116deg));
+  transition: transform 1.1s cubic-bezier(.2,.8,.2,1);
+}
+
+.journey-dots {
+  position: absolute;
+  right: 4%;
+  bottom: 10%;
+  display: flex;
+  gap: 0.35rem;
+}
+
+.journey-dots i {
+  width: 0.42rem;
+  height: 0.42rem;
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  border-radius: 50%;
+  background: rgba(7, 16, 25, 0.82);
+  transition: background 0.4s ease, box-shadow 0.4s ease, transform 0.4s ease;
+}
+
+body[data-progress="1"] .journey-dots i:nth-child(-n + 1),
+body[data-progress="2"] .journey-dots i:nth-child(-n + 2),
+body[data-progress="3"] .journey-dots i:nth-child(-n + 3),
+body[data-progress="4"] .journey-dots i:nth-child(-n + 4) {
+  border-color: var(--scene-a);
+  background: var(--scene-a);
+  box-shadow: 0 0 10px var(--scene-a);
+  transform: scale(1.2);
+}
+
+body.is-thinking .compass-ring--outer {
+  animation-duration: 3s;
+}
+
+body.is-thinking .compass-ring--inner {
+  animation-duration: 2s;
+}
+
+body.is-thinking .compass-orb {
+  transform: scale(1.12);
+  box-shadow: 0 0 42px color-mix(in srgb, var(--scene-a) 72%, transparent);
+  animation: orb-think 1.1s ease-in-out infinite;
+}
+
+body.has-result .compass-scene::before {
+  opacity: 1;
+  animation: reveal-aura 1.4s ease-out both, aura-breathe 5s 1.4s ease-in-out infinite;
+}
+
+body.has-result .compass-ring--outer {
+  border-color: color-mix(in srgb, var(--scene-a) 78%, transparent);
+}
+
+body.has-result .compass-orb {
+  transform: scale(1.18);
+  box-shadow: 0 0 48px color-mix(in srgb, var(--scene-a) 68%, transparent);
 }
 
 .eyebrow {
@@ -223,24 +469,28 @@ form {
 .mode-card {
   display: flex;
   align-items: flex-start;
+  width: 100%;
   gap: 0.8rem;
   min-width: 0;
   padding: 0.9rem;
   border: 1px solid var(--border);
   border-radius: 1rem;
   background: rgba(255, 255, 255, 0.025);
+  color: var(--text);
+  font: inherit;
+  text-align: left;
   cursor: pointer;
 }
 
-.mode-card:has(input:checked) {
+.mode-card[data-selected="true"] {
   border-color: var(--accent);
   background: rgba(124, 229, 215, 0.1);
 }
 
-.mode-card input {
-  flex: 0 0 auto;
-  margin-top: 0.3rem;
-  accent-color: var(--accent);
+.mode-card:hover,
+.mode-card:focus-visible {
+  border-color: var(--accent);
+  background: rgba(124, 229, 215, 0.1);
 }
 
 .mode-card span,

--- a/tests/next-move-lab.test.js
+++ b/tests/next-move-lab.test.js
@@ -87,6 +87,9 @@ test('Next Move Lab sends answers only to its isolated AI endpoint', async () =>
   const css = await readFile(new URL('../next-move-lab/styles.css', import.meta.url), 'utf8');
 
   assert.match(html, /Pick one topic\. Answer three clear questions\./);
+  assert.match(html, /data-mode-choice="career"/);
+  assert.match(html, /data-mode-choice="startup"/);
+  assert.match(html, /data-mode-choice="build"/);
   assert.match(html, /My life or job/);
   assert.match(html, /A business idea/);
   assert.match(html, /Something to build/);
@@ -94,6 +97,8 @@ test('Next Move Lab sends answers only to its isolated AI endpoint', async () =>
   assert.match(html, /See more ideas/);
   assert.match(app, /fetch\('\/api\/openai-site\?provider=next-move'/);
   assert.match(app, /getNextMoveQuestions/);
+  assert.match(app, /showStep\(1\)/);
+  assert.match(app, /form\.elements\.mode\.value = mode/);
   assert.doesNotMatch(app, /localStorage|sessionStorage|Gun\(/);
   assert.match(app, /textContent/);
   assert.match(css, /@media \(max-width: 360px\)/);


### PR DESCRIPTION
### What changed\n- Replace the first topic radio cards with clear tap buttons\n- Move to the first focused question immediately after a topic is chosen\n- Keep Back, progress, easy answer chips, optional typing, and the audiovisual layer\n\n### Checks\n- node --test tests/next-move-lab.test.js tests/still-becoming.test.js\n- node --check next-move-lab/app.js\n- git diff --check