### PR TITLE
fix: route Danny subdomain root

### DIFF
--- a/tests/danny-dictionary.test.js
+++ b/tests/danny-dictionary.test.js
@@ -19,4 +19,5 @@ test('Danny dictionary is routed from the custom subdomain', async () => {
   const vercel = await readFile(new URL('../vercel.json', import.meta.url), 'utf8');
   assert.match(vercel, /danny\.3dvr\.tech/);
   assert.match(vercel, /\/danny\/index\.html/);
+  assert.match(vercel, /"destination": "\/danny\/"/);
 });

--- a/vercel.json
+++ b/vercel.json
@@ -235,6 +235,17 @@
       ],
       "destination": "/crm/",
       "permanent": false
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "danny.3dvr.tech"
+        }
+      ],
+      "destination": "/danny/",
+      "permanent": false
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Ensure danny.3dvr.tech redirects its root directly to the Danny dictionary app shell.