### PR TITLE
Make Smallest Step feel like a focused app

### DIFF
--- a/smallest-step/index.html
+++ b/smallest-step/index.html
@@ -18,35 +18,27 @@
 </head>
 <body>
   <a class="skip-link" href="#mainContent">Skip to Smallest Step</a>
-  <header><a class="brand" href="/"><b>→</b><span><strong>Smallest Step</strong><small>by 3DVR</small></span></a><a href="/">Portal</a></header>
+  <header>
+    <a class="brand" href="/"><b>→</b><strong>Smallest Step</strong></a>
+    <a class="portal-link" href="/" aria-label="Back to 3DVR Portal">×</a>
+  </header>
   <main id="mainContent">
-    <section class="hero">
-      <p class="eyebrow">A quiet practice for becoming</p>
-      <h1>See the life.<br>Take the step.</h1>
-      <p class="lead">You do not need the whole path. You only need the smallest honest move you can make now.</p>
-    </section>
     <form id="stepForm">
       <section class="card">
-        <i>1</i><div><label for="visionInput">Picture your ideal life</label><p>What does it look and feel like when life is going right?</p>
-        <textarea id="visionInput" rows="5" maxlength="1200" placeholder="I wake up with time for my family. My work is meaningful, calm, and free…"></textarea></div>
+        <label for="visionInput"><span>1</span>Visualize your ideal life.</label>
+        <textarea id="visionInput" rows="4" maxlength="1200" placeholder="I have time for my family. My work is meaningful, calm, and free…"></textarea>
       </section>
       <section class="card">
-        <i>2</i><div><label for="stepInput">What is the smallest step you can take right now?</label><p>Make it small enough to begin in five minutes.</p>
+        <label for="stepInput"><span>2</span>What is the smallest step you can take right now?</label>
         <input id="stepInput" maxlength="280" placeholder="Open the document and write one sentence">
-        <div class="examples"><button type="button" data-example="Send one honest message">Send one message</button><button type="button" data-example="Walk for five minutes">Walk five minutes</button><button type="button" data-example="Write the first sentence">Write one sentence</button></div></div>
       </section>
-      <section class="commit">
-        <p class="eyebrow">Make it real</p><h2>Tiny action is proof.</h2>
-        <button class="primary" type="submit">Save my step</button>
-        <p id="syncStatus" class="status" aria-live="polite">Preparing private sync…</p>
-      </section>
+      <button class="primary" type="submit">Save my step <span aria-hidden="true">→</span></button>
+      <p id="syncStatus" class="status" aria-live="polite">Preparing private sync…</p>
     </form>
-    <section class="proof">
-      <div class="heading"><div><p class="eyebrow">Proof of movement</p><h2>Your recent steps</h2></div><p><strong id="completedCount">0</strong> completed</p></div>
+    <details class="proof">
+      <summary><span>Recent steps</span><span><strong id="completedCount">0</strong> done <i>⌃</i></span></summary>
       <div id="recentSteps" class="steps" aria-live="polite"><p class="empty">Your first small step will appear here.</p></div>
-    </section>
-    <aside><p>Manifestation here means pairing a clear vision with real behavior. The app does not promise that thoughts alone control outcomes.</p><a href="/intention-lab/">Open the deeper Intention Lab</a></aside>
+    </details>
   </main>
-  <footer><a href="/">3DVR Portal</a><span>Small moves compound.</span></footer>
 </body>
 </html>

--- a/smallest-step/smallest-step.css
+++ b/smallest-step/smallest-step.css
@@ -1,141 +1,227 @@
 :root {
   color-scheme: dark;
-  --paper: #0d1513;
-  --ink: #f2f0e8;
-  --muted: #aebbb3;
-  --line: #dce9e020;
-  --green: #86c99f;
-  --deep-green: #183b2d;
-  --soft: #1b3028;
-  --sun: #e7b85c;
-  --surface: #131f1b;
-  --surface-raised: #192823;
+  --bg: #0b1210;
+  --surface: #121d19;
+  --surface-2: #192722;
+  --ink: #f4f1e8;
+  --muted: #9caaa2;
+  --line: #dce9e01f;
+  --green: #8ed1a6;
+  --gold: #e7b85c;
 }
 
 * { box-sizing: border-box; }
 
