### PR TITLE
Keep quick payment references internal

### DIFF
--- a/custom-payment/index.html
+++ b/custom-payment/index.html
@@ -48,7 +48,7 @@
           <span class="money-input"><span>$</span><input name="amount" type="number" inputmode="decimal" min="1" step="0.01" required placeholder="75.00"></span>
         </label>
         <label>
-          Reference <small>optional</small>
+          Internal reference <small>optional • customer won’t see this prompt</small>
           <input name="reference" maxlength="80" placeholder="BC-104">
         </label>
       </div>

--- a/src/billing/api-custom-payment.js
+++ b/src/billing/api-custom-payment.js
@@ -78,14 +78,6 @@ export function buildOperatorPaymentSessionPayload({
         optional: false
       });
     }
-    if (!reference) {
-      customFields.push({
-        key: 'reference',
-        label: { type: 'custom', custom: 'Reference or job number (optional)' },
-        type: 'text',
-        optional: true
-      });
-    }
     if (customFields.length) payload.custom_fields = customFields;
   }
 

--- a/tests/custom-payment-page.test.js
+++ b/tests/custom-payment-page.test.js
@@ -13,6 +13,7 @@ describe('custom payment page', () => {
     assert.match(html, /Customer name/);
     assert.match(html, /Customer email/);
     assert.match(html, /What is it for\? <small>optional/);
+    assert.match(html, /Internal reference <small>optional • customer won’t see this prompt/);
     assert.match(html, /Stripe asks the customer for anything you leave blank/);
     assert.ok(app.includes('/api/stripe/custom-payment'));
     assert.match(app, /collectMissingFields = true/);

--- a/tests/custom-payment.test.js
+++ b/tests/custom-payment.test.js
@@ -100,12 +100,10 @@ describe('custom payment', () => {
     assert.equal(payload.line_items[0].price_data.product_data.name, 'Custom 3DVR payment');
     assert.deepEqual(payload.custom_fields.map(field => field.key), [
       'customer_name',
-      'payment_for',
-      'reference'
+      'payment_for'
     ]);
     assert.equal(payload.custom_fields[0].optional, false);
     assert.equal(payload.custom_fields[1].optional, false);
-    assert.equal(payload.custom_fields[2].optional, true);
   });
 
   it('requires portal billing authentication before creating a link', async () => {
@@ -215,8 +213,7 @@ describe('custom payment', () => {
     assert.equal('customer_email' in payload, false);
     assert.deepEqual(payload.custom_fields.map(field => field.key), [
       'customer_name',
-      'payment_for',
-      'reference'
+      'payment_for'
     ]);
   });
 });


### PR DESCRIPTION
Summary:
- stop asking customers for a reference or job number in Stripe Checkout
- keep the optional reference field available to operators for internal tracking
- clarify the internal-only behavior in Quick Payment
- update regression coverage

Testing:
- focused payment and quote tests: 12 passed