### PR TITLE
Add account-free Stripe checkout

### DIFF
--- a/api/stripe/public-checkout.js
+++ b/api/stripe/public-checkout.js
@@ -12,7 +12,21 @@ import {
 const PUBLIC_SUBSCRIPTION_PLANS = new Set(['starter', 'pro', 'builder', 'embedded']);
 
 function readBody(req) {
-  return req?.body && typeof req.body === 'object' ? req.body : {};
+  if (req?.body && typeof req.body === 'object') {
+    return req.body;
+  }
+
+  if (typeof req?.body === 'string') {
+    return Object.fromEntries(new URLSearchParams(req.body));
+  }
+
+  return {};
+}
+
+function requestWantsJson(req) {
+  const contentType = String(req?.headers?.['content-type'] || '').toLowerCase();
+  const accept = String(req?.headers?.accept || '').toLowerCase();
+  return contentType.includes('application/json') || accept.includes('application/json');
 }
 
 export function createPublicStripeCheckoutHandler(options = {}) {
@@ -46,10 +60,9 @@ export function createPublicStripeCheckoutHandler(options = {}) {
     }
 
     const origin = getRequestOrigin(req, config);
-    const checkoutSource = 'public_pay_v1';
     const metadata = {
       plan,
-      checkout_source: checkoutSource
+      checkout_source: 'public_pay_v1'
     };
 
     try {
@@ -74,11 +87,17 @@ export function createPublicStripeCheckoutHandler(options = {}) {
         return res.status(502).json({ error: 'Stripe did not return a checkout URL.' });
       }
 
-      return res.status(200).json({
-        flow: 'public_checkout',
-        plan,
-        url: session.url
-      });
+      if (requestWantsJson(req)) {
+        return res.status(200).json({
+          flow: 'public_checkout',
+          plan,
+          url: session.url
+        });
+      }
+
+      res.statusCode = 303;
+      res.setHeader('Location', session.url);
+      return res.end();
     } catch (error) {
       console.error('Unable to create public Stripe checkout session', error);
       return res.status(500).json({ error: 'Unable to open Stripe checkout right now.' });

--- a/api/stripe/public-checkout.js
+++ b/api/stripe/public-checkout.js
@@ -1,0 +1,89 @@
+import {
+  getRequestOrigin,
+  makeStripeClient,
+  setCorsHeaders
+} from '../../src/billing/stripe.js';
+import {
+  getBillingPlan,
+  normalizeBillingPlan,
+  resolveConfiguredPriceId
+} from '../../src/billing/plans.js';
+
+const PUBLIC_SUBSCRIPTION_PLANS = new Set(['starter', 'pro', 'builder', 'embedded']);
+
+function readBody(req) {
+  return req?.body && typeof req.body === 'object' ? req.body : {};
+}
+
+export function createPublicStripeCheckoutHandler(options = {}) {
+  const config = options.config || process.env;
+  const stripeClient = options.stripeClient || makeStripeClient(config);
+
+  return async function handler(req, res) {
+    setCorsHeaders(res);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    if (req.method !== 'POST') {
+      res.setHeader('Allow', 'POST, OPTIONS');
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    if (!stripeClient?.checkout?.sessions?.create) {
+      return res.status(500).json({ error: 'Stripe is not configured on the server.' });
+    }
+
+    const plan = normalizeBillingPlan(readBody(req).plan);
+    if (!PUBLIC_SUBSCRIPTION_PLANS.has(plan)) {
+      return res.status(400).json({ error: 'Choose a valid monthly plan.' });
+    }
+
+    const priceId = resolveConfiguredPriceId(plan, config);
+    if (!priceId) {
+      return res.status(503).json({ error: `${getBillingPlan(plan)?.label || 'This plan'} is not available yet.` });
+    }
+
+    const origin = getRequestOrigin(req, config);
+    const checkoutSource = 'public_pay_v1';
+    const metadata = {
+      plan,
+      checkout_source: checkoutSource
+    };
+
+    try {
+      const session = await stripeClient.checkout.sessions.create({
+        mode: 'subscription',
+        allow_promotion_codes: true,
+        line_items: [
+          {
+            price: priceId,
+            quantity: 1
+          }
+        ],
+        metadata,
+        subscription_data: {
+          metadata
+        },
+        success_url: `${origin}/pay/?checkout=success&plan=${encodeURIComponent(plan)}`,
+        cancel_url: `${origin}/pay/?checkout=cancel&plan=${encodeURIComponent(plan)}`
+      });
+
+      if (!session?.url) {
+        return res.status(502).json({ error: 'Stripe did not return a checkout URL.' });
+      }
+
+      return res.status(200).json({
+        flow: 'public_checkout',
+        plan,
+        url: session.url
+      });
+    } catch (error) {
+      console.error('Unable to create public Stripe checkout session', error);
+      return res.status(500).json({ error: 'Unable to open Stripe checkout right now.' });
+    }
+  };
+}
+
+export default createPublicStripeCheckoutHandler();

--- a/pay/index.html
+++ b/pay/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Pay 3DVR | Simple Stripe Checkout</title>
+  <meta name="description" content="Choose a 3DVR monthly support plan and pay securely with Stripe. No 3DVR account required.">
+  <link rel="canonical" href="https://portal.3dvr.tech/pay/">
+  <link rel="stylesheet" href="../free-page/styles.css">
+  <style>
+    .pay-shell{width:min(960px,calc(100% - 2rem));margin:0 auto;padding:4.5rem 0 3rem}
+    .pay-hero{max-width:720px;margin-bottom:2rem}.pay-hero h1{max-width:680px}
+    .pay-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:1rem}
+    .pay-card{display:flex;flex-direction:column;gap:.8rem;padding:1.35rem;border:1px solid rgba(255,255,255,.12);border-radius:1rem;background:rgba(8,17,31,.76)}
+    .pay-card.primary{border-color:rgba(103,232,249,.72);box-shadow:0 0 0 1px rgba(103,232,249,.16)}
+    .pay-card h2,.pay-card p{margin:0}.pay-card p{color:#b8c6d9}.pay-price{font-size:2rem;font-weight:800}.pay-price span{font-size:.9rem;color:#b8c6d9;font-weight:600}
+    .pay-card .button{margin-top:auto;justify-content:center;text-align:center}
+    .pay-meta{margin-top:1.5rem;padding:1rem 1.1rem;border:1px solid rgba(255,255,255,.1);border-radius:1rem;background:rgba(8,17,31,.52);color:#b8c6d9}
+    .pay-meta a{color:#67e8f9}.pay-status{margin-top:1rem;min-height:1.5rem;color:#b8c6d9}.pay-status.success{color:#86efac}.pay-status.error{color:#fca5a5}
+    @media(max-width:680px){.pay-shell{padding-top:3rem}.pay-grid{grid-template-columns:1fr}}
+  </style>
+</head>
+<body>
+  <div class="ambient ambient-one"></div>
+  <div class="ambient ambient-two"></div>
+
+  <main class="pay-shell">
+    <section class="pay-hero">
+      <p class="eyebrow">Simple Stripe checkout</p>
+      <h1>Choose a plan. Pay. Keep moving.</h1>
+      <p class="lead">No 3DVR account is required. Stripe handles the payment and receipt. Create a portal account later only if you want saved tools, projects, or account-linked support.</p>
+    </section>
+
+    <section class="pay-grid" aria-label="3DVR monthly plans">
+      <article class="pay-card primary">
+        <p class="eyebrow">Recommended</p>
+        <h2>Build with us</h2>
+        <p class="pay-price">$20 <span>/ month</span></p>
+        <p>Active launch help, updates, product thinking, and practical execution support.</p>
+        <button class="button primary" type="button" data-plan="pro">Pay $20/month with Stripe</button>
+      </article>
+
+      <article class="pay-card">
+        <p class="eyebrow">Friends &amp; family</p>
+        <h2>Support 3DVR</h2>
+        <p class="pay-price">$5 <span>/ month</span></p>
+        <p>A small supporter lane for people who want to help keep 3DVR moving.</p>
+        <button class="button secondary" type="button" data-plan="starter">Pay $5/month with Stripe</button>
+      </article>
+
+      <article class="pay-card">
+        <p class="eyebrow">Builder</p>
+        <h2>Build momentum</h2>
+        <p class="pay-price">$50 <span>/ month</span></p>
+        <p>More hands-on help for an active project or small business that is already moving.</p>
+        <button class="button secondary" type="button" data-plan="builder">Pay $50/month with Stripe</button>
+      </article>
+
+      <article class="pay-card">
+        <p class="eyebrow">Embedded</p>
+        <h2>Dedicated support</h2>
+        <p class="pay-price">$200 <span>/ month</span></p>
+        <p>A deeper monthly execution lane for a team or project that needs recurring attention.</p>
+        <button class="button secondary" type="button" data-plan="embedded">Pay $200/month with Stripe</button>
+      </article>
+    </section>
+
+    <p id="pay-status" class="pay-status" role="status" aria-live="polite"></p>
+
+    <section class="pay-meta">
+      <strong>Already paying?</strong> Use the <a href="../billing/">Billing Center</a> to manage an existing subscription. Need a one-time project price? Email <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>.
+    </section>
+  </main>
+
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/pay/index.html
+++ b/pay/index.html
@@ -14,9 +14,9 @@
     .pay-card{display:flex;flex-direction:column;gap:.8rem;padding:1.35rem;border:1px solid rgba(255,255,255,.12);border-radius:1rem;background:rgba(8,17,31,.76)}
     .pay-card.primary{border-color:rgba(103,232,249,.72);box-shadow:0 0 0 1px rgba(103,232,249,.16)}
     .pay-card h2,.pay-card p{margin:0}.pay-card p{color:#b8c6d9}.pay-price{font-size:2rem;font-weight:800}.pay-price span{font-size:.9rem;color:#b8c6d9;font-weight:600}
-    .pay-card .button{margin-top:auto;justify-content:center;text-align:center}
+    .pay-card form{margin-top:auto}.pay-card .button{width:100%;justify-content:center;text-align:center}
     .pay-meta{margin-top:1.5rem;padding:1rem 1.1rem;border:1px solid rgba(255,255,255,.1);border-radius:1rem;background:rgba(8,17,31,.52);color:#b8c6d9}
-    .pay-meta a{color:#67e8f9}.pay-status{margin-top:1rem;min-height:1.5rem;color:#b8c6d9}.pay-status.success{color:#86efac}.pay-status.error{color:#fca5a5}
+    .pay-meta a{color:#67e8f9}
     @media(max-width:680px){.pay-shell{padding-top:3rem}.pay-grid{grid-template-columns:1fr}}
   </style>
 </head>
@@ -37,7 +37,10 @@
         <h2>Build with us</h2>
         <p class="pay-price">$20 <span>/ month</span></p>
         <p>Active launch help, updates, product thinking, and practical execution support.</p>
-        <button class="button primary" type="button" data-plan="pro">Pay $20/month with Stripe</button>
+        <form method="post" action="/api/stripe/public-checkout">
+          <input type="hidden" name="plan" value="pro">
+          <button class="button primary" type="submit">Pay $20/month with Stripe</button>
+        </form>
       </article>
 
       <article class="pay-card">
@@ -45,7 +48,10 @@
         <h2>Support 3DVR</h2>
         <p class="pay-price">$5 <span>/ month</span></p>
         <p>A small supporter lane for people who want to help keep 3DVR moving.</p>
-        <button class="button secondary" type="button" data-plan="starter">Pay $5/month with Stripe</button>
+        <form method="post" action="/api/stripe/public-checkout">
+          <input type="hidden" name="plan" value="starter">
+          <button class="button secondary" type="submit">Pay $5/month with Stripe</button>
+        </form>
       </article>
 
       <article class="pay-card">
@@ -53,7 +59,10 @@
         <h2>Build momentum</h2>
         <p class="pay-price">$50 <span>/ month</span></p>
         <p>More hands-on help for an active project or small business that is already moving.</p>
-        <button class="button secondary" type="button" data-plan="builder">Pay $50/month with Stripe</button>
+        <form method="post" action="/api/stripe/public-checkout">
+          <input type="hidden" name="plan" value="builder">
+          <button class="button secondary" type="submit">Pay $50/month with Stripe</button>
+        </form>
       </article>
 
       <article class="pay-card">
@@ -61,17 +70,16 @@
         <h2>Dedicated support</h2>
         <p class="pay-price">$200 <span>/ month</span></p>
         <p>A deeper monthly execution lane for a team or project that needs recurring attention.</p>
-        <button class="button secondary" type="button" data-plan="embedded">Pay $200/month with Stripe</button>
+        <form method="post" action="/api/stripe/public-checkout">
+          <input type="hidden" name="plan" value="embedded">
+          <button class="button secondary" type="submit">Pay $200/month with Stripe</button>
+        </form>
       </article>
     </section>
-
-    <p id="pay-status" class="pay-status" role="status" aria-live="polite"></p>
 
     <section class="pay-meta">
       <strong>Already paying?</strong> Use the <a href="../billing/">Billing Center</a> to manage an existing subscription. Need a one-time project price? Email <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>.
     </section>
   </main>
-
-  <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/pay/success.html
+++ b/pay/success.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Payment received | 3DVR</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="../free-page/styles.css">
+  <style>
+    .success-shell{width:min(720px,calc(100% - 2rem));margin:0 auto;padding:5rem 0 3rem}
+    .success-card{padding:1.5rem;border:1px solid rgba(103,232,249,.42);border-radius:1rem;background:rgba(8,17,31,.76)}
+    .success-card p{color:#b8c6d9}.success-actions{display:flex;flex-wrap:wrap;gap:.75rem;margin-top:1.25rem}
+  </style>
+</head>
+<body>
+  <div class="ambient ambient-one"></div>
+  <div class="ambient ambient-two"></div>
+  <main class="success-shell">
+    <section class="success-card">
+      <p class="eyebrow">Payment received</p>
+      <h1>You’re in.</h1>
+      <p class="lead">Stripe will email your receipt. You do not need to create a 3DVR account unless you want saved portal tools or project access.</p>
+      <div class="success-actions">
+        <a class="button primary" href="../">Go to the portal</a>
+        <a class="button secondary" href="../sign-in.html">Optional: create or sign in to an account</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## What changed

- adds `/pay/` as a deliberately small public payment surface for the existing $5, $20, $50, and $200 monthly plans
- adds `/api/stripe/public-checkout` to create Stripe-hosted subscription Checkout Sessions without requiring a 3DVR portal account
- restricts public checkout to the four configured recurring plan IDs already used by portal billing
- keeps customer payment details in Stripe and leaves the existing authenticated Billing Center unchanged for subscription management
- adds a simple post-payment page that makes portal account setup optional

## Why

The current billing center is doing too much work before a new customer can pay. 3DVR already documents the intended principle: pay first, create a portal account only when the portal becomes useful. This PR makes that principle executable without removing any of the account-linked billing machinery that existing customers use.

## Scope / safety

- no Stripe products, prices, customers, or subscriptions are created by this PR itself
- no existing billing routes are modified
- no arbitrary amount is accepted; only `starter`, `pro`, `builder`, and `embedded` resolve to server-configured Stripe Price IDs
- no `payment_method_types` are hard-coded; Stripe Checkout chooses eligible methods
- feature previews continue to rely on the repository's existing Stripe environment separation
- production merge should happen only after preview checkout is exercised with test-mode Stripe configuration

## Validation

- branch is directly ahead of current `main`
- diff is limited to the new public checkout endpoint and `/pay/` pages
- automated test-file creation was blocked by the connected write-safety layer, so this PR intentionally remains draft pending preview verification
