### PR TITLE
fix(life-upgrade): remove bright frame and page scroll

### DIFF
--- a/life-upgrade/styles.css
+++ b/life-upgrade/styles.css
@@ -14,10 +14,10 @@
 
 * { box-sizing: border-box; }
 html { background: var(--page); }
-body { margin: 0; color: var(--ink); font: 16px/1.5 system-ui, sans-serif; background: radial-gradient(circle at 86% 3%, rgba(243, 201, 75, .12), transparent 23rem), radial-gradient(circle at 4% 38%, rgba(22, 107, 104, .18), transparent 24rem), var(--page); }
+body { height: 100svh; overflow: hidden; margin: 0; color: var(--ink); font: 16px/1.5 system-ui, sans-serif; background: radial-gradient(circle at 86% 3%, rgba(243, 201, 75, .12), transparent 23rem), radial-gradient(circle at 4% 38%, rgba(22, 107, 104, .18), transparent 24rem), var(--page); }
 button, input, textarea, select { font: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
-.shell { width: min(760px, calc(100% - 28px)); min-height: 100svh; margin: 0 auto; padding: 14px 0 24px; }
+.shell { display: grid; grid-template-rows: auto minmax(0, 1fr) auto; width: min(760px, calc(100% - 28px)); height: 100svh; margin: 0 auto; padding: 14px 0 8px; }
 .topbar { display: flex; justify-content: space-between; align-items: center; padding: 8px 0 18px; }
 .brand { color: #f4f8f7; font-weight: 850; text-decoration: none; }
 .quiet-link { color: var(--teal); font-size: .82rem; font-weight: 700; }
@@ -50,11 +50,11 @@ h2 { margin-bottom: 8px; line-height: 1.08; letter-spacing: -.025em; }
 .stage-list button:hover { transform: translateX(3px); }
 .stage-list button.is-current { font-weight: 850; }
 .map-footnote { margin: 14px 0 0; color: var(--muted); font-size: .85rem; }
-.journey { display: grid; align-items: center; min-height: calc(100svh - 70px); }
-.work-card { position: relative; overflow: hidden; padding: clamp(20px, 5vw, 40px); background: linear-gradient(145deg, var(--paper) 0%, #fffaf0 68%, var(--blue) 170%); }
+.journey { display: grid; min-height: 0; align-items: center; }
+.work-card { position: relative; height: 100%; overflow: hidden; padding: clamp(20px, 5vw, 40px); border-color: rgba(189, 245, 255, .18); background: linear-gradient(145deg, #182735 0%, #111d29 68%, #102c3b 170%); color: #eefcff; box-shadow: 0 18px 50px rgba(0, 0, 0, .28); }
 .work-card::after { position: absolute; top: -100px; right: -100px; width: 220px; height: 220px; border: 1px solid rgba(219, 118, 91, .2); border-radius: 50%; box-shadow: 0 0 0 18px rgba(219, 118, 91, .05), 0 0 0 38px rgba(219, 118, 91, .035); content: ''; pointer-events: none; }
 .journey-head { display: flex; align-items: start; justify-content: space-between; gap: 16px; }
-.journey-kicker { margin: -7px 0 0; color: var(--muted); font-size: .86rem; }
+.journey-kicker { margin: -7px 0 0; color: #b9c8ca; font-size: .86rem; }
 .stage-count { padding: 7px 10px; border-radius: 99px; background: #fff3c9; color: var(--ink); font-size: .82rem; font-weight: 850; white-space: nowrap; }
 .journey > .work-card > .progress { margin-top: 4px; }
 .game-world { position: relative; height: clamp(240px, 46vw, 360px); margin: 18px -10px 0; overflow: hidden; border: 1px solid rgba(117, 223, 255, .28); border-radius: 20px; background: #071426; box-shadow: inset 0 0 45px rgba(69, 201, 236, .12); }
@@ -101,15 +101,15 @@ legend { margin-bottom: 1px; }
 .primary { background: var(--teal); color: white; box-shadow: 0 7px 0 #0e4f4c; transform: translateY(-2px); }
 .primary:hover, .primary:focus-visible { background: #1b7b77; transform: translateY(-3px); }
 .primary:active { box-shadow: 0 3px 0 #0e4f4c; transform: translateY(2px); }
-.secondary { border: 1px solid var(--line) !important; background: transparent; color: var(--ink); }
-.status { min-height: 1.5em; margin: 12px 0 0; color: var(--muted); font-size: .88rem; }
-.summary { margin-top: 22px; padding: 12px 14px; border-left: 4px solid var(--yellow); background: rgba(255, 255, 255, .55); }
+.secondary { border: 1px solid rgba(189, 245, 255, .28) !important; background: transparent; color: #eefcff; }
+.status { min-height: 1.5em; margin: 12px 0 0; color: #b9c8ca; font-size: .88rem; }
+.summary { margin-top: 22px; padding: 12px 14px; border-left: 4px solid var(--yellow); background: rgba(6, 14, 26, .48); }
 .summary .eyebrow { margin-bottom: 2px; }
-.summary p:last-child { margin-bottom: 0; color: var(--ink); font-weight: 700; }
+.summary p:last-child { margin-bottom: 0; color: #eefcff; font-weight: 700; }
 .privacy-tools { margin: 12px 0 0; color: #b9c8ca; font-size: .82rem; }
 .privacy-tools summary { cursor: pointer; }
 .privacy-tools p { margin: 8px 0; }
-.privacy-tools p { max-width: 60ch; color: var(--muted); }
+.privacy-tools p { max-width: 60ch; color: #9eb0b3; }
 .summary h2 { font-size: 1.35rem; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 @media (min-width: 800px) { .work-card { padding: 42px 56px; } }


### PR DESCRIPTION
## Summary\n- replace the bright white journey frame with a dark game-world surface\n- lock the page shell to the viewport so the document does not vertically scroll\n- preserve internal scrolling for the in-game question panel\n\n## Verification\n- git diff --check\n- node --test tests/life-upgrade.test.js\n- Playwright mobile checks at 390x640 and 390x844: document scrollHeight equals viewport height; gate/question flow remains usable