### PR TITLE
Limit automated no-response follow-ups

### DIFF
--- a/apps/agent/test/campaign-limits.test.js
+++ b/apps/agent/test/campaign-limits.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const {
   campaignIsActive,
+  getFollowupEligibility,
   getCampaignAllowance,
   successfulRecipientKeys,
 } = require('../thomas-agent/node/campaign-limits');
@@ -52,4 +53,59 @@ test('successful recipient keys suppress already-contacted names and addresses',
   assert.equal(keys.has('name:acme studio'), true);
   assert.equal(keys.has('contact:mailto:owner@example.com'), true);
   assert.equal(keys.has('name:retry me'), false);
+});
+
+test('no-response follow-up requires 21 days and allows only one', () => {
+  const lead = { name: 'Acme Studio', contact: 'mailto:owner@example.com' };
+  const initial = {
+    timestamp: '2026-07-01T10:00:00.000Z',
+    status: 'sent',
+    name: lead.name,
+    contact: lead.contact,
+    subject: 'A free page for Acme Studio',
+  };
+
+  assert.deepEqual(
+    getFollowupEligibility([initial], lead, { now: '2026-07-20T10:00:00.000Z' }),
+    {
+      eligible: false,
+      retired: false,
+      reason: 'wait at least 21 days after initial outreach',
+      followupCount: 0,
+      ageDays: 19,
+    },
+  );
+  assert.equal(
+    getFollowupEligibility([initial], lead, { now: '2026-07-22T10:00:00.000Z' }).eligible,
+    true,
+  );
+
+  const followup = {
+    ...initial,
+    timestamp: '2026-07-22T10:00:00.000Z',
+    variant: 'follow-up',
+    subject: 'Quick follow-up',
+  };
+  const retired = getFollowupEligibility([initial, followup], lead, {
+    now: '2026-08-30T10:00:00.000Z',
+  });
+  assert.equal(retired.eligible, false);
+  assert.equal(retired.retired, true);
+  assert.equal(retired.followupCount, 1);
+});
+
+test('recipient history matches either normalized name or exact contact route', () => {
+  const entries = [{
+    timestamp: '2026-07-01T10:00:00.000Z',
+    status: 'sent',
+    name: 'Different Display Name',
+    contact: 'mailto:owner@example.com',
+  }];
+  const policy = getFollowupEligibility(entries, {
+    name: 'Acme Studio',
+    contact: 'mailto:owner@example.com',
+  }, {
+    now: '2026-07-30T10:00:00.000Z',
+  });
+  assert.equal(policy.eligible, true);
 });

