### PR TITLE
Keep Operator pinned only while following latest

### DIFF
--- a/operator/app.js
+++ b/operator/app.js
@@ -27,10 +27,10 @@ const escape=value=>String(value||'').replace(/[&<>"']/g,char=>({'&':'&amp;','<'
 function atLatest(){return log.scrollHeight-log.scrollTop-log.clientHeight<48}
 function updateLatest(){latest.hidden=!history.length||atLatest()}
 function scrollLatest(behavior='auto'){log.scrollTo({top:log.scrollHeight,behavior});updateLatest()}
-function restoreLatest(){requestAnimationFrame(()=>{scrollLatest();setTimeout(()=>scrollLatest(),100)})}
+function followLatest(){requestAnimationFrame(()=>{scrollLatest();setTimeout(()=>{if(atLatest())scrollLatest()},100)})}
 function conversationTitle(conversation){const first=conversation.messages.find(item=>item.role==='user')?.content||'New conversation';return first.length>52?`${first.slice(0,52).trim()}…`:first}
 function renderHistory(){const saved=store.conversations.filter(item=>item.messages.length).sort((a,b)=>String(b.updatedAt).localeCompare(String(a.updatedAt)));historyEmpty.hidden=Boolean(saved.length);historyList.innerHTML=saved.map(item=>`<button type="button" data-conversation-id="${escape(item.id)}" ${item.id===store.activeId?'aria-current="page"':''}><strong>${escape(conversationTitle(item))}</strong><span>${escape(new Date(item.updatedAt).toLocaleString([], {dateStyle:'medium',timeStyle:'short'}))}</span></button>`).join('')}
-function render(){log.innerHTML=history.map((item,index)=>`<article class="message ${item.role}"><span>${item.role==='user'?'You':'Operator'}</span><p>${escape(item.content)}</p>${item.actionUrl?`<a href="${escape(item.actionUrl)}">Open ${escape(item.actionLabel||'workspace')} →</a>`:''}${item.role==='assistant'&&index===history.length-1&&item.suggestions?.length?`<div class="follow-ups" aria-label="Suggested next steps">${item.suggestions.map(suggestion=>`<button type="button" data-suggestion="${escape(suggestion)}">${escape(suggestion)}</button>`).join('')}</div>`:''}</article>`).join('');renderHistory();restoreLatest()}
+function render({forceLatest=false}={}){const shouldFollow=forceLatest||atLatest();log.innerHTML=history.map((item,index)=>`<article class="message ${item.role}"><span>${item.role==='user'?'You':'Operator'}</span><p>${escape(item.content)}</p>${item.actionUrl?`<a href="${escape(item.actionUrl)}">Open ${escape(item.actionLabel||'workspace')} →</a>`:''}${item.role==='assistant'&&index===history.length-1&&item.suggestions?.length?`<div class="follow-ups" aria-label="Suggested next steps">${item.suggestions.map(suggestion=>`<button type="button" data-suggestion="${escape(suggestion)}">${escape(suggestion)}</button>`).join('')}</div>`:''}</article>`).join('');renderHistory();shouldFollow?followLatest():updateLatest()}
 function save(){const conversation=activeConversation();conversation.messages=history.slice(-40);conversation.updatedAt=now();store.conversations=store.conversations.filter(item=>item.messages.length||item.id===store.activeId).sort((a,b)=>String(b.updatedAt).localeCompare(String(a.updatedAt))).slice(0,50);localStorage.setItem(KEY,JSON.stringify(store));if(KEY!==BASE_KEY)localStorage.removeItem(BASE_KEY);localStorage.removeItem(LEGACY_KEY);render();accountSync.save(store)}
 function closeHistory(){historyPanel.hidden=true;showHistory.setAttribute('aria-expanded','false')}
 async function requestOperator(payload){
@@ -47,9 +47,9 @@ log.addEventListener('click',event=>{const button=event.target.closest('[data-su
 document.querySelector('#clear-chat').onclick=()=>{store.conversations=store.conversations.filter(item=>item.messages.length);store.activeId=makeId();history=activeConversation().messages;save();closeHistory();input.focus()};
 showHistory.onclick=()=>{historyPanel.hidden=false;showHistory.setAttribute('aria-expanded','true');historyList.querySelector('[aria-current="page"]')?.focus()||document.querySelector('#close-history').focus()};
 document.querySelector('#close-history').onclick=()=>{closeHistory();showHistory.focus()};
-historyList.onclick=event=>{const button=event.target.closest('[data-conversation-id]');if(!button)return;store.activeId=button.dataset.conversationId;history=activeConversation().messages;localStorage.setItem(KEY,JSON.stringify(store));render();closeHistory();input.focus()};
+historyList.onclick=event=>{const button=event.target.closest('[data-conversation-id]');if(!button)return;store.activeId=button.dataset.conversationId;history=activeConversation().messages;localStorage.setItem(KEY,JSON.stringify(store));render({forceLatest:true});closeHistory();input.focus()};
 log.addEventListener('scroll',updateLatest,{passive:true});
 latest.onclick=()=>scrollLatest('smooth');
-window.addEventListener('pageshow',restoreLatest);
-render();input.focus();
+window.addEventListener('pageshow',()=>{atLatest()?followLatest():updateLatest()});
+render({forceLatest:true});input.focus();
 void accountSync.load(store).then(remoteStore=>{if(!remoteStore)return;store=mergeOperatorStores(store,remoteStore);history=activeConversation().messages;localStorage.setItem(KEY,JSON.stringify(store));render();accountSync.save(store)});

--- a/tests/e2e/operator-user-flow.e2e.js
+++ b/tests/e2e/operator-user-flow.e2e.js
@@ -154,6 +154,53 @@ test('operator makes the latest message obvious after back navigation', async ()
   await browser.close();
 });
 
+test('operator follows new messages only while the reader is at the bottom', async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  let finishReply;
+  await page.route('**/api/openai-site?provider=operator', async route => {
+    await new Promise(resolve => { finishReply = resolve; });
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ reply: 'A newly arrived answer with enough detail to extend the conversation.', suggestions: [], action: { type: 'none' } })
+    });
+  });
+  await page.addInitScript(() => {
+    const messages = Array.from({ length: 18 }, (_, index) => ({
+      role: index % 2 ? 'assistant' : 'user',
+      content: `Earlier message ${index + 1} with enough detail to make the conversation scroll.`
+    }));
+    localStorage.setItem('3dvr.operator.history.v1', JSON.stringify(messages));
+  });
+
+  await page.goto(`${PORTAL_ORIGIN}/operator/`);
+  const log = page.locator('#operator-log');
+  await page.waitForFunction(() => {
+    const element = document.querySelector('#operator-log');
+    return element && element.scrollHeight - element.scrollTop - element.clientHeight < 48;
+  });
+  await page.getByLabel('Message your operator').fill('Give me the newest answer.');
+  await page.getByRole('button', { name: /Do it/ }).click();
+  await page.waitForFunction(() => {
+    const element = document.querySelector('#operator-log');
+    return element && element.scrollHeight - element.scrollTop - element.clientHeight < 48;
+  });
+
+  await log.evaluate(element => { element.scrollTop = 0; });
+  await page.getByRole('button', { name: 'Jump to the latest message' }).waitFor();
+  finishReply();
+  await page.getByText('A newly arrived answer with enough detail').waitFor();
+  assert.equal(await log.evaluate(element => element.scrollTop), 0);
+  assert.equal(await page.getByRole('button', { name: 'Jump to the latest message' }).isVisible(), true);
+
+  await page.getByRole('button', { name: 'Jump to the latest message' }).click();
+  await page.waitForFunction(() => {
+    const element = document.querySelector('#operator-log');
+    return element && element.scrollHeight - element.scrollTop - element.clientHeight < 48;
+  });
+  await browser.close();
+});
+
 test('operator saves and reopens past conversations on mobile', async () => {
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage({ viewport: { width: 390, height: 844 } });


### PR DESCRIPTION
## Summary

- Keep Operator pinned to each new message when the reader is already at the bottom.
- Preserve the reader's position when they scroll up while a reply is pending.
- Keep the existing Latest message control as the explicit way to resume following.

## Verification

- Focused Operator mobile flows: 6/6 passed.
- Operator unit and sync tests: 11/11 passed.
- The full test suite retains one unrelated existing failure: Vercel Hobby API function count is 14 versus an expected 12.
