### PR TITLE
Add no-account Stripe checkout path

### DIFF
--- a/api/public-checkout.js
+++ b/api/public-checkout.js
@@ -1,0 +1,117 @@
+import {
+  getRequestOrigin,
+  makeStripeClient,
+  requireConfiguredPlanPrice,
+  setCorsHeaders
+} from '../src/billing/stripe.js';
+import { getBillingPlan, normalizeBillingPlan } from '../src/billing/plans.js';
+
+const PUBLIC_CHECKOUT_PLANS = new Set(['starter', 'pro', 'builder', 'embedded']);
+
+function readBody(req) {
+  return req?.body && typeof req.body === 'object' ? req.body : {};
+}
+
+export function buildPublicCheckoutSessionPayload({ plan, priceId, origin } = {}) {
+  const normalizedPlan = normalizeBillingPlan(plan);
+  const base = String(origin || 'https://portal.3dvr.tech').trim().replace(/\/+$/, '');
+  const metadata = {
+    plan: normalizedPlan,
+    checkout_path: 'public',
+    source: 'portal-start'
+  };
+
+  return {
+    mode: 'subscription',
+    allow_promotion_codes: true,
+    billing_address_collection: 'auto',
+    line_items: [
+      {
+        price: priceId,
+        quantity: 1
+      }
+    ],
+    metadata,
+    subscription_data: {
+      metadata
+    },
+    success_url: `${base}/start/?checkout=success&plan=${encodeURIComponent(normalizedPlan)}&session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${base}/start/?checkout=cancel&plan=${encodeURIComponent(normalizedPlan)}`
+  };
+}
+
+export function createPublicCheckoutHandler(options = {}) {
+  const config = options.config || process.env;
+  const stripeClient = options.stripeClient || makeStripeClient(config);
+
+  return async function handler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method === 'GET') {
+      return res.status(200).json({
+        stripeConfigured: Boolean(config.STRIPE_SECRET_KEY),
+        plans: Array.from(PUBLIC_CHECKOUT_PLANS).map(plan => ({
+          plan,
+          label: getBillingPlan(plan)?.label || plan,
+          amountLabel: getBillingPlan(plan)?.amountLabel || '',
+          configured: Boolean(
+            (() => {
+              try {
+                return requireConfiguredPlanPrice(plan, config);
+              } catch (error) {
+                return '';
+              }
+            })()
+          )
+        }))
+      });
+    }
+
+    if (req.method !== 'POST') {
+      res.setHeader('Allow', 'GET, POST, OPTIONS');
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    if (!stripeClient?.checkout?.sessions?.create) {
+      return res.status(500).json({ error: 'Stripe is not configured on the server.' });
+    }
+
+    const body = readBody(req);
+    const plan = normalizeBillingPlan(body.plan);
+    if (!PUBLIC_CHECKOUT_PLANS.has(plan)) {
+      return res.status(400).json({ error: 'Choose a valid public plan.' });
+    }
+
+    let priceId = '';
+    try {
+      priceId = requireConfiguredPlanPrice(plan, config);
+    } catch (error) {
+      return res.status(503).json({ error: 'This plan is not ready for checkout yet.' });
+    }
+
+    try {
+      const session = await stripeClient.checkout.sessions.create(
+        buildPublicCheckoutSessionPayload({
+          plan,
+          priceId,
+          origin: getRequestOrigin(req, config)
+        })
+      );
+
+      return res.status(200).json({
+        id: session.id,
+        url: session.url,
+        plan
+      });
+    } catch (error) {
+      console.error('Failed to create public Stripe checkout', error);
+      return res.status(500).json({ error: 'Unable to start Stripe checkout.' });
+    }
+  };
+}
+
+export default createPublicCheckoutHandler();

--- a/start/checkout.html
+++ b/start/checkout.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Secure checkout | 3dvr.tech</title>
+    <link rel="stylesheet" href="/start/style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <main class="hero">
+      <div class="hero-grid">
+        <section class="hero-content" aria-live="polite">
+          <span class="tag">Secure checkout</span>
+          <h1 id="checkoutTitle">Opening Stripe…</h1>
+          <p id="checkoutStatus">
+            No portal account is required. Stripe will collect the information needed for payment.
+          </p>
+          <div class="hero-actions">
+            <button class="button primary" id="checkoutRetry" type="button" hidden>
+              Try again
+            </button>
+            <a class="button tertiary" href="/start/#paid-lanes">Back to plans</a>
+            <a class="button tertiary" href="/billing/">Already subscribed? Manage billing</a>
+          </div>
+        </section>
+
+        <aside class="hero-panel">
+          <span class="panel-label">What happens next</span>
+          <h2>Pay first. Set up the portal when it helps.</h2>
+          <div class="step-list">
+            <div class="step-item">
+              <strong>1. Pay securely in Stripe</strong>
+              <span>Your payment details stay with Stripe.</span>
+            </div>
+            <div class="step-item">
+              <strong>2. Get your receipt</strong>
+              <span>Your email becomes the simplest way to match the purchase later.</span>
+            </div>
+            <div class="step-item">
+              <strong>3. Use the portal after purchase</strong>
+              <span>Sign in later when you want projects, support history, or billing management.</span>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <script type="module" src="/start/checkout.js"></script>
+  </body>
+</html>

