### PR TITLE
Add 3DVR Companion cross-platform device agent seed

### DIFF
--- a/.github/workflows/companion-android.yml
+++ b/.github/workflows/companion-android.yml
@@ -1,0 +1,47 @@
+name: Companion Android
+
+on:
+  pull_request:
+    paths:
+      - 'apps/companion/**'
+      - '.github/workflows/companion-android.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
+        with:
+          channel: stable
+          cache: true
+
+      - name: Scaffold Companion
+        run: |
+          chmod +x apps/companion/scaffold.sh
+          apps/companion/scaffold.sh
+
+      - name: Build debug APK
+        working-directory: apps/companion
+        run: flutter build apk --debug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: 3dvr-companion-debug-apk
+          path: apps/companion/build/app/outputs/flutter-apk/app-debug.apk
+          if-no-files-found: error

--- a/apps/companion/README.md
+++ b/apps/companion/README.md
@@ -1,0 +1,118 @@
+# 3DVR Companion
+
+3DVR Companion is the device-side execution layer for a permissioned personal assistant.
+
+The design goal is not unrestricted remote control. It is a capability-based system where every device exposes a small set of explicit actions, every action has an approval level, and every execution produces an audit record.
+
+## Architecture
+
+```text
+ChatGPT / Life Ops
+        |
+        v
+3DVR Terminal Bridge / future relay
+        |
+        v
+3DVR Companion shared core
+        |
+        +-- Android adapter (deepest device control)
+        +-- iOS adapter (App Intents / Shortcuts / app-owned actions)
+        +-- future desktop adapters
+```
+
+## Shared capability model
+
+Every action has:
+
+- `capability`: stable machine-readable name
+- `risk`: `green`, `yellow`, or `red`
+- `requiresForeground`: whether the user must actively be in the app
+- `requiresConfirmation`: whether Companion must obtain explicit approval
+- `platforms`: where the action is supported
+- `audit`: request, result, device, timestamp, and reason
+
+### Green
+
+Safe to automate after the user grants the OS permission.
+
+Examples: battery state, network state, open a URL, open an app, read Companion-owned files, report bridge/server status.
+
+### Yellow
+
+Allowed only under a user-created rule or explicit confirmation.
+
+Examples: interact with another Android app through Accessibility, fill a known form, change a calendar item, dismiss a notification, restart a known service.
+
+### Red
+
+Always requires an explicit user approval near the time of action.
+
+Examples: spending money, deleting important data, changing credentials, sending sensitive messages, accepting contracts, or making commitments.
+
+## Platform strategy
+
+### Android
+
+Android is the first deep-control platform. Native Kotlin services can expose:
+
+- notification events through `NotificationListenerService`
+- active-window structure through an explicitly enabled `AccessibilityService`
+- taps/swipes through accessibility gesture dispatch
+- app and settings launches through intents
+- device state through normal Android APIs
+
+The Accessibility service is opt-in and must remain visibly disableable by the user.
+
+### iPhone / iPad
+
+iOS intentionally offers a narrower model. Companion should use:
+
+- App Intents
+- Shortcuts
+- Siri / Apple Intelligence surfaces
+- deep links and universal links
+- share extensions
+- app-owned notifications and data
+
+Companion should not claim arbitrary cross-app UI control on iOS. The product should expose the same high-level intent where possible, with a platform capability report explaining what is actually available.
+
+## Shared implementation
+
+Flutter provides the shared UI, capability registry, approvals screen, audit history, and transport protocol. Native platform adapters are reached through platform channels:
+
+- Android: Kotlin
+- iOS: Swift
+
+The shared code never directly decides that a dangerous action is permitted. Platform adapters receive an already-evaluated request plus a local approval token where required.
+
+## v0.1 milestone
+
+1. Shared capability/approval protocol.
+2. Companion home screen showing platform and available capabilities.
+3. Android platform channel for battery + open URL.
+4. Android Accessibility service skeleton with no remote gesture execution enabled yet.
+5. Android notification listener skeleton that stores only local normalized metadata.
+6. iOS App Intent example for opening the Companion dashboard.
+7. Bridge transport schema for future signed device tasks.
+
+## Security rules
+
+- No arbitrary shell command field.
+- No arbitrary Accessibility node selector supplied by a remote task in v0.1.
+- No passwords, tokens, notification bodies, or UI dumps committed to Git.
+- Device permissions are granted locally in the OS.
+- Dangerous capabilities default to disabled.
+- Every remote action must have an idempotency key and expiration.
+- The user can disable the bridge or Companion independently.
+- A future relay must authenticate devices independently instead of trusting a GitHub issue author alone.
+
+## Development
+
+This seed intentionally keeps generated Flutter platform boilerplate out of the first commit. On a machine with Flutter installed:
+
+```bash
+cd apps/companion
+flutter create --org tech.3dvr --platforms=android,ios .
+```
+
+Then retain the files in `lib/`, `native-spec/`, and `docs/` from this branch while wiring the generated Android/iOS projects to the adapters described here.

