### PR TITLE
Align queued drafts with AV offer

### DIFF
--- a/apps/agent/test/outreach-compliance.test.js
+++ b/apps/agent/test/outreach-compliance.test.js
@@ -62,3 +62,18 @@ test('free-page experiment variant b changes the call to action and stays compli
     delete process.env.THREEDVR_OUTREACH_POSTAL_ADDRESS;
   }
 });
+
+test('av-operator offer states the day rate and event crew work', () => {
+  const previousProfile = process.env.THREEDVR_OUTREACH_OFFER_PROFILE;
+  process.env.THREEDVR_OUTREACH_OFFER_PROFILE = 'av-operator';
+  try {
+    const draft = buildTemplateOutreachDraft({ name: 'Local AV Company', experimentVariant: 'a' });
+    assert.equal(draft.source, 'template-av-operator');
+    assert.match(draft.text, /\$500\/day/);
+    assert.match(draft.text, /audio, video, show calls, troubleshooting, load-in, and strike/i);
+    assert.match(draft.text, /Business offer from 3dvr\.tech/i);
+  } finally {
+    if (previousProfile === undefined) delete process.env.THREEDVR_OUTREACH_OFFER_PROFILE;
+    else process.env.THREEDVR_OUTREACH_OFFER_PROFILE = previousProfile;
+  }
+});

--- a/apps/agent/test/outreach-draft-queue.test.js
+++ b/apps/agent/test/outreach-draft-queue.test.js
@@ -31,6 +31,24 @@ test('queues one idempotent lead brief with an opaque personalized preview link'
   }
 });
 
