### PR TITLE
Quarantine dead Chat push relay

### DIFF
--- a/services/newsletter-store/server.mjs
+++ b/services/newsletter-store/server.mjs
@@ -12,8 +12,12 @@ if (!token || !databaseUrl) throw new Error('NEWSLETTER_STORE_TOKEN and DATABASE
 const vapidSubject = String(process.env.CHAT_PUSH_VAPID_SUBJECT || 'mailto:3dvr.tech@gmail.com');
 const vapidPublicKey = String(process.env.CHAT_PUSH_VAPID_PUBLIC_KEY || '');
 const vapidPrivateKey = String(process.env.CHAT_PUSH_VAPID_PRIVATE_KEY || '');
-const gunPeers = String(process.env.CHAT_PUSH_GUN_PEERS || 'https://relay.3dvr.tech/gun,https://gun-relay-3dvr.fly.dev/gun')
-  .split(',').map(value => value.trim()).filter(Boolean);
+const disabledGunPeers = new Set([
+  'https://relay.3dvr.tech/gun',
+  'wss://relay.3dvr.tech/gun'
+]);
+const gunPeers = String(process.env.CHAT_PUSH_GUN_PEERS || 'https://gun-relay-3dvr.fly.dev/gun')
+  .split(',').map(value => value.trim()).filter(peer => peer && !disabledGunPeers.has(peer));
 if (vapidPublicKey && vapidPrivateKey) {
   webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
 }

--- a/tests/gun-peer-config.test.js
+++ b/tests/gun-peer-config.test.js
@@ -46,4 +46,15 @@ describe('Gun peer configuration', () => {
     assert.doesNotMatch(source, /wss:\/\/relay\.3dvr\.tech\/gun/);
     assert.match(source, /wss:\/\/gun-relay-3dvr\.fly\.dev\/gun/);
   });
+
+  it('quarantines the dead relay from the server-side Chat push watcher', async () => {
+    const source = await read('services/newsletter-store/server.mjs');
+    const flyIndex = source.indexOf("process.env.CHAT_PUSH_GUN_PEERS || 'https://gun-relay-3dvr.fly.dev/gun'");
+    const filterIndex = source.indexOf('.filter(peer => peer && !disabledGunPeers.has(peer))');
+
+    assert.notEqual(flyIndex, -1, 'the push watcher should default to the working Fly relay');
+    assert.notEqual(filterIndex, -1, 'configured peers should filter the dead relay');
+    assert.match(source, /'https:\/\/relay\.3dvr\.tech\/gun'/);
+    assert.match(source, /'wss:\/\/relay\.3dvr\.tech\/gun'/);
+  });
 });


### PR DESCRIPTION
Summary:
- default the server-side Chat push watcher to the working Fly relay
- filter the known-dead relay from configured peers
- add a regression assertion for the production watcher path

Evidence:
- dead relay WebSocket failed; Fly WebSocket opened in about 300ms
- focused peer, push, and CRM tests: 9/9 passed
- automated Firefox/Chromium acceptance: 3/3 passed
- live bidirectional Chat: 5/5 delivered once without refresh; p95 2,130ms, so the under-2s target is not claimed

No Stripe, billing, outreach, or email impact. Physical closed-app push remains a separate device check.