### PR TITLE
Bridge legacy revenue contact identities

### DIFF
--- a/apps/agent/test/revenue-inbox-projection.test.js
+++ b/apps/agent/test/revenue-inbox-projection.test.js
@@ -26,3 +26,16 @@ test('inbox message-id projection is replay-safe for replies and bounces', () =>
     assert.equal(bounce.prospect.state, 'bounced');
   } finally { db.close(); fs.rmSync(tmp, { recursive: true, force: true }); }
 });
+
+test('inbox projection bridges legacy mailto contact identities', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-inbox-mailto-'));
+  const db = openLedger({ filePath: path.join(tmp, 'ledger.sqlite') });
+  try {
+    const prospect = createProspect(db, { name: 'Legacy', contact: 'mailto:legacy@test.example' }).prospect;
+    transitionProspect(db, { prospectId: prospect.id, toState: 'verified', idempotencyKey: 'lv' });
+    transitionProspect(db, { prospectId: prospect.id, toState: 'eligible', idempotencyKey: 'le' });
+    transitionProspect(db, { prospectId: prospect.id, toState: 'sent', idempotencyKey: 'ls' });
+    const result = projectInboxMessage(db, { prospectEmail: 'legacy@test.example', messageId: 'legacy-bounce', subject: 'Delivery failure' });
+    assert.equal(result.prospect.state, 'bounced');
+  } finally { db.close(); fs.rmSync(tmp, { recursive: true, force: true }); }
+});

--- a/apps/agent/thomas-agent/node/revenue-ledger.js
+++ b/apps/agent/thomas-agent/node/revenue-ledger.js
@@ -146,7 +146,11 @@ function finishRun(db, { runId, status, summary } = {}) {
 }
 
 function findProspectByContact(db, contact) {
-  return db.prepare('SELECT * FROM prospects WHERE contact_key = ?').get(contactKey({ contact })) || null;
+  const value = normalize(contact);
+  const keys = [contactKey({ contact: value })];
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) keys.push(contactKey({ contact: `mailto:${value}` }));
+  if (/^mailto:/i.test(value)) keys.push(contactKey({ contact: value.replace(/^mailto:/i, '') }));
+  return db.prepare(`SELECT * FROM prospects WHERE contact_key IN (${keys.map(() => '?').join(',')}) LIMIT 1`).get(...new Set(keys)) || null;
 }
 
 function pendingProjections(db, limit = 100) {


### PR DESCRIPTION
Makes inbox reply/bounce projection match both legacy mailto contact keys and normalized email addresses. Focused revenue suite passes.