### PR TITLE
fix: carry portal auth into Life Upgrade

### DIFF
--- a/life-upgrade/app.js
+++ b/life-upgrade/app.js
@@ -54,8 +54,13 @@ sync.ready.then(async (available) => {
   }
   const syncLabel = root?.querySelector('[data-sync-label]');
   const accountLink = root?.querySelector('.account-link');
-  if (syncLabel) syncLabel.textContent = '🔐 Saved to your account';
-  if (accountLink) accountLink.textContent = 'Account sync on';
+  const displayName = sync.getDisplayName?.();
+  if (syncLabel) syncLabel.textContent = displayName
+    ? `🔐 ${displayName}`
+    : '🔐 Saved to your account';
+  if (accountLink) accountLink.textContent = displayName
+    ? `${displayName}'s account`
+    : 'Account sync on';
 });
 
 function hasStageAnswer(stageId, currentPlan = plan) {

--- a/life-upgrade/app.js
+++ b/life-upgrade/app.js
@@ -248,7 +248,7 @@ root?.addEventListener('click', (event) => {
     showFinishPanel(false);
     game?.replay();
     render();
-    setStatus('New goal ready. Fly to the first gate.');
+    setStatus('New gate ready. Fly to the first gate.');
     return;
   }
 

--- a/life-upgrade/game.js
+++ b/life-upgrade/game.js
@@ -20,10 +20,10 @@ const KEYS = {
 
 // One question is one quarter-mile flight. At 120 mph that is a 7.5-second
 // run; holding Fly raises the pace to 240 mph and cuts it to 3.75 seconds.
-// Keep the visual lane compact enough that the goal ring is already visible
-// when a new flight begins, while the HUD still represents the full distance.
+// Keep the visual lane long enough that the player visibly flies to the gate
+// instead of passing it early, while the HUD still represents the full distance.
 const SEGMENT_MILES = 0.25;
-const SEGMENT_SCENE_LENGTH = 52;
+const SEGMENT_SCENE_LENGTH = 120;
 const CRUISE_MPH = 120;
 const BOOST_MPH = 240;
 
@@ -121,8 +121,8 @@ export function createGame(canvas, { onArrive = () => {}, onReplay = () => {} } 
   const shell = canvas.closest('.game-world');
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x071426);
-  scene.fog = new THREE.Fog(0x071426, 28, 150);
-  const camera = new THREE.PerspectiveCamera(58, 1, 0.1, 150);
+  scene.fog = new THREE.Fog(0x071426, 42, 260);
+  const camera = new THREE.PerspectiveCamera(58, 1, 0.1, 280);
   camera.position.set(0, 3.4, 8);
   camera.lookAt(0, 1, -12);
   scene.add(new THREE.HemisphereLight(0x9be8ff, 0x101c37, 2.2));
@@ -195,7 +195,7 @@ export function createGame(canvas, { onArrive = () => {}, onReplay = () => {} } 
     gate.add(ring);
     const core = new THREE.Mesh(new THREE.SphereGeometry(isFinish ? 0.34 : 0.26, 12, 8), new THREE.MeshBasicMaterial({ color: isFinish ? 0xffe08a : 0xffc857 }));
     gate.add(core);
-    gate.add(makeWorldLabel(isFinish ? 'FINISH' : `GOAL ${index + 1}`, { color: isFinish ? '#ffb84d' : isFirst ? '#64f6ff' : '#d6f36d' }));
+    gate.add(makeWorldLabel(isFinish ? 'FINISH' : `GATE ${index + 1}`, { color: isFinish ? '#ffb84d' : isFirst ? '#64f6ff' : '#d6f36d' }));
     world.add(gate);
     gates.push(gate);
   }
@@ -269,8 +269,8 @@ export function createGame(canvas, { onArrive = () => {}, onReplay = () => {} } 
     const sceneProgress = (distance / targetDistance) * SEGMENT_SCENE_LENGTH;
     world.position.z = stageIndex * SEGMENT_SCENE_LENGTH + sceneProgress;
     player.position.z = 3;
-    const gate = gates[stageIndex];
-    if (gate) gate.rotation.z += delta * 0.6;
+    // The gate signs stay upright and still. The flight should carry the
+    // player to a clear landmark, not make the landmark spin past them.
     camera.position.x += (player.position.x * 0.22 - camera.position.x) * 0.08;
     camera.position.y += (player.position.y + 2.8 - camera.position.y) * 0.08;
     camera.lookAt(camera.position.x * 0.45, 1.1, -18 + sceneProgress * 0.08);

--- a/life-upgrade/index.html
+++ b/life-upgrade/index.html
@@ -40,10 +40,10 @@
               <button type="button" class="game-replay" data-game-replay>↻ Replay this flight</button>
               <div data-game-question-content></div>
               <section class="finish-panel" data-finish-panel hidden aria-live="polite">
-                <p class="finish-kicker">🏆 Goal complete</p>
+                <p class="finish-kicker">🏆 Gate complete</p>
                 <h2>You made a real change.</h2>
                 <p>Your win is saved. Want to choose another small thing and take another flight?</p>
-                <button type="button" class="primary finish-start" data-start-another>Start another goal →</button>
+                <button type="button" class="primary finish-start" data-start-another>Start another gate →</button>
                 <p class="finish-note">Your finished goal stays in this browser and on your account.</p>
               </section>
             </div>

--- a/life-upgrade/sync.js
+++ b/life-upgrade/sync.js
@@ -38,12 +38,23 @@ export function createLifeUpgradeSync({ windowObj = window, onStatus = () => {} 
   let secret;
   let ready = false;
 
+  const displayNameFrom = (identity = {}) => {
+    const username = String(identity.username || '').trim();
+    if (username && username.toLowerCase() !== 'guest') return username;
+    const alias = String(identity.alias || '').trim();
+    return alias.includes('@') ? alias.split('@')[0] : alias;
+  };
+
   const init = async () => {
     if (typeof windowObj.Gun !== 'function' || !windowObj.SEA) return false;
     try {
+      // The portal keeps the Gun session in localStorage and mirrors the
+      // display identity in a shared cookie. Hydrate both before recalling Gun
+      // so direct links behave like portal -> Life Upgrade navigation.
+      windowObj.AuthIdentity?.syncStorageFromSharedIdentity?.(windowObj.localStorage);
       gun = windowObj.Gun({ peers: windowObj.__GUN_PEERS__ || [] });
       user = gun.user();
-      user.recall?.({ sessionStorage: true });
+      user.recall?.({ sessionStorage: true, localStorage: true });
       for (let attempt = 0; attempt < 12 && !user.is; attempt += 1) {
         await new Promise((resolve) => windowObj.setTimeout(resolve, 150));
       }
@@ -51,7 +62,11 @@ export function createLifeUpgradeSync({ windowObj = window, onStatus = () => {} 
       if (!user.is?.pub || !secret || typeof windowObj.SEA.encrypt !== 'function') return false;
       node = user.get(SYNC_NODE).get('plan');
       ready = true;
-      onStatus('Account sync is ready.');
+      const identity = windowObj.AuthIdentity?.readSharedIdentity?.() || {};
+      const username = displayNameFrom(identity)
+        || String(windowObj.localStorage?.getItem('username') || '').trim()
+        || String(windowObj.localStorage?.getItem('alias') || '').trim().split('@')[0];
+      onStatus(username ? `Account sync is ready for ${username}.` : 'Account sync is ready.');
       return true;
     } catch {
       return false;
@@ -115,6 +130,12 @@ export function createLifeUpgradeSync({ windowObj = window, onStatus = () => {} 
     },
     isReady() {
       return ready;
+    },
+    getDisplayName() {
+      const identity = windowObj.AuthIdentity?.readSharedIdentity?.() || {};
+      return displayNameFrom(identity)
+        || String(windowObj.localStorage?.getItem('username') || '').trim()
+        || String(windowObj.localStorage?.getItem('alias') || '').trim().split('@')[0];
     }
   };
 }

--- a/sign-in.html
+++ b/sign-in.html
@@ -521,7 +521,9 @@
           <div class="actions">
             <button id="auth-submit" type="submit" class="primary-button">Sign in or sign up</button>
           </div>
-          <div class="oauth-panel" aria-labelledby="oauth-options-title">
+          <!-- OAuth remains wired for later, but is intentionally hidden until
+               the provider flows are ready for reliable sign-in. -->
+          <div class="oauth-panel" aria-labelledby="oauth-options-title" hidden>
             <div class="oauth-divider" id="oauth-options-title">Or continue with OAuth</div>
             <div class="oauth-grid">
               <button id="oauth-google" type="button" class="oauth-button" data-provider="google">Continue with Google</button>

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -87,6 +87,7 @@ test('storage failures do not throw and progress detection supports confirmed re
 test('page is offline-capable, safely rendered, and has the confirmed delete action', async () => {
   const html = await read('life-upgrade/index.html');
   const app = await read('life-upgrade/app.js');
+  const game = await read('life-upgrade/game.js');
   assert.equal(STAGES.length, 8);
   assert.match(html, /Private on this device/);
   assert.match(html, /One small win/);
@@ -129,6 +130,9 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(app, /Congratulations/);
   assert.match(app, /sync\.save/);
   assert.match(app, /getDisplayName/);
+  assert.match(game, /GATE \$\{index \+ 1\}/);
+  assert.match(game, /SEGMENT_SCENE_LENGTH = 120/);
+  assert.doesNotMatch(game, /gate\.rotation\.z \+=/);
   assert.doesNotMatch(app, /\?\.[^;\n]+\.textContent\s*=/);
 });
 

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -102,6 +102,7 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(html, /data-finish-panel/);
   assert.match(html, /data-start-another/);
   assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun/);
+  assert.match(html, /auth-identity\.js/);
   assert.match(html, /You made it/);
   assert.match(html, /Not sure\? Pick one/);
   assert.match(html, /7 days/);
@@ -127,6 +128,7 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(app, /replace this Life Upgrade plan/);
   assert.match(app, /Congratulations/);
   assert.match(app, /sync\.save/);
+  assert.match(app, /getDisplayName/);
   assert.doesNotMatch(app, /\?\.[^;\n]+\.textContent\s*=/);
 });
 

--- a/tests/sign-in-page.test.js
+++ b/tests/sign-in-page.test.js
@@ -44,9 +44,10 @@ describe('sign-in page', () => {
     assert.doesNotMatch(html, /href="\/auth\/recovery\.html"/);
   });
 
-  it('offers OAuth sign-in buttons and runtime wiring for Google, Microsoft, and Apple', async () => {
+  it('keeps OAuth wiring available but hides unfinished provider buttons', async () => {
     const html = await readFile(signInUrl, 'utf8');
     assert.match(html, /<script src="oauth\.js"><\/script>/);
+    assert.match(html, /class="oauth-panel"[^>]*hidden/);
     assert.match(html, /id="oauth-google"/);
     assert.match(html, /id="oauth-microsoft"/);
     assert.match(html, /id="oauth-apple"/);


### PR DESCRIPTION
## What changed

- Carry the signed-in portal Gun session into Life Upgrade from localStorage and sessionStorage.
- Show the signed-in username in the Life Upgrade account status.
- Make flight gates feel reachable, with still upright signs labeled GATE.
- Hide unfinished Google, Microsoft, and Apple sign-in buttons while preserving their wiring for later.

## Verification

- Focused Life Upgrade/auth tests: 17/17
- Focused sign-in/auth tests: 16/16
