### PR TITLE
CRM: guard quiet-until-reply revenue policy

### DIFF
--- a/apps/agent/test/crm-quiet-policy.test.js
+++ b/apps/agent/test/crm-quiet-policy.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildCrmRecord } = require('../thomas-agent/node/crm-sync');
+
+test('contacted leads stay quiet until reply or a new material reason', () => {
+  const record = buildCrmRecord({
+    name: 'Warm Trial Lead',
+    link: 'https://3dvr.tech',
+    contact: 'mailto:warm@example.com',
+    status: 'contacted',
+    date: '2026-08-15',
+    variant: 'trial-signup',
+  }, { now: '2026-08-15T12:00:00.000Z' });
+
+  assert.equal(record.nextFollowUp, '');
+  assert.match(record.nextBestAction, /wait|quiet|reply|new material reason/i);
+  assert.doesNotMatch(record.nextBestAction, /follow up later/i);
+});


### PR DESCRIPTION
Adds an isolated regression test for the revenue outreach rule: after one outbound message, a contacted lead must have no automatic follow-up date and the CRM must tell us to wait for a reply or genuinely new material reason.

This deliberately avoids modifying or replacing the existing CRM test suite. The test is expected to fail against current behavior until the implementation is changed safely.

Refs #1466.

## Fresh delivery status — 2026-08-14

- Draft: yes
- Mergeable: yes
- Vercel Dev Preview: passed on head `1f350acf`
- Playwright Checks: passed on head `1f350acf`
- Agent Checks: failing on head `1f350acf`

Keep this PR in draft until the Agent Checks failure is triaged and the quiet-until-reply regression is intentionally resolved. Do not infer shipping readiness from mergeability alone.