+test('queues the AV operator offer when the AV campaign profile is active', () => {
+  const previousProfile = process.env.THREEDVR_OUTREACH_OFFER_PROFILE;
+  process.env.THREEDVR_OUTREACH_OFFER_PROFILE = 'av-operator';
+  try {
+    const queueDir = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-av-queue-'));
+    const request = enqueueDraftRequest({
+      name: 'OnStage Playhouse',
+      site: 'https://example.org',
+      contact: 'mailto:crew@example.org',
+    }, { queueDir, campaignId: 'av-campaign' });
+    assert.match(request.instructions.offer, /audio-visual operator.*\$500\/day/i);
+    assert.doesNotMatch(request.instructions.prohibited.join(' '), /pricing/i);
+  } finally {
+    if (previousProfile === undefined) delete process.env.THREEDVR_OUTREACH_OFFER_PROFILE;
+    else process.env.THREEDVR_OUTREACH_OFFER_PROFILE = previousProfile;
+  }
+});
+
 test('accepts and revalidates a compliant Codex draft for the exact recipient', () => {
   const queueDir = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-draft-queue-'));
   try {

--- a/apps/agent/thomas-agent/node/lead-crawl.js
+++ b/apps/agent/thomas-agent/node/lead-crawl.js
@@ -21,6 +21,7 @@ const SEARCH_CATEGORY_TERMS = Object.freeze({
   food: Object.freeze(['local restaurant', 'catering company']),
   service: Object.freeze(['auto repair', 'hair salon', 'landscaping service', 'cleaning service']),
   professional: Object.freeze(['law office', 'accounting firm', 'consulting firm', 'real estate agency']),
+  'av-operator': Object.freeze(['audio visual company', 'event production company', 'AV rental company', 'live event production']),
   health: Object.freeze(['dental office', 'physical therapy clinic', 'wellness practice']),
 });
 const BLOCKED_SEARCH_HOST_PATTERN = /(^|\.)(?:ca\.gov|sandiego\.gov|sdcounty\.ca\.gov|yelp\.com|yellowpages\.com|bbb\.org|facebook\.com|instagram\.com|linkedin\.com|wikipedia\.org|indeed\.com|mapquest\.com|chamberofcommerce\.com|angi\.com|thumbtack\.com|expertise\.com)$/i;
@@ -59,6 +60,12 @@ const CATEGORY_PRESETS = Object.freeze({
     'node["office"="estate_agent"]',
     'way["office"="estate_agent"]',
   ]),
+  'av-operator': Object.freeze([
+    'node["office"="company"]',
+    'way["office"="company"]',
+    'node["amenity"="theatre"]',
+    'way["amenity"="theatre"]',
+  ]),
   health: Object.freeze([
     'node["amenity"="dentist"]',
     'way["amenity"="dentist"]',
@@ -71,7 +78,7 @@ const CATEGORY_PRESETS = Object.freeze({
 
 function usage() {
   console.log(`Usage:
-  ask-crawl [--location "San Diego, CA"] [--category coffee|food|service|professional|health] [--limit 25] [--radius-km 8] [--dry-run] [--include-chains] [--source overpass|search|auto]
+  ask-crawl [--location "San Diego, CA"] [--category coffee|food|service|professional|health|av-operator] [--limit 25] [--radius-km 8] [--dry-run] [--include-chains] [--source overpass|search|auto]
 
 Examples:
   ask-crawl --location "San Diego, CA" --category service --limit 30

--- a/apps/agent/thomas-agent/node/outreach-draft-queue.js
+++ b/apps/agent/thomas-agent/node/outreach-draft-queue.js
@@ -17,6 +17,10 @@ function normalizeEmail(value) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : '';
 }
 
+function currentOfferProfile() {
+  return normalizeText(process.env.THREEDVR_OUTREACH_OFFER_PROFILE).toLowerCase();
+}
+
 function cleanId(value) {
   return normalizeText(value).replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 80);
 }
@@ -110,6 +114,7 @@ function enqueueDraftRequest(lead = {}, options = {}) {
     focus: lead.previewFocus,
     action: lead.previewAction,
   }, options);
+  const avOperator = currentOfferProfile() === 'av-operator';
   const request = {
     version: 1,
     id,
@@ -130,8 +135,12 @@ function enqueueDraftRequest(lead = {}, options = {}) {
       requiredGreeting: `Hi ${normalizeText(lead.name)} team,`,
       requiredPreviewUrl: previewUrl,
       sender: 'Thomas at 3dvr.tech in San Diego',
-      offer: 'A no-cost one-page website draft with no obligation to keep it.',
-      prohibited: ['invented observations', 'pricing', 'guarantees', 'hype', 'alternate recipients'],
+      offer: avOperator
+        ? 'Thomas as an audio-visual operator for event days at $500/day, covering audio, video, show calls, troubleshooting, load-in, and strike.'
+        : 'A no-cost one-page website draft with no obligation to keep it.',
+      prohibited: avOperator
+        ? ['invented observations', 'guarantees', 'hype', 'alternate recipients']
+        : ['invented observations', 'pricing', 'guarantees', 'hype', 'alternate recipients'],
     },
   };
   writeJsonAtomic(path.join(paths.pending, `${id}.json`), request);

--- a/apps/agent/thomas-agent/node/outreach-draft.js
+++ b/apps/agent/thomas-agent/node/outreach-draft.js
@@ -104,6 +104,16 @@ function buildTemplateOutreachDraft(lead = {}) {
       text: finalizeCommercialOutreach(body),
     };
   }
+  if (currentOfferProfile() === 'av-operator') {
+    const variant = normalizeText(lead.experimentVariant || lead.variant).toLowerCase();
+    const body = variant === 'b'
+      ? `Hi ${name} team,\n\nI'm Thomas with 3dvr.tech in San Diego. I am available as an audio-visual operator for event days at $500/day. I can step into an existing crew for audio, video, show calls, troubleshooting, load-in, or strike. Travel and special gear are quoted separately.${previewLine}\n\nDo you need reliable AV crew coverage for an upcoming event?\n\nThomas\n3dvr.tech`
+      : `Hi ${name} team,\n\nI'm Thomas with 3dvr.tech in San Diego. I am available for audio-visual operator work at $500/day. I can help with audio, video, show calls, troubleshooting, load-in, and strike, and can join an existing crew.${previewLine}\n\nDo you have any upcoming events that need an experienced AV operator?\n\nThomas\n3dvr.tech`;
+    return {
+      source: variant === 'b' ? 'template-av-operator-b' : 'template-av-operator',
+      text: finalizeCommercialOutreach(body),
+    };
+  }
   const hint = defaultHint(lead.site, lead.contact);
   return {
     source: 'template',
@@ -127,7 +137,14 @@ function buildPrompt(lead = {}) {
       '- Ask whether a simpler page would be useful for the business.',
       '- Say Thomas is with 3dvr.tech in San Diego.',
     ]
-    : [
+    : currentOfferProfile() === 'av-operator'
+      ? [
+        '- Offer Thomas as an audio-visual operator for event days at $500/day.',
+        '- Mention audio, video, show calls, troubleshooting, load-in, and strike.',
+        '- Say travel and special gear are quoted separately.',
+        '- Ask whether they need reliable AV crew coverage for an upcoming event.',
+      ]
+      : [
       '- Mention websites, follow-up systems, or online workflows in a natural way.',
       '- Ask one concise question about whether something in their website or customer flow is harder than it should be.',
     ];
@@ -163,7 +180,13 @@ function buildLocalPrompt(lead = {}) {
       'Offer: a clean one-page website draft at no cost, with no obligation to keep it.',
       'Ask whether a simpler page would be useful for the business.',
     ]
-    : [
+    : currentOfferProfile() === 'av-operator'
+      ? [
+        'Offer: Thomas is available as an audio-visual operator for event days at $500/day.',
+        'Mention audio, video, show calls, troubleshooting, load-in, and strike.',
+        'Ask whether they need reliable AV crew coverage for an upcoming event.',
+      ]
+      : [
       'Ask one concrete question about whether something on the site or in the customer flow is harder than it should be.',
     ];
   return [

--- a/apps/agent/thomas-agent/scripts/ask-send
+++ b/apps/agent/thomas-agent/scripts/ask-send
@@ -223,6 +223,8 @@ route="$(node "$LEAD_ROUTE_JS" --contact "$contact" --link "$link" --variant "$v
 
 if [ "${THREEDVR_OUTREACH_OFFER_PROFILE:-}" = "free-page" ]; then
   subject="A free one-page website for $name"
+elif [ "${THREEDVR_OUTREACH_OFFER_PROFILE:-}" = "av-operator" ]; then
+  subject="AV operator available for upcoming events"
 else
   subject="Question for $name"
 fi

--- a/av-operator/index.html
+++ b/av-operator/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AV Operator Available | 3DVR</title>
+  <meta name="description" content="Experienced audio-visual operator available for event days at $500/day. San Diego and travel work considered.">
+  <link rel="canonical" href="https://portal.3dvr.tech/av-operator/">
+  <style>
+    :root { color-scheme: dark; font-family: Inter, system-ui, sans-serif; background: #10131b; color: #f5f7fb; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; box-sizing: border-box; }
+    main { max-width: 720px; width: 100%; }
+    .eyebrow { color: #8ed8c1; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; font-size: .8rem; }
+    h1 { font-size: clamp(2.5rem, 8vw, 5.5rem); line-height: .95; margin: 16px 0 24px; max-width: 650px; }
+    p, li { font-size: 1.15rem; line-height: 1.55; color: #c9d0dc; }
+    ul { padding-left: 1.2rem; }
+    .card { border: 1px solid #394252; border-radius: 20px; padding: 24px; margin: 28px 0; background: #181d28; }
+    .rate { color: #fff; font-size: 2rem; font-weight: 800; margin: 0 0 8px; }
+    a { color: #8ed8c1; }
+    .button { display: inline-block; background: #8ed8c1; color: #10131b; padding: 14px 20px; border-radius: 999px; text-decoration: none; font-weight: 800; }
+    footer { color: #8e98a8; font-size: .9rem; margin-top: 40px; }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="eyebrow">3DVR · San Diego</p>
+    <h1>Need an AV operator for your event?</h1>
+    <p>I’m Thomas, an experienced audio-visual operator available to join your crew or help run a small event.</p>
+    <section class="card">
+      <p class="rate">$500 per day</p>
+      <p>Available for:</p>
+      <ul>
+        <li>Audio and video</li>
+        <li>Show calls</li>
+        <li>Troubleshooting</li>
+        <li>Load-in and strike</li>
+        <li>Corporate events and live productions</li>
+      </ul>
+      <p>Travel and special gear are quoted separately.</p>
+      <a class="button" href="mailto:3dvr.tech@gmail.com?subject=AV%20operator%20availability">Ask about a date</a>
+    </section>
+    <p>Tell me the event date, city, role, and crew needs. I’ll let you know if I’m a fit.</p>
+    <footer>Thomas · 3DVR · <a href="https://3dvr.tech">3dvr.tech</a></footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
The AV campaign draft queue was still describing the old free-website offer. This makes queued instructions and validation profile-aware, so AV drafts can include the approved $500/day rate and event-operator scope.

Focused queue tests pass.