### PR TITLE
fix(life-upgrade): soften page background

### DIFF
--- a/life-upgrade/styles.css
+++ b/life-upgrade/styles.css
@@ -9,16 +9,17 @@
   --shadow: 0 18px 50px rgba(46, 56, 47, 0.13);
   --coral: #db765b;
   --blue: #dcebea;
+  --page: #101923;
 }
 
 * { box-sizing: border-box; }
-html { background: var(--cream); }
-body { margin: 0; color: var(--ink); font: 16px/1.5 system-ui, sans-serif; background: radial-gradient(circle at 86% 3%, rgba(243, 201, 75, .32), transparent 23rem), radial-gradient(circle at 4% 38%, rgba(22, 107, 104, .09), transparent 24rem); }
+html { background: var(--page); }
+body { margin: 0; color: var(--ink); font: 16px/1.5 system-ui, sans-serif; background: radial-gradient(circle at 86% 3%, rgba(243, 201, 75, .12), transparent 23rem), radial-gradient(circle at 4% 38%, rgba(22, 107, 104, .18), transparent 24rem), var(--page); }
 button, input, textarea, select { font: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
 .shell { width: min(760px, calc(100% - 28px)); min-height: 100svh; margin: 0 auto; padding: 14px 0 24px; }
 .topbar { display: flex; justify-content: space-between; align-items: center; padding: 8px 0 18px; }
-.brand { color: var(--ink); font-weight: 850; text-decoration: none; }
+.brand { color: #f4f8f7; font-weight: 850; text-decoration: none; }
 .quiet-link { color: var(--teal); font-size: .82rem; font-weight: 700; }
 .intro { max-width: 790px; padding: 42px 0 34px; }
 .eyebrow { margin: 0 0 10px; color: var(--teal); font-size: .75rem; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
@@ -105,7 +106,7 @@ legend { margin-bottom: 1px; }
 .summary { margin-top: 22px; padding: 12px 14px; border-left: 4px solid var(--yellow); background: rgba(255, 255, 255, .55); }
 .summary .eyebrow { margin-bottom: 2px; }
 .summary p:last-child { margin-bottom: 0; color: var(--ink); font-weight: 700; }
-.privacy-tools { margin: 12px 0 0; color: var(--muted); font-size: .82rem; }
+.privacy-tools { margin: 12px 0 0; color: #b9c8ca; font-size: .82rem; }
 .privacy-tools summary { cursor: pointer; }
 .privacy-tools p { margin: 8px 0; }
 .privacy-tools p { max-width: 60ch; color: var(--muted); }


### PR DESCRIPTION
## Summary\n- replace the bright outer cream background with a deep navy backdrop\n- preserve the light content card as the primary reading surface\n- keep header and privacy controls readable on the darker page\n\n## Verification\n- git diff --check\n- npm test (11 unrelated existing failures outside Life Upgrade)