### PR TITLE
Keep Companion bridge alive in Android background

### DIFF
--- a/apps/companion/native-spec/android/CompanionKeepAliveService.kt
+++ b/apps/companion/native-spec/android/CompanionKeepAliveService.kt
@@ -1,0 +1,65 @@
+package tech.threedvr.companion
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+
+class CompanionKeepAliveService : Service() {
+    companion object {
+        private const val channelId = "companion_bridge"
+        private const val notificationId = 38473
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannel()
+        startForeground(notificationId, buildNotification())
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val channel = NotificationChannel(
+            channelId,
+            "3DVR Companion bridge",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Keeps the local Companion bridge available while the app is in the background."
+            setShowBadge(false)
+        }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification {
+        val openIntent = packageManager.getLaunchIntentForPackage(packageName)
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            openIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, channelId)
+        } else {
+            @Suppress("DEPRECATION")
+            Notification.Builder(this)
+        }
+        return builder
+            .setContentTitle("3DVR Companion active")
+            .setContentText("Local assistant bridge is available")
+            .setSmallIcon(android.R.drawable.stat_notify_sync_noanim)
+            .setOngoing(true)
+            .setContentIntent(pendingIntent)
+            .build()
+    }
+}

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.BatteryManager
+import android.os.Build
 import android.provider.Settings
 import android.view.accessibility.AccessibilityManager
 import io.flutter.embedding.android.FlutterActivity
@@ -15,6 +16,7 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        startKeepAliveService()
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
             .setMethodCallHandler { call, result ->
                 when (call.method) {
@@ -37,6 +39,15 @@ class MainActivity : FlutterActivity() {
             }
     }
 
+    private fun startKeepAliveService() {
+        val intent = Intent(this, CompanionKeepAliveService::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(intent)
+        } else {
+            startService(intent)
+        }
+    }
+
     private fun deviceStatus(): Map<String, Any?> {
         val battery = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
         return mapOf(
@@ -50,6 +61,7 @@ class MainActivity : FlutterActivity() {
     private fun capabilityStatus(): Map<String, Any> = mapOf(
         "accessibilityEnabled" to isAccessibilityEnabled(),
         "notificationAccessEnabled" to isNotificationAccessEnabled(),
+        "backgroundBridgeEnabled" to true,
         // Remote gesture execution intentionally remains false in v0.1.
         "remoteKnownActionsEnabled" to false,
     )

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -36,6 +36,7 @@ mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
 cp native-spec/android/MainActivity.kt "$KOTLIN_DIR/MainActivity.kt"
 cp native-spec/android/CompanionAccessibilityService.kt "$KOTLIN_DIR/CompanionAccessibilityService.kt"
 cp native-spec/android/CompanionNotificationListener.kt "$KOTLIN_DIR/CompanionNotificationListener.kt"
+cp native-spec/android/CompanionKeepAliveService.kt "$KOTLIN_DIR/CompanionKeepAliveService.kt"
 cp native-spec/android/companion_accessibility_service.xml \
   android/app/src/main/res/xml/companion_accessibility_service.xml
 
@@ -51,13 +52,18 @@ manifest_path = Path('android/app/src/main/AndroidManifest.xml')
 tree = ET.parse(manifest_path)
 root = tree.getroot()
 
-if not any(
-    node.get(a('name')) == 'android.permission.INTERNET'
-    for node in root.findall('uses-permission')
-):
-    root.insert(0, ET.Element('uses-permission', {
-        a('name'): 'android.permission.INTERNET',
-    }))
+permissions = [
+    'android.permission.INTERNET',
+    'android.permission.FOREGROUND_SERVICE',
+    'android.permission.FOREGROUND_SERVICE_SPECIAL_USE',
+    'android.permission.POST_NOTIFICATIONS',
+]
+existing_permissions = {
+    node.get(a('name')) for node in root.findall('uses-permission')
+}
+for permission in reversed(permissions):
+    if permission not in existing_permissions:
+        root.insert(0, ET.Element('uses-permission', {a('name'): permission}))
 
 app = root.find('application')
 if app is None:
@@ -67,6 +73,7 @@ for service in list(app.findall('service')):
     if service.get(a('name')) in {
         '.CompanionAccessibilityService',
         '.CompanionNotificationListener',
+        '.CompanionKeepAliveService',
     }:
         app.remove(service)
 
@@ -94,6 +101,17 @@ notification = ET.SubElement(app, 'service', {
 notification_filter = ET.SubElement(notification, 'intent-filter')
 ET.SubElement(notification_filter, 'action', {
     a('name'): 'android.service.notification.NotificationListenerService',
+})
+
+keepalive = ET.SubElement(app, 'service', {
+    a('name'): '.CompanionKeepAliveService',
+    a('exported'): 'false',
+    a('foregroundServiceType'): 'specialUse',
+    a('stopWithTask'): 'false',
+})
+ET.SubElement(keepalive, 'property', {
+    a('name'): 'android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE',
+    a('value'): 'Keeps the user-enabled local 3DVR Companion bridge reachable while the app is backgrounded.',
 })
 
 ET.indent(tree, space='    ')
@@ -130,4 +148,5 @@ flutter test
 echo
 echo "3DVR Companion scaffolded."
 echo "Android native adapter: wired"
+echo "Android background bridge keep-alive: wired"
 echo "iOS App Intent: staged in ios/CompanionNativeSpec (Xcode target wiring still required)"


### PR DESCRIPTION
Adds an Android foreground keep-alive service so the local loopback bridge remains responsive when Companion is backgrounded. Includes foreground-service permissions and manifest wiring. No new remote capabilities.