### PR TITLE
Update release v0.0.57 through verified Life Space sync

### DIFF
--- a/releases/v0.0.57.html
+++ b/releases/v0.0.57.html
@@ -32,8 +32,8 @@
     <p>
       This week, the portal got easier and safer to use. <a href="../money-printer/">Money Printer</a> can help
       people find new work. <a href="../chat/">Chat</a> works better on phones and web browsers.
-      <a href="../life-space/">Life Space</a> is easier to draw in and move around. We also made a safe way to move
-      old CRM data into a new database.
+      <a href="../life-space/">Life Space</a> is easier to draw in, move around, and use across signed-in devices.
+      We also made a safe way to move old CRM data into a new database.
     </p>
     <ul class="release-summary-list">
       <li>
@@ -65,6 +65,15 @@
         <a href="https://github.com/tmsteph/3dvr-portal/pull/1287">PR #1287</a>.
       </li>
       <li>
+        <strong>Safer account sync:</strong>
+        Life Space now shows the signed-in account name or Guest. Notes that started on one device can safely create
+        the first encrypted account copy and later appear on another device. Interrupted saves stay pending and retry
+        when the connection or account session returns. Life Space only says the account copy is verified after a
+        fresh reader can collect the matching pieces, unlock them, and rebuild the exact workspace. This came from
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1322">PR #1322</a> and
+        <a href="https://github.com/tmsteph/3dvr-portal/pull/1323">PR #1323</a>.
+      </li>
+      <li>
         <strong>Safe CRM move:</strong>
         the CRM tool can test the move before it changes anything. It keeps the old data and does not send messages.
         The test kept 42 leads, linked all 17 work notes, and kept all 59 old rows in
@@ -83,15 +92,16 @@
     <p>
       A person still checks each work reply before it is sent. The CRM tool does not contact anyone. Phone alerts
       still need a test on a real phone. In the live Chat test, every message arrived. The slow end of the test was
-      about 2.13 seconds. We do not promise that speed every time.
+      about 2.13 seconds, so we do not promise that speed every time. Life Space keeps changes on the device when
+      account sync cannot be proven and does not call them verified until a separate reader can rebuild the workspace.
     </p>
   </div>
 
   <div class="section">
     <h2>What this release covers</h2>
     <p>
-      v0.0.57 covers work made after PR #1254. It brings the public release list through
-      <a href="https://github.com/tmsteph/3dvr-portal/pull/1289">PR #1289</a>.
+      v0.0.57 covers product work made after PR #1254. It brings the public release list through
+      <a href="https://github.com/tmsteph/3dvr-portal/pull/1323">PR #1323</a>.
     </p>
   </div>
 

--- a/tests/releases-v57.test.js
+++ b/tests/releases-v57.test.js
@@ -19,8 +19,10 @@ describe('release v0.0.57', () => {
     assert.match(release, /Find new work/);
     assert.match(release, /Better Chat/);
     assert.match(release, /Easier Life Space/);
+    assert.match(release, /Safer account sync/);
     assert.match(release, /Safe CRM move/);
     assert.match(release, /Safety notes/);
-    assert.match(release, /pull\/1289/);
+    assert.match(release, /pull\/1322/);
+    assert.match(release, /pull\/1323/);
   });
 });


### PR DESCRIPTION
## What changed
- update the v0.0.57 release page with the cross-device Life Space work from PRs #1322 and #1323
- explain account identity, first-device account seeding, automatic retry, and independent encrypted read-back in plain language
- move the documented product cutoff from PR #1289 through PR #1323
- update focused release coverage for the new section and source links

## Why
The public v0.0.57 page was written before the final Life Space account-sync reliability work merged. The release should match the production milestone before it is shared in the developer forum.

## Verification
- compared against `main`: only `releases/v0.0.57.html` and `tests/releases-v57.test.js` changed
- preserved the August 3 release date and disabled next-release control
- confirmed the updated page links to PRs #1322 and #1323
- confirmed the release cutoff now points to PR #1323