### PR TITLE
Add bounded canonical email canary

### DIFF
--- a/apps/agent/test/revenue-delivery.test.js
+++ b/apps/agent/test/revenue-delivery.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { createProspect, openLedger, transitionProspect } = require('../thomas-agent/node/revenue-ledger');
+const { createProspect, openLedger, reserveDeliveryAttempt, transitionProspect } = require('../thomas-agent/node/revenue-ledger');
 const { deliverProspect } = require('../thomas-agent/node/revenue-delivery');
 
 function fixture() {
@@ -29,5 +29,20 @@ test('sender timeout deterministically records failed without claiming sent', as
     const result = await deliverProspect(value.db, { prospectId: value.prospect.id, attemptId: 'a2' }, async () => { throw new Error('sender timeout'); });
     assert.equal(result.prospect.state, 'failed');
     assert.match(result.error, /timeout/);
+  } finally { value.close(); }
+});
+
+test('restart with an in-flight attempt quarantines ambiguity without resending', async () => {
+  const value = fixture();
+  try {
+    reserveDeliveryAttempt(value.db, { prospectId: value.prospect.id, attemptId: 'a3' });
+    let calls = 0;
+    const result = await deliverProspect(value.db, { prospectId: value.prospect.id, attemptId: 'a3' }, async () => {
+      calls += 1;
+      return { acknowledged: true };
+    });
+    assert.equal(calls, 0);
+    assert.equal(result.prospect.state, 'eligible');
+    assert.match(result.error, /ambiguous/);
   } finally { value.close(); }
 });

--- a/apps/agent/test/revenue-worker.test.js
+++ b/apps/agent/test/revenue-worker.test.js
@@ -4,11 +4,25 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { run } = require('../thomas-agent/node/revenue-worker');
+const { openLedger } = require('../thomas-agent/node/revenue-ledger');
 
