### PR TITLE
Make portal spinner pull tilt playful

### DIFF
--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -9,8 +9,9 @@
   const SPIN_DECAY = 0.995;
   const FLIP_DECAY = 0.965;
   const MIN_FLIP_VELOCITY = 0.005;
-  const TILT_X_LIMIT = 0.18;
-  const TILT_Y_LIMIT = 0.24;
+  const TILT_X_LIMIT = 0.52;
+  const TILT_Y_LIMIT = 0.68;
+  const PULL_TILT_GAIN = 0.0042;
   const TWIST_LIMIT = 0.045;
   const TWIST_FACTOR = 0.0012;
   const FLIP_DISTANCE_THRESHOLD = 42;
@@ -505,8 +506,12 @@
       const centerX = point.rect.width / 2;
       const centerY = point.rect.height / 2;
       const tiltBoost = getSwipeBoost();
-      state.targetY = clamp((point.x - centerX) / centerX, -1, 1) * TILT_Y_LIMIT * tiltBoost;
-      state.targetX = clamp((point.y - centerY) / centerY, -1, 1) * TILT_X_LIMIT * tiltBoost;
+      const pointerTiltY = clamp((point.x - centerX) / centerX, -1, 1) * TILT_Y_LIMIT;
+      const pointerTiltX = clamp((point.y - centerY) / centerY, -1, 1) * TILT_X_LIMIT;
+      const pullTiltY = state.gestureDX * PULL_TILT_GAIN;
+      const pullTiltX = state.gestureDY * PULL_TILT_GAIN;
+      state.targetY = clamp((pointerTiltY + pullTiltY) * tiltBoost, -TILT_Y_LIMIT, TILT_Y_LIMIT);
+      state.targetX = clamp((pointerTiltX + pullTiltX) * tiltBoost, -TILT_X_LIMIT, TILT_X_LIMIT);
       state.targetZ = clamp((dx - dy) * TWIST_FACTOR, -TWIST_LIMIT, TWIST_LIMIT);
     };
 

--- a/tests/portal-logo-branding.test.js
+++ b/tests/portal-logo-branding.test.js
@@ -67,8 +67,9 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /flipVelocityX/);
     assert.match(swirlScript, /flipVelocityY/);
     assert.match(swirlScript, /MIN_FLIP_VELOCITY = 0\.005/);
-    assert.match(swirlScript, /TILT_Y_LIMIT = 0\.24/);
-    assert.match(swirlScript, /TILT_X_LIMIT = 0\.18/);
+    assert.match(swirlScript, /TILT_Y_LIMIT = 0\.68/);
+    assert.match(swirlScript, /TILT_X_LIMIT = 0\.52/);
+    assert.match(swirlScript, /PULL_TILT_GAIN = 0\.0042/);
     assert.match(swirlScript, /FLIP_STREAK_REQUIRED = 4/);
     assert.match(swirlScript, /FLIP_STREAK_WINDOW = 3200/);
     assert.match(swirlScript, /SWIPE_STREAK_MAX = 5/);
@@ -103,8 +104,10 @@ describe('portal logo branding', () => {
     assert.match(swirlScript, /nearestGoodFaceAngle/);
     assert.match(swirlScript, /UPRIGHT_TEXT_STEP = TAU/);
     assert.match(swirlScript, /nearestUprightTextAngle/);
-    assert.match(swirlScript, /state\.targetY = clamp\(\(point\.x - centerX\) \/ centerX, -1, 1\) \* TILT_Y_LIMIT \* tiltBoost/);
-    assert.match(swirlScript, /state\.targetX = clamp\(\(point\.y - centerY\) \/ centerY, -1, 1\) \* TILT_X_LIMIT \* tiltBoost/);
+    assert.match(swirlScript, /const pullTiltY = state\.gestureDX \* PULL_TILT_GAIN/);
+    assert.match(swirlScript, /const pullTiltX = state\.gestureDY \* PULL_TILT_GAIN/);
+    assert.match(swirlScript, /state\.targetY = clamp\(\(pointerTiltY \+ pullTiltY\) \* tiltBoost, -TILT_Y_LIMIT, TILT_Y_LIMIT\)/);
+    assert.match(swirlScript, /state\.targetX = clamp\(\(pointerTiltX \+ pullTiltX\) \* tiltBoost, -TILT_X_LIMIT, TILT_X_LIMIT\)/);
     assert.match(swirlScript, /getTouchSpinScale/);
     assert.match(swirlScript, /getTouchWobbleScale/);
     assert.match(swirlScript, /getTouchFlipScale/);


### PR DESCRIPTION
## Summary
- expand the spinner tilt range substantially
- add pull-distance tilt so longer drags lean harder
- retain bounded motion and swipe streak boost

## Verification
- node --test tests/portal-logo-branding.test.js