### PR TITLE
Connect 3DVR Companion to the phone bridge

### DIFF
--- a/apps/companion/lib/main.dart
+++ b/apps/companion/lib/main.dart
@@ -1,7 +1,9 @@
 import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
+import 'src/local_bridge_server.dart';
 import 'src/platform_bridge.dart';
 import 'src/protocol.dart';
 
@@ -29,9 +31,11 @@ class CompanionHome extends StatefulWidget {
 
 class _CompanionHomeState extends State<CompanionHome> {
   final CompanionPlatformBridge bridge = const CompanionPlatformBridge();
+  late final LocalCompanionServer localServer = LocalCompanionServer(bridge: bridge);
   Map<String, Object?> status = const {};
   Map<String, Object?> permissionState = const {};
   bool loading = true;
+  String? bridgeError;
 
   CompanionPlatform get currentPlatform {
     if (Platform.isAndroid) return CompanionPlatform.android;
@@ -45,6 +49,22 @@ class _CompanionHomeState extends State<CompanionHome> {
   void initState() {
     super.initState();
     refresh();
+    _startLocalBridge();
+  }
+
+  @override
+  void dispose() {
+    localServer.stop();
+    super.dispose();
+  }
+
+  Future<void> _startLocalBridge() async {
+    try {
+      await localServer.start();
+      if (mounted) setState(() => bridgeError = null);
+    } catch (error) {
+      if (mounted) setState(() => bridgeError = error.toString());
+    }
   }
 
   Future<void> refresh() async {
@@ -69,11 +89,23 @@ class _CompanionHomeState extends State<CompanionHome> {
     }
   }
 
+  Future<void> _copyPairingCommand() async {
+    final endpoint = localServer.endpoint;
+    if (endpoint == null) return;
+    final command = "pair-companion '${localServer.token}' '${endpoint.toString()}'";
+    await Clipboard.setData(ClipboardData(text: command));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Termux pairing command copied')),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final capabilities = companionCapabilities
         .where((capability) => capability.platforms.contains(currentPlatform))
         .toList(growable: false);
+    final endpoint = localServer.endpoint;
 
     return Scaffold(
       appBar: AppBar(
@@ -108,6 +140,33 @@ class _CompanionHomeState extends State<CompanionHome> {
                         ...status.entries.map((entry) => Text('${entry.key}: ${entry.value}')),
                       ],
                     ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Local bridge', style: Theme.of(context).textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  if (bridgeError != null)
+                    Text('Unavailable: $bridgeError')
+                  else if (endpoint == null)
+                    const Text('Starting…')
+                  else ...[
+                    Text('Endpoint: $endpoint'),
+                    const Text('Session: paired green actions only'),
+                    const SizedBox(height: 8),
+                    FilledButton.tonalIcon(
+                      onPressed: _copyPairingCommand,
+                      icon: const Icon(Icons.copy),
+                      label: const Text('Copy Termux pairing command'),
+                    ),
+                  ],
+                ],
+              ),
             ),
           ),
           const SizedBox(height: 12),

--- a/apps/companion/lib/src/local_bridge_server.dart
+++ b/apps/companion/lib/src/local_bridge_server.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'platform_bridge.dart';
+
+class LocalCompanionServer {
+  LocalCompanionServer({required this.bridge});
+
+  static const int defaultPort = 38473;
+  final CompanionPlatformBridge bridge;
+
+  HttpServer? _server;
+  final String token = _newToken();
+
+  bool get isRunning => _server != null;
+  Uri? get endpoint => _server == null
+      ? null
+      : Uri.parse('http://127.0.0.1:${_server!.port}');
+
+  Future<void> start({int port = defaultPort}) async {
+    if (_server != null) return;
+    final server = await HttpServer.bind(
+      InternetAddress.loopbackIPv4,
+      port,
+      shared: false,
+    );
+    _server = server;
+    server.listen(_handle, onDone: () => _server = null);
+  }
+
+  Future<void> stop() async {
+    final server = _server;
+    _server = null;
+    await server?.close(force: true);
+  }
+
+  Future<void> _handle(HttpRequest request) async {
+    request.response.headers.contentType = ContentType.json;
+    request.response.headers.set('Cache-Control', 'no-store');
+
+    if (request.headers.value(HttpHeaders.authorizationHeader) != 'Bearer $token') {
+      request.response.statusCode = HttpStatus.unauthorized;
+      _json(request, {'ok': false, 'error': 'unauthorized'});
+      return;
+    }
+
+    try {
+      if (request.method == 'GET' && request.uri.path == '/v1/health') {
+        _json(request, {
+          'ok': true,
+          'transport': 'loopback',
+          'capabilities': ['device.status', 'url.open'],
+        });
+        return;
+      }
+
+      if (request.method == 'GET' && request.uri.path == '/v1/device-status') {
+        final status = await bridge.getDeviceStatus();
+        _json(request, {'ok': true, 'status': status});
+        return;
+      }
+
+      if (request.method == 'POST' && request.uri.path == '/v1/open-url') {
+        final body = await utf8.decoder.bind(request).join();
+        final decoded = jsonDecode(body);
+        if (decoded is! Map || decoded['url'] is! String) {
+          request.response.statusCode = HttpStatus.badRequest;
+          _json(request, {'ok': false, 'error': 'url is required'});
+          return;
+        }
+        final opened = await bridge.openUrl(decoded['url'] as String);
+        _json(request, {'ok': opened});
+        return;
+      }
+
+      request.response.statusCode = HttpStatus.notFound;
+      _json(request, {'ok': false, 'error': 'not found'});
+    } catch (_) {
+      request.response.statusCode = HttpStatus.internalServerError;
+      _json(request, {'ok': false, 'error': 'request failed'});
+    }
+  }
+
+  void _json(HttpRequest request, Map<String, Object?> value) {
+    request.response.write(jsonEncode(value));
+    request.response.close();
+  }
+
+  static String _newToken() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+    return base64Url.encode(bytes).replaceAll('=', '');
+  }
+}

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -50,6 +50,15 @@ a = lambda name: f'{{{ANDROID}}}{name}'
 manifest_path = Path('android/app/src/main/AndroidManifest.xml')
 tree = ET.parse(manifest_path)
 root = tree.getroot()
+
+if not any(
+    node.get(a('name')) == 'android.permission.INTERNET'
+    for node in root.findall('uses-permission')
+):
+    root.insert(0, ET.Element('uses-permission', {
+        a('name'): 'android.permission.INTERNET',
+    }))
+
 app = root.find('application')
 if app is None:
     raise SystemExit('AndroidManifest.xml has no <application>')


### PR DESCRIPTION
## Summary
- adds a loopback-only Companion HTTP bridge on 127.0.0.1
- generates an ephemeral session token and exposes a one-tap Termux pairing command
- allows only green capabilities in v0.2: health, device status, safe http/https URL open
- adds Android INTERNET permission during scaffold

## Security
- no LAN/public bind
- bearer token required
- token is generated locally and never committed
- no Accessibility gestures or arbitrary commands
- server stops with the app process

## Validation
Existing Companion CI scaffolds, analyzes, tests, and builds the Android APK.