### PR TITLE
Sync Life Space to portal accounts

### DIFF
--- a/life-space/app.js
+++ b/life-space/app.js
@@ -1,4 +1,5 @@
 import { openDatabase, loadState, saveState, saveFile, getFile, exportWorkspace, importWorkspace } from './storage.js';
+import { createLifeSpaceSync } from './sync.js';
 
 const $ = selector => document.querySelector(selector);
 const uid = prefix => `${prefix}-${crypto.randomUUID()}`;
@@ -24,9 +25,11 @@ let drawMode = false;
 let currentStroke = null;
 let interaction = null;
 let saveTimer;
+let syncTimer;
 let history = [];
 let future = [];
 let objectUrls = new Map();
+let sync;
 
 const activeSpace = () => state.spaces.find(space => space.id === state.activeSpaceId) || state.spaces[0];
 const itemById = id => activeSpace().items.find(item => item.id === id);
@@ -49,15 +52,24 @@ function scheduleSave() {
   clearTimeout(saveTimer);
   els.saveStatus.textContent = 'Saving…';
   state.updatedAt = Date.now();
+  activeSpace().updatedAt = state.updatedAt;
   saveTimer = setTimeout(async () => {
     try {
       await saveState(db, state);
       els.saveStatus.textContent = 'Saved on this device';
+      scheduleAccountSync();
     } catch (error) {
       els.saveStatus.textContent = 'Could not save';
       toast(error.message, true);
     }
   }, 220);
+}
+
+function scheduleAccountSync() {
+  clearTimeout(syncTimer);
+  syncTimer = setTimeout(async () => {
+    try { await sync?.save(await exportWorkspace(db, state)); } catch { els.saveStatus.textContent = 'Saved here · Sync will retry'; }
+  }, 1200);
 }
 
 function toast(message, danger = false) {
@@ -84,7 +96,7 @@ function createItem(type, values = {}) {
     id: uid(type), type, x: point.x, y: point.y, w: type === 'image' ? 340 : 300,
     h: type === 'note' ? 220 : type === 'checklist' ? 250 : 190,
     title: type === 'note' ? 'New thought' : type === 'checklist' ? 'Things to do' : '', z: Date.now(),
-    text: '', color: ['#fff3c9','#dff4ea','#e8e1ff','#dcecff'][activeSpace().items.length % 4], createdAt: Date.now()
+    text: '', color: ['#fff3c9','#dff4ea','#e8e1ff','#dcecff'][activeSpace().items.length % 4], createdAt: Date.now(), updatedAt: Date.now()
   };
   const before = snapshot();
   const item = { ...defaults, ...values };
@@ -192,7 +204,7 @@ function pointerDown(event) {
     event.preventDefault();
     const before = snapshot();
     const point = boardPoint(event);
-    currentStroke = { id:uid('stroke'), color:'#ff7a59', width:4 / activeSpace().view.zoom, points:[point] };
+    currentStroke = { id:uid('stroke'), color:'#ff7a59', width:4 / activeSpace().view.zoom, points:[point], createdAt:Date.now(), updatedAt:Date.now() };
     activeSpace().strokes.push(currentStroke);
     interaction = { type:'draw', before };
     els.wrap.setPointerCapture(event.pointerId); renderStrokes(); return;
@@ -245,6 +257,8 @@ function pointerMove(event) {
 
 function pointerUp() {
   if (!interaction) return;
+  if (interaction.item) interaction.item.updatedAt = Date.now();
+  if (interaction.type === 'draw' && currentStroke) currentStroke.updatedAt = Date.now();
   if (interaction.before) commitHistory(interaction.before);
   if (interaction.type !== 'pan') renderBoard(); else scheduleSave();
   document.querySelector('.moving')?.classList.remove('moving');
@@ -261,23 +275,24 @@ function bindEvents() {
     const card = event.target.closest('.life-card');
     if (card && event.target.closest('[data-delete]')) {
       const before = snapshot();
+      activeSpace().deletedItemIds = [...new Set([...(activeSpace().deletedItemIds || []), card.dataset.id])];
       activeSpace().items = activeSpace().items.filter(item => item.id !== card.dataset.id);
       commitHistory(before); scheduleSave(); renderBoard();
     }
     if (card && event.target.closest('[data-color]')) {
       const palette = ['#fff3c9','#dff4ea','#e8e1ff','#dcecff','#ffe1dc','#f4eee4'];
       const item = itemById(card.dataset.id); const before = snapshot();
-      item.color = palette[(palette.indexOf(item.color) + 1) % palette.length];
+      item.color = palette[(palette.indexOf(item.color) + 1) % palette.length]; item.updatedAt = Date.now();
       commitHistory(before); scheduleSave(); renderBoard();
     }
     if (card && event.target.closest('.add-row')) {
       const item = itemById(card.dataset.id); const before = snapshot();
-      item.rows.push({ id:uid('row'), text:'', done:false }); commitHistory(before); scheduleSave(); renderBoard();
+      item.rows.push({ id:uid('row'), text:'', done:false }); item.updatedAt = Date.now(); commitHistory(before); scheduleSave(); renderBoard();
       requestAnimationFrame(() => card.querySelector('[data-row]:last-of-type [data-row-text]')?.focus());
     }
     if (card && event.target.closest('[data-delete-row]')) {
       const item = itemById(card.dataset.id); const row = event.target.closest('[data-row]'); const before = snapshot();
-      item.rows = item.rows.filter(entry => entry.id !== row.dataset.row); commitHistory(before); scheduleSave(); renderBoard();
+      item.rows = item.rows.filter(entry => entry.id !== row.dataset.row); item.updatedAt = Date.now(); commitHistory(before); scheduleSave(); renderBoard();
     }
     if (card && event.target.closest('.download-file')) {
       const item = itemById(card.dataset.id); const stored = await getFile(db, item.fileId);
@@ -288,6 +303,7 @@ function bindEvents() {
     if (spaceButton && !event.target.closest('[data-delete-space]')) { state.activeSpaceId = spaceButton.dataset.space; history=[]; future=[]; updateHistoryButtons(); renderBoard(); scheduleSave(); els.sidebar.classList.remove('open'); }
     if (spaceButton && event.target.closest('[data-delete-space]')) {
       if (!confirm('Delete this space and everything in it?')) return;
+      state.deletedSpaceIds = [...new Set([...(state.deletedSpaceIds || []), spaceButton.dataset.space])];
       state.spaces = state.spaces.filter(space => space.id !== spaceButton.dataset.space); state.activeSpaceId = state.spaces[0].id; renderBoard(); scheduleSave();
     }
   });
@@ -297,12 +313,13 @@ function bindEvents() {
     const item = itemById(card.dataset.id);
     if (event.target.dataset.field) item[event.target.dataset.field] = event.target.innerText;
     if (event.target.hasAttribute('data-row-text')) item.rows.find(row => row.id === event.target.closest('[data-row]').dataset.row).text = event.target.innerText;
+    item.updatedAt = Date.now();
     scheduleSave();
   });
   els.cardLayer.addEventListener('change', event => {
     if (event.target.type !== 'checkbox') return;
     const item = itemById(event.target.closest('.life-card').dataset.id);
-    item.rows.find(row => row.id === event.target.closest('[data-row]').dataset.row).done = event.target.checked; scheduleSave();
+    item.rows.find(row => row.id === event.target.closest('[data-row]').dataset.row).done = event.target.checked; item.updatedAt = Date.now(); scheduleSave();
   });
   els.wrap.addEventListener('pointerdown', pointerDown);
   els.wrap.addEventListener('pointermove', pointerMove);
@@ -312,7 +329,7 @@ function bindEvents() {
 
   $('#draw-tool').onclick = () => { drawMode = !drawMode; $('#draw-tool').classList.toggle('active', drawMode); els.wrap.classList.toggle('drawing', drawMode); toast(drawMode ? 'Draw mode on' : 'Draw mode off'); };
   $('#add-space').onclick = () => { const name = prompt('Name this space', 'New space'); if (!name?.trim()) return; const before=snapshot(); const space={id:uid('space'),name:name.trim(),color:['#ffb66e','#7fd4ad','#a89cf5','#79b9ef'][state.spaces.length%4],view:{x:0,y:0,zoom:1},items:[],strokes:[]}; state.spaces.push(space); state.activeSpaceId=space.id; commitHistory(before); renderBoard(); scheduleSave(); };
-  els.name.addEventListener('input', () => { activeSpace().name = els.name.value; renderSpaces(); scheduleSave(); });
+  els.name.addEventListener('input', () => { activeSpace().name = els.name.value; activeSpace().updatedAt = Date.now(); renderSpaces(); scheduleSave(); });
   els.search.addEventListener('input', renderSpaces);
   $('#zoom-in').onclick = () => setZoom(activeSpace().view.zoom * 1.15);
   $('#zoom-out').onclick = () => setZoom(activeSpace().view.zoom / 1.15);
@@ -359,7 +376,15 @@ async function restore(event) {
 async function init() {
   db=await openDatabase(); state=await loadState(db) || defaultState();
   if (!state.spaces?.length) state=defaultState();
+  sync=createLifeSpaceSync({onStatus:value=>{els.saveStatus.textContent=value;}});
   bindEvents(); renderBoard(); updateHistoryButtons();
+  const localPayload=await exportWorkspace(db,state);
+  const syncedPayload=await sync.load(localPayload);
+  if (syncedPayload) {
+    state=await importWorkspace(db,syncedPayload);
+    renderBoard();
+    await sync.save(await exportWorkspace(db,state));
+  }
 }
 
 init().catch(error => { console.error(error); toast('Life Space could not start. Refresh and try again.', true); });

--- a/life-space/index.html
+++ b/life-space/index.html
@@ -8,6 +8,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <title>Life Space · 3DVR</title>
   <link rel="manifest" href="/app-manifests/life-space.webmanifest">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script src="/gun-init.js"></script>
+  <script src="/auth-identity.js"></script>
   <script src="/pwa-install.js" defer></script>
   <script defer src="/_vercel/insights/script.js"></script>
   <link rel="stylesheet" href="styles.css">
@@ -29,7 +33,7 @@
         <button class="sidebar-action" id="export-data">Export backup</button>
         <button class="sidebar-action" id="import-data">Import backup</button>
         <input id="import-file" type="file" accept="application/json" hidden>
-        <p><span class="status-dot"></span><span id="save-status">Saved on this device</span></p>
+        <p><span class="status-dot"></span><span id="save-status">Checking account sync…</span></p>
       </div>
     </aside>
 
@@ -92,7 +96,7 @@
     <div class="help-grid">
       <article><b>Move freely</b><p>Drag cards by their top edge. Drag empty space to pan. Pinch or use the zoom controls.</p></article>
       <article><b>Edit naturally</b><p>Click text and type. Changes save automatically. Resize a card from its lower corner.</p></article>
-      <article><b>Keep it yours</b><p>Your workspace and files stay in this browser. Export a backup whenever you want to move devices.</p></article>
+      <article><b>Keep it yours</b><p>Your workspace stays available offline. Sign in to sync an encrypted copy across devices, and export a backup whenever you want.</p></article>
       <article><b>Draw over it</b><p>Turn on Draw, sketch with a mouse, pen, or finger, then turn it off to move things again.</p></article>
     </div>
     <button class="primary-button wide" data-close-dialog>Start making space</button>

--- a/life-space/sync.js
+++ b/life-space/sync.js
@@ -1,0 +1,137 @@
+const SYNC_NODE = 'life-space-v01';
+const CHUNK_SIZE = 24 * 1024;
+
+const delay = (windowObj, ms) => new Promise(resolve => windowObj.setTimeout(resolve, ms));
+const once = (node, windowObj) => new Promise(resolve => {
+  let settled = false;
+  const finish = value => { if (!settled) { settled = true; resolve(value); } };
+  try { node.once(finish); windowObj.setTimeout(() => finish(null), 2500); } catch { finish(null); }
+});
+const put = (node, value) => new Promise(resolve => {
+  try { node.put(value, ack => resolve(!ack?.err)); } catch { resolve(false); }
+});
+const modified = value => Number(value?.updatedAt || value?.createdAt || 0);
+
+function mergeById(local = [], remote = []) {
+  const values = new Map();
+  for (const value of [...remote, ...local]) {
+    if (!value?.id) continue;
+    const current = values.get(value.id);
+    if (!current || modified(value) >= modified(current)) values.set(value.id, value);
+  }
+  return [...values.values()];
+}
+
+export function mergeLifeSpaceStates(localState, remoteState) {
+  if (!localState) return remoteState;
+  if (!remoteState) return localState;
+  const deletedSpaces = new Set([...(remoteState.deletedSpaceIds || []), ...(localState.deletedSpaceIds || [])]);
+  const localSpaces = new Map((localState.spaces || []).map(space => [space.id, space]));
+  const remoteSpaces = new Map((remoteState.spaces || []).map(space => [space.id, space]));
+  const spaces = [];
+  for (const id of new Set([...remoteSpaces.keys(), ...localSpaces.keys()])) {
+    if (deletedSpaces.has(id)) continue;
+    const local = localSpaces.get(id);
+    const remote = remoteSpaces.get(id);
+    if (!local || !remote) { spaces.push(local || remote); continue; }
+    const winner = modified(local) >= modified(remote) ? local : remote;
+    const deletedItems = new Set([...(remote.deletedItemIds || []), ...(local.deletedItemIds || [])]);
+    spaces.push({
+      ...winner,
+      items: mergeById(local.items, remote.items).filter(item => !deletedItems.has(item.id)),
+      strokes: mergeById(local.strokes, remote.strokes).filter(stroke => !deletedItems.has(stroke.id)),
+      deletedItemIds: [...deletedItems]
+    });
+  }
+  const winner = modified(localState) >= modified(remoteState) ? localState : remoteState;
+  const activeSpaceId = spaces.some(space => space.id === winner.activeSpaceId) ? winner.activeSpaceId : spaces[0]?.id;
+  return { ...winner, spaces, activeSpaceId, deletedSpaceIds: [...deletedSpaces], updatedAt: Math.max(modified(localState), modified(remoteState)) };
+}
+
+export function mergeLifeSpacePayloads(localPayload, remotePayload) {
+  if (!localPayload) return remotePayload;
+  if (!remotePayload) return localPayload;
+  const files = mergeById(localPayload.files, remotePayload.files);
+  return {
+    format: '3dvr-life-space', version: 1, exportedAt: new Date().toISOString(),
+    state: mergeLifeSpaceStates(localPayload.state, remotePayload.state), files
+  };
+}
+
+export function createLifeSpaceSync({ windowObj = window, onStatus = () => {} } = {}) {
+  let node = null;
+  let secret = null;
+  let ready = false;
+  let revision = 0;
+  const init = async () => {
+    if (typeof windowObj.Gun !== 'function' || !windowObj.SEA) return false;
+    try {
+      windowObj.AuthIdentity?.syncStorageFromSharedIdentity?.(windowObj.localStorage);
+      const gun = windowObj.Gun({ peers: windowObj.__GUN_PEERS__ || [] });
+      const user = gun.user();
+      user.recall?.({ sessionStorage: true, localStorage: true });
+      for (let attempt = 0; attempt < 12 && !user.is; attempt += 1) await delay(windowObj, 150);
+      secret = user?._?.sea || null;
+      if (!user.is?.pub || !secret || typeof windowObj.SEA.encrypt !== 'function' || typeof windowObj.SEA.decrypt !== 'function') {
+        onStatus('Saved on this device · Sign in to sync');
+        return false;
+      }
+      node = user.get(SYNC_NODE).get('workspace');
+      ready = true;
+      onStatus('Account sync ready');
+      return true;
+    } catch {
+      onStatus('Saved on this device');
+      return false;
+    }
+  };
+  const readyPromise = init();
+
+  async function readPayload() {
+    const manifest = await once(node.get('manifest'), windowObj);
+    const count = Number(manifest?.chunks || 0);
+    if (!count || count > 5000) return null;
+    const parts = await Promise.all(Array.from({ length: count }, (_, index) => once(node.get('chunks').get(String(index)), windowObj)));
+    if (parts.some(part => typeof part?.value !== 'string')) return null;
+    const ciphertext = parts.map(part => part.value).join('');
+    const decoded = await windowObj.SEA.decrypt(ciphertext, secret);
+    const payload = typeof decoded === 'string' ? JSON.parse(decoded) : decoded;
+    return payload?.format === '3dvr-life-space' ? payload : null;
+  }
+
+  return {
+    ready: readyPromise,
+    async load(localPayload) {
+      if (!(await readyPromise) || !node) return null;
+      try {
+        const remotePayload = await readPayload();
+        if (!remotePayload) return null;
+        onStatus('Synced to your account');
+        return mergeLifeSpacePayloads(localPayload, remotePayload);
+      } catch {
+        onStatus('Account workspace could not be opened');
+        return null;
+      }
+    },
+    async save(payload) {
+      if (!(await readyPromise) || !node) return false;
+      const saveRevision = ++revision;
+      try {
+        onStatus('Syncing…');
+        const ciphertext = await windowObj.SEA.encrypt(JSON.stringify(payload), secret);
+        const chunks = String(ciphertext).match(new RegExp(`.{1,${CHUNK_SIZE}}`, 'gs')) || [];
+        const results = await Promise.all(chunks.map((value, index) => put(node.get('chunks').get(String(index)), { value })));
+        if (saveRevision !== revision) return false;
+        const saved = results.every(Boolean) && await put(node.get('manifest'), {
+          schemaVersion: 1, chunks: chunks.length, updatedAt: new Date().toISOString()
+        });
+        onStatus(saved ? 'Synced to your account' : 'Saved here · Sync will retry');
+        return saved;
+      } catch {
+        onStatus('Saved here · Sync will retry');
+        return false;
+      }
+    },
+    isReady() { return ready; }
+  };
+}

--- a/tests/life-space-sync.test.js
+++ b/tests/life-space-sync.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createLifeSpaceSync, mergeLifeSpacePayloads } from '../life-space/sync.js';
+
+const state = (updatedAt, spaces) => ({ version: 1, updatedAt, activeSpaceId: spaces[0]?.id, spaces });
+const space = (id, updatedAt, items = []) => ({ id, name: id, updatedAt, view: { x: 0, y: 0, zoom: 1 }, items, strokes: [] });
+const payload = value => ({ format: '3dvr-life-space', version: 1, state: value, files: [] });
+
+test('Life Space account sync merges independent spaces and newer card edits', () => {
+  const local = payload(state(30, [space('home', 30, [{ id: 'note', text: 'new', updatedAt: 30 }])]));
+  const remote = payload(state(20, [space('home', 20, [{ id: 'note', text: 'old', updatedAt: 20 }]), space('work', 20)]));
+  const merged = mergeLifeSpacePayloads(local, remote);
+  assert.deepEqual(merged.state.spaces.map(value => value.id), ['home', 'work']);
+  assert.equal(merged.state.spaces[0].items[0].text, 'new');
+});
+
+test('Life Space account sync respects deletion tombstones', () => {
+  const localSpace = { ...space('home', 30), deletedItemIds: ['gone'] };
+  const remoteSpace = space('home', 20, [{ id: 'gone', text: 'remote', updatedAt: 20 }]);
+  const merged = mergeLifeSpacePayloads(payload(state(30, [localSpace])), payload(state(20, [remoteSpace])));
+  assert.equal(merged.state.spaces[0].items.length, 0);
+});
+
+test('Life Space encrypts and chunks account backups before writing them', async () => {
+  const values = new Map();
+  const makeNode = path => ({
+    get(key) { return makeNode(`${path}/${key}`); },
+    once(callback) { callback(values.get(path) || null); },
+    put(value, callback) { values.set(path, value); callback({ ok: 1 }); }
+  });
+  const root = makeNode('root');
+  const user = { is: { pub: 'account' }, _: { sea: { priv: 'secret' } }, recall() {}, get() { return root; } };
+  const windowObj = {
+    Gun() { return { user() { return user; } }; },
+    SEA: { async encrypt(value) { return `encrypted:${value}`; }, async decrypt(value) { return value.replace('encrypted:', ''); } },
+    AuthIdentity: { syncStorageFromSharedIdentity() {} }, localStorage: {}, __GUN_PEERS__: [], setTimeout
+  };
+  const sync = createLifeSpaceSync({ windowObj });
+  const large = payload(state(1, [space('home', 1, [{ id: 'note', text: 'x'.repeat(30000), updatedAt: 1 }])]));
+  assert.equal(await sync.save(large), true);
+  assert.ok(values.get('root/workspace/manifest').chunks > 1);
+  assert.match(values.get('root/workspace/chunks/0').value, /^encrypted:/);
+});

--- a/tests/life-space.test.js
+++ b/tests/life-space.test.js
@@ -6,6 +6,7 @@ const html = fs.readFileSync(new URL('../life-space/index.html', import.meta.url
 const js = fs.readFileSync(new URL('../life-space/app.js', import.meta.url), 'utf8');
 const storage = fs.readFileSync(new URL('../life-space/storage.js', import.meta.url), 'utf8');
 const css = fs.readFileSync(new URL('../life-space/styles.css', import.meta.url), 'utf8');
+const sync = fs.readFileSync(new URL('../life-space/sync.js', import.meta.url), 'utf8');
 
 test('Life Space exposes every core capture type', () => {
   for (const type of ['note','checklist','link','image','file']) assert.match(html, new RegExp(`data-add="${type}"`));
@@ -17,6 +18,15 @@ test('Life Space is local-first and supports portable backups', () => {
   assert.match(storage, /exportWorkspace/);
   assert.match(storage, /importWorkspace/);
   assert.match(storage, /3dvr-life-space/);
+});
+
+test('Life Space loads encrypted portal-account sync without giving up offline storage', () => {
+  assert.match(html, /gun\/sea\.js/);
+  assert.match(html, /auth-identity\.js/);
+  assert.match(js, /createLifeSpaceSync/);
+  assert.match(sync, /SEA\.encrypt/);
+  assert.match(sync, /CHUNK_SIZE/);
+  assert.match(sync, /Synced to your account/);
 });
 
 test('Life Space implements spatial interaction and history', () => {


### PR DESCRIPTION
## Summary
- sync Life Space through the signed-in portal account
- encrypt and chunk workspace data and attachments before account storage
- merge offline edits by space/item and preserve deletion tombstones
- keep IndexedDB, offline behavior, and export/import backups
- show clear sync/local status in the app

## Verification
- `node --test tests/life-space.test.js tests/life-space-sync.test.js tests/operator-sync.test.js` (10/10)
- `git diff --check`
