### PR TITLE
Use WebSocket peers for Chat push watcher

### DIFF
--- a/services/newsletter-store/server.mjs
+++ b/services/newsletter-store/server.mjs
@@ -11,7 +11,7 @@ if (!token || !databaseUrl) throw new Error('NEWSLETTER_STORE_TOKEN and DATABASE
 const vapidSubject = String(process.env.CHAT_PUSH_VAPID_SUBJECT || 'mailto:3dvr.tech@gmail.com');
 const vapidPublicKey = String(process.env.CHAT_PUSH_VAPID_PUBLIC_KEY || '');
 const vapidPrivateKey = String(process.env.CHAT_PUSH_VAPID_PRIVATE_KEY || '');
-const gunPeers = String(process.env.CHAT_PUSH_GUN_PEERS || 'https://relay.3dvr.tech/gun,https://gun-relay-3dvr.fly.dev/gun')
+const gunPeers = String(process.env.CHAT_PUSH_GUN_PEERS || 'wss://relay.3dvr.tech/gun,wss://gun-relay-3dvr.fly.dev/gun')
   .split(',').map(value => value.trim()).filter(Boolean);
 if (vapidPublicKey && vapidPrivateKey) {
   webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);


### PR DESCRIPTION
Production smoke testing showed the DigitalOcean watcher was healthy but did not receive GUN graph updates over the configured HTTPS peer URLs. This switches the watcher defaults to the same WSS relay endpoints used by the browser Chat client.