### PR TITLE
Verify and retry Life Space Gun sync

### DIFF
--- a/life-space/sync.js
+++ b/life-space/sync.js
@@ -139,6 +139,8 @@ export function createLifeSpaceSync({
   let ready = false;
   let setupPromise = null;
   let pendingPayload = null;
+  let pendingNeedsMerge = false;
+  let initialLoadComplete = false;
   let pendingToken = 0;
   let confirmedToken = 0;
   let drainPromise = null;
@@ -152,21 +154,32 @@ export function createLifeSpaceSync({
     return safeStorageGet(storage, PENDING_KEY);
   }
 
-  function markPending(payload) {
-    pendingPayload = payload;
-    pendingToken += 1;
+  function readPendingMarker() {
+    try { return JSON.parse(pendingMarker()) || null; } catch { return null; }
+  }
+
+  function persistPendingMarker() {
     const marker = {
       queuedAt: Date.now(),
-      stateUpdatedAt: modified(payload?.state),
-      token: pendingToken
+      stateUpdatedAt: modified(pendingPayload?.state),
+      token: pendingToken,
+      needsMerge: pendingNeedsMerge
     };
     safeStorageSet(storage, PENDING_KEY, JSON.stringify(marker));
+  }
+
+  function markPending(payload, { needsMerge = !initialLoadComplete } = {}) {
+    pendingPayload = payload;
+    pendingNeedsMerge = Boolean(needsMerge);
+    pendingToken += 1;
+    persistPendingMarker();
     return pendingToken;
   }
 
   function clearPending(token) {
     if (token !== pendingToken) return;
     pendingPayload = null;
+    pendingNeedsMerge = false;
     confirmedToken = token;
     safeStorageRemove(storage, PENDING_KEY);
     retryDelay = 2000;
@@ -352,6 +365,25 @@ export function createLifeSpaceSync({
     if (!pendingPayload) return false;
     drainPromise = (async () => {
       while (pendingPayload) {
+        if (pendingNeedsMerge) {
+          if (!(await ensureReady()) || !node) {
+            onStatus('Saved here · Account sync pending');
+            scheduleRetry();
+            return false;
+          }
+          try {
+            const remote = await readPayload(node);
+            if (remote.kind === 'ready') pendingPayload = mergeLifeSpacePayloads(pendingPayload, remote.payload);
+            pendingNeedsMerge = false;
+            initialLoadComplete = true;
+            persistPendingMarker();
+          } catch {
+            onStatus('Saved here · Waiting to reconcile account copy');
+            scheduleRetry();
+            return false;
+          }
+        }
+
         const payload = pendingPayload;
         const token = pendingToken;
         const saved = await writeAndVerify(payload);
@@ -394,32 +426,51 @@ export function createLifeSpaceSync({
   return {
     ready: readyPromise,
     async load(localPayload) {
-      if (pendingMarker()) {
+      const storedMarker = readPendingMarker();
+      if (storedMarker) {
         pendingPayload = localPayload;
+        pendingNeedsMerge = storedMarker.needsMerge !== false;
         pendingToken += 1;
       }
-      if (!(await ensureReady()) || !node) return null;
+      if (!(await ensureReady()) || !node) {
+        if (hasWorkspaceContent(localPayload) && !pendingPayload) {
+          markPending(localPayload, { needsMerge: true });
+          onStatus('Saved here · Sign in will resume account sync');
+        }
+        return null;
+      }
       try {
         const remote = await readPayload(node);
+        initialLoadComplete = true;
         if (remote.kind === 'missing') {
           if (!hasWorkspaceContent(localPayload)) {
             onStatus('Account sync ready');
             return null;
           }
+          if (storedMarker) {
+            pendingPayload = localPayload;
+            pendingNeedsMerge = false;
+            persistPendingMarker();
+          }
           onStatus('No account copy yet · Uploading this device…');
           return localPayload;
         }
         const merged = mergeLifeSpacePayloads(localPayload, remote.payload);
-        if (pendingMarker()) pendingPayload = merged;
-        onStatus(pendingMarker() ? 'Account copy loaded · Pending changes will retry' : 'Account copy loaded');
+        if (storedMarker) {
+          pendingPayload = merged;
+          pendingNeedsMerge = false;
+          persistPendingMarker();
+        }
+        onStatus(storedMarker ? 'Account copy loaded · Pending changes will retry' : 'Account copy loaded');
         return merged;
       } catch {
+        if (hasWorkspaceContent(localPayload) && !pendingPayload) markPending(localPayload, { needsMerge: true });
         onStatus('Account workspace could not be opened');
         return null;
       }
     },
     async save(payload) {
-      const token = markPending(payload);
+      const token = markPending(payload, { needsMerge: !initialLoadComplete });
       const saved = await drainPending();
       return saved && confirmedToken >= token;
     },

--- a/life-space/sync.js
+++ b/life-space/sync.js
@@ -1,24 +1,78 @@
 const SYNC_NODE = 'life-space-v01';
 const CHUNK_SIZE = 24 * 1024;
 const READ_TIMEOUT_MS = 6000;
+const SESSION_TIMEOUT_MS = 8000;
+const WRITE_TIMEOUT_MS = 5000;
+const PENDING_KEY = 'life-space:pending-account-sync:v2';
 
 const delay = (windowObj, ms) => new Promise(resolve => windowObj.setTimeout(resolve, ms));
-const once = (node, windowObj, timeoutMs = READ_TIMEOUT_MS) => new Promise(resolve => {
-  let settled = false;
-  const finish = value => { if (!settled) { settled = true; resolve(value); } };
-  try {
-    node.once(value => {
-      // GUN may report an empty local cache before the relay answers. Keep
-      // listening until useful data arrives or the read window expires.
-      if (value !== null && value !== undefined) finish(value);
-    });
-    windowObj.setTimeout(() => finish(null), timeoutMs);
-  } catch { finish(null); }
-});
-const put = (node, value) => new Promise(resolve => {
-  try { node.put(value, ack => resolve(!ack?.err)); } catch { resolve(false); }
-});
 const modified = value => Number(value?.updatedAt || value?.createdAt || 0);
+
+function safeStorageGet(storage, key) {
+  try { return storage?.getItem?.(key) || ''; } catch { return ''; }
+}
+
+function safeStorageSet(storage, key, value) {
+  try { storage?.setItem?.(key, value); return true; } catch { return false; }
+}
+
+function safeStorageRemove(storage, key) {
+  try { storage?.removeItem?.(key); return true; } catch { return false; }
+}
+
+function waitForValue(node, predicate, windowObj, timeoutMs = READ_TIMEOUT_MS) {
+  return new Promise(resolve => {
+    let settled = false;
+    let subscription = null;
+    let timer = null;
+    const finish = value => {
+      if (settled) return;
+      settled = true;
+      if (timer) windowObj.clearTimeout?.(timer);
+      try {
+        if (subscription && typeof subscription.off === 'function') subscription.off();
+        else if (typeof node?.off === 'function') node.off();
+      } catch {}
+      resolve(value);
+    };
+    const accept = value => {
+      try { if (predicate(value)) finish(value); } catch {}
+    };
+    timer = windowObj.setTimeout(() => finish(null), Math.max(0, timeoutMs));
+    try {
+      if (typeof node?.on === 'function') subscription = node.on(accept);
+      else if (typeof node?.once === 'function') node.once(accept);
+      else finish(null);
+    } catch { finish(null); }
+  });
+}
+
+function put(node, value, windowObj, timeoutMs = WRITE_TIMEOUT_MS) {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = result => { if (!settled) { settled = true; resolve(result); } };
+    const timer = windowObj.setTimeout(() => finish(false), Math.max(0, timeoutMs));
+    try {
+      node.put(value, ack => {
+        windowObj.clearTimeout?.(timer);
+        finish(!ack?.err);
+      });
+    } catch {
+      windowObj.clearTimeout?.(timer);
+      finish(false);
+    }
+  });
+}
+
+function mergeById(local = [], remote = []) {
+  const values = new Map();
+  for (const value of [...remote, ...local]) {
+    if (!value?.id) continue;
+    const current = values.get(value.id);
+    if (!current || modified(value) >= modified(current)) values.set(value.id, value);
+  }
+  return [...values.values()];
+}
 
 function hasWorkspaceContent(payload) {
   const state = payload?.state;
@@ -32,16 +86,6 @@ function hasWorkspaceContent(payload) {
     || (space?.id && space.id !== 'space-home')
     || (space?.name && space.name !== 'My Life')
   ));
-}
-
-function mergeById(local = [], remote = []) {
-  const values = new Map();
-  for (const value of [...remote, ...local]) {
-    if (!value?.id) continue;
-    const current = values.get(value.id);
-    if (!current || modified(value) >= modified(current)) values.set(value.id, value);
-  }
-  return [...values.values()];
 }
 
 export function mergeLifeSpaceStates(localState, remoteState) {
@@ -80,95 +124,307 @@ export function mergeLifeSpacePayloads(localPayload, remotePayload) {
   };
 }
 
-export function createLifeSpaceSync({ windowObj = window, onStatus = () => {}, readTimeoutMs = READ_TIMEOUT_MS } = {}) {
+export function createLifeSpaceSync({
+  windowObj = window,
+  onStatus = () => {},
+  readTimeoutMs = READ_TIMEOUT_MS,
+  sessionTimeoutMs = SESSION_TIMEOUT_MS,
+  verifyTimeoutMs = Math.max(readTimeoutMs, 6000),
+  writeTimeoutMs = WRITE_TIMEOUT_MS
+} = {}) {
+  let gun = null;
+  let user = null;
   let node = null;
   let secret = null;
   let ready = false;
-  let revision = 0;
-  const init = async () => {
-    if (typeof windowObj.Gun !== 'function' || !windowObj.SEA) return false;
-    try {
-      windowObj.AuthIdentity?.syncStorageFromSharedIdentity?.(windowObj.localStorage);
-      const gun = windowObj.Gun({ peers: windowObj.__GUN_PEERS__ || [] });
-      const user = gun.user();
-      user.recall?.({ sessionStorage: true, localStorage: true });
-      for (let attempt = 0; attempt < 12 && !user.is; attempt += 1) await delay(windowObj, 150);
-      secret = user?._?.sea || null;
-      if (!user.is?.pub || !secret || typeof windowObj.SEA.encrypt !== 'function' || typeof windowObj.SEA.decrypt !== 'function') {
-        onStatus('Saved on this device · Sign in to sync');
+  let setupPromise = null;
+  let pendingPayload = null;
+  let pendingToken = 0;
+  let confirmedToken = 0;
+  let drainPromise = null;
+  let retryTimer = null;
+  let retryDelay = 2000;
+
+  const storage = windowObj.localStorage;
+  const peers = Array.isArray(windowObj.__GUN_PEERS__) ? windowObj.__GUN_PEERS__ : [];
+
+  function pendingMarker() {
+    return safeStorageGet(storage, PENDING_KEY);
+  }
+
+  function markPending(payload) {
+    pendingPayload = payload;
+    pendingToken += 1;
+    const marker = {
+      queuedAt: Date.now(),
+      stateUpdatedAt: modified(payload?.state),
+      token: pendingToken
+    };
+    safeStorageSet(storage, PENDING_KEY, JSON.stringify(marker));
+    return pendingToken;
+  }
+
+  function clearPending(token) {
+    if (token !== pendingToken) return;
+    pendingPayload = null;
+    confirmedToken = token;
+    safeStorageRemove(storage, PENDING_KEY);
+    retryDelay = 2000;
+  }
+
+  function signedInMarkerExists() {
+    const shared = windowObj.AuthIdentity?.readSharedIdentity?.() || {};
+    return shared.signedIn === true || safeStorageGet(storage, 'signedIn') === 'true';
+  }
+
+  function sessionStatus() {
+    if (signedInMarkerExists()) {
+      return 'Signed in to the portal · Re-enter your password to sync Life Space';
+    }
+    return 'Saved on this device · Sign in to sync';
+  }
+
+  async function waitForSession(timeoutMs = sessionTimeoutMs) {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    while (!user?.is?.pub && Date.now() <= deadline) {
+      await delay(windowObj, 120);
+    }
+    return Boolean(user?.is?.pub);
+  }
+
+  async function restoreSession() {
+    if (user?.is?.pub) return true;
+    try { user?.recall?.({ sessionStorage: true, localStorage: true }); } catch {}
+    if (await waitForSession(Math.min(2400, sessionTimeoutMs))) return true;
+
+    const alias = safeStorageGet(storage, 'alias').trim();
+    const password = safeStorageGet(storage, 'password').trim();
+    if (!alias || !password || typeof user?.auth !== 'function') return false;
+
+    await new Promise(resolve => {
+      let settled = false;
+      const finish = () => { if (!settled) { settled = true; resolve(); } };
+      try { user.auth(alias, password, finish); } catch { finish(); }
+      windowObj.setTimeout(finish, Math.min(2500, sessionTimeoutMs));
+    });
+    return waitForSession(Math.max(0, sessionTimeoutMs - 2400));
+  }
+
+  async function ensureReady() {
+    if (ready && user?.is?.pub && secret && node) return true;
+    if (setupPromise) return setupPromise;
+    setupPromise = (async () => {
+      if (typeof windowObj.Gun !== 'function' || !windowObj.SEA) return false;
+      try {
+        windowObj.AuthIdentity?.syncStorageFromSharedIdentity?.(storage);
+        if (!gun) gun = windowObj.Gun({ peers });
+        if (!user) user = gun.user();
+        if (!(await restoreSession())) {
+          ready = false;
+          onStatus(sessionStatus());
+          return false;
+        }
+        secret = user?._?.sea || null;
+        if (!secret || typeof windowObj.SEA.encrypt !== 'function' || typeof windowObj.SEA.decrypt !== 'function') {
+          ready = false;
+          onStatus(sessionStatus());
+          return false;
+        }
+        node = user.get(SYNC_NODE).get('workspace');
+        ready = true;
+        onStatus(pendingMarker() ? 'Account sync ready · Pending changes will retry' : 'Account sync ready');
+        return true;
+      } catch {
+        ready = false;
+        onStatus('Saved on this device · Account sync unavailable');
         return false;
       }
-      node = user.get(SYNC_NODE).get('workspace');
-      ready = true;
-      onStatus('Account sync ready');
-      return true;
-    } catch {
-      onStatus('Saved on this device');
-      return false;
-    }
-  };
-  const readyPromise = init();
+    })().finally(() => { setupPromise = null; });
+    return setupPromise;
+  }
 
-  async function readPayload() {
-    const manifest = await once(node.get('manifest'), windowObj, readTimeoutMs);
-    if (!manifest) return { kind: 'missing', payload: null };
-    const count = Number(manifest?.chunks || 0);
+  function createVerificationNode() {
+    const pub = user?.is?.pub;
+    if (!pub || typeof windowObj.Gun !== 'function') return null;
+    try {
+      const verifier = windowObj.Gun({ peers, localStorage: false, radisk: false });
+      if (!verifier || typeof verifier.get !== 'function') return null;
+      return verifier.get(`~${pub}`).get(SYNC_NODE).get('workspace');
+    } catch {
+      return null;
+    }
+  }
+
+  async function readPayload(sourceNode = node, { expectedRevision = '', timeoutMs = readTimeoutMs } = {}) {
+    if (!sourceNode) return { kind: 'missing', payload: null };
+    const manifest = await waitForValue(
+      sourceNode.get('manifest'),
+      value => Boolean(value && typeof value === 'object' && (!expectedRevision || value.revision === expectedRevision)),
+      windowObj,
+      timeoutMs
+    );
+    if (!manifest) {
+      if (expectedRevision) throw new Error('Life Space manifest was not visible from the relay');
+      return { kind: 'missing', payload: null };
+    }
+
+    const count = Number(manifest.chunks || 0);
     if (!count || count > 5000) throw new Error('Invalid Life Space sync manifest');
-    const parts = await Promise.all(Array.from(
-      { length: count },
-      (_, index) => once(node.get('chunks').get(String(index)), windowObj, readTimeoutMs)
-    ));
+    const revision = typeof manifest.revision === 'string' ? manifest.revision : '';
+    const requireRevision = Number(manifest.schemaVersion || 1) >= 2 && Boolean(revision);
+    const parts = await Promise.all(Array.from({ length: count }, (_, index) => waitForValue(
+      sourceNode.get('chunks').get(String(index)),
+      part => Boolean(
+        part
+        && typeof part.value === 'string'
+        && (!requireRevision || part.revision === revision)
+      ),
+      windowObj,
+      timeoutMs
+    )));
     if (parts.some(part => typeof part?.value !== 'string')) throw new Error('Incomplete Life Space sync payload');
+
     const ciphertext = parts.map(part => part.value).join('');
+    if (manifest.bytes && Number(manifest.bytes) !== ciphertext.length) throw new Error('Life Space sync payload length did not match');
     const decoded = await windowObj.SEA.decrypt(ciphertext, secret);
+    const serialized = typeof decoded === 'string' ? decoded : JSON.stringify(decoded);
     const payload = typeof decoded === 'string' ? JSON.parse(decoded) : decoded;
     if (payload?.format !== '3dvr-life-space') throw new Error('Unsupported Life Space sync payload');
-    return { kind: 'ready', payload };
+    return { kind: 'ready', payload, serialized, manifest };
   }
+
+  function newRevision() {
+    const random = windowObj.crypto?.randomUUID?.() || Math.random().toString(36).slice(2);
+    return `${Date.now().toString(36)}-${random}`;
+  }
+
+  async function writeAndVerify(payload) {
+    if (!(await ensureReady()) || !node) return false;
+    try {
+      const serialized = JSON.stringify(payload);
+      const ciphertext = await windowObj.SEA.encrypt(serialized, secret);
+      const chunks = String(ciphertext).match(new RegExp(`.{1,${CHUNK_SIZE}}`, 'gs')) || [];
+      const revision = newRevision();
+      onStatus('Syncing…');
+
+      const results = await Promise.all(chunks.map((value, index) => put(
+        node.get('chunks').get(String(index)),
+        { revision, index, value },
+        windowObj,
+        writeTimeoutMs
+      )));
+      if (!results.every(Boolean)) return false;
+
+      const manifestSaved = await put(node.get('manifest'), {
+        schemaVersion: 2,
+        revision,
+        chunks: chunks.length,
+        bytes: String(ciphertext).length,
+        payloadUpdatedAt: modified(payload?.state),
+        updatedAt: new Date().toISOString()
+      }, windowObj, writeTimeoutMs);
+      if (!manifestSaved) return false;
+
+      onStatus('Verifying account copy…');
+      const verificationNode = createVerificationNode();
+      if (!verificationNode) return false;
+      const verified = await readPayload(verificationNode, {
+        expectedRevision: revision,
+        timeoutMs: verifyTimeoutMs
+      });
+      return verified.kind === 'ready' && verified.serialized === serialized;
+    } catch {
+      return false;
+    }
+  }
+
+  function scheduleRetry() {
+    if (retryTimer || !pendingPayload) return;
+    retryTimer = windowObj.setTimeout(() => {
+      retryTimer = null;
+      drainPending();
+    }, retryDelay);
+    retryDelay = Math.min(30000, retryDelay * 2);
+  }
+
+  async function drainPending() {
+    if (drainPromise) return drainPromise;
+    if (!pendingPayload) return false;
+    drainPromise = (async () => {
+      while (pendingPayload) {
+        const payload = pendingPayload;
+        const token = pendingToken;
+        const saved = await writeAndVerify(payload);
+        if (!saved) {
+          onStatus('Saved here · Account sync pending');
+          scheduleRetry();
+          return false;
+        }
+        if (token === pendingToken) {
+          clearPending(token);
+          onStatus('Synced and verified on your account');
+          return true;
+        }
+      }
+      return true;
+    })().finally(() => { drainPromise = null; });
+    return drainPromise;
+  }
+
+  function retryPending() {
+    if (retryTimer) {
+      windowObj.clearTimeout?.(retryTimer);
+      retryTimer = null;
+    }
+    ready = Boolean(ready && user?.is?.pub && secret && node);
+    return drainPending();
+  }
+
+  const retryOnReturn = () => {
+    if (pendingPayload) retryPending();
+  };
+  windowObj.addEventListener?.('online', retryOnReturn);
+  windowObj.addEventListener?.('focus', retryOnReturn);
+  windowObj.document?.addEventListener?.('visibilitychange', () => {
+    if (windowObj.document.visibilityState === 'visible') retryOnReturn();
+  });
+
+  const readyPromise = ensureReady();
 
   return {
     ready: readyPromise,
     async load(localPayload) {
-      if (!(await readyPromise) || !node) return null;
+      if (pendingMarker()) {
+        pendingPayload = localPayload;
+        pendingToken += 1;
+      }
+      if (!(await ensureReady()) || !node) return null;
       try {
-        const remote = await readPayload();
+        const remote = await readPayload(node);
         if (remote.kind === 'missing') {
           if (!hasWorkspaceContent(localPayload)) {
             onStatus('Account sync ready');
             return null;
           }
-          // Returning the local payload lets app startup write the first
-          // encrypted account copy. This is how existing phone-only notes
-          // become available on a second device without requiring a new edit.
           onStatus('No account copy yet · Uploading this device…');
           return localPayload;
         }
-        onStatus('Synced to your account');
-        return mergeLifeSpacePayloads(localPayload, remote.payload);
+        const merged = mergeLifeSpacePayloads(localPayload, remote.payload);
+        if (pendingMarker()) pendingPayload = merged;
+        onStatus(pendingMarker() ? 'Account copy loaded · Pending changes will retry' : 'Account copy loaded');
+        return merged;
       } catch {
         onStatus('Account workspace could not be opened');
         return null;
       }
     },
     async save(payload) {
-      if (!(await readyPromise) || !node) return false;
-      const saveRevision = ++revision;
-      try {
-        onStatus('Syncing…');
-        const ciphertext = await windowObj.SEA.encrypt(JSON.stringify(payload), secret);
-        const chunks = String(ciphertext).match(new RegExp(`.{1,${CHUNK_SIZE}}`, 'gs')) || [];
-        const results = await Promise.all(chunks.map((value, index) => put(node.get('chunks').get(String(index)), { value })));
-        if (saveRevision !== revision) return false;
-        const saved = results.every(Boolean) && await put(node.get('manifest'), {
-          schemaVersion: 1, chunks: chunks.length, updatedAt: new Date().toISOString()
-        });
-        onStatus(saved ? 'Synced to your account' : 'Saved here · Sync will retry');
-        return saved;
-      } catch {
-        onStatus('Saved here · Sync will retry');
-        return false;
-      }
+      const token = markPending(payload);
+      const saved = await drainPending();
+      return saved && confirmedToken >= token;
     },
-    isReady() { return ready; }
+    retry: retryPending,
+    isReady() { return ready; },
+    hasPending() { return Boolean(pendingPayload || pendingMarker()); }
   };
 }

--- a/tests/life-space-sync.test.js
+++ b/tests/life-space-sync.test.js
@@ -94,6 +94,13 @@ function makeSyncHarness({ replicate = true, signedIn = true } = {}) {
     user,
     windowObj,
     setReplicate(value) { shouldReplicate = value; },
+    activateSession() {
+      user.is = { pub: 'account' };
+      user._ = { sea: { priv: 'secret' } };
+      storage.setItem('signedIn', 'true');
+      storage.setItem('alias', 'thomas@3dvr');
+      storage.setItem('password', 'secret');
+    },
     emit(name) { listeners[name]?.(); }
   };
 }
@@ -172,6 +179,28 @@ test('Life Space keeps a pending marker until another Gun instance can reconstru
   assert.equal(await sync.retry(), true);
   assert.equal(sync.hasPending(), false);
   assert.equal(messages.at(-1), 'Synced and verified on your account');
+});
+
+test('Life Space resumes an existing local workspace after the Gun session becomes available', async () => {
+  const harness = makeSyncHarness({ signedIn: false });
+  const messages = [];
+  const sync = createLifeSpaceSync({
+    windowObj: harness.windowObj,
+    onStatus: message => messages.push(message),
+    readTimeoutMs: 0,
+    sessionTimeoutMs: 0,
+    verifyTimeoutMs: 5
+  });
+  const local = payload(state(30, [space('home', 30, [{ id: 'offline-note', text: 'saved before sign-in', updatedAt: 30 }])]));
+
+  assert.equal(await sync.load(local), null);
+  assert.equal(sync.hasPending(), true);
+  assert.match(messages.at(-1), /resume account sync/i);
+
+  harness.activateSession();
+  assert.equal(await sync.retry(), true);
+  assert.equal(sync.hasPending(), false);
+  assert.equal(harness.remoteValues.get('user/life-space-v01/workspace/manifest').schemaVersion, 2);
 });
 
 test('Life Space reads legacy untagged chunk manifests', async () => {

--- a/tests/life-space-sync.test.js
+++ b/tests/life-space-sync.test.js
@@ -6,21 +6,96 @@ const state = (updatedAt, spaces) => ({ version: 1, updatedAt, activeSpaceId: sp
 const space = (id, updatedAt, items = []) => ({ id, name: id, updatedAt, view: { x: 0, y: 0, zoom: 1 }, items, strokes: [] });
 const payload = value => ({ format: '3dvr-life-space', version: 1, state: value, files: [] });
 
-function makeSyncHarness() {
-  const values = new Map();
-  const makeNode = path => ({
-    get(key) { return makeNode(`${path}/${key}`); },
-    once(callback) { callback(values.get(path) || null); },
-    put(value, callback) { values.set(path, value); callback({ ok: 1 }); }
-  });
-  const root = makeNode('root');
-  const user = { is: { pub: 'account' }, _: { sea: { priv: 'secret' } }, recall() {}, get() { return root; } };
-  const windowObj = {
-    Gun() { return { user() { return user; } }; },
-    SEA: { async encrypt(value) { return `encrypted:${value}`; }, async decrypt(value) { return value.replace('encrypted:', ''); } },
-    AuthIdentity: { syncStorageFromSharedIdentity() {} }, localStorage: {}, __GUN_PEERS__: [], setTimeout
+function makeStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem(key) { return values.has(key) ? values.get(key) : null; },
+    setItem(key, value) { values.set(key, String(value)); },
+    removeItem(key) { values.delete(key); }
   };
-  return { values, windowObj };
+}
+
+function makeSyncHarness({ replicate = true, signedIn = true } = {}) {
+  const localValues = new Map();
+  const remoteValues = new Map();
+  const localSubscribers = new Map();
+  const remoteSubscribers = new Map();
+  let shouldReplicate = replicate;
+
+  const notify = (subscribers, path, value) => {
+    for (const callback of subscribers.get(path) || []) callback(value);
+  };
+  const makeNode = (path, values, subscribers, write) => {
+    const node = {
+      get(key) { return makeNode(`${path}/${key}`, values, subscribers, write); },
+      once(callback) { callback(values.get(path) ?? null); return node; },
+      on(callback) {
+        if (!subscribers.has(path)) subscribers.set(path, new Set());
+        subscribers.get(path).add(callback);
+        callback(values.get(path) ?? null);
+        return {
+          off() { subscribers.get(path)?.delete(callback); }
+        };
+      },
+      off() {},
+      put(value, callback) {
+        values.set(path, value);
+        notify(subscribers, path, value);
+        write?.(path, value);
+        callback?.({ ok: 1 });
+        return node;
+      }
+    };
+    return node;
+  };
+
+  const remoteRoot = makeNode('user', remoteValues, remoteSubscribers);
+  const localRoot = makeNode('user', localValues, localSubscribers, (path, value) => {
+    if (!shouldReplicate) return;
+    remoteValues.set(path, value);
+    notify(remoteSubscribers, path, value);
+  });
+  const user = {
+    is: signedIn ? { pub: 'account' } : null,
+    _: signedIn ? { sea: { priv: 'secret' } } : {},
+    recall() {},
+    auth(_alias, _password, callback) { callback?.({ ok: 1 }); },
+    get(key) { return localRoot.get(key); }
+  };
+  const storage = makeStorage(signedIn ? { signedIn: 'true', alias: 'thomas@3dvr', password: 'secret' } : {});
+  const listeners = {};
+  const windowObj = {
+    Gun(options = {}) {
+      if (options.localStorage === false) {
+        return { get(key) { assert.equal(key, '~account'); return remoteRoot; } };
+      }
+      return { user() { return user; } };
+    },
+    SEA: {
+      async encrypt(value) { return `encrypted:${value}`; },
+      async decrypt(value) { return value.replace('encrypted:', ''); }
+    },
+    AuthIdentity: {
+      syncStorageFromSharedIdentity() {},
+      readSharedIdentity() { return signedIn ? { signedIn: true } : null; }
+    },
+    localStorage: storage,
+    __GUN_PEERS__: ['wss://relay.test/gun'],
+    setTimeout,
+    clearTimeout,
+    addEventListener(name, callback) { listeners[name] = callback; },
+    document: { visibilityState: 'visible', addEventListener(name, callback) { listeners[`document:${name}`] = callback; } }
+  };
+
+  return {
+    localValues,
+    remoteValues,
+    storage,
+    user,
+    windowObj,
+    setReplicate(value) { shouldReplicate = value; },
+    emit(name) { listeners[name]?.(); }
+  };
 }
 
 test('Life Space account sync merges independent spaces and newer card edits', () => {
@@ -38,35 +113,77 @@ test('Life Space account sync respects deletion tombstones', () => {
   assert.equal(merged.state.spaces[0].items.length, 0);
 });
 
-test('Life Space encrypts and chunks account backups before writing them', async () => {
-  const { values, windowObj } = makeSyncHarness();
-  const sync = createLifeSpaceSync({ windowObj });
+test('Life Space writes revision-tagged chunks and verifies them through a cache-free Gun reader', async () => {
+  const { remoteValues, windowObj } = makeSyncHarness();
+  const sync = createLifeSpaceSync({ windowObj, readTimeoutMs: 0, sessionTimeoutMs: 0 });
   const large = payload(state(1, [space('home', 1, [{ id: 'note', text: 'x'.repeat(30000), updatedAt: 1 }])]));
+
   assert.equal(await sync.save(large), true);
-  assert.ok(values.get('root/workspace/manifest').chunks > 1);
-  assert.match(values.get('root/workspace/chunks/0').value, /^encrypted:/);
+  const manifest = remoteValues.get('user/life-space-v01/workspace/manifest');
+  assert.equal(manifest.schemaVersion, 2);
+  assert.ok(manifest.chunks > 1);
+  const first = remoteValues.get('user/life-space-v01/workspace/chunks/0');
+  assert.equal(first.revision, manifest.revision);
+  assert.match(first.value, /^encrypted:/);
+  assert.equal(sync.hasPending(), false);
 });
 
 test('Life Space seeds an empty signed-in account from the first device with content', async () => {
-  const { values, windowObj } = makeSyncHarness();
+  const { remoteValues, windowObj } = makeSyncHarness();
   const messages = [];
-  const sync = createLifeSpaceSync({ windowObj, onStatus: message => messages.push(message), readTimeoutMs: 0 });
+  const sync = createLifeSpaceSync({ windowObj, onStatus: message => messages.push(message), readTimeoutMs: 0, sessionTimeoutMs: 0 });
   const local = payload(state(10, [space('home', 10, [{ id: 'phone-note', text: 'from phone', updatedAt: 10 }])]));
 
   assert.deepEqual(await sync.load(local), local);
   assert.match(messages.at(-1), /Uploading this device/);
   assert.equal(await sync.save(local), true);
-  assert.equal(values.get('root/workspace/manifest').chunks, 1);
+  assert.equal(remoteValues.get('user/life-space-v01/workspace/manifest').schemaVersion, 2);
 });
 
 test('Life Space does not seed a truly empty device when the account read is empty', async () => {
-  const { values, windowObj } = makeSyncHarness();
+  const { remoteValues, windowObj } = makeSyncHarness();
   const messages = [];
-  const sync = createLifeSpaceSync({ windowObj, onStatus: message => messages.push(message), readTimeoutMs: 0 });
+  const sync = createLifeSpaceSync({ windowObj, onStatus: message => messages.push(message), readTimeoutMs: 0, sessionTimeoutMs: 0 });
   const emptyHome = { ...space('space-home', 0), name: 'My Life', updatedAt: undefined };
   const local = payload(state(Date.now(), [emptyHome]));
 
   assert.equal(await sync.load(local), null);
   assert.equal(messages.at(-1), 'Account sync ready');
-  assert.equal(values.has('root/workspace/manifest'), false);
+  assert.equal(remoteValues.has('user/life-space-v01/workspace/manifest'), false);
+});
+
+test('Life Space keeps a pending marker until another Gun instance can reconstruct the save', async () => {
+  const harness = makeSyncHarness({ replicate: false });
+  const messages = [];
+  const sync = createLifeSpaceSync({
+    windowObj: harness.windowObj,
+    onStatus: message => messages.push(message),
+    readTimeoutMs: 5,
+    sessionTimeoutMs: 0,
+    verifyTimeoutMs: 5
+  });
+  const local = payload(state(20, [space('home', 20, [{ id: 'note', text: 'must reach relay', updatedAt: 20 }])]));
+
+  assert.equal(await sync.save(local), false);
+  assert.equal(sync.hasPending(), true);
+  assert.match(messages.at(-1), /pending/i);
+
+  harness.setReplicate(true);
+  assert.equal(await sync.retry(), true);
+  assert.equal(sync.hasPending(), false);
+  assert.equal(messages.at(-1), 'Synced and verified on your account');
+});
+
+test('Life Space reads legacy untagged chunk manifests', async () => {
+  const harness = makeSyncHarness();
+  const remote = payload(state(25, [space('home', 25, [{ id: 'legacy-note', text: 'legacy', updatedAt: 25 }])]));
+  const serialized = JSON.stringify(remote);
+  const encrypted = `encrypted:${serialized}`;
+  harness.localValues.set('user/life-space-v01/workspace/manifest', { schemaVersion: 1, chunks: 1 });
+  harness.localValues.set('user/life-space-v01/workspace/chunks/0', { value: encrypted });
+  const sync = createLifeSpaceSync({ windowObj: harness.windowObj, readTimeoutMs: 0, sessionTimeoutMs: 0 });
+  const local = payload(state(1, [space('home', 1)]));
+
+  const merged = await sync.load(local);
+  assert.equal(merged.state.spaces[0].items[0].id, 'legacy-note');
 });


### PR DESCRIPTION
## What changed
- keep a persistent pending-sync marker until the encrypted workspace is genuinely recoverable
- retry failed saves with backoff and again when the browser reconnects, regains focus, or becomes visible
- restore the Gun user session for longer and retry with the locally stored Gun credentials when available
- preserve existing local work when authentication is unavailable, reconcile it with the account copy after sign-in, and then resume syncing without requiring another edit
- tag every encrypted chunk with a unique revision so overlapping saves cannot produce a mixed workspace
- write the manifest last, then open a cache-free Gun client and reconstruct the exact payload before reporting success
- retain compatibility with the existing untagged v1 manifest and chunk format

## Why
A successful `put` acknowledgement and a read from the same browser can still reflect local Gun state. Life Space was therefore able to say `Synced to your account` without proving that another device could reconstruct the workspace. The old shared chunk paths also had no revision marker, so overlapping saves could expose a manifest alongside chunks from different writes.

Life Space could also load existing local notes before the SEA session became available and then never retry them unless the user edited again. The pending marker now records that those notes still need an account merge before upload.

## Validation
- `node --check life-space/sync.js`
- focused Node tests: 8/8 passed
- coverage includes multi-chunk verified saves, first-device account seeding, empty-device protection, relay verification failure and retry, pending-marker cleanup, authentication recovery without a new edit, and legacy manifest reads

## Expected user-visible behavior
The status only becomes `Synced and verified on your account` after a fresh cache-free Gun client can read the manifest, collect matching revision-tagged chunks, decrypt them, and reproduce the exact workspace JSON. Otherwise the workspace stays safe in IndexedDB and shows a pending status while it retries. Existing local work also resumes automatically after the Gun account session is restored.