### PR TITLE
Turn Smallest Step into a multi-view app

### DIFF
--- a/smallest-step/index.html
+++ b/smallest-step/index.html
@@ -23,23 +23,54 @@
     <a class="portal-link" href="/" aria-label="Back to 3DVR Portal">×</a>
   </header>
   <main id="mainContent">
-    <form id="stepForm">
-      <p class="intro">You do not need the whole path. You need the smallest honest move you can make right now.</p>
-      <section class="card">
-        <label for="visionInput"><span>1</span>Visualize your ideal life.</label>
-        <textarea id="visionInput" rows="4" maxlength="1200" placeholder="I have time for my family. My work is meaningful, calm, and free…"></textarea>
-      </section>
-      <section class="card">
-        <label for="stepInput"><span>2</span>What is the smallest step you can take right now?</label>
-        <input id="stepInput" maxlength="280" placeholder="Open the document and write one sentence">
-      </section>
-      <button class="primary" type="submit">Save my step <span aria-hidden="true">→</span></button>
-      <p id="syncStatus" class="status" aria-live="polite">Preparing private sync…</p>
-    </form>
-    <details class="proof">
-      <summary><span>Recent steps</span><span><strong id="completedCount">0</strong> done <i>⌃</i></span></summary>
+    <section class="view active" data-view="today">
+      <form id="stepForm">
+        <p class="intro">You do not need the whole path. You need the smallest honest move you can make right now.</p>
+        <section class="card">
+          <label for="visionInput"><span>1</span>Visualize your ideal life.</label>
+          <textarea id="visionInput" rows="4" maxlength="1200" placeholder="I have time for my family. My work is meaningful, calm, and free…"></textarea>
+        </section>
+        <section class="card">
+          <label for="stepInput"><span>2</span>What is the smallest step you can take right now?</label>
+          <input id="stepInput" maxlength="280" placeholder="Open the document and write one sentence">
+        </section>
+        <button class="primary" type="submit">Save my step <span aria-hidden="true">→</span></button>
+        <p id="syncStatus" class="status" aria-live="polite">Preparing private sync…</p>
+      </form>
+    </section>
+    <section class="view history-view" data-view="steps" hidden>
+      <div class="view-heading">
+        <p class="eyebrow">Proof of movement</p>
+        <h1>Saved steps</h1>
+        <p>Every honest move counts.</p>
+      </div>
       <div id="recentSteps" class="steps" aria-live="polite"><p class="empty">Your first small step will appear here.</p></div>
-    </details>
+    </section>
+    <section class="view guide-view" data-view="guide" hidden>
+      <div class="view-heading">
+        <p class="eyebrow">How it works</p>
+        <h1>See it. Move toward it.</h1>
+      </div>
+      <article class="guide-card">
+        <h2>Start tiny</h2>
+        <p>You do not need to know the whole path. Choose something honest that you can begin in five minutes.</p>
+        <div class="examples">
+          <button type="button" data-example="Send one honest message">Send one message</button>
+          <button type="button" data-example="Walk for five minutes">Walk five minutes</button>
+          <button type="button" data-example="Write the first sentence">Write one sentence</button>
+        </div>
+      </article>
+      <article class="guide-card">
+        <h2>Thought plus action</h2>
+        <p>Manifestation here means pairing a clear vision with real behavior. The app does not promise that thoughts alone control outcomes.</p>
+        <a href="/intention-lab/">Open the deeper Intention Lab →</a>
+      </article>
+    </section>
   </main>
+  <nav class="tabbar" aria-label="Smallest Step">
+    <button type="button" data-view-target="today" aria-selected="true"><span aria-hidden="true">✦</span>Today</button>
+    <button type="button" data-view-target="steps" aria-selected="false"><span aria-hidden="true">✓</span>Steps <b id="completedCount">0</b></button>
+    <button type="button" data-view-target="guide" aria-selected="false"><span aria-hidden="true">?</span>Guide</button>
+  </nav>
 </body>
 </html>

