### PR TITLE
Add portal release v0.0.56

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -99,18 +99,27 @@
   <div class="section">
     <h2>Latest Release</h2>
     <article class="release-card">
-      <a class="release-link" href="v0.0.55.html">v0.0.55</a>
-      <span class="release-meta">Week of July 20, 2026</span>
+      <a class="release-link" href="v0.0.56.html">v0.0.56</a>
+      <span class="release-meta">Week of July 27, 2026</span>
       <p class="release-summary">
-        A playable <a href="../life-upgrade/">Life Upgrade</a> journey, clearer <a href="../next-move-lab/">Next Move</a>
-        guidance, <a href="../danny/">Danny’s Dictionary</a>, the <a href="../wenzo/">Wenzo gallery</a>, and a
-        weather-aware <a href="../sky-room/">Sky Room</a> refined for desktop and mobile.
+        A conversation-first <a href="../operator/">Operator</a>, visual <a href="../life-space/">Life Space</a>,
+        local-business <a href="../lead-finder/">Lead Finder</a>, and connected quote and payment tools turn the
+        portal into a system that can organize work and take useful action.
       </p>
     </article>
   </div>
   <div class="section">
     <h2>Release History</h2>
     <ul class="release-grid">
+      <li class="release-card">
+        <a class="release-link" href="v0.0.56.html">v0.0.56</a>
+        <span class="release-meta">Week of July 27, 2026</span>
+        <p class="release-summary">
+          A conversation-first <a href="../operator/">Operator</a>, visual <a href="../life-space/">Life Space</a>,
+          local-business <a href="../lead-finder/">Lead Finder</a>, and connected quote and payment tools turn the
+          portal into a system that can organize work and take useful action.
+        </p>
+      </li>
       <li class="release-card">
         <a class="release-link" href="v0.0.55.html">v0.0.55</a>
         <span class="release-meta">Week of July 20, 2026</span>

--- a/releases/v0.0.55.html
+++ b/releases/v0.0.55.html
@@ -24,7 +24,7 @@
   <p><a class="back-link" href="index.html">Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
     <a class="release-nav-link" href="v0.0.54.html">Previous release</a>
-    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+    <a class="release-nav-link" href="v0.0.56.html">Next release</a>
   </nav>
   <h1>Release v0.0.55</h1>
   <div class="tag">Week of July 20, 2026</div>

