### PR TITLE
Verify Chat push through the live server

### DIFF
--- a/chat/index.html
+++ b/chat/index.html
@@ -319,10 +319,12 @@ const notificationsSupported = 'Notification' in window;
 const notificationsPreferenceKey = 'chatNotificationsEnabled';
 const notificationIconPath = '/icons/icon-192.png';
 const notificationStateStorageKey = 'chatNotificationState';
+const pushDeliveryVerifiedStorageKey = 'chatPushDeliveryVerified';
 const chatPushApiPath = '/api/trial';
 const INITIAL_SYNC_GRACE_MS = 1500;
 let notificationsEnabled = false;
 let closedAppNotificationsEnabled = false;
+let pushDeliveryVerified = false;
 let serviceWorkerRegistration = null;
 let currentRoomStream = null;
 const roomInitialSyncTimers = {};
@@ -1050,11 +1052,12 @@ async function getChatPushPublicKey() {
   return String(config.chatPushPublicKey || '');
 }
 
-async function ensurePushSubscription() {
+async function ensurePushSubscription({ verifyDelivery = false } = {}) {
   const registration = serviceWorkerRegistration || await ensureChatServiceWorkerRegistration();
   if (!registration?.pushManager) return false;
 
   let subscription = await registration.pushManager.getSubscription();
+  let createdSubscription = false;
   if (!subscription) {
     const publicKey = await getChatPushPublicKey();
     if (!publicKey) return false;
@@ -1062,15 +1065,20 @@ async function ensurePushSubscription() {
       userVisibleOnly: true,
       applicationServerKey: decodeVapidPublicKey(publicKey)
     });
+    createdSubscription = true;
   }
 
-  await callChatPushApi('subscribe', {
+  const result = await callChatPushApi('subscribe', {
     userId,
     rooms: getAvailableChatRooms(),
     subscription: subscription.toJSON(),
-    userAgent: navigator.userAgent
+    userAgent: navigator.userAgent,
+    verifyDelivery: verifyDelivery || createdSubscription
   });
-  return true;
+  return {
+    subscribed: true,
+    deliveryAccepted: result.deliveryAccepted === true
+  };
 }
 
 async function removePushSubscription() {
@@ -1099,7 +1107,13 @@ async function initNotifications() {
   if (savedPreference && Notification.permission === 'granted') {
     notificationsEnabled = true;
     try {
-      closedAppNotificationsEnabled = await ensurePushSubscription();
+      pushDeliveryVerified = safeGetStorage(pushDeliveryVerifiedStorageKey) === 'true';
+      const pushState = await ensurePushSubscription({ verifyDelivery: !pushDeliveryVerified });
+      closedAppNotificationsEnabled = pushState.subscribed;
+      if (pushState.deliveryAccepted) {
+        pushDeliveryVerified = true;
+        safeSetStorage(pushDeliveryVerifiedStorageKey, 'true');
+      }
     } catch (error) {
       console.warn('Closed-app notifications could not be restored', error);
     }
@@ -1127,9 +1141,9 @@ function updateNotificationUI() {
   notificationToggleButton.textContent = notificationsEnabled ? 'Disable Notifications' : 'Enable Notifications';
 
   if (notificationsEnabled && Notification.permission === 'granted') {
-    notificationStatusText.textContent = closedAppNotificationsEnabled
-      ? 'On, including when Chat is closed.'
-      : 'On while Chat is running. Closed-app alerts are temporarily unavailable.';
+    notificationStatusText.textContent = closedAppNotificationsEnabled && pushDeliveryVerified
+      ? 'On. A test notification was sent through the live server.'
+      : 'On while Chat is running. Server push has not been verified.';
   } else {
     notificationStatusText.textContent = 'Off. Enable alerts while Chat is running.';
   }
@@ -1141,7 +1155,9 @@ async function toggleNotifications() {
   if (notificationsEnabled) {
     notificationsEnabled = false;
     closedAppNotificationsEnabled = false;
+    pushDeliveryVerified = false;
     safeSetStorage(notificationsPreferenceKey, 'false');
+    safeRemoveStorage(pushDeliveryVerifiedStorageKey);
     try {
       await removePushSubscription();
     } catch (error) {
@@ -1155,12 +1171,14 @@ async function toggleNotifications() {
     notificationsEnabled = true;
     safeSetStorage(notificationsPreferenceKey, 'true');
     try {
-      closedAppNotificationsEnabled = await ensurePushSubscription();
+      const pushState = await ensurePushSubscription({ verifyDelivery: true });
+      closedAppNotificationsEnabled = pushState.subscribed;
+      pushDeliveryVerified = pushState.deliveryAccepted;
+      safeSetStorage(pushDeliveryVerifiedStorageKey, pushDeliveryVerified ? 'true' : 'false');
     } catch (error) {
       console.warn('Closed-app notifications could not be enabled', error);
     }
     updateNotificationUI();
-    sendNotificationPreview();
     return;
   }
 
@@ -1174,7 +1192,10 @@ async function toggleNotifications() {
 
   if (notificationsEnabled) {
     try {
-      closedAppNotificationsEnabled = await ensurePushSubscription();
+      const pushState = await ensurePushSubscription({ verifyDelivery: true });
+      closedAppNotificationsEnabled = pushState.subscribed;
+      pushDeliveryVerified = pushState.deliveryAccepted;
+      safeSetStorage(pushDeliveryVerifiedStorageKey, pushDeliveryVerified ? 'true' : 'false');
     } catch (error) {
       console.warn('Closed-app notifications could not be enabled', error);
     }
@@ -1182,9 +1203,6 @@ async function toggleNotifications() {
 
   updateNotificationUI();
 
-  if (permission === 'granted') {
-    sendNotificationPreview();
-  }
 }
 
 async function attemptServiceWorkerNotification(registration, title, options) {
@@ -1262,18 +1280,6 @@ async function showChatNotification(title, options = {}, config = {}) {
     console.error('Service worker readiness error', error);
     fallbackToPageNotification();
   }
-}
-
-function sendNotificationPreview() {
-  showChatNotification(
-    'Chat notifications enabled',
-    {
-      body: 'Alerts are ready, including when Chat is closed.',
-      tag: 'chat-notification-preview',
-      data: { room: currentRoom }
-    },
-    { requireHidden: false }
-  );
 }
 
 function maybeNotifyNewMessage(message, id) {

--- a/services/newsletter-store/chat-push-proof.mjs
+++ b/services/newsletter-store/chat-push-proof.mjs
@@ -1,0 +1,16 @@
+export const CHAT_PUSH_PROOF_PAYLOAD = Object.freeze({
+  title: '3DVR Chat test',
+  body: 'This notification came through the live server push path.',
+  room: 'general',
+  messageId: '',
+  tag: 'chat-push-delivery-test'
+});
+
+export async function sendChatPushProof(subscription, webpushClient) {
+  await webpushClient.sendNotification(
+    subscription,
+    JSON.stringify(CHAT_PUSH_PROOF_PAYLOAD),
+    { TTL: 60, urgency: 'high' }
+  );
+  return { deliveryAccepted: true };
+}

--- a/services/newsletter-store/server.mjs
+++ b/services/newsletter-store/server.mjs
@@ -3,6 +3,7 @@ import http from 'node:http';
 import Gun from 'gun';
 import { Pool } from 'pg';
 import webpush from 'web-push';
+import { sendChatPushProof } from './chat-push-proof.mjs';
 
 const port = Number.parseInt(process.env.PORT || '8787', 10);
 const token = String(process.env.NEWSLETTER_STORE_TOKEN || '');
@@ -72,6 +73,17 @@ async function saveChatSubscription(input) {
       user_agent = EXCLUDED.user_agent,
       updated_at = NOW()
   `, [subscription.endpoint, userId, JSON.stringify(subscription), rooms, cleanText(input.userAgent, 500) || null]);
+
+  if (input.verifyDelivery !== true) return { deliveryAccepted: false };
+
+  try {
+    return await sendChatPushProof(subscription, webpush);
+  } catch (error) {
+    if (error?.statusCode === 404 || error?.statusCode === 410) {
+      await pool.query('DELETE FROM chat_push_subscriptions WHERE endpoint = $1', [subscription.endpoint]);
+    }
+    throw error;
+  }
 }
 
 async function removeChatSubscription(input) {
@@ -192,8 +204,8 @@ const server = http.createServer(async (req, res) => {
     }
     if (req.url === '/v1/chat/subscribe' && req.method === 'POST') {
       if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });
-      await saveChatSubscription(await readBody(req));
-      return json(res, 201, { ok: true });
+      const result = await saveChatSubscription(await readBody(req));
+      return json(res, 201, { ok: true, ...result });
     }
     if (req.url === '/v1/chat/unsubscribe' && req.method === 'POST') {
       if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });

--- a/tests/chat-notification-routing.test.js
+++ b/tests/chat-notification-routing.test.js
@@ -79,8 +79,10 @@ describe('chat notification routing', () => {
     assert.match(chatHtml, /navigator\.serviceWorker\.getRegistration\('\/'\)/);
     assert.match(chatHtml, /existing \|\| await navigator\.serviceWorker\.register/);
     assert.doesNotMatch(chatHtml, /navigator\.serviceWorker\.ready\s*\.then/);
-    assert.match(chatHtml, /On, including when Chat is closed\./);
+    assert.match(chatHtml, /A test notification was sent through the live server\./);
     assert.match(chatHtml, /registration\.pushManager\.subscribe/);
+    assert.match(chatHtml, /verifyDelivery: true/);
+    assert.doesNotMatch(chatHtml, /sendNotificationPreview/);
     assert.match(chatHtml, /action, \.\.\.payload/);
 
     assert.match(serviceWorker, /importScripts\('\/chat\/notification-routing\.js'\);/);

--- a/tests/chat-push-proof.test.js
+++ b/tests/chat-push-proof.test.js
@@ -1,0 +1,37 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CHAT_PUSH_PROOF_PAYLOAD,
+  sendChatPushProof
+} from '../services/newsletter-store/chat-push-proof.mjs';
+
+describe('chat push delivery proof', () => {
+  it('uses the real Web Push sender with a visible server-path message', async () => {
+    const subscription = { endpoint: 'https://push.example.test/subscription' };
+    const webpushClient = {
+      sendNotification: mock.fn(async () => ({ statusCode: 201 }))
+    };
+
+    const result = await sendChatPushProof(subscription, webpushClient);
+
+    assert.deepEqual(result, { deliveryAccepted: true });
+    assert.equal(webpushClient.sendNotification.mock.calls.length, 1);
+    const [actualSubscription, rawPayload, options] = webpushClient.sendNotification.mock.calls[0].arguments;
+    assert.equal(actualSubscription, subscription);
+    assert.deepEqual(JSON.parse(rawPayload), CHAT_PUSH_PROOF_PAYLOAD);
+    assert.match(JSON.parse(rawPayload).body, /live server push path/);
+    assert.deepEqual(options, { TTL: 60, urgency: 'high' });
+  });
+
+  it('does not claim verification when the push service rejects delivery', async () => {
+    const deliveryError = Object.assign(new Error('expired'), { statusCode: 410 });
+    const webpushClient = {
+      sendNotification: mock.fn(async () => { throw deliveryError; })
+    };
+
+    await assert.rejects(
+      sendChatPushProof({ endpoint: 'https://push.example.test/expired' }, webpushClient),
+      deliveryError
+    );
+  });
+});


### PR DESCRIPTION
## Outcome
Chat no longer uses a local notification preview as proof that closed-app Web Push works. Enabling notifications asks DigitalOcean to send a real Web Push test through the saved browser subscription.

## Changes
- send a visible server-originated proof notification after new subscriptions and first upgrade
- persist whether the push service accepted the proof
- report permission/subscription separately from verified server delivery
- remove expired proof subscriptions
- add success and rejection coverage for the Web Push sender

## Verification
- full `npm test` suite passed
- focused Chat/Push/Trial suite: 17/17
- real mobile Chromium guest Chat flow passed

No Stripe, billing, or account-linking impact.