### PR TITLE
Harden Postgres and Gun backup architecture

### DIFF
--- a/docs/data-storage-policy.md
+++ b/docs/data-storage-policy.md
@@ -1,0 +1,89 @@
+# 3DVR Data Storage Policy
+
+Status: active architecture policy
+
+## Rule of thumb
+
+- **Postgres is the durable business ledger.**
+- **GunJS is the realtime/local-first synchronization layer.**
+- **Object storage holds files and large binary assets.**
+
+Do not make Postgres and Gun compete as interchangeable databases. Choose the authority per data class and make every secondary copy reconstructable from that authority when practical.
+
+## Postgres: canonical business data
+
+Postgres is the canonical source of truth for data that creates a business, financial, security, or customer obligation, including:
+
+- CRM contacts and activities
+- orders and fulfillment state
+- subscription/payment mirrors and reconciliation records
+- newsletter subscriptions and suppression state
+- audit and delivery records
+- server-side permissions or entitlement records
+- any record whose loss could create a customer, legal, or accounting problem
+
+Where a Gun projection also exists, the Postgres record wins during reconciliation.
+
+## GunJS: realtime and local-first state
+
+Gun remains a first-class 3DVR technology. Use it for:
+
+- realtime collaboration
+- offline/local-first state
+- presence and ephemeral UI state
+- peer synchronization
+- chat and community experiences where eventual consistency is acceptable
+- experiments, labs, and distributed application state
+
+Gun data that becomes business-critical should be projected into Postgres or another durable canonical store.
+
+Browser localStorage/Radisk is a cache and offline replica, not a backup strategy.
+
+## Files and binary assets
+
+Do not store large artwork, media, exports, or other binary payloads directly in Postgres or Gun unless there is a specific technical reason.
+
+Use private object storage for the bytes. Keep durable metadata in Postgres, including the owning record ID, object key, content type, byte size, checksum, created timestamp, and retention state.
+
+## Backup standard
+
+A datastore is not considered backed up until a recoverable copy exists independently of the primary failure domain.
+
+Minimum standard:
+
+1. Postgres: nightly validated custom-format dump.
+2. Gun: nightly known-root JSON snapshot on a host separate from the Fly relay.
+3. Gun relay: full RAD/radata archive from the Fly persistent volume.
+4. Checksums for backup artifacts.
+5. At least one off-host/off-provider copy for canonical business data.
+6. Periodic restore tests into disposable environments.
+
+A file on the same VM or volume as the live database is only a local recovery point, not a complete backup.
+
+## Current operational paths
+
+- Postgres local dumps: `/var/backups/3dvr/postgres`
+- Gun known-root snapshots: `/var/backups/3dvr/gun-snapshots`
+- Gun relay peer: `wss://gun-relay-3dvr.fly.dev/gun`
+- Gun full RAD backup helper: `ops/gun/archive-rad.sh`
+- Postgres backup helper: `ops/postgres/backup.sh`
+- Storage/backup report: `ops/data/storage-report.sh`
+
+## Recovery priority
+
+1. Restore Postgres business records first.
+2. Restore Gun relay RAD data when available.
+3. Use known-root Gun snapshots for inspection or targeted recovery.
+4. Allow clients to rebuild caches and projections after canonical stores are healthy.
+
+## Migration rule
+
+Do not perform a broad Gun-to-Postgres rewrite merely for architectural purity. Move a data class when one of these is true:
+
+- it has become financially or operationally critical;
+- it needs reliable querying/reporting;
+- it needs referential integrity or transaction semantics;
+- backup/recovery requirements exceed the current Gun path;
+- real production usage proves the migration is worth its complexity.
+
+This keeps the distributed/open architecture while making the business core deliberately boring and recoverable.

--- a/ops/control-plane/home/RUNBOOKS/portal-gunjs-backups.md
+++ b/ops/control-plane/home/RUNBOOKS/portal-gunjs-backups.md
@@ -1,25 +1,24 @@
 # Portal GunJS Backups
 
