### PR TITLE
Preserve CRM identities in revenue projection

### DIFF
--- a/apps/agent/test/revenue-crm-projection.test.js
+++ b/apps/agent/test/revenue-crm-projection.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { createProspect, openLedger, pendingProjections, transitionProspect } = require('../thomas-agent/node/revenue-ledger');
-const { projectPendingCrm } = require('../thomas-agent/node/revenue-crm-projection');
+const { projectPendingCrm, recordFor } = require('../thomas-agent/node/revenue-crm-projection');
 
 test('CRM projection retries a timeout and completes idempotently', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-crm-projection-'));
@@ -19,4 +19,11 @@ test('CRM projection retries a timeout and completes idempotently', async () => 
     assert.equal(succeeded.succeeded, 1);
     assert.equal(pendingProjections(db).length, 0);
   } finally { db.close(); fs.rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('CRM projection preserves the legacy stable record identity', () => {
+  const record = recordFor({ id: 'uuid', name: 'Acme', contact: 'mailto:info@acme.test', source_url: 'https://acme.test', state: 'sent', campaign_id: '', created_at: '2026-01-01T00:00:00Z' }, { id: 'event' }, '2026-01-02T00:00:00Z');
+  assert.equal(record.id, 'agent-lead-info-acme-test');
+  assert.equal(record.status, 'Warm - Follow-up');
+  assert.equal(record.canonicalState, 'sent');
 });

--- a/apps/agent/thomas-agent/node/revenue-crm-projection.js
+++ b/apps/agent/thomas-agent/node/revenue-crm-projection.js
@@ -1,14 +1,20 @@
 const { finishProjection, getProspect, pendingProjections } = require('./revenue-ledger');
-const { writeCrmSync } = require('./crm-sync');
+const { buildLeadId, writeCrmSync } = require('./crm-sync');
 
 function recordFor(prospect, event, now) {
+  const crmStatus = {
+    prospect: 'Lead', verified: 'Lead', drafted: 'Lead', eligible: 'Lead',
+    sent: 'Warm - Follow-up', replied: 'Warm - Discovery', bounced: 'Lost',
+    failed: 'Lost', suppressed: 'Closed',
+  }[prospect.state] || 'Lead';
   return {
-    id: `revenue-${prospect.id}`,
+    id: buildLeadId({ name: prospect.name, contact: prospect.contact, link: prospect.source_url }),
     recordType: 'person',
     name: prospect.name,
     company: prospect.name,
     email: /@/.test(prospect.contact) ? prospect.contact.replace(/^mailto:/i, '') : '',
-    status: prospect.state,
+    status: crmStatus,
+    canonicalState: prospect.state,
     source: '3dvr-revenue-ledger',
     campaignId: prospect.campaign_id,
     lastSignal: `Canonical revenue state: ${prospect.state}`,
@@ -20,10 +26,11 @@ function recordFor(prospect, event, now) {
 }
 
 function touchFor(prospect, event, now) {
+  const recordId = buildLeadId({ name: prospect.name, contact: prospect.contact, link: prospect.source_url });
   return {
     id: `revenue-event-${event.id}`,
-    recordId: `revenue-${prospect.id}`,
-    crmRecordId: `revenue-${prospect.id}`,
+    recordId,
+    crmRecordId: recordId,
     contactName: prospect.name,
     type: 'note',
     touchType: event.type,


### PR DESCRIPTION
Maps canonical ledger state onto existing stable CRM record IDs instead of creating duplicate UUID-based contacts. Focused revenue suite passes.