### PR TITLE
Make Life Upgrade easier to follow

### DIFF
--- a/life-upgrade/app.js
+++ b/life-upgrade/app.js
@@ -51,8 +51,15 @@ function render() {
   const stage = getStage(plan);
   root.querySelector('[data-stage-label]').textContent = stage.label;
   root.querySelector('[data-stage-prompt]').textContent = stage.prompt;
+  root.querySelector('[data-stage-support]').textContent = stage.support;
   root.querySelector('[data-stage-count]').textContent = `${STAGES.findIndex((item) => item.id === stage.id) + 1} of ${STAGES.length}`;
   root.querySelector('[data-progress]').style.width = `${((STAGES.findIndex((item) => item.id === stage.id) + 1) / STAGES.length) * 100}%`;
+  const completedActions = plan.actions.filter((action) => action.completed).length;
+  root.querySelector('[data-momentum]').textContent = completedActions
+    ? `${completedActions} of 3 real-world moves complete. Keep the next one small.`
+    : hasUsefulResult(plan)
+      ? 'Your result has a shape. Now give it one real-world move.'
+      : 'One useful move starts here.';
 
   root.querySelectorAll('[data-stage]').forEach((button) => {
     const selected = button.dataset.stage === stage.id;

--- a/life-upgrade/app.js
+++ b/life-upgrade/app.js
@@ -56,10 +56,10 @@ function render() {
   root.querySelector('[data-progress]').style.width = `${((STAGES.findIndex((item) => item.id === stage.id) + 1) / STAGES.length) * 100}%`;
   const completedActions = plan.actions.filter((action) => action.completed).length;
   root.querySelector('[data-momentum]').textContent = completedActions
-    ? `${completedActions} of 3 real-world moves complete. Keep the next one small.`
+    ? `⭐ ${completedActions} of 3 tiny wins done. Keep going!`
     : hasUsefulResult(plan)
-      ? 'Your result has a shape. Now give it one real-world move.'
-      : 'One useful move starts here.';
+      ? 'You picked your win. Now take one small step.'
+      : '🎮 Your first tiny win starts here.';
 
   root.querySelectorAll('[data-stage]').forEach((button) => {
     const selected = button.dataset.stage === stage.id;
@@ -80,7 +80,7 @@ function render() {
   });
   root.querySelector('#summary').textContent = hasUsefulResult(plan)
     ? `${plan.upgrade}: ${plan.result}`
-    : 'Your seven-day result will appear here.';
+    : 'Your 7-day win will show up here.';
 }
 
 function handleField(event) {

--- a/life-upgrade/app.js
+++ b/life-upgrade/app.js
@@ -54,6 +54,10 @@ function render() {
   root.querySelector('[data-stage-support]').textContent = stage.support;
   root.querySelector('[data-stage-count]').textContent = `${STAGES.findIndex((item) => item.id === stage.id) + 1} of ${STAGES.length}`;
   root.querySelector('[data-progress]').style.width = `${((STAGES.findIndex((item) => item.id === stage.id) + 1) / STAGES.length) * 100}%`;
+  root.querySelectorAll('[data-stage-field]').forEach((field) => {
+    const visible = field.dataset.stageField.split(' ').includes(stage.id);
+    field.hidden = !visible;
+  });
   const completedActions = plan.actions.filter((action) => action.completed).length;
   root.querySelector('[data-momentum]').textContent = completedActions
     ? `⭐ ${completedActions} of 3 tiny wins done. Keep going!`

--- a/life-upgrade/index.html
+++ b/life-upgrade/index.html
@@ -28,11 +28,11 @@
       </section>
 
       <section class="workspace" aria-label="Life Upgrade workspace">
-        <nav class="map card" aria-label="Flexible eight-stage map">
-          <div class="map-heading"><span>Your 7-day game</span><span data-stage-count>1 of 8</span></div>
+        <details class="map card">
+          <summary class="map-heading"><span>Your 7-day game</span><span data-stage-count>1 of 8</span></summary>
           <div class="progress"><span data-progress></span></div>
           <p class="momentum" data-momentum>🎮 Your first tiny win starts here.</p>
-          <div class="stage-list">
+          <nav class="stage-list" aria-label="Choose a step">
             <button type="button" data-stage="check-in">1. Notice</button>
             <button type="button" data-stage="choose">2. Pick one</button>
             <button type="button" data-stage="result">3. Name your win</button>
@@ -41,9 +41,9 @@
             <button type="button" data-stage="evidence">6. Spot the change</button>
             <button type="button" data-stage="review">7. Look back</button>
             <button type="button" data-stage="next">8. Pick your next step</button>
-          </div>
+          </nav>
           <p class="map-footnote">Jump around when life calls for it. The map is a guide, not a test.</p>
-        </nav>
+        </details>
 
         <section class="card work-card" aria-labelledby="stage-title">
           <div class="card-heading">
@@ -53,28 +53,28 @@
           </div>
 
           <div class="fields">
-            <label>What is on your mind?
+            <label data-stage-field="check-in">What is on your mind?
               <textarea id="checkIn" name="checkIn" rows="3" placeholder="A problem, hope, job, room, or person."></textarea>
             </label>
-            <label>Pick one thing
+            <label data-stage-field="choose">Pick one thing
               <input id="upgrade" name="upgrade" placeholder="My room, sleep, money, or work..." />
             </label>
-            <label>Your win in 7 days
+            <label data-stage-field="result">Your win in 7 days
               <textarea id="result" name="result" rows="3" placeholder="I will see, use, or share..." ></textarea>
             </label>
-            <fieldset>
+            <fieldset data-stage-field="plan complete">
               <legend>Three tiny steps</legend>
             <label class="action-row"><span class="sr-only">Tiny step one</span><input data-action-index="0" placeholder="1. The easiest step" /><span><input type="checkbox" data-action-complete="0" /> Done!</span></label>
             <label class="action-row"><span class="sr-only">Tiny step two</span><input data-action-index="1" placeholder="2. One more small step" /><span><input type="checkbox" data-action-complete="1" /> Done!</span></label>
             <label class="action-row"><span class="sr-only">Tiny step three</span><input data-action-index="2" placeholder="3. The last small step" /><span><input type="checkbox" data-action-complete="2" /> Done!</span></label>
           </fieldset>
-            <label>What changed?
+            <label data-stage-field="evidence">What changed?
               <textarea id="evidence" name="evidence" rows="3" placeholder="A photo, link, sent note, finished thing, or what you saw."></textarea>
             </label>
-            <label>What did you learn?
+            <label data-stage-field="review">What did you learn?
               <textarea id="review" name="review" rows="3" placeholder="What worked? What got in the way?"></textarea>
             </label>
-            <label>Your next step
+            <label data-stage-field="next">Your next step
               <input id="nextMove" name="nextMove" placeholder="Keep going, change it, or pick a new thing." />
             </label>
           </div>

--- a/life-upgrade/index.html
+++ b/life-upgrade/index.html
@@ -15,9 +15,14 @@
       </header>
 
       <section class="intro" aria-labelledby="page-title">
-        <p class="eyebrow">Life Upgrade · v0.1</p>
-        <h1 id="page-title">Make one useful thing real this week.</h1>
-        <p class="lead">The seven-day upgrade cycle helps you check in, choose one upgrade, plan three actions, complete one, and learn from what happened.</p>
+        <p class="eyebrow">A small act of agency · Life Upgrade v0.1</p>
+        <h1 id="page-title">Give this week a shape you can feel.</h1>
+        <p class="lead">You do not need to fix everything. Find one honest starting point and make one useful thing real.</p>
+        <div class="promise" aria-label="The three promises of this cycle">
+          <span><strong>01</strong> Notice what matters</span>
+          <span><strong>02</strong> Make one move</span>
+          <span><strong>03</strong> Keep the proof</span>
+        </div>
         <p class="map-footnote">This is a flexible seven-day cycle, not a replacement for the longer Stabilize → Understand → Choose → Practice → Help → Earn → Build → Teach growth map.</p>
         <p class="privacy-note"><span aria-hidden="true">🔒</span> Private by default. This guest plan stays on this device.</p>
       </section>
@@ -26,6 +31,7 @@
         <nav class="map card" aria-label="Flexible eight-stage map">
           <div class="map-heading"><span>Seven-day upgrade cycle</span><span data-stage-count>1 of 8</span></div>
           <div class="progress"><span data-progress></span></div>
+          <p class="momentum" data-momentum>One useful move starts here.</p>
           <div class="stage-list">
             <button type="button" data-stage="check-in">1. Check in</button>
             <button type="button" data-stage="choose">2. Choose one</button>
@@ -43,6 +49,7 @@
           <div class="card-heading">
             <p class="eyebrow" data-stage-label>Check in</p>
             <h2 id="stage-title" data-stage-prompt>What would make this week feel useful?</h2>
+            <p class="stage-support" data-stage-support>Start with what is true. You do not have to make it sound tidy.</p>
           </div>
 
           <div class="fields">
@@ -73,7 +80,7 @@
           </div>
 
           <div class="actions">
-            <button class="primary" type="button" id="nextStage">Save and move to the next stage</button>
+            <button class="primary" type="button" id="nextStage">Keep this and take the next step</button>
             <button class="secondary" type="button" id="resetPlan">Start over</button>
           </div>
           <p class="status" id="saveStatus" role="status" aria-live="polite">Checking private browser storage…</p>
@@ -81,7 +88,7 @@
       </section>
 
       <aside class="summary card" aria-labelledby="summary-title">
-        <p class="eyebrow">Current upgrade</p>
+        <p class="eyebrow">Your reason to keep going</p>
         <h2 id="summary-title">Keep the result in view</h2>
         <p id="summary">Your seven-day result will appear here.</p>
       </aside>

--- a/life-upgrade/index.html
+++ b/life-upgrade/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Turn one area of life into one completed useful result within seven days." />
+    <meta name="description" content="Pick one small thing, make it better in seven days, and keep your tiny win." />
     <title>Life Upgrade | 3dvr Portal</title>
     <link rel="stylesheet" href="./styles.css" />
   </head>
@@ -15,82 +15,82 @@
       </header>
 
       <section class="intro" aria-labelledby="page-title">
-        <p class="eyebrow">A small act of agency · Life Upgrade v0.1</p>
-        <h1 id="page-title">Give this week a shape you can feel.</h1>
-        <p class="lead">You do not need to fix everything. Find one honest starting point and make one useful thing real.</p>
-        <div class="promise" aria-label="The three promises of this cycle">
-          <span><strong>01</strong> Notice what matters</span>
-          <span><strong>02</strong> Make one move</span>
-          <span><strong>03</strong> Keep the proof</span>
+        <p class="eyebrow">Your 7-day game · Life Upgrade</p>
+        <h1 id="page-title">Make one good thing happen this week.</h1>
+        <p class="lead">Pick one small thing. Do it. See what changed.</p>
+        <div class="promise" aria-label="The three steps of this game">
+          <span><strong aria-hidden="true">👀</strong> See what matters</span>
+          <span><strong aria-hidden="true">👟</strong> Take one step</span>
+          <span><strong aria-hidden="true">⭐</strong> Keep your win</span>
         </div>
-        <p class="map-footnote">This is a flexible seven-day cycle, not a replacement for the longer Stabilize → Understand → Choose → Practice → Help → Earn → Build → Teach growth map.</p>
+        <p class="map-footnote">This is a flexible seven-day upgrade cycle, not a replacement for the longer Stabilize → Understand → Choose → Practice → Help → Earn → Build → Teach growth map.</p>
         <p class="privacy-note"><span aria-hidden="true">🔒</span> Private by default. This guest plan stays on this device.</p>
       </section>
 
       <section class="workspace" aria-label="Life Upgrade workspace">
         <nav class="map card" aria-label="Flexible eight-stage map">
-          <div class="map-heading"><span>Seven-day upgrade cycle</span><span data-stage-count>1 of 8</span></div>
+          <div class="map-heading"><span>Your 7-day game</span><span data-stage-count>1 of 8</span></div>
           <div class="progress"><span data-progress></span></div>
-          <p class="momentum" data-momentum>One useful move starts here.</p>
+          <p class="momentum" data-momentum>🎮 Your first tiny win starts here.</p>
           <div class="stage-list">
-            <button type="button" data-stage="check-in">1. Check in</button>
-            <button type="button" data-stage="choose">2. Choose one</button>
-            <button type="button" data-stage="result">3. Name the result</button>
-            <button type="button" data-stage="plan">4. Plan three</button>
-            <button type="button" data-stage="complete">5. Complete one</button>
-            <button type="button" data-stage="evidence">6. Capture evidence</button>
-            <button type="button" data-stage="review">7. Review the week</button>
-            <button type="button" data-stage="next">8. Choose next</button>
+            <button type="button" data-stage="check-in">1. Notice</button>
+            <button type="button" data-stage="choose">2. Pick one</button>
+            <button type="button" data-stage="result">3. Name your win</button>
+            <button type="button" data-stage="plan">4. Make a plan</button>
+            <button type="button" data-stage="complete">5. Do one thing</button>
+            <button type="button" data-stage="evidence">6. Spot the change</button>
+            <button type="button" data-stage="review">7. Look back</button>
+            <button type="button" data-stage="next">8. Pick your next step</button>
           </div>
           <p class="map-footnote">Jump around when life calls for it. The map is a guide, not a test.</p>
         </nav>
 
         <section class="card work-card" aria-labelledby="stage-title">
           <div class="card-heading">
-            <p class="eyebrow" data-stage-label>Check in</p>
-            <h2 id="stage-title" data-stage-prompt>What would make this week feel useful?</h2>
-            <p class="stage-support" data-stage-support>Start with what is true. You do not have to make it sound tidy.</p>
+            <p class="eyebrow" data-stage-label>Notice</p>
+            <h2 id="stage-title" data-stage-prompt>What needs your care this week?</h2>
+            <p class="stage-support" data-stage-support>Just tell the truth. Short is good.</p>
           </div>
 
           <div class="fields">
-            <label>What is taking your attention?
-              <textarea id="checkIn" name="checkIn" rows="3" placeholder="A situation, responsibility, hope, or source of friction."></textarea>
+            <label>What is on your mind?
+              <textarea id="checkIn" name="checkIn" rows="3" placeholder="A problem, hope, job, room, or person."></textarea>
             </label>
-            <label>One area to upgrade
-              <input id="upgrade" name="upgrade" placeholder="My kitchen, sleep, finances, job search..." />
+            <label>Pick one thing
+              <input id="upgrade" name="upgrade" placeholder="My room, sleep, money, or work..." />
             </label>
-            <label>Useful result by seven days
-              <textarea id="result" name="result" rows="3" placeholder="I will be able to see, use, or share..." ></textarea>
+            <label>Your win in 7 days
+              <textarea id="result" name="result" rows="3" placeholder="I will see, use, or share..." ></textarea>
             </label>
             <fieldset>
-              <legend>Three actions</legend>
-            <label class="action-row"><span class="sr-only">Action one</span><input data-action-index="0" placeholder="1. The smallest meaningful action" /><span><input type="checkbox" data-action-complete="0" /> Done</span></label>
-            <label class="action-row"><span class="sr-only">Action two</span><input data-action-index="1" placeholder="2. A second action" /><span><input type="checkbox" data-action-complete="1" /> Done</span></label>
-            <label class="action-row"><span class="sr-only">Action three</span><input data-action-index="2" placeholder="3. A third action" /><span><input type="checkbox" data-action-complete="2" /> Done</span></label>
+              <legend>Three tiny steps</legend>
+            <label class="action-row"><span class="sr-only">Tiny step one</span><input data-action-index="0" placeholder="1. The easiest step" /><span><input type="checkbox" data-action-complete="0" /> Done!</span></label>
+            <label class="action-row"><span class="sr-only">Tiny step two</span><input data-action-index="1" placeholder="2. One more small step" /><span><input type="checkbox" data-action-complete="1" /> Done!</span></label>
+            <label class="action-row"><span class="sr-only">Tiny step three</span><input data-action-index="2" placeholder="3. The last small step" /><span><input type="checkbox" data-action-complete="2" /> Done!</span></label>
           </fieldset>
-            <label>Evidence of movement
-              <textarea id="evidence" name="evidence" rows="3" placeholder="A photo, link, sent message, finished item, measurement, or clear observation."></textarea>
+            <label>What changed?
+              <textarea id="evidence" name="evidence" rows="3" placeholder="A photo, link, sent note, finished thing, or what you saw."></textarea>
             </label>
-            <label>What did the week teach you?
-              <textarea id="review" name="review" rows="3" placeholder="What worked? What got in the way? What would you change?"></textarea>
+            <label>What did you learn?
+              <textarea id="review" name="review" rows="3" placeholder="What worked? What got in the way?"></textarea>
             </label>
-            <label>Next move
-              <input id="nextMove" name="nextMove" placeholder="Continue, adjust, pause, or choose a new upgrade." />
+            <label>Your next step
+              <input id="nextMove" name="nextMove" placeholder="Keep going, change it, or pick a new thing." />
             </label>
           </div>
 
           <div class="actions">
-            <button class="primary" type="button" id="nextStage">Keep this and take the next step</button>
-            <button class="secondary" type="button" id="resetPlan">Start over</button>
+            <button class="primary" type="button" id="nextStage">Save &amp; keep going →</button>
+            <button class="secondary" type="button" id="resetPlan">Start fresh</button>
           </div>
           <p class="status" id="saveStatus" role="status" aria-live="polite">Checking private browser storage…</p>
         </section>
       </section>
 
       <aside class="summary card" aria-labelledby="summary-title">
-        <p class="eyebrow">Your reason to keep going</p>
-        <h2 id="summary-title">Keep the result in view</h2>
-        <p id="summary">Your seven-day result will appear here.</p>
+        <p class="eyebrow">Your tiny win</p>
+        <h2 id="summary-title">Keep your win in view</h2>
+        <p id="summary">Your 7-day win will show up here.</p>
       </aside>
       <section class="privacy-tools card" aria-labelledby="privacy-tools-title">
         <h2 id="privacy-tools-title">Your private data</h2>

--- a/life-upgrade/state.js
+++ b/life-upgrade/state.js
@@ -2,14 +2,14 @@ export const STORAGE_KEY = '3dvr-life-upgrade-v01';
 export const SCHEMA_VERSION = 1;
 
 export const STAGES = Object.freeze([
-  { id: 'check-in', label: 'Check in', prompt: 'What deserves your attention before the week disappears?', support: 'Start with what is true. You do not have to make it sound tidy.' },
-  { id: 'choose', label: 'Choose one', prompt: 'What part of life is asking for a little care?', support: 'A small surface you can touch is more useful than a giant life category.' },
-  { id: 'result', label: 'Name the result', prompt: 'What would you be proud to point to in seven days?', support: 'Make it visible. “Feel better” can become “one calm morning” or “a sent proposal.”' },
-  { id: 'plan', label: 'Plan three', prompt: 'What three small moves would make that result more likely?', support: 'Give future-you a few easy doors to walk through.' },
-  { id: 'complete', label: 'Complete one', prompt: 'Which move can you make real today?', support: 'Momentum starts when an intention leaves your head and meets the world.' },
-  { id: 'evidence', label: 'Capture evidence', prompt: 'What is different enough to notice?', support: 'Keep the proof for yourself. A finished thing, a photo, or a clear observation all count.' },
-  { id: 'review', label: 'Review the week', prompt: 'What did this week teach you about how you move?', support: 'Learning is part of the upgrade—not a consolation prize when plans change.' },
-  { id: 'next', label: 'Choose next', prompt: 'What is the next kind move—not the biggest one?', support: 'Keep what worked. Adjust what did not. You are allowed to build slowly.' }
+  { id: 'check-in', label: 'Notice', prompt: 'What needs your care this week?', support: 'Just tell the truth. Short is good.' },
+  { id: 'choose', label: 'Pick one', prompt: 'What one thing will you work on?', support: 'Pick a small thing you can touch and change.' },
+  { id: 'result', label: 'Name your win', prompt: 'What would make you proud in 7 days?', support: 'Make it easy to see. “Feel better” could be “one calm morning.”' },
+  { id: 'plan', label: 'Make a plan', prompt: 'What three tiny steps can help?', support: 'Make each step so small you can start today.' },
+  { id: 'complete', label: 'Do one thing', prompt: 'Which step can you do today?', support: 'A small step is still a step. Go!' },
+  { id: 'evidence', label: 'Spot the change', prompt: 'What changed?', support: 'A photo, note, finished thing, or clear thought all count.' },
+  { id: 'review', label: 'Look back', prompt: 'What did you learn?', support: 'Plans can change. That is okay. Notice what helped.' },
+  { id: 'next', label: 'Pick your next step', prompt: 'What small step comes next?', support: 'Keep what worked. Try a new way for what did not.' }
 ]);
 
 export function createPlan() {

--- a/life-upgrade/state.js
+++ b/life-upgrade/state.js
@@ -2,14 +2,14 @@ export const STORAGE_KEY = '3dvr-life-upgrade-v01';
 export const SCHEMA_VERSION = 1;
 
 export const STAGES = Object.freeze([
-  { id: 'check-in', label: 'Check in', prompt: 'What would make this week feel useful?' },
-  { id: 'choose', label: 'Choose one', prompt: 'Choose one area to upgrade.' },
-  { id: 'result', label: 'Name the result', prompt: 'What will be different by the end of seven days?' },
-  { id: 'plan', label: 'Plan three', prompt: 'Write three actions that can get you there.' },
-  { id: 'complete', label: 'Complete one', prompt: 'Do one action now or schedule it.' },
-  { id: 'evidence', label: 'Capture evidence', prompt: 'Record what proves movement happened.' },
-  { id: 'review', label: 'Review the week', prompt: 'Notice what worked, what did not, and what you learned.' },
-  { id: 'next', label: 'Choose next', prompt: 'Choose the next move without starting over.' }
+  { id: 'check-in', label: 'Check in', prompt: 'What deserves your attention before the week disappears?', support: 'Start with what is true. You do not have to make it sound tidy.' },
+  { id: 'choose', label: 'Choose one', prompt: 'What part of life is asking for a little care?', support: 'A small surface you can touch is more useful than a giant life category.' },
+  { id: 'result', label: 'Name the result', prompt: 'What would you be proud to point to in seven days?', support: 'Make it visible. “Feel better” can become “one calm morning” or “a sent proposal.”' },
+  { id: 'plan', label: 'Plan three', prompt: 'What three small moves would make that result more likely?', support: 'Give future-you a few easy doors to walk through.' },
+  { id: 'complete', label: 'Complete one', prompt: 'Which move can you make real today?', support: 'Momentum starts when an intention leaves your head and meets the world.' },
+  { id: 'evidence', label: 'Capture evidence', prompt: 'What is different enough to notice?', support: 'Keep the proof for yourself. A finished thing, a photo, or a clear observation all count.' },
+  { id: 'review', label: 'Review the week', prompt: 'What did this week teach you about how you move?', support: 'Learning is part of the upgrade—not a consolation prize when plans change.' },
+  { id: 'next', label: 'Choose next', prompt: 'What is the next kind move—not the biggest one?', support: 'Keep what worked. Adjust what did not. You are allowed to build slowly.' }
 ]);
 
 export function createPlan() {

--- a/life-upgrade/styles.css
+++ b/life-upgrade/styles.css
@@ -33,6 +33,12 @@ h2 { margin-bottom: 8px; line-height: 1.08; letter-spacing: -.025em; }
 .promise strong { font-size: 1.15rem; line-height: 1; }
 .card { min-width: 0; border: 1px solid var(--line); border-radius: 24px; background: var(--paper); box-shadow: var(--shadow); }
 .map { padding: 18px; background: rgba(255, 253, 248, .82); }
+.map summary { cursor: pointer; list-style: none; }
+.map summary::-webkit-details-marker { display: none; }
+.map summary::after { content: '＋'; color: var(--teal); font-size: 1.1rem; }
+.map[open] summary::after { content: '−'; }
+.map summary:focus-visible { outline: 3px solid var(--yellow); outline-offset: 4px; border-radius: 8px; }
+.map:not([open]) { box-shadow: 0 8px 24px rgba(46, 56, 47, .08); }
 .map-heading { display: flex; justify-content: space-between; margin-bottom: 10px; font-size: .82rem; font-weight: 800; }
 .progress { height: 7px; overflow: hidden; border-radius: 99px; background: #e9e1d4; }
 .progress span { display: block; height: 100%; width: 12.5%; border-radius: inherit; background: var(--yellow); transition: width .2s ease; }

--- a/life-upgrade/styles.css
+++ b/life-upgrade/styles.css
@@ -30,7 +30,7 @@ h2 { margin-bottom: 8px; line-height: 1.08; letter-spacing: -.025em; }
 .privacy-note { display: inline-flex; gap: 8px; margin: 8px 0 0; color: var(--teal); font-size: .9rem; font-weight: 700; }
 .promise { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; max-width: 700px; margin: 28px 0 4px; }
 .promise span { display: grid; gap: 5px; padding: 13px 14px; border: 1px solid rgba(22, 107, 104, .14); border-radius: 16px; background: rgba(255, 253, 248, .62); color: var(--muted); font-size: .82rem; }
-.promise strong { color: var(--coral); font-size: .7rem; letter-spacing: .1em; }
+.promise strong { font-size: 1.15rem; line-height: 1; }
 .card { min-width: 0; border: 1px solid var(--line); border-radius: 24px; background: var(--paper); box-shadow: var(--shadow); }
 .map { padding: 18px; background: rgba(255, 253, 248, .82); }
 .map-heading { display: flex; justify-content: space-between; margin-bottom: 10px; font-size: .82rem; font-weight: 800; }
@@ -39,7 +39,9 @@ h2 { margin-bottom: 8px; line-height: 1.08; letter-spacing: -.025em; }
 .momentum { min-height: 1.4em; margin: 12px 0 0; color: var(--teal); font-size: .84rem; font-weight: 750; }
 .stage-list { display: grid; gap: 5px; margin-top: 14px; }
 .stage-list button { border: 0; border-radius: 12px; padding: 10px 12px; background: transparent; color: var(--muted); text-align: left; cursor: pointer; }
+.stage-list button { transition: transform .15s ease, background .15s ease; }
 .stage-list button:hover, .stage-list button:focus-visible, .stage-list button.is-current { background: #fff3c9; color: var(--ink); }
+.stage-list button:hover { transform: translateX(3px); }
 .stage-list button.is-current { font-weight: 850; }
 .map-footnote { margin: 14px 0 0; color: var(--muted); font-size: .85rem; }
 .work-card { position: relative; overflow: hidden; padding: clamp(20px, 5vw, 40px); background: linear-gradient(145deg, var(--paper) 0%, #fffaf0 68%, var(--blue) 170%); }
@@ -60,7 +62,9 @@ fieldset { display: grid; gap: 10px; margin: 0; padding: 0; border: 0; }
 legend { margin-bottom: 1px; }
 .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px; }
 .actions button { min-height: 46px; border: 0; border-radius: 999px; padding: 11px 16px; font-weight: 850; cursor: pointer; }
-.primary { background: var(--teal); color: white; }
+.primary { background: var(--teal); color: white; box-shadow: 0 7px 0 #0e4f4c; transform: translateY(-2px); }
+.primary:hover, .primary:focus-visible { background: #1b7b77; transform: translateY(-3px); }
+.primary:active { box-shadow: 0 3px 0 #0e4f4c; transform: translateY(2px); }
 .secondary { border: 1px solid var(--line) !important; background: transparent; color: var(--ink); }
 .status { min-height: 1.5em; margin: 12px 0 0; color: var(--muted); font-size: .88rem; }
 .summary { margin-top: 16px; padding: 22px; background: var(--ink); color: var(--paper); }

--- a/life-upgrade/styles.css
+++ b/life-upgrade/styles.css
@@ -7,11 +7,13 @@
   --teal: #166b68;
   --yellow: #f3c94b;
   --shadow: 0 18px 50px rgba(46, 56, 47, 0.13);
+  --coral: #db765b;
+  --blue: #dcebea;
 }
 
 * { box-sizing: border-box; }
 html { background: var(--cream); }
-body { margin: 0; color: var(--ink); font: 16px/1.5 system-ui, sans-serif; }
+body { margin: 0; color: var(--ink); font: 16px/1.5 system-ui, sans-serif; background: radial-gradient(circle at 86% 3%, rgba(243, 201, 75, .32), transparent 23rem), radial-gradient(circle at 4% 38%, rgba(22, 107, 104, .09), transparent 24rem); }
 button, input, textarea, select { font: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
 .shell { width: min(1120px, calc(100% - 28px)); margin: 0 auto; padding: 14px 0 48px; }
@@ -19,26 +21,32 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .topbar { display: flex; justify-content: space-between; align-items: center; padding: 8px 0 20px; }
 .brand { color: var(--ink); font-weight: 850; text-decoration: none; }
 .quiet-link { color: var(--teal); font-weight: 700; }
-.intro { max-width: 720px; padding: 24px 0 30px; }
+.intro { max-width: 790px; padding: 42px 0 34px; }
 .eyebrow { margin: 0 0 10px; color: var(--teal); font-size: .75rem; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
 h1, h2, p { margin-top: 0; }
-h1 { max-width: 12ch; margin-bottom: 14px; font-size: clamp(2.4rem, 10vw, 5.5rem); line-height: .96; letter-spacing: -.06em; }
+h1 { max-width: 12ch; margin-bottom: 14px; font-size: clamp(2.8rem, 10vw, 6rem); line-height: .92; letter-spacing: -.07em; }
 h2 { margin-bottom: 8px; line-height: 1.08; letter-spacing: -.025em; }
 .lead { max-width: 600px; color: var(--muted); font-size: 1.12rem; }
 .privacy-note { display: inline-flex; gap: 8px; margin: 8px 0 0; color: var(--teal); font-size: .9rem; font-weight: 700; }
+.promise { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; max-width: 700px; margin: 28px 0 4px; }
+.promise span { display: grid; gap: 5px; padding: 13px 14px; border: 1px solid rgba(22, 107, 104, .14); border-radius: 16px; background: rgba(255, 253, 248, .62); color: var(--muted); font-size: .82rem; }
+.promise strong { color: var(--coral); font-size: .7rem; letter-spacing: .1em; }
 .card { min-width: 0; border: 1px solid var(--line); border-radius: 24px; background: var(--paper); box-shadow: var(--shadow); }
-.map { padding: 18px; }
+.map { padding: 18px; background: rgba(255, 253, 248, .82); }
 .map-heading { display: flex; justify-content: space-between; margin-bottom: 10px; font-size: .82rem; font-weight: 800; }
 .progress { height: 7px; overflow: hidden; border-radius: 99px; background: #e9e1d4; }
 .progress span { display: block; height: 100%; width: 12.5%; border-radius: inherit; background: var(--yellow); transition: width .2s ease; }
+.momentum { min-height: 1.4em; margin: 12px 0 0; color: var(--teal); font-size: .84rem; font-weight: 750; }
 .stage-list { display: grid; gap: 5px; margin-top: 14px; }
 .stage-list button { border: 0; border-radius: 12px; padding: 10px 12px; background: transparent; color: var(--muted); text-align: left; cursor: pointer; }
 .stage-list button:hover, .stage-list button:focus-visible, .stage-list button.is-current { background: #fff3c9; color: var(--ink); }
 .stage-list button.is-current { font-weight: 850; }
 .map-footnote { margin: 14px 0 0; color: var(--muted); font-size: .85rem; }
-.work-card { padding: clamp(20px, 5vw, 40px); }
+.work-card { position: relative; overflow: hidden; padding: clamp(20px, 5vw, 40px); background: linear-gradient(145deg, var(--paper) 0%, #fffaf0 68%, var(--blue) 170%); }
+.work-card::after { position: absolute; top: -100px; right: -100px; width: 220px; height: 220px; border: 1px solid rgba(219, 118, 91, .2); border-radius: 50%; box-shadow: 0 0 0 18px rgba(219, 118, 91, .05), 0 0 0 38px rgba(219, 118, 91, .035); content: ''; pointer-events: none; }
 .card-heading { margin-bottom: 24px; }
 .card-heading h2 { max-width: 25ch; font-size: clamp(1.6rem, 5vw, 2.5rem); }
+.stage-support { max-width: 52ch; margin: 10px 0 0; color: var(--muted); }
 .fields { display: grid; gap: 16px; }
 .action-row { grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
 .action-row > span { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; font-size: .85rem; }
@@ -55,11 +63,12 @@ legend { margin-bottom: 1px; }
 .primary { background: var(--teal); color: white; }
 .secondary { border: 1px solid var(--line) !important; background: transparent; color: var(--ink); }
 .status { min-height: 1.5em; margin: 12px 0 0; color: var(--muted); font-size: .88rem; }
-.summary { margin-top: 16px; padding: 22px; }
+.summary { margin-top: 16px; padding: 22px; background: var(--ink); color: var(--paper); }
 .privacy-tools { margin-top: 16px; padding: 22px; }
 .privacy-tools p { max-width: 60ch; color: var(--muted); }
 .summary h2 { font-size: 1.35rem; }
-.summary p:last-child { margin-bottom: 0; color: var(--muted); }
+.summary p:last-child { margin-bottom: 0; color: #d3dfdc; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 @media (min-width: 800px) { .workspace { grid-template-columns: 280px minmax(0, 1fr); align-items: start; } .map { position: sticky; top: 16px; } .summary { margin-left: 296px; max-width: calc(100% - 296px); } }
+@media (max-width: 520px) { .promise { grid-template-columns: 1fr; } .promise span { grid-template-columns: auto 1fr; align-items: center; } }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; } }

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -91,6 +91,8 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(html, /Private by default/);
   assert.match(html, /Make one good thing happen this week/);
   assert.match(html, /See what matters/);
+  assert.match(html, /<details class="map card">/);
+  assert.match(html, /data-stage-field="check-in"/);
   assert.match(html, /seven-day upgrade cycle/i);
   assert.match(html, /Stabilize → Understand → Choose → Practice → Help → Earn → Build → Teach/);
   assert.match(html, /id="deleteAll"/);

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -89,8 +89,8 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   const app = await read('life-upgrade/app.js');
   assert.equal(STAGES.length, 8);
   assert.match(html, /Private by default/);
-  assert.match(html, /Give this week a shape you can feel/);
-  assert.match(html, /Notice what matters/);
+  assert.match(html, /Make one good thing happen this week/);
+  assert.match(html, /See what matters/);
   assert.match(html, /seven-day upgrade cycle/i);
   assert.match(html, /Stabilize → Understand → Choose → Practice → Help → Earn → Build → Teach/);
   assert.match(html, /id="deleteAll"/);

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -89,6 +89,8 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   const app = await read('life-upgrade/app.js');
   assert.equal(STAGES.length, 8);
   assert.match(html, /Private by default/);
+  assert.match(html, /Give this week a shape you can feel/);
+  assert.match(html, /Notice what matters/);
   assert.match(html, /seven-day upgrade cycle/i);
   assert.match(html, /Stabilize → Understand → Choose → Practice → Help → Earn → Build → Teach/);
   assert.match(html, /id="deleteAll"/);
@@ -100,6 +102,7 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(app, /deleteStoredPlan/);
   assert.match(app, /Could not save in this browser/);
   assert.match(app, /Could not delete saved data/);
+  assert.match(app, /data-momentum/);
   assert.match(app, /replace this Life Upgrade plan/);
 });
 


### PR DESCRIPTION
## What changed\n- hide the full step list inside a small game menu\n- show only the fields for the current step\n- keep the next action clear on mobile and desktop\n\nFocused tests: TAP version 13
# Subtest: initial state is a v1 plan with three independent actions
ok 1 - initial state is a v1 plan with three independent actions
  ---
  duration_ms: 2.17512
  type: 'test'
  ...
# Subtest: malformed or missing stored JSON safely returns a usable initial state
ok 2 - malformed or missing stored JSON safely returns a usable initial state
  ---
  duration_ms: 2.376081
  type: 'test'
  ...
# Subtest: restore preserves workflow position and active upgrade
ok 3 - restore preserves workflow position and active upgrade
  ---
  duration_ms: 0.883592
  type: 'test'
  ...
# Subtest: actions can be edited and completed independently
ok 4 - actions can be edited and completed independently
  ---
  duration_ms: 0.576469
  type: 'test'
  ...
# Subtest: private evidence is part of the local plan and useful results remain detectable
ok 5 - private evidence is part of the local plan and useful results remain detectable
  ---
  duration_ms: 0.315418
  type: 'test'
  ...
# Subtest: delete-all removes only the Life Upgrade browser record
ok 6 - delete-all removes only the Life Upgrade browser record
  ---
  duration_ms: 0.25223
  type: 'test'
  ...
# Subtest: storage failures do not throw and progress detection supports confirmed replacement
ok 7 - storage failures do not throw and progress detection supports confirmed replacement
  ---
  duration_ms: 0.466048
  type: 'test'
  ...
# Subtest: page is offline-capable, safely rendered, and has the confirmed delete action
ok 8 - page is offline-capable, safely rendered, and has the confirmed delete action
  ---
  duration_ms: 13.897693
  type: 'test'
  ...
# Subtest: portal home and Start page expose the Life Upgrade entry point
ok 9 - portal home and Start page expose the Life Upgrade entry point
  ---
  duration_ms: 2.660236
  type: 'test'
  ...
1..9
# tests 9
# suites 0
# pass 9
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 131.334909 (9/9).