### PR TITLE
docs: prepare weekly release v0.0.55

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -99,18 +99,27 @@
   <div class="section">
     <h2>Latest Release</h2>
     <article class="release-card">
-      <a class="release-link" href="v0.0.54.html">v0.0.54</a>
-      <span class="release-meta">Week of July 13, 2026</span>
+      <a class="release-link" href="v0.0.55.html">v0.0.55</a>
+      <span class="release-meta">Week of July 20, 2026</span>
       <p class="release-summary">
-        A measurable <a href="../free-page/">Free Page</a> outreach funnel with personalized previews, explicit
-        engagement and claim events, folded-phone polish, guarded Money Printer execution, and a deeper
-        <a href="../research/">OpenClaw research library</a>.
+        A playable <a href="../life-upgrade/">Life Upgrade</a> journey, clearer <a href="../next-move-lab/">Next Move</a>
+        guidance, <a href="../danny/">Danny’s Dictionary</a>, the <a href="../wenzo/">Wenzo gallery</a>, and a
+        weather-aware <a href="../sky-room/">Sky Room</a> refined for desktop and mobile.
       </p>
     </article>
   </div>
   <div class="section">
     <h2>Release History</h2>
     <ul class="release-grid">
+      <li class="release-card">
+        <a class="release-link" href="v0.0.55.html">v0.0.55</a>
+        <span class="release-meta">Week of July 20, 2026</span>
+        <p class="release-summary">
+          A playable <a href="../life-upgrade/">Life Upgrade</a> journey, clearer <a href="../next-move-lab/">Next Move</a>
+          guidance, <a href="../danny/">Danny’s Dictionary</a>, the <a href="../wenzo/">Wenzo gallery</a>, and a
+          weather-aware <a href="../sky-room/">Sky Room</a> refined for desktop and mobile.
+        </p>
+      </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.54.html">v0.0.54</a>
         <span class="release-meta">Week of July 13, 2026</span>

