### PR TITLE
Make Operator and Life Space searchable

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,6 +624,11 @@
             <span class="app-card__title">Growth Operator</span>
             <span class="app-card__meta">Find leads, prepare approved email, triage support, and keep delivery moving.</span>
           </a>
+          <a href="operator/" class="app-card" data-app-keywords="operator openclaw assistant chat agent telegram command center personal technology department">
+            <span class="app-card__icon" aria-hidden="true">OP</span>
+            <span class="app-card__title">Operator</span>
+            <span class="app-card__meta">Talk with your OpenClaw operator, review conversations, and run work from one command center.</span>
+          </a>
           <a href="lead-finder/" class="app-card" data-app-keywords="lead finder local businesses prospects website audit preview outreach crm sales revenue">
             <span class="app-card__icon" aria-hidden="true">LF</span>
             <span class="app-card__title">Lead Finder</span>
@@ -916,7 +921,7 @@
             <span class="app-card__title">Meetings</span>
             <span class="app-card__meta">Take attendance and capture collaborative notes.</span>
           </a>
-          <a href="life-space/" class="app-card">
+          <a href="life-space/" class="app-card" data-app-keywords="life space visual canvas board private notes photos links files lists sketches mind map spatial workspace">
             <span class="app-card__icon" aria-hidden="true">✦</span>
             <span class="app-card__title">Life Space</span>
             <span class="app-card__meta">Arrange private notes, photos, links, files, lists, and sketches on a visual canvas.</span>
@@ -2193,6 +2198,7 @@
       ],
       life: [
         'Daily Direction',
+        'Life Space',
         'Alive System',
         'Sober Spark',
         'Wellness',
@@ -2204,6 +2210,7 @@
         'Life Force Room',
       ],
       ideas: [
+        'Life Space',
         'Notes',
         'TinyMark',
         'Clipboard',
@@ -2212,6 +2219,7 @@
         'Workbench Ideas',
       ],
       projects: [
+        'Operator',
         '3DVR Forge',
         'Forge Sprint',
         'Lead Rescue Sprint',
@@ -2228,6 +2236,7 @@
         'Pocket Workstation',
       ],
       work: [
+        'Operator',
         'Revenue Desk',
         'Lead Rescue Sprint',
         'Portfolio Validation Sprint',
@@ -2313,6 +2322,8 @@
       'Life',
       'Start Here',
       'Friends & Family Pass',
+      'Operator',
+      'Life Space',
       'Notes',
       'Purpose',
       'Ideas Lab',

--- a/tests/homepage-search-ux.test.js
+++ b/tests/homepage-search-ux.test.js
@@ -64,6 +64,23 @@ test('homepage app search can find CRM by CRM keywords', async () => {
   assert.match(html, /keywordIncludesQuery/);
 });
 
+test('homepage app search exposes Operator and Life Space in the default app lane', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  assert.match(
+    html,
+    /href="operator\/" class="app-card" data-app-keywords="[^"]*\bopenclaw\b[^"]*\btelegram\b[^"]*"/
+  );
+  assert.match(
+    html,
+    /href="life-space\/" class="app-card" data-app-keywords="[^"]*\bvisual canvas\b[^"]*\bprivate notes\b[^"]*"/
+  );
+  assert.match(html, /const simpleDockTitles = new Set\(\[[\s\S]*?'Operator',[\s\S]*?'Life Space',/);
+  assert.match(html, /life: \[[\s\S]*?'Life Space',/);
+  assert.match(html, /ideas: \[[\s\S]*?'Life Space',/);
+  assert.match(html, /work: \[[\s\S]*?'Operator',/);
+});
+
 test('homepage app dock has lane filters and generated search context', async () => {
   const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
 


### PR DESCRIPTION
## Summary

- add Operator as a first-class portal app card with OpenClaw, Telegram, assistant, and command-center search aliases
- add richer visual-canvas and private-workspace search terms to Life Space
- assign Operator and Life Space to their relevant human rooms
- include both apps in the default Simple lane so search results are not hidden by the initial filter

## Verification

- `node --test tests/homepage-search-ux.test.js tests/portal-home-mobile-layout.test.js` (12/12 passed)
- Chromium at 390x844 and 1280x900:
  - `operator` and `openclaw` return Operator
  - `life space` and `visual canvas` return Life Space