-The portal currently treats GunJS as the source of truth for shared app state, CRM records, guest profiles,
-billing mirrors, agent ops, notes, chat, and lab data. Backups need two layers:
+GunJS is the realtime/local-first synchronization layer for 3DVR. It remains authoritative for Gun-native distributed state that has not been promoted into a durable business system, but it is **not** the canonical ledger for CRM, orders, payments, subscriptions, or other business-critical records. Those records belong in Postgres according to `docs/data-storage-policy.md`.
 
-1. Archive the relay's RAD data directory. This is the authoritative backup.
-2. Capture known root snapshots as JSON. This is useful for inspection, restore drills, and quick sanity checks, but it
-   cannot prove every Gun soul was discovered.
+Gun backups still need two layers:
+
+1. Archive the relay's RAD data directory. This is the complete relay-level backup.
+2. Capture known root snapshots as JSON on a separate host. This is useful for inspection, targeted recovery, and resilience if the Fly relay is unavailable, but it cannot prove every Gun soul was discovered.
 
 ## What To Back Up
 
 - Relay peer: `wss://gun-relay-3dvr.fly.dev/gun`
 - Default Gun RAD directory when not overridden: `radata`
 - Portal root manifest: `ops/gun/portal-gun-roots.json`
-- Local snapshot output: `backups/gun-snapshots/`
+- Independent snapshot output: `/var/backups/3dvr/gun-snapshots`
 
-Treat every backup artifact as sensitive. Even encrypted SEA records, billing mirrors, guest profiles, and key-vault
-ciphertexts should not be committed or shared casually.
+Treat every backup artifact as sensitive. Even encrypted SEA records, billing mirrors, guest profiles, and key-vault ciphertexts should not be committed or shared casually.
 
-## Daily Host Archive
+## Daily Relay RAD Archive
 
-Run this on the host or container that owns the relay data volume:
+Run this on the Fly host/container that owns the relay data volume:
 
 ```sh
 GUN_RAD_DIR=/path/to/radata \
@@ -37,38 +36,42 @@ GUN_RELAY_SERVICE=gun-relay.service \
 ops/gun/archive-rad.sh
 ```
 
-Off-host copy is required. A local archive on the same VM or Fly volume is only a short-term safety net.
-Use `GUN_BACKUP_RCLONE_REMOTE` once rclone is configured for DigitalOcean Spaces, S3, Backblaze, or another store:
+A local archive on the same VM or Fly volume is only a short-term recovery point. The complete backup standard requires an off-host copy. `archive-rad.sh` supports `GUN_BACKUP_RCLONE_REMOTE` once an external destination is configured.
+
+## Nightly Independent Known-Roots Snapshot
+
+The repository now includes:
+
+- `ops/systemd/3dvr-gun-snapshot.service`
+- `ops/systemd/3dvr-gun-snapshot.timer`
+
+Install and enable these on a host separate from the Fly relay after the repository is deployed to `/opt/3dvr-portal`:
 
 ```sh
-GUN_RAD_DIR=/path/to/radata \
-GUN_BACKUP_RCLONE_REMOTE=do-spaces:3dvr-backups/gun-rad \
-ops/gun/archive-rad.sh
+sudo cp ops/systemd/3dvr-gun-snapshot.service /etc/systemd/system/
+sudo cp ops/systemd/3dvr-gun-snapshot.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now 3dvr-gun-snapshot.timer
 ```
 
-## Daily Known-Roots Snapshot
+The service writes snapshots under `/var/backups/3dvr/gun-snapshots` and connects to the Fly relay over the network.
 
