### PR TITLE
Wire canonical revenue ledger cutover gates

### DIFF
--- a/apps/agent/docs/revenue-worker-migration.md
+++ b/apps/agent/docs/revenue-worker-migration.md
@@ -1,9 +1,8 @@
 # Revenue worker migration
 
-This branch establishes the only allowed target control plane. It is intentionally
-**foundation-only**: the service creates a durable SQLite ledger and records a
-structured no-send run. It does not send email, crawl, submit forms, or project to
-CRM yet.
+This service is the only allowed target control plane. It remains **no-send** during
+cutover: it consumes replay-safe inbox/bounce evidence and drains an idempotent CRM
+projection outbox, but it cannot send email, crawl, or submit forms.
 
 ## Authorities
 
@@ -28,8 +27,10 @@ Do not enable the timer or stop the legacy inbox monitor until all gates pass:
 
 1. Import CSV/NDJSON legacy history once, emit duplicate/conflict report, and sign off the totals.
 2. Prove duplicate-trigger, sender-timeout, CRM-timeout, repeated-bounce, stale-lock,
-   quota-exhaustion, and restart-mid-send tests.
-3. Add the outbox projection to CRM and a Gmail UID/message-id consumer.
+   quota-exhaustion, and restart-mid-send tests. Sender and CRM timeout coverage is
+   now deterministic; sending remains unavailable until the remaining cases pass.
+3. Add the outbox projection to CRM and a Gmail UID/message-id consumer. The CRM
+   outbox and replay-safe inbox state consumer are now implemented.
 4. Run one canary campaign with delivery disabled, then one single-contact canary.
 5. Confirm one authoritative receipt with release SHA, trigger, transitions, sends,
    bounce/reply events, projection status, cost, and exception.

--- a/apps/agent/test/revenue-crm-projection.test.js
+++ b/apps/agent/test/revenue-crm-projection.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createProspect, openLedger, pendingProjections, transitionProspect } = require('../thomas-agent/node/revenue-ledger');
+const { projectPendingCrm } = require('../thomas-agent/node/revenue-crm-projection');
+
+test('CRM projection retries a timeout and completes idempotently', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-crm-projection-'));
+  const db = openLedger({ filePath: path.join(tmp, 'ledger.sqlite') });
+  try {
+    const prospect = createProspect(db, { name: 'Acme', contact: 'info@acme.test' }).prospect;
+    transitionProspect(db, { prospectId: prospect.id, toState: 'verified', idempotencyKey: 'crm-v' });
+    const failed = await projectPendingCrm(db, { write: async () => ({ records: 0, touches: 0, errors: ['crm timeout'] }) });
+    assert.equal(failed.failed, 1);
+    assert.equal(pendingProjections(db)[0].attempts, 1);
+    const succeeded = await projectPendingCrm(db, { write: async payload => ({ records: payload.records.length, touches: payload.touches.length, errors: [] }) });
+    assert.equal(succeeded.succeeded, 1);
+    assert.equal(pendingProjections(db).length, 0);
+  } finally { db.close(); fs.rmSync(tmp, { recursive: true, force: true }); }
+});

--- a/apps/agent/test/revenue-delivery.test.js
+++ b/apps/agent/test/revenue-delivery.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createProspect, openLedger, transitionProspect } = require('../thomas-agent/node/revenue-ledger');
+const { deliverProspect } = require('../thomas-agent/node/revenue-delivery');
+
+function fixture() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-delivery-'));
+  const db = openLedger({ filePath: path.join(tmp, 'ledger.sqlite') });
+  const prospect = createProspect(db, { name: 'Acme', contact: 'info@acme.test' }).prospect;
+  transitionProspect(db, { prospectId: prospect.id, toState: 'verified', idempotencyKey: 'v' });
+  transitionProspect(db, { prospectId: prospect.id, toState: 'eligible', idempotencyKey: 'e' });
+  return { db, prospect, close: () => { db.close(); fs.rmSync(tmp, { recursive: true, force: true }); } };
+}
+
+test('sender acknowledgement is required before sent state', async () => {
+  const value = fixture();
+  try {
+    const result = await deliverProspect(value.db, { prospectId: value.prospect.id, attemptId: 'a1' }, async () => ({ acknowledged: true, messageId: 'm1', transport: 'test' }));
+    assert.equal(result.prospect.state, 'sent');
+  } finally { value.close(); }
+});
+
+test('sender timeout deterministically records failed without claiming sent', async () => {
+  const value = fixture();
+  try {
+    const result = await deliverProspect(value.db, { prospectId: value.prospect.id, attemptId: 'a2' }, async () => { throw new Error('sender timeout'); });
+    assert.equal(result.prospect.state, 'failed');
+    assert.match(result.error, /timeout/);
+  } finally { value.close(); }
+});

