### PR TITLE
Use paid invoice as launch proof

### DIFF
--- a/new-business-launch/index.html
+++ b/new-business-launch/index.html
@@ -97,7 +97,7 @@
         <p class="eyebrow">Simple monthly path</p>
         <h2>Pay for help, not a huge tool pile.</h2>
         <p><strong>$5/mo</strong> keeps your page live. <strong>$20/mo</strong> adds launch help and updates. <strong>$50/mo</strong> adds help with leads and follow-up. Teams can use the <strong>$200/mo</strong> plan for deeper help. You can pay in the secure portal.</p>
-        <p class="checkout-proof"><strong>Real checkout proof:</strong> a customer has successfully started the $20/month plan through the live 3DVR checkout. We’re sharing the receipt-level fact—not promising that every business gets the same outcome.</p>
+        <p class="checkout-proof"><strong>Real checkout proof:</strong> a customer paid the first $20 invoice and now has an active $20/month 3DVR subscription. That confirms the checkout and billing path work; it does not promise a particular business outcome.</p>
       </div>
       <div class="hero-actions">
         <a class="button primary" href="../free-page/#brief">Start with the free draft</a>


### PR DESCRIPTION
Strengthens the launch-page proof note using the verified live billing fact: the first $20 invoice was paid and the $20/month subscription is active.

Keeps the claim narrow: this proves the checkout/billing path works, not that customers are guaranteed business outcomes.

No checkout behavior, pricing, outreach, or infrastructure changes.