### PR TITLE
Pan Life Space from card bodies

### DIFF
--- a/life-space/app.js
+++ b/life-space/app.js
@@ -234,9 +234,11 @@ function pointerDown(event) {
     interaction = { type:'resize', item, startX:event.clientX, startY:event.clientY, w:item.w, h:item.h, before:snapshot() };
     els.wrap.setPointerCapture(event.pointerId); return;
   }
-  if (card && event.pointerType !== 'mouse' && !event.target.closest('button, a, input')) {
-    const item = itemById(card.dataset.id);
-    interaction = { type:'card-touch', item, card, startX:event.clientX, startY:event.clientY, x:item.x, y:item.y };
+  if (card && !event.target.closest('button, a, input')) {
+    interaction = {
+      type:'card-pan', startX:event.clientX, startY:event.clientY,
+      x:activeSpace().view.x, y:activeSpace().view.y
+    };
     els.wrap.setPointerCapture(event.pointerId); return;
   }
   if (!card && event.button === 0) {
@@ -248,13 +250,12 @@ function pointerDown(event) {
 function pointerMove(event) {
   if (!interaction) return;
   const view = activeSpace().view;
-  if (interaction.type === 'card-touch') {
+  if (interaction.type === 'card-pan') {
     const moved = Math.hypot(event.clientX - interaction.startX, event.clientY - interaction.startY);
     if (moved < 8) return;
     event.preventDefault();
-    interaction.before = snapshot();
-    interaction.type = 'drag';
-    interaction.card.classList.add('moving');
+    interaction.type = 'pan';
+    els.wrap.classList.add('panning');
   }
   if (interaction.type === 'draw') {
     const point = boardPoint(event);
@@ -283,7 +284,7 @@ function pointerMove(event) {
 
 function pointerUp() {
   if (!interaction) return;
-  if (interaction.type === 'card-touch') { interaction = null; return; }
+  if (interaction.type === 'card-pan') { interaction = null; return; }
   if (interaction.item) interaction.item.updatedAt = Date.now();
   if (interaction.type === 'draw' && currentStroke) currentStroke.updatedAt = Date.now();
   if (interaction.before) commitHistory(interaction.before);

--- a/tests/life-space.test.js
+++ b/tests/life-space.test.js
@@ -37,11 +37,12 @@ test('Life Space implements spatial interaction and history', () => {
   assert.match(js, /function travel/);
 });
 
-test('Life Space raises touched cards and lets people drag from the card body', () => {
+test('Life Space raises touched cards and pans the world from the card body', () => {
   assert.match(js, /function bringItemToFront/);
   assert.match(js, /item\.z >= 1000000/);
   assert.match(js, /card\.style\.zIndex = bringItemToFront\(selected\)/);
-  assert.match(js, /type:'card-touch'/);
+  assert.match(js, /type:'card-pan'/);
+  assert.match(js, /interaction\.type = 'pan'/);
   assert.match(js, /Math\.hypot\(event\.clientX - interaction\.startX, event\.clientY - interaction\.startY\)/);
   assert.match(js, /if \(moved < 8\) return/);
 });


### PR DESCRIPTION
## What changed
- pan the whole Life Space when dragging from the center/body of a card
- keep the card header as the individual-card drag handle
- preserve tap-to-edit behavior with an 8px movement threshold
- retain the browser-safe last-touched-card layering fix

## Verification
- focused Life Space and sync tests: 9/9 passed
- Chromium mobile viewport: world moved continuously from 30×20px to 65×45px while the card coordinates stayed unchanged

No Stripe, portal-origin, or account-linking behavior changed.