### PR TITLE
fix(wenzo): link footer to 3dvr.tech

### DIFF
--- a/tests/wenzo.test.js
+++ b/tests/wenzo.test.js
@@ -39,4 +39,8 @@ describe('Wenzo art gallery', () => {
     assert.match(app, /uploadRotation = \(uploadRotation \+ 1\) % 4/);
     assert.match(app, /publishWork\(updated\)/);
   });
+  it('links back to the public 3DVR site from the footer', async () => {
+    const html = await readFile(new URL('../wenzo/index.html', import.meta.url), 'utf8');
+    assert.match(html, /<footer><a href="https:\/\/3dvr\.tech">3DVR Portal<\/a>/);
+  });
 });

--- a/wenzo/index.html
+++ b/wenzo/index.html
@@ -20,6 +20,6 @@
       <figcaption id="lightboxTitle" class="lightbox__caption"></figcaption>
     </figure>
   </div>
-  <footer><a href="/">3DVR Portal</a><span>Wenzo · Wendy’s open studio</span></footer>
+  <footer><a href="https://3dvr.tech">3DVR Portal</a><span>Wenzo · Wendy’s open studio</span></footer>
 </body>
 </html>


### PR DESCRIPTION
Update the Wenzo footer's 3DVR Portal link to the public https://3dvr.tech site instead of the current site's root. Focused Wenzo tests pass 6/6.