### PR TITLE
Add consent-based weekly field guide newsletter

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -1,0 +1,37 @@
+name: Weekly Field Guide Newsletter
+
+on:
+  schedule:
+    # Monday 10:30 AM Pacific Standard / 11:30 AM Pacific Daylight.
+    # This stays inside business hours year-round and runs once weekly.
+    - cron: '30 18 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Read the consented list and write no email'
+        required: false
+        default: 'true'
+
+jobs:
+  newsletter:
+    name: Send weekly field guide
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GMAIL_USER: ${{ secrets.GMAIL_USER }}
+      GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+      NEWSLETTER_REPLY_TO: ${{ vars.NEWSLETTER_REPLY_TO }}
+      THREEDVR_GUN_RELAY: ${{ vars.GROWTH_GUN_PEERS }}
+      NEWSLETTER_DRY_RUN: ${{ inputs.dry_run || 'false' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Send newsletter
+        run: node apps/agent/thomas-agent/node/weekly-newsletter.js

--- a/apps/agent/thomas-agent/node/weekly-newsletter.js
+++ b/apps/agent/thomas-agent/node/weekly-newsletter.js
@@ -1,0 +1,92 @@
+const crypto = require('crypto');
+const { createGmailTransport } = require('./gmail-transport');
+const { portalCrmNode, gun } = require('./gun-db');
+
+const NEWSLETTER_ROOT = gun.get('3dvr-portal').get('newsletter-weekly');
+const RELAY_READ_MS = Number.parseInt(process.env.NEWSLETTER_RELAY_READ_MS || '4000', 10);
+const DRY_RUN = /^(1|true|yes|on)$/i.test(String(process.env.NEWSLETTER_DRY_RUN || '').trim());
+const FROM = process.env.NEWSLETTER_FROM || process.env.GMAIL_USER || '3dvr.tech@gmail.com';
+const REPLY_TO = process.env.NEWSLETTER_REPLY_TO || '3dvr.tech@gmail.com';
+
+function nowIso() { return new Date().toISOString(); }
+function weekKey(date = new Date()) {
+  const copy = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = copy.getUTCDay() || 7;
+  copy.setUTCDate(copy.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(copy.getUTCFullYear(), 0, 1));
+  return `${copy.getUTCFullYear()}-W${String(Math.ceil((((copy - yearStart) / 86400000) + 1) / 7)).padStart(2, '0')}`;
+}
+function emailKey(email) { return crypto.createHash('sha256').update(email).digest('hex').slice(0, 24); }
+function text(value) { return String(value || '').trim(); }
+function isSubscriber(record) {
+  const tags = Array.isArray(record?.tags) ? record.tags : text(record?.tags).split(',');
+  const tagSet = new Set(tags.map((tag) => text(tag).toLowerCase()));
+  const status = text(record?.status).toLowerCase();
+  return Boolean(record?.email)
+    && tagSet.has('blog-subscriber')
+    && !tagSet.has('unsubscribed')
+    && !tagSet.has('newsletter-unsubscribed')
+    && !['unsubscribed', 'do-not-contact', 'bounced'].includes(status)
+    && /consent recorded|permission-based|subscribed/i.test(text(record?.notes) + ' ' + text(record?.nextBestAction));
+}
+function once(node, timeout = RELAY_READ_MS) {
+  return new Promise((resolve) => {
+    let done = false;
+    const timer = setTimeout(() => { if (!done) { done = true; resolve(null); } }, timeout);
+    node.once((data) => { if (!done) { done = true; clearTimeout(timer); resolve(data || null); } });
+  });
+}
+function put(node, payload) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Gun write timeout')), 5000);
+    node.put(payload, (ack) => { clearTimeout(timer); if (ack?.err) reject(new Error(ack.err)); else resolve(ack || {}); });
+  });
+}
+function collectSubscribers() {
+  return new Promise((resolve) => {
+    const found = new Map();
+    portalCrmNode().map().once((record) => {
+      if (!isSubscriber(record)) return;
+      const email = text(record.email).toLowerCase();
+      found.set(email, { ...record, email });
+    });
+    setTimeout(() => resolve([...found.values()].sort((a, b) => a.email.localeCompare(b.email))), RELAY_READ_MS);
+  });
+}
+function issue() {
+  return {
+    subject: 'A field note: build one paid bridge',
+    text: `Hi there,\n\nThis week’s note: if your day job is draining you, do not begin with a dramatic leap. Build one paid bridge.\n\nChoose a problem you already know how to solve, describe one useful outcome, put a price on it, and talk to ten plausible buyers. The goal is not to become a different person overnight. It is to create evidence and options while your current responsibilities still have to work.\n\nA good first bridge is small enough to deliver this month and specific enough that someone can say yes or no. Keep the promises honest, record what you learn, and improve the offer from real conversations.\n\nRead the field guide: https://portal.3dvr.tech/blog/\n\n— Thomas / 3DVR\n\nYou asked to receive these weekly notes. To unsubscribe, reply to this email with “unsubscribe”.`,
+    html: '<p>Hi there,</p><p><strong>This week’s note:</strong> if your day job is draining you, do not begin with a dramatic leap. Build one paid bridge.</p><p>Choose a problem you already know how to solve, describe one useful outcome, put a price on it, and talk to ten plausible buyers. The goal is not to become a different person overnight. It is to create evidence and options while your current responsibilities still have to work.</p><p>A good first bridge is small enough to deliver this month and specific enough that someone can say yes or no. Keep the promises honest, record what you learn, and improve the offer from real conversations.</p><p><a href="https://portal.3dvr.tech/blog/">Read the field guide →</a></p><p>— Thomas / 3DVR</p><hr><p style="font-size:12px;color:#666">You asked to receive these weekly notes. To unsubscribe, reply to this email with “unsubscribe”.</p>',
+  };
+}
+async function main() {
+  const week = process.env.NEWSLETTER_WEEK || weekKey();
+  const subscribers = await collectSubscribers();
+  const mail = issue();
+  const transport = DRY_RUN ? null : createGmailTransport();
+  const result = { week, dryRun: DRY_RUN, subscribers: subscribers.length, sent: 0, skipped: 0, failed: [] };
+  for (const subscriber of subscribers) {
+    const id = emailKey(subscriber.email);
+    const node = NEWSLETTER_ROOT.get(week).get(id);
+    const prior = await once(node, 1800);
+    if (prior?.status === 'sent') { result.skipped += 1; continue; }
+    const started = nowIso();
+    await put(node, { id, week, email: subscriber.email, status: DRY_RUN ? 'dry-run' : 'sending', startedAt: started, updatedAt: started });
+    try {
+      if (!DRY_RUN) await transport.sendMail({
+        from: FROM, to: subscriber.email, replyTo: REPLY_TO, subject: mail.subject,
+        text: mail.text, html: mail.html,
+        headers: { 'List-Unsubscribe': `<mailto:${REPLY_TO}?subject=unsubscribe>`, 'Precedence': 'bulk' },
+      });
+      await put(node, { id, week, email: subscriber.email, status: DRY_RUN ? 'dry-run' : 'sent', sentAt: nowIso(), updatedAt: nowIso(), subject: mail.subject });
+      result.sent += 1;
+    } catch (error) {
+      await put(node, { id, week, email: subscriber.email, status: 'failed', error: text(error.message).slice(0, 300), updatedAt: nowIso() });
+      result.failed.push({ email: subscriber.email, error: text(error.message).slice(0, 300) });
+    }
+  }
+  console.log(JSON.stringify(result, null, 2));
+  if (result.failed.length) process.exitCode = 1;
+}
+main().catch((error) => { console.error(error.stack || error); process.exitCode = 1; });


### PR DESCRIPTION
## What changed
- Adds a Monday business-hours weekly newsletter workflow.
- Reads only explicitly opted-in `blog-subscriber` CRM records.
- Uses a durable Gun send ledger to prevent duplicate weekly sends.
- Logs sent, failed, dry-run, and skipped states.
- Includes plain-text unsubscribe by reply plus List-Unsubscribe header.

## Verification
- `node --check apps/agent/thomas-agent/node/weekly-newsletter.js`
- Live dry run found 0 qualifying subscribers and sent 0 emails.