### PR TITLE
fix: route Wenzo custom domain to gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>if (location.hostname === 'wenzo.3dvr.tech' && location.pathname === '/') location.replace('/wenzo/');</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>3DVR Portal</title>

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,17 @@
 {
+  "redirects": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "wenzo.3dvr.tech"
+        }
+      ],
+      "destination": "/wenzo/",
+      "permanent": false
+    }
+  ],
   "crons": [
     {
       "path": "/api/growth/homepage-hero-cron",
@@ -304,14 +317,14 @@
       "destination": "/danny/index.html"
     },
     {
-      "source": "/",
+      "source": "/:path*",
       "has": [
         {
           "type": "host",
           "value": "wenzo.3dvr.tech"
         }
       ],
-      "destination": "/wenzo/index.html"
+      "destination": "/wenzo/:path*"
     },
     {
       "source": "/webhooks/stripe",

--- a/wenzo/index.html
+++ b/wenzo/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Wenzo — a living gallery for Wendy's art."><title>Wenzo · Wendy's art</title>
-  <link rel="stylesheet" href="./styles.css"><script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script><script src="../gun-init.js"></script><script defer src="./app.js"></script>
+  <link rel="stylesheet" href="./styles.css"><script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script><script src="https://portal.3dvr.tech/gun-init.js"></script><script defer src="./app.js"></script>
 </head>
 <body>
   <header class="site-header"><nav><a class="wordmark" href="/"><span class="mark">W</span><span>Wenzo</span></a><a href="#gallery">Gallery</a><a href="#about">About Wendy</a><a class="nav-button" href="#addWork">Add artwork</a></nav></header>


### PR DESCRIPTION
Route wenzo.3dvr.tech through the existing portal project and preserve the standalone Wenzo asset paths.

Live browser verification: root lands at /wenzo/, title is Wenzo · Wendy's art, upload form and stylesheet load.