### PR TITLE
Fix revenue worker on read-only runtime

### DIFF
--- a/apps/agent/test/revenue-crm-projection.test.js
+++ b/apps/agent/test/revenue-crm-projection.test.js
@@ -29,6 +29,8 @@ test('CRM projection preserves the legacy stable record identity', () => {
 
 test('remote projection roots do not initialize a local radata store', () => {
   const source = fs.readFileSync(require.resolve('../thomas-agent/node/revenue-crm-projection'), 'utf8');
+  assert.match(source, /axe:\s*false/);
   assert.match(source, /rad:\s*false/);
   assert.match(source, /radisk:\s*false/);
+  assert.match(source, /stats:\s*false/);
 });

--- a/apps/agent/thomas-agent/node/revenue-crm-projection.js
+++ b/apps/agent/thomas-agent/node/revenue-crm-projection.js
@@ -5,9 +5,12 @@ function remoteProjectionRoots() {
   const Gun = require('gun');
   const gun = Gun({
     peers: [process.env.THREEDVR_GUN_RELAY || 'wss://gun-relay-3dvr.fly.dev/gun'],
+    axe: false,
+    multicast: false,
     rad: false,
     radisk: false,
     localStorage: false,
+    stats: false,
   });
   return {
     crmRoot: gun.get('3dvr-crm'),


### PR DESCRIPTION
## Summary

- disable Gun stats and AXE background writers in the canonical revenue worker CRM projection
- preserve the existing in-memory, remote-only projection path
- extend the regression guard for read-only production filesystems

## Verification

- `node --test test/revenue-crm-projection.test.js test/revenue-worker.test.js`
- `git diff --check`
- production systemd no-send canary after merge