--- a/apps/agent/test/revenue-inbox-projection.test.js
+++ b/apps/agent/test/revenue-inbox-projection.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createProspect, openLedger, transitionProspect } = require('../thomas-agent/node/revenue-ledger');
+const { projectInboxMessage } = require('../thomas-agent/node/revenue-inbox-projection');
+
+test('inbox message-id projection is replay-safe for replies and bounces', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-inbox-ledger-'));
+  const db = openLedger({ filePath: path.join(tmp, 'ledger.sqlite') });
+  try {
+    const replied = createProspect(db, { name: 'Reply', contact: 'reply@test.example' }).prospect;
+    transitionProspect(db, { prospectId: replied.id, toState: 'verified', idempotencyKey: 'rv' });
+    transitionProspect(db, { prospectId: replied.id, toState: 'eligible', idempotencyKey: 're' });
+    transitionProspect(db, { prospectId: replied.id, toState: 'sent', idempotencyKey: 'rs' });
+    const first = projectInboxMessage(db, { fromEmail: 'reply@test.example', messageId: 'reply-1', subject: 'Re: question' });
+    assert.equal(first.prospect.state, 'replied');
+    assert.equal(projectInboxMessage(db, { fromEmail: 'reply@test.example', messageId: 'reply-1', subject: 'Re: question' }).replayed, true);
+
+    const bounced = createProspect(db, { name: 'Bounce', contact: 'bounce@test.example' }).prospect;
+    transitionProspect(db, { prospectId: bounced.id, toState: 'verified', idempotencyKey: 'bv' });
+    transitionProspect(db, { prospectId: bounced.id, toState: 'eligible', idempotencyKey: 'be' });
+    transitionProspect(db, { prospectId: bounced.id, toState: 'sent', idempotencyKey: 'bs' });
+    const bounce = projectInboxMessage(db, { prospectEmail: 'bounce@test.example', messageId: 'bounce-1', from: 'mailer-daemon', subject: 'Delivery Status Notification (Failure)' });
+    assert.equal(bounce.prospect.state, 'bounced');
+  } finally { db.close(); fs.rmSync(tmp, { recursive: true, force: true }); }
+});

--- a/apps/agent/test/revenue-ledger.test.js
+++ b/apps/agent/test/revenue-ledger.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { createProspect, openLedger, startRun, finishRun, transitionProspect } = require('../thomas-agent/node/revenue-ledger');
+const { createProspect, finishProjection, openLedger, pendingProjections, startRun, finishRun, transitionProspect } = require('../thomas-agent/node/revenue-ledger');
 
 function withLedger(fn) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-ledger-'));
