### PR TITLE
Fix durable cross-browser Chat delivery

### DIFF
--- a/api/trial.js
+++ b/api/trial.js
@@ -126,6 +126,21 @@ export function createTrialHandler(options = {}) {
       }
     }
 
+    if (kind === 'chat-message') {
+      const action = String(req.body?.action || '');
+      if (!['publish', 'sync'].includes(action)) {
+        return res.status(400).json({ error: 'Invalid chat message action.' });
+      }
+
+      try {
+        const result = await chatPushStore(action, req.body || {}, config);
+        return res.status(200).json(result);
+      } catch (error) {
+        console.error('Chat message request failed:', error);
+        return res.status(503).json({ error: 'Chat sync is temporarily unavailable.' });
+      }
+    }
+
     // Keep the blog form on an existing serverless route. The Hobby plan has a
     // function limit, and this route already has the configured mail transport.
     if (kind === 'blog-signup') {

--- a/chat/index.html
+++ b/chat/index.html
@@ -5,8 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3DVR - Group Chat</title>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script>
+    if (!window.Gun) {
+      document.write('<script src="https://unpkg.com/gun/gun.js"><\\/script>');
+    }
+  </script>
   <script src="/gun-init.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script>
+    if (!window.SEA) {
+      document.write('<script src="https://unpkg.com/gun/sea.js"><\\/script>');
+    }
+  </script>
   <script src="/score.js"></script>
   <script src="/pwa-install.js" defer></script>
   <link rel="stylesheet" href="/styles/global.css">
@@ -165,7 +175,6 @@
 <script src="/chat/notification-routing.js"></script>
 <script>
 const gun = Gun(window.__GUN_PEERS__ || [
-  'wss://relay.3dvr.tech/gun',
   'wss://gun-relay-3dvr.fly.dev/gun'
 ]);
 const portalRoot = gun.get('3dvr-portal');
@@ -322,14 +331,23 @@ const notificationStateStorageKey = 'chatNotificationState';
 const pushDeliveryVerifiedStorageKey = 'chatPushDeliveryVerified';
 const chatPushApiPath = '/api/trial';
 const INITIAL_SYNC_GRACE_MS = 1500;
+const ROOM_RECONCILE_MS = 3000;
 let notificationsEnabled = false;
 let closedAppNotificationsEnabled = false;
 let pushDeliveryVerified = false;
 let serviceWorkerRegistration = null;
 let currentRoomStream = null;
+let currentLatestMessageStream = null;
+let roomReconcileTimer = 0;
+let currentRoomReconcile = null;
+let chatPublishQueue = Promise.resolve();
 const roomInitialSyncTimers = {};
 const notifiedMessageIdsByRoom = {};
 const notifiedMessageQueueByRoom = {};
+const latestMessageIdsByRoom = {};
+const latestMessageTimesByRoom = {};
+const recentSentMessagesByRoom = {};
+const pendingMessagesByRoom = {};
 
 const CHAT_USER_ROOT = '3dvr-users';
 const CHAT_GUEST_ROOT = '3dvr-guests';
@@ -802,16 +820,74 @@ function sendMessage() {
     text,
     sender: userId,
     username: cachedUsername,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    previousMessageId: latestMessageIdsByRoom[currentRoom] || ''
   };
 
-  chat.get(messageId).put(message);
+  const roomName = currentRoom;
+  const roomNode = chat;
+  latestMessageIdsByRoom[roomName] = messageId;
+  latestMessageTimesByRoom[roomName] = message.createdAt;
+  if (!recentSentMessagesByRoom[roomName]) {
+    recentSentMessagesByRoom[roomName] = [];
+  }
+  recentSentMessagesByRoom[roomName].push({ id: messageId, message });
+  recentSentMessagesByRoom[roomName] = recentSentMessagesByRoom[roomName].slice(-20);
+  if (!pendingMessagesByRoom[roomName]) {
+    pendingMessagesByRoom[roomName] = {};
+  }
+  pendingMessagesByRoom[roomName][messageId] = message;
+  messages[messageId] = message;
+  displayMessages();
+  writeChatMessage(messageId, message, roomNode, roomName);
+  roomNode.get('_latest').put(buildLatestMessagePointer(roomName, messageId, message.createdAt));
+  chatPublishQueue = chatPublishQueue
+    .then(() => publishChatMessageToServer(roomName, messageId, message))
+    .catch(error => {
+      console.warn('Durable chat delivery will retry during GUN sync', error);
+    });
 
   input.value = '';
 
   if (scoreManager) {
     scoreManager.increment(1);
   }
+}
+
+function buildLatestMessagePointer(roomName, messageId, createdAt) {
+  return {
+    id: messageId,
+    createdAt,
+    recent: JSON.stringify(recentSentMessagesByRoom[roomName] || [])
+  };
+}
+
+function writeChatMessage(messageId, message, roomNode, roomName, attempt = 0) {
+  let acknowledged = false;
+  const retryTimer = window.setTimeout(() => {
+    if (!acknowledged && attempt < 2) {
+      writeChatMessage(messageId, message, roomNode, roomName, attempt + 1);
+    }
+  }, 4000);
+
+  roomNode.get(messageId).put(message, ack => {
+    if (ack?.err) {
+      console.warn('Chat message write failed', ack.err);
+      if (attempt < 2) {
+        window.clearTimeout(retryTimer);
+        window.setTimeout(() => writeChatMessage(messageId, message, roomNode, roomName, attempt + 1), 500);
+      }
+      return;
+    }
+
+    if (ack?.ok) {
+      acknowledged = true;
+      window.clearTimeout(retryTimer);
+      if (latestMessageIdsByRoom[roomName] === messageId) {
+        roomNode.get('_latest').put(buildLatestMessagePointer(roomName, messageId, message.createdAt));
+      }
+    }
+  });
 }
 
 const messages = {};
