### PR TITLE
Fix weekly newsletter worker dependencies

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -34,5 +34,7 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Install newsletter worker dependencies
+        run: npm --prefix apps/agent ci
       - name: Send newsletter
         run: node apps/agent/thomas-agent/node/weekly-newsletter.js


### PR DESCRIPTION
Installs the agent package before running the weekly newsletter job. This fixes the missing imapflow module uncovered by the production dry run.