### PR TITLE
feat(life-upgrade): gate questions behind flight

### DIFF
--- a/life-upgrade/app.js
+++ b/life-upgrade/app.js
@@ -18,12 +18,25 @@ import { createGame } from './game.js';
 const root = document.querySelector('[data-life-upgrade]');
 let storageAvailable = true;
 let plan = loadPlan();
+const gameQuestionContent = root?.querySelector('[data-game-question-content]');
+gameQuestionContent?.append(
+  root?.querySelector('.suggestions'),
+  root?.querySelector('.fields'),
+  root?.querySelector('.actions')
+);
 const game = createGame(root?.querySelector('[data-game-canvas]'), {
   onLand: () => {
     root?.querySelector('[data-stage-field]:not([hidden]) input, [data-stage-field]:not([hidden]) textarea')?.focus();
     setStatus('You landed! Answer the question, then keep going.');
   }
 });
+
+function hasStageAnswer(stageId, currentPlan = plan) {
+  if (stageId === 'plan') return currentPlan.actions.some((action) => action.text);
+  if (stageId === 'complete') return currentPlan.actions.some((action) => action.text || action.completed);
+  const field = { 'check-in': 'checkIn', choose: 'upgrade', result: 'result', evidence: 'evidence', review: 'review', next: 'nextMove' }[stageId];
+  return Boolean(field && currentPlan[field]);
+}
 
 function loadPlan() {
   try {
@@ -59,6 +72,8 @@ function render() {
   root.querySelector('[data-stage-label]').textContent = stage.label;
   root.querySelector('[data-stage-prompt]').textContent = stage.prompt;
   root.querySelector('[data-stage-support]').textContent = stage.support;
+  root.querySelector('[data-game-question-prompt]').textContent = stage.prompt;
+  root.querySelector('[data-game-question-support]').textContent = stage.support;
   root.querySelector('[data-stage-count]').textContent = `${STAGES.findIndex((item) => item.id === stage.id) + 1} of ${STAGES.length}`;
   root.querySelector('[data-progress]').style.width = `${((STAGES.findIndex((item) => item.id === stage.id) + 1) / STAGES.length) * 100}%`;
   renderSuggestions(stage);
@@ -70,7 +85,10 @@ function render() {
   game?.update({
     stageIndex: STAGES.findIndex((item) => item.id === stage.id),
     completedActions,
-    hasResult: hasUsefulResult(plan)
+    hasResult: hasUsefulResult(plan),
+    answered: hasStageAnswer(stage.id),
+    prompt: stage.prompt,
+    support: stage.support
   });
   root.querySelector('[data-momentum]').textContent = completedActions
     ? `⭐ ${completedActions} of 3 tiny wins done. Keep going!`
@@ -135,6 +153,7 @@ function handleField(event) {
     plan = updatePlan(plan, { [target.name]: target.value });
   }
   savePlan();
+  game?.setAnswered(hasStageAnswer(getStage(plan).id));
 }
 
 root?.addEventListener('input', handleField);
@@ -160,6 +179,10 @@ root?.addEventListener('click', (event) => {
   }
 
   if (event.target.closest('#nextStage')) {
+    if (!hasStageAnswer(getStage(plan).id)) {
+      setStatus('Fly to the gate and answer the question first.');
+      return;
+    }
     plan = nextStage(plan);
     savePlan();
     render();

--- a/life-upgrade/game.js
+++ b/life-upgrade/game.js
@@ -31,15 +31,26 @@ function makeButtonControl(button, control, state) {
     state[control] = false;
     button.classList.remove('is-held');
   };
+  const tap = (event) => {
+    if (event.detail === 0) return;
+    state[control] = true;
+    button.classList.add('is-held');
+    window.setTimeout(() => {
+      state[control] = false;
+      button.classList.remove('is-held');
+    }, control === 'fly' ? 450 : 700);
+  };
   button.addEventListener('pointerdown', on);
   button.addEventListener('pointerup', off);
   button.addEventListener('pointercancel', off);
   button.addEventListener('lostpointercapture', off);
+  button.addEventListener('click', tap);
   return () => {
     button.removeEventListener('pointerdown', on);
     button.removeEventListener('pointerup', off);
     button.removeEventListener('pointercancel', off);
     button.removeEventListener('lostpointercapture', off);
+    button.removeEventListener('click', tap);
   };
 }
 
@@ -118,8 +129,16 @@ export function createGame(canvas, { onLand = () => {} } = {}) {
     cleanup.push(makeButtonControl(button, button.dataset.gameControl, state));
   });
   const landButton = shell?.querySelector('[data-game-land]');
-  landButton?.addEventListener('click', () => onLand());
-  cleanup.push(() => landButton?.removeEventListener('click', onLand));
+  const questionCard = shell?.querySelector('[data-game-question]');
+  const flightControls = shell?.querySelector('.flight-controls');
+  const land = () => {
+    if (landButton?.disabled) return;
+    if (questionCard) questionCard.hidden = false;
+    flightControls?.classList.add('is-landed');
+    onLand();
+  };
+  landButton?.addEventListener('click', land);
+  cleanup.push(() => landButton?.removeEventListener('click', land));
 
   let stageIndex = 0;
   let distance = 0;
@@ -165,11 +184,13 @@ export function createGame(canvas, { onLand = () => {} } = {}) {
   render(performance.now());
 
   return {
-    update({ stageIndex: nextStage = 0, completedActions = 0, hasResult = false } = {}) {
+    update({ stageIndex: nextStage = 0, completedActions = 0, hasResult = false, answered = false, prompt = '', support = '' } = {}) {
       if (nextStage !== stageIndex) {
         stageIndex = nextStage;
         distance = 0;
         arrived = false;
+        if (questionCard) questionCard.hidden = true;
+        flightControls?.classList.remove('is-landed');
         if (landButton) { landButton.disabled = true; landButton.textContent = 'Fly to answer'; }
       }
       targetDistance = Math.max(2.5, Math.min(12, 3 + nextStage * 1.1 + completedActions * 0.5 + (hasResult ? 0.8 : 0)));
@@ -178,7 +199,17 @@ export function createGame(canvas, { onLand = () => {} } = {}) {
       const messageEl = shell?.querySelector('[data-game-message]');
       if (levelEl) levelEl.textContent = `Level ${level}`;
       if (messageEl) messageEl.textContent = STAGE_MESSAGES[Math.min(nextStage, STAGE_MESSAGES.length - 1)];
+      const promptEl = shell?.querySelector('[data-game-question-prompt]');
+      const supportEl = shell?.querySelector('[data-game-question-support]');
+      const stateEl = shell?.querySelector('[data-game-question-state]');
+      if (promptEl) promptEl.textContent = prompt;
+      if (supportEl) supportEl.textContent = support;
+      if (stateEl && arrived) stateEl.textContent = answered ? '⭐ Nice! Save your answer to unlock the next flight.' : 'You reached the gate.';
       if (landButton && !arrived) landButton.textContent = `Fly ${Math.round((distance / targetDistance) * 100)}%`;
+    },
+    setAnswered(answered) {
+      const stateEl = shell?.querySelector('[data-game-question-state]');
+      if (stateEl && arrived) stateEl.textContent = answered ? '⭐ Nice! Save your answer to unlock the next flight.' : 'You reached the gate.';
     },
     destroy() {
       window.cancelAnimationFrame(frame);

--- a/life-upgrade/index.html
+++ b/life-upgrade/index.html
@@ -33,8 +33,14 @@
               <button type="button" class="boost" data-game-control="fly">Fly</button>
               <button type="button" class="land" data-game-land disabled>Land to answer</button>
             </div>
+            <div class="game-question" data-game-question hidden>
+              <p class="game-question-state" data-game-question-state>You reached the gate.</p>
+              <h2 data-game-question-prompt>What needs your care this week?</h2>
+              <p data-game-question-support>Answer one small question, then keep flying.</p>
+              <div data-game-question-content></div>
+            </div>
           </section>
-          <div class="card-heading">
+          <div class="card-heading" hidden>
             <p class="eyebrow" data-stage-label>Notice</p>
             <h2 id="stage-title" data-stage-prompt>What needs your care this week?</h2>
             <p class="stage-support" data-stage-support>Just tell the truth. Short is good.</p>

--- a/life-upgrade/styles.css
+++ b/life-upgrade/styles.css
@@ -61,12 +61,21 @@ h2 { margin-bottom: 8px; line-height: 1.08; letter-spacing: -.025em; }
 .game-hud { position: absolute; top: 12px; left: 14px; right: 14px; display: flex; justify-content: space-between; color: #bdf5ff; font-size: .8rem; font-weight: 850; pointer-events: none; }
 .game-hud strong { padding: 4px 8px; border-radius: 99px; background: rgba(6, 14, 26, .82); color: #fff1b4; }
 .game-world > p { position: absolute; top: 38px; right: 14px; max-width: 25ch; margin: 0; color: #bdf5ff; font-size: .76rem; font-weight: 750; text-align: right; pointer-events: none; }
-.flight-controls { position: absolute; right: 12px; bottom: 12px; left: 12px; display: flex; align-items: end; justify-content: center; gap: 7px; pointer-events: none; }
-.flight-controls button { min-width: 40px; min-height: 38px; border: 1px solid rgba(189, 245, 255, .35); border-radius: 11px; padding: 7px 10px; background: rgba(6, 14, 26, .78); color: #eefcff; font-weight: 850; cursor: pointer; pointer-events: auto; touch-action: none; }
+.flight-controls { position: absolute; right: 12px; bottom: 12px; left: 12px; display: flex; align-items: end; justify-content: center; gap: 7px; pointer-events: none; transition: opacity .2s ease; }
+.flight-controls.is-landed { opacity: .12; pointer-events: none; }
+.flight-controls button { min-width: 40px; min-height: 38px; border: 1px solid rgba(189, 245, 255, .35); border-radius: 11px; padding: 7px 10px; background: rgba(6, 14, 26, .78); color: #eefcff; font-weight: 850; cursor: pointer; pointer-events: auto; touch-action: manipulation; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none; }
 .flight-controls button.is-held, .flight-controls button:hover { background: rgba(44, 156, 186, .65); }
 .flight-controls .boost { border-color: rgba(255, 179, 71, .6); color: #ffd98d; }
 .flight-controls .land { border-color: rgba(103, 242, 165, .55); color: #9fffc5; }
 .flight-controls .land:disabled { opacity: .55; cursor: not-allowed; }
+.game-question { position: absolute; right: 12px; bottom: 12px; left: 12px; z-index: 5; max-height: calc(100% - 24px); overflow: auto; padding: 14px; border: 1px solid rgba(189, 245, 255, .34); border-radius: 16px; background: rgba(6, 14, 26, .92); color: #eefcff; box-shadow: 0 14px 35px rgba(0, 0, 0, .35); }
+.game-question[hidden] { display: none; }
+.game-question h2 { margin: 0 0 4px; color: #fff1b4; font-size: clamp(1.2rem, 4vw, 1.7rem); }
+.game-question-state, .game-question-support { margin: 0 0 8px; color: #bdf5ff; font-size: .8rem; }
+.game-question .suggestions { margin: 8px 0 12px; }
+.game-question .suggestions-label, .game-question label, .game-question legend { color: #c5dce2; }
+.game-question input, .game-question textarea { border-color: rgba(189, 245, 255, .28); background: rgba(255, 255, 255, .96); }
+.game-question .actions { margin-top: 12px; }
 .card-heading { margin: clamp(28px, 7vw, 58px) 0 24px; }
 .card-heading h2 { max-width: 25ch; font-size: clamp(1.6rem, 5vw, 2.5rem); }
 .stage-support { max-width: 52ch; margin: 10px 0 0; color: var(--muted); }

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -98,6 +98,7 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(html, /data-game-level/);
   assert.match(html, /data-game-control="forward"/);
   assert.match(html, /data-game-land/);
+  assert.match(html, /data-game-question/);
   assert.match(html, /Not sure\? Pick one/);
   assert.match(html, /7 days/);
   assert.match(html, /Stabilize → Understand → Choose → Practice → Help → Earn → Build → Teach/);
@@ -114,6 +115,7 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(app, /renderSuggestions/);
   assert.match(app, /createGame/);
   assert.match(app, /onLand/);
+  assert.match(app, /Fly to the gate and answer/);
   assert.match(app, /dispatchEvent\(new Event\('input'/);
   assert.match(app, /replace this Life Upgrade plan/);
 });


### PR DESCRIPTION
## What changed
- make each question appear inside the 3D gate after the player lands
- require an answer before the next flight unlocks
- move the existing private fields and actions into the game question card
- make forward/fly controls work with taps as well as holds
- prevent mobile text highlighting and callout selection on game controls

## Checks
- `node --test tests/life-upgrade.test.js`
- `git diff --check`
- local Chromium: flight → land → answer → next stage
- local Chromium: no page errors