### PR TITLE
CRM: keep contacted leads quiet until reply

### DIFF
--- a/apps/agent/test/revenue-crm-projection.test.js
+++ b/apps/agent/test/revenue-crm-projection.test.js
@@ -20,10 +20,11 @@ test('CRM projection retries a timeout and completes idempotently', async () => 
   } finally { db.close(); fs.rmSync(tmp, { recursive: true, force: true }); }
 });
 
-test('CRM projection preserves the legacy stable record identity', () => {
+test('CRM projection preserves the legacy stable record identity while waiting quietly after contact', () => {
   const record = recordFor({ id: 'uuid', name: 'Acme', contact: 'mailto:info@acme.test', source_url: 'https://acme.test', state: 'sent', campaign_id: '', created_at: '2026-01-01T00:00:00Z' }, { id: 'event' }, '2026-01-02T00:00:00Z');
   assert.equal(record.id, 'agent-lead-info-acme-test');
-  assert.equal(record.status, 'Warm - Follow-up');
+  assert.equal(record.status, 'Warm - Waiting');
+  assert.equal(record.nextBestAction, 'Wait for reply or a genuinely new material reason to contact. Do not schedule an automatic sales follow-up.');
   assert.equal(record.canonicalState, 'sent');
 });
 

--- a/apps/agent/thomas-agent/node/revenue-crm-projection.js
+++ b/apps/agent/thomas-agent/node/revenue-crm-projection.js
@@ -21,9 +21,15 @@ function remoteProjectionRoots() {
 function recordFor(prospect, event, now) {
   const crmStatus = {
     prospect: 'Lead', verified: 'Lead', drafted: 'Lead', eligible: 'Lead',
-    sent: 'Warm - Follow-up', replied: 'Warm - Discovery', bounced: 'Lost',
+    sent: 'Warm - Waiting', replied: 'Warm - Discovery', bounced: 'Lost',
     failed: 'Lost', suppressed: 'Closed',
   }[prospect.state] || 'Lead';
+  const nextBestAction = {
+    sent: 'Wait for reply or a genuinely new material reason to contact. Do not schedule an automatic sales follow-up.',
+    replied: 'Continue discovery from the customer reply.',
+    bounced: 'Do not contact.',
+    suppressed: 'Do not contact.',
+  }[prospect.state] || 'Follow the canonical revenue state machine.';
   return {
     id: buildLeadId({ name: prospect.name, contact: prospect.contact, link: prospect.source_url }),
     recordType: 'person',
@@ -35,7 +41,7 @@ function recordFor(prospect, event, now) {
     source: '3dvr-revenue-ledger',
     campaignId: prospect.campaign_id,
     lastSignal: `Canonical revenue state: ${prospect.state}`,
-    nextBestAction: ['bounced', 'suppressed'].includes(prospect.state) ? 'Do not contact.' : 'Follow the canonical revenue state machine.',
+    nextBestAction,
     created: prospect.created_at,
     updated: now,
     canonicalEventId: event.id,


### PR DESCRIPTION
Revenue safeguard: Portal CRM currently projects a sent lead as `Warm - Follow-up`, which encourages the exact consecutive follow-up behavior we want to avoid.

This isolated change makes sent prospects `Warm - Waiting` and sets the next action to wait for a reply or genuinely new material reason. Replied prospects continue into discovery; bounced/suppressed remain do-not-contact.

No outreach is sent by this change. Reversible and isolated to CRM projection behavior.