### PR TITLE
Add real checkout proof to launch offer

### DIFF
--- a/new-business-launch/index.html
+++ b/new-business-launch/index.html
@@ -39,6 +39,8 @@
     .subscription-card h3{margin:.45rem 0;font-size:1.25rem}.subscription-card p{color:#b8c6d9;font-size:.9rem;min-height:4.2rem}
     .subscription-card small{color:#67e8f9;text-transform:uppercase;letter-spacing:.16em;font-size:.62rem;font-weight:800}
     .subscription-card .button{margin-top:auto;text-align:center;justify-content:center}
+    .checkout-proof{margin:1.25rem 0 0;padding:1rem 1.1rem;border:1px solid rgba(103,232,249,.28);border-radius:.85rem;background:rgba(103,232,249,.06);color:#d7e5f5}
+    .checkout-proof strong{color:#67e8f9}
     @media(max-width:900px){.subscription-grid{grid-template-columns:repeat(2,1fr)}}
     @media(max-width:560px){.subscription-grid{grid-template-columns:1fr}.subscription-card p{min-height:0}}
   </style>
@@ -95,6 +97,7 @@
         <p class="eyebrow">Simple monthly path</p>
         <h2>Pay for help, not a huge tool pile.</h2>
         <p><strong>$5/mo</strong> keeps your page live. <strong>$20/mo</strong> adds launch help and updates. <strong>$50/mo</strong> adds help with leads and follow-up. Teams can use the <strong>$200/mo</strong> plan for deeper help. You can pay in the secure portal.</p>
+        <p class="checkout-proof"><strong>Real checkout proof:</strong> a customer has successfully started the $20/month plan through the live 3DVR checkout. We’re sharing the receipt-level fact—not promising that every business gets the same outcome.</p>
       </div>
       <div class="hero-actions">
         <a class="button primary" href="../free-page/#brief">Start with the free draft</a>


### PR DESCRIPTION
Revenue-focused conversion improvement. Adds a concise, factual proof note beside the monthly plans: a customer successfully started the live $20/month plan. Avoids causal or outcome claims and does not change checkout behavior.