--- a/apps/companion/README.md
+++ b/apps/companion/README.md
@@ -112,7 +112,7 @@ This seed intentionally keeps generated Flutter platform boilerplate out of the 
 
 ```bash
 cd apps/companion
-flutter create --org tech.3dvr --platforms=android,ios .
+flutter create --org tech.threedvr --platforms=android,ios .
 ```
 
 Then retain the files in `lib/`, `native-spec/`, and `docs/` from this branch while wiring the generated Android/iOS projects to the adapters described here.

--- a/apps/companion/analysis_options.yaml
+++ b/apps/companion/analysis_options.yaml
@@ -1,0 +1,9 @@
+analyzer:
+  exclude:
+    - ios/CompanionNativeSpec/**
+
+linter:
+  rules:
+    avoid_print: true
+    prefer_const_constructors: true
+    prefer_const_declarations: true

--- a/apps/companion/docs/DISTRIBUTION.md
+++ b/apps/companion/docs/DISTRIBUTION.md
@@ -1,0 +1,41 @@
+# Companion distribution boundaries
+
+## Android
+
+3DVR Companion has two distinct product modes in mind:
+
+### Store mode
+
+Designed for Google Play distribution.
+
+- Prefer narrow Android APIs, intents, app integrations, and user-triggered actions.
+- Accessibility-based automation must stay narrow, clearly disclosed, consented, and deterministic.
+- An AI model must not autonomously plan and execute arbitrary Accessibility actions on the user's behalf.
+- Accessibility is not presented as a disability accessibility tool unless that genuinely becomes the product's primary purpose.
+
+### Power mode
+
+A private/sideloaded build for the device owner.
+
+- May expose additional local device capabilities after explicit OS permission.
+- Still uses the same green/yellow/red approval protocol.
+- Still rejects arbitrary remote code, arbitrary selectors, and unbounded gesture scripts.
+- The user can disable Accessibility, notification access, Companion, or the bridge independently.
+
+The v0.1 Android Accessibility skeleton is an experimental Power Mode component. Gesture dispatch is disabled.
+
+## iOS / iPadOS
+
+The store and private capability surface is fundamentally narrower than Android. Companion should use Apple-supported integrations such as App Intents, Shortcuts, Siri/Apple Intelligence surfaces, deep links, share extensions, and app-owned APIs.
+
+Unsupported Android capabilities return an explicit unsupported result rather than claiming equivalent iOS control.
+
+## Desktop
+
+Future macOS, Windows, and Linux adapters should follow the same capability contract. Platform-native permissions and sandboxing stay authoritative.
+
+## Product rule
+
+The cross-platform abstraction is the user's intent, not a promise that every operating system exposes the same mechanism.
+
+For example, `navigation.open_destination` might be fulfilled by an Android intent, an iOS App Intent/deep link, or a desktop URL handler. The Life Ops layer asks for the intent and Companion reports whether the local platform supports it.

--- a/apps/companion/docs/TRANSPORT.md
+++ b/apps/companion/docs/TRANSPORT.md
@@ -1,0 +1,92 @@
+# Companion task transport v1
+
+The Companion transport is intentionally separate from the current GitHub Issue queue. The Issue bridge can carry these envelopes during development, but the long-term relay should use authenticated device channels.
+
+## Request envelope
+
+```json
+{
+  "version": 1,
+  "id": "01J...",
+  "device": "phone",
+  "capability": "device.status",
+  "createdAt": "2026-08-06T23:00:00Z",
+  "expiresAt": "2026-08-06T23:02:00Z",
+  "reason": "Build the Life Ops morning brief",
+  "arguments": {},
+  "approval": null
+}
+```
+
+Rules:
+
+- `id` is globally unique and is the idempotency key.
+- `device` is a locally enrolled device identifier.
+- `capability` must match the local registry exactly.
+- expired requests are rejected before execution.
+- unknown fields may be logged but must not grant capabilities.
+- remote input never contains arbitrary shell, Accessibility selectors, JavaScript, Swift, Kotlin, or executable code.
+
+## Approval envelope
+
+Yellow/red actions require a local approval record.
+
+```json
+{
+  "requestId": "01J...",
+  "capability": "ui.perform_known_action",
+  "approvedAt": "2026-08-06T23:00:30Z",
+  "expiresAt": "2026-08-06T23:01:30Z",
+  "scope": {
+    "knownAction": "open_navigation_to_calendar_event"
+  }
+}
+```
+
+An approval token must be bound to the request/capability/scope and expire quickly. A generic permanent "yes to everything" token is not supported.
+
+## Result envelope
+
+```json
+{
+  "version": 1,
+  "id": "01J...",
+  "ok": true,
+  "finishedAt": "2026-08-06T23:00:42Z",
+  "output": {
+    "batteryPercent": 71
+  }
+}
+```
+
+Results should be small, structured, and redacted before leaving the device.
+
+## Android Accessibility boundary
+
+Remote tasks may request only locally implemented named actions, for example:
+
+```text
+ui.perform_known_action / open_navigation_to_calendar_event
+```
+
+They may not submit arbitrary coordinates, text selectors, XPath-like expressions, package-specific scripts, or gesture sequences. The local implementation owns those details and can require foreground confirmation.
+
+## iOS boundary
+
+A capability is supported only if Companion itself can implement it through an Apple-supported surface such as App Intents, Shortcuts, deep links, app extensions, or app-owned APIs. Unsupported cross-app Android capabilities must return `unsupported_on_platform`, not silently degrade into brittle UI automation claims.
+
+## Audit record
+
+Every accepted request creates a local record containing:
+
+- request id
+- capability
+- risk level
+- requester/transport identity
+- reason
+- approval reference when applicable
+- start/end time
+- result status
+- redacted output summary
+
+Audit retention and export are user-controlled.

--- a/apps/companion/lib/main.dart
+++ b/apps/companion/lib/main.dart
@@ -1,0 +1,165 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+
+import 'src/platform_bridge.dart';
+import 'src/protocol.dart';
+
+void main() => runApp(const CompanionApp());
+
+class CompanionApp extends StatelessWidget {
+  const CompanionApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: '3DVR Companion',
+      theme: ThemeData(useMaterial3: true),
+      home: const CompanionHome(),
+    );
+  }
+}
+
+class CompanionHome extends StatefulWidget {
+  const CompanionHome({super.key});
+
+  @override
+  State<CompanionHome> createState() => _CompanionHomeState();
+}
+
+class _CompanionHomeState extends State<CompanionHome> {
+  final CompanionPlatformBridge bridge = const CompanionPlatformBridge();
+  Map<String, Object?> status = const {};
+  Map<String, Object?> permissionState = const {};
+  bool loading = true;
+
+  CompanionPlatform get currentPlatform {
+    if (Platform.isAndroid) return CompanionPlatform.android;
+    if (Platform.isIOS) return CompanionPlatform.ios;
+    if (Platform.isMacOS) return CompanionPlatform.macos;
+    if (Platform.isWindows) return CompanionPlatform.windows;
+    return CompanionPlatform.linux;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    refresh();
+  }
+
+  Future<void> refresh() async {
+    setState(() => loading = true);
+    try {
+      final values = await Future.wait([
+        bridge.getDeviceStatus(),
+        bridge.getCapabilityStatus(),
+      ]);
+      if (!mounted) return;
+      setState(() {
+        status = values[0];
+        permissionState = values[1];
+        loading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        status = {'error': error.toString()};
+        loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final capabilities = companionCapabilities
+        .where((capability) => capability.platforms.contains(currentPlatform))
+        .toList(growable: false);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('3DVR Companion'),
+        actions: [
+          IconButton(onPressed: refresh, icon: const Icon(Icons.refresh)),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Permissioned device assistant',
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Companion exposes explicit capabilities to Life Ops. Dangerous actions stay disabled until you approve them locally.',
+          ),
+          const SizedBox(height: 20),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: loading
+                  ? const Center(child: CircularProgressIndicator())
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('Device', style: Theme.of(context).textTheme.titleMedium),
+                        const SizedBox(height: 8),
+                        Text('Platform: ${currentPlatform.name}'),
+                        ...status.entries.map((entry) => Text('${entry.key}: ${entry.value}')),
+                      ],
+                    ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text('Capabilities', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 8),
+          for (final capability in capabilities)
+            Card(
+              child: ListTile(
+                leading: Icon(_riskIcon(capability.risk)),
+                title: Text(capability.name),
+                subtitle: Text(capability.description),
+                trailing: Text(capability.risk.name.toUpperCase()),
+              ),
+            ),
+          if (Platform.isAndroid) ...[
+            const SizedBox(height: 16),
+            FilledButton.tonal(
+              onPressed: bridge.openAccessibilitySettings,
+              child: const Text('Accessibility settings'),
+            ),
+            const SizedBox(height: 8),
+            FilledButton.tonal(
+              onPressed: bridge.openNotificationAccessSettings,
+              child: const Text('Notification access settings'),
+            ),
+          ],
+          const SizedBox(height: 16),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Local permission state'),
+                  const SizedBox(height: 8),
+                  if (permissionState.isEmpty)
+                    const Text('No native permission adapter connected yet.')
+                  else
+                    ...permissionState.entries
+                        .map((entry) => Text('${entry.key}: ${entry.value}')),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+IconData _riskIcon(CompanionRisk risk) => switch (risk) {
+      CompanionRisk.green => Icons.check_circle_outline,
+      CompanionRisk.yellow => Icons.shield_outlined,
+      CompanionRisk.red => Icons.lock_outline,
+    };

--- a/apps/companion/lib/src/platform_bridge.dart
+++ b/apps/companion/lib/src/platform_bridge.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/services.dart';
+
+class CompanionPlatformBridge {
+  const CompanionPlatformBridge();
+
+  static const MethodChannel _channel = MethodChannel('tech.3dvr.companion/platform');
+
+  Future<Map<String, Object?>> getDeviceStatus() async {
+    final result = await _channel.invokeMapMethod<String, Object?>('deviceStatus');
+    return result ?? const {};
+  }
+
+  Future<bool> openUrl(String url) async {
+    final result = await _channel.invokeMethod<bool>('openUrl', {'url': url});
+    return result ?? false;
+  }
+
+  Future<Map<String, Object?>> getCapabilityStatus() async {
+    final result = await _channel.invokeMapMethod<String, Object?>('capabilityStatus');
+    return result ?? const {};
+  }
+
+  Future<bool> openAccessibilitySettings() async {
+    final result = await _channel.invokeMethod<bool>('openAccessibilitySettings');
+    return result ?? false;
+  }
+
+  Future<bool> openNotificationAccessSettings() async {
+    final result = await _channel.invokeMethod<bool>('openNotificationAccessSettings');
+    return result ?? false;
+  }
+}

--- a/apps/companion/lib/src/protocol.dart
+++ b/apps/companion/lib/src/protocol.dart
@@ -1,0 +1,145 @@
+enum CompanionRisk { green, yellow, red }
+
+enum CompanionPlatform { android, ios, macos, windows, linux }
+
+class CompanionCapability {
+  const CompanionCapability({
+    required this.name,
+    required this.risk,
+    required this.platforms,
+    this.requiresForeground = false,
+    this.requiresConfirmation = false,
+    this.description = '',
+  });
+
+  final String name;
+  final CompanionRisk risk;
+  final Set<CompanionPlatform> platforms;
+  final bool requiresForeground;
+  final bool requiresConfirmation;
+  final String description;
+
+  Map<String, Object?> toJson() => {
+        'name': name,
+        'risk': risk.name,
+        'platforms': platforms.map((value) => value.name).toList(),
+        'requiresForeground': requiresForeground,
+        'requiresConfirmation': requiresConfirmation,
+        'description': description,
+      };
+}
+
+class CompanionActionRequest {
+  const CompanionActionRequest({
+    required this.id,
+    required this.capability,
+    required this.createdAt,
+    required this.expiresAt,
+    required this.reason,
+    this.arguments = const {},
+    this.approvalToken,
+  });
+
+  final String id;
+  final String capability;
+  final DateTime createdAt;
+  final DateTime expiresAt;
+  final String reason;
+  final Map<String, Object?> arguments;
+  final String? approvalToken;
+
+  bool get isExpired => DateTime.now().toUtc().isAfter(expiresAt.toUtc());
+
+  Map<String, Object?> toJson() => {
+        'version': 1,
+        'id': id,
+        'capability': capability,
+        'createdAt': createdAt.toUtc().toIso8601String(),
+        'expiresAt': expiresAt.toUtc().toIso8601String(),
+        'reason': reason,
+        'arguments': arguments,
+        if (approvalToken != null) 'approvalToken': approvalToken,
+      };
+}
+
+class CompanionActionResult {
+  const CompanionActionResult({
+    required this.id,
+    required this.ok,
+    required this.finishedAt,
+    this.output = const {},
+    this.error,
+  });
+
+  final String id;
+  final bool ok;
+  final DateTime finishedAt;
+  final Map<String, Object?> output;
+  final String? error;
+
+  Map<String, Object?> toJson() => {
+        'version': 1,
+        'id': id,
+        'ok': ok,
+        'finishedAt': finishedAt.toUtc().toIso8601String(),
+        'output': output,
+        if (error != null) 'error': error,
+      };
+}
+
+const companionCapabilities = <CompanionCapability>[
+  CompanionCapability(
+    name: 'device.status',
+    risk: CompanionRisk.green,
+    platforms: {
+      CompanionPlatform.android,
+      CompanionPlatform.ios,
+      CompanionPlatform.macos,
+      CompanionPlatform.windows,
+      CompanionPlatform.linux,
+    },
+    description: 'Report basic device and Companion health.',
+  ),
+  CompanionCapability(
+    name: 'url.open',
+    risk: CompanionRisk.green,
+    platforms: {
+      CompanionPlatform.android,
+      CompanionPlatform.ios,
+      CompanionPlatform.macos,
+      CompanionPlatform.windows,
+      CompanionPlatform.linux,
+    },
+    description: 'Open an http/https URL using the operating system.',
+  ),
+  CompanionCapability(
+    name: 'notification.metadata.read',
+    risk: CompanionRisk.yellow,
+    platforms: {CompanionPlatform.android},
+    requiresConfirmation: true,
+    description: 'Read normalized Android notification metadata after local permission is granted.',
+  ),
+  CompanionCapability(
+    name: 'ui.snapshot',
+    risk: CompanionRisk.yellow,
+    platforms: {CompanionPlatform.android},
+    requiresForeground: true,
+    requiresConfirmation: true,
+    description: 'Return a bounded description of the active Android accessibility tree.',
+  ),
+  CompanionCapability(
+    name: 'ui.perform_known_action',
+    risk: CompanionRisk.yellow,
+    platforms: {CompanionPlatform.android},
+    requiresForeground: true,
+    requiresConfirmation: true,
+    description: 'Perform a locally defined Android accessibility action. Remote arbitrary selectors are not allowed.',
+  ),
+  CompanionCapability(
+    name: 'shortcut.run',
+    risk: CompanionRisk.yellow,
+    platforms: {CompanionPlatform.ios},
+    requiresConfirmation: true,
+    description: 'Invoke an app-owned iOS action exposed through App Intents/Shortcuts.',
+  ),
+];

--- a/apps/companion/native-spec/android/CompanionAccessibilityService.kt
+++ b/apps/companion/native-spec/android/CompanionAccessibilityService.kt
@@ -1,0 +1,43 @@
+package tech.threedvr.companion
+
+import android.accessibilityservice.AccessibilityService
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+
+/**
+ * v0.1 deliberately observes only bounded metadata.
+ *
+ * Remote gesture execution is NOT enabled here. Future known actions must be
+ * implemented as local named functions with explicit package/selector rules.
+ */
+class CompanionAccessibilityService : AccessibilityService() {
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        // Keep v0.1 local-only. Do not upload raw accessibility events or text.
+    }
+
+    override fun onInterrupt() = Unit
+
+    fun activeWindowSummary(): Map<String, Any?> {
+        val root = rootInActiveWindow ?: return mapOf("available" to false)
+        return mapOf(
+            "available" to true,
+            "packageName" to root.packageName?.toString(),
+            "className" to root.className?.toString(),
+            "nodeCount" to countNodes(root, 250),
+        )
+    }
+
+    private fun countNodes(root: AccessibilityNodeInfo, limit: Int): Int {
+        var count = 0
+        val queue = ArrayDeque<AccessibilityNodeInfo>()
+        queue.add(root)
+        while (queue.isNotEmpty() && count < limit) {
+            val node = queue.removeFirst()
+            count += 1
+            for (index in 0 until node.childCount) {
+                node.getChild(index)?.let(queue::add)
+            }
+        }
+        return count
+    }
+}