--- a/releases/v0.0.55.html
+++ b/releases/v0.0.55.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.55 (Week of July 20, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+    .release-nav-link.is-disabled { opacity: 0.4; pointer-events: none; cursor: default; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.54.html">Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+  </nav>
+  <h1>Release v0.0.55</h1>
+  <div class="tag">Week of July 20, 2026</div>
+  <div class="release-summary">
+    <p>
+      This week turned the portal toward guided change and visible worlds: a private Life Upgrade journey, a clearer
+      Next Move Lab, new language and art destinations, and a weather-aware Sky Room that works across desktop and
+      mobile.
+    </p>
+    <ul class="release-summary-list">
+      <li>
+        <strong>Guided personal change:</strong>
+        <a href="../life-upgrade/">Life Upgrade</a> became a playable, resumable journey with account handoff,
+        encrypted completion sync, reachable question gates, and a small Three.js world across
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1173">PR #1173</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1188">PR #1188</a>.
+      </li>
+      <li>
+        <strong>One-question-at-a-time guidance:</strong>
+        <a href="../next-move-lab/">Next Move Lab</a> now narrows topics, uses plain language, offers AI guidance, and
+        makes the next action easier to follow in <a href="https://github.com/tmsteph/3dvr-portal/pull/1160">PR #1160</a>
+        through <a href="https://github.com/tmsteph/3dvr-portal/pull/1168">PR #1168</a>.
+      </li>
+      <li>
+        <strong>New places to learn and look:</strong>
+        <a href="../danny/">Danny’s Dictionary</a>, the <a href="../wenzo/">Wenzo art gallery</a>, and the
+        <a href="../still-becoming/">Still Becoming</a> audio-visual experience add focused public destinations,
+        with the supporting agent monorepo and production dependency hardening in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1159">PR #1159</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1208">PR #1208</a>.
+      </li>
+      <li>
+        <strong><a href="../sky-room/">Sky Room</a>:</strong>
+        the outdoor scene now responds to location, season, weather, wildlife, daylight, sunrise, and sunset, with
+        fullscreen and mobile controls refined through <a href="https://github.com/tmsteph/3dvr-portal/pull/1189">PR #1189</a>
+        through <a href="https://github.com/tmsteph/3dvr-portal/pull/1212">PR #1212</a>.
+      </li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Release cadence</h2>
+    <p>
+      v0.0.55 is the next weekly release candidate and covers work merged from
+      <a href="https://github.com/tmsteph/3dvr-portal/pull/1156">PR #1156</a> through
+      <a href="https://github.com/tmsteph/3dvr-portal/pull/1212">PR #1212</a>. Discuss it Thursday, test the live
+      experiences through the weekend, and publish Monday morning, July 27, 2026, after the final production check.
+    </p>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">&copy; 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -15,12 +15,19 @@ async function fileExists(path) {
 }
 
 describe('release hub backfill', () => {
-  it('updates the release index with the weekly milestones through v0.0.54', async () => {
+  it('updates the release index with the weekly milestones through v0.0.55', async () => {
     const indexUrl = new URL('index.html', baseDir);
     assert.equal(await fileExists(indexUrl), true, 'releases/index.html should exist');
 
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /Latest Release/);
+    assert.match(html, /href="v0\.0\.55\.html">v0\.0\.55</);
+    assert.match(html, /Week of July 20, 2026/);
+    assert.match(html, /Life Upgrade/);
+    assert.match(html, /Next Move/);
+    assert.match(html, /Danny’s Dictionary/);
+    assert.match(html, /Wenzo gallery/);
+    assert.match(html, /Sky Room/);
     assert.match(html, /href="v0\.0\.54\.html">v0\.0\.54</);
     assert.match(html, /Week of July 13, 2026/);
     assert.match(html, /personalized previews/);
@@ -95,6 +102,7 @@ describe('release hub backfill', () => {
 
   it('ships the new milestone pages with coherent navigation, summaries, and source links', async () => {
     const releases = [
+      ['v0.0.55.html', /Week of July 20, 2026/, /Guided personal change/i, /aria-disabled="true"/],
       ['v0.0.54.html', /Week of July 13, 2026/, /Personalized preview funnel/i, /aria-disabled="true"/],
       ['v0.0.53.html', /Week of July 6, 2026/, /Money Printer becomes an operating loop/i, /href="v0\.0\.54\.html"/],
       ['v0.0.52.html', /Week of June 29, 2026/, /Free-first portal and Monday release path/i, /pull\/977/],
@@ -128,6 +136,7 @@ describe('release hub backfill', () => {
   });
 
   it('links shipped apps and docs inline where the release summaries mention them', async () => {
+    const release55 = await readFile(new URL('v0.0.55.html', baseDir), 'utf8');
     const release54 = await readFile(new URL('v0.0.54.html', baseDir), 'utf8');
     const release53 = await readFile(new URL('v0.0.53.html', baseDir), 'utf8');
     const release52 = await readFile(new URL('v0.0.52.html', baseDir), 'utf8');
@@ -212,5 +221,14 @@ describe('release hub backfill', () => {
     assert.match(release48, /href="\.\.\/stellar-flight\.html">Stellar Drift</);
     assert.match(release48, /<strong>Wellness and consciousness apps:<\/strong>[\s\S]*href="\.\.\/intention-lab\/"/);
     assert.match(release48, /pull\/672/);
+
+    assert.match(release55, /href="\.\.\/life-upgrade\/">Life Upgrade</);
+    assert.match(release55, /href="\.\.\/next-move-lab\/">Next Move Lab</);
+    assert.match(release55, /href="\.\.\/danny\/">Danny’s Dictionary</);
+    assert.match(release55, /href="\.\.\/wenzo\/">Wenzo art gallery</);
+    assert.match(release55, /href="\.\.\/still-becoming\/">Still Becoming</);
+    assert.match(release55, /href="\.\.\/sky-room\/">Sky Room</);
+    assert.match(release55, /pull\/1156/);
+    assert.match(release55, /pull\/1212/);
   });
 });


### PR DESCRIPTION
## Summary
- add the v0.0.55 release page for the week of July 20, 2026
- update the release hub's latest-release and history entries
- cover merged work from PR #1156 through PR #1212, including Life Upgrade, Next Move Lab, Danny's Dictionary, Wenzo, Still Becoming, and Sky Room
- document the Thursday discussion, weekend test window, and planned Monday morning release

## Verification
- `node --test tests/releases-hub.test.js`
- `git diff --check`

## Release plan
- Discuss: Thursday, July 23
- Test: through the weekend
- Release: Monday morning, July 27, after final production verification
