### PR TITLE
fix: let flying pass through Life Upgrade gates

### DIFF
--- a/life-upgrade/game.js
+++ b/life-upgrade/game.js
@@ -26,7 +26,9 @@ const KEYS = {
 const SEGMENT_MILES = 0.25;
 const SEGMENT_SCENE_LENGTH = 220;
 const PLAYER_SCENE_Z = 3;
-const GATE_ARRIVAL_RADIUS = 1.6;
+// The player can fly above the gate center; use the visible ring's outer
+// radius so a straight flight through the gate counts without a walk tap.
+const GATE_ARRIVAL_RADIUS = 2.4;
 const CRUISE_MPH = 120;
 const BOOST_MPH = 240;
 

--- a/tests/life-upgrade.test.js
+++ b/tests/life-upgrade.test.js
@@ -132,7 +132,7 @@ test('page is offline-capable, safely rendered, and has the confirmed delete act
   assert.match(app, /getDisplayName/);
   assert.match(game, /GATE \$\{index \+ 1\}/);
   assert.match(game, /SEGMENT_SCENE_LENGTH = 220/);
-  assert.match(game, /GATE_ARRIVAL_RADIUS = 1\.6/);
+  assert.match(game, /GATE_ARRIVAL_RADIUS = 2\.4/);
   assert.match(game, /gateDistance <= GATE_ARRIVAL_RADIUS/);
   assert.doesNotMatch(game, /gate\.rotation\.z \+=/);
   assert.doesNotMatch(app, /\?\.[^;\n]+\.textContent\s*=/);


### PR DESCRIPTION
The Fly control raises the player above the gate center, so the previous 1.6-unit center-distance check required a walk tap to finish. Use the visible gate ring's 2.4-unit outer radius so a straight flight through the gate triggers arrival.\n\nFocused tests pass: 9/9.