### PR TITLE
[SUPERSEDED by #1501] Add RUNE v0.1 mission language

### DIFF
--- a/apps/agent/docs/rune-missions.md
+++ b/apps/agent/docs/rune-missions.md
@@ -1,0 +1,112 @@
+# RUNE missions v0.1
+
+RUNE is a small, human-readable mission language for the existing 3DVR agent runtime.
+
+It does **not** replace the mission runner. A `.rune` file is parsed into the same versioned mission object used by JSON missions, so dependency handling, retries, evidence, state, and approval gates keep the same behavior.
+
+## First principle
+
+Write the intent and the proof before giving an agent permission to act.
+
+```text
+human intent
+  -> RUNE mission
+  -> existing mission schema
+  -> planner / worker
+  -> evidence
+  -> evaluator
+  -> approval gate
+```
+
+## Minimal mission
+
+```rune
+mission inspect-portal {
+  repository: "tmsteph/3dvr-portal"
+  objective: "Inspect the portal without changing it."
+
+  task inspect {
+    objective: "Read the current repository state."
+    command: ["git", "status", "-sb"]
+    evidence: "git status"
+  }
+}
+```
+
+The safe defaults are:
+
+- `branch: "main"`
+- `backend: deterministic`
+- `risk: read_only`
+- `model: review`
+- `worktree: false`
+- `retries: 1`
+- a conservative approval policy for consequential external writes, money, credentials, destructive actions, and production deployment
+
+## Task fields
+
+```rune
+task repair-homepage {
+  objective: "Repair the homepage without broadening scope."
+  backend: codex
+  risk: workspace_write
+  model: coding
+  worktree: true
+  depends: [inspect]
+  files: ["index.html", "tests/homepage.test.js"]
+  command: ["node", "--test", "tests/homepage.test.js"]
+  accept: "focused homepage tests pass"
+  evidence: "changed files"
+  evidence: "test results"
+  retries: 2
+}
+```
+
+Repeated `command`, `accept`, and `evidence` fields append to their corresponding lists.
+
+Commands are argument arrays, not shell strings. This preserves the mission runner's bounded execution model and avoids adding a second shell parser to RUNE.
+
+## Approval gates
+
+```rune
+task merge {
+  objective: "Stop for explicit human merge approval."
+  backend: deterministic
+  risk: external_write
+  depends: [repair-homepage]
+  gate: [merge_pull_request, "tmsteph/3dvr-portal#1234"]
+  evidence: "approval record"
+}
+```
+
+A gate compiles to the existing scoped approval record. RUNE does not bypass or weaken approval handling.
+
+## Use it
+
+Mission lookup prefers the existing `.json` definition when one exists. If JSON is absent, the runner loads the matching `.rune` file and compiles it in memory.
+
+```sh
+3dvr mission validate rune-demo-v01
+3dvr mission run rune-demo-v01
+3dvr mission run rune-demo-v01 --execute
+3dvr mission status rune-demo-v01
+```
+
+`run` remains inspect-only by default. `--execute` is still required before declared commands run.
+
+See `apps/agent/missions/rune-demo-v01.rune` for the first tracked example.
+
+## Deliberate limits in v0.1
+
+RUNE v0.1 is intentionally small:
+
+- one mission per file
+- one statement per line
+- no variables
+- no loops
+- no conditionals
+- no inline shell
+- no hidden model calls
+- no implicit external writes
+
+Those limits keep the language readable and make the compiled mission easy to inspect. Add syntax only when a real mission cannot be expressed cleanly with the existing schema.

--- a/apps/agent/missions/rune-demo-v01.rune
+++ b/apps/agent/missions/rune-demo-v01.rune
@@ -1,0 +1,32 @@
+# RUNE v0.1 mission example
+mission rune-demo-v01 {
+  repository: "tmsteph/3dvr-portal"
+  branch: "main"
+  objective: "Prove that a human-readable RUNE mission can drive the existing 3DVR mission runtime."
+  approval_policy: "Pause before consequential external writes, money, credentials, destructive actions, or production deployment."
+
+  task inspect-repository {
+    objective: "Inspect the repository without changing it."
+    backend: deterministic
+    risk: read_only
+    model: review
+    worktree: false
+    command: ["git", "status", "-sb"]
+    command: ["git", "rev-parse", "--show-toplevel"]
+    accept: "Repository state can be inspected without writes."
+    evidence: "git status"
+    evidence: "repository root"
+    retries: 2
+  }
+
+  task describe-next-step {
+    objective: "Record the next bounded step after repository inspection."
+    backend: deterministic
+    risk: read_only
+    model: review
+    worktree: false
+    depends: [inspect-repository]
+    accept: "The first task completed before this task becomes ready."
+    evidence: "dependency-aware mission state"
+  }
+}

--- a/apps/agent/test/mission-rune.test.js
+++ b/apps/agent/test/mission-rune.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { compileRune, splitList } = require('../thomas-agent/node/mission-rune');
+const { validateMission } = require('../thomas-agent/node/mission-schema');
+const { loadMission, runMission } = require('../thomas-agent/node/mission-runner');
+
+const SOURCE = `
+mission parser-test {
+  repository: "tmsteph/3dvr-portal"
+  objective: "Turn human intent into a bounded mission."
+
+  task inspect {
+    objective: "Inspect the repository."
+    command: ["git", "status", "-sb"]
+    evidence: "git status"
+    retries: 2
+  }
+
+  task repair {
+    objective: "Delegate one bounded repair."
+    backend: codex
+    risk: workspace_write
+    model: coding
+    worktree: true
+    depends: [inspect]
+    files: ["index.html", "tests/homepage.test.js"]
+    accept: "focused tests pass"
+    evidence: "changed files"
+  }
+
+  task merge {
+    objective: "Stop for human merge approval."
+    backend: deterministic
+    risk: external_write
+    depends: [repair]
+    gate: [merge_pull_request, "tmsteph/3dvr-portal#1234"]
+    evidence: "approval record"
+  }
+}
+`;
+
+async function temp() {
+  return fs.mkdtemp(path.join(os.tmpdir(), '3dvr-rune-'));
+}
+
+test('RUNE compiles into the existing versioned mission schema', () => {
+  const mission = compileRune(SOURCE);
+  assert.equal(mission.schemaVersion, 1);
+  assert.equal(mission.missionId, 'parser-test');
+  assert.equal(mission.defaultBranch, 'main');
+  assert.equal(mission.tasks.length, 3);
+  assert.deepEqual(mission.tasks[0].commands, [['git', 'status', '-sb']]);
+  assert.deepEqual(mission.tasks[1].dependsOn, ['inspect']);
+  assert.deepEqual(mission.tasks[1].allowedFiles, ['index.html', 'tests/homepage.test.js']);
+  assert.deepEqual(mission.tasks[2].approvalGate, { action: 'merge_pull_request', target: 'tmsteph/3dvr-portal#1234' });
+  assert.deepEqual(validateMission(mission), []);
+});
+
+test('RUNE lists accept quoted values and bare identifiers', () => {
+  assert.deepEqual(splitList('[inspect, "repair task"]', 1), ['inspect', 'repair task']);
+});
+
+test('RUNE rejects unknown fields instead of silently guessing', () => {
+  assert.throws(() => compileRune(SOURCE.replace('evidence: "git status"', 'magic: true')), /unknown task field: magic/);
+});
+
+test('mission loader falls back from JSON to RUNE and keeps inspect-only execution', async () => {
+  const missionsDir = await temp();
+  const stateRoot = await temp();
+  await fs.writeFile(path.join(missionsDir, 'parser-test.rune'), SOURCE);
+  const mission = await loadMission('parser-test', missionsDir);
+  assert.equal(mission.missionId, 'parser-test');
+  const result = await runMission(['run', 'parser-test', '--state-root', stateRoot], { missionsDir, options: { stateRoot } });
+  assert.equal(result.status, 'ready');
+  assert.equal(result.taskId, 'inspect');
+  assert.deepEqual(result.checks, [['git', 'status', '-sb']]);
+});

--- a/apps/agent/thomas-agent/node/mission-rune.js
+++ b/apps/agent/thomas-agent/node/mission-rune.js
@@ -1,0 +1,227 @@
+const { validateMission } = require('./mission-schema');
+
+const MISSION_KEYS = new Map([
+  ['repository', 'repository'],
+  ['branch', 'defaultBranch'],
+  ['default_branch', 'defaultBranch'],
+  ['objective', 'objective'],
+  ['approval_policy', 'approvalPolicy']
+]);
+
+const TASK_KEYS = new Map([
+  ['objective', 'objective'],
+  ['backend', 'backend'],
+  ['risk', 'riskClass'],
+  ['risk_class', 'riskClass'],
+  ['model', 'modelTier'],
+  ['model_tier', 'modelTier'],
+  ['worktree', 'worktree']
+]);
+
+function runeError(lineNumber, message) {
+  const error = new Error(`RUNE line ${lineNumber}: ${message}`);
+  error.code = 'RUNE_PARSE_ERROR';
+  return error;
+}
+
+function parseScalar(raw, lineNumber) {
+  const value = raw.trim();
+  if (!value) throw runeError(lineNumber, 'missing value');
+  if (value.startsWith('"')) {
+    try { return JSON.parse(value); } catch { throw runeError(lineNumber, 'invalid quoted string'); }
+  }
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (/^-?\d+$/.test(value)) return Number.parseInt(value, 10);
+  return value;
+}
+
+function splitList(raw, lineNumber) {
+  const value = raw.trim();
+  if (!value.startsWith('[') || !value.endsWith(']')) throw runeError(lineNumber, 'expected a list in [brackets]');
+  const body = value.slice(1, -1).trim();
+  if (!body) return [];
+  const items = [];
+  let current = '';
+  let quoted = false;
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quoted) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      current += char;
+      quoted = !quoted;
+      continue;
+    }
+    if (char === ',' && !quoted) {
+      items.push(parseScalar(current, lineNumber));
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (quoted) throw runeError(lineNumber, 'unterminated quoted value');
+  items.push(parseScalar(current, lineNumber));
+  return items;
+}
+
+function stringList(raw, lineNumber, key) {
+  const values = splitList(raw, lineNumber);
+  if (values.some(value => typeof value !== 'string' || !value.trim())) throw runeError(lineNumber, `${key} must contain only strings`);
+  return values;
+}
+
+function defaultTask(id) {
+  return {
+    id,
+    objective: '',
+    dependsOn: [],
+    status: 'queued',
+    riskClass: 'read_only',
+    modelTier: 'review',
+    backend: 'deterministic',
+    worktree: false,
+    allowedFiles: [],
+    commands: [],
+    acceptanceTests: [],
+    evidenceRequired: [],
+    approvalGate: null,
+    retryPolicy: { maxAttempts: 1 }
+  };
+}
+
+function setMissionField(mission, key, raw, lineNumber) {
+  const target = MISSION_KEYS.get(key);
+  if (!target) throw runeError(lineNumber, `unknown mission field: ${key}`);
+  const value = parseScalar(raw, lineNumber);
+  if (typeof value !== 'string') throw runeError(lineNumber, `${key} must be text`);
+  mission[target] = value;
+}
+
+function setTaskField(task, key, raw, lineNumber) {
+  if (TASK_KEYS.has(key)) {
+    const target = TASK_KEYS.get(key);
+    const value = parseScalar(raw, lineNumber);
+    if (target === 'worktree') {
+      if (typeof value !== 'boolean') throw runeError(lineNumber, 'worktree must be true or false');
+    } else if (typeof value !== 'string') {
+      throw runeError(lineNumber, `${key} must be text`);
+    }
+    task[target] = value;
+    return;
+  }
+  if (key === 'depends') {
+    task.dependsOn = stringList(raw, lineNumber, key);
+    return;
+  }
+  if (key === 'files') {
+    task.allowedFiles = stringList(raw, lineNumber, key);
+    return;
+  }
+  if (key === 'command') {
+    const command = stringList(raw, lineNumber, key);
+    if (!command.length) throw runeError(lineNumber, 'command cannot be empty');
+    task.commands.push(command);
+    return;
+  }
+  if (key === 'accept') {
+    const value = parseScalar(raw, lineNumber);
+    if (typeof value !== 'string') throw runeError(lineNumber, 'accept must be text');
+    task.acceptanceTests.push(value);
+    return;
+  }
+  if (key === 'evidence') {
+    const value = parseScalar(raw, lineNumber);
+    if (typeof value !== 'string') throw runeError(lineNumber, 'evidence must be text');
+    task.evidenceRequired.push(value);
+    return;
+  }
+  if (key === 'retries') {
+    const value = parseScalar(raw, lineNumber);
+    if (!Number.isInteger(value) || value < 1) throw runeError(lineNumber, 'retries must be an integer of 1 or more');
+    task.retryPolicy.maxAttempts = value;
+    return;
+  }
+  if (key === 'gate') {
+    const values = stringList(raw, lineNumber, key);
+    if (values.length !== 2) throw runeError(lineNumber, 'gate must be [action, target]');
+    task.approvalGate = { action: values[0], target: values[1] };
+    return;
+  }
+  throw runeError(lineNumber, `unknown task field: ${key}`);
+}
+
+function compileRune(source, options = {}) {
+  const lines = String(source || '').replace(/\r\n/g, '\n').split('\n');
+  let mission = null;
+  let currentTask = null;
+  let missionClosed = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const lineNumber = index + 1;
+    const line = lines[index].trim();
+    if (!line || line.startsWith('#') || line.startsWith('//')) continue;
+
+    const missionStart = line.match(/^mission\s+([A-Za-z0-9._-]+)\s*\{$/);
+    if (missionStart) {
+      if (mission) throw runeError(lineNumber, 'only one mission is allowed per file');
+      mission = {
+        schemaVersion: 1,
+        missionId: missionStart[1],
+        repository: '',
+        defaultBranch: 'main',
+        objective: '',
+        approvalPolicy: 'Pause before consequential external writes, money, credentials, destructive actions, or production deployment.',
+        tasks: []
+      };
+      continue;
+    }
+
+    const taskStart = line.match(/^task\s+([A-Za-z0-9._-]+)\s*\{$/);
+    if (taskStart) {
+      if (!mission || missionClosed) throw runeError(lineNumber, 'task must be inside a mission');
+      if (currentTask) throw runeError(lineNumber, 'nested tasks are not supported');
+      currentTask = defaultTask(taskStart[1]);
+      continue;
+    }
+
+    if (line === '}') {
+      if (currentTask) {
+        mission.tasks.push(currentTask);
+        currentTask = null;
+      } else if (mission && !missionClosed) {
+        missionClosed = true;
+      } else {
+        throw runeError(lineNumber, 'unexpected closing brace');
+      }
+      continue;
+    }
+
+    if (!mission || missionClosed) throw runeError(lineNumber, 'expected mission NAME {');
+    const field = line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.+)$/);
+    if (!field) throw runeError(lineNumber, 'expected field: value');
+    if (currentTask) setTaskField(currentTask, field[1], field[2], lineNumber);
+    else setMissionField(mission, field[1], field[2], lineNumber);
+  }
+
+  if (!mission) throw runeError(1, 'missing mission declaration');
+  if (currentTask) throw runeError(lines.length, `task ${currentTask.id} is missing a closing brace`);
+  if (!missionClosed) throw runeError(lines.length, `mission ${mission.missionId} is missing a closing brace`);
+
+  const errors = validateMission(mission);
+  if (errors.length) {
+    const sourceName = options.sourceName ? ` in ${options.sourceName}` : '';
+    throw new Error(`Invalid RUNE mission${sourceName}: ${errors.join('; ')}`);
+  }
+  return mission;
+}
+
+module.exports = { compileRune, parseScalar, splitList };

