### PR TITLE
Smooth Life Space drawing and pinch gestures

### DIFF
--- a/life-space/app.js
+++ b/life-space/app.js
@@ -30,6 +30,8 @@ let history = [];
 let future = [];
 let objectUrls = new Map();
 let sync;
+const activePointers = new Map();
+let pinch = null;
 
 const activeSpace = () => state.spaces.find(space => space.id === state.activeSpaceId) || state.spaces[0];
 const itemById = id => activeSpace().items.find(item => item.id === id);
@@ -213,22 +215,70 @@ function boardPoint(event) {
   return { x:(event.clientX - rect.left - view.x) / view.zoom, y:(event.clientY - rect.top - view.y) / view.zoom };
 }
 
-function drawingPoint(event, stroke) {
-  const point = boardPoint(event);
-  const item = stroke.itemId ? itemById(stroke.itemId) : null;
+function drawingPointForItem(point, itemId) {
+  const item = itemId ? itemById(itemId) : null;
   return item ? { x:point.x - item.x, y:point.y - item.y } : point;
 }
 
+function drawingItemAt(event) {
+  return document.elementFromPoint(event.clientX, event.clientY)?.closest('.life-card')?.dataset.id;
+}
+
+function beginPinch() {
+  const points = [...activePointers.values()];
+  if (points.length < 2) return;
+  if (interaction?.before) {
+    state = JSON.parse(interaction.before);
+    renderBoard();
+  }
+  currentStroke = null;
+  interaction = null;
+  els.wrap.classList.remove('panning');
+  const [a, b] = points;
+  const rect = els.wrap.getBoundingClientRect();
+  const center = { x:(a.x + b.x) / 2 - rect.left, y:(a.y + b.y) / 2 - rect.top };
+  const view = activeSpace().view;
+  pinch = {
+    distance: Math.max(1, Math.hypot(a.x - b.x, a.y - b.y)),
+    zoom: view.zoom,
+    worldX: (center.x - view.x) / view.zoom,
+    worldY: (center.y - view.y) / view.zoom
+  };
+}
+
+function updatePinch() {
+  const points = [...activePointers.values()];
+  if (!pinch || points.length < 2) return;
+  const [a, b] = points;
+  const rect = els.wrap.getBoundingClientRect();
+  const center = { x:(a.x + b.x) / 2 - rect.left, y:(a.y + b.y) / 2 - rect.top };
+  const distance = Math.max(1, Math.hypot(a.x - b.x, a.y - b.y));
+  const view = activeSpace().view;
+  view.zoom = clamp(pinch.zoom * distance / pinch.distance, .35, 2);
+  view.x = center.x - pinch.worldX * view.zoom;
+  view.y = center.y - pinch.worldY * view.zoom;
+  applyView();
+}
+
 function pointerDown(event) {
+  activePointers.set(event.pointerId, { x:event.clientX, y:event.clientY });
+  if (activePointers.size === 2) {
+    event.preventDefault();
+    els.wrap.setPointerCapture(event.pointerId);
+    beginPinch();
+    return;
+  }
+  if (pinch) return;
   const card = event.target.closest('.life-card');
   if (drawMode && !event.target.closest('.tool-dock')) {
     event.preventDefault();
     const before = snapshot();
-    currentStroke = { id:uid('stroke'), color:'#ff7a59', width:4 / activeSpace().view.zoom, points:[], createdAt:Date.now(), updatedAt:Date.now() };
+    currentStroke = { id:uid('stroke'), gestureId:uid('gesture'), color:'#ff7a59', width:4 / activeSpace().view.zoom, points:[], createdAt:Date.now(), updatedAt:Date.now() };
     if (card) currentStroke.itemId = card.dataset.id;
-    currentStroke.points.push(drawingPoint(event, currentStroke));
+    const point = boardPoint(event);
+    currentStroke.points.push(drawingPointForItem(point, currentStroke.itemId));
     activeSpace().strokes.push(currentStroke);
-    interaction = { type:'draw', before };
+    interaction = { type:'draw', before, lastBoardPoint:point };
     els.wrap.setPointerCapture(event.pointerId); renderStrokes(); return;
   }
   if (card && event.target.closest('.drag-handle') && !event.target.closest('button')) {
@@ -260,6 +310,12 @@ function pointerDown(event) {
 }
 
 function pointerMove(event) {
+  if (activePointers.has(event.pointerId)) activePointers.set(event.pointerId, { x:event.clientX, y:event.clientY });
+  if (pinch) {
+    event.preventDefault();
+    updatePinch();
+    return;
+  }
   if (!interaction) return;
   const view = activeSpace().view;
   if (interaction.type === 'card-pan') {
@@ -275,9 +331,25 @@ function pointerMove(event) {
     return;
   }
   if (interaction.type === 'draw') {
-    const point = drawingPoint(event, currentStroke);
+    const board = boardPoint(event);
+    const itemId = drawingItemAt(event);
+    if (itemId !== currentStroke.itemId) {
+      currentStroke.updatedAt = Date.now();
+      currentStroke = {
+        id:uid('stroke'), gestureId:currentStroke.gestureId, itemId,
+        color:currentStroke.color, width:currentStroke.width,
+        points:[drawingPointForItem(interaction.lastBoardPoint, itemId)],
+        createdAt:Date.now(), updatedAt:Date.now()
+      };
+      if (!itemId) delete currentStroke.itemId;
+      activeSpace().strokes.push(currentStroke);
+    }
+    const point = drawingPointForItem(board, currentStroke.itemId);
     const last = currentStroke.points.at(-1);
-    if (Math.hypot(point.x-last.x, point.y-last.y) > 2) currentStroke.points.push(point);
+    if (Math.hypot(point.x-last.x, point.y-last.y) > 2) {
+      currentStroke.points.push(point);
+      interaction.lastBoardPoint = board;
+    }
     renderStrokes();
   }
   if (interaction.type === 'drag') {
@@ -300,6 +372,14 @@ function pointerMove(event) {
 }
 
 function pointerUp(event) {
+  activePointers.delete(event.pointerId);
+  if (pinch) {
+    if (activePointers.size === 0) {
+      pinch = null;
+      scheduleSave();
+    }
+    return;
+  }
   if (!interaction) return;
   if (interaction.type === 'card-pan') {
     if (interaction.moved) scheduleSave();

--- a/tests/life-space.test.js
+++ b/tests/life-space.test.js
@@ -39,12 +39,28 @@ test('Life Space implements spatial interaction and history', () => {
 
 test('Life Space attaches drawings started on cards and renders them above card content', () => {
   assert.match(js, /if \(card\) currentStroke\.itemId = card\.dataset\.id/);
-  assert.match(js, /function drawingPoint/);
+  assert.match(js, /function drawingPointForItem/);
   assert.match(js, /point\.x - item\.x/);
   assert.match(js, /stroke\.itemId === layer\.dataset\.cardDrawings/);
   assert.match(js, /activeSpace\(\)\.strokes = activeSpace\(\)\.strokes\.filter\(stroke => stroke\.itemId !== card\.dataset\.id\)/);
   assert.match(css, /\.card-drawing-layer\{[^}]*z-index:4/);
   assert.match(html, /Draw on a card and the sketch moves with it/);
+});
+
+test('Life Space keeps drawing gestures visually continuous across cards and the background', () => {
+  assert.match(js, /function drawingItemAt/);
+  assert.match(js, /itemId !== currentStroke\.itemId/);
+  assert.match(js, /gestureId:currentStroke\.gestureId/);
+  assert.match(js, /points:\[drawingPointForItem\(interaction\.lastBoardPoint, itemId\)\]/);
+});
+
+test('Life Space supports two-pointer pinch zoom anchored between the fingers', () => {
+  assert.match(js, /const activePointers = new Map\(\)/);
+  assert.match(js, /function beginPinch/);
+  assert.match(js, /function updatePinch/);
+  assert.match(js, /pinch\.zoom \* distance \/ pinch\.distance/);
+  assert.match(js, /view\.x = center\.x - pinch\.worldX \* view\.zoom/);
+  assert.match(js, /view\.y = center\.y - pinch\.worldY \* view\.zoom/);
 });
 
 test('Life Space raises tapped or header-dragged cards and continuously pans from the card body', () => {


### PR DESCRIPTION
## What changed
- split a drawing gesture only when it crosses between a card and the world layer, duplicating the boundary point so it looks continuous
- preserve card-relative stroke segments so annotations continue moving with their cards
- add two-pointer pinch zoom and pan anchored between the fingers
- cancel an in-progress one-finger interaction cleanly when a pinch begins

## Verification
- `node --check life-space/app.js`
- 27 focused Life/Life Space tests pass
- mobile browser interaction exercised at 390×844

Stripe/account impact: none.