### PR TITLE
Store blog subscribers in Postgres

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -20,8 +20,9 @@ jobs:
     env:
       GMAIL_USER: ${{ secrets.GMAIL_USER }}
       GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+      NEWSLETTER_STORE_TOKEN: ${{ secrets.NEWSLETTER_STORE_TOKEN }}
       NEWSLETTER_REPLY_TO: ${{ vars.NEWSLETTER_REPLY_TO }}
-      THREEDVR_GUN_RELAY: ${{ vars.GROWTH_GUN_PEERS }}
+      NEWSLETTER_STORE_URL: ${{ vars.NEWSLETTER_STORE_URL }}
       NEWSLETTER_DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
       - name: Checkout repository

--- a/api/_lib/newsletter-store.js
+++ b/api/_lib/newsletter-store.js
@@ -1,0 +1,20 @@
+function value(input) {
+  return String(input || '').trim();
+}
+
+export async function saveNewsletterSubscriber(input, config = process.env, fetchImpl = fetch) {
+  const baseUrl = value(config.NEWSLETTER_STORE_URL).replace(/\/$/, '');
+  const token = value(config.NEWSLETTER_STORE_TOKEN);
+  if (!baseUrl || !token) throw new Error('Newsletter store is not configured.');
+  const response = await fetchImpl(`${baseUrl}/v1/subscribers`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(input),
+    signal: AbortSignal.timeout(8_000)
+  });
+  if (!response.ok) throw new Error(`Newsletter store returned ${response.status}.`);
+  return response.json();
+}

--- a/api/trial.js
+++ b/api/trial.js
@@ -1,5 +1,6 @@
 import Stripe from 'stripe';
 import nodemailer from 'nodemailer';
