### PR TITLE
Attach Life Space drawings to cards

### DIFF
--- a/life-space/app.js
+++ b/life-space/app.js
@@ -136,7 +136,9 @@ function cardTemplate(item) {
   if (item.type === 'file') body = `<p class="type-label">File</p><div class="file-mark">${escapeHtml(fileExtension(item.fileName))}</div>${title}<p class="file-meta">${escapeHtml(formatBytes(item.fileSize))}</p><button class="download-file">Open file</button>`;
   return `<article class="life-card type-${item.type}" data-id="${item.id}" style="--card:${item.color};left:${item.x}px;top:${item.y}px;width:${item.w}px;height:${item.h}px;z-index:${item.z || 1}">
     <div class="drag-handle"><span class="card-kind">${({note:'Thought',checklist:'List',link:'Link',image:'Photo',file:'File'})[item.type]}</span><div class="card-actions"><button data-color title="Change color">●</button><button data-delete title="Delete">×</button></div></div>
-    <div class="card-body">${body}</div><div class="resize-handle" title="Resize"></div></article>`;
+    <div class="card-body">${body}</div>
+    <svg class="card-drawing-layer" data-card-drawings="${item.id}" aria-hidden="true"></svg>
+    <div class="resize-handle" title="Resize"></div></article>`;
 }
 
 function safeHost(url) { try { return new URL(url).hostname.replace(/^www\./,''); } catch { return url; } }
@@ -176,7 +178,12 @@ function renderSpaces() {
 }
 
 function renderStrokes() {
-  els.drawingLayer.innerHTML = activeSpace().strokes.map(stroke => `<polyline data-stroke="${stroke.id}" points="${stroke.points.map(p => `${p.x},${p.y}`).join(' ')}" fill="none" stroke="${stroke.color}" stroke-width="${stroke.width}" stroke-linecap="round" stroke-linejoin="round"/>`).join('');
+  const strokes = activeSpace().strokes;
+  const strokeMarkup = stroke => `<polyline data-stroke="${stroke.id}" points="${stroke.points.map(p => `${p.x},${p.y}`).join(' ')}" fill="none" stroke="${stroke.color}" stroke-width="${stroke.width}" stroke-linecap="round" stroke-linejoin="round"/>`;
+  els.drawingLayer.innerHTML = strokes.filter(stroke => !stroke.itemId).map(strokeMarkup).join('');
+  els.cardLayer.querySelectorAll('[data-card-drawings]').forEach(layer => {
+    layer.innerHTML = strokes.filter(stroke => stroke.itemId === layer.dataset.cardDrawings).map(strokeMarkup).join('');
+  });
 }
 
 function applyView() {
@@ -206,13 +213,20 @@ function boardPoint(event) {
   return { x:(event.clientX - rect.left - view.x) / view.zoom, y:(event.clientY - rect.top - view.y) / view.zoom };
 }
 
+function drawingPoint(event, stroke) {
+  const point = boardPoint(event);
+  const item = stroke.itemId ? itemById(stroke.itemId) : null;
+  return item ? { x:point.x - item.x, y:point.y - item.y } : point;
+}
+
 function pointerDown(event) {
   const card = event.target.closest('.life-card');
   if (drawMode && !event.target.closest('.tool-dock')) {
     event.preventDefault();
     const before = snapshot();
-    const point = boardPoint(event);
-    currentStroke = { id:uid('stroke'), color:'#ff7a59', width:4 / activeSpace().view.zoom, points:[point], createdAt:Date.now(), updatedAt:Date.now() };
+    currentStroke = { id:uid('stroke'), color:'#ff7a59', width:4 / activeSpace().view.zoom, points:[], createdAt:Date.now(), updatedAt:Date.now() };
+    if (card) currentStroke.itemId = card.dataset.id;
+    currentStroke.points.push(drawingPoint(event, currentStroke));
     activeSpace().strokes.push(currentStroke);
     interaction = { type:'draw', before };
     els.wrap.setPointerCapture(event.pointerId); renderStrokes(); return;
@@ -261,7 +275,7 @@ function pointerMove(event) {
     return;
   }
   if (interaction.type === 'draw') {
-    const point = boardPoint(event);
+    const point = drawingPoint(event, currentStroke);
     const last = currentStroke.points.at(-1);
     if (Math.hypot(point.x-last.x, point.y-last.y) > 2) currentStroke.points.push(point);
     renderStrokes();
@@ -315,8 +329,10 @@ function bindEvents() {
     const card = event.target.closest('.life-card');
     if (card && event.target.closest('[data-delete]')) {
       const before = snapshot();
-      activeSpace().deletedItemIds = [...new Set([...(activeSpace().deletedItemIds || []), card.dataset.id])];
+      const attachedStrokeIds = activeSpace().strokes.filter(stroke => stroke.itemId === card.dataset.id).map(stroke => stroke.id);
+      activeSpace().deletedItemIds = [...new Set([...(activeSpace().deletedItemIds || []), card.dataset.id, ...attachedStrokeIds])];
       activeSpace().items = activeSpace().items.filter(item => item.id !== card.dataset.id);
+      activeSpace().strokes = activeSpace().strokes.filter(stroke => stroke.itemId !== card.dataset.id);
       commitHistory(before); scheduleSave(); renderBoard();
     }
     if (card && event.target.closest('[data-color]')) {

--- a/life-space/index.html
+++ b/life-space/index.html
@@ -97,7 +97,7 @@
       <article><b>Move freely</b><p>Drag cards by their top edge. Drag empty space to pan. Pinch or use the zoom controls.</p></article>
       <article><b>Edit naturally</b><p>Click text and type. Changes save automatically. Resize a card from its lower corner.</p></article>
       <article><b>Keep it yours</b><p>Your workspace stays available offline. Sign in to sync an encrypted copy across devices, and export a backup whenever you want.</p></article>
-      <article><b>Draw over it</b><p>Turn on Draw, sketch with a mouse, pen, or finger, then turn it off to move things again.</p></article>
+      <article><b>Draw over it</b><p>Draw on a card and the sketch moves with it. Draw on empty space and the sketch stays with the world.</p></article>
     </div>
     <button class="primary-button wide" data-close-dialog>Start making space</button>
   </dialog>

--- a/life-space/styles.css
+++ b/life-space/styles.css
@@ -3,3 +3,4 @@
 .card-body{touch-action:none}
 .app-shell,.workspace{height:100vh;height:100lvh}
 @media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;transition:none!important}}
+.card-drawing-layer{position:absolute;inset:0;width:100%;height:100%;overflow:hidden;pointer-events:none;z-index:4}

--- a/tests/life-space.test.js
+++ b/tests/life-space.test.js
@@ -37,6 +37,16 @@ test('Life Space implements spatial interaction and history', () => {
   assert.match(js, /function travel/);
 });
 
+test('Life Space attaches drawings started on cards and renders them above card content', () => {
+  assert.match(js, /if \(card\) currentStroke\.itemId = card\.dataset\.id/);
+  assert.match(js, /function drawingPoint/);
+  assert.match(js, /point\.x - item\.x/);
+  assert.match(js, /stroke\.itemId === layer\.dataset\.cardDrawings/);
+  assert.match(js, /activeSpace\(\)\.strokes = activeSpace\(\)\.strokes\.filter\(stroke => stroke\.itemId !== card\.dataset\.id\)/);
+  assert.match(css, /\.card-drawing-layer\{[^}]*z-index:4/);
+  assert.match(html, /Draw on a card and the sketch moves with it/);
+});
+
 test('Life Space raises tapped or header-dragged cards and continuously pans from the card body', () => {
   assert.match(js, /function bringItemToFront/);
   assert.match(js, /item\.z >= 1000000/);


### PR DESCRIPTION
## Summary

- attach strokes started on a Life Space card to that card
- render card annotations above card contents while world ink stays underneath cards
- remove attached strokes with their card and keep the change undoable
- explain the two drawing behaviors in Life Space help

## Verification

- `node --test tests/life-space.test.js tests/life-space-sync.test.js` (10/10)
- 390×844 real Chromium gesture: draw on card, move card 80px, annotation remains attached with unchanged local points
- `git diff --check`

## Local full-suite note

The full local test command encountered unrelated billing browser timeouts. GitHub CI remains the full repository gate.
