### PR TITLE
feat: add evidence-backed Opportunity Inbox

### DIFF
--- a/money-printer/app.js
+++ b/money-printer/app.js
@@ -25,11 +25,24 @@ import {
   createMessageReviewItem,
   seedTrustReviewQueue
 } from '../src/money-printer/messageReview.js';
+import {
+  addOpportunity,
+  readOpportunityEngineState,
+  sortOpportunityClusters,
+  updateOpportunity,
+  writeOpportunityEngineState
+} from '../src/money-printer/opportunityEngine.js';
 
 const elements = {
   form: document.getElementById('missionForm'),
   missionInput: document.getElementById('missionInput'),
   missionStatus: document.getElementById('missionStatus'),
+  opportunityCaptureForm: document.getElementById('opportunityCaptureForm'),
+  opportunityCapturePanel: document.getElementById('opportunityCapturePanel'),
+  opportunityCaptureStatus: document.getElementById('opportunityCaptureStatus'),
+  opportunityFilter: document.getElementById('opportunityFilter'),
+  opportunityInbox: document.getElementById('opportunityInbox'),
+  opportunitySummary: document.getElementById('opportunitySummary'),
   metricsGrid: document.getElementById('metricsGrid'),
   messageReviewQueue: document.getElementById('messageReviewQueue'),
   runtimeStatusGrid: document.getElementById('runtimeStatusGrid'),
@@ -52,6 +65,7 @@ const MESSAGE_REVIEW_STORAGE_KEY = '3dvr.moneyPrinter.messageReviewQueue.v1';
 let connectorStatuses = [];
 let state = moneyPrinterStorage.hydrate();
 let messageReviewQueue = loadMessageReviewQueue();
+let opportunityEngineState = readOpportunityEngineState();
 
 function saveState() {
   if (!moneyPrinterStorage.write(state)) {
@@ -159,6 +173,174 @@ function money(value) {
   }).format(Number.isFinite(numeric) ? numeric : 0);
 }
 
+function moneyRange(minimum, maximum) {
+  const min = Number(minimum || 0);
+  const max = Number(maximum || min);
+  if (!min && !max) return 'Unknown';
+  return min === max ? money(min) : `${money(min)}–${money(max)}`;
+}
+
+function saveOpportunityEngineState() {
+  if (!writeOpportunityEngineState(opportunityEngineState)) {
+    elements.opportunityCaptureStatus.textContent = 'Browser storage is unavailable; this opportunity will not survive a refresh.';
+  }
+}
+
+function opportunityPrimarySignal(opportunity = {}) {
+  return Array.isArray(opportunity.signals) ? opportunity.signals[0] || {} : {};
+}
+
+function renderOpportunityInbox() {
+  if (!elements.opportunityInbox) return;
+  const filter = elements.opportunityFilter?.value || 'active';
+  const all = sortOpportunityClusters(opportunityEngineState.opportunities);
+  const visible = all.filter(opportunity => {
+    if (filter === 'all') return true;
+    if (filter === 'passed') return ['passed', 'expired'].includes(opportunity.status);
+    return !['passed', 'expired', 'won'].includes(opportunity.status);
+  });
+
+  const activeCount = all.filter(opportunity => !['passed', 'expired', 'won'].includes(opportunity.status)).length;
+  elements.opportunitySummary.textContent = activeCount
+    ? `${activeCount} active ${activeCount === 1 ? 'opportunity' : 'opportunities'}, ranked by actionability.`
+    : 'No qualified opportunities yet. Forward a real request to begin.';
+
+  if (!visible.length) {
+    replaceChildren(elements.opportunityInbox, [
+      textElement('p', 'empty-state', filter === 'active'
+        ? 'No active opportunities. Add a real request above; Money Printer will preserve the evidence and next action.'
+        : 'No opportunities match this filter.')
+    ]);
+    return;
+  }
+
+  const cards = visible.map(opportunity => {
+    const signal = opportunityPrimarySignal(opportunity);
+    const marginMin = Math.max(0, Number(signal.estimatedValueMin || 0) - Number(signal.estimatedCostMax || 0));
+    const card = document.createElement('article');
+    card.className = 'opportunity-card';
+    card.dataset.status = opportunity.status;
+
+    const top = document.createElement('div');
+    top.className = 'opportunity-card__top';
+    const heading = document.createElement('div');
+    heading.append(
+      textElement('span', 'mp-card-label', opportunity.status.replace(/-/g, ' ')),
+      textElement('h3', '', opportunity.title)
+    );
+    const score = textElement('strong', 'opportunity-score', `${opportunity.actionabilityScore}`);
+    score.title = 'Actionability score';
+    top.append(heading, score);
+
+    const economics = document.createElement('div');
+    economics.className = 'opportunity-economics';
+    [
+      ['Value', moneyRange(signal.estimatedValueMin, signal.estimatedValueMax)],
+      ['Cost', moneyRange(signal.estimatedCostMin, signal.estimatedCostMax)],
+      ['Margin floor', signal.estimatedValueMin ? money(marginMin) : 'Unknown'],
+      ['Confidence', `${signal.confidence}%`]
+    ].forEach(([label, value]) => {
+      const item = document.createElement('div');
+      item.append(textElement('span', '', label), textElement('strong', '', value));
+      economics.append(item);
+    });
+
+    const evidence = document.createElement('blockquote');
+    evidence.className = 'opportunity-evidence';
+    evidence.textContent = signal.buyerWords || 'No buyer wording saved.';
+
+    const details = document.createElement('dl');
+    details.className = 'opportunity-details';
+    [
+      ['Location', signal.location],
+      ['Urgency', titleFromKey(signal.urgency)],
+      ['Source', `${signal.sourceLabel} · ${signal.acquisitionMode}`],
+      ['Permission', `${signal.policyStatus} · ${signal.contactPermission}`]
+    ].forEach(([label, value]) => {
+      const row = document.createElement('div');
+      row.append(textElement('dt', '', label), textElement('dd', '', value));
+      details.append(row);
+    });
+
+    const response = document.createElement('div');
+    response.className = 'opportunity-response';
+    response.append(
+      textElement('span', 'mp-card-label', 'Suggested response'),
+      textElement('p', '', opportunity.suggestedResponse || 'Draft a helpful response before review.'),
+      textElement('span', 'mp-card-label', 'Next action'),
+      textElement('strong', '', opportunity.nextAction)
+    );
+
+    const actions = document.createElement('div');
+    actions.className = 'opportunity-actions';
+    if (!['passed', 'expired', 'won'].includes(opportunity.status)) {
+      actions.append(
+        button('Review response', {
+          className: 'mp-button mp-button--primary',
+          'data-opportunity-action': 'review',
+          'data-opportunity-id': opportunity.id
+        }),
+        button('Pass', {
+          'data-opportunity-action': 'pass',
+          'data-opportunity-id': opportunity.id
+        })
+      );
+    }
+    card.append(top, economics, evidence, details, response, actions);
+    return card;
+  });
+  replaceChildren(elements.opportunityInbox, cards);
+}
+
+function addOpportunityToReviewQueue(opportunity) {
+  const signal = opportunityPrimarySignal(opportunity);
+  const reviewKey = `opportunity:${opportunity.id}`;
+  const existing = messageReviewQueue.find(item => item.leadId === reviewKey);
+  if (existing) return false;
+  messageReviewQueue = [createMessageReviewItem({
+    id: `review-${opportunity.id}`,
+    leadId: reviewKey,
+    leadName: opportunity.title,
+    whyGenerated: `Opportunity Inbox evidence: ${signal.buyerWords || opportunity.title}`,
+    offer: opportunity.title,
+    offerConnection: `Connects to the evidence-backed Opportunity Inbox item: ${opportunity.title}.`,
+    subject: `About ${opportunity.title}`,
+    body: opportunity.suggestedResponse || '',
+    riskLevel: 'YELLOW',
+    riskExplanation: 'This is a first contact or reply prepared from manually forwarded evidence. Human review and sending are required.',
+    safeguards: [
+      `Source: ${signal.sourceLabel} (${signal.acquisitionMode})`,
+      `Permission: ${signal.policyStatus}; ${signal.contactPermission}`,
+      'No automatic send is enabled from Opportunity Inbox.'
+    ],
+    canAutoSend: false,
+    status: 'review-required'
+  }), ...messageReviewQueue];
+  saveMessageReviewQueue();
+  return true;
+}
+
+function handleOpportunityAction(action, opportunityId) {
+  const opportunity = opportunityEngineState.opportunities.find(item => item.id === opportunityId);
+  if (!opportunity) return;
+  if (action === 'review') {
+    const added = addOpportunityToReviewQueue(opportunity);
+    opportunityEngineState = updateOpportunity(opportunityEngineState, opportunityId, { status: 'reviewing' });
+    saveOpportunityEngineState();
+    renderOpportunityInbox();
+    renderMessageReviewQueue();
+    setStatus(added ? 'Response added to the human review queue. Nothing was sent.' : 'This response is already in the human review queue.');
+    document.getElementById('reviewQueueTitle')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return;
+  }
+  if (action === 'pass') {
+    opportunityEngineState = updateOpportunity(opportunityEngineState, opportunityId, { status: 'passed' });
+    saveOpportunityEngineState();
+    renderOpportunityInbox();
+    elements.opportunityCaptureStatus.textContent = 'Opportunity passed and preserved for learning.';
+  }
+}
+
 function renderMetrics() {
   const metrics = buildMetrics(state);
   const metricCards = [
@@ -186,9 +368,9 @@ function riskTone(riskLevel = '') {
   return 'yellow';
 }
 
-function actionLabel(action) {
+function actionLabel(action, item = {}) {
   return {
-    'approve-send': 'Approve & Send',
+    'approve-send': item.canAutoSend ? 'Approve & Send' : 'Approve draft',
     edit: 'Edit',
     skip: 'Skip',
     'ban-lead': 'Ban Lead',
@@ -259,7 +441,7 @@ function renderMessageReviewQueue() {
       <div class="review-actions">
         ${item.actions.map(action => `
           <button class="mp-button ${action === 'approve-send' ? 'mp-button--primary' : ''}" type="button" data-review-action="${safeText(action)}" data-review-id="${safeText(item.id)}">
-            ${safeText(actionLabel(action))}
+            ${safeText(actionLabel(action, item))}
           </button>
         `).join('')}
       </div>
@@ -627,6 +809,7 @@ function renderTools() {
 }
 
 function render() {
+  renderOpportunityInbox();
   renderMetrics();
   renderMessageReviewQueue();
   renderRuntimeStatus();
@@ -774,6 +957,37 @@ elements.form.addEventListener('submit', event => {
   runGenerateMachine();
 });
 
+elements.opportunityCaptureForm?.addEventListener('submit', event => {
+  event.preventDefault();
+  const formData = new FormData(elements.opportunityCaptureForm);
+  const now = new Date();
+  opportunityEngineState = addOpportunity(opportunityEngineState, {
+    need: formData.get('need'),
+    buyerWords: formData.get('buyerWords'),
+    location: formData.get('location'),
+    urgency: formData.get('urgency'),
+    estimatedValueMin: formData.get('estimatedValueMin'),
+    estimatedValueMax: formData.get('estimatedValueMin'),
+    estimatedCostMax: formData.get('estimatedCostMax'),
+    estimatedCostMin: formData.get('estimatedCostMax'),
+    suggestedResponse: formData.get('suggestedResponse'),
+    nextAction: formData.get('nextAction'),
+    sourceLabel: 'Manual forward',
+    acquisitionMode: 'manual-forward',
+    policyStatus: 'human-provided',
+    contactPermission: 'review-required',
+    confidence: 60,
+    createdAt: now.toISOString()
+  }, now);
+  saveOpportunityEngineState();
+  elements.opportunityCaptureForm.reset();
+  elements.opportunityCapturePanel.open = false;
+  elements.opportunityCaptureStatus.textContent = 'Opportunity saved with its evidence. No contact was made.';
+  renderOpportunityInbox();
+});
+
+elements.opportunityFilter?.addEventListener('change', renderOpportunityInbox);
+
 elements.missionInput.addEventListener('input', () => {
   state.mission = elements.missionInput.value;
   saveState();
@@ -828,6 +1042,12 @@ document.addEventListener('click', event => {
   const reviewButton = event.target.closest('[data-review-action]');
   if (reviewButton) {
     handleReviewAction(reviewButton.dataset.reviewAction, reviewButton.dataset.reviewId);
+    return;
+  }
+
+  const opportunityButton = event.target.closest('[data-opportunity-action]');
+  if (opportunityButton) {
+    handleOpportunityAction(opportunityButton.dataset.opportunityAction, opportunityButton.dataset.opportunityId);
   }
 });
 
@@ -853,6 +1073,9 @@ document.addEventListener('change', event => {
 
 async function boot() {
   elements.missionInput.value = state.mission || DEFAULT_MISSION;
+  if (elements.opportunityCapturePanel) {
+    elements.opportunityCapturePanel.open = opportunityEngineState.opportunities.length === 0;
+  }
   render();
   try {
     connectorStatuses = await readConnectorStatuses();

--- a/money-printer/index.html
+++ b/money-printer/index.html
@@ -59,6 +59,77 @@
         </form>
       </section>
 
+      <section class="mp-band opportunity-inbox" aria-labelledby="opportunityInboxTitle">
+        <div class="mp-section-heading mp-section-heading--wide">
+          <span class="eyebrow">3DVR Opportunity Engine</span>
+          <h2 id="opportunityInboxTitle">Opportunity Inbox</h2>
+          <p>Real needs with source evidence, economics, permission state, and one next action. Nothing here contacts anyone automatically.</p>
+        </div>
+
+        <details id="opportunityCapturePanel" class="opportunity-capture-panel">
+          <summary>
+            <span>Forward an opportunity</span>
+            <small>Paste a request you found or received</small>
+          </summary>
+          <form id="opportunityCaptureForm" class="opportunity-capture" autocomplete="off">
+          <label class="opportunity-field opportunity-field--wide">
+            <span>What do they need?</span>
+            <input name="need" required placeholder="Example: 200 business cards by tomorrow morning">
+          </label>
+          <label class="opportunity-field opportunity-field--wide">
+            <span>Their actual words</span>
+            <textarea name="buyerWords" required rows="3" placeholder="Paste the relevant request or inquiry here."></textarea>
+          </label>
+          <label class="opportunity-field">
+            <span>Location</span>
+            <input name="location" placeholder="San Diego">
+          </label>
+          <label class="opportunity-field">
+            <span>Urgency</span>
+            <select name="urgency">
+              <option value="immediate">Immediate</option>
+              <option value="high">High</option>
+              <option value="medium" selected>Medium</option>
+              <option value="low">Low</option>
+            </select>
+          </label>
+          <label class="opportunity-field">
+            <span>Estimated value</span>
+            <input name="estimatedValueMin" inputmode="decimal" type="number" min="0" placeholder="250">
+          </label>
+          <label class="opportunity-field">
+            <span>Estimated cost</span>
+            <input name="estimatedCostMax" inputmode="decimal" type="number" min="0" placeholder="140">
+          </label>
+          <label class="opportunity-field opportunity-field--wide">
+            <span>Suggested response</span>
+            <textarea name="suggestedResponse" rows="3" placeholder="Draft a helpful response. It will still require review."></textarea>
+          </label>
+          <label class="opportunity-field opportunity-field--wide">
+            <span>Next action</span>
+            <input name="nextAction" placeholder="Confirm artwork and collect deposit">
+          </label>
+            <div class="opportunity-capture__actions opportunity-field--wide">
+              <button class="mp-button mp-button--primary" type="submit">Add to Opportunity Inbox</button>
+              <p id="opportunityCaptureStatus" aria-live="polite">Saved locally in this browser with manual-source provenance.</p>
+            </div>
+          </form>
+        </details>
+
+        <div class="opportunity-toolbar">
+          <p id="opportunitySummary" aria-live="polite">No qualified opportunities yet.</p>
+          <label>
+            <span>Show</span>
+            <select id="opportunityFilter">
+              <option value="active">Active</option>
+              <option value="all">All</option>
+              <option value="passed">Passed</option>
+            </select>
+          </label>
+        </div>
+        <div id="opportunityInbox" class="opportunity-grid" aria-live="polite"></div>
+      </section>
+
       <section class="mp-journey" aria-labelledby="journeyTitle">
         <div class="mp-section-heading">
           <span class="eyebrow">Simple path</span>

--- a/money-printer/styles.css
+++ b/money-printer/styles.css
@@ -72,6 +72,227 @@ body.money-printer-page {
   box-shadow: 0 20px 64px rgba(0, 0, 0, 0.28);
 }
 
+.opportunity-inbox {
+  border-color: rgba(134, 239, 172, 0.42);
+  background:
+    linear-gradient(145deg, rgba(134, 239, 172, 0.07), rgba(147, 197, 253, 0.04)),
+    rgba(8, 12, 18, 0.9);
+}
+
+.opportunity-capture-panel {
+  border: 1px solid rgba(160, 174, 192, 0.22);
+  border-radius: 8px;
+  background: rgba(3, 8, 13, 0.66);
+}
+
+.opportunity-capture-panel > summary {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.85rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.opportunity-capture-panel > summary::-webkit-details-marker {
+  display: none;
+}
+
+.opportunity-capture-panel > summary span {
+  color: var(--mp-text);
+  font-weight: 900;
+}
+
+.opportunity-capture-panel > summary small {
+  color: var(--mp-muted);
+}
+
+.opportunity-capture {
+  display: grid;
+  gap: 0.8rem;
+  padding: 0 0.85rem 0.85rem;
+}
+
+.opportunity-capture__actions p,
+.opportunity-toolbar p {
+  margin: 0;
+}
+
+.opportunity-field {
+  display: grid;
+  gap: 0.38rem;
+}
+
+.opportunity-capture__heading p,
+.opportunity-capture__actions p,
+.opportunity-toolbar p {
+  color: var(--mp-muted);
+}
+
+.opportunity-field > span,
+.opportunity-toolbar label > span {
+  color: #d5fffa;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.opportunity-field input,
+.opportunity-field textarea,
+.opportunity-field select,
+.opportunity-toolbar select {
+  width: 100%;
+  border: 1px solid rgba(160, 174, 192, 0.28);
+  border-radius: 8px;
+  background: rgba(3, 8, 13, 0.92);
+  color: var(--mp-text);
+  font: inherit;
+  padding: 0.72rem;
+}
+
+.opportunity-field textarea {
+  resize: vertical;
+}
+
+.opportunity-capture__actions {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.opportunity-toolbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.opportunity-toolbar label {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 9rem;
+}
+
+.opportunity-grid {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.opportunity-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  border: 1px solid rgba(134, 239, 172, 0.34);
+  border-radius: 8px;
+  background: var(--mp-panel);
+}
+
+.opportunity-card[data-status="reviewing"] {
+  border-color: rgba(251, 191, 36, 0.5);
+}
+
+.opportunity-card[data-status="passed"],
+.opportunity-card[data-status="expired"] {
+  border-color: rgba(160, 174, 192, 0.2);
+  opacity: 0.78;
+}
+
+.opportunity-card__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.opportunity-card h3 {
+  margin: 0.18rem 0 0;
+  font-size: 1.15rem;
+}
+
+.opportunity-score {
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.65rem;
+  min-height: 2.65rem;
+  border: 1px solid rgba(134, 239, 172, 0.5);
+  border-radius: 999px;
+  background: rgba(134, 239, 172, 0.12);
+  color: #bbf7d0;
+}
+
+.opportunity-economics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.opportunity-economics div {
+  padding: 0.6rem;
+  border: 1px solid rgba(160, 174, 192, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.opportunity-economics span,
+.opportunity-details dt {
+  display: block;
+  color: var(--mp-subtle);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.opportunity-economics strong {
+  display: block;
+  margin-top: 0.16rem;
+}
+
+.opportunity-evidence {
+  margin: 0;
+  padding: 0.8rem;
+  border-left: 3px solid var(--mp-cyan);
+  background: rgba(45, 212, 191, 0.07);
+  color: var(--mp-text);
+  font-style: normal;
+}
+
+.opportunity-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.opportunity-details div {
+  min-width: 0;
+}
+
+.opportunity-details dd {
+  margin: 0.12rem 0 0;
+  color: var(--mp-muted);
+  overflow-wrap: anywhere;
+}
+
+.opportunity-response {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.8rem;
+  border: 1px solid rgba(251, 191, 36, 0.24);
+  border-radius: 8px;
+  background: rgba(251, 191, 36, 0.07);
+}
+
+.opportunity-response p,
+.opportunity-response strong {
+  margin: 0;
+}
+
+.opportunity-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
 .mp-hero {
   display: grid;
   gap: 1rem;
@@ -928,6 +1149,18 @@ body.money-printer-page {
 }
 
 @media (min-width: 760px) {
+  .opportunity-capture {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .opportunity-field--wide {
+    grid-column: 1 / -1;
+  }
+
+  .opportunity-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .mp-hero {
     grid-template-columns: minmax(0, 0.94fr) minmax(340px, 0.72fr);
     padding: 1.2rem;

--- a/src/money-printer/opportunityEngine.js
+++ b/src/money-printer/opportunityEngine.js
@@ -1,0 +1,184 @@
+// Browser- and Node-safe Opportunity Engine records.
+// External source connectors may add DemandSignals later, but every signal must
+// retain its provenance and policy state before it can become actionable.
+
+export const OPPORTUNITY_ENGINE_SCHEMA_VERSION = 1;
+export const OPPORTUNITY_ENGINE_STORAGE_KEY = '3dvr.money-printer.opportunity-engine.v1';
+
+const URGENCY_WEIGHTS = {
+  immediate: 30,
+  high: 24,
+  medium: 14,
+  low: 6
+};
+
+function text(value, fallback = '') {
+  return String(value ?? fallback).trim();
+}
+
+function number(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function list(value) {
+  if (Array.isArray(value)) return value.map(item => text(item)).filter(Boolean);
+  return text(value)
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+function timestamp(value, fallback = new Date().toISOString()) {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback;
+}
+
+function makeId(prefix = 'record') {
+  if (globalThis.crypto?.randomUUID) return `${prefix}-${globalThis.crypto.randomUUID()}`;
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export function createDemandSignal(input = {}, now = new Date()) {
+  const createdAt = timestamp(input.createdAt, now.toISOString());
+  return {
+    schemaVersion: OPPORTUNITY_ENGINE_SCHEMA_VERSION,
+    id: text(input.id) || makeId('signal'),
+    need: text(input.need, 'Unspecified need'),
+    buyerWords: text(input.buyerWords || input.evidence),
+    sourceLabel: text(input.sourceLabel || input.source, 'Manual forward'),
+    sourceUrl: text(input.sourceUrl),
+    acquisitionMode: text(input.acquisitionMode, 'manual-forward'),
+    policyStatus: text(input.policyStatus, 'human-provided'),
+    contactPermission: text(input.contactPermission, 'review-required'),
+    location: text(input.location, 'Location unknown'),
+    deadline: text(input.deadline),
+    urgency: text(input.urgency, 'medium').toLowerCase(),
+    estimatedValueMin: Math.max(0, number(input.estimatedValueMin)),
+    estimatedValueMax: Math.max(0, number(input.estimatedValueMax || input.estimatedValueMin)),
+    estimatedCostMin: Math.max(0, number(input.estimatedCostMin)),
+    estimatedCostMax: Math.max(0, number(input.estimatedCostMax || input.estimatedCostMin)),
+    skills: list(input.skills),
+    confidence: Math.min(100, Math.max(0, number(input.confidence, 50))),
+    suggestedResponse: text(input.suggestedResponse),
+    nextAction: text(input.nextAction, 'Review the evidence and choose the next action.'),
+    createdAt,
+    updatedAt: timestamp(input.updatedAt, createdAt),
+    expiresAt: input.expiresAt ? timestamp(input.expiresAt, '') : ''
+  };
+}
+
+export function scoreOpportunityCluster(cluster = {}, now = new Date()) {
+  const signals = Array.isArray(cluster.signals) ? cluster.signals : [];
+  const primary = signals[0] || cluster;
+  const urgency = URGENCY_WEIGHTS[text(primary.urgency, 'medium').toLowerCase()] || URGENCY_WEIGHTS.medium;
+  const confidence = Math.min(25, number(primary.confidence) / 4);
+  const evidence = text(primary.buyerWords).length >= 12 ? 15 : 0;
+  const permission = ['approved-api', 'first-party', 'human-provided', 'explicit-consent'].includes(text(primary.policyStatus)) ? 12 : 0;
+  const margin = Math.max(0, number(primary.estimatedValueMin) - number(primary.estimatedCostMax));
+  const marginScore = Math.min(12, margin / 25);
+  const expiresAt = Date.parse(primary.expiresAt);
+  const expirationPenalty = Number.isFinite(expiresAt) && expiresAt < now.getTime() ? 100 : 0;
+  return Math.max(0, Math.round(urgency + confidence + evidence + permission + marginScore - expirationPenalty));
+}
+
+export function createOpportunityCluster(input = {}, now = new Date()) {
+  const signals = (Array.isArray(input.signals) && input.signals.length ? input.signals : [input])
+    .map(signal => createDemandSignal(signal, now));
+  const primary = signals[0];
+  const cluster = {
+    schemaVersion: OPPORTUNITY_ENGINE_SCHEMA_VERSION,
+    id: text(input.id) || makeId('opportunity'),
+    title: text(input.title || input.need, primary.need),
+    status: text(input.status, 'new'),
+    owner: text(input.owner, 'Thomas'),
+    signals,
+    suggestedResponse: text(input.suggestedResponse, primary.suggestedResponse),
+    nextAction: text(input.nextAction, primary.nextAction),
+    createdAt: timestamp(input.createdAt, primary.createdAt),
+    updatedAt: timestamp(input.updatedAt, primary.updatedAt),
+    expiresAt: input.expiresAt ? timestamp(input.expiresAt, primary.expiresAt) : primary.expiresAt
+  };
+  return {
+    ...cluster,
+    actionabilityScore: scoreOpportunityCluster(cluster, now)
+  };
+}
+
+export function createOpportunityEngineState(input = {}, now = new Date()) {
+  const signals = (Array.isArray(input.signals) ? input.signals : []).map(signal => createDemandSignal(signal, now));
+  const opportunities = (Array.isArray(input.opportunities) ? input.opportunities : [])
+    .map(cluster => createOpportunityCluster(cluster, now));
+  return {
+    schemaVersion: OPPORTUNITY_ENGINE_SCHEMA_VERSION,
+    signals,
+    opportunities,
+    updatedAt: timestamp(input.updatedAt, now.toISOString())
+  };
+}
+
+export function addOpportunity(state = {}, input = {}, now = new Date()) {
+  const current = createOpportunityEngineState(state, now);
+  const signal = createDemandSignal(input, now);
+  const opportunity = createOpportunityCluster({ ...input, signals: [signal] }, now);
+  return {
+    ...current,
+    signals: [signal, ...current.signals],
+    opportunities: [opportunity, ...current.opportunities],
+    updatedAt: now.toISOString()
+  };
+}
+
+export function updateOpportunity(state = {}, opportunityId, patch = {}, now = new Date()) {
+  const current = createOpportunityEngineState(state, now);
+  return {
+    ...current,
+    opportunities: current.opportunities.map(opportunity => (
+      opportunity.id === opportunityId
+        ? createOpportunityCluster({ ...opportunity, ...patch, updatedAt: now.toISOString() }, now)
+        : opportunity
+    )),
+    updatedAt: now.toISOString()
+  };
+}
+
+export function sortOpportunityClusters(opportunities = [], now = new Date()) {
+  const statusOrder = { new: 0, 'response-ready': 1, reviewing: 2, contacted: 3, won: 4, passed: 5, expired: 6 };
+  return [...opportunities]
+    .map(opportunity => createOpportunityCluster(opportunity, now))
+    .sort((left, right) => {
+      const leftStatus = statusOrder[left.status] ?? 3;
+      const rightStatus = statusOrder[right.status] ?? 3;
+      if (leftStatus !== rightStatus) return leftStatus - rightStatus;
+      if (right.actionabilityScore !== left.actionabilityScore) return right.actionabilityScore - left.actionabilityScore;
+      return String(right.updatedAt).localeCompare(String(left.updatedAt));
+    });
+}
+
+function getDefaultStorage() {
+  try {
+    return globalThis.localStorage || null;
+  } catch {
+    return null;
+  }
+}
+
+export function readOpportunityEngineState(storage = getDefaultStorage(), key = OPPORTUNITY_ENGINE_STORAGE_KEY) {
+  if (!storage) return createOpportunityEngineState();
+  try {
+    const raw = storage.getItem(key);
+    return createOpportunityEngineState(raw ? JSON.parse(raw) : {});
+  } catch {
+    return createOpportunityEngineState();
+  }
+}
+
+export function writeOpportunityEngineState(state, storage = getDefaultStorage(), key = OPPORTUNITY_ENGINE_STORAGE_KEY) {
+  if (!storage) return false;
+  try {
+    storage.setItem(key, JSON.stringify(createOpportunityEngineState(state)));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/money-printer-opportunity-engine.test.js
+++ b/tests/money-printer-opportunity-engine.test.js
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  OPPORTUNITY_ENGINE_SCHEMA_VERSION,
+  addOpportunity,
+  createDemandSignal,
+  createOpportunityCluster,
+  createOpportunityEngineState,
+  readOpportunityEngineState,
+  sortOpportunityClusters,
+  updateOpportunity,
+  writeOpportunityEngineState
+} from '../src/money-printer/opportunityEngine.js';
+
+const NOW = new Date('2026-08-01T17:00:00.000Z');
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem(key) { return values.get(key) ?? null; },
+    setItem(key, value) { values.set(key, value); },
+    removeItem(key) { values.delete(key); }
+  };
+}
+
+describe('Money Printer Opportunity Engine', () => {
+  it('creates versioned demand evidence with provenance and permission state', () => {
+    const signal = createDemandSignal({
+      need: '200 business cards tomorrow',
+      buyerWords: 'I need 200 business cards before our event tomorrow morning.',
+      location: 'San Diego',
+      urgency: 'immediate',
+      sourceLabel: 'Forwarded email',
+      acquisitionMode: 'manual-forward',
+      policyStatus: 'human-provided',
+      contactPermission: 'review-required'
+    }, NOW);
+
+    assert.equal(signal.schemaVersion, OPPORTUNITY_ENGINE_SCHEMA_VERSION);
+    assert.equal(signal.need, '200 business cards tomorrow');
+    assert.match(signal.buyerWords, /event tomorrow/);
+    assert.equal(signal.policyStatus, 'human-provided');
+    assert.equal(signal.contactPermission, 'review-required');
+  });
+
+  it('ranks urgent, evidenced, permitted demand above vague demand', () => {
+    const strong = createOpportunityCluster({
+      id: 'strong',
+      need: 'Urgent print delivery',
+      buyerWords: 'We need 200 cards delivered by 8 AM tomorrow.',
+      urgency: 'immediate',
+      confidence: 90,
+      policyStatus: 'human-provided',
+      estimatedValueMin: 250,
+      estimatedCostMax: 120
+    }, NOW);
+    const vague = createOpportunityCluster({
+      id: 'vague',
+      need: 'Maybe help someday',
+      urgency: 'low',
+      confidence: 20,
+      policyStatus: 'unknown'
+    }, NOW);
+
+    assert.deepEqual(sortOpportunityClusters([vague, strong], NOW).map(item => item.id), ['strong', 'vague']);
+  });
+
+  it('preserves passed opportunities for learning while removing them from active priority', () => {
+    let state = addOpportunity(createOpportunityEngineState({}, NOW), {
+      id: 'signal-one',
+      need: 'AV support this week',
+      buyerWords: 'We need an A1 for our event this Thursday.'
+    }, NOW);
+    const opportunityId = state.opportunities[0].id;
+    state = updateOpportunity(state, opportunityId, { status: 'passed' }, NOW);
+
+    assert.equal(state.opportunities.length, 1);
+    assert.equal(state.opportunities[0].status, 'passed');
+    assert.equal(state.signals.length, 1);
+  });
+
+  it('round-trips the versioned state through browser-compatible storage', () => {
+    const storage = memoryStorage();
+    const state = addOpportunity({}, {
+      need: 'Landing page by Friday',
+      buyerWords: 'Can someone build a launch page before Friday?',
+      policyStatus: 'human-provided'
+    }, NOW);
+
+    assert.equal(writeOpportunityEngineState(state, storage), true);
+    const restored = readOpportunityEngineState(storage);
+    assert.equal(restored.schemaVersion, OPPORTUNITY_ENGINE_SCHEMA_VERSION);
+    assert.equal(restored.opportunities.length, 1);
+    assert.equal(restored.signals.length, 1);
+    assert.equal(restored.opportunities[0].title, 'Landing page by Friday');
+  });
+});

--- a/tests/money-printer-opportunity-inbox.e2e.test.js
+++ b/tests/money-printer-opportunity-inbox.e2e.test.js
@@ -1,0 +1,79 @@
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { chromium } from 'playwright';
+
+let browser;
+let server;
+const TEST_ORIGIN = 'http://127.0.0.1:4317';
+
+async function waitForServer() {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      const response = await fetch(`${TEST_ORIGIN}/money-printer/`);
+      if (response.ok) return;
+    } catch {
+      // Server is still starting.
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error('Opportunity Inbox test server did not start.');
+}
+
+before(async () => {
+  server = spawn(process.execPath, ['scripts/dev-server.mjs'], {
+    cwd: new URL('..', import.meta.url),
+    env: { ...process.env, PORT: '4317', HOST: '127.0.0.1' },
+    stdio: 'ignore'
+  });
+  await waitForServer();
+  browser = await chromium.launch({ headless: true });
+});
+
+after(async () => {
+  await browser?.close();
+  server?.kill('SIGTERM');
+});
+
+describe('Money Printer Opportunity Inbox', () => {
+  it('captures evidence, persists it, and routes a response to human review without sending', async () => {
+    const page = await browser.newPage({ viewport: { width: 390, height: 844 }, isMobile: true });
+    await page.goto(`${TEST_ORIGIN}/money-printer/`, { waitUntil: 'networkidle' });
+
+    await page.locator('[name="need"]').fill('200 business cards tomorrow morning');
+    await page.locator('[name="buyerWords"]').fill('I need 200 business cards delivered before 8 AM tomorrow.');
+    await page.locator('[name="location"]').fill('San Diego');
+    await page.locator('[name="urgency"]').selectOption('immediate');
+    await page.locator('[name="estimatedValueMin"]').fill('250');
+    await page.locator('[name="estimatedCostMax"]').fill('140');
+    await page.locator('[name="suggestedResponse"]').fill('I can confirm the artwork and arrange delivery by 8 AM.');
+    await page.locator('[name="nextAction"]').fill('Confirm artwork and collect deposit');
+    await page.getByRole('button', { name: 'Add to Opportunity Inbox' }).click();
+
+    const card = page.locator('.opportunity-card');
+    await card.waitFor();
+    assert.match(await card.textContent(), /200 business cards tomorrow morning/);
+    assert.match(await card.textContent(), /San Diego/);
+    assert.match(await card.textContent(), /manual-forward/);
+    assert.match(await card.textContent(), /review-required/);
+    assert.match(await card.textContent(), /Confirm artwork and collect deposit/);
+
+    await page.reload({ waitUntil: 'networkidle' });
+    assert.equal(await page.locator('.opportunity-card').count(), 1);
+
+    await page.getByRole('button', { name: 'Review response' }).click();
+    const reviewCard = page.locator('.message-review-card').filter({ hasText: '200 business cards tomorrow morning' });
+    await reviewCard.waitFor();
+    assert.match(await reviewCard.textContent(), /human review is required before sending/i);
+    assert.match(await reviewCard.textContent(), /Approve draft/);
+    assert.match(await page.locator('#missionStatus').textContent(), /Nothing was sent/);
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth), true);
+
+    await page.screenshot({ path: '/tmp/opportunity-inbox-mobile.png', fullPage: true });
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.locator('#opportunityInboxTitle').scrollIntoViewIfNeeded();
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth), true);
+    await page.screenshot({ path: '/tmp/opportunity-inbox-desktop.png', fullPage: false });
+    await page.close();
+  });
+});

--- a/tests/money-printer-page.test.js
+++ b/tests/money-printer-page.test.js
@@ -38,6 +38,10 @@ describe('money-printer MVP', () => {
     assert.match(html, /Advanced tools/);
     assert.match(html, /Server and connector status/);
     assert.match(html, /Opportunity Engine/);
+    assert.match(html, /Opportunity Inbox/);
+    assert.match(html, /id="opportunityCaptureForm"/);
+    assert.match(html, /id="opportunityInbox"/);
+    assert.match(html, /Nothing here contacts anyone automatically/);
     assert.match(html, /Founder Command Brief/);
     assert.match(html, /Bot Dashboard/);
     assert.match(html, /Autonomy Zones/);
@@ -55,6 +59,7 @@ describe('money-printer MVP', () => {
       'moneyPrinterExperiments.js',
       'moneyPrinterConnectors.js',
       'moneyPrinterStorage.js',
+      'opportunityEngine.js',
       'moneyPrinterData.js',
       'ToolConnector.js'
     ];


### PR DESCRIPTION
Implements Phase 1 of the 3DVR Opportunity Engine:\n\n- versioned DemandSignal and OpportunityCluster records\n- browser-local persistence with provenance and policy state\n- manual-forward capture as the first safe source\n- ranked Opportunity Inbox with evidence, economics, confidence, permission, and next action\n- Review response handoff into the existing human review queue\n- no send, spend, or new external source automation\n- responsive mobile and desktop layout\n\nVerification:\n- 4 Opportunity Engine unit tests\n- Money Printer page tests\n- real Chromium mobile/desktop capture, persistence, review handoff, and overflow test\n- git diff --check\n\nThe full npm test suite still has the pre-existing calendar-provider API-count failure (14 functions vs an asserted Hobby limit of 12); this PR adds no API functions.