### PR TITLE
Update v0.0.56 with latest Life Space work

### DIFF
--- a/releases/v0.0.56.html
+++ b/releases/v0.0.56.html
@@ -33,7 +33,8 @@
       This week turns the portal into an operator people can talk to. The new
       <a href="../operator/">3DVR Operator</a> guides users, remembers conversations, and safely uses portal tools
       behind the chat, while <a href="../life-space/">Life Space</a>, <a href="../lead-finder/">Lead Finder</a>,
-      Quote Builder, and Quick Payment provide the working machinery underneath it.
+      Quote Builder, and Quick Payment provide the working machinery underneath it. Operator and Life Space now
+      preserve encrypted account memory while remaining useful offline and on individual devices.
     </p>
     <ul class="release-summary-list">
       <li>
@@ -46,9 +47,14 @@
       <li>
         <strong>Visual personal workspace:</strong>
         <a href="../life-space/">Life Space</a> adds free-position notes, checklists, links, photos, files, drawing,
-        search, backups, and local-first persistence, with Operator able to create useful items directly through
-        <a href="https://github.com/tmsteph/3dvr-portal/pull/1236">PR #1236</a> and
-        <a href="https://github.com/tmsteph/3dvr-portal/pull/1242">PR #1242</a>.
+        search, backups, and local-first persistence. Operator can create useful items directly, and signed-in users
+        now receive encrypted account sync with offline merging, attachment support, clearer sync status, natural
+        touch gestures, card-body canvas panning, and a stable mobile keyboard experience through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1236">PR #1236</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1242">PR #1242</a>,
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1248">PR #1248</a>, and
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1252">PR #1252</a> through
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1254">PR #1254</a>.
       </li>
       <li>
         <strong>Lead-to-preview workflow:</strong>
@@ -77,9 +83,11 @@
   <div class="section">
     <h2>Release cadence</h2>
     <p>
-      v0.0.56 covers work merged from <a href="https://github.com/tmsteph/3dvr-portal/pull/1225">PR #1225</a>
-      through <a href="https://github.com/tmsteph/3dvr-portal/pull/1246">PR #1246</a>. The portal release hub now
-      matches the current production milestone, with the latest main-branch browser and deployment checks passing.
+      v0.0.56 began with work merged from <a href="https://github.com/tmsteph/3dvr-portal/pull/1225">PR #1225</a>
+      through <a href="https://github.com/tmsteph/3dvr-portal/pull/1246">PR #1246</a> and now incorporates the
+      encrypted Life Space sync and mobile interaction refinements completed through
+      <a href="https://github.com/tmsteph/3dvr-portal/pull/1254">PR #1254</a>. The release hub now matches the
+      current production milestone and its latest focused browser checks.
     </p>
   </div>
 


### PR DESCRIPTION
## What changed
- extend release v0.0.56 through the newest Life Space work
- document encrypted account sync, offline merging, and attachment support
- document improved mobile card gestures, canvas panning, and keyboard stability
- update the release cadence through PR #1254

## Why
The release page was created before the final Life Space sync and mobile refinements landed, so the public history did not fully match the production milestone.

## Verification
- reviewed the final release HTML on the branch
- limited to `releases/v0.0.56.html`; no runtime, billing, account-linking, or deployment behavior changed