### PR TITLE
feat: sync Opportunity Inbox securely

### DIFF
--- a/money-printer/app.js
+++ b/money-printer/app.js
@@ -26,6 +26,10 @@ import {
   seedTrustReviewQueue
 } from '../src/money-printer/messageReview.js';
 import {
+  createOpportunityEngineSync,
+  mergeOpportunityEngineStates
+} from '../src/money-printer/opportunityEngineSync.js';
+import {
   addOpportunity,
   readOpportunityEngineState,
   sortOpportunityClusters,
@@ -42,6 +46,7 @@ const elements = {
   opportunityCaptureStatus: document.getElementById('opportunityCaptureStatus'),
   opportunityFilter: document.getElementById('opportunityFilter'),
   opportunityInbox: document.getElementById('opportunityInbox'),
+  opportunitySyncStatus: document.getElementById('opportunitySyncStatus'),
   opportunitySummary: document.getElementById('opportunitySummary'),
   metricsGrid: document.getElementById('metricsGrid'),
   messageReviewQueue: document.getElementById('messageReviewQueue'),
@@ -66,6 +71,8 @@ let connectorStatuses = [];
 let state = moneyPrinterStorage.hydrate();
 let messageReviewQueue = loadMessageReviewQueue();
 let opportunityEngineState = readOpportunityEngineState();
+let opportunityEngineSync = null;
+let opportunitySyncWrites = Promise.resolve();
 
 function saveState() {
   if (!moneyPrinterStorage.write(state)) {
@@ -183,6 +190,65 @@ function moneyRange(minimum, maximum) {
 function saveOpportunityEngineState() {
   if (!writeOpportunityEngineState(opportunityEngineState)) {
     elements.opportunityCaptureStatus.textContent = 'Browser storage is unavailable; this opportunity will not survive a refresh.';
+  }
+  if (opportunityEngineSync?.available) {
+    elements.opportunitySyncStatus.textContent = 'Syncing securely…';
+    const snapshot = opportunityEngineState;
+    opportunitySyncWrites = opportunitySyncWrites
+      .catch(() => undefined)
+      .then(() => opportunityEngineSync.write(snapshot))
+      .then(() => {
+        elements.opportunitySyncStatus.textContent = 'Synced securely';
+      })
+      .catch(() => {
+        elements.opportunitySyncStatus.textContent = 'Saved locally · sync retry needed';
+      });
+  }
+}
+
+function waitForGunAuthentication(user, timeoutMs = 2200) {
+  if (user?.is?.pub) return Promise.resolve(true);
+  try {
+    user?.recall?.({ sessionStorage: true, localStorage: true });
+  } catch (_error) {
+    return Promise.resolve(false);
+  }
+  return new Promise(resolve => {
+    const startedAt = Date.now();
+    const check = () => {
+      if (user?.is?.pub) return resolve(true);
+      if (Date.now() - startedAt >= timeoutMs) return resolve(false);
+      setTimeout(check, 80);
+    };
+    check();
+  });
+}
+
+async function initializeOpportunitySync() {
+  if (typeof window.Gun !== 'function') {
+    elements.opportunitySyncStatus.textContent = 'Saved on this device';
+    return;
+  }
+  const gun = window.Gun(window.__GUN_PEERS__ || ['wss://gun-relay-3dvr.fly.dev/gun']);
+  const user = gun.user();
+  const authenticated = await waitForGunAuthentication(user);
+  opportunityEngineSync = createOpportunityEngineSync({ user, SEA: window.SEA || window.Gun.SEA });
+  if (!authenticated || !opportunityEngineSync.available) {
+    elements.opportunitySyncStatus.textContent = 'Saved on this device · sign in to sync';
+    return;
+  }
+  elements.opportunitySyncStatus.textContent = 'Checking secure sync…';
+  try {
+    const remoteState = await opportunityEngineSync.read();
+    if (remoteState) {
+      opportunityEngineState = mergeOpportunityEngineStates(opportunityEngineState, remoteState);
+      writeOpportunityEngineState(opportunityEngineState);
+      renderOpportunityInbox();
+    }
+    await opportunityEngineSync.write(opportunityEngineState);
+    elements.opportunitySyncStatus.textContent = 'Synced securely';
+  } catch (_error) {
+    elements.opportunitySyncStatus.textContent = 'Saved locally · sync retry needed';
   }
 }
 
@@ -1077,6 +1143,7 @@ async function boot() {
     elements.opportunityCapturePanel.open = opportunityEngineState.opportunities.length === 0;
   }
   render();
+  initializeOpportunitySync();
   try {
     connectorStatuses = await readConnectorStatuses();
     renderTools();

--- a/money-printer/index.html
+++ b/money-printer/index.html
@@ -126,6 +126,7 @@
               <option value="passed">Passed</option>
             </select>
           </label>
+          <span id="opportunitySyncStatus" class="opportunity-sync-status">Saved on this device</span>
         </div>
         <div id="opportunityInbox" class="opportunity-grid" aria-live="polite"></div>
       </section>
@@ -329,6 +330,9 @@
     </footer>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script src="/gun-init.js"></script>
   <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/money-printer/styles.css
+++ b/money-printer/styles.css
@@ -167,6 +167,12 @@ body.money-printer-page {
   flex-wrap: wrap;
 }
 
+.opportunity-sync-status {
+  color: var(--muted-text, #b9c2d0);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
 .opportunity-toolbar label {
   display: grid;
   gap: 0.3rem;

--- a/src/money-printer/opportunityEngineSync.js
+++ b/src/money-printer/opportunityEngineSync.js
@@ -1,0 +1,96 @@
+import { createOpportunityEngineState } from './opportunityEngine.js';
+
+export const OPPORTUNITY_ENGINE_GUN_NODE = 'opportunity-engine-v1';
+
+function recordTimestamp(record = {}) {
+  const timestamp = Date.parse(record.updatedAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function mergeRecords(localRecords = [], remoteRecords = []) {
+  const records = new Map();
+  [...localRecords, ...remoteRecords].forEach(record => {
+    if (!record?.id) return;
+    const current = records.get(record.id);
+    if (!current || recordTimestamp(record) >= recordTimestamp(current)) {
+      records.set(record.id, record);
+    }
+  });
+  return [...records.values()];
+}
+
+export function mergeOpportunityEngineStates(localState = {}, remoteState = {}, now = new Date()) {
+  const local = createOpportunityEngineState(localState, now);
+  const remote = createOpportunityEngineState(remoteState, now);
+  return createOpportunityEngineState({
+    signals: mergeRecords(local.signals, remote.signals),
+    opportunities: mergeRecords(local.opportunities, remote.opportunities),
+    updatedAt: new Date(Math.max(
+      recordTimestamp(local),
+      recordTimestamp(remote),
+      now.getTime()
+    )).toISOString()
+  }, now);
+}
+
+function once(node, timeoutMs = 2500) {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = value => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value || null);
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    node.once(data => finish(data));
+  });
+}
+
+function put(node, value, timeoutMs = 3000) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error, result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(result);
+    };
+    const timer = setTimeout(() => finish(new Error('Opportunity sync timed out.')), timeoutMs);
+    node.put(value, acknowledgement => {
+      if (acknowledgement?.err) finish(new Error(acknowledgement.err));
+      else finish(null, acknowledgement || {});
+    });
+  });
+}
+
+export function createOpportunityEngineSync({ user, SEA, nodeName = OPPORTUNITY_ENGINE_GUN_NODE } = {}) {
+  const pair = user?._?.sea;
+  const available = Boolean(user?.is?.pub && pair && SEA?.encrypt && SEA?.decrypt && user?.get);
+  const node = available ? user.get('money-printer').get(nodeName) : null;
+
+  return {
+    available,
+    async read() {
+      if (!available) return null;
+      const record = await once(node);
+      if (!record?.ciphertext) return null;
+      const decrypted = await SEA.decrypt(record.ciphertext, pair);
+      if (!decrypted) throw new Error('Unable to decrypt the shared Opportunity Inbox.');
+      return createOpportunityEngineState(typeof decrypted === 'string' ? JSON.parse(decrypted) : decrypted);
+    },
+    async write(state) {
+      if (!available) return false;
+      const normalized = createOpportunityEngineState(state);
+      const ciphertext = await SEA.encrypt(JSON.stringify(normalized), pair);
+      if (!ciphertext) throw new Error('Unable to encrypt the Opportunity Inbox.');
+      await put(node, {
+        ciphertext,
+        schemaVersion: normalized.schemaVersion,
+        updatedAt: normalized.updatedAt
+      });
+      return true;
+    }
+  };
+}

--- a/tests/money-printer-opportunity-sync.test.js
+++ b/tests/money-printer-opportunity-sync.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createOpportunityEngineSync,
+  mergeOpportunityEngineStates
+} from '../src/money-printer/opportunityEngineSync.js';
+import { addOpportunity, createOpportunityEngineState } from '../src/money-printer/opportunityEngine.js';
+
+function fakeGunUser() {
+  let stored = null;
+  const node = {
+    get() { return this; },
+    once(callback) { callback(stored); },
+    put(value, callback) { stored = value; callback({ ok: 1 }); }
+  };
+  return {
+    is: { pub: 'test-public-key' },
+    _: { sea: { priv: 'private-key' } },
+    get() { return node; },
+    readStored() { return stored; }
+  };
+}
+
+const encryptedValues = new Map();
+const fakeSea = {
+  async encrypt(value) {
+    const ciphertext = `encrypted-${encryptedValues.size + 1}`;
+    encryptedValues.set(ciphertext, value);
+    return ciphertext;
+  },
+  async decrypt(value) { return encryptedValues.get(value); }
+};
+
+describe('Opportunity Engine shared storage', () => {
+  it('merges records by id and keeps the newest version', () => {
+    const first = addOpportunity(createOpportunityEngineState(), {
+      id: 'op-1', need: 'Old title', buyerWords: 'Original request'
+    }, new Date('2026-08-01T10:00:00Z'));
+    const newer = {
+      ...first,
+      opportunities: [{ ...first.opportunities[0], title: 'Updated title', updatedAt: '2026-08-01T11:00:00Z' }],
+      updatedAt: '2026-08-01T11:00:00Z'
+    };
+    const merged = mergeOpportunityEngineStates(first, newer, new Date('2026-08-01T12:00:00Z'));
+    assert.equal(merged.opportunities.length, 1);
+    assert.equal(merged.opportunities[0].title, 'Updated title');
+  });
+
+  it('encrypts before writing and decrypts after reading', async () => {
+    const user = fakeGunUser();
+    const sync = createOpportunityEngineSync({ user, SEA: fakeSea });
+    const state = addOpportunity(createOpportunityEngineState(), {
+      need: 'Private buyer request', buyerWords: 'Please do not publish this'
+    });
+    assert.equal(sync.available, true);
+    await sync.write(state);
+    assert.match(user.readStored().ciphertext, /^encrypted-/);
+    assert.doesNotMatch(JSON.stringify(user.readStored()), /Private buyer request/);
+    const restored = await sync.read();
+    assert.equal(restored.opportunities[0].title, 'Private buyer request');
+  });
+
+  it('stays unavailable for guests instead of writing to a public graph', () => {
+    const sync = createOpportunityEngineSync({ user: { get() { throw new Error('must not write'); } }, SEA: fakeSea });
+    assert.equal(sync.available, false);
+  });
+});


### PR DESCRIPTION
## What changed

- adds encrypted, signed-in GUN storage for Opportunity Inbox state
- keeps browser-local storage as the instant offline and guest fallback
- merges local and remote records by ID and latest update time
- migrates local opportunities into secure sync after authentication
- shows clear local, syncing, synced, and retry states in the inbox
- refuses shared writes when no authenticated GUN user is available

## Privacy boundary

Buyer wording and opportunity details are encrypted with the authenticated user's SEA keypair before they reach the GUN graph. Guest records remain only in browser storage.

## Verification

- `npm test` (746 tests passed)
- focused Opportunity Engine tests (11/11)
- existing mobile Opportunity Inbox Chromium flow
- real GUN SEA encrypted write/read round-trip; plaintext absent from stored record
- `git diff --check`
