### PR TITLE
Add no-account Custom Payment app

### DIFF
--- a/api/stripe/[route].js
+++ b/api/stripe/[route].js
@@ -1,6 +1,7 @@
 import Stripe from 'stripe';
 import { resolvePlanFromSubscription } from '../../src/money/access.js';
 import { createStripeCheckoutHandler } from '../../src/billing/api-checkout.js';
+import { createCustomPaymentHandler } from '../../src/billing/api-custom-payment.js';
 import { createStripeStatusHandler } from '../../src/billing/api-status.js';
 
 const SAMPLE_STOREFRONT_PRODUCTS = Object.freeze({
@@ -854,6 +855,10 @@ export function createStripeDashboardHandler({
     stripeClient: resolvedStripeClient,
     config,
   });
+  const customPaymentHandler = createCustomPaymentHandler({
+    stripeClient: resolvedStripeClient,
+    config,
+  });
 
   return async function handler(req, res) {
     const route = getRouteValue(req);
@@ -862,6 +867,9 @@ export function createStripeDashboardHandler({
     }
     if (route === 'status') {
       return statusHandler(req, res);
+    }
+    if (route === 'custom-payment') {
+      return customPaymentHandler(req, res);
     }
     if (route === 'storefront-checkout') {
       try {

--- a/custom-payment/app.js
+++ b/custom-payment/app.js
@@ -1,0 +1,141 @@
+const gun = Gun({ peers: window.__GUN_PEERS__ || undefined })
+const user = gun.user()
+const form = document.getElementById('payment-form')
+const signedOut = document.getElementById('signed-out')
+const status = document.getElementById('status')
+const createButton = document.getElementById('create-button')
+const result = document.getElementById('result')
+const paymentLink = document.getElementById('payment-link')
+const previewLink = document.getElementById('preview-link')
+const copyButton = document.getElementById('copy-button')
+const shareButton = document.getElementById('share-button')
+const newButton = document.getElementById('new-button')
+const customerResult = document.getElementById('customer-result')
+const customerResultTitle = document.getElementById('customer-result-title')
+const customerResultCopy = document.getElementById('customer-result-copy')
+
+function stored(key) {
+  try {
+    return localStorage.getItem(key) || ''
+  } catch {
+    return ''
+  }
+}
+
+function currentPub() {
+  return String(user?._?.sea?.pub || user?.is?.pub || '').trim()
+}
+
+async function waitForSession(timeoutMs = 2500) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (currentPub() && user?._?.sea) return true
+    await new Promise(resolve => window.setTimeout(resolve, 100))
+  }
+  return false
+}
+
+async function restoreSession() {
+  const paymentState = new URLSearchParams(window.location.search).get('payment')
+  if (paymentState === 'success' || paymentState === 'cancel') {
+    form.hidden = true
+    signedOut.hidden = true
+    customerResult.hidden = false
+    if (paymentState === 'cancel') {
+      customerResultTitle.textContent = 'Payment not completed'
+      customerResultCopy.textContent = 'No charge was made. You can return to the Stripe checkout link whenever you are ready.'
+    }
+    return false
+  }
+
+  const alias = stored('alias').trim()
+  const password = stored('password')
+  const signedIn = stored('signedIn') === 'true'
+
+  try {
+    user.recall({ sessionStorage: true, localStorage: true })
+  } catch {}
+
+  if (signedIn && alias && password && !(await waitForSession(500))) {
+    await new Promise(resolve => user.auth(alias, password, () => resolve()))
+  }
+
+  const ready = signedIn && alias && await waitForSession()
+  form.hidden = !ready
+  signedOut.hidden = ready
+  return ready
+}
+
+async function buildAuth() {
+  const alias = stored('alias').trim()
+  const pub = currentPub()
+  if (!alias || !pub || !user?._?.sea) {
+    throw new Error('Sign in again to create a payment link.')
+  }
+
+  return {
+    portalAlias: alias,
+    portalPub: pub,
+    authPub: pub,
+    authProof: await Gun.SEA.sign({
+      scope: 'stripe-billing',
+      action: 'custom-payment',
+      alias,
+      pub,
+      origin: window.location.origin,
+      iat: Date.now()
+    }, user._.sea)
+  }
+}
+
+form.addEventListener('submit', async event => {
+  event.preventDefault()
+  createButton.disabled = true
+  status.textContent = 'Creating secure Stripe checkout…'
+
+  try {
+    const fields = Object.fromEntries(new FormData(form))
+    const auth = await buildAuth()
+    const response = await fetch('/api/stripe/custom-payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...fields, ...auth })
+    })
+    const body = await response.json().catch(() => ({}))
+    if (!response.ok) throw new Error(body.error || 'Could not create the payment link.')
+
+    paymentLink.value = body.url
+    previewLink.href = body.url
+    form.hidden = true
+    result.hidden = false
+    status.textContent = ''
+  } catch (error) {
+    status.textContent = error.message
+  } finally {
+    createButton.disabled = false
+  }
+})
+
+copyButton.addEventListener('click', async () => {
+  await navigator.clipboard.writeText(paymentLink.value)
+  copyButton.textContent = 'Copied'
+  window.setTimeout(() => { copyButton.textContent = 'Copy link' }, 1600)
+})
+
+if (navigator.share) {
+  shareButton.hidden = false
+  shareButton.addEventListener('click', () => navigator.share({
+    title: '3DVR payment',
+    text: 'Here is your secure 3DVR payment link:',
+    url: paymentLink.value
+  }))
+}
+
+newButton.addEventListener('click', () => {
+  form.reset()
+  result.hidden = true
+  form.hidden = false
+  form.querySelector('input')?.focus()
+})
+
+void restoreSession()

--- a/custom-payment/index.html
+++ b/custom-payment/index.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0b1118">
+  <meta name="robots" content="noindex">
+  <title>Custom Payment | 3DVR Portal</title>
+  <meta name="description" content="Create a secure Stripe checkout link for a custom 3DVR payment.">
+  <link rel="stylesheet" href="./styles.css">
+  <script defer src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script defer src="/gun-init.js"></script>
+  <script defer src="./app.js"></script>
+</head>
+<body>
+  <main class="app-shell">
+    <header>
+      <a href="/" class="back" aria-label="Back to portal">← Portal</a>
+      <p class="eyebrow">3DVR • Stripe</p>
+      <h1>Custom Payment</h1>
+      <p>Create the checkout, then send the secure Stripe link. Your customer does not need an account.</p>
+    </header>
+
+    <section id="customer-result" class="result" hidden>
+      <p class="eyebrow">3DVR Payment</p>
+      <h2 id="customer-result-title">Payment received</h2>
+      <p id="customer-result-copy">Thank you. Stripe will email your receipt.</p>
+    </section>
+
+    <section id="signed-out" class="notice" hidden>
+      <p>Sign in to create payment links.</p>
+      <a class="button" href="/sign-in.html?redirect=%2Fcustom-payment%2F">Sign in</a>
+    </section>
+
+    <form id="payment-form" autocomplete="on">
+      <label>
+        Customer name
+        <input name="customerName" autocomplete="name" required maxlength="120" placeholder="Jane Smith">
+      </label>
+      <label>
+        Customer email
+        <input name="customerEmail" type="email" autocomplete="email" required placeholder="jane@example.com">
+      </label>
+      <div class="split">
+        <label>
+          Amount
+          <span class="money-input"><span>$</span><input name="amount" type="number" inputmode="decimal" min="1" step="0.01" required placeholder="75.00"></span>
+        </label>
+        <label>
+          Reference <small>optional</small>
+          <input name="reference" maxlength="80" placeholder="BC-104">
+        </label>
+      </div>
+      <label>
+        What is it for?
+        <input name="description" required maxlength="120" placeholder="250 business cards">
+      </label>
+      <button id="create-button" class="button" type="submit">Create payment link</button>
+      <p id="status" class="status" role="status" aria-live="polite"></p>
+    </form>
+
+    <section id="result" class="result" hidden>
+      <p class="eyebrow">Ready to send</p>
+      <h2>Payment link created</h2>
+      <input id="payment-link" readonly aria-label="Payment link">
+      <div class="actions">
+        <button id="copy-button" class="button" type="button">Copy link</button>
+        <button id="share-button" class="button secondary" type="button" hidden>Share</button>
+        <a id="preview-link" class="button secondary" target="_blank" rel="noreferrer">Preview</a>
+      </div>
+      <button id="new-button" class="text-button" type="button">Create another</button>
+    </section>
+
+    <footer>Cards are entered on Stripe. 3DVR never sees or stores card details.</footer>
+  </main>
+</body>
+</html>

--- a/custom-payment/styles.css
+++ b/custom-payment/styles.css
@@ -1,0 +1,36 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  background: #0b1118;
+  color: #f4f7f5;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100svh; background: radial-gradient(circle at top, #18302d 0, #0b1118 42%); }
+.app-shell { width: min(100% - 32px, 620px); margin: auto; padding: 28px 0 22px; }
+header { margin-bottom: 24px; }
+.back { color: #9fc7bd; text-decoration: none; }
+.eyebrow { color: #78d3bc; font-size: .75rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+h1 { margin: 8px 0; font-size: clamp(2rem, 10vw, 3.5rem); line-height: .95; }
+h2 { margin: 6px 0 16px; }
+header > p:last-child, footer { color: #aebbb7; line-height: 1.5; }
+form, .result, .notice { display: grid; gap: 18px; padding: 22px; border: 1px solid #29423d; border-radius: 22px; background: rgba(13, 24, 28, .92); box-shadow: 0 24px 80px #0007; }
+label { display: grid; gap: 8px; color: #dce7e3; font-size: .9rem; font-weight: 650; }
+small { color: #82948f; font-weight: 400; }
+input { width: 100%; min-height: 50px; padding: 0 14px; border: 1px solid #36524b; border-radius: 12px; background: #091014; color: #fff; font: inherit; }
+input:focus { outline: 3px solid #78d3bc45; border-color: #78d3bc; }
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.money-input { display: flex; align-items: center; padding-left: 14px; border: 1px solid #36524b; border-radius: 12px; background: #091014; }
+.money-input input { border: 0; background: transparent; }
+.button { min-height: 50px; display: inline-grid; place-items: center; padding: 0 18px; border: 0; border-radius: 12px; background: #78d3bc; color: #07110e; font: inherit; font-weight: 800; text-decoration: none; cursor: pointer; }
+.button:disabled { opacity: .6; cursor: wait; }
+.secondary { background: #243732; color: #ecf8f4; }
+.status { min-height: 1.3em; margin: -6px 0 0; color: #efb873; }
+.actions { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.text-button { justify-self: center; border: 0; background: none; color: #9fc7bd; text-decoration: underline; cursor: pointer; }
+footer { padding: 20px 8px 0; text-align: center; font-size: .8rem; }
+[hidden] { display: none !important; }
+@media (max-width: 480px) {
+  .split, .actions { grid-template-columns: 1fr; }
+  .app-shell { width: min(100% - 20px, 620px); padding-top: 18px; }
+}

--- a/index.html
+++ b/index.html
@@ -719,6 +719,11 @@
             <span class="app-card__title">Billing</span>
             <span class="app-card__meta">Manage plans, invoices, renewals, and Stripe-linked account status.</span>
           </a>
+          <a href="custom-payment/" class="app-card" data-app-keywords="custom payment checkout stripe invoice deposit business cards">
+            <span class="app-card__icon" aria-hidden="true">💵</span>
+            <span class="app-card__title">Custom Payment</span>
+            <span class="app-card__meta">Create a no-account Stripe checkout link for a customer.</span>
+          </a>
           <a href="finance/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">💰</span>
             <span class="app-card__title">Finance</span>

--- a/src/billing/api-custom-payment.js
+++ b/src/billing/api-custom-payment.js
@@ -1,0 +1,122 @@
+import { verifyBillingAuthPayload } from './auth.js';
+import { getRequestOrigin, makeStripeClient, setCorsHeaders } from './stripe.js';
+import { isValidBillingEmail, normalizeBillingEmail, normalizeCustomAmount } from './plans.js';
+
+function cleanText(value, limit) {
+  return String(value || '').trim().replace(/\s+/g, ' ').slice(0, limit);
+}
+
+export function buildOperatorPaymentSessionPayload({
+  amountCents,
+  customerEmail,
+  customerName,
+  description,
+  reference,
+  origin
+}) {
+  const metadata = {
+    payment_source: 'custom-payment',
+    customer_name: customerName,
+    customer_email: customerEmail,
+    reference,
+    description
+  };
+  const compactMetadata = Object.fromEntries(
+    Object.entries(metadata).filter(([, value]) => Boolean(value))
+  );
+
+  return {
+    mode: 'payment',
+    customer_email: customerEmail,
+    customer_creation: 'always',
+    billing_address_collection: 'auto',
+    payment_intent_data: {
+      description,
+      metadata: compactMetadata
+    },
+    line_items: [{
+      quantity: 1,
+      price_data: {
+        currency: 'usd',
+        unit_amount: amountCents,
+        product_data: {
+          name: description,
+          metadata: compactMetadata
+        }
+      }
+    }],
+    metadata: compactMetadata,
+    success_url: `${origin}/custom-payment/?payment=success`,
+    cancel_url: `${origin}/custom-payment/?payment=cancel`
+  };
+}
+
+export function createCustomPaymentHandler(options = {}) {
+  const config = options.config || process.env;
+  const stripeClient = options.stripeClient || makeStripeClient(config);
+
+  return async function handler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+    if (req.method !== 'POST') {
+      res.setHeader('Allow', 'POST, OPTIONS');
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+    if (!stripeClient) {
+      return res.status(500).json({ error: 'Stripe is not configured on the server.' });
+    }
+
+    const body = req?.body && typeof req.body === 'object' ? req.body : {};
+    const origin = getRequestOrigin(req, config);
+    const auth = await verifyBillingAuthPayload(body, {
+      config,
+      expectedOrigin: origin
+    });
+    if (!auth.ok) {
+      return res.status(401).json({ error: auth.reason });
+    }
+
+    const customerEmail = normalizeBillingEmail(body.customerEmail);
+    const customerName = cleanText(body.customerName, 120);
+    const description = cleanText(body.description, 120);
+    const reference = cleanText(body.reference, 80);
+    const amountCents = normalizeCustomAmount(body.amount);
+
+    if (!customerName) {
+      return res.status(400).json({ error: 'Enter the customer name.' });
+    }
+    if (!isValidBillingEmail(customerEmail)) {
+      return res.status(400).json({ error: 'Enter a valid customer email.' });
+    }
+    if (!description) {
+      return res.status(400).json({ error: 'Enter what the payment is for.' });
+    }
+    if (!amountCents || amountCents < 100 || amountCents > 99999999) {
+      return res.status(400).json({ error: 'Enter an amount from $1 to $999,999.99.' });
+    }
+
+    try {
+      const session = await stripeClient.checkout.sessions.create(
+        buildOperatorPaymentSessionPayload({
+          amountCents,
+          customerEmail,
+          customerName,
+          description,
+          reference,
+          origin
+        })
+      );
+
+      return res.status(200).json({
+        id: session.id,
+        url: session.url
+      });
+    } catch (error) {
+      console.error('Failed to create custom Stripe payment', error);
+      return res.status(500).json({ error: 'Unable to create the payment link right now.' });
+    }
+  };
+}

--- a/tests/custom-payment-page.test.js
+++ b/tests/custom-payment-page.test.js
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('custom payment page', () => {
+  it('keeps the customer checkout flow minimal and no-account', async () => {
+    const [html, app, portal] = await Promise.all([
+      readFile(new URL('../custom-payment/index.html', import.meta.url), 'utf8'),
+      readFile(new URL('../custom-payment/app.js', import.meta.url), 'utf8'),
+      readFile(new URL('../index.html', import.meta.url), 'utf8')
+    ]);
+
+    assert.match(html, /Customer name/);
+    assert.match(html, /Customer email/);
+    assert.match(html, /What is it for/);
+    assert.match(html, /does not need an account/);
+    assert.ok(app.includes('/api/stripe/custom-payment'));
+    assert.match(app, /navigator\.clipboard/);
+    assert.ok(portal.includes('href="custom-payment/"'));
+  });
+});

--- a/tests/custom-payment.test.js
+++ b/tests/custom-payment.test.js
@@ -1,0 +1,112 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import SEA from 'gun/sea.js';
+import {
+  buildOperatorPaymentSessionPayload,
+  createCustomPaymentHandler
+} from '../src/billing/api-custom-payment.js';
+
+const config = {
+  STRIPE_SECRET_KEY: 'sk_test_key',
+  PORTAL_ORIGIN: 'https://portal.3dvr.tech'
+};
+
+function response() {
+  return {
+    statusCode: 200,
+    headers: {},
+    status(code) { this.statusCode = code; return this; },
+    setHeader(key, value) { this.headers[key] = value; },
+    json(body) { this.body = body; return this; },
+    end() { return this; }
+  };
+}
+
+async function authBody(extra = {}) {
+  const pair = await SEA.pair();
+  const payload = {
+    scope: 'stripe-billing',
+    action: 'custom-payment',
+    alias: 'operator@3dvr',
+    pub: pair.pub,
+    origin: config.PORTAL_ORIGIN,
+    iat: Date.now()
+  };
+
+  return {
+    ...extra,
+    portalAlias: payload.alias,
+    portalPub: pair.pub,
+    authPub: pair.pub,
+    authProof: await SEA.sign(payload, pair)
+  };
+}
+
+describe('custom payment', () => {
+  it('builds a no-account Stripe checkout with customer receipt details', () => {
+    const payload = buildOperatorPaymentSessionPayload({
+      amountCents: 12550,
+      customerEmail: 'buyer@example.com',
+      customerName: 'Buyer Name',
+      description: '250 business cards',
+      reference: 'BC-104',
+      origin: config.PORTAL_ORIGIN
+    });
+
+    assert.equal(payload.mode, 'payment');
+    assert.equal(payload.customer_email, 'buyer@example.com');
+    assert.equal(payload.customer_creation, 'always');
+    assert.equal(payload.line_items[0].price_data.unit_amount, 12550);
+    assert.equal(payload.line_items[0].price_data.product_data.name, '250 business cards');
+    assert.equal(payload.metadata.customer_name, 'Buyer Name');
+    assert.equal(payload.success_url, 'https://portal.3dvr.tech/custom-payment/?payment=success');
+  });
+
+  it('requires portal billing authentication before creating a link', async () => {
+    const stripe = { checkout: { sessions: { create: mock.fn() } } };
+    const handler = createCustomPaymentHandler({ stripeClient: stripe, config });
+    const res = response();
+
+    await handler({
+      method: 'POST',
+      body: {
+        customerName: 'Buyer',
+        customerEmail: 'buyer@example.com',
+        amount: 25,
+        description: 'Business cards'
+      }
+    }, res);
+
+    assert.equal(res.statusCode, 401);
+    assert.equal(stripe.checkout.sessions.create.mock.calls.length, 0);
+  });
+
+  it('creates a Stripe URL for valid operator-entered payment details', async () => {
+    const create = mock.fn(async () => ({
+      id: 'cs_custom',
+      url: 'https://checkout.stripe.com/c/pay/cs_custom'
+    }));
+    const handler = createCustomPaymentHandler({
+      stripeClient: { checkout: { sessions: { create } } },
+      config
+    });
+    const res = response();
+
+    await handler({
+      method: 'POST',
+      body: await authBody({
+        customerName: ' Buyer Name ',
+        customerEmail: 'BUYER@example.com',
+        amount: '75.25',
+        description: '  Business card print run ',
+        reference: ' JOB-12 '
+      })
+    }, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.url, 'https://checkout.stripe.com/c/pay/cs_custom');
+    assert.equal(create.mock.calls.length, 1);
+    assert.equal(create.mock.calls[0].arguments[0].line_items[0].price_data.unit_amount, 7525);
+    assert.equal(create.mock.calls[0].arguments[0].customer_email, 'buyer@example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add a separate Custom Payment portal app for operator-entered one-time charges
- create signed, account-gated Stripe Checkout Sessions while customers pay without portal accounts
- add copy, native share, preview, and customer success/cancel states
- list the app separately from Billing on the portal home

## Stripe impact
- uses the existing mode-consistent `STRIPE_SECRET_KEY`
- creates one-time USD Checkout Sessions with customer email/name, description, and optional reference
- card data remains entirely on Stripe
- does not change subscriptions, current Billing, webhooks, or account linking

## Verification
- `node --test tests/custom-payment.test.js tests/custom-payment-page.test.js tests/stripe-dashboard-route.test.js` (10 pass)
- dev server booted successfully
- `git diff --check`