### PR TITLE
Harden Chat guest mode and notification startup

### DIFF
--- a/chat/index.html
+++ b/chat/index.html
@@ -80,7 +80,7 @@
         <div id="notification-settings" class="chat-card chat-card--accent">
           <div class="chat-card__header">
             <span class="chat-card__eyebrow">Notifications</span>
-            <h2 class="chat-card__title">Stay in the loop</h2>
+            <h2 class="chat-card__title">While Chat is running</h2>
           </div>
           <p id="notification-status" class="chat-card__muted">Checking permissions…</p>
           <button
@@ -845,7 +845,16 @@ function displayMessages() {
       (message.sender || 'Anonymous');
     const time = message.createdAt ? timeAgoOrFullDate(message.createdAt) : '';
 
-    msgDiv.innerHTML = `<div><strong>${username}:</strong> ${message.text}</div><div class="meta">${time}</div>`;
+    const content = document.createElement('div');
+    const author = document.createElement('strong');
+    author.textContent = `${username}:`;
+    content.append(author, document.createTextNode(` ${String(message.text || '')}`));
+
+    const metadata = document.createElement('div');
+    metadata.className = 'meta';
+    metadata.textContent = time;
+
+    msgDiv.append(content, metadata);
     messagesDiv.appendChild(msgDiv);
   }
 
@@ -996,6 +1005,20 @@ window.addEventListener('hashchange', () => {
   }
 });
 
+async function ensureChatServiceWorkerRegistration() {
+  if (!('serviceWorker' in navigator)) return null;
+
+  try {
+    const existing = await navigator.serviceWorker.getRegistration('/');
+    const registration = existing || await navigator.serviceWorker.register('/service-worker.js', { scope: '/' });
+    serviceWorkerRegistration = registration;
+    return registration;
+  } catch (error) {
+    console.error('Service worker registration failed for chat notifications', error);
+    return null;
+  }
+}
+
 function initNotifications() {
   if (!notificationToggleButton || !notificationStatusText) return;
 
@@ -1005,24 +1028,9 @@ function initNotifications() {
     return;
   }
 
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready
-      .then((registration) => {
-        serviceWorkerRegistration = registration;
-        return registration;
-      })
-      .catch(() => navigator.serviceWorker.register('/service-worker.js', { scope: '/' }))
-      .then((registration) => {
-        if (registration) {
-          serviceWorkerRegistration = registration;
-        }
-      })
-      .catch((error) => {
-        console.error('Service worker registration failed for chat notifications', error);
-      });
-  }
+  ensureChatServiceWorkerRegistration();
 
-  const savedPreference = localStorage.getItem(notificationsPreferenceKey) === 'true';
+  const savedPreference = safeGetStorage(notificationsPreferenceKey) === 'true';
   if (savedPreference && Notification.permission === 'granted') {
     notificationsEnabled = true;
   }
@@ -1049,9 +1057,9 @@ function updateNotificationUI() {
   notificationToggleButton.textContent = notificationsEnabled ? 'Disable Notifications' : 'Enable Notifications';
 
   if (notificationsEnabled && Notification.permission === 'granted') {
-    notificationStatusText.textContent = 'Notifications are on. We will alert you about new messages.';
+    notificationStatusText.textContent = 'On while Chat is open or running in the background.';
   } else {
-    notificationStatusText.textContent = 'Notifications are off. Click enable to stay updated.';
+    notificationStatusText.textContent = 'Off. Enable alerts while Chat is running.';
   }
 }
 
