### PR TITLE
Keep long Chat links inside mobile viewport

### DIFF
--- a/styles/chat.css
+++ b/styles/chat.css
@@ -245,6 +245,7 @@ body.chat-page {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  min-width: 0;
 }
 
 .chat-card {
@@ -405,13 +406,17 @@ body.chat-page {
 
 .chat-main__body {
   gap: 1.25rem;
+  min-width: 0;
 }
 
 .chat-messages {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-width: 0;
+  max-width: 100%;
   max-height: clamp(360px, 60vh, 520px);
+  overflow-x: hidden;
   overflow-y: auto;
   padding-right: 0.25rem;
 }
@@ -433,6 +438,8 @@ body.chat-page {
 .message {
   display: grid;
   gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
   padding: 1.1rem 1.25rem;
   border-radius: var(--radius-md);
   background: var(--surface-alt);
@@ -441,6 +448,12 @@ body.chat-page {
   transition: transform var(--transition-base),
     border-color var(--transition-base),
     box-shadow var(--transition-base);
+}
+
+.message > div:first-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .message--focused {

--- a/tests/chat-guest-mode.e2e.test.js
+++ b/tests/chat-guest-mode.e2e.test.js
@@ -74,4 +74,39 @@ describe('Chat guest mode', () => {
     assert.equal(pageErrors.length, 0, pageErrors.join('\n'));
     await context.close();
   });
+
+  it('keeps long YouTube links inside the mobile chat viewport', async () => {
+    const context = await browser.newContext({ viewport: { width: 390, height: 844 }, isMobile: true });
+    const page = await context.newPage();
+
+    await page.goto(`${TEST_ORIGIN}/chat/`, { waitUntil: 'domcontentloaded' });
+    await page.evaluate(() => {
+      const message = document.createElement('div');
+      message.className = 'message';
+      const content = document.createElement('div');
+      content.textContent = `Guest: https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=share&list=${'long-unbroken-value'.repeat(20)}`;
+      const metadata = document.createElement('div');
+      metadata.className = 'meta';
+      metadata.textContent = 'now';
+      message.append(content, metadata);
+      document.querySelector('#messages').replaceChildren(message);
+    });
+
+    const dimensions = await page.evaluate(() => {
+      const message = document.querySelector('.message');
+      const messages = document.querySelector('#messages');
+      return {
+        viewport: document.documentElement.clientWidth,
+        page: document.documentElement.scrollWidth,
+        messagesClient: messages.clientWidth,
+        messagesScroll: messages.scrollWidth,
+        messageRight: Math.ceil(message.getBoundingClientRect().right)
+      };
+    });
+
+    assert.equal(dimensions.page, dimensions.viewport);
+    assert.equal(dimensions.messagesScroll, dimensions.messagesClient);
+    assert.ok(dimensions.messageRight <= dimensions.viewport, JSON.stringify(dimensions));
+    await context.close();
+  });
 });


### PR DESCRIPTION
## Summary

- prevent long YouTube URLs and other unbroken message text from widening Chat
- allow the chat grid and message column to shrink within the mobile viewport
- add a real 390px Chromium regression test for page and message-list overflow

## Verification

- `node --test --test-reporter=spec tests/chat-guest-mode.e2e.test.js`
- `node --test --test-reporter=spec tests/chat-notification-routing.test.js tests/chat-push-proof.test.js tests/chat-push-store.test.js`
- Full suite was attempted; unrelated billing Playwright cases timed out while focused Chat tests remained green.