-Run this from a repo checkout with dependencies installed:
-
-```sh
-npm run gun:backup
-```
-
-The snapshot command now stops at three independent safety boundaries by default: a 10-minute
-process timeout, 500 total Gun node reads, and 256 MB RSS. These limits make the JSON layer
-inspection-friendly without allowing it to compete with the OpenClaw gateway for all host memory.
-Keep this job in a separate service/container or on the relay host; never launch it as a child of
-the OpenClaw gateway service.
-
-Useful overrides:
+Manual equivalent:
 
 ```sh
 GUN_BACKUP_OUT_DIR=/var/backups/3dvr/gun-snapshots \
-GUN_BACKUP_PEERS='wss://gun-relay-3dvr.fly.dev/gun https://gun-relay-3dvr.fly.dev/gun' \
+GUN_BACKUP_PEERS='wss://gun-relay-3dvr.fly.dev/gun,https://gun-relay-3dvr.fly.dev/gun' \
 GUN_BACKUP_MAX_NODES=500 \
 GUN_BACKUP_MAX_MEMORY_MB=256 \
 npm run gun:backup
 ```
+
+The snapshot command stops at independent safety boundaries for process time, node reads, and memory. Keep it separate from the OpenClaw gateway service.
+
+The command writes:
+
+- `portal-gun-known-roots-<timestamp>.json`
+- `portal-gun-known-roots-<timestamp>.json.sha256`
 
 Dry-run the manifest without connecting:
 
@@ -76,25 +79,15 @@ Dry-run the manifest without connecting:
 npm run gun:backup -- --dry-run
 ```
 
-Snapshot one root for a quick health check:
+## Storage and Backup Report
+
+On any host with the repository available:
 
 ```sh