--- a/releases/v0.0.56.html
+++ b/releases/v0.0.56.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Portal - Release v0.0.56 (Week of July 27, 2026)</title>
+  <style>
+    body { margin: 0 auto; font-family: Arial, Helvetica, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.65; padding: 20px; max-width: 920px; }
+    h1, h2, h3 { color: #58a6ff; }
+    a { color: #58a6ff; }
+    .section { margin: 30px 0; padding: 20px; background: #161b22; border-radius: 10px; border: 1px solid #30363d; }
+    .tag { background: #1f6feb; padding: 4px 10px; border-radius: 6px; display: inline-block; font-size: 14px; margin-bottom: 20px; }
+    .release-summary { margin: 0 0 24px; font-size: 16px; color: #9ba3b4; }
+    .release-summary-list, .link-list { margin: 0; padding-left: 20px; color: #c9d1d9; }
+    .release-summary-list li + li, .link-list li + li { margin-top: 8px; }
+    .back-link, .release-nav-link { color: #58a6ff; text-decoration: none; font-weight: 600; }
+    .back-link:hover, .release-nav-link:hover { text-decoration: underline; }
+    .release-nav { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; margin: 20px 0 40px; }
+    .release-nav-link.is-disabled { opacity: 0.4; pointer-events: none; cursor: default; }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <p><a class="back-link" href="index.html">Back to releases</a></p>
+  <nav class="release-nav" aria-label="Release navigation">
+    <a class="release-nav-link" href="v0.0.55.html">Previous release</a>
+    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+  </nav>
+  <h1>Release v0.0.56</h1>
+  <div class="tag">Week of July 27, 2026</div>
+  <div class="release-summary">
+    <p>
+      This week turns the portal into an operator people can talk to. The new
+      <a href="../operator/">3DVR Operator</a> guides users, remembers conversations, and safely uses portal tools
+      behind the chat, while <a href="../life-space/">Life Space</a>, <a href="../lead-finder/">Lead Finder</a>,
+      Quote Builder, and Quick Payment provide the working machinery underneath it.
+    </p>
+    <ul class="release-summary-list">
+      <li>
+        <strong>Conversation-first portal:</strong>
+        <a href="../operator/">Operator</a> launched with a focused mobile-app layout, saved and account-synced
+        conversations, quick-start ideas, contextual next steps, clearer navigation, and a safe action bridge in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1239">PR #1239</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1246">PR #1246</a>.
+      </li>
+      <li>
+        <strong>Visual personal workspace:</strong>
+        <a href="../life-space/">Life Space</a> adds free-position notes, checklists, links, photos, files, drawing,
+        search, backups, and local-first persistence, with Operator able to create useful items directly through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1236">PR #1236</a> and
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1242">PR #1242</a>.
+      </li>
+      <li>
+        <strong>Lead-to-preview workflow:</strong>
+        <a href="../lead-finder/">Lead Finder</a> scores public local-business opportunities, prepares personalized
+        outreach, and hands prospects into CRM, Growth Operator, and Web Builder. Blank business-type searches now
+        cover all businesses in a location through <a href="https://github.com/tmsteph/3dvr-portal/pull/1237">PR #1237</a>
+        and <a href="https://github.com/tmsteph/3dvr-portal/pull/1238">PR #1238</a>.
+      </li>
+      <li>
+        <strong>Quoting and payment:</strong>
+        no-account Custom Payment, CRM-connected quotes, customer-completed checkout details, and internal-only job
+        references make it easier to move a qualified conversation toward payment in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1231">PR #1231</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1235">PR #1235</a>.
+      </li>
+      <li>
+        <strong>Smaller next steps and safer outreach:</strong>
+        <a href="../smallest-step/">Smallest Step</a> became a calm multi-view app with bounded snapshots, and the
+        automated outreach loop now stops repeated no-response follow-ups in
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1225">PR #1225</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1230">PR #1230</a>.
+      </li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Release cadence</h2>
+    <p>
+      v0.0.56 covers work merged from <a href="https://github.com/tmsteph/3dvr-portal/pull/1225">PR #1225</a>
+      through <a href="https://github.com/tmsteph/3dvr-portal/pull/1246">PR #1246</a>. The portal release hub now
+      matches the current production milestone, with the latest main-branch browser and deployment checks passing.
+    </p>
+  </div>
+
+  <p style="margin-top: 40px; opacity: 0.6;">&copy; 2026 3dvr.tech - Open source for everyone.</p>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/tests/releases-hub.test.js
+++ b/tests/releases-hub.test.js
@@ -15,12 +15,17 @@ async function fileExists(path) {
 }
 
 describe('release hub backfill', () => {
-  it('updates the release index with the weekly milestones through v0.0.55', async () => {
+  it('updates the release index with the weekly milestones through v0.0.56', async () => {
     const indexUrl = new URL('index.html', baseDir);
     assert.equal(await fileExists(indexUrl), true, 'releases/index.html should exist');
 
     const html = await readFile(indexUrl, 'utf8');
     assert.match(html, /Latest Release/);
+    assert.match(html, /href="v0\.0\.56\.html">v0\.0\.56</);
+    assert.match(html, /Week of July 27, 2026/);
+    assert.match(html, /Operator/);
+    assert.match(html, /Life Space/);
+    assert.match(html, /Lead Finder/);
     assert.match(html, /href="v0\.0\.55\.html">v0\.0\.55</);
     assert.match(html, /Week of July 20, 2026/);
     assert.match(html, /Life Upgrade/);
@@ -102,7 +107,8 @@ describe('release hub backfill', () => {
 
   it('ships the new milestone pages with coherent navigation, summaries, and source links', async () => {
     const releases = [
-      ['v0.0.55.html', /Week of July 20, 2026/, /Guided personal change/i, /aria-disabled="true"/],
+      ['v0.0.56.html', /Week of July 27, 2026/, /Conversation-first portal/i, /aria-disabled="true"/],
+      ['v0.0.55.html', /Week of July 20, 2026/, /Guided personal change/i, /href="v0\.0\.56\.html"/],
       ['v0.0.54.html', /Week of July 13, 2026/, /Personalized preview funnel/i, /aria-disabled="true"/],
       ['v0.0.53.html', /Week of July 6, 2026/, /Money Printer becomes an operating loop/i, /href="v0\.0\.54\.html"/],
       ['v0.0.52.html', /Week of June 29, 2026/, /Free-first portal and Monday release path/i, /pull\/977/],
@@ -136,6 +142,7 @@ describe('release hub backfill', () => {
   });
 
   it('links shipped apps and docs inline where the release summaries mention them', async () => {
+    const release56 = await readFile(new URL('v0.0.56.html', baseDir), 'utf8');
     const release55 = await readFile(new URL('v0.0.55.html', baseDir), 'utf8');
     const release54 = await readFile(new URL('v0.0.54.html', baseDir), 'utf8');
     const release53 = await readFile(new URL('v0.0.53.html', baseDir), 'utf8');
@@ -145,6 +152,12 @@ describe('release hub backfill', () => {
     const release49 = await readFile(new URL('v0.0.49.html', baseDir), 'utf8');
     const release47 = await readFile(new URL('v0.0.47.html', baseDir), 'utf8');
     const release48 = await readFile(new URL('v0.0.48.html', baseDir), 'utf8');
+
+    assert.match(release56, /href="\.\.\/operator\/">3DVR Operator</);
+    assert.match(release56, /href="\.\.\/life-space\/">Life Space</);
+    assert.match(release56, /href="\.\.\/lead-finder\/">Lead Finder</);
+    assert.match(release56, /pull\/1225/);
+    assert.match(release56, /pull\/1246/);
 
     assert.match(release54, /href="\.\.\/free-page\/">Free Page</);
     assert.match(release54, /href="\.\.\/free-page\/preview\/">personalized Free Page previews</);


### PR DESCRIPTION
## Summary
- add portal release v0.0.56 for the week of July 27
- cover Operator, Life Space, Lead Finder, quote/payment, Smallest Step, and outreach safeguards
- update release index, navigation, and regression coverage

## Verification
- `node --test tests/releases-hub.test.js`
- `git diff --check`
