### PR TITLE
fix(life-upgrade): restore app initialization after sync update

### DIFF
--- a/life-upgrade/app.js
+++ b/life-upgrade/app.js
@@ -52,8 +52,10 @@ sync.ready.then(async (available) => {
   } else if (hasProgress(plan)) {
     sync.save(plan);
   }
-  root?.querySelector('[data-sync-label]').textContent = '🔐 Saved to your account';
-  root?.querySelector('.account-link').textContent = 'Account sync on';
+  const syncLabel = root?.querySelector('[data-sync-label]');
+  const accountLink = root?.querySelector('.account-link');
+  if (syncLabel) syncLabel.textContent = '🔐 Saved to your account';
+  if (accountLink) accountLink.textContent = 'Account sync on';
 });
 
 function hasStageAnswer(stageId, currentPlan = plan) {

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -127,6 +127,7 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(app, /replace this Life Upgrade plan/);
   assert.match(app, /Congratulations/);
   assert.match(app, /sync\.save/);
+  assert.doesNotMatch(app, /\?\.[^;\n]+\.textContent\s*=/);
 });
 
 test('portal home and Start page expose the Life Upgrade entry point', async () => {


### PR DESCRIPTION
## Fix
The account-sync status update used optional chaining on the left side of an assignment, which is invalid JavaScript. That prevented the Life Upgrade module from loading and left the raw form layout visible.

## Verification
- node --check life-upgrade/app.js
- node --test tests/life-upgrade.test.js (9/9)
- local Playwright smoke: no page errors; fields mount inside the game question panel

This is a client-only hotfix based directly on current main.