### PR TITLE
docs: define Money Printer business nervous system

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ npm run dev
 
 ### Money Printer
 
+The canonical product architecture is [Money Printer: Business Nervous System](docs/money-printer-business-nervous-system.md). It defines the full demand → offer → customer → workforce → delivery → reputation loop, its human approval gates, channel-policy constraints, the current implementation gaps, and the phased build order. Operator activity that does not materially advance that loop should remain silent.
+
 The `money-printer` app is available at `/money-printer/`. It is the cockpit for a local-first venture operator that
 generates ideas, scores opportunities, creates validation tests, promotes experiments, drafts founder briefs, plans
 connector operations, and recommends the next best money action.

--- a/docs/money-printer-business-nervous-system.md
+++ b/docs/money-printer-business-nervous-system.md
@@ -1,0 +1,174 @@
+# Money Printer: Business Nervous System
+
+Money Printer is not a business-idea generator and it is not a scraping or spam bot. It is a supervised operating system that turns permitted evidence of demand into a tested offer, a customer, coordinated fulfillment, and a stronger reputation.
+
+Its canonical loop is:
+
+> Demand → offer → customer → workforce → delivery → reputation → better demand data
+
+The system should advance work around that loop. A run that only restates status, reports unchanged counts, or asks the owner to inspect its output has not done useful work and should stay silent.
+
+## 1. Demand Radar
+
+The radar observes only sources that permit the intended access and use. It looks for concrete buying signals: requests for help, urgent needs, complaints with willingness to switch, repeated underserved questions, and jobs that a small team could fulfill.
+
+Every signal becomes a structured opportunity:
+
+- source and permitted acquisition method
+- the buyer's own words or a short attributed excerpt
+- location and service radius
+- urgency and deadline
+- apparent budget or budget range
+- required skills and resources
+- buying-intent confidence
+- proposed offer and helpful response
+- consent, provenance, retention, and contact restrictions
+
+Signals are clustered by problem, buyer, location, urgency, and fulfillment fit. A cluster—not a clever prompt—is what justifies building an offer.
+
+## 2. Offer Builder
+
+The builder converts a demand cluster into the smallest testable offer. It produces:
+
+- scope, exclusions, price, and delivery window
+- landing-page copy and a lightweight intake form
+- proposal, checkout destination, and follow-up sequence
+- delivery checklist and frequently asked questions
+- success metric, test budget, stop condition, and expiration date
+
+The default is validation before infrastructure. Money Printer should not create a large site, campaign, or company until a real demand signal warrants it.
+
+## 3. Customer Acquisition
+
+Acquisition uses approved, channel-native mechanisms:
+
+- inbound forms, referrals, and warm contacts
+- official advertising and lead APIs
+- owner-reviewed responses to public requests
+- helpful content and legitimate classifieds posted by a human where required
+- a suppression-aware outreach queue with bounded follow-up
+
+Every contact records its provenance, legal basis, channel policy, consent state, last contact, next permitted action, and suppression state. A decline or unsubscribe is terminal across all automated follow-up.
+
+The agent may prepare campaigns and responses. Spending money, publishing externally, or contacting a new person requires the configured approval gate unless Thomas has explicitly authorized that bounded campaign.
+
+## 4. Workforce Builder
+
+After a customer commits, the system decides whether 3DVR can fulfill the work directly. If help is required, it can:
+
+- decompose the job into tasks, skills, deadlines, and acceptance criteria
+- draft a worker listing and collect applications
+- organize portfolios and qualifications against job-relevant criteria
+- schedule interviews and prepare onboarding and contract materials
+- track assignments, deliverables, approvals, and payment readiness
+
+Humans retain final authority over hiring, rejection, firing, compensation, contracts, and sensitive employment decisions. The system must not infer protected traits or use proxies for them.
+
+## 5. Fulfillment and Reputation
+
+Fulfillment closes the loop rather than declaring victory at lead generation:
+
+- assign work and confirm ownership
+- send useful customer updates
+- check deliverables against explicit acceptance criteria
+- collect approval and payment
+- prepare worker payment for human authorization
+- request a review or referral at an appropriate moment
+- record defects, delays, margin, satisfaction, and lessons
+- feed observed outcomes back into scoring, pricing, and offer design
+
+The primary business metrics are paid conversions, delivery success, contribution margin, time to value, repeat business, referrals, and customer satisfaction—not leads generated or messages sent.
+
+## Channel policy
+
+| Source | Allowed initial mode | Prohibited default | Unlock condition |
+| --- | --- | --- | --- |
+| First-party forms, CRM, email replies | Automated ingestion and triage | Contact beyond consent or suppression state | Existing consent or a documented lawful basis |
+| Meta | Official Ads, Lead Ads, Graph, and Conversions APIs | Scraping profiles, groups, or arbitrary product data | Approved Meta app, permissions, and campaign budget |
+| Reddit | Human research and owner-posted participation | Commercial API/data use or automated engagement without approval | Reddit's written approval and applicable API/Devvit terms |
+| Craigslist | Human opens or pastes a listing for analysis | Crawling, harvesting, automated posting, or unsolicited contact | Express permission from Craigslist; otherwise remain human-operated |
+| Public web | Policy-aware discovery of business pages | Harvesting personal data or indiscriminate messaging | Source terms allow it and contact provenance is retained |
+
+These rules are hard constraints, not suggestions. When a source cannot be used automatically, Money Printer should create a short human research task rather than work around the restriction.
+
+## Human approval gates
+
+Money Printer may autonomously read permitted sources, structure evidence, deduplicate leads, score opportunities, draft assets, prepare work packets, measure results, and stay silent.
+
+It must stop for approval before:
+
+- launching or increasing paid spend
+- publishing a new public claim or offer
+- initiating outreach outside an already approved campaign
+- changing price, payment, refund, or contractual terms
+- hiring, rejecting, firing, or changing worker pay
+- releasing customer funds or worker payments
+- using a new data source whose terms or consent basis are unclear
+
+## What exists now
+
+The repository already has useful pieces of this architecture:
+
+- Market Pulse and market scoring provide early demand research.
+- Autopilot can select a market, generate an offer, publish bounded assets, and critique the result.
+- The Meta market worker provides a path toward official Page and campaign workflows.
+- Guarded outreach supports explicit contact files, provenance checks, suppression, sender identity, and daily caps.
+- The learning ledger records experiments and avoids timestamp-only churn.
+- The supervisor and approval system constrain risky execution.
+
+The critical gaps are equally clear:
+
+1. Demand evidence is not yet a durable, source-attributed opportunity store.
+2. Offer generation is not gated on a minimum cluster of genuine buying signals.
+3. Acquisition is stronger than fulfillment; there is no end-to-end job, worker, delivery, payment-readiness, and review state machine.
+4. Revenue and delivery outcomes do not yet flow back into opportunity scoring.
+5. Operator reports can describe activity more easily than they can prove one material advance around the loop.
+
+## Implementation sequence
+
+### Phase 1 — Evidence before activity
+
+- Add a versioned `DemandSignal` and `OpportunityCluster` schema.
+- Store source URL, excerpt, acquisition mode, policy state, contact provenance, urgency, budget, and confidence.
+- Require evidence thresholds before creating an offer.
+- Make every cycle return either one material state transition or a silent no-op.
+
+### Phase 2 — Testable offers
+
+- Add an `OfferExperiment` record with hypothesis, target cluster, price, channel, budget cap, success metric, stop condition, and expiration.
+- Connect landing pages, intake, checkout, and campaign assets to that experiment ID.
+- Prevent expired campaigns from generating recycled reports or outreach.
+
+### Phase 3 — Customer and fulfillment state machine
+
+- Add `CustomerJob`, `WorkPackage`, `WorkerCandidate`, `Assignment`, `Deliverable`, and `Outcome` records.
+- Add explicit owner approval checkpoints for contracts, hiring, pay, and release of funds.
+- Give customers and workers status updates from the same canonical job record.
+
+### Phase 4 — Reputation flywheel
+
+- Capture margin, cycle time, acceptance, defects, review, referral, repeat purchase, and reasons lost.
+- Update demand and offer scores from realized outcomes.
+- Rank the next action by expected learning or profit, not by ease of generating a report.
+
+## Definition of a useful operator run
+
+A run is reportable only when it produces at least one of these:
+
+- a new, policy-compliant, evidence-backed opportunity cluster
+- a bounded offer experiment ready for one explicit approval
+- a confirmed customer action, response, payment, or submission
+- a fulfillment milestone or exception requiring a decision
+- a measurable experiment outcome that changes the next action
+- one precise yes/no question whose answer immediately unlocks work
+
+Everything else is internal telemetry and stays out of Thomas's inbox and Telegram.
+
+## Policy references
+
+- Craigslist Terms of Use: https://www.craigslist.org/about/terms
+- Reddit Developer Terms: https://redditinc.com/policies/developer-terms
+- Reddit Data API Terms: https://redditinc.com/policies/data-api-terms
+- Meta Automated Data Collection Terms: https://www.facebook.com/legal/automated_data_collection_terms
+- Meta lead ads: https://www.facebook.com/business/ads/ad-objectives/lead-generation/lead-ads-with-messaging
+- Meta Conversions API: https://www.facebook.com/business/help/AboutConversionsAPI


### PR DESCRIPTION
Defines the canonical demand-to-reputation loop for Money Printer, maps the current implementation and gaps, adds channel-policy constraints and human approval gates, and establishes a phased implementation sequence. Also links the architecture from the README.\n\nVerification: git diff --check