### PR TITLE
Add CRM-connected Quote Builder

### DIFF
--- a/crm/app.js
+++ b/crm/app.js
@@ -2893,6 +2893,7 @@ function buildDetailActions(record) {
   return `
     <button data-action="ensure-contact" data-record-id="${safeAttr(record.id)}" class="bg-teal-600 hover:bg-teal-500 text-white text-sm px-3 py-1.5 rounded">${safe(getContactButtonLabel(record))}</button>
     <a href="${safeAttr(buildEmailOperatorHref(record))}" class="inline-flex items-center justify-center bg-sky-500 hover:bg-sky-400 text-white text-sm px-3 py-1.5 rounded">Queue outreach</a>
+    <a href="../quote-builder/?crmRecordId=${encodeURIComponent(record.id)}" class="inline-flex items-center justify-center bg-emerald-600 hover:bg-emerald-500 text-white text-sm px-3 py-1.5 rounded">Build quote</a>
     <button data-action="log-touch" data-record-id="${safeAttr(record.id)}" class="bg-indigo-500 hover:bg-indigo-600 text-white text-sm px-3 py-1.5 rounded">Log touch</button>
     <button data-action="quick-follow-up" data-record-id="${safeAttr(record.id)}" class="bg-amber-500 hover:bg-amber-600 text-white text-sm px-3 py-1.5 rounded">+7d follow-up</button>
     <button data-action="edit-record" data-record-id="${safeAttr(record.id)}" class="bg-yellow-500 hover:bg-yellow-600 text-white text-sm px-3 py-1.5 rounded">Edit</button>

--- a/index.html
+++ b/index.html
@@ -724,6 +724,11 @@
             <span class="app-card__title">Custom Payment</span>
             <span class="app-card__meta">Create a no-account Stripe checkout link for a customer.</span>
           </a>
+          <a href="quote-builder/" class="app-card" data-app-keywords="quote estimate invoice pdf crm payment business cards shirts">
+            <span class="app-card__icon" aria-hidden="true">🧾</span>
+            <span class="app-card__title">Quote Builder</span>
+            <span class="app-card__meta">Build a clean quote from CRM and turn it into a payment link.</span>
+          </a>
           <a href="finance/index.html" class="app-card">
             <span class="app-card__icon" aria-hidden="true">💰</span>
             <span class="app-card__title">Finance</span>

--- a/quote-builder/app.js
+++ b/quote-builder/app.js
@@ -1,0 +1,458 @@
+import {
+  QUOTE_STATUS_OPTIONS,
+  buildCrmQuoteFields,
+  calculateQuoteTotals,
+  centsToMoney,
+  normalizeQuoteItem,
+  quoteFromGunData,
+  quoteToGunData,
+  sanitizeQuote,
+} from './quote-model.js';
+
+const gun = Gun(window.__GUN_PEERS__ || ['wss://gun-relay-3dvr.fly.dev/gun']);
+const user = gun.user();
+const crmRoot = gun.get('3dvr-crm');
+const quotesRoot = gun.get('3dvr-portal').get('quotes');
+const crmIndex = Object.create(null);
+const quoteIndex = Object.create(null);
+const state = {
+  id: '',
+  created: '',
+  paymentUrl: '',
+  stripeSessionId: '',
+  handledRequestedRecord: false,
+};
+const requestedCrmRecordId = new URLSearchParams(window.location.search).get('crmRecordId') || '';
+
+const byId = id => document.getElementById(id);
+const workspace = byId('workspace');
+const signedOut = byId('signed-out');
+const lineItems = byId('line-items');
+const statusMessage = byId('status-message');
+const paymentResult = byId('payment-result');
+const paymentLink = byId('payment-link');
+
+function stored(key) {
+  try {
+    return localStorage.getItem(key) || '';
+  } catch {
+    return '';
+  }
+}
+
+function currentPub() {
+  return String(user?._?.sea?.pub || user?.is?.pub || '').trim();
+}
+
+async function waitForSession(timeoutMs = 2500) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (currentPub() && user?._?.sea) return true;
+    await new Promise(resolve => window.setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+async function restoreSession() {
+  const alias = stored('alias').trim();
+  const password = stored('password');
+  const signedIn = stored('signedIn') === 'true';
+
+  try {
+    user.recall({ sessionStorage: true, localStorage: true });
+  } catch {}
+
+  if (signedIn && alias && password && !(await waitForSession(500))) {
+    await new Promise(resolve => user.auth(alias, password, () => resolve()));
+  }
+
+  const ready = signedIn && alias && await waitForSession();
+  workspace.hidden = !ready;
+  signedOut.hidden = ready;
+  return ready;
+}
+
+function makeId(prefix = 'quote') {
+  if (globalThis.crypto?.randomUUID) return `${prefix}-${crypto.randomUUID()}`;
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function makeReference() {
+  const now = new Date();
+  return `Q-${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}-${String(Date.now()).slice(-5)}`;
+}
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function put(node, data) {
+  return new Promise((resolve, reject) => {
+    node.put(data, ack => {
+      if (ack?.err) reject(new Error(ack.err));
+      else resolve(ack);
+    });
+  });
+}
+
+function addLineItem(item = {}) {
+  const normalized = normalizeQuoteItem(item);
+  const row = document.createElement('div');
+  row.className = 'line-item';
+  row.dataset.itemId = normalized.id;
+  row.innerHTML = `
+    <label class="description">Description
+      <input data-field="description" maxlength="160" value="${escapeHtml(normalized.description)}" placeholder="Custom printed shirts">
+    </label>
+    <label>Qty
+      <input data-field="quantity" type="number" min="1" step="1" value="${normalized.quantity}">
+    </label>
+    <label>Sale price
+      <span class="money-input"><span>$</span><input data-field="unitPrice" type="number" min="0" step="0.01" value="${(normalized.unitPriceCents / 100).toFixed(2)}"></span>
+    </label>
+    <label>Our cost <small>private</small>
+      <span class="money-input"><span>$</span><input data-field="unitCost" type="number" min="0" step="0.01" value="${(normalized.unitCostCents / 100).toFixed(2)}"></span>
+    </label>
+    <button class="remove-item" type="button" aria-label="Remove line item">Remove</button>
+  `;
+  row.querySelectorAll('input').forEach(input => input.addEventListener('input', renderPreview));
+  row.querySelector('.remove-item').addEventListener('click', () => {
+    row.remove();
+    if (!lineItems.children.length) addLineItem();
+    renderPreview();
+  });
+  lineItems.append(row);
+}
+
+function readItems() {
+  return Array.from(lineItems.querySelectorAll('.line-item')).map(row => normalizeQuoteItem({
+    id: row.dataset.itemId,
+    description: row.querySelector('[data-field="description"]').value,
+    quantity: row.querySelector('[data-field="quantity"]').value,
+    unitPrice: row.querySelector('[data-field="unitPrice"]').value,
+    unitCost: row.querySelector('[data-field="unitCost"]').value,
+  }));
+}
+
+function readQuote() {
+  return sanitizeQuote({
+    id: state.id || makeId(),
+    created: state.created,
+    reference: byId('reference').value,
+    crmRecordId: byId('crm-record').value,
+    customerName: byId('customer-name').value,
+    customerEmail: byId('customer-email').value,
+    status: byId('quote-status').value,
+    items: readItems(),
+    taxRate: byId('tax-rate').value,
+    shipping: byId('shipping').value,
+    artworkNotes: byId('artwork-notes').value,
+    terms: byId('terms').value,
+    paymentUrl: state.paymentUrl,
+    stripeSessionId: state.stripeSessionId,
+  });
+}
+
+function renderPreview() {
+  const quote = readQuote();
+  const totals = calculateQuoteTotals(quote);
+  byId('preview-reference').textContent = quote.reference || 'Draft quote';
+  byId('preview-date').textContent = new Date(quote.created).toLocaleDateString();
+  byId('preview-customer').textContent = quote.customerName || 'Choose a customer';
+  byId('preview-email').textContent = quote.customerEmail;
+  byId('preview-items').innerHTML = totals.items.filter(item => item.description).map(item => `
+    <tr>
+      <td>${escapeHtml(item.description)}</td>
+      <td>${item.quantity}</td>
+      <td>${centsToMoney(item.unitPriceCents)}</td>
+      <td>${centsToMoney(item.quantity * item.unitPriceCents)}</td>
+    </tr>
+  `).join('') || '<tr><td colspan="4">Add products or services to this quote.</td></tr>';
+  byId('preview-subtotal').textContent = centsToMoney(totals.subtotalCents);
+  byId('preview-tax').textContent = centsToMoney(totals.taxCents);
+  byId('preview-tax-row').hidden = totals.taxCents === 0;
+  byId('preview-shipping').textContent = centsToMoney(totals.shippingCents);
+  byId('preview-shipping-row').hidden = totals.shippingCents === 0;
+  byId('preview-total').textContent = centsToMoney(totals.totalCents);
+  byId('preview-notes').textContent = quote.artworkNotes;
+  byId('preview-notes-wrap').hidden = !quote.artworkNotes;
+  byId('preview-terms').textContent = quote.terms;
+  byId('internal-cost').textContent = centsToMoney(totals.internalCostCents);
+  byId('internal-margin').textContent = centsToMoney(totals.marginCents);
+}
+
+function fillQuote(input = {}) {
+  const quote = sanitizeQuote(input);
+  state.id = quote.id;
+  state.created = quote.created;
+  state.paymentUrl = quote.paymentUrl;
+  state.stripeSessionId = quote.stripeSessionId;
+  byId('crm-record').value = quote.crmRecordId;
+  byId('customer-name').value = quote.customerName;
+  byId('customer-email').value = quote.customerEmail;
+  byId('reference').value = quote.reference || makeReference();
+  byId('quote-status').value = quote.status;
+  byId('tax-rate').value = quote.taxRate;
+  byId('shipping').value = (quote.shippingCents / 100).toFixed(2);
+  byId('artwork-notes').value = quote.artworkNotes;
+  byId('terms').value = quote.terms || 'Quote valid for 14 days. Production begins after artwork approval and payment.';
+  lineItems.innerHTML = '';
+  (quote.items.length ? quote.items : [{}]).forEach(addLineItem);
+  paymentLink.value = quote.paymentUrl;
+  byId('preview-payment').href = quote.paymentUrl;
+  paymentResult.hidden = !quote.paymentUrl;
+  renderPreview();
+}
+
+function resetQuote() {
+  state.id = '';
+  state.created = '';
+  state.paymentUrl = '';
+  state.stripeSessionId = '';
+  byId('saved-quotes').value = '';
+  fillQuote({
+    reference: makeReference(),
+    status: 'Draft',
+    terms: 'Quote valid for 14 days. Production begins after artwork approval and payment.',
+    items: [{}],
+  });
+  byId('crm-record').value = '';
+  statusMessage.textContent = '';
+}
+
+function renderCrmOptions() {
+  const current = byId('crm-record').value;
+  const records = Object.values(crmIndex)
+    .filter(record => record && String(record.recordType || 'person') === 'person')
+    .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
+  byId('crm-record').innerHTML = '<option value="">Choose a customer</option>' + records
+    .map(record => `<option value="${escapeHtml(record.id)}">${escapeHtml(record.name || record.email || record.id)}</option>`)
+    .join('');
+  byId('crm-record').value = current;
+}
+
+function renderQuoteOptions() {
+  const current = byId('saved-quotes').value;
+  const quotes = Object.values(quoteIndex)
+    .filter(Boolean)
+    .sort((a, b) => String(b.updated || '').localeCompare(String(a.updated || '')));
+  byId('saved-quotes').innerHTML = '<option value="">New quote</option>' + quotes
+    .map(quote => `<option value="${escapeHtml(quote.id)}">${escapeHtml(quote.reference || 'Quote')} — ${escapeHtml(quote.customerName || 'Customer')} — ${centsToMoney(quote.totalCents)}</option>`)
+    .join('');
+  byId('saved-quotes').value = current;
+}
+
+async function saveQuote({ message = 'Quote saved to CRM.' } = {}) {
+  const quote = readQuote();
+  if (!quote.customerName) throw new Error('Choose or enter a customer name.');
+  if (!quote.items.some(item => item.description && item.unitPriceCents > 0)) {
+    throw new Error('Add at least one priced line item.');
+  }
+
+  state.id = quote.id;
+  state.created = quote.created;
+  await put(quotesRoot.get(quote.id), quoteToGunData(quote));
+  quoteIndex[quote.id] = quote;
+
+  if (quote.crmRecordId && crmIndex[quote.crmRecordId]) {
+    const crmUpdate = {
+      ...buildCrmQuoteFields(quote),
+      id: quote.crmRecordId,
+    };
+    await put(crmRoot.get(quote.crmRecordId), crmUpdate);
+    crmIndex[quote.crmRecordId] = { ...crmIndex[quote.crmRecordId], ...crmUpdate };
+  }
+
+  renderQuoteOptions();
+  byId('saved-quotes').value = quote.id;
+  statusMessage.textContent = message;
+  return quote;
+}
+
+async function buildAuth() {
+  const alias = stored('alias').trim();
+  const pub = currentPub();
+  if (!alias || !pub || !user?._?.sea) throw new Error('Sign in again to create a payment link.');
+  return {
+    portalAlias: alias,
+    portalPub: pub,
+    authPub: pub,
+    authProof: await Gun.SEA.sign({
+      scope: 'stripe-billing',
+      action: 'custom-payment',
+      alias,
+      pub,
+      origin: window.location.origin,
+      iat: Date.now(),
+    }, user._.sea),
+  };
+}
+
+async function createPaymentLink() {
+  let quote = readQuote();
+  if (!quote.customerEmail) throw new Error('Add the customer email before creating a payment link.');
+  if (quote.totalCents < 100) throw new Error('The quote total must be at least $1.');
+
+  statusMessage.textContent = 'Creating secure Stripe checkout…';
+  byId('create-payment').disabled = true;
+  try {
+    quote = await saveQuote({ message: '' });
+    const auth = await buildAuth();
+    const response = await fetch('/api/stripe/custom-payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        customerName: quote.customerName,
+        customerEmail: quote.customerEmail,
+        amount: (quote.totalCents / 100).toFixed(2),
+        description: `3DVR quote ${quote.reference}`,
+        reference: quote.reference,
+        quoteId: quote.id,
+        crmRecordId: quote.crmRecordId,
+        ...auth,
+      }),
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(body.error || 'Could not create the payment link.');
+
+    state.paymentUrl = body.url;
+    state.stripeSessionId = body.id;
+    byId('quote-status').value = 'Payment link created';
+    quote = await saveQuote({ message: 'Payment link created and saved to CRM.' });
+    paymentLink.value = body.url;
+    byId('preview-payment').href = body.url;
+    paymentResult.hidden = false;
+  } finally {
+    byId('create-payment').disabled = false;
+  }
+}
+
+function applyCrmRecord(id) {
+  const record = crmIndex[id];
+  if (!record) return;
+  byId('crm-record').value = id;
+  byId('customer-name').value = record.name || '';
+  byId('customer-email').value = record.email || '';
+  if (record.quoteId && quoteIndex[record.quoteId]) {
+    byId('saved-quotes').value = record.quoteId;
+    fillQuote(quoteIndex[record.quoteId]);
+  }
+  renderPreview();
+}
+
+function presetPedriAndChester() {
+  Object.values(crmIndex).forEach(record => {
+    const name = String(record?.name || '').trim().toLowerCase();
+    if (name === 'pedri' && !state.id) {
+      // Pricing confirmed July 29, 2026: retail follows the MOO quote; 4over stays private.
+      quoteIndex['pedri-draft'] ||= sanitizeQuote({
+        id: 'pedri-draft',
+        reference: 'PEDRI-001',
+        crmRecordId: record.id,
+        customerName: record.name,
+        customerEmail: record.email,
+        status: 'Draft',
+        items: [
+          { description: 'Custom printed shirts', quantity: 6, unitPrice: 30, unitCost: 0 },
+          { description: 'Two-sided business cards (200 + 50 bonus)', quantity: 1, unitPrice: 78, unitCost: 12 },
+        ],
+        artworkNotes: 'Business cards: 200 requested; provide the full 250-card production run as a bonus. Confirm shirt sizes, garment color, and artwork before production.',
+        terms: 'Quote valid for 14 days. Production begins after artwork approval and payment.',
+      });
+    }
+    if (name === 'chester' && !state.id) {
+      quoteIndex['chester-draft'] ||= sanitizeQuote({
+        id: 'chester-draft',
+        reference: 'CHESTER-001',
+        crmRecordId: record.id,
+        customerName: record.name,
+        customerEmail: record.email,
+        status: 'Draft',
+        items: [
+          { description: 'Two-sided business cards (50 + 50 bonus)', quantity: 1, unitPrice: 0, unitCost: 6 },
+        ],
+        artworkNotes: 'Front: black scribble logo with the confirmed statement. Back: skull artwork. Confirm final proof and the previously promised MOO-based sale price.',
+        terms: 'Quote valid for 14 days. Production begins after artwork approval and payment.',
+      });
+    }
+  });
+}
+
+function bindEvents() {
+  ['customer-name', 'customer-email', 'reference', 'quote-status', 'tax-rate', 'shipping', 'artwork-notes', 'terms']
+    .forEach(id => byId(id).addEventListener('input', renderPreview));
+  byId('crm-record').addEventListener('change', event => applyCrmRecord(event.target.value));
+  byId('saved-quotes').addEventListener('change', event => {
+    if (!event.target.value) resetQuote();
+    else fillQuote(quoteIndex[event.target.value]);
+  });
+  byId('add-item').addEventListener('click', () => {
+    addLineItem();
+    renderPreview();
+  });
+  byId('new-quote').addEventListener('click', resetQuote);
+  byId('save-quote').addEventListener('click', async () => {
+    try {
+      await saveQuote();
+    } catch (error) {
+      statusMessage.textContent = error.message;
+    }
+  });
+  byId('print-quote').addEventListener('click', () => window.print());
+  byId('create-payment').addEventListener('click', async () => {
+    try {
+      await createPaymentLink();
+    } catch (error) {
+      statusMessage.textContent = error.message;
+    }
+  });
+  byId('copy-payment').addEventListener('click', async () => {
+    await navigator.clipboard.writeText(paymentLink.value);
+    byId('copy-payment').textContent = 'Copied';
+    window.setTimeout(() => { byId('copy-payment').textContent = 'Copy link'; }, 1600);
+  });
+}
+
+async function init() {
+  QUOTE_STATUS_OPTIONS.forEach(status => {
+    byId('quote-status').add(new Option(status, status));
+  });
+  bindEvents();
+  resetQuote();
+  if (!(await restoreSession())) return;
+
+  crmRoot.map().on((data, id) => {
+    if (!id) return;
+    if (data) crmIndex[id] = { ...crmIndex[id], ...data, id };
+    else delete crmIndex[id];
+    renderCrmOptions();
+    presetPedriAndChester();
+    renderQuoteOptions();
+    if (requestedCrmRecordId === id && !state.handledRequestedRecord) {
+      applyCrmRecord(id);
+      if (!crmIndex[id]?.quoteId) state.handledRequestedRecord = true;
+    }
+  });
+
+  quotesRoot.map().on((data, id) => {
+    if (!id) return;
+    if (data) quoteIndex[id] = quoteFromGunData({ ...quoteIndex[id], ...data, id });
+    else delete quoteIndex[id];
+    renderQuoteOptions();
+    if (
+      requestedCrmRecordId
+      && !state.handledRequestedRecord
+      && crmIndex[requestedCrmRecordId]?.quoteId === id
+    ) {
+      applyCrmRecord(requestedCrmRecordId);
+      state.handledRequestedRecord = true;
+    }
+  });
+}
+
+void init();

--- a/quote-builder/index.html
+++ b/quote-builder/index.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0b1118">
+  <meta name="robots" content="noindex">
+  <title>Quote Builder | 3DVR Portal</title>
+  <meta name="description" content="Build customer quotes from CRM records and turn them into secure Stripe payment links.">
+  <link rel="stylesheet" href="./styles.css">
+  <script defer src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script defer src="/gun-init.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script type="module" src="./app.js"></script>
+</head>
+<body>
+  <main class="app-shell">
+    <header class="app-header no-print">
+      <a href="/" class="back">← Portal</a>
+      <p class="eyebrow">3DVR • Sales</p>
+      <h1>Quote Builder</h1>
+      <p>Build the quote, save it to CRM, then make a payment link when the customer is ready.</p>
+    </header>
+
+    <section id="signed-out" class="notice no-print" hidden>
+      <p>Sign in to build and save quotes.</p>
+      <a class="button" href="/sign-in.html?redirect=%2Fquote-builder%2F">Sign in</a>
+    </section>
+
+    <div id="workspace" hidden>
+      <section class="editor no-print" aria-label="Quote editor">
+        <div class="editor-heading">
+          <div>
+            <p class="eyebrow">Customer and quote</p>
+            <h2>Quote details</h2>
+          </div>
+          <select id="saved-quotes" aria-label="Open saved quote">
+            <option value="">New quote</option>
+          </select>
+        </div>
+
+        <div class="form-grid">
+          <label class="wide">
+            Pull from CRM
+            <select id="crm-record">
+              <option value="">Choose a customer</option>
+            </select>
+          </label>
+          <label>
+            Customer name
+            <input id="customer-name" maxlength="120" required>
+          </label>
+          <label>
+            Customer email
+            <input id="customer-email" type="email" maxlength="200">
+          </label>
+          <label>
+            Quote number
+            <input id="reference" maxlength="80">
+          </label>
+          <label>
+            Status
+            <select id="quote-status"></select>
+          </label>
+        </div>
+
+        <div class="line-heading">
+          <div>
+            <p class="eyebrow">Products and services</p>
+            <h2>Line items</h2>
+          </div>
+          <button id="add-item" class="button secondary" type="button">Add item</button>
+        </div>
+        <div id="line-items" class="line-items"></div>
+
+        <div class="form-grid totals-inputs">
+          <label>
+            Tax rate %
+            <input id="tax-rate" type="number" inputmode="decimal" min="0" max="100" step="0.01" value="0">
+          </label>
+          <label>
+            Shipping
+            <span class="money-input"><span>$</span><input id="shipping" type="number" inputmode="decimal" min="0" step="0.01" value="0"></span>
+          </label>
+          <label class="wide">
+            Artwork / fulfillment notes <small>internal and customer-safe</small>
+            <textarea id="artwork-notes" rows="3" maxlength="600"></textarea>
+          </label>
+          <label class="wide">
+            Terms
+            <textarea id="terms" rows="3" maxlength="600">Quote valid for 14 days. Production begins after artwork approval and payment.</textarea>
+          </label>
+        </div>
+
+        <p id="status-message" class="status" role="status" aria-live="polite"></p>
+        <div class="actions">
+          <button id="save-quote" class="button" type="button">Save quote</button>
+          <button id="print-quote" class="button secondary" type="button">Print / Save PDF</button>
+          <button id="create-payment" class="button accent" type="button">Create payment link</button>
+          <button id="new-quote" class="text-button" type="button">Start new</button>
+        </div>
+        <section id="payment-result" class="payment-result" hidden>
+          <label>
+            Secure Stripe link
+            <input id="payment-link" readonly>
+          </label>
+          <button id="copy-payment" class="button secondary" type="button">Copy link</button>
+          <a id="preview-payment" class="button secondary" target="_blank" rel="noreferrer">Preview</a>
+        </section>
+      </section>
+
+      <section id="quote-preview" class="quote-paper" aria-label="Customer quote">
+        <div class="quote-brand">
+          <div>
+            <p class="eyebrow">3DVR.tech</p>
+            <h2>Quote</h2>
+          </div>
+          <div class="quote-meta">
+            <strong id="preview-reference">Draft quote</strong>
+            <span id="preview-date"></span>
+          </div>
+        </div>
+        <div class="customer-block">
+          <span>Prepared for</span>
+          <strong id="preview-customer">Choose a customer</strong>
+          <span id="preview-email"></span>
+        </div>
+        <table>
+          <thead>
+            <tr><th>Description</th><th>Qty</th><th>Rate</th><th>Amount</th></tr>
+          </thead>
+          <tbody id="preview-items"></tbody>
+        </table>
+        <div class="quote-totals">
+          <div><span>Subtotal</span><strong id="preview-subtotal">$0.00</strong></div>
+          <div id="preview-tax-row"><span>Tax</span><strong id="preview-tax">$0.00</strong></div>
+          <div id="preview-shipping-row"><span>Shipping</span><strong id="preview-shipping">$0.00</strong></div>
+          <div class="grand-total"><span>Total</span><strong id="preview-total">$0.00</strong></div>
+        </div>
+        <div id="preview-notes-wrap" class="quote-copy">
+          <h3>Artwork and fulfillment</h3>
+          <p id="preview-notes"></p>
+        </div>
+        <div class="quote-copy">
+          <h3>Terms</h3>
+          <p id="preview-terms"></p>
+        </div>
+        <footer>
+          <strong>3DVR.tech</strong>
+          <span>3dvr.tech@gmail.com</span>
+        </footer>
+      </section>
+
+      <aside class="internal-summary no-print">
+        <p class="eyebrow">Private • Never prints</p>
+        <h2>Internal margin</h2>
+        <div><span>Known costs entered</span><strong id="internal-cost">$0.00</strong></div>
+        <div><span>Revenue after known costs</span><strong id="internal-margin">$0.00</strong></div>
+        <p class="internal-note">Enter every supplier cost before treating this as final margin.</p>
+      </aside>
+    </div>
+  </main>
+</body>
+</html>

--- a/quote-builder/quote-model.js
+++ b/quote-builder/quote-model.js
@@ -1,0 +1,135 @@
+export const QUOTE_STATUS_OPTIONS = Object.freeze([
+  'Draft',
+  'Sent',
+  'Approved',
+  'Payment link created',
+  'Paid',
+  'Cancelled',
+]);
+
+function cleanText(value, limit = 240) {
+  return String(value || '').trim().replace(/\s+/g, ' ').slice(0, limit);
+}
+
+export function moneyToCents(value) {
+  const normalized = String(value ?? '').replace(/[$,\s]/g, '');
+  if (!normalized) return 0;
+  const amount = Number(normalized);
+  return Number.isFinite(amount) ? Math.max(0, Math.round(amount * 100)) : 0;
+}
+
+export function centsToMoney(value) {
+  const cents = Number.isFinite(Number(value)) ? Number(value) : 0;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(cents / 100);
+}
+
+export function normalizeQuoteItem(item = {}) {
+  const quantity = Math.max(1, Number.parseInt(item.quantity, 10) || 1);
+  return {
+    id: cleanText(item.id, 80) || `item-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    description: cleanText(item.description, 160),
+    quantity,
+    unitPriceCents: Number.isFinite(Number(item.unitPriceCents))
+      ? Math.max(0, Math.round(Number(item.unitPriceCents)))
+      : moneyToCents(item.unitPrice),
+    unitCostCents: Number.isFinite(Number(item.unitCostCents))
+      ? Math.max(0, Math.round(Number(item.unitCostCents)))
+      : moneyToCents(item.unitCost),
+  };
+}
+
+export function calculateQuoteTotals(quote = {}) {
+  const items = (Array.isArray(quote.items) ? quote.items : [])
+    .map(normalizeQuoteItem)
+    .filter(item => item.description);
+  const subtotalCents = items.reduce(
+    (sum, item) => sum + (item.quantity * item.unitPriceCents),
+    0
+  );
+  const internalCostCents = items.reduce(
+    (sum, item) => sum + (item.quantity * item.unitCostCents),
+    0
+  );
+  const shippingCents = moneyToCents(
+    quote.shippingCents != null ? Number(quote.shippingCents) / 100 : quote.shipping
+  );
+  const taxRate = Math.min(100, Math.max(0, Number(quote.taxRate) || 0));
+  const taxCents = Math.round(subtotalCents * (taxRate / 100));
+  const totalCents = subtotalCents + taxCents + shippingCents;
+
+  return {
+    items,
+    subtotalCents,
+    internalCostCents,
+    marginCents: subtotalCents - internalCostCents,
+    taxRate,
+    taxCents,
+    shippingCents,
+    totalCents,
+  };
+}
+
+export function sanitizeQuote(input = {}) {
+  let inputItems = input.items;
+  if (!Array.isArray(inputItems) && input.itemsJson) {
+    try {
+      inputItems = JSON.parse(input.itemsJson);
+    } catch {
+      inputItems = [];
+    }
+  }
+  const totals = calculateQuoteTotals({ ...input, items: inputItems });
+  const now = new Date().toISOString();
+  return {
+    id: cleanText(input.id, 100),
+    reference: cleanText(input.reference, 80),
+    crmRecordId: cleanText(input.crmRecordId, 100),
+    customerName: cleanText(input.customerName, 120),
+    customerEmail: cleanText(input.customerEmail, 200).toLowerCase(),
+    status: QUOTE_STATUS_OPTIONS.includes(input.status) ? input.status : 'Draft',
+    items: totals.items,
+    taxRate: totals.taxRate,
+    shippingCents: totals.shippingCents,
+    subtotalCents: totals.subtotalCents,
+    taxCents: totals.taxCents,
+    totalCents: totals.totalCents,
+    internalCostCents: totals.internalCostCents,
+    marginCents: totals.marginCents,
+    artworkNotes: cleanText(input.artworkNotes, 600),
+    terms: cleanText(input.terms, 600),
+    paymentUrl: cleanText(input.paymentUrl, 500),
+    stripeSessionId: cleanText(input.stripeSessionId, 120),
+    created: cleanText(input.created, 40) || now,
+    updated: now,
+  };
+}
+
+export function quoteToGunData(quote = {}) {
+  const safeQuote = sanitizeQuote(quote);
+  const { items, ...fields } = safeQuote;
+  return {
+    ...fields,
+    itemsJson: JSON.stringify(items),
+  };
+}
+
+export function quoteFromGunData(data = {}) {
+  return sanitizeQuote(data);
+}
+
+export function buildCrmQuoteFields(quote = {}) {
+  const safeQuote = sanitizeQuote(quote);
+  return {
+    quoteId: safeQuote.id,
+    quoteReference: safeQuote.reference,
+    quoteStatus: safeQuote.status,
+    quoteTotalCents: safeQuote.totalCents,
+    quotePaymentUrl: safeQuote.paymentUrl,
+    quoteUpdated: safeQuote.updated,
+    offerAmount: centsToMoney(safeQuote.totalCents),
+    updated: safeQuote.updated,
+  };
+}