--- a/apps/companion/native-spec/android/CompanionNotificationListener.kt
+++ b/apps/companion/native-spec/android/CompanionNotificationListener.kt
@@ -1,0 +1,25 @@
+package tech.threedvr.companion
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+
+/**
+ * Notification listener seed.
+ *
+ * v0.1 intentionally normalizes only low-sensitivity metadata and does not
+ * persist notification body text, message content, or tokens.
+ */
+class CompanionNotificationListener : NotificationListenerService() {
+    override fun onNotificationPosted(sbn: StatusBarNotification?) {
+        val notification = sbn ?: return
+        val metadata = mapOf(
+            "packageName" to notification.packageName,
+            "postedAt" to notification.postTime,
+            "isOngoing" to notification.isOngoing,
+            "category" to notification.notification.category,
+        )
+        // TODO: hand this local metadata to Companion's encrypted local store.
+        @Suppress("UNUSED_VARIABLE")
+        val normalized = metadata
+    }
+}

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -1,0 +1,86 @@
+package tech.`3dvr`.companion
+
+import android.content.Intent
+import android.net.Uri
+import android.os.BatteryManager
+import android.provider.Settings
+import android.service.notification.NotificationListenerService
+import android.text.TextUtils
+import android.view.accessibility.AccessibilityManager
+import androidx.core.content.getSystemService
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+class MainActivity : FlutterActivity() {
+    private val channelName = "tech.3dvr.companion/platform"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "deviceStatus" -> result.success(deviceStatus())
+                    "capabilityStatus" -> result.success(capabilityStatus())
+                    "openUrl" -> {
+                        val raw = call.argument<String>("url") ?: ""
+                        result.success(openHttpUrl(raw))
+                    }
+                    "openAccessibilitySettings" -> {
+                        startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+                        result.success(true)
+                    }
+                    "openNotificationAccessSettings" -> {
+                        startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+                        result.success(true)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    private fun deviceStatus(): Map<String, Any?> {
+        val battery = getSystemService<BatteryManager>()
+        return mapOf(
+            "sdk" to android.os.Build.VERSION.SDK_INT,
+            "manufacturer" to android.os.Build.MANUFACTURER,
+            "model" to android.os.Build.MODEL,
+            "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY),
+        )
+    }
+
+    private fun capabilityStatus(): Map<String, Any> = mapOf(
+        "accessibilityEnabled" to isAccessibilityEnabled(),
+        "notificationAccessEnabled" to isNotificationAccessEnabled(),
+        // Remote gesture execution intentionally remains false in v0.1.
+        "remoteKnownActionsEnabled" to false,
+    )
+
+    private fun openHttpUrl(raw: String): Boolean {
+        val uri = runCatching { Uri.parse(raw) }.getOrNull() ?: return false
+        if (uri.scheme != "https" && uri.scheme != "http") return false
+        startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        return true
+    }
+
+    private fun isAccessibilityEnabled(): Boolean {
+        val manager = getSystemService<AccessibilityManager>() ?: return false
+        return manager.getEnabledAccessibilityServiceList(
+            android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_ALL_MASK,
+        ).any { info ->
+            info.resolveInfo.serviceInfo.packageName == packageName &&
+                info.resolveInfo.serviceInfo.name.endsWith("CompanionAccessibilityService")
+        }
+    }
+
+    private fun isNotificationAccessEnabled(): Boolean {
+        val enabled = Settings.Secure.getString(
+            contentResolver,
+            "enabled_notification_listeners",
+        ) ?: return false
+        return TextUtils.SimpleStringSplitter(':').let { splitter ->
+            splitter.setString(enabled)
+            splitter.any { component -> component.startsWith("$packageName/") }
+        }
+    }
+}

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -1,12 +1,11 @@
 package tech.threedvr.companion
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.BatteryManager
 import android.provider.Settings
-import android.text.TextUtils
 import android.view.accessibility.AccessibilityManager
-import androidx.core.content.getSystemService
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -39,7 +38,7 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun deviceStatus(): Map<String, Any?> {
-        val battery = getSystemService<BatteryManager>()
+        val battery = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
         return mapOf(
             "sdk" to android.os.Build.VERSION.SDK_INT,
             "manufacturer" to android.os.Build.MANUFACTURER,
@@ -63,7 +62,8 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun isAccessibilityEnabled(): Boolean {
-        val manager = getSystemService<AccessibilityManager>() ?: return false
+        val manager = getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+            ?: return false
         return manager.getEnabledAccessibilityServiceList(
             android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_ALL_MASK,
         ).any { info ->
@@ -77,9 +77,6 @@ class MainActivity : FlutterActivity() {
             contentResolver,
             "enabled_notification_listeners",
         ) ?: return false
-        return TextUtils.SimpleStringSplitter(':').let { splitter ->
-            splitter.setString(enabled)
-            splitter.any { component -> component.startsWith("$packageName/") }
-        }
+        return enabled.split(':').any { component -> component.startsWith("$packageName/") }
     }
 }

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -1,10 +1,9 @@
-package tech.`3dvr`.companion
+package tech.threedvr.companion
 
 import android.content.Intent
 import android.net.Uri
 import android.os.BatteryManager
 import android.provider.Settings
-import android.service.notification.NotificationListenerService
 import android.text.TextUtils
 import android.view.accessibility.AccessibilityManager
 import androidx.core.content.getSystemService

--- a/apps/companion/native-spec/android/companion_accessibility_service.xml
+++ b/apps/companion/native-spec/android/companion_accessibility_service.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowsChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:canRetrieveWindowContent="true"
+    android:canPerformGestures="false"
+    android:notificationTimeout="250"
+    android:description="@string/companion_accessibility_description" />

--- a/apps/companion/native-spec/ios/OpenCompanionDashboardIntent.swift
+++ b/apps/companion/native-spec/ios/OpenCompanionDashboardIntent.swift
@@ -1,0 +1,25 @@
+import AppIntents
+
+struct OpenCompanionDashboardIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open 3DVR Companion"
+    static var description = IntentDescription("Open the 3DVR Companion dashboard and approval queue.")
+    static var openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        .result()
+    }
+}
+
+struct CompanionShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenCompanionDashboardIntent(),
+            phrases: [
+                "Open Companion in \(.applicationName)",
+                "Show my assistant in \(.applicationName)",
+            ],
+            shortTitle: "Open Companion",
+            systemImageName: "sparkles"
+        )
+    }
+}