+import { saveNewsletterSubscriber } from './_lib/newsletter-store.js';
 
 function setCorsHeaders(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -120,6 +121,13 @@ export function createTrialHandler(options = {}) {
       }
       const signedUpAt = new Date().toISOString();
       try {
+        // Postgres is the canonical subscriber ledger. The mailbox copy below
+        // remains a recovery trail while the rest of the CRM moves off Gun.
+        await saveNewsletterSubscriber({
+          email: normalizedEmail,
+          source: normalizedSource,
+          consentedAt: signedUpAt
+        }, config);
         await transporter.sendMail({
           from: `"3DVR Field Guide" <${config.GMAIL_USER}>`,
           to: normalizedEmail,

--- a/apps/agent/thomas-agent/node/weekly-newsletter.js
+++ b/apps/agent/thomas-agent/node/weekly-newsletter.js
@@ -1,13 +1,10 @@
-const crypto = require('crypto');
 const { ImapFlow } = require('imapflow');
 const { createGmailTransport } = require('./gmail-transport');
-const { portalCrmNode, gun } = require('./gun-db');
-
-const NEWSLETTER_ROOT = gun.get('3dvr-portal').get('newsletter-weekly');
-const RELAY_READ_MS = Number.parseInt(process.env.NEWSLETTER_RELAY_READ_MS || '4000', 10);
 const DRY_RUN = /^(1|true|yes|on)$/i.test(String(process.env.NEWSLETTER_DRY_RUN || '').trim());
 const FROM = process.env.NEWSLETTER_FROM || process.env.GMAIL_USER || '3dvr.tech@gmail.com';
 const REPLY_TO = process.env.NEWSLETTER_REPLY_TO || '3dvr.tech@gmail.com';
+const STORE_URL = text(process.env.NEWSLETTER_STORE_URL).replace(/\/$/, '');
+const STORE_TOKEN = text(process.env.NEWSLETTER_STORE_TOKEN);
 
 function nowIso() { return new Date().toISOString(); }
 function weekKey(date = new Date()) {
@@ -17,24 +14,21 @@ function weekKey(date = new Date()) {
   const yearStart = new Date(Date.UTC(copy.getUTCFullYear(), 0, 1));
   return `${copy.getUTCFullYear()}-W${String(Math.ceil((((copy - yearStart) / 86400000) + 1) / 7)).padStart(2, '0')}`;
 }
-function emailKey(email) { return crypto.createHash('sha256').update(email).digest('hex').slice(0, 24); }
 function text(value) { return String(value || '').trim(); }
-function isSubscriber(record) {
-  const tags = Array.isArray(record?.tags) ? record.tags : text(record?.tags).split(',');
-  const tagSet = new Set(tags.map((tag) => text(tag).toLowerCase()));
-  const status = text(record?.status).toLowerCase();
-  return Boolean(record?.email)
-    && tagSet.has('blog-subscriber')
-    && !tagSet.has('unsubscribed')
-    && !tagSet.has('newsletter-unsubscribed')
-    && !['unsubscribed', 'do-not-contact', 'bounced'].includes(status)
-    && /consent recorded|permission-based|subscribed/i.test(text(record?.notes) + ' ' + text(record?.nextBestAction));
+async function store(path, options = {}) {
+  if (!STORE_URL || !STORE_TOKEN) throw new Error('NEWSLETTER_STORE_URL and NEWSLETTER_STORE_TOKEN are required.');
+  const response = await fetch(`${STORE_URL}${path}`, {
+    ...options,
+    headers: { authorization: `Bearer ${STORE_TOKEN}`, 'content-type': 'application/json', ...(options.headers || {}) },
+    signal: AbortSignal.timeout(10_000)
+  });
+  if (!response.ok) throw new Error(`Newsletter store returned ${response.status}.`);
+  return response.json();
 }
-function once(node, timeout = RELAY_READ_MS) {
-  return new Promise((resolve) => {
-    let done = false;
-    const timer = setTimeout(() => { if (!done) { done = true; resolve(null); } }, timeout);
-    node.once((data) => { if (!done) { done = true; clearTimeout(timer); resolve(data || null); } });
+async function saveSubscriber(record) {
+  return store('/v1/subscribers', {
+    method: 'POST',
+    body: JSON.stringify({ email: record.email, source: record.source || 'mailbox-import', consentedAt: record.consentedAt || record.at || nowIso() })
   });
 }
 async function collectMailboxSubscribers() {
@@ -56,7 +50,7 @@ async function collectMailboxSubscribers() {
           const record = JSON.parse(match[0]);
           const email = text(record.email).toLowerCase();
           if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && record.consent === true) {
-            found.set(email, { id: `subscriber-${emailKey(email)}`, email, tags: ['blog-subscriber', 'digital-nomad', 'inbound'], status: 'new', notes: `Consent recorded ${text(record.at) || nowIso()}. Imported from signup mailbox.` });
+            found.set(email, { email, source: record.source || 'mailbox-import', consentedAt: text(record.at) || nowIso() });
           }
         } catch (_) {}
       }
@@ -68,26 +62,11 @@ async function collectMailboxSubscribers() {
   }
   return [...found.values()];
 }
-function put(node, payload) {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error('Gun write timeout')), 5000);
-    node.put(payload, (ack) => { clearTimeout(timer); if (ack?.err) reject(new Error(ack.err)); else resolve(ack || {}); });
-  });
-}
 async function collectSubscribers() {
   const mailboxSubscribers = await collectMailboxSubscribers();
-  return new Promise((resolve) => {
-    const found = new Map();
-    portalCrmNode().map().once((record) => {
-      if (!isSubscriber(record)) return;
-      const email = text(record.email).toLowerCase();
-      found.set(email, { ...record, email });
-    });
-    setTimeout(() => {
-      for (const subscriber of mailboxSubscribers) found.set(subscriber.email, subscriber);
-      resolve([...found.values()].sort((a, b) => a.email.localeCompare(b.email)));
-    }, RELAY_READ_MS);
-  });
+  for (const subscriber of mailboxSubscribers) await saveSubscriber(subscriber);
+  const result = await store('/v1/subscribers');
+  return (result.subscribers || []).map(record => ({ ...record, email: text(record.email).toLowerCase() }));
 }
 function issue() {
   return {
@@ -103,22 +82,20 @@ async function main() {
   const transport = DRY_RUN ? null : createGmailTransport();
   const result = { week, dryRun: DRY_RUN, subscribers: subscribers.length, sent: 0, skipped: 0, failed: [] };
   for (const subscriber of subscribers) {
-    const id = emailKey(subscriber.email);
-    const node = NEWSLETTER_ROOT.get(week).get(id);
-    const prior = await once(node, 1800);
-    if (prior?.status === 'sent') { result.skipped += 1; continue; }
-    const started = nowIso();
-    await put(node, { id, week, email: subscriber.email, status: DRY_RUN ? 'dry-run' : 'sending', startedAt: started, updatedAt: started });
+    const path = `/v1/sends/${encodeURIComponent(week)}/${encodeURIComponent(subscriber.email)}`;
+    const prior = await store(path);
+    if (prior.send?.status === 'sent') { result.skipped += 1; continue; }
+    await store(path, { method: 'PUT', body: JSON.stringify({ status: DRY_RUN ? 'dry-run' : 'sending' }) });
     try {
       if (!DRY_RUN) await transport.sendMail({
         from: FROM, to: subscriber.email, replyTo: REPLY_TO, subject: mail.subject,
         text: mail.text, html: mail.html,
         headers: { 'List-Unsubscribe': `<mailto:${REPLY_TO}?subject=unsubscribe>`, 'Precedence': 'bulk' },
       });
-      await put(node, { id, week, email: subscriber.email, status: DRY_RUN ? 'dry-run' : 'sent', sentAt: nowIso(), updatedAt: nowIso(), subject: mail.subject });
+      await store(path, { method: 'PUT', body: JSON.stringify({ status: DRY_RUN ? 'dry-run' : 'sent', subject: mail.subject }) });
       result.sent += 1;
     } catch (error) {
-      await put(node, { id, week, email: subscriber.email, status: 'failed', error: text(error.message).slice(0, 300), updatedAt: nowIso() });
+      await store(path, { method: 'PUT', body: JSON.stringify({ status: 'failed', error: text(error.message).slice(0, 300) }) });
       result.failed.push({ email: subscriber.email, error: text(error.message).slice(0, 300) });
     }
   }

--- a/services/newsletter-store/3dvr-newsletter-store.service
+++ b/services/newsletter-store/3dvr-newsletter-store.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=3DVR newsletter Postgres API
+Wants=network-online.target
+After=network-online.target postgresql.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/3dvr-newsletter-store
+EnvironmentFile=/etc/3dvr/newsletter-store.env
+ExecStart=/usr/bin/node /opt/3dvr-newsletter-store/server.mjs
+Restart=on-failure
+RestartSec=3
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/services/newsletter-store/Caddyfile
+++ b/services/newsletter-store/Caddyfile
@@ -1,0 +1,13 @@
+selfhost.3dvr.tech {
+  handle_path /api/newsletter/* {
+    reverse_proxy 127.0.0.1:8787
+  }
+
+  root * /var/www/3dvr-test
+  file_server
+}
+
+:80 {
+  root * /var/www/3dvr-test
+  file_server
+}

--- a/services/newsletter-store/package.json
+++ b/services/newsletter-store/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "3dvr-newsletter-store",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "pg": "^8.16.3"
+  }
+}

--- a/services/newsletter-store/schema.sql
+++ b/services/newsletter-store/schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS newsletter_subscribers (
+  email TEXT PRIMARY KEY,
+  source TEXT NOT NULL DEFAULT 'blog',
+  consented_at TIMESTAMPTZ NOT NULL,
+  unsubscribed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS newsletter_sends (
+  week_key TEXT NOT NULL,
+  email TEXT NOT NULL REFERENCES newsletter_subscribers(email) ON DELETE CASCADE,
+  status TEXT NOT NULL CHECK (status IN ('sending', 'sent', 'failed', 'dry-run')),
+  subject TEXT,
+  error TEXT,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  sent_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (week_key, email)
+);
+
+CREATE INDEX IF NOT EXISTS newsletter_subscribers_active_idx
+  ON newsletter_subscribers (email)
+  WHERE unsubscribed_at IS NULL;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON newsletter_subscribers, newsletter_sends TO newsletter_store;

--- a/services/newsletter-store/server.mjs
+++ b/services/newsletter-store/server.mjs
@@ -1,0 +1,93 @@
+import crypto from 'node:crypto';
+import http from 'node:http';
+import { Pool } from 'pg';
+
+const port = Number.parseInt(process.env.PORT || '8787', 10);
+const token = String(process.env.NEWSLETTER_STORE_TOKEN || '');
+const databaseUrl = String(process.env.DATABASE_URL || '');
+if (!token || !databaseUrl) throw new Error('NEWSLETTER_STORE_TOKEN and DATABASE_URL are required.');
+
+const pool = new Pool({ connectionString: databaseUrl, max: 4, idleTimeoutMillis: 10_000 });
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function json(res, status, body) {
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' });
+  res.end(JSON.stringify(body));
+}
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+      if (body.length > 16_384) reject(new Error('Request is too large.'));
+    });
+    req.on('end', () => {
+      try { resolve(body ? JSON.parse(body) : {}); } catch (_) { reject(new Error('Invalid JSON.')); }
+    });
+    req.on('error', reject);
+  });
+}
+function authorized(req) {
+  const provided = String(req.headers.authorization || '').replace(/^Bearer\s+/i, '');
+  return provided.length === token.length && crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(token));
+}
+function normalizeEmail(value) { return String(value || '').trim().toLowerCase(); }
+async function upsertSubscriber(input) {
+  const email = normalizeEmail(input.email);
+  const source = String(input.source || 'blog').trim().slice(0, 120) || 'blog';
+  const consentedAt = new Date(input.consentedAt || Date.now());
+  if (!emailPattern.test(email) || Number.isNaN(consentedAt.getTime())) throw new Error('Enter a valid email.');
+  await pool.query(`
+    INSERT INTO newsletter_subscribers (email, source, consented_at, updated_at)
+    VALUES ($1, $2, $3, NOW())
+    ON CONFLICT (email) DO UPDATE SET
+      source = EXCLUDED.source,
+      consented_at = LEAST(newsletter_subscribers.consented_at, EXCLUDED.consented_at),
+      unsubscribed_at = NULL,
+      updated_at = NOW()
+  `, [email, source, consentedAt.toISOString()]);
+  return email;
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.url === '/healthz' && req.method === 'GET') {
+      await pool.query('SELECT 1'); return json(res, 200, { ok: true });
+    }
+    if (req.url === '/v1/subscribers' && req.method === 'POST') {
+      if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });
+      const email = await upsertSubscriber(await readBody(req));
+      return json(res, 201, { ok: true, email });
+    }
+    if (req.url === '/v1/subscribers' && req.method === 'GET') {
+      if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });
+      const { rows } = await pool.query('SELECT email, source, consented_at FROM newsletter_subscribers WHERE unsubscribed_at IS NULL ORDER BY consented_at ASC');
+      return json(res, 200, { subscribers: rows });
+    }
+    const sendMatch = req.url?.match(/^\/v1\/sends\/([\w-]+)\/([^/]+)$/);
+    if (sendMatch && req.method === 'GET') {
+      if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });
+      const { rows } = await pool.query('SELECT status FROM newsletter_sends WHERE week_key = $1 AND email = $2', [sendMatch[1], decodeURIComponent(sendMatch[2])]);
+      return json(res, 200, { send: rows[0] || null });
+    }
+    if (sendMatch && req.method === 'PUT') {
+      if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });
+      const input = await readBody(req); const email = normalizeEmail(decodeURIComponent(sendMatch[2]));
+      const status = String(input.status || '');
+      if (!emailPattern.test(email) || !['sending', 'sent', 'failed', 'dry-run'].includes(status)) return json(res, 400, { error: 'Invalid send record.' });
+      await pool.query(`
+        INSERT INTO newsletter_sends (week_key, email, status, subject, error, started_at, sent_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, NOW(), CASE WHEN $3 = 'sent' THEN NOW() ELSE NULL END, NOW())
+        ON CONFLICT (week_key, email) DO UPDATE SET
+          status = EXCLUDED.status, subject = COALESCE(EXCLUDED.subject, newsletter_sends.subject),
+          error = EXCLUDED.error, sent_at = CASE WHEN EXCLUDED.status = 'sent' THEN NOW() ELSE newsletter_sends.sent_at END,
+          updated_at = NOW()
+      `, [sendMatch[1], email, status, String(input.subject || '').slice(0, 300) || null, String(input.error || '').slice(0, 500) || null]);
+      return json(res, 200, { ok: true });
+    }
+    return json(res, 404, { error: 'Not found.' });
+  } catch (error) {
+    console.error(error); return json(res, 500, { error: 'Service error.' });
+  }
+});
+server.listen(port, '127.0.0.1', () => console.log(`newsletter store listening on ${port}`));


### PR DESCRIPTION
Moves blog signup and weekly-send records from the unreliable Gun relay to a private PostgreSQL instance behind the existing DigitalOcean HTTPS reverse proxy. PostgreSQL listens only on localhost; the Vercel and GitHub Action clients authenticate to the API with a secret.