--- a/apps/agent/thomas-agent/node/mission-runner.js
+++ b/apps/agent/thomas-agent/node/mission-runner.js
@@ -3,6 +3,7 @@ const fs = require('node:fs/promises');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
 const { validateMission } = require('./mission-schema');
+const { compileRune } = require('./mission-rune');
 const { DEFAULT_STATE_ROOT, appendEvent, initialState, loadState, readEvents, saveState, transition } = require('./mission-store');
 const { approve: approveRecord, createApproval } = require('./mission-approvals');
 const { nextTask, plan, retryAllowed } = require('./mission-planner');
@@ -39,7 +40,20 @@ function parseArgs(argv = process.argv.slice(2)) {
 }
 
 async function loadMission(missionId, missionsDir = MISSIONS) {
-  const mission = JSON.parse(await fs.readFile(path.join(missionsDir, `${missionId}.json`), 'utf8'));
+  const jsonPath = path.join(missionsDir, `${missionId}.json`);
+  const runePath = path.join(missionsDir, `${missionId}.rune`);
+  let mission;
+  try {
+    mission = JSON.parse(await fs.readFile(jsonPath, 'utf8'));
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    try {
+      mission = compileRune(await fs.readFile(runePath, 'utf8'), { sourceName: runePath });
+    } catch (runeError) {
+      if (runeError.code === 'ENOENT') throw new Error(`Mission ${missionId} was not found as JSON or RUNE.`);
+      throw runeError;
+    }
+  }
   const errors = validateMission(mission); if (errors.length) throw new Error(errors.join('; '));
   return mission;
 }


