### PR TITLE
Add safe app launch and notification metadata to Companion

### DIFF
--- a/apps/companion/lib/src/local_bridge_server.dart
+++ b/apps/companion/lib/src/local_bridge_server.dart
@@ -50,7 +50,12 @@ class LocalCompanionServer {
         _json(request, {
           'ok': true,
           'transport': 'loopback',
-          'capabilities': ['device.status', 'url.open'],
+          'capabilities': [
+            'device.status',
+            'url.open',
+            'app.open_known',
+            'notification.metadata.read',
+          ],
         });
         return;
       }
@@ -61,16 +66,35 @@ class LocalCompanionServer {
         return;
       }
 
+      if (request.method == 'GET' && request.uri.path == '/v1/notification-metadata') {
+        final notifications = await bridge.getNotificationMetadata();
+        _json(request, {'ok': true, 'notifications': notifications});
+        return;
+      }
+
       if (request.method == 'POST' && request.uri.path == '/v1/open-url') {
-        final body = await utf8.decoder.bind(request).join();
-        final decoded = jsonDecode(body);
-        if (decoded is! Map || decoded['url'] is! String) {
+        final decoded = await _readObject(request);
+        final url = decoded?['url'];
+        if (url is! String) {
           request.response.statusCode = HttpStatus.badRequest;
           _json(request, {'ok': false, 'error': 'url is required'});
           return;
         }
-        final opened = await bridge.openUrl(decoded['url'] as String);
+        final opened = await bridge.openUrl(url);
         _json(request, {'ok': opened});
+        return;
+      }
+
+      if (request.method == 'POST' && request.uri.path == '/v1/open-app') {
+        final decoded = await _readObject(request);
+        final alias = decoded?['alias'];
+        if (alias is! String) {
+          request.response.statusCode = HttpStatus.badRequest;
+          _json(request, {'ok': false, 'error': 'alias is required'});
+          return;
+        }
+        final opened = await bridge.openKnownApp(alias);
+        _json(request, {'ok': opened, 'alias': alias});
         return;
       }
 
@@ -80,6 +104,13 @@ class LocalCompanionServer {
       request.response.statusCode = HttpStatus.internalServerError;
       _json(request, {'ok': false, 'error': 'request failed'});
     }
+  }
+
+  Future<Map<String, Object?>?> _readObject(HttpRequest request) async {
+    final body = await utf8.decoder.bind(request).join();
+    final decoded = jsonDecode(body);
+    if (decoded is! Map) return null;
+    return decoded.map((key, value) => MapEntry(key.toString(), value));
   }
 
   void _json(HttpRequest request, Map<String, Object?> value) {

--- a/apps/companion/lib/src/platform_bridge.dart
+++ b/apps/companion/lib/src/platform_bridge.dart
@@ -15,6 +15,20 @@ class CompanionPlatformBridge {
     return result ?? false;
   }
 
+  Future<bool> openKnownApp(String alias) async {
+    final result = await _channel.invokeMethod<bool>('openKnownApp', {'alias': alias});
+    return result ?? false;
+  }
+
+  Future<List<Map<String, Object?>>> getNotificationMetadata() async {
+    final result = await _channel.invokeListMethod<Map>('notificationMetadata');
+    if (result == null) return const [];
+    return result
+        .map((item) => item.map((key, value) => MapEntry(key.toString(), value)))
+        .cast<Map<String, Object?>>()
+        .toList(growable: false);
+  }
+
   Future<Map<String, Object?>> getCapabilityStatus() async {
     final result = await _channel.invokeMapMethod<String, Object?>('capabilityStatus');
     return result ?? const {};

--- a/apps/companion/lib/src/protocol.dart
+++ b/apps/companion/lib/src/protocol.dart
@@ -113,6 +113,12 @@ const companionCapabilities = <CompanionCapability>[
     description: 'Open an http/https URL using the operating system.',
   ),
   CompanionCapability(
+    name: 'app.open_known',
+    risk: CompanionRisk.green,
+    platforms: {CompanionPlatform.android},
+    description: 'Open one locally allowlisted Android app by friendly alias.',
+  ),
+  CompanionCapability(
     name: 'notification.metadata.read',
     risk: CompanionRisk.yellow,
     platforms: {CompanionPlatform.android},

--- a/apps/companion/native-spec/android/CompanionNotificationListener.kt
+++ b/apps/companion/native-spec/android/CompanionNotificationListener.kt
@@ -3,23 +3,46 @@ package tech.threedvr.companion
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 
-/**
- * Notification listener seed.
- *
- * v0.1 intentionally normalizes only low-sensitivity metadata and does not
- * persist notification body text, message content, or tokens.
- */
-class CompanionNotificationListener : NotificationListenerService() {
-    override fun onNotificationPosted(sbn: StatusBarNotification?) {
-        val notification = sbn ?: return
+object NotificationMetadataStore {
+    private const val maxEntries = 50
+    private val lock = Any()
+    private val entries = LinkedHashMap<String, Map<String, Any?>>()
+
+    fun upsert(notification: StatusBarNotification) {
         val metadata = mapOf(
             "packageName" to notification.packageName,
             "postedAt" to notification.postTime,
             "isOngoing" to notification.isOngoing,
             "category" to notification.notification.category,
         )
-        // TODO: hand this local metadata to Companion's encrypted local store.
-        @Suppress("UNUSED_VARIABLE")
-        val normalized = metadata
+        synchronized(lock) {
+            entries[notification.key] = metadata
+            while (entries.size > maxEntries) {
+                val firstKey = entries.keys.firstOrNull() ?: break
+                entries.remove(firstKey)
+            }
+        }
+    }
+
+    fun remove(notification: StatusBarNotification) {
+        synchronized(lock) { entries.remove(notification.key) }
+    }
+
+    fun snapshot(): List<Map<String, Any?>> = synchronized(lock) {
+        entries.values.toList().asReversed()
+    }
+}
+
+/**
+ * Keeps only low-sensitivity notification metadata in memory.
+ * Message bodies, titles, text, tokens, and notification extras are never stored.
+ */
+class CompanionNotificationListener : NotificationListenerService() {
+    override fun onNotificationPosted(sbn: StatusBarNotification?) {
+        sbn?.let(NotificationMetadataStore::upsert)
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+        sbn?.let(NotificationMetadataStore::remove)
     }
 }

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -14,6 +14,16 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity : FlutterActivity() {
     private val channelName = "tech.3dvr.companion/platform"
 
+    private val knownApps = mapOf(
+        "chatgpt" to listOf("com.openai.chatgpt"),
+        "maps" to listOf("com.google.android.apps.maps"),
+        "gmail" to listOf("com.google.android.gm"),
+        "chrome" to listOf("com.android.chrome"),
+        "termux" to listOf("com.termux"),
+        "calendar" to listOf("com.google.android.calendar", "com.samsung.android.calendar"),
+        "camera" to listOf("com.sec.android.app.camera", "com.google.android.GoogleCamera"),
+    )
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         startKeepAliveService()
@@ -22,9 +32,14 @@ class MainActivity : FlutterActivity() {
                 when (call.method) {
                     "deviceStatus" -> result.success(deviceStatus())
                     "capabilityStatus" -> result.success(capabilityStatus())
+                    "notificationMetadata" -> result.success(NotificationMetadataStore.snapshot())
                     "openUrl" -> {
                         val raw = call.argument<String>("url") ?: ""
                         result.success(openHttpUrl(raw))
+                    }
+                    "openKnownApp" -> {
+                        val alias = call.argument<String>("alias") ?: ""
+                        result.success(openKnownApp(alias))
                     }
                     "openAccessibilitySettings" -> {
                         startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
@@ -51,9 +66,9 @@ class MainActivity : FlutterActivity() {
     private fun deviceStatus(): Map<String, Any?> {
         val battery = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
         return mapOf(
-            "sdk" to android.os.Build.VERSION.SDK_INT,
-            "manufacturer" to android.os.Build.MANUFACTURER,
-            "model" to android.os.Build.MODEL,
+            "sdk" to Build.VERSION.SDK_INT,
+            "manufacturer" to Build.MANUFACTURER,
+            "model" to Build.MODEL,
             "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY),
         )
     }
@@ -62,7 +77,7 @@ class MainActivity : FlutterActivity() {
         "accessibilityEnabled" to isAccessibilityEnabled(),
         "notificationAccessEnabled" to isNotificationAccessEnabled(),
         "backgroundBridgeEnabled" to true,
-        // Remote gesture execution intentionally remains false in v0.1.
+        "knownAppLaunchEnabled" to true,
         "remoteKnownActionsEnabled" to false,
     )
 
@@ -71,6 +86,22 @@ class MainActivity : FlutterActivity() {
         if (uri.scheme != "https" && uri.scheme != "http") return false
         startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
         return true
+    }
+
+    private fun openKnownApp(rawAlias: String): Boolean {
+        val alias = rawAlias.trim().lowercase()
+        if (alias == "settings") {
+            startActivity(Intent(Settings.ACTION_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            return true
+        }
+        val candidates = knownApps[alias] ?: return false
+        for (packageName in candidates) {
+            val launchIntent = packageManager.getLaunchIntentForPackage(packageName) ?: continue
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(launchIntent)
+            return true
+        }
+        return false
     }
 
     private fun isAccessibilityEnabled(): Boolean {


### PR DESCRIPTION
Adds v0.3 Android capabilities: allowlisted app launch (ChatGPT, Maps, Gmail, Chrome, Termux, Calendar, Camera, Settings) and in-memory notification metadata only. No notification bodies/titles/text are stored. No UI gestures, message sending, purchases, deletions, or arbitrary package execution.