### PR TITLE
Use a calm dark theme for Smallest Step

### DIFF
--- a/smallest-step/index.html
+++ b/smallest-step/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Smallest Step | 3DVR Portal</title>
   <meta name="description" content="Picture the life you want, choose one tiny move, and build proof through action.">
-  <meta name="theme-color" content="#f4efe5">
+  <meta name="theme-color" content="#0d1513">
   <meta name="analytics" content="disabled">
   <link rel="stylesheet" href="/styles/global.css">
   <link rel="stylesheet" href="./smallest-step.css">

--- a/smallest-step/smallest-step.css
+++ b/smallest-step/smallest-step.css
@@ -1,1 +1,141 @@
-:root{color-scheme:light;--paper:#f4efe5;--ink:#1f2924;--muted:#667168;--line:#1f29242e;--green:#315f49;--soft:#dbe5d8;--sun:#e9b95d;--white:#fffdf8}*{box-sizing:border-box}body{margin:0;color:var(--ink);background:radial-gradient(circle at 85% 0,#e9b95d38,transparent 28rem),linear-gradient(#fbf8f1,var(--paper) 34rem);font:17px/1.55 Inter,system-ui,sans-serif}button,input,textarea{font:inherit}a{color:inherit}.skip-link{position:absolute;top:-5rem}.skip-link:focus{top:1rem}header,main,footer{width:min(calc(100% - 2rem),880px);margin:auto}header{min-height:76px;display:flex;justify-content:space-between;align-items:center}.brand{display:flex;align-items:center;gap:.65rem;text-decoration:none}.brand b{display:grid;place-items:center;width:42px;height:42px;border-radius:50%;background:var(--green);color:white;font-size:1.4rem}.brand strong,.brand small{display:block}.brand small{color:var(--muted);font-size:.72rem;text-transform:uppercase;letter-spacing:.12em}main{padding:4rem 0 3rem}.hero{max-width:720px;margin-bottom:3rem}.eyebrow{margin:0 0 .7rem;color:var(--green);font-size:.76rem;font-weight:800;letter-spacing:.14em;text-transform:uppercase}h1,h2,h3,p{margin-top:0}h1{margin-bottom:1.2rem;font:700 clamp(3rem,9vw,6.5rem)/.91 Georgia,serif;letter-spacing:-.055em}h2{font:700 clamp(1.8rem,5vw,3rem)/1 Georgia,serif}.lead,.card p,.empty,aside{color:var(--muted)}form{display:grid;gap:1rem}.card{display:grid;grid-template-columns:44px 1fr;gap:1rem;padding:clamp(1.2rem,4vw,2rem);border:1px solid var(--line);border-radius:22px;background:#fffdf8c2}.card i{display:grid;place-items:center;width:38px;height:38px;border-radius:50%;background:var(--soft);color:var(--green);font-style:normal;font-weight:800}label{display:block;font:700 clamp(1.35rem,4vw,2rem)/1.1 Georgia,serif}textarea,input{width:100%;border:1px solid var(--line);border-radius:14px;padding:1rem;background:var(--white)}.examples{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.75rem}.examples button,.steps button{border:1px solid var(--line);border-radius:99px;padding:.5rem .8rem;background:var(--soft);color:var(--green)}.commit{margin:1rem 0 4rem;padding:2rem;border-radius:22px;background:var(--green);color:white;text-align:center}.commit .eyebrow{color:#cae0d2}.primary{border:0;border-radius:99px;padding:.9rem 1.3rem;background:var(--sun);font-weight:800}.status{margin:.8rem 0 0;color:#d6e2da}.status.warn{color:#ffe0a4}.heading{display:flex;justify-content:space-between;align-items:end}.steps{display:grid;gap:.7rem}.steps article{display:flex;justify-content:space-between;align-items:center;gap:1rem;padding:1rem 1.2rem;border:1px solid var(--line);border-radius:16px;background:var(--white)}.steps article p{margin:0;color:var(--muted)}.steps .done{opacity:.7}.steps .done h3{text-decoration:line-through}aside{margin-top:2rem;padding:1.2rem;border-left:4px solid var(--sun);background:#fffdf88f}aside p{margin-bottom:.5rem}footer{display:flex;justify-content:space-between;padding:1.5rem 0 3rem;border-top:1px solid var(--line);color:var(--muted)}@media(max-width:560px){main{padding-top:2.5rem}.card{grid-template-columns:1fr}.heading,.steps article,footer{align-items:flex-start;flex-direction:column}.steps button{width:100%}}
+:root {
+  color-scheme: dark;
+  --paper: #0d1513;
+  --ink: #f2f0e8;
+  --muted: #aebbb3;
+  --line: #dce9e020;
+  --green: #86c99f;
+  --deep-green: #183b2d;
+  --soft: #1b3028;
+  --sun: #e7b85c;
+  --surface: #131f1b;
+  --surface-raised: #192823;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 85% 0, #e7b85c12, transparent 28rem),
+    linear-gradient(#101a17, var(--paper) 34rem);
+  font: 17px/1.55 Inter, system-ui, sans-serif;
+}
+
+button, input, textarea { font: inherit; }
+a { color: inherit; }
+.skip-link { position: absolute; top: -5rem; }
+.skip-link:focus { top: 1rem; }
+header, main, footer { width: min(calc(100% - 2rem), 880px); margin: auto; }
+header { min-height: 76px; display: flex; justify-content: space-between; align-items: center; }
+.brand { display: flex; align-items: center; gap: .65rem; text-decoration: none; }
+.brand b {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--deep-green);
+  color: var(--green);
+  font-size: 1.4rem;
+}
+.brand strong, .brand small { display: block; }
+.brand small { color: var(--muted); font-size: .72rem; text-transform: uppercase; letter-spacing: .12em; }
+main { padding: 4rem 0 3rem; }
+.hero { max-width: 720px; margin-bottom: 3rem; }
+.eyebrow {
+  margin: 0 0 .7rem;
+  color: var(--green);
+  font-size: .76rem;
+  font-weight: 800;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+h1, h2, h3, p { margin-top: 0; }
+h1 { margin-bottom: 1.2rem; font: 700 clamp(3rem, 9vw, 6.5rem)/.91 Georgia, serif; letter-spacing: -.055em; }
+h2 { font: 700 clamp(1.8rem, 5vw, 3rem)/1 Georgia, serif; }
+.lead, .card p, .empty, aside { color: var(--muted); }
+form { display: grid; gap: 1rem; }
+.card {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 1rem;
+  padding: clamp(1.2rem, 4vw, 2rem);
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: #131f1be8;
+  box-shadow: 0 18px 55px #00000024;
+}
+.card i {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: var(--soft);
+  color: var(--green);
+  font-style: normal;
+  font-weight: 800;
+}
+label { display: block; font: 700 clamp(1.35rem, 4vw, 2rem)/1.1 Georgia, serif; }
+textarea, input {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1rem;
+  background: #09110f;
+  color: var(--ink);
+  caret-color: var(--sun);
+}
+textarea::placeholder, input::placeholder { color: #839089; opacity: 1; }
+textarea:focus, input:focus, button:focus-visible, a:focus-visible {
+  outline: 3px solid var(--sun);
+  outline-offset: 3px;
+}
+.examples { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: .75rem; }
+.examples button, .steps button {
+  border: 1px solid var(--line);
+  border-radius: 99px;
+  padding: .5rem .8rem;
+  background: var(--soft);
+  color: #b9e7ca;
+}
+.commit {
+  margin: 1rem 0 4rem;
+  padding: 2rem;
+  border: 1px solid #86c99f2e;
+  border-radius: 22px;
+  background: linear-gradient(145deg, #173b2c, #10291f);
+  color: var(--ink);
+  text-align: center;
+}
+.commit .eyebrow { color: #b9e7ca; }
+.primary { border: 0; border-radius: 99px; padding: .9rem 1.3rem; background: var(--sun); color: #251b08; font-weight: 800; }
+.status { margin: .8rem 0 0; color: #b7c9be; }
+.status.warn { color: #ffe0a4; }
+.heading { display: flex; justify-content: space-between; align-items: end; }
+.steps { display: grid; gap: .7rem; }
+.steps article {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface-raised);
+}
+.steps article p { margin: 0; color: var(--muted); }
+.steps .done { opacity: .7; }
+.steps .done h3 { text-decoration: line-through; }
+aside { margin-top: 2rem; padding: 1.2rem; border-left: 4px solid var(--sun); background: #19231f; }
+aside p { margin-bottom: .5rem; }
+footer { display: flex; justify-content: space-between; padding: 1.5rem 0 3rem; border-top: 1px solid var(--line); color: var(--muted); }
+
+@media (max-width: 560px) {
+  main { padding-top: 2.5rem; }
+  .card { grid-template-columns: 1fr; }
+  .heading, .steps article, footer { align-items: flex-start; flex-direction: column; }
+  .steps button { width: 100%; }
+}

--- a/tests/smallest-step.test.js
+++ b/tests/smallest-step.test.js
@@ -18,14 +18,17 @@ test('Recent steps are newest first and app-scoped', () => {
 });
 
 test('Smallest Step ships as a private GUN-backed portal app', async () => {
-  const [html, js, manifest, portal] = await Promise.all([
+  const [html, css, js, manifest, portal] = await Promise.all([
     readFile(new URL('../smallest-step/index.html', import.meta.url), 'utf8'),
+    readFile(new URL('../smallest-step/smallest-step.css', import.meta.url), 'utf8'),
     readFile(new URL('../smallest-step/smallest-step.js', import.meta.url), 'utf8'),
     readFile(new URL('../app-manifests/smallest-step.webmanifest', import.meta.url), 'utf8'),
     readFile(new URL('../index.html', import.meta.url), 'utf8')
   ]);
   assert.match(html, /What is the smallest step you can take right now/);
   assert.match(html, /analytics" content="disabled/);
+  assert.match(html, /theme-color" content="#0d1513"/);
+  assert.match(css, /color-scheme:\s*dark/);
   assert.match(js, /get\('3dvr-portal'\)\.get\('smallest-step'\)/);
   assert.match(js, /get\('steps'\)\.get\(record\.id\)\.put\(record/);
   assert.match(manifest, /smallest-step\/\?source=pwa/);


### PR DESCRIPTION
Makes Smallest Step dark, warm, and low-glare by default. Preserves accessible contrast, visible focus states, readable inputs, and a matching browser/PWA theme color.\n\nTested: node --test tests/smallest-step.test.js