### PR TITLE
Ingest first-party opportunities once

### DIFF
--- a/money-printer/app.js
+++ b/money-printer/app.js
@@ -30,7 +30,7 @@ import {
   mergeOpportunityEngineStates
 } from '../src/money-printer/opportunityEngineSync.js';
 import {
-  addOpportunity,
+  ingestOpportunity,
   readOpportunityEngineState,
   sortOpportunityClusters,
   updateOpportunity,
@@ -1027,7 +1027,13 @@ elements.opportunityCaptureForm?.addEventListener('submit', event => {
   event.preventDefault();
   const formData = new FormData(elements.opportunityCaptureForm);
   const now = new Date();
-  opportunityEngineState = addOpportunity(opportunityEngineState, {
+  const acquisitionMode = String(formData.get('acquisitionMode') || 'manual-forward');
+  const sourcePolicy = acquisitionMode === 'first-party-form'
+    ? { sourceLabel: '3DVR form submission', policyStatus: 'first-party' }
+    : acquisitionMode === 'email-reply'
+      ? { sourceLabel: 'Email reply', policyStatus: 'first-party' }
+      : { sourceLabel: 'Manual forward', policyStatus: 'human-provided' };
+  const ingestion = ingestOpportunity(opportunityEngineState, {
     need: formData.get('need'),
     buyerWords: formData.get('buyerWords'),
     location: formData.get('location'),
@@ -1038,13 +1044,18 @@ elements.opportunityCaptureForm?.addEventListener('submit', event => {
     estimatedCostMin: formData.get('estimatedCostMax'),
     suggestedResponse: formData.get('suggestedResponse'),
     nextAction: formData.get('nextAction'),
-    sourceLabel: 'Manual forward',
-    acquisitionMode: 'manual-forward',
-    policyStatus: 'human-provided',
+    ...sourcePolicy,
+    externalId: formData.get('externalId'),
+    acquisitionMode,
     contactPermission: 'review-required',
     confidence: 60,
     createdAt: now.toISOString()
   }, now);
+  if (!ingestion.created) {
+    elements.opportunityCaptureStatus.textContent = 'Already in the inbox. The duplicate was not added.';
+    return;
+  }
+  opportunityEngineState = ingestion.state;
   saveOpportunityEngineState();
   elements.opportunityCaptureForm.reset();
   elements.opportunityCapturePanel.open = false;

--- a/money-printer/index.html
+++ b/money-printer/index.html
@@ -72,6 +72,18 @@
             <small>Paste a request you found or received</small>
           </summary>
           <form id="opportunityCaptureForm" class="opportunity-capture" autocomplete="off">
+          <label class="opportunity-field">
+            <span>How did it arrive?</span>
+            <select name="acquisitionMode">
+              <option value="email-reply">Email reply</option>
+              <option value="first-party-form">3DVR form submission</option>
+              <option value="manual-forward" selected>Manually forwarded post</option>
+            </select>
+          </label>
+          <label class="opportunity-field">
+            <span>Message or submission ID</span>
+            <input name="externalId" placeholder="Optional, prevents duplicates">
+          </label>
           <label class="opportunity-field opportunity-field--wide">
             <span>What do they need?</span>
             <input name="need" required placeholder="Example: 200 business cards by tomorrow morning">
@@ -111,7 +123,7 @@
           </label>
             <div class="opportunity-capture__actions opportunity-field--wide">
               <button class="mp-button mp-button--primary" type="submit">Add to Opportunity Inbox</button>
-              <p id="opportunityCaptureStatus" aria-live="polite">Saved locally in this browser with manual-source provenance.</p>
+              <p id="opportunityCaptureStatus" aria-live="polite">Source and permission are preserved. Repeated messages are added only once.</p>
             </div>
           </form>
         </details>

--- a/src/money-printer/opportunityEngine.js
+++ b/src/money-printer/opportunityEngine.js
@@ -39,6 +39,22 @@ function makeId(prefix = 'record') {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
+function normalizeFingerprintPart(value) {
+  return text(value).toLowerCase().replace(/\s+/g, ' ');
+}
+
+export function opportunitySignalFingerprint(input = {}) {
+  const explicitId = normalizeFingerprintPart(input.externalId || input.sourceId);
+  if (explicitId) {
+    return [normalizeFingerprintPart(input.acquisitionMode), explicitId].join(':');
+  }
+  return [
+    normalizeFingerprintPart(input.sourceLabel || input.source),
+    normalizeFingerprintPart(input.buyerWords || input.evidence),
+    normalizeFingerprintPart(input.need)
+  ].join('|');
+}
+
 export function createDemandSignal(input = {}, now = new Date()) {
   const createdAt = timestamp(input.createdAt, now.toISOString());
   return {
@@ -48,6 +64,8 @@ export function createDemandSignal(input = {}, now = new Date()) {
     buyerWords: text(input.buyerWords || input.evidence),
     sourceLabel: text(input.sourceLabel || input.source, 'Manual forward'),
     sourceUrl: text(input.sourceUrl),
+    externalId: text(input.externalId || input.sourceId),
+    sourceFingerprint: text(input.sourceFingerprint) || opportunitySignalFingerprint(input),
     acquisitionMode: text(input.acquisitionMode, 'manual-forward'),
     policyStatus: text(input.policyStatus, 'human-provided'),
     contactPermission: text(input.contactPermission, 'review-required'),
@@ -127,6 +145,16 @@ export function addOpportunity(state = {}, input = {}, now = new Date()) {
     opportunities: [opportunity, ...current.opportunities],
     updatedAt: now.toISOString()
   };
+}
+
+export function ingestOpportunity(state = {}, input = {}, now = new Date()) {
+  const current = createOpportunityEngineState(state, now);
+  const fingerprint = opportunitySignalFingerprint(input);
+  const duplicate = current.signals.find(signal => signal.sourceFingerprint === fingerprint);
+  if (duplicate) {
+    return { state: current, created: false, duplicateSignalId: duplicate.id };
+  }
+  return { state: addOpportunity(current, { ...input, sourceFingerprint: fingerprint }, now), created: true };
 }
 
 export function updateOpportunity(state = {}, opportunityId, patch = {}, now = new Date()) {

--- a/tests/money-printer-opportunity-engine.test.js
+++ b/tests/money-printer-opportunity-engine.test.js
@@ -6,6 +6,8 @@ import {
   createDemandSignal,
   createOpportunityCluster,
   createOpportunityEngineState,
+  ingestOpportunity,
+  opportunitySignalFingerprint,
   readOpportunityEngineState,
   sortOpportunityClusters,
   updateOpportunity,
@@ -93,5 +95,38 @@ describe('Money Printer Opportunity Engine', () => {
     assert.equal(restored.opportunities.length, 1);
     assert.equal(restored.signals.length, 1);
     assert.equal(restored.opportunities[0].title, 'Landing page by Friday');
+  });
+
+  it('deduplicates repeated first-party submissions by source id', () => {
+    const intake = {
+      externalId: 'form-4821',
+      acquisitionMode: 'first-party-form',
+      policyStatus: 'first-party',
+      need: 'Website help',
+      buyerWords: 'Please help us repair our company website.'
+    };
+    const first = ingestOpportunity({}, intake, NOW);
+    const repeated = ingestOpportunity(first.state, { ...intake, buyerWords: 'Changed webhook copy' }, NOW);
+
+    assert.equal(first.created, true);
+    assert.equal(repeated.created, false);
+    assert.equal(repeated.state.opportunities.length, 1);
+    assert.equal(opportunitySignalFingerprint(intake), 'first-party-form:form-4821');
+  });
+
+  it('deduplicates manual forwards using normalized evidence when no source id exists', () => {
+    const first = ingestOpportunity({}, {
+      sourceLabel: 'Forwarded email',
+      need: 'AV support',
+      buyerWords: 'We need an A1 this Friday.'
+    }, NOW);
+    const repeated = ingestOpportunity(first.state, {
+      sourceLabel: 'forwarded EMAIL',
+      need: 'av support',
+      buyerWords: '  We need an A1 this Friday.  '
+    }, NOW);
+
+    assert.equal(repeated.created, false);
+    assert.equal(repeated.state.signals.length, 1);
   });
 });

--- a/tests/money-printer-page.test.js
+++ b/tests/money-printer-page.test.js
@@ -40,6 +40,9 @@ describe('money-printer MVP', () => {
     assert.match(html, /Opportunity Engine/);
     assert.match(html, /Opportunity Inbox/);
     assert.match(html, /id="opportunityCaptureForm"/);
+    assert.match(html, /name="acquisitionMode"/);
+    assert.match(html, /name="externalId"/);
+    assert.match(html, /Email reply/);
     assert.match(html, /id="opportunityInbox"/);
     assert.match(html, /Nothing here contacts anyone automatically/);
     assert.match(html, /Founder Command Brief/);


### PR DESCRIPTION
## Outcome\n- classify email replies, 3DVR form submissions, and manual forwards with explicit provenance\n- preserve external message/submission IDs\n- prevent duplicate opportunities when a connector or operator replays the same item\n- keep every resulting response behind human review\n\n## Verification\n- 14/14 focused Opportunity Engine, shared-sync, page, and real-Chromium inbox tests pass\n- full suite exercised; unrelated baseline failures remain in Forge link and GUN/browser persistence tests\n\nNo billing, Stripe, or autonomous outreach behavior changes.