--- a/quote-builder/styles.css
+++ b/quote-builder/styles.css
@@ -1,0 +1,410 @@
+:root {
+  color-scheme: dark;
+  --bg: #071018;
+  --panel: #101c27;
+  --line: rgba(255, 255, 255, 0.12);
+  --muted: #9fb0bd;
+  --ink: #f7fbff;
+  --accent: #74e8c3;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(33, 160, 190, 0.15), transparent 34rem),
+    var(--bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.app-shell {
+  width: min(1180px, calc(100% - 28px));
+  margin: 0 auto;
+  padding: 28px 0 64px;
+}
+
+.app-header {
+  margin-bottom: 24px;
+}
+
+.back,
+.text-button {
+  color: var(--accent);
+}
+
+.back {
+  text-decoration: none;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 8px;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+#workspace {
+  display: grid;
+  gap: 22px;
+}
+
+.editor,
+.internal-summary,
+.notice {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: rgba(16, 28, 39, 0.94);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.2);
+}
+
+.editor-heading,
+.line-heading,
+.quote-brand,
+.actions,
+.payment-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+  margin: 18px 0 26px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: #d7e3ea;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+small {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  outline: none;
+  background: #09131c;
+  color: var(--ink);
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(116, 232, 195, 0.12);
+}
+
+.money-input {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #09131c;
+}
+
+.money-input > span {
+  padding-left: 12px;
+  color: var(--muted);
+}
+
+.money-input input {
+  border: 0;
+  background: transparent;
+}
+
+.line-items {
+  display: grid;
+  gap: 10px;
+  margin: 14px 0;
+}
+
+.line-item {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(5, 12, 18, 0.45);
+}
+
+.line-item .description {
+  grid-column: 1 / -1;
+}
+
+.remove-item {
+  align-self: end;
+  min-height: 44px;
+  border: 1px solid rgba(255, 121, 121, 0.25);
+  border-radius: 10px;
+  background: rgba(99, 26, 26, 0.35);
+  color: #ffc4c4;
+  cursor: pointer;
+}
+
+.button,
+.text-button {
+  min-height: 44px;
+  padding: 10px 16px;
+  border: 0;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.button {
+  background: var(--accent);
+  color: #06120f;
+  text-decoration: none;
+}
+
+.button.secondary {
+  border: 1px solid var(--line);
+  background: #1a2a36;
+  color: var(--ink);
+}
+
+.button.accent {
+  background: #f7cf69;
+  color: #1c1504;
+}
+
+.button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.text-button {
+  background: transparent;
+}
+
+.status {
+  min-height: 24px;
+  color: #b8cbc5;
+}
+
+.payment-result {
+  margin-top: 16px;
+  padding: 14px;
+  border: 1px solid rgba(116, 232, 195, 0.25);
+  border-radius: 14px;
+  background: rgba(24, 76, 64, 0.2);
+}
+
+.payment-result label {
+  flex: 1 1 320px;
+}
+
+.quote-paper {
+  padding: clamp(24px, 6vw, 54px);
+  border-radius: 4px;
+  background: #fff;
+  color: #15212a;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.26);
+}
+
+.quote-paper .eyebrow {
+  color: #14785e;
+}
+
+.quote-meta {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  color: #56636c;
+}
+
+.customer-block {
+  display: grid;
+  gap: 4px;
+  margin: 38px 0;
+}
+
+.customer-block span,
+.quote-paper footer,
+.quote-copy p {
+  color: #56636c;
+}
+
+.customer-block strong {
+  font-size: 1.25rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 13px 8px;
+  border-bottom: 1px solid #dfe5e8;
+  text-align: right;
+}
+
+th:first-child,
+td:first-child {
+  text-align: left;
+}
+
+.quote-totals {
+  width: min(340px, 100%);
+  margin: 24px 0 30px auto;
+}
+
+.quote-totals > div,
+.internal-summary > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 8px 0;
+}
+
+.grand-total {
+  margin-top: 6px;
+  border-top: 2px solid #17242d;
+  font-size: 1.25rem;
+}
+
+.quote-copy {
+  margin-top: 24px;
+  white-space: pre-wrap;
+}
+
+.quote-copy h3 {
+  margin-bottom: 8px;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.quote-paper footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 48px;
+  padding-top: 18px;
+  border-top: 1px solid #dfe5e8;
+}
+
+.internal-summary {
+  align-self: start;
+}
+
+.internal-note {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+@media (min-width: 720px) {
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .wide {
+    grid-column: 1 / -1;
+  }
+
+  .line-item {
+    grid-template-columns: minmax(240px, 2fr) 80px 130px 130px 90px;
+  }
+
+  .line-item .description {
+    grid-column: auto;
+  }
+}
+
+@media (min-width: 1040px) {
+  #workspace {
+    grid-template-columns: minmax(0, 1.05fr) minmax(420px, 0.95fr);
+  }
+
+  .internal-summary {
+    grid-column: 1;
+  }
+
+  .quote-paper {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+  }
+}
+
+@media print {
+  @page {
+    margin: 0.55in;
+  }
+
+  body {
+    background: #fff;
+  }
+
+  .app-shell {
+    width: 100%;
+    padding: 0;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+
+  #workspace,
+  .quote-paper {
+    display: block !important;
+  }
+
+  .quote-paper {
+    padding: 0;
+    box-shadow: none;
+  }
+}

--- a/src/billing/api-custom-payment.js
+++ b/src/billing/api-custom-payment.js
@@ -12,6 +12,8 @@ export function buildOperatorPaymentSessionPayload({
   customerName,
   description,
   reference,
+  quoteId,
+  crmRecordId,
   origin
 }) {
   const metadata = {
@@ -19,7 +21,9 @@ export function buildOperatorPaymentSessionPayload({
     customer_name: customerName,
     customer_email: customerEmail,
     reference,
-    description
+    description,
+    quote_id: quoteId,
+    crm_record_id: crmRecordId
   };
   const compactMetadata = Object.fromEntries(
     Object.entries(metadata).filter(([, value]) => Boolean(value))
@@ -83,6 +87,8 @@ export function createCustomPaymentHandler(options = {}) {
     const customerName = cleanText(body.customerName, 120);
     const description = cleanText(body.description, 120);
     const reference = cleanText(body.reference, 80);
+    const quoteId = cleanText(body.quoteId, 100);
+    const crmRecordId = cleanText(body.crmRecordId, 100);
     const amountCents = normalizeCustomAmount(body.amount);
 
     if (!customerName) {
@@ -106,6 +112,8 @@ export function createCustomPaymentHandler(options = {}) {
           customerName,
           description,
           reference,
+          quoteId,
+          crmRecordId,
           origin
         })
       );

--- a/tests/custom-payment.test.js
+++ b/tests/custom-payment.test.js
@@ -50,6 +50,8 @@ describe('custom payment', () => {
       customerName: 'Buyer Name',
       description: '250 business cards',
       reference: 'BC-104',
+      quoteId: 'quote-104',
+      crmRecordId: 'lead-104',
       origin: config.PORTAL_ORIGIN
     });
 
@@ -59,6 +61,8 @@ describe('custom payment', () => {
     assert.equal(payload.line_items[0].price_data.unit_amount, 12550);
     assert.equal(payload.line_items[0].price_data.product_data.name, '250 business cards');
     assert.equal(payload.metadata.customer_name, 'Buyer Name');
+    assert.equal(payload.metadata.quote_id, 'quote-104');
+    assert.equal(payload.metadata.crm_record_id, 'lead-104');
     assert.equal(payload.success_url, 'https://portal.3dvr.tech/custom-payment/?payment=success');
   });
 
@@ -99,7 +103,9 @@ describe('custom payment', () => {
         customerEmail: 'BUYER@example.com',
         amount: '75.25',
         description: '  Business card print run ',
-        reference: ' JOB-12 '
+        reference: ' JOB-12 ',
+        quoteId: ' quote-12 ',
+        crmRecordId: ' lead-12 '
       })
     }, res);
 
@@ -108,5 +114,7 @@ describe('custom payment', () => {
     assert.equal(create.mock.calls.length, 1);
     assert.equal(create.mock.calls[0].arguments[0].line_items[0].price_data.unit_amount, 7525);
     assert.equal(create.mock.calls[0].arguments[0].customer_email, 'buyer@example.com');
+    assert.equal(create.mock.calls[0].arguments[0].metadata.quote_id, 'quote-12');
+    assert.equal(create.mock.calls[0].arguments[0].metadata.crm_record_id, 'lead-12');
   });
 });

--- a/tests/quote-builder.test.js
+++ b/tests/quote-builder.test.js
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  buildCrmQuoteFields,
+  calculateQuoteTotals,
+  quoteFromGunData,
+  quoteToGunData,
+  sanitizeQuote,
+} from '../quote-builder/quote-model.js';
+
+describe('quote builder', () => {
+  it('keeps retail, supplier cost, tax, shipping, and margin separate', () => {
+    const totals = calculateQuoteTotals({
+      items: [
+        { description: 'Custom shirts', quantity: 6, unitPrice: 30, unitCost: 15 },
+        { description: 'Business cards', quantity: 1, unitPrice: 78, unitCost: 12 },
+      ],
+      taxRate: 8,
+      shipping: 10,
+    });
+
+    assert.equal(totals.subtotalCents, 25800);
+    assert.equal(totals.internalCostCents, 10200);
+    assert.equal(totals.marginCents, 15600);
+    assert.equal(totals.taxCents, 2064);
+    assert.equal(totals.shippingCents, 1000);
+    assert.equal(totals.totalCents, 28864);
+  });
+
+  it('builds compact quote status fields for the linked CRM record', () => {
+    const quote = sanitizeQuote({
+      id: 'quote-pedri',
+      reference: 'PEDRI-001',
+      crmRecordId: 'lead-pedri',
+      customerName: 'Pedri',
+      status: 'Payment link created',
+      items: [{ description: 'Order', quantity: 1, unitPrice: 258 }],
+      paymentUrl: 'https://checkout.stripe.com/example',
+    });
+    const fields = buildCrmQuoteFields(quote);
+
+    assert.equal(fields.quoteId, 'quote-pedri');
+    assert.equal(fields.quoteStatus, 'Payment link created');
+    assert.equal(fields.quoteTotalCents, 25800);
+    assert.equal(fields.offerAmount, '$258.00');
+  });
+
+  it('round-trips line items through Gun-safe flat data', () => {
+    const stored = quoteToGunData({
+      id: 'quote-1',
+      customerName: 'Customer',
+      items: [{ description: 'Cards', quantity: 1, unitPrice: 78, unitCost: 12 }],
+    });
+
+    assert.equal('items' in stored, false);
+    assert.equal(typeof stored.itemsJson, 'string');
+    const restored = quoteFromGunData(stored);
+    assert.equal(restored.items.length, 1);
+    assert.equal(restored.items[0].unitPriceCents, 7800);
+    assert.equal(restored.items[0].unitCostCents, 1200);
+  });
+
+  it('ships as a portal app with CRM, PDF, and payment actions', async () => {
+    const [html, app, css, portal, crmApp] = await Promise.all([
+      readFile(new URL('../quote-builder/index.html', import.meta.url), 'utf8'),
+      readFile(new URL('../quote-builder/app.js', import.meta.url), 'utf8'),
+      readFile(new URL('../quote-builder/styles.css', import.meta.url), 'utf8'),
+      readFile(new URL('../index.html', import.meta.url), 'utf8'),
+      readFile(new URL('../crm/app.js', import.meta.url), 'utf8'),
+    ]);
+
+    assert.match(html, /Pull from CRM/);
+    assert.match(html, /Print \/ Save PDF/);
+    assert.match(html, /Create payment link/);
+    assert.match(app, /gun\.get\('3dvr-crm'\)/);
+    assert.match(app, /\/api\/stripe\/custom-payment/);
+    assert.match(css, /@media print/);
+    assert.match(css, /\.no-print/);
+    assert.match(portal, /href="quote-builder\/"/);
+    assert.match(crmApp, /quote-builder\/\?crmRecordId=/);
+  });
+});


### PR DESCRIPTION
## Outcome\n- adds a dedicated Quote Builder portal app\n- pulls customer records from CRM and writes quote/payment status back\n- keeps supplier cost private from the printable customer quote\n- prints clean quotes with browser Save as PDF\n- creates Stripe Custom Payment links with quote and CRM metadata\n- adds a Build quote action to CRM\n\n## Customer data\nPedri and Chester were added to the shared CRM separately. Pedri has a confirmed $258 draft. Chester remains price-pending rather than inventing the missing MOO amount.\n\n## Stripe impact\nUses the existing Custom Payment endpoint and Stripe mode. Adds optional quote_id and crm_record_id metadata only; no price IDs or billing-mode changes.\n\n## Verification\n- 18/18 focused tests pass\n- JavaScript syntax and diff checks pass\n- mobile viewport has no horizontal overflow\n- fresh browser session verified shared CRM and Gun quote records\n- full repository suite: 790 pass, 12 existing baseline failures, 2 skipped