### PR TITLE
Fix continuous Life Space body panning

### DIFF
--- a/life-space/app.js
+++ b/life-space/app.js
@@ -208,11 +208,6 @@ function boardPoint(event) {
 
 function pointerDown(event) {
   const card = event.target.closest('.life-card');
-  if (card) {
-    const selected = itemById(card.dataset.id);
-    card.style.zIndex = bringItemToFront(selected);
-    scheduleSave();
-  }
   if (drawMode && !event.target.closest('.tool-dock')) {
     event.preventDefault();
     const before = snapshot();
@@ -225,6 +220,8 @@ function pointerDown(event) {
   if (card && event.target.closest('.drag-handle') && !event.target.closest('button')) {
     event.preventDefault();
     const item = itemById(card.dataset.id);
+    card.style.zIndex = bringItemToFront(item);
+    scheduleSave();
     interaction = { type:'drag', item, startX:event.clientX, startY:event.clientY, x:item.x, y:item.y, before:snapshot() };
     card.classList.add('moving'); els.wrap.setPointerCapture(event.pointerId); return;
   }
@@ -237,7 +234,8 @@ function pointerDown(event) {
   if (card && !event.target.closest('button, a, input')) {
     interaction = {
       type:'card-pan', startX:event.clientX, startY:event.clientY,
-      x:activeSpace().view.x, y:activeSpace().view.y
+      x:activeSpace().view.x, y:activeSpace().view.y,
+      card, item:itemById(card.dataset.id), moved:false
     };
     els.wrap.setPointerCapture(event.pointerId); return;
   }
@@ -251,11 +249,16 @@ function pointerMove(event) {
   if (!interaction) return;
   const view = activeSpace().view;
   if (interaction.type === 'card-pan') {
-    const moved = Math.hypot(event.clientX - interaction.startX, event.clientY - interaction.startY);
-    if (moved < 8) return;
+    const dx = event.clientX - interaction.startX;
+    const dy = event.clientY - interaction.startY;
+    if (!interaction.moved && Math.hypot(dx, dy) < 8) return;
     event.preventDefault();
-    interaction.type = 'pan';
+    interaction.moved = true;
     els.wrap.classList.add('panning');
+    view.x = interaction.x + dx;
+    view.y = interaction.y + dy;
+    applyView();
+    return;
   }
   if (interaction.type === 'draw') {
     const point = boardPoint(event);
@@ -282,9 +285,18 @@ function pointerMove(event) {
   }
 }
 
-function pointerUp() {
+function pointerUp(event) {
   if (!interaction) return;
-  if (interaction.type === 'card-pan') { interaction = null; return; }
+  if (interaction.type === 'card-pan') {
+    if (interaction.moved) scheduleSave();
+    else if (event.type !== 'pointercancel') {
+      interaction.card.style.zIndex = bringItemToFront(interaction.item);
+      scheduleSave();
+    }
+    els.wrap.classList.remove('panning');
+    interaction = null;
+    return;
+  }
   if (interaction.item) interaction.item.updatedAt = Date.now();
   if (interaction.type === 'draw' && currentStroke) currentStroke.updatedAt = Date.now();
   if (interaction.before) commitHistory(interaction.before);

--- a/tests/life-space.test.js
+++ b/tests/life-space.test.js
@@ -37,14 +37,17 @@ test('Life Space implements spatial interaction and history', () => {
   assert.match(js, /function travel/);
 });
 
-test('Life Space raises touched cards and pans the world from the card body', () => {
+test('Life Space raises tapped or header-dragged cards and continuously pans from the card body', () => {
   assert.match(js, /function bringItemToFront/);
   assert.match(js, /item\.z >= 1000000/);
-  assert.match(js, /card\.style\.zIndex = bringItemToFront\(selected\)/);
+  assert.match(js, /card\.style\.zIndex = bringItemToFront\(item\)/);
+  assert.match(js, /interaction\.card\.style\.zIndex = bringItemToFront\(interaction\.item\)/);
   assert.match(js, /type:'card-pan'/);
-  assert.match(js, /interaction\.type = 'pan'/);
-  assert.match(js, /Math\.hypot\(event\.clientX - interaction\.startX, event\.clientY - interaction\.startY\)/);
-  assert.match(js, /if \(moved < 8\) return/);
+  assert.match(js, /moved:false/);
+  assert.match(js, /if \(!interaction\.moved && Math\.hypot\(dx, dy\) < 8\) return/);
+  assert.match(js, /view\.x = interaction\.x \+ dx/);
+  assert.match(js, /view\.y = interaction\.y \+ dy/);
+  assert.doesNotMatch(js, /if \(card\) \{\s*const selected = itemById/);
 });
 
 test('Life Space provides responsive mobile controls', () => {


### PR DESCRIPTION
## Summary

- keep body-pan gestures in one continuous interaction instead of handing them off after the drag threshold
- defer body-tap layer promotion until pointer release
- keep immediate layer promotion when dragging from the note header
- avoid promoting a note when a body gesture becomes a world pan or is cancelled

## Verification

- `node --test tests/life-space.test.js tests/life-space-sync.test.js` (9/9 passed)
- mobile-sized Chromium gesture at 390x844: board transform progressed from `(0, 0)` to `(25, 20)` to `(70, 55)` during one held body drag
- verified layer values: body drag `1 -> 1`, header drag `1 -> 2`, body tap `2 -> 3`
- full `npm test` completed with 819 passing, 12 unrelated existing repository failures, and 2 skipped