--- a/apps/agent/test/crm-sync.test.js
+++ b/apps/agent/test/crm-sync.test.js
@@ -47,7 +47,7 @@ test('buildCrmRecord maps an agent lead into the portal CRM shape', () => {
   assert.equal(record.warmth, 'warm');
   assert.equal(record.marketSegment, 'Professional services');
   assert.equal(record.lastContacted, '2026-05-27');
-  assert.equal(record.nextFollowUp, '2026-06-03');
+  assert.equal(record.nextFollowUp, '2026-06-17');
   assert.match(record.tags, /source\/3dvr-agent/);
   assert.match(record.tags, /route\/email/);
   assert.match(record.nextBestAction, /Watch for a reply/);

--- a/apps/agent/thomas-agent/node/autopilot.js
+++ b/apps/agent/thomas-agent/node/autopilot.js
@@ -6,7 +6,11 @@ const { execFile } = require('child_process');
 const { promisify } = require('util');
 const nodemailer = require('nodemailer');
 const { buildGmailTransportOptions } = require('./gmail-transport');
-const { getCampaignAllowance, successfulRecipientKeys } = require('./campaign-limits');
+const {
+  getCampaignAllowance,
+  getFollowupEligibility,
+  successfulRecipientKeys,
+} = require('./campaign-limits');
 const { chooseExperimentVariant } = require('./experiment-optimizer');
 const { readOutreachLog } = require('./outreach-log');
 const { qualifyLeadWebsite } = require('./lead-quality');
@@ -44,6 +48,8 @@ const DEFAULT_CAMPAIGN_ID = normalizeText(
 );
 const DEFAULT_CAMPAIGN_START = normalizeText(process.env.THREEDVR_AUTOPILOT_CAMPAIGN_START);
 const DEFAULT_CAMPAIGN_END = normalizeText(process.env.THREEDVR_AUTOPILOT_CAMPAIGN_END);
+const DEFAULT_FOLLOWUP_MINIMUM_DAYS = parseInteger(process.env.THREEDVR_OUTREACH_FOLLOWUP_MINIMUM_DAYS, 21);
+const DEFAULT_FOLLOWUP_MAXIMUM = parseInteger(process.env.THREEDVR_OUTREACH_FOLLOWUP_MAXIMUM, 1);
 const DEFAULT_EXPERIMENT_VARIANTS = splitList(process.env.THREEDVR_AUTOPILOT_EXPERIMENT_VARIANTS || 'a;b');
 const DEFAULT_EXPERIMENT_MIN_SAMPLE = parseInteger(process.env.THREEDVR_AUTOPILOT_EXPERIMENT_MIN_SAMPLE, 8);
 const DEFAULT_EXPERIMENT_MIN_REPLIES = parseInteger(process.env.THREEDVR_AUTOPILOT_EXPERIMENT_MIN_REPLIES, 2);
@@ -714,8 +720,8 @@ function buildActionItems(summary) {
   if (summary.counts.new >= DEFAULT_NOTIFY_NEW_LEADS) {
     actions.push(`Review/send new outreach: ${summary.topNew.join(', ') || `${summary.counts.new} new lead(s)`}`);
   }
-  if (summary.counts.contacted > 0) {
-    actions.push(`Check follow-ups for ${summary.counts.contacted} contacted lead(s)`);
+  if (summary.followups?.eligible > 0) {
+    actions.push(`Review ${summary.followups.eligible} final follow-up candidate(s); each gets one maximum`);
   }
   if (summary.openAiCosts?.limitExceeded) {
     actions.push(`OpenAI spend guard hit: $${summary.openAiCosts.totalUsd.toFixed(2)} / $${summary.openAiCosts.limitUsd.toFixed(2)}`);
@@ -1108,6 +1114,24 @@ async function main() {
   const topReplied = topLeadNames(finalRows, 'replied');
   const topForm = topRouteLeadNames(finalRows, 'form');
   const topPageOnly = topRouteLeadNames(finalRows, 'contact-page').concat(topRouteLeadNames(finalRows, 'site'));
+  const followupPolicies = finalRows
+    .filter((row) => normalizeText(row.status).toLowerCase() === 'contacted')
+    .map((row) => ({
+      lead: row,
+      ...getFollowupEligibility(outreachEntries, row, {
+        minimumDays: DEFAULT_FOLLOWUP_MINIMUM_DAYS,
+        maximumFollowups: DEFAULT_FOLLOWUP_MAXIMUM,
+      }),
+    }));
+  const followups = {
+    minimumDays: DEFAULT_FOLLOWUP_MINIMUM_DAYS,
+    maximumPerNoResponseLead: DEFAULT_FOLLOWUP_MAXIMUM,
+    eligible: followupPolicies.filter((entry) => entry.eligible).length,
+    waiting: followupPolicies.filter((entry) => !entry.eligible && !entry.retired).length,
+    retired: followupPolicies.filter((entry) => entry.retired).length,
+    eligibleNames: followupPolicies.filter((entry) => entry.eligible).map((entry) => entry.lead.name),
+    retiredNames: followupPolicies.filter((entry) => entry.retired).map((entry) => entry.lead.name),
+  };
 
   const codex = await readCodexSummary(options.statusProbe);
   let openAiCosts = { available: false, reason: 'cost checks disabled' };
@@ -1125,7 +1149,7 @@ async function main() {
     commands.push('ask-next');
     commands.push('ask-send --enrich --mark "Lead Name"');
   }
-  if (counts.contacted > 0) {
+  if (followups.eligible > 0) {
     commands.push('ask-track followup');
   }
   if (routeCounts.formReady > 0 && topForm[0]) {
@@ -1156,7 +1180,7 @@ async function main() {
       sendWindow,
       ...campaignAllowance,
     },
-    experiment: chooseExperimentVariant(readOutreachLog(), {
+    experiment: chooseExperimentVariant(outreachEntries, {
       campaignId: DEFAULT_CAMPAIGN_ID,
       variants: DEFAULT_EXPERIMENT_VARIANTS,
       minSampleSize: DEFAULT_EXPERIMENT_MIN_SAMPLE,
@@ -1165,6 +1189,7 @@ async function main() {
     }),
     leadsFile: LEADS_FILE,
     counts,
+    followups,
     beforeCounts,
     beforeRouteCounts,
     beforeEnrichmentNeeded,
@@ -1219,6 +1244,7 @@ async function main() {
 
   console.log(`Autopilot run: ${summary.runId}`);
   console.log(`Counts: ${formatCounts(summary.counts)}`);
+  console.log(`Follow-ups: eligible=${summary.followups.eligible} waiting=${summary.followups.waiting} retired=${summary.followups.retired} minimumDays=${summary.followups.minimumDays} maximum=${summary.followups.maximumPerNoResponseLead}`);
   console.log(`Routes: ${formatRouteCounts(summary.routeCounts)}`);
   console.log(`Campaign: ${summary.campaign.id || 'unscoped'} daily=${summary.campaign.dailySent}/${summary.campaign.dailyLimit} total=${summary.campaign.campaignSent}/${summary.campaign.totalLimit || 'unlimited'}${summary.campaign.sendBlockedReason ? ` blocked=${summary.campaign.sendBlockedReason}` : ''}`);
   console.log(`Experiment: phase=${summary.experiment.phase} next=${summary.experiment.variant || 'off'}${summary.experiment.winner ? ` winner=${summary.experiment.winner}` : ''}`);

--- a/apps/agent/thomas-agent/node/campaign-limits.js
+++ b/apps/agent/thomas-agent/node/campaign-limits.js
@@ -64,10 +64,81 @@ function successfulRecipientKeys(entries = []) {
   return keys;
 }
 
+function isFollowupEntry(entry = {}) {
+  const text = [
+    entry.source,
+    entry.variant,
+    entry.subject,
+    entry.note,
+  ].map(normalizeText).join(' ').toLowerCase();
+  return /\bfollow[\s-]?up\b/.test(text);
+}
+
+function recipientEntries(entries = [], lead = {}) {
+  const name = normalizeText(lead.name).toLowerCase();
+  const contact = normalizeText(lead.contact).toLowerCase();
+  return entries
+    .filter(successfulOutreach)
+    .filter((entry) => {
+      const entryName = normalizeText(entry.name).toLowerCase();
+      const entryContact = normalizeText(entry.contact).toLowerCase();
+      return Boolean(
+        (name && entryName === name)
+        || (contact && entryContact === contact)
+      );
+    })
+    .sort((left, right) => normalizeText(left.timestamp).localeCompare(normalizeText(right.timestamp)));
+}
+
+function getFollowupEligibility(entries = [], lead = {}, options = {}) {
+  const minimumDays = parseLimit(options.minimumDays, 21);
+  const maximumFollowups = parseLimit(options.maximumFollowups, 1);
+  const now = new Date(options.now || Date.now());
+  const history = recipientEntries(entries, lead);
+  const followups = history.filter(isFollowupEntry);
+  const first = history[0];
+  const firstSentAt = first ? new Date(first.timestamp) : null;
+  const ageDays = firstSentAt && Number.isFinite(firstSentAt.getTime())
+    ? Math.floor((now.getTime() - firstSentAt.getTime()) / 86400000)
+    : null;
+
+  if (!history.length) {
+    return { eligible: false, retired: false, reason: 'no successful initial outreach', followupCount: 0, ageDays };
+  }
+  if (followups.length >= maximumFollowups) {
+    return {
+      eligible: false,
+      retired: true,
+      reason: 'maximum no-response follow-ups reached',
+      followupCount: followups.length,
+      ageDays,
+    };
+  }
+  if (ageDays === null || ageDays < minimumDays) {
+    return {
+      eligible: false,
+      retired: false,
+      reason: `wait at least ${minimumDays} days after initial outreach`,
+      followupCount: followups.length,
+      ageDays,
+    };
+  }
+  return {
+    eligible: true,
+    retired: false,
+    reason: 'one final no-response follow-up allowed',
+    followupCount: followups.length,
+    ageDays,
+  };
+}
+
 module.exports = {
   campaignIsActive,
+  getFollowupEligibility,
   getCampaignAllowance,
+  isFollowupEntry,
   parseLimit,
+  recipientEntries,
   successfulOutreach,
   successfulRecipientKeys,
 };

--- a/apps/agent/thomas-agent/node/crm-sync.js
+++ b/apps/agent/thomas-agent/node/crm-sync.js
@@ -193,7 +193,7 @@ function buildCrmRecord(lead, options = {}) {
     ? isoDate(lead.date, new Date(now))
     : '';
   const nextFollowUp = status === 'contacted'
-    ? isoDate(addDays(new Date(lastContacted || now), 7))
+    ? isoDate(addDays(new Date(lastContacted || now), 21))
     : '';
   const tags = [
     'source/3dvr-agent',


### PR DESCRIPTION
## Summary
- require 21 days before a no-response follow-up
- allow at most one follow-up per lead, then retire it
- expose eligibility counts in autopilot and move CRM follow-up dates to 21 days

## Verification
- focused policy, CRM, and routing tests passed (17/17)
- broader legacy suite passed 160 tests; 21 environment-coupled CLI tests failed because they read live lead/config files instead of fixtures