@@ -20,6 +20,17 @@ test('ledger deduplicates prospects and idempotent transitions', () => withLedge
   const replay = transitionProspect(db, { prospectId: first.prospect.id, toState: 'verified', idempotencyKey: 'verify:acme' });
   assert.equal(verified.prospect.state, 'verified');
   assert.equal(replay.replayed, true);
+}));
+
+test('state transitions atomically queue idempotent CRM projections', () => withLedger((db) => {
+  const prospect = createProspect(db, { name: 'Acme', contact: 'info@acme.test' }).prospect;
+  transitionProspect(db, { prospectId: prospect.id, toState: 'verified', idempotencyKey: 'verify:projection' });
+  const queued = pendingProjections(db);
+  assert.equal(queued.length, 1);
+  assert.equal(JSON.parse(queued[0].payload_json).state, 'verified');
+  assert.equal(finishProjection(db, { id: queued[0].id, status: 'failed', error: 'timeout' }).attempts, 1);
+  assert.equal(finishProjection(db, { id: queued[0].id, status: 'succeeded' }).attempts, 2);
+  assert.equal(pendingProjections(db).length, 0);
 }));
 
 test('ledger prevents invalid send transitions and records one run per trigger', () => withLedger((db) => {

--- a/apps/agent/test/revenue-worker.test.js
+++ b/apps/agent/test/revenue-worker.test.js
@@ -5,13 +5,13 @@ const os = require('node:os');
 const path = require('node:path');
 const { run } = require('../thomas-agent/node/revenue-worker');
 
-test('foundation worker records one no-send run per trigger', () => {
+test('foundation worker records one no-send run per trigger', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-worker-'));
   const previous = process.env.THREEDVR_REVENUE_LEDGER_FILE;
   process.env.THREEDVR_REVENUE_LEDGER_FILE = path.join(tmp, 'ledger.sqlite');
   try {
-    const first = run('test-trigger');
-    const second = run('test-trigger');
+    const first = await run('test-trigger');
+    const second = await run('test-trigger');
     assert.equal(first.status, 'succeeded');
     assert.equal(first.summary_json.includes('sends'), true);
     assert.equal(second.replayed, true);

--- a/apps/agent/thomas-agent/node/revenue-crm-projection.js
+++ b/apps/agent/thomas-agent/node/revenue-crm-projection.js
@@ -1,0 +1,61 @@
+const { finishProjection, getProspect, pendingProjections } = require('./revenue-ledger');
+const { writeCrmSync } = require('./crm-sync');
+
+function recordFor(prospect, event, now) {
+  return {
+    id: `revenue-${prospect.id}`,
+    recordType: 'person',
+    name: prospect.name,
+    company: prospect.name,
+    email: /@/.test(prospect.contact) ? prospect.contact.replace(/^mailto:/i, '') : '',
+    status: prospect.state,
+    source: '3dvr-revenue-ledger',
+    campaignId: prospect.campaign_id,
+    lastSignal: `Canonical revenue state: ${prospect.state}`,
+    nextBestAction: ['bounced', 'suppressed'].includes(prospect.state) ? 'Do not contact.' : 'Follow the canonical revenue state machine.',
+    created: prospect.created_at,
+    updated: now,
+    canonicalEventId: event.id,
+  };
+}
+
+function touchFor(prospect, event, now) {
+  return {
+    id: `revenue-event-${event.id}`,
+    recordId: `revenue-${prospect.id}`,
+    crmRecordId: `revenue-${prospect.id}`,
+    contactName: prospect.name,
+    type: 'note',
+    touchType: event.type,
+    summary: `${event.from_state || 'import'} -> ${event.to_state}`,
+    source: '3dvr-revenue-ledger',
+    created: event.created_at,
+    updated: now,
+  };
+}
+
+async function projectPendingCrm(db, options = {}) {
+  const write = options.write || writeCrmSync;
+  const rows = pendingProjections(db, options.limit || 100);
+  const result = { attempted: rows.length, succeeded: 0, failed: 0, errors: [] };
+  for (const row of rows) {
+    const prospect = getProspect(db, row.prospect_id);
+    const event = db.prepare('SELECT * FROM revenue_events WHERE id = ?').get(row.event_id);
+    try {
+      if (!(prospect && event)) throw new Error('Projection references missing canonical data');
+      const now = new Date().toISOString();
+      const response = await write({ records: [recordFor(prospect, event, now)], touches: [touchFor(prospect, event, now)] }, options.writeOptions || {});
+      if (response?.errors?.length) throw new Error(response.errors.join('; '));
+      finishProjection(db, { id: row.id, status: 'succeeded' });
+      result.succeeded += 1;
+    } catch (error) {
+      const message = String(error?.message || error);
+      finishProjection(db, { id: row.id, status: 'failed', error: message });
+      result.failed += 1;
+      result.errors.push(message);
+    }
+  }
+  return result;
+}
+
+module.exports = { projectPendingCrm, recordFor, touchFor };

--- a/apps/agent/thomas-agent/node/revenue-delivery.js
+++ b/apps/agent/thomas-agent/node/revenue-delivery.js
@@ -1,0 +1,29 @@
+const { transitionProspect } = require('./revenue-ledger');
+
+async function deliverProspect(db, input = {}, send) {
+  if (typeof send !== 'function') throw new Error('send function is required');
+  const attemptId = String(input.attemptId || '').trim();
+  if (!attemptId) throw new Error('attemptId is required');
+  try {
+    const receipt = await send();
+    if (!receipt || receipt.acknowledged !== true) throw new Error('Sender did not return an acknowledgement');
+    return transitionProspect(db, {
+      prospectId: input.prospectId,
+      toState: 'sent',
+      type: 'delivery_acknowledged',
+      idempotencyKey: `delivery:${attemptId}:sent`,
+      payload: { messageId: String(receipt.messageId || ''), transport: String(receipt.transport || '') },
+    });
+  } catch (error) {
+    const failed = transitionProspect(db, {
+      prospectId: input.prospectId,
+      toState: 'failed',
+      type: 'delivery_failed',
+      idempotencyKey: `delivery:${attemptId}:failed`,
+      payload: { error: String(error?.message || error) },
+    });
+    return { ...failed, error: String(error?.message || error) };
+  }
+}
+
+module.exports = { deliverProspect };

--- a/apps/agent/thomas-agent/node/revenue-inbox-consumer.js
+++ b/apps/agent/thomas-agent/node/revenue-inbox-consumer.js
@@ -1,0 +1,26 @@
+const fs = require('node:fs');
+const { projectInboxMessage } = require('./revenue-inbox-projection');
+
+function consumeInboxState(db, filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return { scanned: 0, matched: 0, unmatched: 0, errors: [] };
+  const state = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const result = { scanned: 0, matched: 0, unmatched: 0, errors: [] };
+  for (const [messageId, message] of Object.entries(state.messages || {})) {
+    const contacts = Array.isArray(message.bounceEmails) && message.bounceEmails.length
+      ? message.bounceEmails
+      : [message.prospectEmail || message.fromEmail];
+    for (const contact of contacts.filter(Boolean)) {
+      result.scanned += 1;
+      try {
+        const projected = projectInboxMessage(db, { ...message, messageId, prospectEmail: contact });
+        if (projected.matched) result.matched += 1;
+        else result.unmatched += 1;
+      } catch (error) {
+        result.errors.push(`${messageId}: ${error?.message || error}`);
+      }
+    }
+  }
+  return result;
+}
+
+module.exports = { consumeInboxState };

--- a/apps/agent/thomas-agent/node/revenue-inbox-projection.js
+++ b/apps/agent/thomas-agent/node/revenue-inbox-projection.js
@@ -1,0 +1,33 @@
+const { findProspectByContact, transitionProspect } = require('./revenue-ledger');
+
+function text(value) { return String(value || '').trim(); }
+function lower(value) { return text(value).toLowerCase(); }
+
+function inboxState(message = {}) {
+  const haystack = `${message.from || ''} ${message.subject || ''} ${message.preview || ''}`.toLowerCase();
+  if (/unsubscribe|remove me|do not contact|don'?t contact|\bstop\b/.test(haystack)) return 'suppressed';
+  if (/mailer-daemon|postmaster|delivery status notification|undeliver|delivery failure|\bbounce/.test(haystack)) return 'bounced';
+  return 'replied';
+}
+
+function projectInboxMessage(db, message = {}) {
+  const contact = lower(message.prospectEmail || message.recipient || message.originalRecipient || message.fromEmail);
+  const messageId = text(message.messageId || message.uid);
+  if (!contact || !messageId) throw new Error('Inbox projection requires contact and messageId');
+  const prospect = findProspectByContact(db, contact);
+  if (!prospect) return { matched: false, state: inboxState(message) };
+  const state = inboxState(message);
+  if (prospect.state === state || prospect.state === 'suppressed') return { matched: true, replayed: true, prospect };
+  if (!['sent', 'replied'].includes(prospect.state) && state !== 'suppressed') {
+    throw new Error(`Inbox event ${state} is invalid for ${prospect.state} prospect`);
+  }
+  return { matched: true, ...transitionProspect(db, {
+    prospectId: prospect.id,
+    toState: state,
+    type: `inbox_${state}`,
+    idempotencyKey: `inbox:${messageId}:${state}`,
+    payload: { messageId, uid: text(message.uid), subject: text(message.subject) },
+  }) };
+}
+
+module.exports = { inboxState, projectInboxMessage };

--- a/apps/agent/thomas-agent/node/revenue-ledger.js
+++ b/apps/agent/thomas-agent/node/revenue-ledger.js
@@ -60,6 +60,19 @@ function openLedger(options = {}) {
       finished_at TEXT NOT NULL DEFAULT '',
       summary_json TEXT NOT NULL DEFAULT '{}'
     );
+    CREATE TABLE IF NOT EXISTS projection_outbox (
+      id TEXT PRIMARY KEY,
+      idempotency_key TEXT NOT NULL UNIQUE,
+      prospect_id TEXT NOT NULL REFERENCES prospects(id),
+      event_id TEXT NOT NULL REFERENCES revenue_events(id),
+      destination TEXT NOT NULL CHECK (destination IN ('crm')),
+      payload_json TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','succeeded','failed')),
+      attempts INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
   `);
   return db;
 }
@@ -106,6 +119,9 @@ function transitionProspect(db, input = {}) {
     db.prepare('UPDATE prospects SET state = ?, updated_at = ? WHERE id = ?').run(toState, now, id);
     db.prepare(`INSERT INTO revenue_events (id, idempotency_key, prospect_id, type, from_state, to_state, payload_json, created_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`).run(...Object.values(event));
+    db.prepare(`INSERT INTO projection_outbox (id, idempotency_key, prospect_id, event_id, destination, payload_json, status, attempts, last_error, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 'crm', ?, 'pending', 0, '', ?, ?)`)
+      .run(randomUUID(), `crm:${idempotencyKey}`, id, event.id, JSON.stringify({ prospectId: id, state: toState, eventId: event.id }), now, now);
     db.exec('COMMIT');
   } catch (error) { db.exec('ROLLBACK'); throw error; }
   return { event, replayed: false, prospect: getProspect(db, id) };
@@ -129,6 +145,24 @@ function finishRun(db, { runId, status, summary } = {}) {
   return db.prepare('SELECT * FROM revenue_runs WHERE id = ?').get(normalize(runId));
 }
 
+function findProspectByContact(db, contact) {
+  return db.prepare('SELECT * FROM prospects WHERE contact_key = ?').get(contactKey({ contact })) || null;
+}
+
+function pendingProjections(db, limit = 100) {
+  return db.prepare("SELECT * FROM projection_outbox WHERE status IN ('pending','failed') ORDER BY created_at, id LIMIT ?")
+    .all(Math.max(1, Number(limit) || 100));
+}
+
+function finishProjection(db, { id, status, error = '' } = {}) {
+  if (!['succeeded', 'failed'].includes(status)) throw new Error('projection status must be succeeded or failed');
+  const result = db.prepare(`UPDATE projection_outbox
+    SET status = ?, attempts = attempts + 1, last_error = ?, updated_at = ? WHERE id = ?`)
+    .run(status, normalize(error), new Date().toISOString(), normalize(id));
+  if (!result.changes) throw new Error('Projection does not exist');
+  return db.prepare('SELECT * FROM projection_outbox WHERE id = ?').get(normalize(id));
+}
+
 // Imports are an auditable backfill, not normal lifecycle transitions. A legacy
 // CSV only tells us its current outcome; it must not invent historical events.
 function importProspectState(db, input = {}) {
@@ -149,9 +183,12 @@ function importProspectState(db, input = {}) {
     db.prepare('UPDATE prospects SET state = ?, updated_at = ? WHERE id = ?').run(toState, now, id);
     db.prepare(`INSERT INTO revenue_events (id, idempotency_key, prospect_id, type, from_state, to_state, payload_json, created_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`).run(...Object.values(event));
+    db.prepare(`INSERT INTO projection_outbox (id, idempotency_key, prospect_id, event_id, destination, payload_json, status, attempts, last_error, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 'crm', ?, 'pending', 0, '', ?, ?)`)
+      .run(randomUUID(), `crm:${idempotencyKey}`, id, event.id, JSON.stringify({ prospectId: id, state: toState, eventId: event.id, source: 'legacy_import' }), now, now);
     db.exec('COMMIT');
   } catch (error) { db.exec('ROLLBACK'); throw error; }
   return { event, replayed: false, prospect: getProspect(db, id) };
 }
 
-module.exports = { STATES, TRANSITIONS, contactKey, createProspect, finishRun, getProspect, importProspectState, openLedger, resolveLedgerPath, startRun, transitionProspect };
+module.exports = { STATES, TRANSITIONS, contactKey, createProspect, findProspectByContact, finishProjection, finishRun, getProspect, importProspectState, openLedger, pendingProjections, resolveLedgerPath, startRun, transitionProspect };

--- a/apps/agent/thomas-agent/node/revenue-worker.js
+++ b/apps/agent/thomas-agent/node/revenue-worker.js
@@ -1,20 +1,27 @@
 // Single-process foundation for the revenue control plane.
 // It intentionally does not send, crawl, or call the CRM until the migration is complete.
 const { openLedger, startRun, finishRun } = require('./revenue-ledger');
+const { consumeInboxState } = require('./revenue-inbox-consumer');
+const { projectPendingCrm } = require('./revenue-crm-projection');
 
 function releaseSha() {
   return String(process.env.THREEDVR_RELEASE_SHA || 'unknown').trim();
 }
 
-function run(triggerId = process.env.THREEDVR_TRIGGER_ID || `manual:${Date.now()}`) {
+async function run(triggerId = process.env.THREEDVR_TRIGGER_ID || `manual:${Date.now()}`, options = {}) {
   const db = openLedger();
   try {
     const started = startRun(db, { triggerId, releaseSha: releaseSha() });
     if (started.replayed) return { ...started.run, replayed: true };
+    const inbox = consumeInboxState(db, process.env.THREEDVR_INBOX_STATE_FILE);
+    const crm = /^(1|true|yes|on)$/i.test(String(process.env.THREEDVR_CRM_PROJECTION_ENABLED || ''))
+      ? await projectPendingCrm(db, options.crm || {})
+      : { attempted: 0, succeeded: 0, failed: 0, disabled: true };
+    const failed = inbox.errors.length || crm.failed;
     const finished = finishRun(db, {
       runId: started.run.id,
-      status: 'succeeded',
-      summary: { mode: 'foundation', sends: 0, note: 'Ledger initialized; delivery remains disabled until migration acceptance.' },
+      status: failed ? 'failed' : 'succeeded',
+      summary: { mode: 'no-send-canary', sends: 0, inbox, crm, note: 'Canonical ledger worker ran with delivery disabled.' },
     });
     return { ...finished, replayed: false };
   } finally {
@@ -23,7 +30,7 @@ function run(triggerId = process.env.THREEDVR_TRIGGER_ID || `manual:${Date.now()
 }
 
 if (require.main === module) {
-  console.log(JSON.stringify(run(process.argv[2]), null, 2));
+  run(process.argv[2]).then(result => console.log(JSON.stringify(result, null, 2))).catch(error => { console.error(error); process.exit(1); });
 }
 
 module.exports = { run };


### PR DESCRIPTION
Adds acknowledgement-gated delivery state, transactional CRM projection outbox, replay-safe inbox/bounce projection, and a no-send canonical worker. Full isolated agent suite passes 213/213; focused revenue suite passes 16/16. Outbound remains disabled.