### PR TITLE
Fix Next release link on v0.0.56

### DIFF
--- a/releases/v0.0.56.html
+++ b/releases/v0.0.56.html
@@ -24,7 +24,7 @@
   <p><a class="back-link" href="index.html">Back to releases</a></p>
   <nav class="release-nav" aria-label="Release navigation">
     <a class="release-nav-link" href="v0.0.55.html">Previous release</a>
-    <span class="release-nav-link is-disabled" aria-disabled="true">Next release</span>
+    <a class="release-nav-link" href="v0.0.57.html">Next release</a>
   </nav>
   <h1>Release v0.0.56</h1>
   <div class="tag">Week of July 27, 2026</div>


### PR DESCRIPTION
## Summary
- replace the disabled “Next release” control on release v0.0.56 with a link to v0.0.57

## Verification
- confirmed the branch differs from `main` by one line in `releases/v0.0.56.html`
- confirmed `releases/v0.0.57.html` exists on `main`
- confirmed the updated control points to `v0.0.57.html`