+html, body { height: 100%; }
+
 body {
   margin: 0;
+  overflow: hidden;
   color: var(--ink);
   background:
-    radial-gradient(circle at 85% 0, #e7b85c12, transparent 28rem),
-    linear-gradient(#101a17, var(--paper) 34rem);
-  font: 17px/1.55 Inter, system-ui, sans-serif;
+    radial-gradient(circle at 85% 0, #e7b85c12, transparent 24rem),
+    var(--bg);
+  font: 16px/1.45 Inter, system-ui, sans-serif;
 }
 
 button, input, textarea { font: inherit; }
 a { color: inherit; }
 .skip-link { position: absolute; top: -5rem; }
-.skip-link:focus { top: 1rem; }
-header, main, footer { width: min(calc(100% - 2rem), 880px); margin: auto; }
-header { min-height: 76px; display: flex; justify-content: space-between; align-items: center; }
-.brand { display: flex; align-items: center; gap: .65rem; text-decoration: none; }
+.skip-link:focus { top: .5rem; left: .5rem; z-index: 20; }
+
+header, main {
+  width: min(calc(100% - 1.5rem), 680px);
+  margin-inline: auto;
+}
+
+header {
+  height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: .65rem;
+  text-decoration: none;
+  font-size: .9rem;
+}
+
 .brand b {
   display: grid;
   place-items: center;
-  width: 42px;
-  height: 42px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
-  background: var(--deep-green);
+  background: #183b2d;
   color: var(--green);
-  font-size: 1.4rem;
 }
-.brand strong, .brand small { display: block; }
-.brand small { color: var(--muted); font-size: .72rem; text-transform: uppercase; letter-spacing: .12em; }
-main { padding: 4rem 0 3rem; }
-.hero { max-width: 720px; margin-bottom: 3rem; }
-.eyebrow {
-  margin: 0 0 .7rem;
-  color: var(--green);
-  font-size: .76rem;
-  font-weight: 800;
-  letter-spacing: .14em;
-  text-transform: uppercase;
-}
-h1, h2, h3, p { margin-top: 0; }
-h1 { margin-bottom: 1.2rem; font: 700 clamp(3rem, 9vw, 6.5rem)/.91 Georgia, serif; letter-spacing: -.055em; }
-h2 { font: 700 clamp(1.8rem, 5vw, 3rem)/1 Georgia, serif; }
-.lead, .card p, .empty, aside { color: var(--muted); }
-form { display: grid; gap: 1rem; }
-.card {
-  display: grid;
-  grid-template-columns: 44px 1fr;
-  gap: 1rem;
-  padding: clamp(1.2rem, 4vw, 2rem);
-  border: 1px solid var(--line);
-  border-radius: 22px;
-  background: #131f1be8;
-  box-shadow: 0 18px 55px #00000024;
-}
-.card i {
+
+.portal-link {
   display: grid;
   place-items: center;
   width: 38px;
   height: 38px;
-  border-radius: 50%;
-  background: var(--soft);
-  color: var(--green);
-  font-style: normal;
-  font-weight: 800;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 1.6rem;
 }
-label { display: block; font: 700 clamp(1.35rem, 4vw, 2rem)/1.1 Georgia, serif; }
+
+main {
+  height: calc(100dvh - 58px);
+  min-height: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+form {
+  min-height: 0;
+  display: grid;
+  align-content: center;
+  gap: clamp(.75rem, 2.3vh, 1.25rem);
+  padding: .5rem 0 1rem;
+}
+
+.card {
+  display: grid;
+  gap: .75rem;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: #121d19e8;
+  box-shadow: 0 16px 45px #00000024;
+}
+
+label {
+  display: flex;
+  align-items: flex-start;
+  gap: .7rem;
+  font: 700 clamp(1.25rem, 4.5vw, 1.8rem)/1.12 Georgia, serif;
+}
+
+label span {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #1b3028;
+  color: var(--green);
+  font: 800 .78rem/1 Inter, system-ui, sans-serif;
+}
+
 textarea, input {
   width: 100%;
   border: 1px solid var(--line);
-  border-radius: 14px;
-  padding: 1rem;
-  background: #09110f;
+  border-radius: 13px;
+  padding: .85rem 1rem;
+  background: #080e0c;
   color: var(--ink);
-  caret-color: var(--sun);
+  caret-color: var(--gold);
 }
-textarea::placeholder, input::placeholder { color: #839089; opacity: 1; }
-textarea:focus, input:focus, button:focus-visible, a:focus-visible {
-  outline: 3px solid var(--sun);
-  outline-offset: 3px;
+
+textarea {
+  min-height: clamp(82px, 14vh, 118px);
+  resize: none;
 }
-.examples { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: .75rem; }
-.examples button, .steps button {
-  border: 1px solid var(--line);
-  border-radius: 99px;
-  padding: .5rem .8rem;
-  background: var(--soft);
-  color: #b9e7ca;
+
+textarea::placeholder, input::placeholder {
+  color: #7f8d85;
+  opacity: 1;
 }
-.commit {
-  margin: 1rem 0 4rem;
-  padding: 2rem;
-  border: 1px solid #86c99f2e;
-  border-radius: 22px;
-  background: linear-gradient(145deg, #173b2c, #10291f);
-  color: var(--ink);
-  text-align: center;
+
+textarea:focus, input:focus, button:focus-visible, a:focus-visible, summary:focus-visible {
+  outline: 3px solid var(--gold);
+  outline-offset: 2px;
 }
-.commit .eyebrow { color: #b9e7ca; }
-.primary { border: 0; border-radius: 99px; padding: .9rem 1.3rem; background: var(--sun); color: #251b08; font-weight: 800; }
-.status { margin: .8rem 0 0; color: #b7c9be; }
+
+.primary {
+  min-height: 52px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: .65rem;
+  border: 0;
+  border-radius: 15px;
+  padding: .85rem 1.2rem;
+  background: var(--gold);
+  color: #251b08;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.primary span { font-size: 1.3rem; }
+.status { min-height: 1.35rem; margin: -.35rem 0 0; color: var(--muted); text-align: center; font-size: .8rem; }
 .status.warn { color: #ffe0a4; }
-.heading { display: flex; justify-content: space-between; align-items: end; }
-.steps { display: grid; gap: .7rem; }
+
+.proof {
+  position: relative;
+  z-index: 5;
+  border-top: 1px solid var(--line);
+  background: var(--bg);
+}
+
+.proof summary {
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--muted);
+  cursor: pointer;
+  list-style: none;
+  font-size: .85rem;
+}
+
+.proof summary::-webkit-details-marker { display: none; }
+.proof summary strong { color: var(--ink); }
+.proof summary i { display: inline-block; margin-left: .5rem; font-style: normal; transition: transform .2s ease; }
+.proof[open] summary i { transform: rotate(180deg); }
+
+.steps {
+  position: absolute;
+  right: 0;
+  bottom: 48px;
+  left: 0;
+  max-height: min(54dvh, 430px);
+  display: grid;
+  gap: .55rem;
+  overflow-y: auto;
+  padding: .75rem;
+  border: 1px solid var(--line);
+  border-radius: 18px 18px 0 0;
+  background: #101a17;
+  box-shadow: 0 -18px 60px #000a;
+}
+
 .steps article {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  padding: 1rem 1.2rem;
+  gap: .75rem;
+  padding: .9rem;
   border: 1px solid var(--line);
-  border-radius: 16px;
-  background: var(--surface-raised);
+  border-radius: 13px;
+  background: var(--surface-2);
 }
-.steps article p { margin: 0; color: var(--muted); }
-.steps .done { opacity: .7; }
-.steps .done h3 { text-decoration: line-through; }
-aside { margin-top: 2rem; padding: 1.2rem; border-left: 4px solid var(--sun); background: #19231f; }
-aside p { margin-bottom: .5rem; }
-footer { display: flex; justify-content: space-between; padding: 1.5rem 0 3rem; border-top: 1px solid var(--line); color: var(--muted); }
 
-@media (max-width: 560px) {
-  main { padding-top: 2.5rem; }
-  .card { grid-template-columns: 1fr; }
-  .heading, .steps article, footer { align-items: flex-start; flex-direction: column; }
-  .steps button { width: 100%; }
+.steps h3 { margin: 0 0 .15rem; font-size: .95rem; }
+.steps article p, .empty { margin: 0; color: var(--muted); font-size: .8rem; }
+.steps button {
+  flex: 0 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: .5rem .75rem;
+  background: #1b3028;
+  color: #b9e7ca;
+}
+.steps .done { opacity: .68; }
+.steps .done h3 { text-decoration: line-through; }
+
+@media (max-height: 650px) {
+  form { align-content: start; overflow-y: auto; padding-top: 0; }
+  .card { padding: .85rem; }
+  textarea { min-height: 72px; }
 }

--- a/tests/smallest-step.test.js
+++ b/tests/smallest-step.test.js
@@ -26,9 +26,13 @@ test('Smallest Step ships as a private GUN-backed portal app', async () => {
     readFile(new URL('../index.html', import.meta.url), 'utf8')
   ]);
   assert.match(html, /What is the smallest step you can take right now/);
+  assert.match(html, /Visualize your ideal life\./);
+  assert.doesNotMatch(html, /What does it look and feel like when life is going right/);
+  assert.doesNotMatch(html, /Make it small enough to begin in five minutes/);
   assert.match(html, /analytics" content="disabled/);
   assert.match(html, /theme-color" content="#0d1513"/);
   assert.match(css, /color-scheme:\s*dark/);
+  assert.match(css, /100dvh/);
   assert.match(js, /get\('3dvr-portal'\)\.get\('smallest-step'\)/);
   assert.match(js, /get\('steps'\)\.get\(record\.id\)\.put\(record/);
   assert.match(manifest, /smallest-step\/\?source=pwa/);


### PR DESCRIPTION
Turns Smallest Step into a concise, single-screen app flow: two prompts, two fields, and one primary action. Removes explanatory copy and example chips, prevents normal page scrolling, and moves history into a compact bottom drawer. No framework was added because the existing vanilla implementation covers this interaction with less weight.\n\nTested: node --test tests/smallest-step.test.js