### PR TITLE
Fix weekly newsletter worker shutdown

### DIFF
--- a/apps/agent/thomas-agent/node/weekly-newsletter.js
+++ b/apps/agent/thomas-agent/node/weekly-newsletter.js
@@ -87,6 +87,8 @@ async function main() {
     }
   }
   console.log(JSON.stringify(result, null, 2));
-  if (result.failed.length) process.exitCode = 1;
+  // Gun keeps relay sockets open after the work is complete; explicitly end the
+  // worker so scheduled CI runs do not hang after a successful send/dry-run.
+  process.exit(result.failed.length ? 1 : 0);
 }
-main().catch((error) => { console.error(error.stack || error); process.exitCode = 1; });
+main().catch((error) => { console.error(error.stack || error); process.exit(1); });


### PR DESCRIPTION
The first production dry run completed its work but kept the Gun relay socket open. Explicitly exit after the send/dry-run result so scheduled Actions jobs finish cleanly.

No email was sent during the hanging dry run.