@@ -1060,14 +1068,14 @@ function toggleNotifications() {
 
   if (notificationsEnabled) {
     notificationsEnabled = false;
-    localStorage.setItem(notificationsPreferenceKey, 'false');
+    safeSetStorage(notificationsPreferenceKey, 'false');
     updateNotificationUI();
     return;
   }
 
   if (Notification.permission === 'granted') {
     notificationsEnabled = true;
-    localStorage.setItem(notificationsPreferenceKey, 'true');
+    safeSetStorage(notificationsPreferenceKey, 'true');
     updateNotificationUI();
     sendNotificationPreview();
     return;
@@ -1075,7 +1083,7 @@ function toggleNotifications() {
 
   Notification.requestPermission().then(permission => {
     notificationsEnabled = permission === 'granted';
-    localStorage.setItem(notificationsPreferenceKey, notificationsEnabled ? 'true' : 'false');
+    safeSetStorage(notificationsPreferenceKey, notificationsEnabled ? 'true' : 'false');
 
     if (permission === 'denied') {
       notificationStatusText.textContent = 'Notifications are blocked in your browser settings.';
@@ -1170,7 +1178,7 @@ function sendNotificationPreview() {
   showChatNotification(
     'Chat notifications enabled',
     {
-      body: 'We will let you know when someone posts a new message.',
+      body: 'Alerts are ready while Chat is open or running in the background.',
       tag: 'chat-notification-preview',
       data: { room: currentRoom }
     },

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,7 +3,7 @@
 importScripts('/chat/notification-routing.js');
 
 // Increment this to bust old caches when you deploy
-const CACHE_VERSION = 'v18';
+const CACHE_VERSION = 'v19';
 const STATIC_CACHE = `3dvr-static-${CACHE_VERSION}`;
 const HTML_CACHE = `3dvr-html-${CACHE_VERSION}`;
 const chatNotificationRouting = self.ChatNotificationRouting || null;

--- a/tests/chat-guest-mode.e2e.test.js
+++ b/tests/chat-guest-mode.e2e.test.js
@@ -1,0 +1,77 @@
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { chromium } from 'playwright';
+
+let browser;
+let server;
+const TEST_ORIGIN = 'http://127.0.0.1:4318';
+
+async function waitForServer() {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      const response = await fetch(`${TEST_ORIGIN}/chat/`);
+      if (response.ok) return;
+    } catch {
+      // Server is still starting.
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error('Chat test server did not start.');
+}
+
+before(async () => {
+  server = spawn(process.execPath, ['scripts/dev-server.mjs'], {
+    cwd: new URL('..', import.meta.url),
+    env: { ...process.env, PORT: '4318', HOST: '127.0.0.1' },
+    stdio: 'ignore'
+  });
+  await waitForServer();
+  browser = await chromium.launch({ headless: true });
+});
+
+after(async () => {
+  await browser?.close();
+  server?.kill('SIGTERM');
+});
+
+describe('Chat guest mode', () => {
+  it('boots without page errors and lets a guest send a safe message', async () => {
+    const context = await browser.newContext({ viewport: { width: 390, height: 844 }, isMobile: true });
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    await page.goto(`${TEST_ORIGIN}/chat/`, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => document.querySelector('#current-username')?.textContent !== 'Loading...');
+
+    const identity = await page.evaluate(() => ({
+      guest: localStorage.getItem('guest'),
+      guestId: localStorage.getItem('guestId'),
+      username: document.querySelector('#current-username')?.textContent
+    }));
+    assert.equal(identity.guest, 'true');
+    assert.match(identity.guestId || '', /^guest_/);
+    assert.match(identity.username || '', /^Guest/);
+
+    const notificationRegistration = await page.evaluate(async () => {
+      const registration = await navigator.serviceWorker.getRegistration('/');
+      return registration ? new URL(registration.scope).pathname : '';
+    });
+    assert.equal(notificationRegistration, '/');
+
+    await page.locator('#message-input').fill('<img src=x onerror="window.chatInjected=true"> hello');
+    await page.getByRole('button', { name: 'Send' }).click();
+    await page.locator('.message').filter({ hasText: 'hello' }).first().waitFor();
+
+    assert.equal(await page.evaluate(() => window.chatInjected), undefined);
+    assert.equal(pageErrors.length, 0, pageErrors.join('\n'));
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => document.querySelector('#current-username')?.textContent !== 'Loading...');
+    assert.equal(await page.evaluate(() => localStorage.getItem('guestId')), identity.guestId);
+    assert.match(await page.locator('#current-username').textContent(), /^Guest/);
+    assert.equal(pageErrors.length, 0, pageErrors.join('\n'));
+    await context.close();
+  });
+});

--- a/tests/chat-notification-routing.test.js
+++ b/tests/chat-notification-routing.test.js
@@ -76,6 +76,10 @@ describe('chat notification routing', () => {
     assert.match(chatHtml, /function handleNotificationNavigation\(target = \{\}\)/);
     assert.match(chatHtml, /window\.addEventListener\('hashchange'/);
     assert.match(chatHtml, /buildChatTargetUrl\(\{\s*room: currentRoom,\s*messageId: id\s*\}\)/);
+    assert.match(chatHtml, /navigator\.serviceWorker\.getRegistration\('\/'\)/);
+    assert.match(chatHtml, /existing \|\| await navigator\.serviceWorker\.register/);
+    assert.doesNotMatch(chatHtml, /navigator\.serviceWorker\.ready\s*\.then/);
+    assert.match(chatHtml, /On while Chat is open or running in the background\./);
 
     assert.match(serviceWorker, /importScripts\('\/chat\/notification-routing\.js'\);/);
     assert.match(serviceWorker, /client\.postMessage\(\{\s*type: 'notification-clicked'/);

--- a/tests/mobile-browser-resilience.test.js
+++ b/tests/mobile-browser-resilience.test.js
@@ -56,7 +56,7 @@ test('root service worker does not cache stale portal HTML or Vercel checkpoints
   const source = await readProjectFile('service-worker.js');
   const staticAssetsBlock = source.match(/const STATIC_ASSETS = \[[\s\S]*?\];/)?.[0] || '';
 
-  assert.match(source, /const CACHE_VERSION = 'v18';/);
+  assert.match(source, /const CACHE_VERSION = 'v19';/);
   assert.match(source, /const AUTH_CRITICAL_HTML_PATHS = new Set\(\[/);
   assert.match(source, /'\/index\.html'/);
   assert.match(source, /'\/profile\.html'/);


### PR DESCRIPTION
## Outcome
- add a real mobile guest-mode acceptance test covering identity, send, safe render, and reload persistence
- render guest messages as text so chat content cannot execute HTML
- register the root notification service worker deterministically instead of waiting forever on serviceWorker.ready when no registration exists
- preserve notification preference safely when browser storage is restricted
- describe the honest current boundary: alerts work while Chat is open or backgrounded; true closed-app push needs a server-backed subscription layer
- bust the root service-worker cache

## Verification
- 14/14 focused Chat, guest entrypoint, notification routing, and mobile browser resilience tests pass
- real Chromium mobile flow passes with no page errors

No billing, Stripe, or autonomous outreach changes.