-npm run gun:backup -- --root portal --depth 0
+ops/data/storage-report.sh
 ```
 
-The command writes:
-
-- `portal-gun-known-roots-<timestamp>.json`
-- `portal-gun-known-roots-<timestamp>.json.sha256`
-
-## Cron Example
-
-Run both layers nightly and keep stdout/stderr in system logs:
-
-```cron
-15 7 * * * cd /opt/3dvr-portal && GUN_RAD_DIR=/path/to/radata ops/gun/archive-rad.sh
-30 7 * * * cd /opt/3dvr-portal && GUN_BACKUP_MAX_NODES=500 GUN_BACKUP_MAX_MEMORY_MB=256 npm run gun:backup
-```
+On the Fly relay host, set `GUN_RAD_DIR` if the RAD directory is not one of the common locations. The report shows RAD size, local snapshot size, latest snapshot path, and Postgres information when that database is reachable from the same shell.
 
 ## Restore Notes
 
@@ -107,19 +100,14 @@ For a RAD archive restore:
 3. Verify the archive checksum.
 4. Extract the tarball into the expected parent directory.
 5. Start the relay.
-6. Use `gun-explorer/`, `test-gun.html`, and a few app pages to verify critical paths such as:
-   - `3dvr-portal/billing`
-   - `3dvr-portal/agentOps`
-   - `3dvr-crm`
-   - `3dvr-guests`
-   - `3dvr-chat`
+6. Verify representative application roots.
 
-Known-root JSON snapshots are not a full restore source unless the missing data is known to live under one of the
-manifest paths. Use them first for inspection and emergency record recovery, not as the only backup.
+Known-root JSON snapshots are not a full restore source unless the missing data is known to live under one of the manifest paths. Use them for inspection and emergency record recovery, not as the only backup.
 
-## Immediate Standard
+## Required Standard
 
-- Nightly RAD archive.
-- Nightly known-root JSON snapshot.
-- Off-host copy before considering the system backed up.
-- Weekly restore drill into a disposable relay.
+- Nightly relay RAD archive.
+- Nightly known-root snapshot on a different host.
+- Independent copy before considering critical Gun data fully backed up.
+- Periodic restore drill into a disposable relay.
+- Business-critical records projected to Postgres rather than relying on Gun alone.

--- a/ops/data/storage-report.sh
+++ b/ops/data/storage-report.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+set -eu
+
+printf '%s\n' '3DVR data storage report'
+printf 'Generated: %s\n\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '%s\n' 'Postgres'
+if command -v psql >/dev/null 2>&1; then
+  if [ -n "${DATABASE_URL:-}" ]; then
+    psql "$DATABASE_URL" -Atqc "SELECT current_database() || '|' || pg_database_size(current_database()) || '|' || pg_size_pretty(pg_database_size(current_database()));" \
+      | awk -F'|' '{printf "database=%s bytes=%s pretty=%s\n", $1, $2, $3}' || true
+  elif [ -n "${PGDATABASE:-}" ] || [ -n "${PGSERVICE:-}" ]; then
+    psql -Atqc "SELECT current_database() || '|' || pg_database_size(current_database()) || '|' || pg_size_pretty(pg_database_size(current_database()));" \
+      | awk -F'|' '{printf "database=%s bytes=%s pretty=%s\n", $1, $2, $3}' || true
+  else
+    echo 'database connection not configured in this shell'
+  fi
+else
+  echo 'psql not installed'
+fi
+
+pg_backup_dir="${PG_BACKUP_DIR:-/var/backups/3dvr/postgres}"
+if [ -d "$pg_backup_dir" ]; then
+  printf 'local_backup_bytes='
+  du -sk "$pg_backup_dir" | awk '{print $1 * 1024}'
+  printf 'latest_backup='
+  find "$pg_backup_dir" -maxdepth 1 -type f -name 'portal-postgres-*.dump' -print 2>/dev/null | sort | tail -n 1
+else
+  echo 'local_backup_dir=missing'
+fi
+
+printf '\n%s\n' 'Gun'
+rad_dir="${GUN_RAD_DIR:-}"
+if [ -z "$rad_dir" ]; then
+  for candidate in /data/radata /data/gun/radata /opt/gun-relay/radata /opt/3dvr-gun-relay/radata ./radata; do
+    if [ -d "$candidate" ]; then
+      rad_dir="$candidate"
+      break
+    fi
+  done
+fi
+if [ -n "$rad_dir" ] && [ -d "$rad_dir" ]; then
+  printf 'rad_dir=%s\n' "$rad_dir"
+  printf 'rad_bytes='
+  du -sk "$rad_dir" | awk '{print $1 * 1024}'
+else
+  echo 'rad_dir=not present on this host'
+fi
+
+gun_snapshot_dir="${GUN_BACKUP_OUT_DIR:-/var/backups/3dvr/gun-snapshots}"
+if [ -d "$gun_snapshot_dir" ]; then
+  printf 'snapshot_bytes='
+  du -sk "$gun_snapshot_dir" | awk '{print $1 * 1024}'
+  printf 'latest_snapshot='
+  find "$gun_snapshot_dir" -maxdepth 1 -type f -name 'portal-gun-known-roots-*.json' -print 2>/dev/null | sort | tail -n 1
+else
+  echo 'snapshot_dir=missing'
+fi

--- a/ops/postgres/backup.sh
+++ b/ops/postgres/backup.sh
@@ -27,9 +27,16 @@ cleanup() {
 }
 trap cleanup INT TERM EXIT
 
-# pg_dump will use the standard libpq environment (PGHOST, PGDATABASE, PGUSER,
-# PGPASSWORD) or PGSERVICE supplied by the host. Do not put credentials in git.
-pg_dump --format=custom --no-owner --no-privileges --file="$tmp"
+# Prefer the existing DATABASE_URL used by the 3DVR store service. If it is not
+# set, pg_dump will use the standard libpq environment (PGHOST, PGDATABASE,
+# PGUSER, PGPASSWORD) or PGSERVICE. Do not put credentials in git.
+if [ -n "${DATABASE_URL:-}" ]; then
+  pg_dump --dbname="$DATABASE_URL" --format=custom --no-owner --no-privileges --file="$tmp"
+else
+  pg_dump --format=custom --no-owner --no-privileges --file="$tmp"
+fi
+
+# Validate the archive before publishing it as a completed backup.
 pg_restore --list "$tmp" >/dev/null
 mv "$tmp" "$archive"
 chmod 600 "$archive"

--- a/ops/postgres/backup.sh
+++ b/ops/postgres/backup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -eu
+
+# Creates a local PostgreSQL custom-format dump and checksum.
+# Connection details are supplied by the host environment and are never printed.
+
+if ! command -v pg_dump >/dev/null 2>&1; then
+  echo "pg_dump is required" >&2
+  exit 1
+fi
+if ! command -v pg_restore >/dev/null 2>&1; then
+  echo "pg_restore is required" >&2
+  exit 1
+fi
+
+backup_dir="${PG_BACKUP_DIR:-/var/backups/3dvr/postgres}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+host="$(hostname | tr -c 'A-Za-z0-9_.-' '-')"
+archive="${backup_dir}/portal-postgres-${host}-${timestamp}.dump"
+tmp="${archive}.tmp"
+
+mkdir -p "$backup_dir"
+chmod 700 "$backup_dir"
+
+cleanup() {
+  rm -f "$tmp"
+}
+trap cleanup INT TERM EXIT
+
+# pg_dump will use the standard libpq environment (PGHOST, PGDATABASE, PGUSER,
+# PGPASSWORD) or PGSERVICE supplied by the host. Do not put credentials in git.
+pg_dump --format=custom --no-owner --no-privileges --file="$tmp"
+pg_restore --list "$tmp" >/dev/null
+mv "$tmp" "$archive"
+chmod 600 "$archive"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$backup_dir" && sha256sum "$(basename "$archive")" > "$(basename "$archive").sha256")
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$backup_dir" && shasum -a 256 "$(basename "$archive")" > "$(basename "$archive").sha256")
+else
+  echo "No SHA-256 tool found" >&2
+  exit 1
+fi
+chmod 600 "${archive}.sha256"
+
+trap - INT TERM EXIT
+printf 'Postgres backup written and validated: %s\n' "$archive"

--- a/ops/systemd/3dvr-gun-snapshot.service
+++ b/ops/systemd/3dvr-gun-snapshot.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=3DVR Gun known-root snapshot
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/opt/3dvr-portal
+Environment=GUN_BACKUP_OUT_DIR=/var/backups/3dvr/gun-snapshots
+Environment=GUN_BACKUP_PEERS=wss://gun-relay-3dvr.fly.dev/gun,https://gun-relay-3dvr.fly.dev/gun
+Environment=GUN_BACKUP_MAX_NODES=500
+Environment=GUN_BACKUP_MAX_MEMORY_MB=256
+ExecStart=/usr/bin/npm run gun:backup
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true

--- a/ops/systemd/3dvr-gun-snapshot.service
+++ b/ops/systemd/3dvr-gun-snapshot.service
@@ -11,7 +11,7 @@ Environment=GUN_BACKUP_OUT_DIR=/var/backups/3dvr/gun-snapshots
 Environment=GUN_BACKUP_PEERS=wss://gun-relay-3dvr.fly.dev/gun,https://gun-relay-3dvr.fly.dev/gun
 Environment=GUN_BACKUP_MAX_NODES=500
 Environment=GUN_BACKUP_MAX_MEMORY_MB=256
-ExecStart=/usr/bin/npm run gun:backup
+ExecStart=/usr/bin/node /opt/3dvr-portal/scripts/gun/backup-known-roots.mjs
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=true

--- a/ops/systemd/3dvr-gun-snapshot.timer
+++ b/ops/systemd/3dvr-gun-snapshot.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nightly 3DVR Gun known-root snapshot
+
+[Timer]
+OnCalendar=*-*-* 07:35:00 UTC
+Persistent=true
+RandomizedDelaySec=10m
+Unit=3dvr-gun-snapshot.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/systemd/3dvr-postgres-backup.service
+++ b/ops/systemd/3dvr-postgres-backup.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=3DVR PostgreSQL backup
+Wants=network-online.target
+After=network-online.target postgresql.service
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/opt/3dvr-portal
+EnvironmentFile=/etc/3dvr/newsletter-store.env
+Environment=PG_BACKUP_DIR=/var/backups/3dvr/postgres
+ExecStart=/bin/sh /opt/3dvr-portal/ops/postgres/backup.sh
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true

--- a/ops/systemd/3dvr-postgres-backup.timer
+++ b/ops/systemd/3dvr-postgres-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nightly 3DVR PostgreSQL backup
+
+[Timer]
+OnCalendar=*-*-* 07:15:00 UTC
+Persistent=true
+RandomizedDelaySec=10m
+Unit=3dvr-postgres-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/data-resilience.test.js
+++ b/tests/data-resilience.test.js
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const text = relativePath => readFile(new URL(`../${relativePath}`, import.meta.url), 'utf8');
+
+describe('3DVR data resilience', () => {
+  it('makes Postgres the durable business ledger and Gun the realtime layer', async () => {
+    const policy = await text('docs/data-storage-policy.md');
+    assert.match(policy, /Postgres is the durable business ledger/);
+    assert.match(policy, /GunJS is the realtime\/local-first synchronization layer/);
+    assert.match(policy, /Object storage holds files and large binary assets/);
+    assert.match(policy, /CRM contacts and activities/);
+    assert.match(policy, /orders and fulfillment state/);
+  });
+
+  it('validates Postgres dumps before publishing them', async () => {
+    const backup = await text('ops/postgres/backup.sh');
+    assert.match(backup, /pg_dump/);
+    assert.match(backup, /--format=custom/);
+    assert.match(backup, /pg_restore --list "\$tmp"/);
+    assert.match(backup, /sha256sum|shasum/);
+    assert.doesNotMatch(backup, /echo .*DATABASE_URL/);
+  });
+
+  it('schedules persistent nightly backups without coupling Gun to the relay host', async () => {
+    const pgTimer = await text('ops/systemd/3dvr-postgres-backup.timer');
+    const gunTimer = await text('ops/systemd/3dvr-gun-snapshot.timer');
+    const gunService = await text('ops/systemd/3dvr-gun-snapshot.service');
+    assert.match(pgTimer, /Persistent=true/);
+    assert.match(gunTimer, /Persistent=true/);
+    assert.match(gunService, /gun-relay-3dvr\.fly\.dev/);
+    assert.match(gunService, /backup-known-roots\.mjs/);
+    assert.match(gunService, /GUN_BACKUP_OUT_DIR=\/var\/backups\/3dvr\/gun-snapshots/);
+  });
+
+  it('does not describe Gun as the canonical CRM ledger anymore', async () => {
+    const runbook = await text('ops/control-plane/home/RUNBOOKS/portal-gunjs-backups.md');
+    assert.doesNotMatch(runbook, /GunJS as the source of truth for shared app state, CRM records/);
+    assert.match(runbook, /not.*canonical ledger for CRM/i);
+  });
+});


### PR DESCRIPTION
## Summary
- define Postgres as the durable business ledger and Gun as the realtime/local-first layer
- add validated PostgreSQL dump tooling
- add nightly systemd timers for Postgres backups and independent Gun known-root snapshots
- add a storage/backup health report
- align the Gun backup runbook with the new source-of-truth policy
- add regression tests for the data-resilience contract

## Verification
- `sh -n` passes for the new shell scripts
- data-resilience test passes 4/4 locally
- systemd calendar expressions validate
- Vercel status is currently blocked by the account build-rate limit; this change does not modify website runtime code

## Remaining host action
The repository can prepare and schedule the jobs, but the current ChatGPT environment has no SSH/DigitalOcean/Fly connector, so the units still need to be installed/enabled on the host and the Fly RAD volume/off-host destination must be verified separately.