--- a/start/checkout.js
+++ b/start/checkout.js
@@ -1,0 +1,74 @@
+const PLAN_DETAILS = Object.freeze({
+  starter: Object.freeze({ label: 'Family & Friends', amount: '$5 / month' }),
+  pro: Object.freeze({ label: 'Founder', amount: '$20 / month' }),
+  builder: Object.freeze({ label: 'Builder', amount: '$50 / month' }),
+  embedded: Object.freeze({ label: 'Embedded', amount: '$200 / month' })
+});
+
+function getSelectedPlan(locationLike = window.location) {
+  const params = new URLSearchParams(locationLike.search || '');
+  const plan = String(params.get('plan') || '').trim().toLowerCase();
+  return PLAN_DETAILS[plan] ? plan : '';
+}
+
+async function startCheckout(root = document, locationLike = window.location) {
+  const title = root.querySelector('#checkoutTitle');
+  const status = root.querySelector('#checkoutStatus');
+  const retry = root.querySelector('#checkoutRetry');
+  const plan = getSelectedPlan(locationLike);
+  const details = PLAN_DETAILS[plan];
+
+  if (!title || !status || !retry) {
+    return;
+  }
+
+  if (!details) {
+    title.textContent = 'Choose a valid plan';
+    status.textContent = 'Go back to the paid plans and choose the support level you want.';
+    retry.hidden = true;
+    return;
+  }
+
+  title.textContent = `${details.label} — ${details.amount}`;
+  status.textContent = 'Opening secure Stripe checkout. No portal account is required.';
+  retry.hidden = true;
+  retry.disabled = true;
+
+  try {
+    const response = await fetch('/api/public-checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ plan })
+    });
+    const payload = await response.json().catch(() => ({}));
+
+    if (!response.ok || !payload.url) {
+      throw new Error(payload.error || 'Unable to start checkout.');
+    }
+
+    locationLike.replace(payload.url);
+  } catch (error) {
+    title.textContent = 'Checkout did not open';
+    status.textContent = error?.message || 'Unable to start checkout. Please try again.';
+    retry.hidden = false;
+    retry.disabled = false;
+  }
+}
+
+function initCheckout(root = document, locationLike = window.location) {
+  const retry = root.querySelector('#checkoutRetry');
+  if (retry) {
+    retry.addEventListener('click', () => startCheckout(root, locationLike));
+  }
+  startCheckout(root, locationLike);
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => {
+    initCheckout(document, window.location);
+  });
+}
+
+export { PLAN_DETAILS, getSelectedPlan, initCheckout, startCheckout };


### PR DESCRIPTION
## What changed

- Added `/api/public-checkout` for the four fixed 3DVR subscription lanes: $5, $20, $50, and $200.
- The endpoint creates a Stripe-hosted subscription Checkout Session without requiring portal authentication first.
- Added `/start/checkout.html` and `/start/checkout.js` as a minimal bridge that takes a selected plan and redirects into Stripe.
- Existing account-linked `/billing/` behavior is untouched.

## Why

The current purchase path requires a portal account before Stripe checkout. That is useful for account management, but it adds friction before a new customer can pay. This PR separates the responsibilities: Stripe handles the purchase first; the portal remains the relationship and billing-management layer afterward.

## Stripe / portal impact

- Uses existing configured `STRIPE_PRICE_*` IDs; it does not create new Stripe products or prices.
- Does not set `payment_method_types`, so Stripe can choose eligible payment methods dynamically.
- Does not attach a portal customer or portal identity before checkout.
- Adds `plan`, `checkout_path=public`, and `source=portal-start` metadata to the Checkout Session/subscription for later reconciliation.
- Existing subscribers still use the current billing center and Customer Portal flows.
- Feature previews must use matching Stripe test keys and test price IDs per repo policy.

## Validation

The change is intentionally isolated in new files because the connected repository tool blocked edits to existing production files during this session. Existing start-page buttons are therefore not switched in this PR yet. The direct test URLs are:

- `/start/checkout.html?plan=starter`
- `/start/checkout.html?plan=pro`
- `/start/checkout.html?plan=builder`
- `/start/checkout.html?plan=embedded`

Recommended preview check: confirm each route creates the expected test-mode Stripe Checkout Session, cancellation returns safely, and existing `/billing/` behavior is unchanged.