-test('foundation worker records one no-send run per trigger', async () => {
+function candidate(filePath) {
+  fs.writeFileSync(filePath, JSON.stringify({
+    name: 'Acme',
+    contact: 'owner@acme.test',
+    sourceUrl: 'https://acme.test',
+    subject: 'Research question',
+    body: 'Commercial message. Postal address: 1 Test St. Reply unsubscribe or stop.',
+    attemptId: 'canary-1',
+  }));
+}
+
+test('worker records one no-send run per trigger', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-worker-'));
   const previous = process.env.THREEDVR_REVENUE_LEDGER_FILE;
+  const delivery = process.env.THREEDVR_REVENUE_DELIVERY_ENABLED;
   process.env.THREEDVR_REVENUE_LEDGER_FILE = path.join(tmp, 'ledger.sqlite');
+  delete process.env.THREEDVR_REVENUE_DELIVERY_ENABLED;
   try {
     const first = await run('test-trigger');
     const second = await run('test-trigger');
@@ -18,6 +32,95 @@ test('foundation worker records one no-send run per trigger', async () => {
   } finally {
     if (previous === undefined) delete process.env.THREEDVR_REVENUE_LEDGER_FILE;
     else process.env.THREEDVR_REVENUE_LEDGER_FILE = previous;
+    if (delivery === undefined) delete process.env.THREEDVR_REVENUE_DELIVERY_ENABLED;
+    else process.env.THREEDVR_REVENUE_DELIVERY_ENABLED = delivery;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('worker sends one canonical candidate and does not resend it', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-worker-send-'));
+  const previous = {
+    ledger: process.env.THREEDVR_REVENUE_LEDGER_FILE,
+    candidate: process.env.THREEDVR_REVENUE_CANDIDATE_FILE,
+    delivery: process.env.THREEDVR_REVENUE_DELIVERY_ENABLED,
+  };
+  const ledger = path.join(tmp, 'ledger.sqlite');
+  const candidateFile = path.join(tmp, 'candidate.json');
+  candidate(candidateFile);
+  process.env.THREEDVR_REVENUE_LEDGER_FILE = ledger;
+  process.env.THREEDVR_REVENUE_CANDIDATE_FILE = candidateFile;
+  process.env.THREEDVR_REVENUE_DELIVERY_ENABLED = 'true';
+  let calls = 0;
+  try {
+    const first = await run('send-1', { send: async () => { calls += 1; return { acknowledged: true, messageId: 'm1', transport: 'test' }; } });
+    const second = await run('send-2', { send: async () => { calls += 1; return { acknowledged: true, messageId: 'm2', transport: 'test' }; } });
+    assert.equal(JSON.parse(first.summary_json).sends, 1);
+    assert.equal(JSON.parse(second.summary_json).sends, 0);
+    assert.equal(calls, 1);
+    const db = openLedger({ filePath: ledger });
+    try { assert.equal(db.prepare("SELECT state FROM prospects").get().state, 'sent'); } finally { db.close(); }
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      const env = { ledger: 'THREEDVR_REVENUE_LEDGER_FILE', candidate: 'THREEDVR_REVENUE_CANDIDATE_FILE', delivery: 'THREEDVR_REVENUE_DELIVERY_ENABLED' }[key];
+      if (value === undefined) delete process.env[env]; else process.env[env] = value;
+    }
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('worker records sender failure without claiming a send', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-worker-fail-'));
+  const previous = {
+    ledger: process.env.THREEDVR_REVENUE_LEDGER_FILE,
+    candidate: process.env.THREEDVR_REVENUE_CANDIDATE_FILE,
+    delivery: process.env.THREEDVR_REVENUE_DELIVERY_ENABLED,
+  };
+  const candidateFile = path.join(tmp, 'candidate.json');
+  candidate(candidateFile);
+  process.env.THREEDVR_REVENUE_LEDGER_FILE = path.join(tmp, 'ledger.sqlite');
+  process.env.THREEDVR_REVENUE_CANDIDATE_FILE = candidateFile;
+  process.env.THREEDVR_REVENUE_DELIVERY_ENABLED = 'true';
+  try {
+    const result = await run('fail-1', { send: async () => { throw new Error('sender timeout'); } });
+    const summary = JSON.parse(result.summary_json);
+    assert.equal(result.status, 'failed');
+    assert.equal(summary.sends, 0);
+    assert.match(summary.delivery.error, /timeout/);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      const env = { ledger: 'THREEDVR_REVENUE_LEDGER_FILE', candidate: 'THREEDVR_REVENUE_CANDIDATE_FILE', delivery: 'THREEDVR_REVENUE_DELIVERY_ENABLED' }[key];
+      if (value === undefined) delete process.env[env]; else process.env[env] = value;
+    }
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('worker enforces the default one-send daily quota', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-worker-quota-'));
+  const previous = {
+    ledger: process.env.THREEDVR_REVENUE_LEDGER_FILE,
+    candidate: process.env.THREEDVR_REVENUE_CANDIDATE_FILE,
+    delivery: process.env.THREEDVR_REVENUE_DELIVERY_ENABLED,
+  };
+  const candidateFile = path.join(tmp, 'candidate.json');
+  candidate(candidateFile);
+  process.env.THREEDVR_REVENUE_LEDGER_FILE = path.join(tmp, 'ledger.sqlite');
+  process.env.THREEDVR_REVENUE_CANDIDATE_FILE = candidateFile;
+  process.env.THREEDVR_REVENUE_DELIVERY_ENABLED = 'true';
+  let calls = 0;
+  try {
+    await run('quota-1', { send: async () => { calls += 1; return { acknowledged: true }; } });
+    const data = JSON.parse(fs.readFileSync(candidateFile, 'utf8'));
+    fs.writeFileSync(candidateFile, JSON.stringify({ ...data, name: 'Beta', contact: 'owner@beta.test', sourceUrl: 'https://beta.test', attemptId: 'canary-2' }));
+    const second = await run('quota-2', { send: async () => { calls += 1; return { acknowledged: true }; } });
+    assert.equal(calls, 1);
+    assert.equal(JSON.parse(second.summary_json).delivery.reason, 'quota exhausted');
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      const env = { ledger: 'THREEDVR_REVENUE_LEDGER_FILE', candidate: 'THREEDVR_REVENUE_CANDIDATE_FILE', delivery: 'THREEDVR_REVENUE_DELIVERY_ENABLED' }[key];
+      if (value === undefined) delete process.env[env]; else process.env[env] = value;
+    }
     fs.rmSync(tmp, { recursive: true, force: true });
   }
 });

--- a/apps/agent/thomas-agent/node/revenue-delivery.js
+++ b/apps/agent/thomas-agent/node/revenue-delivery.js
@@ -1,19 +1,25 @@
-const { transitionProspect } = require('./revenue-ledger');
+const { finishDeliveryAttempt, getProspect, reserveDeliveryAttempt, transitionProspect } = require('./revenue-ledger');
 
 async function deliverProspect(db, input = {}, send) {
   if (typeof send !== 'function') throw new Error('send function is required');
   const attemptId = String(input.attemptId || '').trim();
   if (!attemptId) throw new Error('attemptId is required');
+  const reserved = reserveDeliveryAttempt(db, { attemptId, prospectId: input.prospectId });
+  if (reserved.replayed) {
+    const error = reserved.attempt.status === 'in_flight'
+      ? 'Delivery attempt is ambiguous after interruption; refusing to resend'
+      : reserved.attempt.error;
+    return {
+      prospect: getProspect(db, input.prospectId),
+      replayed: true,
+      error,
+      attempt: reserved.attempt,
+    };
+  }
+  let receipt;
   try {
-    const receipt = await send();
+    receipt = await send();
     if (!receipt || receipt.acknowledged !== true) throw new Error('Sender did not return an acknowledgement');
-    return transitionProspect(db, {
-      prospectId: input.prospectId,
-      toState: 'sent',
-      type: 'delivery_acknowledged',
-      idempotencyKey: `delivery:${attemptId}:sent`,
-      payload: { messageId: String(receipt.messageId || ''), transport: String(receipt.transport || '') },
-    });
   } catch (error) {
     const failed = transitionProspect(db, {
       prospectId: input.prospectId,
@@ -22,7 +28,31 @@ async function deliverProspect(db, input = {}, send) {
       idempotencyKey: `delivery:${attemptId}:failed`,
       payload: { error: String(error?.message || error) },
     });
+    finishDeliveryAttempt(db, { attemptId, status: 'failed', error: String(error?.message || error) });
     return { ...failed, error: String(error?.message || error) };
+  }
+  try {
+    const sent = transitionProspect(db, {
+      prospectId: input.prospectId,
+      toState: 'sent',
+      type: 'delivery_acknowledged',
+      idempotencyKey: `delivery:${attemptId}:sent`,
+      payload: { messageId: String(receipt.messageId || ''), transport: String(receipt.transport || '') },
+    });
+    finishDeliveryAttempt(db, {
+      attemptId,
+      status: 'acknowledged',
+      messageId: receipt.messageId,
+      transport: receipt.transport,
+    });
+    return { ...sent, attempt: reserved.attempt };
+  } catch (error) {
+    return {
+      prospect: getProspect(db, input.prospectId),
+      replayed: false,
+      error: `Sender acknowledged but ledger finalization failed: ${error?.message || error}`,
+      attempt: reserved.attempt,
+    };
   }
 }
 

--- a/apps/agent/thomas-agent/node/revenue-ledger.js
+++ b/apps/agent/thomas-agent/node/revenue-ledger.js
@@ -60,6 +60,17 @@ function openLedger(options = {}) {
       finished_at TEXT NOT NULL DEFAULT '',
       summary_json TEXT NOT NULL DEFAULT '{}'
     );
+    CREATE TABLE IF NOT EXISTS delivery_attempts (
+      id TEXT PRIMARY KEY,
+      attempt_key TEXT NOT NULL UNIQUE,
+      prospect_id TEXT NOT NULL REFERENCES prospects(id),
+      status TEXT NOT NULL CHECK (status IN ('in_flight','acknowledged','failed')),
+      message_id TEXT NOT NULL DEFAULT '',
+      transport TEXT NOT NULL DEFAULT '',
+      error TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
     CREATE TABLE IF NOT EXISTS projection_outbox (
       id TEXT PRIMARY KEY,
       idempotency_key TEXT NOT NULL UNIQUE,
@@ -75,6 +86,45 @@ function openLedger(options = {}) {
     );
   `);
   return db;
+}
+
+function reserveDeliveryAttempt(db, { attemptId, prospectId } = {}) {
+  const key = normalize(attemptId);
+  const prospect = normalize(prospectId);
+  if (!key || !prospect) throw new Error('attemptId and prospectId are required');
+  const existing = db.prepare('SELECT * FROM delivery_attempts WHERE attempt_key = ?').get(key);
+  if (existing) return { attempt: existing, replayed: true };
+  const now = new Date().toISOString();
+  const attempt = {
+    id: randomUUID(), attempt_key: key, prospect_id: prospect, status: 'in_flight',
+    message_id: '', transport: '', error: '', created_at: now, updated_at: now,
+  };
+  db.prepare(`INSERT INTO delivery_attempts
+    (id, attempt_key, prospect_id, status, message_id, transport, error, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(...Object.values(attempt));
+  return { attempt, replayed: false };
+}
+
+function finishDeliveryAttempt(db, { attemptId, status, messageId = '', transport = '', error = '' } = {}) {
+  if (!['acknowledged', 'failed'].includes(status)) throw new Error('delivery status must be acknowledged or failed');
+  const result = db.prepare(`UPDATE delivery_attempts
+    SET status = ?, message_id = ?, transport = ?, error = ?, updated_at = ?
+    WHERE attempt_key = ? AND status = 'in_flight'`)
+    .run(status, normalize(messageId), normalize(transport), normalize(error), new Date().toISOString(), normalize(attemptId));
+  if (!result.changes) throw new Error('Delivery attempt was not in flight');
+  return db.prepare('SELECT * FROM delivery_attempts WHERE attempt_key = ?').get(normalize(attemptId));
+}
+
+function acknowledgedDeliveryCount(db, { since = '', campaignId = '' } = {}) {
+  const values = [normalize(since)];
+  let campaign = '';
+  if (normalize(campaignId)) {
+    campaign = ' AND p.campaign_id = ?';
+    values.push(normalize(campaignId));
+  }
+  return db.prepare(`SELECT COUNT(*) AS total FROM delivery_attempts d
+    JOIN prospects p ON p.id = d.prospect_id
+    WHERE d.status = 'acknowledged' AND d.updated_at >= ?${campaign}`).get(...values).total;
 }
 
 function contactKey({ contact, sourceUrl, name } = {}) {
@@ -195,4 +245,4 @@ function importProspectState(db, input = {}) {
   return { event, replayed: false, prospect: getProspect(db, id) };
 }
 
-module.exports = { STATES, TRANSITIONS, contactKey, createProspect, findProspectByContact, finishProjection, finishRun, getProspect, importProspectState, openLedger, pendingProjections, resolveLedgerPath, startRun, transitionProspect };
+module.exports = { STATES, TRANSITIONS, acknowledgedDeliveryCount, contactKey, createProspect, findProspectByContact, finishDeliveryAttempt, finishProjection, finishRun, getProspect, importProspectState, openLedger, pendingProjections, reserveDeliveryAttempt, resolveLedgerPath, startRun, transitionProspect };

--- a/apps/agent/thomas-agent/node/revenue-worker.js
+++ b/apps/agent/thomas-agent/node/revenue-worker.js
@@ -1,11 +1,102 @@
-// Single-process foundation for the revenue control plane.
-// It intentionally does not send, crawl, or call the CRM until the migration is complete.
-const { openLedger, startRun, finishRun } = require('./revenue-ledger');
+const fs = require('node:fs');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+const { acknowledgedDeliveryCount, createProspect, getProspect, openLedger, startRun, finishRun, transitionProspect } = require('./revenue-ledger');
+const { deliverProspect } = require('./revenue-delivery');
 const { consumeInboxState } = require('./revenue-inbox-consumer');
 const { projectPendingCrm } = require('./revenue-crm-projection');
 
+const execFileAsync = promisify(execFile);
+
 function releaseSha() {
   return String(process.env.THREEDVR_RELEASE_SHA || 'unknown').trim();
+}
+
+function enabled(value) {
+  return /^(1|true|yes|on)$/i.test(String(value || ''));
+}
+
+function loadCandidate(filePath = process.env.THREEDVR_REVENUE_CANDIDATE_FILE) {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  const candidate = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  for (const field of ['name', 'contact', 'sourceUrl', 'subject', 'body', 'attemptId']) {
+    if (!String(candidate[field] || '').trim()) throw new Error(`Revenue candidate is missing ${field}`);
+  }
+  return candidate;
+}
+
+function prepareCandidate(db, candidate) {
+  const created = createProspect(db, {
+    name: candidate.name,
+    contact: candidate.contact,
+    sourceUrl: candidate.sourceUrl,
+    campaignId: candidate.campaignId || 'market-research',
+  });
+  let prospect = created.prospect;
+  if (['sent', 'bounced', 'replied', 'suppressed'].includes(prospect.state)) {
+    return { prospect, eligible: false, reason: `terminal state: ${prospect.state}` };
+  }
+  if (['prospect', 'failed'].includes(prospect.state)) {
+    prospect = transitionProspect(db, {
+      prospectId: prospect.id,
+      toState: 'verified',
+      type: 'candidate_verified',
+      idempotencyKey: `candidate:${candidate.attemptId}:verified`,
+      payload: { sourceUrl: candidate.sourceUrl },
+    }).prospect;
+  }
+  if (['verified', 'drafted'].includes(prospect.state)) {
+    prospect = transitionProspect(db, {
+      prospectId: prospect.id,
+      toState: 'eligible',
+      type: 'candidate_eligible',
+      idempotencyKey: `candidate:${candidate.attemptId}:eligible`,
+      payload: { subject: candidate.subject },
+    }).prospect;
+  }
+  return { prospect: getProspect(db, prospect.id), eligible: prospect.state === 'eligible' };
+}
+
+async function sendCandidate(candidate) {
+  const script = require.resolve('./send-outreach-email');
+  const contact = String(candidate.contact).replace(/^mailto:/i, '');
+  const result = await execFileAsync(process.execPath, [
+    script, '--to', contact, '--subject', candidate.subject, '--text', candidate.body,
+  ], { timeout: Number.parseInt(process.env.THREEDVR_REVENUE_SEND_TIMEOUT_MS || '30000', 10) });
+  return { acknowledged: true, messageId: '', transport: 'portal', stdout: result.stdout };
+}
+
+async function deliverCandidate(db, options = {}) {
+  if (!enabled(process.env.THREEDVR_REVENUE_DELIVERY_ENABLED)) {
+    return { attempted: 0, sends: 0, disabled: true };
+  }
+  const candidate = loadCandidate();
+  if (!candidate) return { attempted: 0, sends: 0, reason: 'no candidate' };
+  const startOfUtcDay = new Date();
+  startOfUtcDay.setUTCHours(0, 0, 0, 0);
+  const dailyLimit = Number.parseInt(process.env.THREEDVR_REVENUE_DAILY_SEND_LIMIT || '1', 10);
+  const campaignLimit = Number.parseInt(process.env.THREEDVR_REVENUE_CAMPAIGN_SEND_LIMIT || '10', 10);
+  const dailySent = acknowledgedDeliveryCount(db, { since: startOfUtcDay.toISOString() });
+  const campaignSent = acknowledgedDeliveryCount(db, { since: '1970-01-01T00:00:00.000Z', campaignId: candidate.campaignId || 'market-research' });
+  if (dailySent >= dailyLimit || campaignSent >= campaignLimit) {
+    return { attempted: 0, sends: 0, reason: 'quota exhausted', dailySent, dailyLimit, campaignSent, campaignLimit };
+  }
+  const prepared = prepareCandidate(db, candidate);
+  if (!prepared.eligible) {
+    return { attempted: 0, sends: 0, reason: prepared.reason || 'candidate not eligible', prospectId: prepared.prospect.id };
+  }
+  const result = await deliverProspect(
+    db,
+    { prospectId: prepared.prospect.id, attemptId: candidate.attemptId },
+    () => (options.send || sendCandidate)(candidate),
+  );
+  return {
+    attempted: 1,
+    sends: result.prospect.state === 'sent' && !result.replayed ? 1 : 0,
+    prospectId: prepared.prospect.id,
+    state: result.prospect.state,
+    error: result.error || '',
+  };
 }
 
 async function run(triggerId = process.env.THREEDVR_TRIGGER_ID || `manual:${Date.now()}`, options = {}) {
@@ -14,14 +105,21 @@ async function run(triggerId = process.env.THREEDVR_TRIGGER_ID || `manual:${Date
     const started = startRun(db, { triggerId, releaseSha: releaseSha() });
     if (started.replayed) return { ...started.run, replayed: true };
     const inbox = consumeInboxState(db, process.env.THREEDVR_INBOX_STATE_FILE);
+    const delivery = await deliverCandidate(db, options);
     const crm = /^(1|true|yes|on)$/i.test(String(process.env.THREEDVR_CRM_PROJECTION_ENABLED || ''))
       ? await projectPendingCrm(db, options.crm || {})
       : { attempted: 0, succeeded: 0, failed: 0, disabled: true };
-    const failed = inbox.errors.length || crm.failed;
+    const failed = inbox.errors.length || crm.failed || delivery.error;
     const finished = finishRun(db, {
       runId: started.run.id,
       status: failed ? 'failed' : 'succeeded',
-      summary: { mode: 'no-send-canary', sends: 0, inbox, crm, note: 'Canonical ledger worker ran with delivery disabled.' },
+      summary: {
+        mode: delivery.disabled ? 'no-send-canary' : 'bounded-delivery',
+        sends: delivery.sends,
+        delivery,
+        inbox,
+        crm,
+      },
     });
     return { ...finished, replayed: false };
   } finally {
@@ -35,4 +133,4 @@ if (require.main === module) {
     .catch(error => { console.error(error); process.exit(1); });
 }
 
-module.exports = { run };
+module.exports = { deliverCandidate, loadCandidate, prepareCandidate, run, sendCandidate };


### PR DESCRIPTION
## Summary

- add one-candidate canonical email delivery behind an explicit production gate
- reserve each delivery attempt before sending so restart ambiguity cannot cause a duplicate
- require sender acknowledgment before recording `sent`
- enforce one-send daily and bounded campaign quotas
- project delivery state to the canonical CRM outbox

## Verification

- 15 focused ledger, delivery, inbox, CRM, worker, restart, and quota tests pass
- JavaScript syntax checks pass
- `git diff --check` passes

## Rollout

1. deploy exact merged SHA
2. run with delivery disabled
3. stage one genuine market-research candidate
4. enable one-contact canary
5. verify sender acknowledgment, ledger state, CRM projection, and inbox monitoring
