### PR TITLE
Make revenue CRM projection a remote one-shot

### DIFF
--- a/apps/agent/thomas-agent/node/revenue-crm-projection.js
+++ b/apps/agent/thomas-agent/node/revenue-crm-projection.js
@@ -1,6 +1,19 @@
 const { finishProjection, getProspect, pendingProjections } = require('./revenue-ledger');
 const { buildLeadId, writeCrmSync } = require('./crm-sync');
 
+function remoteProjectionRoots() {
+  const Gun = require('gun');
+  const gun = Gun({
+    peers: [process.env.THREEDVR_GUN_RELAY || 'wss://gun-relay-3dvr.fly.dev/gun'],
+    radisk: false,
+    localStorage: false,
+  });
+  return {
+    crmRoot: gun.get('3dvr-crm'),
+    touchRoot: gun.get(process.env.THREEDVR_GUN_PORTAL_ROOT || '3dvr-portal').get('crm-touch-log'),
+  };
+}
+
 function recordFor(prospect, event, now) {
   const crmStatus = {
     prospect: 'Lead', verified: 'Lead', drafted: 'Lead', eligible: 'Lead',
@@ -43,6 +56,7 @@ function touchFor(prospect, event, now) {
 
 async function projectPendingCrm(db, options = {}) {
   const write = options.write || writeCrmSync;
+  const writeOptions = options.writeOptions || (options.write ? {} : remoteProjectionRoots());
   const rows = pendingProjections(db, options.limit || 100);
   const result = { attempted: rows.length, succeeded: 0, failed: 0, errors: [] };
   for (const row of rows) {
@@ -51,7 +65,7 @@ async function projectPendingCrm(db, options = {}) {
     try {
       if (!(prospect && event)) throw new Error('Projection references missing canonical data');
       const now = new Date().toISOString();
-      const response = await write({ records: [recordFor(prospect, event, now)], touches: [touchFor(prospect, event, now)] }, options.writeOptions || {});
+      const response = await write({ records: [recordFor(prospect, event, now)], touches: [touchFor(prospect, event, now)] }, writeOptions);
       if (response?.errors?.length) throw new Error(response.errors.join('; '));
       finishProjection(db, { id: row.id, status: 'succeeded' });
       result.succeeded += 1;
@@ -65,4 +79,4 @@ async function projectPendingCrm(db, options = {}) {
   return result;
 }
 
-module.exports = { projectPendingCrm, recordFor, touchFor };
+module.exports = { projectPendingCrm, recordFor, remoteProjectionRoots, touchFor };

--- a/apps/agent/thomas-agent/node/revenue-worker.js
+++ b/apps/agent/thomas-agent/node/revenue-worker.js
@@ -30,7 +30,9 @@ async function run(triggerId = process.env.THREEDVR_TRIGGER_ID || `manual:${Date
 }
 
 if (require.main === module) {
-  run(process.argv[2]).then(result => console.log(JSON.stringify(result, null, 2))).catch(error => { console.error(error); process.exit(1); });
+  run(process.argv[2])
+    .then(result => { console.log(JSON.stringify(result, null, 2)); process.exit(result.status === 'succeeded' ? 0 : 1); })
+    .catch(error => { console.error(error); process.exit(1); });
 }
 
 module.exports = { run };


### PR DESCRIPTION
Disables Gun local disk persistence for the canonical remote CRM projection and explicitly exits the oneshot worker after its receipt. This repairs the production read-only filesystem and timeout failure while preserving retryable outbox events.