### PR TITLE
feat(life-upgrade): add completion loop and encrypted account sync

### DIFF
--- a/life-upgrade/app.js
+++ b/life-upgrade/app.js
@@ -1,8 +1,10 @@
 import {
   STAGES,
+  COMPLETED_STORAGE_KEY,
   STORAGE_KEY,
   createPlan,
   completeAction,
+  completePlan,
   deleteStoredPlan,
   getStage,
   hasUsefulResult,
@@ -14,10 +16,14 @@ import {
   updatePlan
 } from './state.js';
 import { createGame } from './game.js';
+import { createLifeUpgradeSync } from './sync.js';
 
 const root = document.querySelector('[data-life-upgrade]');
 let storageAvailable = true;
 let plan = loadPlan();
+const sync = createLifeUpgradeSync({
+  onStatus: (message) => setStatus(message)
+});
 const gameQuestionContent = root?.querySelector('[data-game-question-content]');
 gameQuestionContent?.append(
   root?.querySelector('.suggestions'),
@@ -32,6 +38,22 @@ const game = createGame(root?.querySelector('[data-game-canvas]'), {
   onReplay: () => {
     setStatus('Flight replayed. Fly to the gate whenever you are ready.');
   }
+});
+
+sync.ready.then(async (available) => {
+  if (!available) return;
+  const remote = await sync.load(plan);
+  const localTime = Date.parse(plan.updatedAt || '') || 0;
+  const remoteTime = Date.parse(remote?.updatedAt || '') || 0;
+  if (remoteTime > localTime || (!hasProgress(plan) && hasProgress(remote))) {
+    plan = loadStoredPlan(JSON.stringify(remote));
+    savePlan({ announce: false });
+    render();
+  } else if (hasProgress(plan)) {
+    sync.save(plan);
+  }
+  root?.querySelector('[data-sync-label]').textContent = '🔐 Saved to your account';
+  root?.querySelector('.account-link').textContent = 'Account sync on';
 });
 
 function hasStageAnswer(stageId, currentPlan = plan) {
@@ -55,7 +77,7 @@ function setStatus(message) {
   if (status) status.textContent = message;
 }
 
-function savePlan() {
+function savePlan({ announce = true } = {}) {
   let saved = false;
   try {
     saved = saveStoredPlan(window.localStorage, plan);
@@ -63,9 +85,10 @@ function savePlan() {
     saved = false;
   }
   storageAvailable = saved;
-  setStatus(saved
+  if (announce) setStatus(saved
     ? 'Saved privately in this browser.'
     : 'Could not save in this browser. Your changes remain on this page until you leave.');
+  sync.save(plan);
   return saved;
 }
 
@@ -120,6 +143,13 @@ function render() {
   root.querySelector('#summary').textContent = hasUsefulResult(plan)
     ? `${plan.upgrade}: ${plan.result}`
     : 'Your 7-day win will show up here.';
+}
+
+function showFinishPanel(show) {
+  const panel = root.querySelector('[data-finish-panel]');
+  if (!panel) return;
+  panel.hidden = !show;
+  game?.setFinished(show);
 }
 
 function renderSuggestions(stage) {
@@ -183,10 +213,36 @@ root?.addEventListener('click', (event) => {
   }
 
   if (event.target.closest('#nextStage')) {
+    if (getStage(plan).id === 'next') {
+      plan = completePlan(plan);
+      savePlan();
+      render();
+      showFinishPanel(true);
+      setStatus('🏆 Congratulations! You completed this Life Upgrade.');
+      return;
+    }
     plan = nextStage(plan);
     savePlan();
     render();
     root.querySelector('[data-stage-field]:not([hidden]) input, [data-stage-field]:not([hidden]) textarea')?.focus();
+  }
+
+  if (event.target.closest('[data-start-another]')) {
+    try {
+      const completed = JSON.parse(window.localStorage.getItem(COMPLETED_STORAGE_KEY) || '[]');
+      completed.push(plan);
+      window.localStorage.setItem(COMPLETED_STORAGE_KEY, JSON.stringify(completed.slice(-12)));
+    } catch {
+      // The active plan can still be restarted if archive storage is unavailable.
+    }
+    sync.saveCompleted(plan);
+    plan = createPlan();
+    savePlan();
+    showFinishPanel(false);
+    game?.replay();
+    render();
+    setStatus('New goal ready. Fly to the first gate.');
+    return;
   }
 
   if (event.target.closest('#resetPlan')) {

--- a/life-upgrade/game.js
+++ b/life-upgrade/game.js
@@ -316,6 +316,14 @@ export function createGame(canvas, { onArrive = () => {}, onReplay = () => {} } 
       const stateEl = shell?.querySelector('[data-game-question-state]');
       if (stateEl && arrived) stateEl.textContent = answered ? '🎉 Nice work! Save this answer to unlock the next flight.' : '🎉 You made it! Take a moment for this one question.';
     },
+    setFinished(finished) {
+      if (!questionCard) return;
+      questionCard.classList.toggle('is-finished', finished === true);
+      if (finished) {
+        questionCard.hidden = false;
+        flightControls?.classList.add('is-landed');
+      }
+    },
     replay,
     destroy() {
       window.cancelAnimationFrame(frame);

--- a/life-upgrade/index.html
+++ b/life-upgrade/index.html
@@ -11,7 +11,8 @@
     <main class="shell" data-life-upgrade>
       <header class="topbar">
         <a href="../index.html" class="brand">3dvr.tech</a>
-      <span class="quiet-link">🔒 Private on this device</span>
+      <span class="quiet-link" data-sync-label>🔒 Private on this device</span>
+      <a class="account-link" href="../sign-in.html?redirect=%2Flife-upgrade%2F">Save across devices</a>
       </header>
 
       <section class="journey" aria-label="Your Life Upgrade journey">
@@ -38,6 +39,13 @@
               <p data-game-question-support>Answer one small question, then keep flying.</p>
               <button type="button" class="game-replay" data-game-replay>↻ Replay this flight</button>
               <div data-game-question-content></div>
+              <section class="finish-panel" data-finish-panel hidden aria-live="polite">
+                <p class="finish-kicker">🏆 Goal complete</p>
+                <h2>You made a real change.</h2>
+                <p>Your win is saved. Want to choose another small thing and take another flight?</p>
+                <button type="button" class="primary finish-start" data-start-another>Start another goal →</button>
+                <p class="finish-note">Your finished goal stays in this browser and on your account.</p>
+              </section>
             </div>
           </section>
           <div class="card-heading" hidden>
@@ -96,6 +104,10 @@
         <button class="secondary" type="button" id="deleteAll">Delete my plan</button>
       </details>
     </main>
+    <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+    <script src="../gun-init.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+    <script src="../auth-identity.js"></script>
     <script type="module" src="./app.js"></script>
   </body>
 </html>

--- a/life-upgrade/state.js
+++ b/life-upgrade/state.js
@@ -1,4 +1,5 @@
 export const STORAGE_KEY = '3dvr-life-upgrade-v01';
+export const COMPLETED_STORAGE_KEY = '3dvr-life-upgrade-completed-v01';
 export const SCHEMA_VERSION = 1;
 
 export const STAGES = Object.freeze([
@@ -17,6 +18,7 @@ export function createPlan() {
     schemaVersion: SCHEMA_VERSION,
     updatedAt: null,
     currentStage: 'check-in',
+    completedAt: null,
     checkIn: '',
     upgrade: '',
     result: '',
@@ -42,6 +44,7 @@ export function normalizePlan(value) {
     currentStage: STAGES.some((stage) => stage.id === source.currentStage)
       ? source.currentStage
       : plan.currentStage,
+    completedAt: typeof source.completedAt === 'string' ? source.completedAt : plan.completedAt,
     actions: [0, 1, 2].map((index) => {
       const action = actions[index];
       if (typeof action === 'string') return { text: action.trim(), completed: false };
@@ -112,6 +115,10 @@ export function nextStage(plan) {
   const current = normalizePlan(plan);
   const index = STAGES.findIndex((stage) => stage.id === current.currentStage);
   return updatePlan(current, { currentStage: STAGES[Math.min(index + 1, STAGES.length - 1)].id });
+}
+
+export function completePlan(plan) {
+  return updatePlan(plan, { completedAt: new Date().toISOString(), currentStage: 'next' });
 }
 
 export function hasUsefulResult(plan) {

--- a/life-upgrade/styles.css
+++ b/life-upgrade/styles.css
@@ -19,9 +19,10 @@ body { height: 100svh; overflow: hidden; margin: 0; color: var(--ink); font: 16p
 button, input, textarea, select { font: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
 .shell { display: grid; grid-template-rows: auto minmax(0, 1fr) auto; width: min(760px, calc(100% - 28px)); height: 100svh; margin: 0 auto; padding: 14px 0 8px; }
-.topbar { display: flex; justify-content: space-between; align-items: center; padding: 8px 0 18px; }
+.topbar { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 8px 0 18px; }
 .brand { color: #f4f8f7; font-weight: 850; text-decoration: none; }
 .quiet-link { color: var(--teal); font-size: .82rem; font-weight: 700; }
+.account-link { color: #bdf5ff; font-size: .78rem; font-weight: 800; text-decoration: none; }
 .intro { max-width: 790px; padding: 42px 0 34px; }
 .eyebrow { margin: 0 0 10px; color: var(--teal); font-size: .75rem; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
 h1, h2, p { margin-top: 0; }
@@ -85,6 +86,13 @@ h2 { margin-bottom: 8px; line-height: 1.08; letter-spacing: -.025em; }
 .game-question[data-game-stage="plan"] .game-question-support { display: none; }
 .game-question input, .game-question textarea { padding: 9px 11px; }
 .game-question textarea { height: 56px; min-height: 56px; }
+.game-question.is-finished > :not(.finish-panel) { display: none; }
+.finish-panel { display: grid; gap: 8px; align-content: center; height: 100%; text-align: center; }
+.finish-panel h2 { margin: 0; color: #fff1b4; font-size: clamp(1.5rem, 6vw, 2.3rem); }
+.finish-panel p { margin: 0; color: #c5dce2; }
+.finish-kicker { color: #ffb84d !important; font-size: .8rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
+.finish-start { justify-self: center; margin-top: 12px; }
+.finish-note { font-size: .75rem; }
 .game-replay { border: 0; padding: 0; background: transparent; color: #bdf5ff; font-size: .8rem; font-weight: 800; cursor: pointer; }
 .game-replay:hover, .game-replay:focus-visible { color: #fff1b4; text-decoration: underline; }
 .card-heading { margin: clamp(28px, 7vw, 58px) 0 24px; }

--- a/life-upgrade/sync.js
+++ b/life-upgrade/sync.js
@@ -1,0 +1,120 @@
+const SYNC_NODE = 'life-upgrade-v01';
+
+function getUserSecret(user) {
+  return user?._?.sea || null;
+}
+
+function once(node, timerWindow = window) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    try {
+      node.once(finish);
+      timerWindow.setTimeout(() => finish(null), 2500);
+    } catch {
+      finish(null);
+    }
+  });
+}
+
+function put(node, value) {
+  return new Promise((resolve) => {
+    try {
+      node.put(value, (ack) => resolve(!ack?.err));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+export function createLifeUpgradeSync({ windowObj = window, onStatus = () => {} } = {}) {
+  let gun;
+  let user;
+  let node;
+  let secret;
+  let ready = false;
+
+  const init = async () => {
+    if (typeof windowObj.Gun !== 'function' || !windowObj.SEA) return false;
+    try {
+      gun = windowObj.Gun({ peers: windowObj.__GUN_PEERS__ || [] });
+      user = gun.user();
+      user.recall?.({ sessionStorage: true });
+      for (let attempt = 0; attempt < 12 && !user.is; attempt += 1) {
+        await new Promise((resolve) => windowObj.setTimeout(resolve, 150));
+      }
+      secret = getUserSecret(user);
+      if (!user.is?.pub || !secret || typeof windowObj.SEA.encrypt !== 'function') return false;
+      node = user.get(SYNC_NODE).get('plan');
+      ready = true;
+      onStatus('Account sync is ready.');
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  return {
+    ready: init(),
+    async load(localPlan) {
+      if (!(await this.ready) || !node) return localPlan;
+      const record = await once(node, windowObj);
+      if (!record?.ciphertext) return localPlan;
+      try {
+        const decoded = await windowObj.SEA.decrypt(record.ciphertext, secret);
+        if (typeof decoded === 'string') {
+          try {
+            return JSON.parse(decoded);
+          } catch {
+            return localPlan;
+          }
+        }
+        return decoded && typeof decoded === 'object' ? decoded : localPlan;
+      } catch {
+        onStatus('Your account is connected, but its saved plan could not be opened.');
+        return localPlan;
+      }
+    },
+    async save(plan) {
+      if (!(await this.ready) || !node) return false;
+      try {
+        const ciphertext = await windowObj.SEA.encrypt(JSON.stringify(plan), secret);
+        const saved = await put(node, {
+          schemaVersion: 1,
+          updatedAt: plan.updatedAt,
+          ciphertext
+        });
+        if (saved) onStatus('Saved securely to your account and this browser.');
+        return saved;
+      } catch {
+        onStatus('Saved in this browser. Account sync will retry when available.');
+        return false;
+      }
+    },
+    async saveCompleted(plan) {
+      if (!(await this.ready) || !node) return false;
+      try {
+        const historyNode = user.get(SYNC_NODE).get('completed');
+        const record = await once(historyNode, windowObj);
+        let history = [];
+        if (record?.ciphertext) {
+          const decoded = await windowObj.SEA.decrypt(record.ciphertext, secret);
+          history = typeof decoded === 'string' ? JSON.parse(decoded) : decoded;
+        }
+        if (!Array.isArray(history)) history = [];
+        if (!history.some((item) => item?.completedAt === plan.completedAt)) history.push(plan);
+        const ciphertext = await windowObj.SEA.encrypt(JSON.stringify(history.slice(-12)), secret);
+        return put(historyNode, { schemaVersion: 1, ciphertext });
+      } catch {
+        return false;
+      }
+    },
+    isReady() {
+      return ready;
+    }
+  };
+}

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -99,13 +99,16 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(html, /data-game-control="forward"/);
   assert.match(html, /data-game-question/);
   assert.match(html, /data-game-replay/);
+  assert.match(html, /data-finish-panel/);
+  assert.match(html, /data-start-another/);
+  assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun/);
   assert.match(html, /You made it/);
   assert.match(html, /Not sure\? Pick one/);
   assert.match(html, /7 days/);
   assert.match(html, /Stabilize → Understand → Choose → Practice → Help → Earn → Build → Teach/);
   assert.match(html, /id="deleteAll"/);
   assert.match(html, /type="module" src="\.\/app\.js"/);
-  assert.doesNotMatch(`${html}\n${app}`, /Gun\(|fetch\(|XMLHttpRequest|WebSocket|sendBeacon|<script[^>]+src="https?:\/\//i);
+  assert.doesNotMatch(app, /fetch\(|XMLHttpRequest|WebSocket|sendBeacon/i);
   assert.match(app, /textContent/);
   assert.doesNotMatch(app, /innerHTML/);
   assert.match(app, /confirm\(/);
@@ -122,6 +125,8 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.doesNotMatch(app, /Fly to the gate and answer/);
   assert.match(app, /dispatchEvent\(new Event\('input'/);
   assert.match(app, /replace this Life Upgrade plan/);
+  assert.match(app, /Congratulations/);
+  assert.match(app, /sync\.save/);
 });
 
 test('portal home and Start page expose the Life Upgrade entry point', async () => {


### PR DESCRIPTION
## What changed
- Add a congratulations finish state with a Start another goal loop.
- Preserve completed goals locally and in encrypted Gun account history.
- Keep guest plans browser-local while signed-in users can restore their plan across devices.
- Add a Save across devices sign-in entry point.

## Verification
- node --test tests/life-upgrade.test.js (9/9 passing)
- git diff --check

## Deployment impact
Life Upgrade browser UX and client-side encrypted Gun sync only; no API, billing, or server configuration changes.