### PR TITLE
Keep Daily Direction check-ins device-private

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ Keep this portal human-readable and maintainable. Favor clear intent over AI cha
 - Treat GunJS as the source of truth. Read and write through shared Gun nodes, not device-local storage.
 - When caching, always sync back to the originating Gun node and describe node shapes near the related code.
 - Use explicit node paths (e.g., `gun.get('namespace').get('resource')`) to keep data portable across sessions.
+- Sensitive guest life data may remain device-local until encrypted, owner-scoped sync is implemented and approved.
 
 ## Design & UX
 - Build mobile-first layouts that adapt gracefully to all screen sizes, including ultra-wide and VR displays.

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Automation data sync is available in the UI at `/money-ai/`, which writes each r
 - `gun.get('3dvr-portal').get('money-ai').get('runs')`
 - `gun.get('3dvr-portal').get('money-ai').get('opportunities')`
 - `gun.get('3dvr-portal').get('money-ai').get('ads')`
-- `gun.get('3dvr-portal').get('life').get('entries')`
+- Daily Direction check-ins remain in browser storage under `portal-life-checkins` until encrypted, owner-scoped sync is implemented.
 
 Legacy mirror writes also continue to `gun.get('money-ai')` for older clients.
 

--- a/docs/life-upgrade-privacy.md
+++ b/docs/life-upgrade-privacy.md
@@ -7,6 +7,13 @@ Draft text uses `portal-life-draft`. The life page does not write check-ins to G
 not subscribe to a shared life collection. It remains usable when Gun, a relay, or an account
 is unavailable.
 
+On first visit after this privacy change, a local migration sanitizes the old check-in cache
+before anything is rendered. It retains only legacy records whose non-empty `author` exactly
+matches the existing local `guestId` (or the legacy `userId` fallback), removes records whose
+ownership cannot be proven, and records a versioned migration marker. Later visits continue to
+reject records with a different non-empty author while preserving new device-local records that
+do not need an author field. Drafts in `portal-life-draft` are not part of this migration.
+
 This is device-only storage, not encrypted sync. A check-in saved in one browser or device is
 not available on another device.
 
@@ -33,6 +40,7 @@ the device.
 ## Separate relay audit
 
 Any records synchronized by an earlier version require a separate relay audit and an intentional
-cleanup or migration plan. Browser code for Daily Direction must not attempt relay cleanup. The
-audit should identify historical paths, retention, backups, replicas, and deletion guarantees
-before a future privacy release is approved.
+cleanup or migration plan. The local cache sanitation above does not delete or modify historical
+relay records. Browser code for Daily Direction must not attempt relay cleanup. The audit should
+identify historical paths, retention, backups, replicas, and deletion guarantees before a future
+privacy release is approved.

--- a/docs/life-upgrade-privacy.md
+++ b/docs/life-upgrade-privacy.md
@@ -1,0 +1,38 @@
+# Daily Direction and Life Upgrade privacy
+
+## Current behavior
+
+Daily Direction stores check-ins in the browser's local storage key `portal-life-checkins`.
+Draft text uses `portal-life-draft`. The life page does not write check-ins to Gun and does
+not subscribe to a shared life collection. It remains usable when Gun, a relay, or an account
+is unavailable.
+
+This is device-only storage, not encrypted sync. A check-in saved in one browser or device is
+not available on another device.
+
+## Browser-storage limitations
+
+Browser storage can be cleared by the user, browser settings, private browsing behavior, site
+data cleanup, or a browser profile reset. Anyone with access to the unlocked device and browser
+profile may be able to inspect it. The current page does not promise recovery, encryption, or
+cross-device availability.
+
+## Explicit sync requirement
+
+Future sync requires an explicit product decision and an approved design for encryption,
+owner-scoped authorization, key recovery, deletion, and relay behavior. A signed-in account or
+an author field alone is not sufficient privacy.
+
+## Shared-node prohibition
+
+Never store plaintext moods, constraints, life notes, outcomes, evidence, or reviews in a shared
+global Gun node. Do not treat an obscure node path, random identifier, or hidden author field as
+an access control boundary. Until encrypted owner-scoped sync exists, guest life data stays on
+the device.
+
+## Separate relay audit
+
+Any records synchronized by an earlier version require a separate relay audit and an intentional
+cleanup or migration plan. Browser code for Daily Direction must not attempt relay cleanup. The
+audit should identify historical paths, retention, backups, replicas, and deletion guarantees
+before a future privacy release is approved.