@@ -844,7 +920,8 @@ function displayMessages() {
   const messagesDiv = document.getElementById('messages');
   messagesDiv.innerHTML = '';
 
-  const sorted = Object.entries(messages).sort(([, a], [, b]) => (b.createdAt || 0) - (a.createdAt || 0));
+  const visibleMessages = { ...messages, ...(pendingMessagesByRoom[currentRoom] || {}) };
+  const sorted = Object.entries(visibleMessages).sort(([, a], [, b]) => (b.createdAt || 0) - (a.createdAt || 0));
   for (const [id, message] of sorted) {
     const msgDiv = document.createElement('div');
     msgDiv.className = 'message';
@@ -947,40 +1024,108 @@ function loadRoom(roomName) {
   if (currentRoomStream && typeof currentRoomStream.off === 'function') {
     currentRoomStream.off();
   }
+  if (currentLatestMessageStream && typeof currentLatestMessageStream.off === 'function') {
+    currentLatestMessageStream.off();
+  }
+  if (roomReconcileTimer) {
+    window.clearInterval(roomReconcileTimer);
+    roomReconcileTimer = 0;
+  }
 
   chat = gun.get('3dvr-chat').get(roomName);
   const roomStream = chat.map();
   currentRoomStream = roomStream;
 
-  roomStream.on((message, id) => {
-    if (!message || messages[id]) return;
+  const ingestMessage = (message, id) => {
+    if (!message || !id || roomName !== currentRoom) return;
+    const mergedMessage = { ...(messages[id] || {}), ...message };
+    if (typeof mergedMessage.text !== 'string' || !mergedMessage.text.trim()) return;
+    const createdAt = Number(mergedMessage.createdAt) || 0;
+    if (createdAt >= (latestMessageTimesByRoom[roomName] || 0)) {
+      latestMessageTimesByRoom[roomName] = createdAt;
+      latestMessageIdsByRoom[roomName] = id;
+    }
 
-    if (message.sender) {
-      const existingUsername = typeof message.username === 'string'
-        ? message.username.trim()
+    if (mergedMessage.sender) {
+      const existingUsername = typeof mergedMessage.username === 'string'
+        ? mergedMessage.username.trim()
         : '';
       if (existingUsername) {
-        message.username = existingUsername;
-        messages[id] = message;
+        mergedMessage.username = existingUsername;
+        messages[id] = mergedMessage;
         displayMessages();
-        maybeNotifyNewMessage(message, id);
+        maybeNotifyNewMessage(mergedMessage, id);
         return;
       }
 
-      fetchSenderUsername(message.sender, resolvedName => {
-        const finalName = resolvedName || message.sender;
-        message.username = finalName;
-        messages[id] = message;
+      fetchSenderUsername(mergedMessage.sender, resolvedName => {
+        if (roomName !== currentRoom) return;
+        const finalName = resolvedName || mergedMessage.sender;
+        mergedMessage.username = finalName;
+        messages[id] = mergedMessage;
         displayMessages();
-        maybeNotifyNewMessage(message, id);
+        maybeNotifyNewMessage(mergedMessage, id);
       });
     } else {
-      messages[id] = message;
+      messages[id] = mergedMessage;
       displayMessages();
-      maybeNotifyNewMessage(message, id);
+      maybeNotifyNewMessage(mergedMessage, id);
     }
-  });
+  };
+
+  roomStream.on(ingestMessage);
+
+  const followedMessageIds = new Set();
+  const followMessageChain = (messageId, remaining = 50) => {
+    if (!messageId || remaining <= 0 || followedMessageIds.has(messageId)) return;
+    followedMessageIds.add(messageId);
+    const messageNode = chat.get(messageId);
+    messageNode.on(message => {
+      if (!message || typeof message.text !== 'string' || !message.text.trim()) return;
+      ingestMessage(message, messageId);
+      if (typeof messageNode.off === 'function') {
+        messageNode.off();
+      }
+      followMessageChain(message.previousMessageId, remaining - 1);
+    });
+  };
+
+  currentLatestMessageStream = chat.get('_latest');
+  const ingestLatestPointer = pointer => {
+    if (roomName !== currentRoom || !pointer) return;
+    if (typeof pointer.recent === 'string') {
+      try {
+        const recentMessages = JSON.parse(pointer.recent);
+        if (Array.isArray(recentMessages)) {
+          recentMessages.forEach(entry => ingestMessage(entry?.message, entry?.id));
+        }
+      } catch (error) {
+        console.warn('Unable to reconcile recent chat messages', error);
+      }
+    }
+    followMessageChain(pointer.id);
+  };
+  currentLatestMessageStream.on(ingestLatestPointer);
+
+  const reconcileRoom = () => {
+    if (roomName !== currentRoom) return;
+    chat.map().once(ingestMessage);
+    chat.get('_latest').once(ingestLatestPointer);
+    syncChatMessagesFromServer(roomName)
+      .then(entries => entries.forEach(entry => ingestMessage(entry?.message, entry?.id)))
+      .catch(error => console.warn('Durable chat sync unavailable; using GUN fallback', error));
+  };
+  currentRoomReconcile = reconcileRoom;
+  reconcileRoom();
+  roomReconcileTimer = window.setInterval(reconcileRoom, ROOM_RECONCILE_MS);
 }
+
+window.addEventListener('online', () => currentRoomReconcile?.());
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    currentRoomReconcile?.();
+  }
+});
 
 function changeRoom() {
   const select = roomSelectEl || document.getElementById('room');
@@ -1043,6 +1188,32 @@ async function callChatPushApi(action, payload = {}) {
   });
   if (!response.ok) throw new Error(`Chat push API returned ${response.status}`);
   return response.json();
+}
+
+async function callChatMessageApi(action, payload = {}) {
+  const response = await fetch(chatPushApiPath, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ kind: 'chat-message', action, ...payload })
+  });
+  if (!response.ok) throw new Error(`Chat message API returned ${response.status}`);
+  return response.json();
+}
+
+async function publishChatMessageToServer(room, messageId, message) {
+  return callChatMessageApi('publish', {
+    room,
+    messageId,
+    senderId: message.sender,
+    username: message.username,
+    text: message.text,
+    createdAt: message.createdAt
+  });
+}
+
+async function syncChatMessagesFromServer(room) {
+  const result = await callChatMessageApi('sync', { room });
+  return Array.isArray(result?.messages) ? result.messages : [];
 }
 
 async function getChatPushPublicKey() {

--- a/services/newsletter-store/schema.sql
+++ b/services/newsletter-store/schema.sql
@@ -43,4 +43,18 @@ CREATE TABLE IF NOT EXISTS chat_push_deliveries (
   PRIMARY KEY (room, message_id)
 );
 
-GRANT SELECT, INSERT, UPDATE, DELETE ON newsletter_subscribers, newsletter_sends, chat_push_subscriptions, chat_push_deliveries TO newsletter_store;
+CREATE TABLE IF NOT EXISTS chat_messages (
+  room TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  sender_id TEXT NOT NULL,
+  username TEXT,
+  body TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (room, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS chat_messages_room_created_idx
+  ON chat_messages (room, created_at DESC);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON newsletter_subscribers, newsletter_sends, chat_push_subscriptions, chat_push_deliveries, chat_messages TO newsletter_store;

--- a/services/newsletter-store/server.mjs
+++ b/services/newsletter-store/server.mjs
@@ -141,6 +141,51 @@ async function claimChatMessage(room, messageId) {
   return rowCount === 1;
 }
 
+async function listChatMessages(input) {
+  const room = cleanText(input.room, 32);
+  if (!chatRooms.has(room)) throw new Error('Invalid chat room.');
+  const { rows } = await pool.query(`
+    SELECT message_id, sender_id, username, body, created_at
+    FROM chat_messages
+    WHERE room = $1
+    ORDER BY created_at DESC
+    LIMIT 100
+  `, [room]);
+  return rows.map(row => ({
+    id: row.message_id,
+    message: {
+      sender: row.sender_id,
+      username: row.username || '',
+      text: row.body,
+      createdAt: new Date(row.created_at).getTime()
+    }
+  }));
+}
+
+async function publishChatMessage(input) {
+  const room = cleanText(input.room, 32);
+  const messageId = cleanText(input.messageId, 220);
+  const senderId = cleanText(input.senderId, 160);
+  const username = cleanText(input.username, 80);
+  const text = cleanText(input.text, 4000);
+  const createdAt = new Date(Number(input.createdAt) || Date.now());
+  if (!chatRooms.has(room) || !messageId || !senderId || !text || Number.isNaN(createdAt.getTime())) {
+    throw new Error('Invalid chat message.');
+  }
+
+  const { rowCount } = await pool.query(`
+    INSERT INTO chat_messages (room, message_id, sender_id, username, body, created_at)
+    VALUES ($1, $2, $3, $4, $5, $6)
+    ON CONFLICT (room, message_id) DO NOTHING
+  `, [room, messageId, senderId, username || null, text, createdAt.toISOString()]);
+
+  if (rowCount === 1 && await claimChatMessage(room, messageId)) {
+    await sendChatNotifications({ room, messageId, senderId, username, text });
+  }
+
+  return listChatMessages({ room });
+}
+
 function startChatPushWatcher() {
   if (!vapidPublicKey || !vapidPrivateKey || gunPeers.length === 0) {
     console.warn('chat push watcher disabled: VAPID or GUN peers are not configured');
@@ -211,6 +256,16 @@ const server = http.createServer(async (req, res) => {
       if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });
       await removeChatSubscription(await readBody(req));
       return json(res, 200, { ok: true });
+    }
+    if (req.url === '/v1/chat/publish' && req.method === 'POST') {
+      if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });
+      const messages = await publishChatMessage(await readBody(req));
+      return json(res, 201, { ok: true, messages });
+    }
+    if (req.url === '/v1/chat/sync' && req.method === 'POST') {
+      if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });
+      const messages = await listChatMessages(await readBody(req));
+      return json(res, 200, { ok: true, messages });
     }
     if (req.url === '/v1/subscribers' && req.method === 'GET') {
       if (!authorized(req)) return json(res, 401, { error: 'Unauthorized.' });

--- a/tests/chat-cross-browser.e2e.test.js
+++ b/tests/chat-cross-browser.e2e.test.js
@@ -1,0 +1,170 @@
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { chromium, firefox } from 'playwright';
+
+let chromiumBrowser;
+let firefoxBrowser;
+let server;
+const TEST_ORIGIN = 'http://127.0.0.1:4320';
+
+async function waitForServer() {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      const response = await fetch(`${TEST_ORIGIN}/chat/`);
+      if (response.ok) return;
+    } catch {
+      // Server is still starting.
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error('Chat test server did not start.');
+}
+
+async function openRandomRoom(browser, durableMessages) {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    serviceWorkers: 'block'
+  });
+  await context.addInitScript(() => {
+    window.__GUN_PEERS__ = [];
+  });
+  await context.route('**/api/trial', async route => {
+    const request = route.request();
+    if (request.method() === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ chatPushPublicKey: '' }) });
+    }
+    const body = request.postDataJSON();
+    if (body.kind === 'chat-message' && body.action === 'publish') {
+      if (!durableMessages.some(entry => entry.id === body.messageId)) {
+        durableMessages.push({
+          id: body.messageId,
+          message: {
+            sender: body.senderId,
+            username: body.username,
+            text: body.text,
+            createdAt: body.createdAt
+          }
+        });
+      }
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, messages: durableMessages })
+    });
+  });
+  const page = await context.newPage();
+  await page.goto(`${TEST_ORIGIN}/chat/#support`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => document.querySelector('#current-username')?.textContent !== 'Loading...');
+  return { context, page };
+}
+
+async function waitForMessage(page, text, timeout = 15_000) {
+  await page.waitForFunction(
+    expected => [...document.querySelectorAll('.message')]
+      .some(node => node.textContent?.includes(expected)),
+    text,
+    { timeout }
+  );
+}
+
+before(async () => {
+  server = spawn(process.execPath, ['scripts/dev-server.mjs'], {
+    cwd: new URL('..', import.meta.url),
+    env: { ...process.env, PORT: '4320', HOST: '127.0.0.1' },
+    stdio: 'ignore'
+  });
+  await waitForServer();
+  [chromiumBrowser, firefoxBrowser] = await Promise.all([
+    chromium.launch({ headless: true }),
+    firefox.launch({ headless: true })
+  ]);
+});
+
+after(async () => {
+  await Promise.all([chromiumBrowser?.close(), firefoxBrowser?.close()]);
+  server?.kill('SIGTERM');
+});
+
+describe('Chat cross-browser delivery', () => {
+  it('delivers a Firefox message to an already-open Chromium chat', async () => {
+    const durableMessages = [];
+    const [{ context: chromeContext, page: chromePage }, { context: firefoxContext, page: firefoxPage }] =
+      await Promise.all([
+        openRandomRoom(chromiumBrowser, durableMessages),
+        openRandomRoom(firefoxBrowser, durableMessages)
+      ]);
+    const message = `Cross-browser sync test ${Date.now()}`;
+
+    await firefoxPage.locator('#message-input').fill(message);
+    await firefoxPage.getByRole('button', { name: 'Send' }).click();
+    try {
+      await waitForMessage(firefoxPage, message);
+    } catch (error) {
+      const state = await firefoxPage.evaluate(() => ({
+        input: document.querySelector('#message-input')?.value,
+        messages: [...document.querySelectorAll('.message')].slice(0, 5).map(node => node.textContent),
+        sendMessageType: typeof sendMessage,
+        optimisticSource: sendMessage.toString().includes('messages[messageId] = message'),
+        pendingSource: displayMessages.toString().includes('pendingMessagesByRoom[currentRoom]'),
+        pending: Object.values(pendingMessagesByRoom[currentRoom] || {}).map(message => message.text),
+        stored: Object.values(messages).slice(0, 5).map(message => message.text),
+        room: currentRoom
+      }));
+      throw new Error(`Firefox did not render its own message: ${JSON.stringify(state)}`, { cause: error });
+    }
+    await waitForMessage(chromePage, message);
+
+    assert.match(await chromePage.locator('.message').filter({ hasText: message }).first().textContent(), /Cross-browser sync test/);
+    await Promise.all([chromeContext.close(), firefoxContext.close()]);
+  });
+
+  it('does not omit a burst of Firefox messages from Chromium', async () => {
+    const durableMessages = [];
+    const [{ context: chromeContext, page: chromePage }, { context: firefoxContext, page: firefoxPage }] =
+      await Promise.all([
+        openRandomRoom(chromiumBrowser, durableMessages),
+        openRandomRoom(firefoxBrowser, durableMessages)
+      ]);
+    const prefix = `Cross-browser burst ${Date.now()}`;
+    const messages = Array.from({ length: 12 }, (_, index) => `${prefix} ${index + 1}`);
+
+    for (const message of messages) {
+      await firefoxPage.locator('#message-input').fill(message);
+      await firefoxPage.getByRole('button', { name: 'Send' }).click();
+      try {
+        await waitForMessage(firefoxPage, message, 5_000);
+      } catch (error) {
+        const state = await firefoxPage.evaluate(expected => ({
+          expected,
+          input: document.querySelector('#message-input')?.value,
+          rendered: [...document.querySelectorAll('.message')].map(node => node.textContent),
+          pending: Object.values(pendingMessagesByRoom[currentRoom] || {}).map(entry => entry.text),
+          stored: Object.values(messages).map(entry => entry.text)
+        }), message);
+        throw new Error(`Firefox lost optimistic burst message: ${JSON.stringify(state)}`, { cause: error });
+      }
+    }
+
+    try {
+      await chromePage.waitForFunction(
+        ({ expectedPrefix, count }) =>
+          [...document.querySelectorAll('.message')]
+            .filter(node => node.textContent?.includes(expectedPrefix)).length === count,
+        { expectedPrefix: prefix, count: messages.length },
+        { timeout: 30_000 }
+      );
+    } catch (error) {
+      const received = await chromePage.locator('.message').filter({ hasText: prefix }).allTextContents();
+      throw new Error(
+        `Chromium received ${received.length}/${messages.length}; durable store has ${durableMessages.length}: ${JSON.stringify(received)}`,
+        { cause: error }
+      );
+    }
+
+    const received = await chromePage.locator('.message').filter({ hasText: prefix }).allTextContents();
+    assert.equal(received.length, messages.length);
+    await Promise.all([chromeContext.close(), firefoxContext.close()]);
+  });
+});

--- a/tests/gun-peer-config.test.js
+++ b/tests/gun-peer-config.test.js
@@ -39,4 +39,11 @@ describe('Gun peer configuration', () => {
       assert.match(source, /wss:\/\/gun-relay-3dvr\.fly\.dev\/gun/, `${path} should include the Fly relay fallback`);
     }
   });
+
+  it('does not let Chat try the dead relay before the working Fly relay', async () => {
+    const source = await read('chat/index.html');
+
+    assert.doesNotMatch(source, /wss:\/\/relay\.3dvr\.tech\/gun/);
+    assert.match(source, /wss:\/\/gun-relay-3dvr\.fly\.dev\/gun/);
+  });
 });


### PR DESCRIPTION
Removes the dead Chat relay, preserves the existing durable Postgres reconciliation work, and adds deterministic Firefox-to-Chromium delivery coverage including a burst test. Guest mode, mobile overflow, push routing, and peer configuration tests pass sequentially. No autonomous outreach changes.