### PR TITLE
Let customers complete quick payment details

### DIFF
--- a/custom-payment/app.js
+++ b/custom-payment/app.js
@@ -95,6 +95,8 @@ form.addEventListener('submit', async event => {
 
   try {
     const fields = Object.fromEntries(new FormData(form))
+    fields.collectCustomerEmail = !fields.customerEmail
+    fields.collectMissingFields = true
     const auth = await buildAuth()
     const response = await fetch('/api/stripe/custom-payment', {
       method: 'POST',

--- a/custom-payment/index.html
+++ b/custom-payment/index.html
@@ -18,8 +18,8 @@
     <header>
       <a href="/" class="back" aria-label="Back to portal">← Portal</a>
       <p class="eyebrow">3DVR • Stripe</p>
-      <h1>Custom Payment</h1>
-      <p>Create the checkout, then send the secure Stripe link. Your customer does not need an account.</p>
+      <h1>Quick Payment</h1>
+      <p>Enter what you know. Stripe asks the customer for anything you leave blank.</p>
     </header>
 
     <section id="customer-result" class="result" hidden>
@@ -35,12 +35,12 @@
 
     <form id="payment-form" autocomplete="on">
       <label>
-        Customer name
-        <input name="customerName" autocomplete="name" required maxlength="120" placeholder="Jane Smith">
+        Customer name <small>optional</small>
+        <input name="customerName" autocomplete="name" maxlength="120" placeholder="Customer can enter this">
       </label>
       <label>
-        Customer email
-        <input name="customerEmail" type="email" autocomplete="email" required placeholder="jane@example.com">
+        Customer email <small>optional</small>
+        <input name="customerEmail" type="email" autocomplete="email" placeholder="Customer can enter this">
       </label>
       <div class="split">
         <label>
@@ -53,8 +53,8 @@
         </label>
       </div>
       <label>
-        What is it for?
-        <input name="description" required maxlength="120" placeholder="250 business cards">
+        What is it for? <small>optional</small>
+        <input name="description" maxlength="120" placeholder="Customer can enter this">
       </label>
       <button id="create-button" class="button" type="submit">Create payment link</button>
       <p id="status" class="status" role="status" aria-live="polite"></p>

--- a/src/billing/api-custom-payment.js
+++ b/src/billing/api-custom-payment.js
@@ -15,8 +15,10 @@ export function buildOperatorPaymentSessionPayload({
   quoteId,
   crmRecordId,
   collectCustomerEmail = false,
+  collectMissingFields = false,
   origin
 }) {
+  const sessionDescription = description || 'Custom 3DVR payment';
   const metadata = {
     payment_source: 'custom-payment',
     customer_name: customerName,
@@ -35,7 +37,7 @@ export function buildOperatorPaymentSessionPayload({
     customer_creation: 'always',
     billing_address_collection: 'auto',
     payment_intent_data: {
-      description,
+      description: sessionDescription,
       metadata: compactMetadata
     },
     line_items: [{
@@ -44,7 +46,7 @@ export function buildOperatorPaymentSessionPayload({
         currency: 'usd',
         unit_amount: amountCents,
         product_data: {
-          name: description,
+          name: sessionDescription,
           metadata: compactMetadata
         }
       }
@@ -56,6 +58,35 @@ export function buildOperatorPaymentSessionPayload({
 
   if (!collectCustomerEmail) {
     payload.customer_email = customerEmail;
+  }
+
+  if (collectMissingFields) {
+    const customFields = [];
+    if (!customerName) {
+      customFields.push({
+        key: 'customer_name',
+        label: { type: 'custom', custom: 'Your name' },
+        type: 'text',
+        optional: false
+      });
+    }
+    if (!description) {
+      customFields.push({
+        key: 'payment_for',
+        label: { type: 'custom', custom: 'What is this payment for?' },
+        type: 'text',
+        optional: false
+      });
+    }
+    if (!reference) {
+      customFields.push({
+        key: 'reference',
+        label: { type: 'custom', custom: 'Reference or job number (optional)' },
+        type: 'text',
+        optional: true
+      });
+    }
+    if (customFields.length) payload.custom_fields = customFields;
   }
 
   return payload;
@@ -96,15 +127,16 @@ export function createCustomPaymentHandler(options = {}) {
     const quoteId = cleanText(body.quoteId, 100);
     const crmRecordId = cleanText(body.crmRecordId, 100);
     const collectCustomerEmail = body.collectCustomerEmail === true;
+    const collectMissingFields = body.collectMissingFields === true;
     const amountCents = normalizeCustomAmount(body.amount);
 
-    if (!customerName) {
+    if (!collectMissingFields && !customerName) {
       return res.status(400).json({ error: 'Enter the customer name.' });
     }
     if (!collectCustomerEmail && !isValidBillingEmail(customerEmail)) {
       return res.status(400).json({ error: 'Enter a valid customer email.' });
     }
-    if (!description) {
+    if (!collectMissingFields && !description) {
       return res.status(400).json({ error: 'Enter what the payment is for.' });
     }
     if (!amountCents || amountCents < 100 || amountCents > 99999999) {
@@ -122,6 +154,7 @@ export function createCustomPaymentHandler(options = {}) {
           quoteId,
           crmRecordId,
           collectCustomerEmail,
+          collectMissingFields,
           origin
         })
       );

--- a/tests/custom-payment-page.test.js
+++ b/tests/custom-payment-page.test.js
@@ -12,9 +12,10 @@ describe('custom payment page', () => {
 
     assert.match(html, /Customer name/);
     assert.match(html, /Customer email/);
-    assert.match(html, /What is it for/);
-    assert.match(html, /does not need an account/);
+    assert.match(html, /What is it for\? <small>optional/);
+    assert.match(html, /Stripe asks the customer for anything you leave blank/);
     assert.ok(app.includes('/api/stripe/custom-payment'));
+    assert.match(app, /collectMissingFields = true/);
     assert.match(app, /navigator\.clipboard/);
     assert.ok(portal.includes('href="custom-payment/"'));
   });

--- a/tests/custom-payment.test.js
+++ b/tests/custom-payment.test.js
@@ -84,6 +84,30 @@ describe('custom payment', () => {
     assert.equal(payload.metadata.customer_email, undefined);
   });
 
+  it('collects blank quick-payment details from the customer in Stripe', () => {
+    const payload = buildOperatorPaymentSessionPayload({
+      amountCents: 7500,
+      customerEmail: '',
+      customerName: '',
+      description: '',
+      reference: '',
+      collectCustomerEmail: true,
+      collectMissingFields: true,
+      origin: config.PORTAL_ORIGIN
+    });
+
+    assert.equal('customer_email' in payload, false);
+    assert.equal(payload.line_items[0].price_data.product_data.name, 'Custom 3DVR payment');
+    assert.deepEqual(payload.custom_fields.map(field => field.key), [
+      'customer_name',
+      'payment_for',
+      'reference'
+    ]);
+    assert.equal(payload.custom_fields[0].optional, false);
+    assert.equal(payload.custom_fields[1].optional, false);
+    assert.equal(payload.custom_fields[2].optional, true);
+  });
+
   it('requires portal billing authentication before creating a link', async () => {
     const stripe = { checkout: { sessions: { create: mock.fn() } } };
     const handler = createCustomPaymentHandler({ stripeClient: stripe, config });
@@ -163,5 +187,36 @@ describe('custom payment', () => {
     assert.equal(res.statusCode, 200);
     assert.equal('customer_email' in create.mock.calls[0].arguments[0], false);
     assert.equal(create.mock.calls[0].arguments[0].metadata.quote_id, 'pedri-draft');
+  });
+
+  it('creates a quick-payment checkout with only an operator-entered amount', async () => {
+    const create = mock.fn(async () => ({
+      id: 'cs_open_payment',
+      url: 'https://checkout.stripe.com/c/pay/cs_open_payment'
+    }));
+    const handler = createCustomPaymentHandler({
+      stripeClient: { checkout: { sessions: { create } } },
+      config
+    });
+    const res = response();
+
+    await handler({
+      method: 'POST',
+      body: await authBody({
+        amount: '75',
+        collectCustomerEmail: true,
+        collectMissingFields: true
+      })
+    }, res);
+
+    assert.equal(res.statusCode, 200);
+    const payload = create.mock.calls[0].arguments[0];
+    assert.equal(payload.line_items[0].price_data.unit_amount, 7500);
+    assert.equal('customer_email' in payload, false);
+    assert.deepEqual(payload.custom_fields.map(field => field.key), [
+      'customer_name',
+      'payment_for',
+      'reference'
+    ]);
   });
 });


### PR DESCRIPTION
Summary:
- make name, email, payment purpose, and reference optional in Quick Payment
- collect missing details inside Stripe Checkout
- keep amount required and preserve existing prefilled behavior
- add API and page regression coverage

Testing:
- focused custom payment and quote builder tests: 12 passed