--- a/life/app.js
+++ b/life/app.js
@@ -1,3 +1,5 @@
+import { migrateLegacyCheckins } from './privacy-migration.js';
+
 const STORAGE_KEY = 'portal-life-checkins';
 const DRAFT_KEY = 'portal-life-draft';
 
@@ -107,8 +109,9 @@ function setValue(id, value) {
 }
 
 function loadStoredEntries() {
-  const parsed = parseJson(window.localStorage.getItem(STORAGE_KEY), []);
-  return Array.isArray(parsed) ? parsed.map((entry) => normalizeEntry(entry)) : [];
+  const migration = migrateLegacyCheckins(window.localStorage);
+  migrationNotice = migration.removedCount > 0;
+  return migration.entries.map((entry) => normalizeEntry(entry));
 }
 
 function saveStoredEntries(entries) {
@@ -329,9 +332,16 @@ function initializeEntries() {
   for (const entry of loadStoredEntries()) {
     entriesById.set(entry.id, entry);
   }
+  if (migrationNotice) {
+    const status = document.getElementById('saveStatus');
+    if (status) {
+      status.textContent = 'Older synced check-ins were removed from this browser for privacy.';
+    }
+  }
   render();
 }
 const entriesById = new Map();
+let migrationNotice = false;
 
 const form = document.getElementById('lifeForm');
 const saveStatus = document.getElementById('saveStatus');

--- a/life/app.js
+++ b/life/app.js
@@ -9,77 +9,6 @@ const defaultCategories = Object.freeze({
   mission: 3
 });
 
-function createLocalGunNodeStub() {
-  const node = {
-    __isGunStub: true,
-    get() {
-      return createLocalGunNodeStub();
-    },
-    put(_value, callback) {
-      if (typeof callback === 'function') {
-        setTimeout(() => callback({ err: 'gun-unavailable' }), 0);
-      }
-      return node;
-    },
-    map() {
-      return {
-        on() {
-          return { off() {} };
-        }
-      };
-    }
-  };
-
-  return node;
-}
-
-function createLocalGunUserStub() {
-  return {
-    is: null
-  };
-}
-
-function ensureGunContext(factory, label) {
-  const ensureGun = window.ScoreSystem && typeof window.ScoreSystem.ensureGun === 'function'
-    ? window.ScoreSystem.ensureGun.bind(window.ScoreSystem)
-    : null;
-
-  if (ensureGun) {
-    return ensureGun(factory, { label });
-  }
-
-  if (typeof factory === 'function') {
-    try {
-      const instance = factory();
-      if (instance) {
-        return {
-          gun: instance,
-          user: typeof instance.user === 'function' ? instance.user() : createLocalGunUserStub(),
-          isStub: Boolean(instance.__isGunStub)
-        };
-      }
-    } catch (error) {
-      console.warn('Life could not start Gun. Saving on this device.', error);
-    }
-  }
-
-  const gun = {
-    __isGunStub: true,
-    get() {
-      return createLocalGunNodeStub();
-    },
-    user() {
-      return createLocalGunUserStub();
-    }
-  };
-
-  return {
-    gun,
-    user: gun.user(),
-    isStub: true
-  };
-}
-
 function clampMood(value) {
   const number = Number(value);
   if (!Number.isFinite(number)) {
@@ -290,7 +219,7 @@ function updateResponseLoop(entry) {
   }
 
   const step = getEntryStep(entry);
-  const textLink = document.getElementById('textThomasLink');
+  const textLink = document.getElementById('shareTrustedLink');
   if (textLink) {
     textLink.href = `sms:?&body=${encodeURIComponent(buildStepMessage(step))}`;
   }
@@ -324,49 +253,12 @@ function render() {
   renderEntryList(entries);
 }
 
-function mergeEntry(entry, id) {
-  const normalized = normalizeEntry({ ...entry, id }, id);
-  entriesById.set(normalized.id, normalized);
-  saveStoredEntries(getAllEntries());
-  render();
-}
-
 function writeEntry(entry) {
   const id = entry.id || makeId();
   const normalized = normalizeEntry({ ...entry, id }, id);
   entriesById.set(normalized.id, normalized);
   saveStoredEntries(getAllEntries());
   render();
-
-  if (entriesRoot && typeof entriesRoot.get === 'function') {
-    entriesRoot.get(normalized.id).put(normalized, (ack) => {
-      const status = document.getElementById('saveStatus');
-      if (!status) {
-        return;
-      }
-
-      status.textContent = ack && ack.err
-        ? 'Saved on this phone.'
-        : 'Saved.';
-    });
-  }
-}
-
-function loadEntriesFromGun() {
-  if (!entriesRoot || typeof entriesRoot.map !== 'function') {
-    return;
-  }
-
-  const mapped = entriesRoot.map();
-  if (!mapped || typeof mapped.on !== 'function') {
-    return;
-  }
-
-  mapped.on((entry, id) => {
-    if (entry && id) {
-      mergeEntry(entry, id);
-    }
-  });
 }
 
 function syncMoodOutput() {
@@ -438,38 +330,14 @@ function initializeEntries() {
     entriesById.set(entry.id, entry);
   }
   render();
-  loadEntriesFromGun();
 }
-
-const gunContext = ensureGunContext(
-  () => (typeof Gun === 'function'
-    ? Gun({
-      peers: window.__GUN_PEERS__ || [
-        'wss://relay.3dvr.tech/gun',
-        'wss://gun-relay-3dvr.fly.dev/gun'
-      ],
-      axe: true
-    })
-    : null),
-  'life'
-);
-
-const gun = gunContext.gun;
-const user = gunContext.user;
-const portalRoot = gun && typeof gun.get === 'function'
-  ? gun.get('3dvr-portal')
-  : createLocalGunNodeStub();
-const lifeRoot = portalRoot.get('life');
-const entriesRoot = lifeRoot.get('entries');
 const entriesById = new Map();
 
 const form = document.getElementById('lifeForm');
 const saveStatus = document.getElementById('saveStatus');
 
 if (saveStatus) {
-  saveStatus.textContent = gunContext.isStub
-    ? 'Saves on this phone.'
-    : 'Ready.';
+  saveStatus.textContent = 'Your check-ins stay private on this device.';
 }
 
 initializeForm();
@@ -481,10 +349,7 @@ form?.addEventListener('submit', (event) => {
   const draft = getFormDraft();
   const entry = normalizeEntry({
     ...draft,
-    createdAt: new Date().toISOString(),
-    author: window.ScoreSystem && typeof window.ScoreSystem.ensureGuestIdentity === 'function'
-      ? window.ScoreSystem.ensureGuestIdentity()
-      : (user && user.is && user.is.pub) || ''
+    createdAt: new Date().toISOString()
   });
 
   writeEntry(entry);
@@ -492,7 +357,7 @@ form?.addEventListener('submit', (event) => {
   applyDraft({ date: toDateInputValue(), mood: entry.mood });
 
   if (saveStatus) {
-    saveStatus.textContent = 'Saved. Do one small step.';
+    saveStatus.textContent = 'Saved privately on this device. Do one small step.';
   }
 });
 

--- a/life/index.html
+++ b/life/index.html
@@ -538,6 +538,6 @@
     <p class="footer-note">Saved privately on this device. Encrypted sync can come later.</p>
   </main>
 
-  <script src="./app.js?v=20260630-daily-direction"></script>
+  <script type="module" src="./app.js?v=20260630-daily-direction"></script>
 </body>
 </html>

--- a/life/index.html
+++ b/life/index.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Daily Direction | 3dvr Portal</title>
-  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
-  <script src="../gun-init.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
-  <script src="../score.js"></script>
   <style>
     :root {
       --bg: #07131d;
@@ -519,7 +515,7 @@
               <strong>Your next step is saved.</strong>
               <p>Want to do anything else?</p>
               <div class="response-loop__actions">
-                <a class="button" id="textThomasLink" href="sms:?&body=I%20tried%20Daily%20Direction.%20My%20next%20step%20is%3A%20">Text this to Thomas</a>
+                <a class="button" id="shareTrustedLink" href="sms:?&body=I%20tried%20Daily%20Direction.%20My%20next%20step%20is%3A%20">Share with someone I trust</a>
                 <button class="button" type="button" id="copyStepButton">Copy my next step</button>
                 <button class="button" type="button" id="copyFreeLinkButton">Save my free link</button>
                 <a class="button" href="../friends-family/">See support options</a>
@@ -539,7 +535,7 @@
       </aside>
     </section>
 
-    <p class="footer-note">Saves here. Can sync later.</p>
+    <p class="footer-note">Saved privately on this device. Encrypted sync can come later.</p>
   </main>
 
   <script src="./app.js?v=20260630-daily-direction"></script>

--- a/life/privacy-migration.js
+++ b/life/privacy-migration.js
@@ -1,0 +1,72 @@
+export const LIFE_CHECKINS_MIGRATION_KEY = 'portal-life-checkins-migration';
+export const LIFE_CHECKINS_MIGRATION_VERSION = 'v1';
+
+function text(value) {
+  return String(value ?? '').trim();
+}
+
+export function getLegacyLocalIdentity(storage) {
+  return text(storage.getItem('guestId')) || text(storage.getItem('userId'));
+}
+
+export function filterPrivateCheckins(entries, identity, migrationComplete) {
+  const source = Array.isArray(entries) ? entries : [];
+  const currentIdentity = text(identity);
+
+  if (!migrationComplete) {
+    const retained = currentIdentity
+      ? source.filter((entry) => text(entry?.author) === currentIdentity)
+      : [];
+
+    return {
+      entries: retained,
+      removedCount: source.length - retained.length,
+      migrated: true
+    };
+  }
+
+  const retained = source.filter((entry) => {
+    const author = text(entry?.author);
+    return !author || author === currentIdentity;
+  });
+
+  return {
+    entries: retained,
+    removedCount: source.length - retained.length,
+    migrated: false
+  };
+}
+
+export function migrateLegacyCheckins(storage) {
+  const source = parseStoredEntries(storage.getItem('portal-life-checkins'));
+  const migrationComplete = storage.getItem(LIFE_CHECKINS_MIGRATION_KEY)
+    === LIFE_CHECKINS_MIGRATION_VERSION;
+  const result = filterPrivateCheckins(
+    source,
+    getLegacyLocalIdentity(storage),
+    migrationComplete
+  );
+
+  if (result.migrated || result.removedCount > 0) {
+    storage.setItem('portal-life-checkins', JSON.stringify(result.entries));
+  }
+
+  if (result.migrated) {
+    storage.setItem(LIFE_CHECKINS_MIGRATION_KEY, LIFE_CHECKINS_MIGRATION_VERSION);
+  }
+
+  return result;
+}
+
+function parseStoredEntries(value) {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}

--- a/tests/life.test.js
+++ b/tests/life.test.js
@@ -1,6 +1,26 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import { migrateLegacyCheckins } from '../life/privacy-migration.js';
+
+function makeStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    snapshot(key) {
+      return values.get(key);
+    }
+  };
+}
+
+function storedEntries(entries) {
+  return JSON.stringify(entries);
+}
 
 describe('life app', () => {
   it('ships a private-by-default Daily Direction app with device-local check-ins', async () => {
@@ -69,5 +89,75 @@ describe('life app', () => {
 
     assert.match(readme, /\[Life\]\(https:\/\/3dvr-portal\.vercel\.app\/life\/\)/);
     assert.match(readme, /browser storage under `portal-life-checkins`/);
+  });
+
+  it('retains only matching legacy authors during the first migration', () => {
+    const storage = makeStorage({
+      userId: 'guest-local',
+      'portal-life-checkins': storedEntries([
+        { id: 'mine', author: 'guest-local', trueTask: 'Keep mine' },
+        { id: 'other', author: 'guest-other', trueTask: 'Remove theirs' },
+        { id: 'unknown', trueTask: 'Remove unknown' }
+      ]),
+      'portal-life-draft': '{"today":"Keep this draft"}'
+    });
+
+    const result = migrateLegacyCheckins(storage);
+
+    assert.deepEqual(result.entries.map((entry) => entry.id), ['mine']);
+    assert.equal(result.removedCount, 2);
+    assert.equal(storage.snapshot('portal-life-checkins'), storedEntries([
+      { id: 'mine', author: 'guest-local', trueTask: 'Keep mine' }
+    ]));
+    assert.equal(storage.snapshot('portal-life-checkins-migration'), 'v1');
+    assert.equal(storage.snapshot('portal-life-draft'), '{"today":"Keep this draft"}');
+  });
+
+  it('removes all legacy entries when no local identity can be recovered', () => {
+    const storage = makeStorage({
+      'portal-life-checkins': storedEntries([
+        { id: 'authored', author: 'guest-other' },
+        { id: 'unattributed' }
+      ])
+    });
+
+    const result = migrateLegacyCheckins(storage);
+
+    assert.deepEqual(result.entries, []);
+    assert.equal(result.removedCount, 2);
+    assert.equal(storage.snapshot('portal-life-checkins'), '[]');
+  });
+
+  it('preserves new device-local entries after migration and filters later mismatches', () => {
+    const storage = makeStorage({
+      guestId: 'guest-local',
+      'portal-life-checkins': storedEntries([
+        { id: 'local', trueTask: 'Keep local' },
+        { id: 'wrong', author: 'guest-other', trueTask: 'Remove wrong owner' }
+      ])
+    });
+
+    const first = migrateLegacyCheckins(storage);
+    assert.deepEqual(first.entries.map((entry) => entry.id), []);
+
+    const postMigration = JSON.parse(storage.snapshot('portal-life-checkins'));
+    postMigration.push({ id: 'new-local', trueTask: 'Keep after migration' });
+    storage.setItem('portal-life-checkins', JSON.stringify(postMigration));
+
+    const second = migrateLegacyCheckins(storage);
+    assert.deepEqual(second.entries.map((entry) => entry.id), ['new-local']);
+    assert.equal(second.migrated, false);
+  });
+
+  it('runs migration before rendering and keeps the privacy boundaries in place', async () => {
+    const app = await readFile(new URL('../life/app.js', import.meta.url), 'utf8');
+    const migrationCall = app.indexOf('migrateLegacyCheckins(window.localStorage)');
+    const renderCall = app.indexOf('render();', migrationCall);
+
+    assert.ok(migrationCall >= 0);
+    assert.ok(renderCall > migrationCall);
+    assert.doesNotMatch(app, /Gun\s*\(|fetch\s*\(|XMLHttpRequest|WebSocket|sendBeacon/);
+    assert.doesNotMatch(app, /3dvr-portal.*life|life.*entries|\.map\(\)\.on\(/);
+    assert.doesNotMatch(await readFile(new URL('../life/index.html', import.meta.url), 'utf8'), /gun(\.min)?\.js|gun-init\.js|sea\.js|score\.js/);
   });
 });

--- a/tests/life.test.js
+++ b/tests/life.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 describe('life app', () => {
-  it('ships a simple Daily Direction app with Gun-backed check-ins', async () => {
+  it('ships a private-by-default Daily Direction app with device-local check-ins', async () => {
     const lifeHtml = await readFile(new URL('../life/index.html', import.meta.url), 'utf8');
     const lifeJs = await readFile(new URL('../life/app.js', import.meta.url), 'utf8');
     const portalIndex = await readFile(new URL('../index.html', import.meta.url), 'utf8');
@@ -21,31 +21,39 @@ describe('life app', () => {
     assert.match(lifeHtml, /data-step="Drink water\."/);
     assert.match(lifeHtml, /Do this next/);
     assert.match(lifeHtml, /Your next step is saved\./);
-    assert.match(lifeHtml, /Text this to Thomas/);
+    assert.match(lifeHtml, /Share with someone I trust/);
+    assert.match(lifeHtml, /href="sms:\?&body=/);
+    assert.doesNotMatch(lifeHtml, /Thomas/);
+    assert.doesNotMatch(lifeHtml, /gun(\.min)?\.js|gun-init\.js|sea\.js|score\.js/);
     assert.match(lifeHtml, /Copy my next step/);
     assert.match(lifeHtml, /Save my free link/);
     assert.match(lifeHtml, /See support options/);
     assert.match(lifeHtml, /Last notes/);
-    assert.match(lifeHtml, /Saves here\. Can sync later\./);
+    assert.match(lifeHtml, /Saved privately on this device/);
     assert.doesNotMatch(lifeHtml, /Life OS/);
     assert.doesNotMatch(lifeHtml, /What am I avoiding\?/);
     assert.doesNotMatch(lifeHtml, /Weekly reflection/);
     assert.doesNotMatch(lifeHtml, /Category balance/);
 
-    assert.match(lifeJs, /get\('3dvr-portal'\)/);
-    assert.match(lifeJs, /get\('life'\)/);
-    assert.match(lifeJs, /get\('entries'\)/);
-    assert.match(lifeJs, /ensureGuestIdentity/);
     assert.match(lifeJs, /portal-life-checkins/);
+    assert.doesNotMatch(lifeJs, /get\(['"]3dvr-portal['"]\)/);
+    assert.doesNotMatch(lifeJs, /get\(['"]life['"]\)/);
+    assert.doesNotMatch(lifeJs, /get\(['"]entries['"]\)/);
+    assert.doesNotMatch(lifeJs, /entriesRoot/);
+    assert.doesNotMatch(lifeJs, /\.map\(\)\s*\.on\(/);
+    assert.doesNotMatch(lifeJs, /Gun\s*\(/);
+    assert.match(lifeJs, /escapeHtml\(getEntryStep\(entry\)\)/);
+    assert.match(lifeJs, /escapeHtml\(getEntryNeed\(entry\)\)/);
     assert.match(lifeJs, /alignment/);
     assert.match(lifeJs, /avoidance/);
     assert.match(lifeJs, /trueTask/);
     assert.match(lifeJs, /vision/);
     assert.match(lifeJs, /mission/);
     assert.match(lifeJs, /value\.projects/);
-    assert.match(lifeJs, /Saved\. Do one small step\./);
+    assert.match(lifeJs, /Saved privately on this device\. Do one small step\./);
     assert.match(lifeJs, /function buildStepMessage/);
     assert.match(lifeJs, /I tried Daily Direction\. My next step is:/);
+    assert.match(lifeJs, /shareTrustedLink/);
     assert.match(lifeJs, /function updateResponseLoop/);
     assert.match(lifeJs, /copyStepButton/);
     assert.match(lifeJs, /copyFreeLinkButton/);
@@ -60,6 +68,6 @@ describe('life app', () => {
     assert.match(freeTrial, /href="\/life\/index\.html"/);
 
     assert.match(readme, /\[Life\]\(https:\/\/3dvr-portal\.vercel\.app\/life\/\)/);
-    assert.match(readme, /gun\.get\('3dvr-portal'\)\.get\('life'\)\.get\('entries'\)/);
+    assert.match(readme, /browser storage under `portal-life-checkins`/);
   });
 });


### PR DESCRIPTION
## Summary

- removes Gun, SEA, and shared-node synchronization from Daily Direction
- keeps new Daily Direction check-ins and drafts in browser storage
- sanitizes the legacy browser cache before any check-in is rendered
- replaces the Thomas-specific SMS action with generic trusted-person sharing
- documents browser-storage limitations and requirements for future encrypted sync
- adds regression coverage preventing the shared life/entries path from returning

## Privacy impact

Daily Direction no longer writes personal moods, needs, or next steps to the shared 3dvr-portal/life/entries Gun node.

A versioned one-time browser migration handles records cached by the previous global subscription:

- it reads guestId, falling back to legacy userId
- it retains only legacy records with an exact non-empty matching author
- it removes mismatched and unattributed legacy records
- it removes all legacy records when no local identity can be recovered
- it performs this migration before rendering
- it preserves portal-life-draft
- after migration, new authorless device-local check-ins remain available
- later loads continue rejecting records with a mismatched non-empty author

Some older cached portal-life-checkins records may therefore be removed intentionally. Removed content is not displayed or reported.

Browser storage is not encrypted and may be accessible to someone using the same unlocked browser profile.

Previously synchronized relay records require a separate operator audit and are not modified by this PR.

## Validation

- node --check life/app.js
- node --check life/privacy-migration.js
- node --test tests/life.test.js — 5 tests
- git diff --check origin/main...HEAD
- Vercel Dev Preview — passed
- Playwright Checks — passed
- forbidden Gun, SEA, shared-node, and global-subscription grep returned no matches

## Not included

- encrypted cross-device sync
- authentication changes
- remote relay cleanup
- Life Upgrade v0.1
- production deployment