### PR TITLE
Add AV operator day-rate offer

### DIFF
--- a/apps/agent/test/outreach-compliance.test.js
+++ b/apps/agent/test/outreach-compliance.test.js
@@ -62,3 +62,18 @@ test('free-page experiment variant b changes the call to action and stays compli
     delete process.env.THREEDVR_OUTREACH_POSTAL_ADDRESS;
   }
 });
+
+test('av-operator offer states the day rate and event crew work', () => {
+  const previousProfile = process.env.THREEDVR_OUTREACH_OFFER_PROFILE;
+  process.env.THREEDVR_OUTREACH_OFFER_PROFILE = 'av-operator';
+  try {
+    const draft = buildTemplateOutreachDraft({ name: 'Local AV Company', experimentVariant: 'a' });
+    assert.equal(draft.source, 'template-av-operator');
+    assert.match(draft.text, /\$500\/day/);
+    assert.match(draft.text, /audio, video, show calls, troubleshooting, load-in, and strike/i);
+    assert.match(draft.text, /Business offer from 3dvr\.tech/i);
+  } finally {
+    if (previousProfile === undefined) delete process.env.THREEDVR_OUTREACH_OFFER_PROFILE;
+    else process.env.THREEDVR_OUTREACH_OFFER_PROFILE = previousProfile;
+  }
+});

--- a/apps/agent/thomas-agent/node/outreach-draft.js
+++ b/apps/agent/thomas-agent/node/outreach-draft.js
@@ -104,6 +104,16 @@ function buildTemplateOutreachDraft(lead = {}) {
       text: finalizeCommercialOutreach(body),
     };
   }
+  if (currentOfferProfile() === 'av-operator') {
+    const variant = normalizeText(lead.experimentVariant || lead.variant).toLowerCase();
+    const body = variant === 'b'
+      ? `Hi ${name} team,\n\nI'm Thomas with 3dvr.tech in San Diego. I am available as an audio-visual operator for event days at $500/day. I can step into an existing crew for audio, video, show calls, troubleshooting, load-in, or strike. Travel and special gear are quoted separately.${previewLine}\n\nDo you need reliable AV crew coverage for an upcoming event?\n\nThomas\n3dvr.tech`
+      : `Hi ${name} team,\n\nI'm Thomas with 3dvr.tech in San Diego. I am available for audio-visual operator work at $500/day. I can help with audio, video, show calls, troubleshooting, load-in, and strike, and can join an existing crew.${previewLine}\n\nDo you have any upcoming events that need an experienced AV operator?\n\nThomas\n3dvr.tech`;
+    return {
+      source: variant === 'b' ? 'template-av-operator-b' : 'template-av-operator',
+      text: finalizeCommercialOutreach(body),
+    };
+  }
   const hint = defaultHint(lead.site, lead.contact);
   return {
     source: 'template',
@@ -127,7 +137,14 @@ function buildPrompt(lead = {}) {
       '- Ask whether a simpler page would be useful for the business.',
       '- Say Thomas is with 3dvr.tech in San Diego.',
     ]
-    : [
+    : currentOfferProfile() === 'av-operator'
+      ? [
+        '- Offer Thomas as an audio-visual operator for event days at $500/day.',
+        '- Mention audio, video, show calls, troubleshooting, load-in, and strike.',
+        '- Say travel and special gear are quoted separately.',
+        '- Ask whether they need reliable AV crew coverage for an upcoming event.',
+      ]
+      : [
       '- Mention websites, follow-up systems, or online workflows in a natural way.',
       '- Ask one concise question about whether something in their website or customer flow is harder than it should be.',
     ];
@@ -163,7 +180,13 @@ function buildLocalPrompt(lead = {}) {
       'Offer: a clean one-page website draft at no cost, with no obligation to keep it.',
       'Ask whether a simpler page would be useful for the business.',
     ]
-    : [
+    : currentOfferProfile() === 'av-operator'
+      ? [
+        'Offer: Thomas is available as an audio-visual operator for event days at $500/day.',
+        'Mention audio, video, show calls, troubleshooting, load-in, and strike.',
+        'Ask whether they need reliable AV crew coverage for an upcoming event.',
+      ]
+      : [
       'Ask one concrete question about whether something on the site or in the customer flow is harder than it should be.',
     ];
   return [

--- a/apps/agent/thomas-agent/scripts/ask-send
+++ b/apps/agent/thomas-agent/scripts/ask-send
@@ -223,6 +223,8 @@ route="$(node "$LEAD_ROUTE_JS" --contact "$contact" --link "$link" --variant "$v
 
 if [ "${THREEDVR_OUTREACH_OFFER_PROFILE:-}" = "free-page" ]; then
   subject="A free one-page website for $name"
+elif [ "${THREEDVR_OUTREACH_OFFER_PROFILE:-}" = "av-operator" ]; then
+  subject="AV operator available for upcoming events"
 else
   subject="Question for $name"
 fi

--- a/av-operator/index.html
+++ b/av-operator/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AV Operator Available | 3DVR</title>
+  <meta name="description" content="Experienced audio-visual operator available for event days at $500/day. San Diego and travel work considered.">
+  <link rel="canonical" href="https://portal.3dvr.tech/av-operator/">
+  <style>
+    :root { color-scheme: dark; font-family: Inter, system-ui, sans-serif; background: #10131b; color: #f5f7fb; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; box-sizing: border-box; }
+    main { max-width: 720px; width: 100%; }
+    .eyebrow { color: #8ed8c1; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; font-size: .8rem; }
+    h1 { font-size: clamp(2.5rem, 8vw, 5.5rem); line-height: .95; margin: 16px 0 24px; max-width: 650px; }
+    p, li { font-size: 1.15rem; line-height: 1.55; color: #c9d0dc; }
+    ul { padding-left: 1.2rem; }
+    .card { border: 1px solid #394252; border-radius: 20px; padding: 24px; margin: 28px 0; background: #181d28; }
+    .rate { color: #fff; font-size: 2rem; font-weight: 800; margin: 0 0 8px; }
+    a { color: #8ed8c1; }
+    .button { display: inline-block; background: #8ed8c1; color: #10131b; padding: 14px 20px; border-radius: 999px; text-decoration: none; font-weight: 800; }
+    footer { color: #8e98a8; font-size: .9rem; margin-top: 40px; }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="eyebrow">3DVR · San Diego</p>
+    <h1>Need an AV operator for your event?</h1>
+    <p>I’m Thomas, an experienced audio-visual operator available to join your crew or help run a small event.</p>
+    <section class="card">
+      <p class="rate">$500 per day</p>
+      <p>Available for:</p>
+      <ul>
+        <li>Audio and video</li>
+        <li>Show calls</li>
+        <li>Troubleshooting</li>
+        <li>Load-in and strike</li>
+        <li>Corporate events and live productions</li>
+      </ul>
+      <p>Travel and special gear are quoted separately.</p>
+      <a class="button" href="mailto:3dvr.tech@gmail.com?subject=AV%20operator%20availability">Ask about a date</a>
+    </section>
+    <p>Tell me the event date, city, role, and crew needs. I’ll let you know if I’m a fit.</p>
+    <footer>Thomas · 3DVR · <a href="https://3dvr.tech">3dvr.tech</a></footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Adds the first concrete fast-cash offer for the automated business.

- Adds `/av-operator/` public offer page
- Adds compliant `av-operator` outreach profile with two copy variants
- Adds $500/day subject handling
- Adds focused regression coverage

The live campaign config will be updated only after this PR passes.