--- a/apps/companion/native-spec/ios/OpenCompanionDashboardIntent.swift
+++ b/apps/companion/native-spec/ios/OpenCompanionDashboardIntent.swift
@@ -1,5 +1,6 @@
 import AppIntents
 
+@available(iOS 16.0, *)
 struct OpenCompanionDashboardIntent: AppIntent {
     static var title: LocalizedStringResource = "Open 3DVR Companion"
     static var description = IntentDescription("Open the 3DVR Companion dashboard and approval queue.")
@@ -10,6 +11,7 @@ struct OpenCompanionDashboardIntent: AppIntent {
     }
 }
 
+@available(iOS 16.0, *)
 struct CompanionShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(

--- a/apps/companion/pubspec.yaml
+++ b/apps/companion/pubspec.yaml
@@ -10,5 +10,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
 flutter:
   uses-material-design: true

--- a/apps/companion/pubspec.yaml
+++ b/apps/companion/pubspec.yaml
@@ -1,0 +1,14 @@
+name: companion
+version: 0.1.0+1
+publish_to: none
+description: Permissioned device-side companion for 3DVR Life Ops.
+
+environment:
+  sdk: '>=3.7.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -13,7 +13,9 @@ BACKUP="$(mktemp -d)"
 trap 'rm -rf "$BACKUP"' EXIT
 
 cp -R lib "$BACKUP/lib"
+cp -R test "$BACKUP/test"
 cp pubspec.yaml "$BACKUP/pubspec.yaml"
+cp README.md "$BACKUP/README.md"
 
 flutter create \
   --org tech.threedvr \
@@ -21,9 +23,11 @@ flutter create \
   --platforms=android,ios \
   .
 
-rm -rf lib
+rm -rf lib test
 cp -R "$BACKUP/lib" lib
+cp -R "$BACKUP/test" test
 cp "$BACKUP/pubspec.yaml" pubspec.yaml
+cp "$BACKUP/README.md" README.md
 
 KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
 mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
@@ -108,8 +112,9 @@ cp native-spec/ios/OpenCompanionDashboardIntent.swift \
   ios/CompanionNativeSpec/OpenCompanionDashboardIntent.swift
 
 flutter pub get
-dart format lib
+dart format lib test
 flutter analyze
+flutter test
 
 echo
 echo "3DVR Companion scaffolded."

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -16,6 +16,7 @@ cp -R lib "$BACKUP/lib"
 cp -R test "$BACKUP/test"
 cp pubspec.yaml "$BACKUP/pubspec.yaml"
 cp README.md "$BACKUP/README.md"
+cp analysis_options.yaml "$BACKUP/analysis_options.yaml"
 
 flutter create \
   --org tech.threedvr \
@@ -28,6 +29,7 @@ cp -R "$BACKUP/lib" lib
 cp -R "$BACKUP/test" test
 cp "$BACKUP/pubspec.yaml" pubspec.yaml
 cp "$BACKUP/README.md" README.md
+cp "$BACKUP/analysis_options.yaml" analysis_options.yaml
 
 KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
 mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$APP_DIR"
+
+command -v flutter >/dev/null 2>&1 || {
+  echo "flutter is required"
+  exit 1
+}
+
+BACKUP="$(mktemp -d)"
+trap 'rm -rf "$BACKUP"' EXIT
+
+cp -R lib "$BACKUP/lib"
+cp pubspec.yaml "$BACKUP/pubspec.yaml"
+
+flutter create \
+  --org tech.threedvr \
+  --project-name companion \
+  --platforms=android,ios \
+  .
+
+rm -rf lib
+cp -R "$BACKUP/lib" lib
+cp "$BACKUP/pubspec.yaml" pubspec.yaml
+
+KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
+mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
+cp native-spec/android/MainActivity.kt "$KOTLIN_DIR/MainActivity.kt"
+cp native-spec/android/CompanionAccessibilityService.kt "$KOTLIN_DIR/CompanionAccessibilityService.kt"
+cp native-spec/android/CompanionNotificationListener.kt "$KOTLIN_DIR/CompanionNotificationListener.kt"
+cp native-spec/android/companion_accessibility_service.xml \
+  android/app/src/main/res/xml/companion_accessibility_service.xml
+
+python3 <<'PY'
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+ANDROID = 'http://schemas.android.com/apk/res/android'
+ET.register_namespace('android', ANDROID)
+a = lambda name: f'{{{ANDROID}}}{name}'
+
+manifest_path = Path('android/app/src/main/AndroidManifest.xml')
+tree = ET.parse(manifest_path)
+root = tree.getroot()
+app = root.find('application')
+if app is None:
+    raise SystemExit('AndroidManifest.xml has no <application>')
+
+for service in list(app.findall('service')):
+    if service.get(a('name')) in {
+        '.CompanionAccessibilityService',
+        '.CompanionNotificationListener',
+    }:
+        app.remove(service)
+
+accessibility = ET.SubElement(app, 'service', {
+    a('name'): '.CompanionAccessibilityService',
+    a('permission'): 'android.permission.BIND_ACCESSIBILITY_SERVICE',
+    a('exported'): 'true',
+    a('label'): '3DVR Companion accessibility',
+})
+intent_filter = ET.SubElement(accessibility, 'intent-filter')
+ET.SubElement(intent_filter, 'action', {
+    a('name'): 'android.accessibilityservice.AccessibilityService',
+})
+ET.SubElement(accessibility, 'meta-data', {
+    a('name'): 'android.accessibilityservice',
+    a('resource'): '@xml/companion_accessibility_service',
+})
+
+notification = ET.SubElement(app, 'service', {
+    a('name'): '.CompanionNotificationListener',
+    a('permission'): 'android.permission.BIND_NOTIFICATION_LISTENER_SERVICE',
+    a('exported'): 'false',
+    a('label'): '3DVR Companion notifications',
+})
+notification_filter = ET.SubElement(notification, 'intent-filter')
+ET.SubElement(notification_filter, 'action', {
+    a('name'): 'android.service.notification.NotificationListenerService',
+})
+
+ET.indent(tree, space='    ')
+tree.write(manifest_path, encoding='utf-8', xml_declaration=True)
+
+strings_path = Path('android/app/src/main/res/values/strings.xml')
+if strings_path.exists():
+    strings_tree = ET.parse(strings_path)
+    strings_root = strings_tree.getroot()
+else:
+    strings_path.parent.mkdir(parents=True, exist_ok=True)
+    strings_root = ET.Element('resources')
+    strings_tree = ET.ElementTree(strings_root)
+
+for node in list(strings_root.findall('string')):
+    if node.get('name') == 'companion_accessibility_description':
+        strings_root.remove(node)
+entry = ET.SubElement(strings_root, 'string', {'name': 'companion_accessibility_description'})
+entry.text = 'Lets 3DVR Companion inspect limited screen structure for user-approved assistive actions.'
+ET.indent(strings_tree, space='    ')
+strings_tree.write(strings_path, encoding='utf-8', xml_declaration=True)
+PY
+
+# Keep the iOS App Intent as a reference until we add it to the Xcode project on macOS.
+mkdir -p ios/CompanionNativeSpec
+cp native-spec/ios/OpenCompanionDashboardIntent.swift \
+  ios/CompanionNativeSpec/OpenCompanionDashboardIntent.swift
+
+flutter pub get
+dart format lib
+flutter analyze
+
+echo
+echo "3DVR Companion scaffolded."
+echo "Android native adapter: wired"
+echo "iOS App Intent: staged in ios/CompanionNativeSpec (Xcode target wiring still required)"

--- a/apps/companion/test/protocol_test.dart
+++ b/apps/companion/test/protocol_test.dart
@@ -1,0 +1,35 @@
+import 'package:companion/src/protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('all capabilities have at least one platform', () {
+    expect(
+      companionCapabilities.every((capability) => capability.platforms.isNotEmpty),
+      isTrue,
+    );
+  });
+
+  test('remote Android UI actions require confirmation', () {
+    final capability = companionCapabilities.singleWhere(
+      (value) => value.name == 'ui.perform_known_action',
+    );
+
+    expect(capability.risk, CompanionRisk.yellow);
+    expect(capability.requiresConfirmation, isTrue);
+    expect(capability.platforms, contains(CompanionPlatform.android));
+    expect(capability.platforms, isNot(contains(CompanionPlatform.ios)));
+  });
+
+  test('expired action requests reject themselves locally', () {
+    final now = DateTime.now().toUtc();
+    final request = CompanionActionRequest(
+      id: 'test-expired',
+      capability: 'device.status',
+      createdAt: now.subtract(const Duration(minutes: 2)),
+      expiresAt: now.subtract(const Duration(minutes: 1)),
+      reason: 'test',
+    );
+
+    expect(request.isExpired, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- adds `apps/companion/` as the cross-platform device-side execution layer for Life Ops
- defines a shared capability/risk/approval/audit protocol
- adds a Flutter shell and platform channel
- adds Android native reference adapters for battery/status, URL launching, Accessibility, and notification access
- keeps Android gesture execution disabled in v0.1
- adds an iOS App Intents/Shortcuts seed with explicit platform limitations
- adds a bounded transport contract with expiration/idempotency/scoped approvals
- adds a scaffold script that generates Android/iOS Flutter boilerplate and wires Android services
- adds protocol tests and Android CI that builds a debug APK

## Security boundaries
- no arbitrary shell execution
- no remote arbitrary Accessibility selectors/coordinates/scripts
- no notification body persistence in v0.1
- device permissions remain locally granted/revoked by the OS
- dangerous actions require scoped approval and default disabled
- iOS does not claim arbitrary third-party UI control

## Validation
CI runs:
- `apps/companion/scaffold.sh`
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug`

The first goal is install -> grant explicit permissions -> report capability state -> audit actions. Cross-app gesture actions come only after that path is proven.