### PR DESCRIPTION
## What changed

- adds `mission-rune.js`, a deliberately small parser for human-readable `.rune` missions
- makes the existing mission loader fall back from `<id>.json` to `<id>.rune`
- preserves the existing versioned mission schema, dependency planner, retries, evidence, state, and approval gates
- adds a read-only `rune-demo-v01.rune` mission
- adds focused parser/loader tests and RUNE syntax documentation

## Why

This is the first executable slice of the AI-native computing vision: human intent becomes a bounded, inspectable mission without creating a second orchestration engine. RUNE v0.1 is only a mission specification language; it intentionally has no variables, loops, inline shell, hidden model calls, or implicit external writes.

## Safety / scope

- agent-only change under `apps/agent`
- existing JSON missions remain preferred and unchanged
- `3dvr mission run` remains inspect-only unless `--execute` is explicit
- commands stay argument arrays rather than shell strings
- RUNE approval gates compile to the existing scoped approval records
- no portal, Stripe, auth, production deployment, or customer-data behavior changes

## Validation

- focused parser smoke test passed locally, including command arrays, dependencies, and approval-gate compilation
- Playwright Checks: passed on head `360cce3`
- Vercel Dev Preview: passed on head `360cce3`
- Agent Checks: **blocked before tests run** because the `Audit production dependencies` step failed; the actual agent-check step was skipped. This PR should not be treated as fully CI-validated until that dependency-audit failure is resolved or explicitly triaged.

## Current delivery blocker

The branch is stale relative to current `main` (`47d891b9` as of 2026-08-15; this PR was based on `4968ab1e`). GitHub Actions run 31360962968 failed at the production dependency audit before RUNE's agent tests executed.

**Before promoting from draft:** sync/rebase onto current `main`, rerun the full Agent Checks workflow, and require the production dependency audit plus RUNE agent tests to pass. Keep this PR in draft until that fresh validation is green.