--- a/smallest-step/smallest-step.css
+++ b/smallest-step/smallest-step.css
@@ -11,16 +11,16 @@
 }
 
 * { box-sizing: border-box; }
-
 html, body { height: 100%; }
 
 body {
   margin: 0;
+  height: 100dvh;
   overflow: hidden;
+  display: grid;
+  grid-template-rows: 58px minmax(0, 1fr) 66px;
   color: var(--ink);
-  background:
-    radial-gradient(circle at 85% 0, #e7b85c12, transparent 24rem),
-    var(--bg);
+  background: radial-gradient(circle at 85% 0, #e7b85c12, transparent 24rem), var(--bg);
   font: 16px/1.45 Inter, system-ui, sans-serif;
 }
 
@@ -29,26 +29,13 @@ a { color: inherit; }
 .skip-link { position: absolute; top: -5rem; }
 .skip-link:focus { top: .5rem; left: .5rem; z-index: 20; }
 
-header, main {
+header, main, .tabbar {
   width: min(calc(100% - 1.5rem), 680px);
   margin-inline: auto;
 }
 
-header {
-  height: 58px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: .65rem;
-  text-decoration: none;
-  font-size: .9rem;
-}
-
+header { display: flex; align-items: center; justify-content: space-between; }
+.brand { display: flex; align-items: center; gap: .65rem; text-decoration: none; font-size: .9rem; }
 .brand b {
   display: grid;
   place-items: center;
@@ -58,7 +45,6 @@ header {
   background: #183b2d;
   color: var(--green);
 }
-
 .portal-link {
   display: grid;
   place-items: center;
@@ -69,19 +55,17 @@ header {
   font-size: 1.6rem;
 }
 
-main {
-  height: calc(100dvh - 58px);
-  min-height: 0;
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-}
+main { min-height: 0; }
+.view { height: 100%; min-height: 0; }
+.view[hidden] { display: none; }
 
 form {
+  height: 100%;
   min-height: 0;
   display: grid;
   align-content: center;
-  gap: clamp(.75rem, 2.3vh, 1.25rem);
-  padding: .5rem 0 1rem;
+  gap: clamp(.7rem, 2vh, 1.15rem);
+  padding: .35rem 0 .7rem;
 }
 
 .intro {
@@ -92,10 +76,10 @@ form {
   font: 600 clamp(.95rem, 3vw, 1.12rem)/1.4 Georgia, serif;
 }
 
-.card {
+.card, .guide-card {
   display: grid;
   gap: .75rem;
-  padding: clamp(1rem, 3vw, 1.5rem);
+  padding: clamp(1rem, 3vw, 1.4rem);
   border: 1px solid var(--line);
   border-radius: 20px;
   background: #121d19e8;
@@ -106,7 +90,7 @@ label {
   display: flex;
   align-items: flex-start;
   gap: .7rem;
-  font: 700 clamp(1.25rem, 4.5vw, 1.8rem)/1.12 Georgia, serif;
+  font: 700 clamp(1.2rem, 4.5vw, 1.7rem)/1.12 Georgia, serif;
 }
 
 label span {
@@ -130,106 +114,96 @@ textarea, input {
   color: var(--ink);
   caret-color: var(--gold);
 }
-
-textarea {
-  min-height: clamp(82px, 14vh, 118px);
-  resize: none;
-}
-
-textarea::placeholder, input::placeholder {
-  color: #7f8d85;
-  opacity: 1;
-}
-
-textarea:focus, input:focus, button:focus-visible, a:focus-visible, summary:focus-visible {
+textarea { min-height: clamp(78px, 12vh, 110px); resize: none; }
+textarea::placeholder, input::placeholder { color: #7f8d85; opacity: 1; }
+textarea:focus, input:focus, button:focus-visible, a:focus-visible {
   outline: 3px solid var(--gold);
   outline-offset: 2px;
 }
 
 .primary {
-  min-height: 52px;
+  min-height: 50px;
   display: flex;
   justify-content: center;
   align-items: center;
   gap: .65rem;
   border: 0;
   border-radius: 15px;
-  padding: .85rem 1.2rem;
+  padding: .8rem 1.2rem;
   background: var(--gold);
   color: #251b08;
   font-weight: 850;
   cursor: pointer;
 }
-
 .primary span { font-size: 1.3rem; }
-.status { min-height: 1.35rem; margin: -.35rem 0 0; color: var(--muted); text-align: center; font-size: .8rem; }
+.status { min-height: 1.2rem; margin: -.35rem 0 0; color: var(--muted); text-align: center; font-size: .78rem; }
 .status.warn { color: #ffe0a4; }
 
-.proof {
-  position: relative;
-  z-index: 5;
-  border-top: 1px solid var(--line);
-  background: var(--bg);
-}
+.history-view, .guide-view { overflow-y: auto; padding: 1rem 0 1.5rem; }
+.view-heading { margin-bottom: 1.2rem; }
+.view-heading h1 { margin: 0 0 .35rem; font: 700 clamp(2rem, 8vw, 3.5rem)/1 Georgia, serif; }
+.view-heading p:last-child { margin: 0; color: var(--muted); }
+.eyebrow { margin: 0 0 .45rem; color: var(--green); font-size: .72rem; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
 
-.proof summary {
-  height: 48px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: var(--muted);
-  cursor: pointer;
-  list-style: none;
-  font-size: .85rem;
-}
-
-.proof summary::-webkit-details-marker { display: none; }
-.proof summary strong { color: var(--ink); }
-.proof summary i { display: inline-block; margin-left: .5rem; font-style: normal; transition: transform .2s ease; }
-.proof[open] summary i { transform: rotate(180deg); }
-
-.steps {
-  position: absolute;
-  right: 0;
-  bottom: 48px;
-  left: 0;
-  max-height: min(54dvh, 430px);
-  display: grid;
-  gap: .55rem;
-  overflow-y: auto;
-  padding: .75rem;
-  border: 1px solid var(--line);
-  border-radius: 18px 18px 0 0;
-  background: #101a17;
-  box-shadow: 0 -18px 60px #000a;
-}
-
+.steps { display: grid; gap: .65rem; }
 .steps article {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: .75rem;
-  padding: .9rem;
+  padding: 1rem;
   border: 1px solid var(--line);
-  border-radius: 13px;
+  border-radius: 15px;
   background: var(--surface-2);
 }
-
-.steps h3 { margin: 0 0 .15rem; font-size: .95rem; }
-.steps article p, .empty { margin: 0; color: var(--muted); font-size: .8rem; }
-.steps button {
+.steps h3 { margin: 0 0 .2rem; font-size: 1rem; }
+.steps article p, .empty { margin: 0; color: var(--muted); font-size: .82rem; }
+.steps button, .examples button {
   flex: 0 0 auto;
   border: 1px solid var(--line);
   border-radius: 999px;
-  padding: .5rem .75rem;
+  padding: .55rem .8rem;
   background: #1b3028;
   color: #b9e7ca;
 }
 .steps .done { opacity: .68; }
 .steps .done h3 { text-decoration: line-through; }
 
-@media (max-height: 650px) {
-  form { align-content: start; overflow-y: auto; padding-top: 0; }
+.guide-view { display: grid; align-content: start; gap: .85rem; }
+.guide-card h2 { margin: 0; font: 700 1.35rem/1.15 Georgia, serif; }
+.guide-card p { margin: 0; color: var(--muted); }
+.guide-card a { color: var(--green); font-weight: 700; }
+.examples { display: flex; flex-wrap: wrap; gap: .5rem; }
+
+.tabbar {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--line);
+  background: #0b1210f2;
+}
+.tabbar button {
+  position: relative;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: .74rem;
+  cursor: pointer;
+}
+.tabbar button > span { display: block; margin-bottom: .1rem; font-size: 1.15rem; }
+.tabbar button[aria-selected="true"] { color: var(--green); }
+.tabbar b {
+  display: inline-grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  margin-left: .15rem;
+  border-radius: 999px;
+  background: #1b3028;
+  font-size: .65rem;
+}
+
+@media (max-height: 680px) {
+  form { align-content: start; overflow-y: auto; }
   .card { padding: .85rem; }
-  textarea { min-height: 72px; }
+  textarea { min-height: 68px; }
 }

--- a/smallest-step/smallest-step.js
+++ b/smallest-step/smallest-step.js
@@ -95,6 +95,19 @@ function init() {
     list: document.getElementById('recentSteps'), count: document.getElementById('completedCount'),
   };
   if (!refs.form) return;
+  const switchView = name => {
+    const next = ['today', 'steps', 'guide'].includes(name) ? name : 'today';
+    document.querySelectorAll('[data-view]').forEach(view => {
+      const active = view.dataset.view === next;
+      view.hidden = !active;
+      view.classList.toggle('active', active);
+    });
+    document.querySelectorAll('[data-view-target]').forEach(button => {
+      button.setAttribute('aria-selected', String(button.dataset.viewTarget === next));
+    });
+    if (history.replaceState) history.replaceState(null, '', `#${next}`);
+  };
+  document.querySelectorAll('[data-view-target]').forEach(button => button.addEventListener('click', () => switchView(button.dataset.viewTarget)));
   const context = gunContext();
   const state = { author: author(context.user), root: context.gun?.get('3dvr-portal').get('smallest-step'), steps: new Map() };
   refs.form.addEventListener('submit', event => {
@@ -108,8 +121,14 @@ function init() {
     state.root?.get('authors').get(record.author.id).get('steps').get(record.id).put(true);
     refs.step.value = '';
     render(refs, state);
+    switchView('steps');
   });
-  document.querySelectorAll('[data-example]').forEach(button => button.addEventListener('click', () => { refs.step.value = button.dataset.example; refs.step.focus(); }));
+  document.querySelectorAll('[data-example]').forEach(button => button.addEventListener('click', () => {
+    refs.step.value = button.dataset.example;
+    switchView('today');
+    refs.step.focus();
+  }));
+  switchView(location.hash.slice(1));
   if (!state.root) { status(refs, 'Offline mode. Sync will resume automatically.', true); return; }
   status(refs, context.isStub ? 'Offline mode. Sync will resume automatically.' : 'GUN sync ready.', context.isStub);
   state.root.get('steps').map().on((record, key) => {

--- a/tests/smallest-step.test.js
+++ b/tests/smallest-step.test.js
@@ -28,6 +28,10 @@ test('Smallest Step ships as a private GUN-backed portal app', async () => {
   assert.match(html, /What is the smallest step you can take right now/);
   assert.match(html, /Visualize your ideal life\./);
   assert.match(html, /You do not need the whole path\. You need the smallest honest move you can make right now\./);
+  assert.match(html, /data-view="steps"/);
+  assert.match(html, /data-view="guide"/);
+  assert.match(html, /Saved steps/);
+  assert.match(html, /Open the deeper Intention Lab/);
   assert.doesNotMatch(html, /What does it look and feel like when life is going right/);
   assert.doesNotMatch(html, /Make it small enough to begin in five minutes/);
   assert.match(html, /analytics" content="disabled/);
@@ -36,6 +40,7 @@ test('Smallest Step ships as a private GUN-backed portal app', async () => {
   assert.match(css, /100dvh/);
   assert.match(js, /get\('3dvr-portal'\)\.get\('smallest-step'\)/);
   assert.match(js, /get\('steps'\)\.get\(record\.id\)\.put\(record/);
+  assert.match(js, /switchView\('steps'\)/);
   assert.match(manifest, /smallest-step\/\?source=pwa/);
   assert.match(portal, /href="smallest-step\/"/);
 });


### PR DESCRIPTION
Replaces the hidden history drawer with clear Today, Steps, and Guide views in a persistent bottom navigation. Saving moves directly to Steps, where saved and completed actions are visible. Restores the supporting explanation, action examples, and Intention Lab link in Guide without adding page-level scrolling.\n\nTested: node --test tests/smallest-step.test.js