### PR TITLE
Let quote customers enter email at checkout

### DIFF
--- a/quote-builder/app.js
+++ b/quote-builder/app.js
@@ -295,7 +295,6 @@ async function buildAuth() {
 
 async function createPaymentLink() {
   let quote = readQuote();
-  if (!quote.customerEmail) throw new Error('Add the customer email before creating a payment link.');
   if (quote.totalCents < 100) throw new Error('The quote total must be at least $1.');
 
   statusMessage.textContent = 'Creating secure Stripe checkout…';
@@ -314,6 +313,7 @@ async function createPaymentLink() {
         reference: quote.reference,
         quoteId: quote.id,
         crmRecordId: quote.crmRecordId,
+        collectCustomerEmail: !quote.customerEmail,
         ...auth,
       }),
     });

--- a/quote-builder/index.html
+++ b/quote-builder/index.html
@@ -52,8 +52,8 @@
             <input id="customer-name" maxlength="120" required>
           </label>
           <label>
-            Customer email
-            <input id="customer-email" type="email" maxlength="200">
+            Customer email <small>optional</small>
+            <input id="customer-email" type="email" maxlength="200" placeholder="Customer can enter this at checkout">
           </label>
           <label>
             Quote number
@@ -97,7 +97,7 @@
         <div class="actions">
           <button id="save-quote" class="button" type="button">Save quote</button>
           <button id="print-quote" class="button secondary" type="button">Print / Save PDF</button>
-          <button id="create-payment" class="button accent" type="button">Create payment link</button>
+          <button id="create-payment" class="button accent" type="button">Create customer payment link</button>
           <button id="new-quote" class="text-button" type="button">Start new</button>
         </div>
         <section id="payment-result" class="payment-result" hidden>

--- a/src/billing/api-custom-payment.js
+++ b/src/billing/api-custom-payment.js
@@ -14,6 +14,7 @@ export function buildOperatorPaymentSessionPayload({
   reference,
   quoteId,
   crmRecordId,
+  collectCustomerEmail = false,
   origin
 }) {
   const metadata = {
@@ -29,9 +30,8 @@ export function buildOperatorPaymentSessionPayload({
     Object.entries(metadata).filter(([, value]) => Boolean(value))
   );
 
-  return {
+  const payload = {
     mode: 'payment',
-    customer_email: customerEmail,
     customer_creation: 'always',
     billing_address_collection: 'auto',
     payment_intent_data: {
@@ -53,6 +53,12 @@ export function buildOperatorPaymentSessionPayload({
     success_url: `${origin}/custom-payment/?payment=success`,
     cancel_url: `${origin}/custom-payment/?payment=cancel`
   };
+
+  if (!collectCustomerEmail) {
+    payload.customer_email = customerEmail;
+  }
+
+  return payload;
 }
 
 export function createCustomPaymentHandler(options = {}) {
@@ -89,12 +95,13 @@ export function createCustomPaymentHandler(options = {}) {
     const reference = cleanText(body.reference, 80);
     const quoteId = cleanText(body.quoteId, 100);
     const crmRecordId = cleanText(body.crmRecordId, 100);
+    const collectCustomerEmail = body.collectCustomerEmail === true;
     const amountCents = normalizeCustomAmount(body.amount);
 
     if (!customerName) {
       return res.status(400).json({ error: 'Enter the customer name.' });
     }
-    if (!isValidBillingEmail(customerEmail)) {
+    if (!collectCustomerEmail && !isValidBillingEmail(customerEmail)) {
       return res.status(400).json({ error: 'Enter a valid customer email.' });
     }
     if (!description) {
@@ -114,6 +121,7 @@ export function createCustomPaymentHandler(options = {}) {
           reference,
           quoteId,
           crmRecordId,
+          collectCustomerEmail,
           origin
         })
       );

--- a/tests/custom-payment.test.js
+++ b/tests/custom-payment.test.js
@@ -66,6 +66,24 @@ describe('custom payment', () => {
     assert.equal(payload.success_url, 'https://portal.3dvr.tech/custom-payment/?payment=success');
   });
 
+  it('lets Stripe collect the customer email at checkout when requested', () => {
+    const payload = buildOperatorPaymentSessionPayload({
+      amountCents: 25800,
+      customerEmail: '',
+      customerName: 'Pedri',
+      description: '3DVR quote PEDRI-001',
+      reference: 'PEDRI-001',
+      quoteId: 'pedri-draft',
+      crmRecordId: 'lead-pedri',
+      collectCustomerEmail: true,
+      origin: config.PORTAL_ORIGIN
+    });
+
+    assert.equal('customer_email' in payload, false);
+    assert.equal(payload.customer_creation, 'always');
+    assert.equal(payload.metadata.customer_email, undefined);
+  });
+
   it('requires portal billing authentication before creating a link', async () => {
     const stripe = { checkout: { sessions: { create: mock.fn() } } };
     const handler = createCustomPaymentHandler({ stripeClient: stripe, config });
@@ -116,5 +134,34 @@ describe('custom payment', () => {
     assert.equal(create.mock.calls[0].arguments[0].customer_email, 'buyer@example.com');
     assert.equal(create.mock.calls[0].arguments[0].metadata.quote_id, 'quote-12');
     assert.equal(create.mock.calls[0].arguments[0].metadata.crm_record_id, 'lead-12');
+  });
+
+  it('creates a checkout that asks the customer for email when the quote has none', async () => {
+    const create = mock.fn(async () => ({
+      id: 'cs_customer_email',
+      url: 'https://checkout.stripe.com/c/pay/cs_customer_email'
+    }));
+    const handler = createCustomPaymentHandler({
+      stripeClient: { checkout: { sessions: { create } } },
+      config
+    });
+    const res = response();
+
+    await handler({
+      method: 'POST',
+      body: await authBody({
+        customerName: 'Pedri',
+        customerEmail: '',
+        collectCustomerEmail: true,
+        amount: '258',
+        description: '3DVR quote PEDRI-001',
+        quoteId: 'pedri-draft',
+        crmRecordId: 'lead-pedri'
+      })
+    }, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal('customer_email' in create.mock.calls[0].arguments[0], false);
+    assert.equal(create.mock.calls[0].arguments[0].metadata.quote_id, 'pedri-draft');
   });
 });

--- a/tests/quote-builder.test.js
+++ b/tests/quote-builder.test.js
@@ -72,9 +72,11 @@ describe('quote builder', () => {
 
     assert.match(html, /Pull from CRM/);
     assert.match(html, /Print \/ Save PDF/);
-    assert.match(html, /Create payment link/);
+    assert.match(html, /Create customer payment link/);
+    assert.match(html, /Customer can enter this at checkout/);
     assert.match(app, /gun\.get\('3dvr-crm'\)/);
     assert.match(app, /\/api\/stripe\/custom-payment/);
+    assert.match(app, /collectCustomerEmail: !quote\.customerEmail/);
     assert.match(css, /@media print/);
     assert.match(css, /\.no-print/);
     assert.match(portal, /href="quote-builder\/"/);


### PR DESCRIPTION
Summary:
- make customer email optional in Quote Builder
- let Stripe Checkout collect the email when it is not already known
- preserve prefilled email behavior for existing CRM contacts
- add API and UI regression coverage

Testing:
- focused custom payment and quote builder tests: 9 passed
- full suite: 792 passed, 12 pre-existing unrelated failures, 2 skipped