### PR TITLE
surface Agent as a first-class Portal app

### DIFF
--- a/docs/future-portal-agent-monorepo.md
+++ b/docs/future-portal-agent-monorepo.md
@@ -1,6 +1,6 @@
 # Portal + Agent Monorepo Design
 
-Status: implemented July 16, 2026.
+Status: implemented July 16, 2026; Portal surface promoted August 15, 2026.
 
 ## Decision
 
@@ -26,6 +26,17 @@ Status: implemented July 16, 2026.
 
 The asymmetric shape is intentional. A monorepo does not require moving every application at once, and keeping the portal at the root avoids changing its current Vercel project root, imports, scripts, and deployment assumptions.
 
+## Product surface
+
+Agent is part of Portal OS, not a separate customer-facing product. Portal Home exposes Agent as a first-class entry point and routes operators to the existing Agent Operations workbench in `/admin/#agent-ops-card`.
+
+This keeps the product model simple:
+
+- Portal is the user-facing operating system.
+- Agent is the execution layer inside Portal.
+- `apps/agent` remains independently deployable because the worker has different runtime and secret requirements.
+- Shared packages should be extracted only when Portal and Agent genuinely share stable code contracts.
+
 ## Runtime boundaries
 
 - The portal remains a Vercel deployment built from the repository root.
@@ -42,6 +53,7 @@ The asymmetric shape is intentional. A monorepo does not require moving every ap
 4. Vercel excludes `apps/agent` from the public deployment; the worker remains a separate runtime.
 5. The combined portal and agent suites must pass before the production worker checkout changes.
 6. The standalone `3dvr-agent` repository remains read-only during the transition and is not deleted.
+7. Portal Home now exposes Agent directly while reusing the existing authenticated Agent Operations workbench.
 
 ## Deferred work
 

--- a/home/index.html
+++ b/home/index.html
@@ -24,6 +24,7 @@
         </div>
         <div class="status-right">
           <div class="status-quick-links" aria-label="Quick links">
+            <a href="/admin/#agent-ops-card" class="status-link">Agent</a>
             <a href="/calendar" class="status-link">Calendar</a>
             <a href="/tasks/" class="status-link">Tasks</a>
             <a href="/chat/" class="status-link">Chat</a>
@@ -36,6 +37,12 @@
       </header>
       <main class="workspace" id="workspace" tabindex="0">
         <ul class="desktop-shortcuts" aria-label="Desktop shortcuts">
+          <li>
+            <a class="shortcut" style="text-decoration: none;" href="/admin/#agent-ops-card" aria-label="Open 3DVR Agent Operations">
+              <span class="shortcut-icon">✨</span>
+              <span class="shortcut-label">Agent</span>
+            </a>
+          </li>
           <li>
             <button class="shortcut" type="button" data-app="navigator" aria-label="Open Navigator">
               <span class="shortcut-icon">🧭</span>
@@ -86,6 +93,7 @@
       </nav>
       <div class="launcher-panel" id="launcher-panel" role="menu" aria-label="Launcher">
         <div class="launcher-header">Pinned</div>
+        <a class="launcher-item" href="/admin/#agent-ops-card">Agent Operations</a>
         <button class="launcher-item" type="button" data-app="navigator">Navigator</button>
         <button class="launcher-item" type="button" data-app="notes">Notes</button>
         <button class="launcher-item" type="button" data-app="mindfulness">Mindfulness</button>


### PR DESCRIPTION
## What changed

- adds Agent to the Portal Home quick links
- adds a desktop Agent shortcut and launcher entry
- routes users to the existing authenticated Agent Operations workbench
- documents the product boundary: Portal is the user-facing OS; Agent is its execution layer

## Why

The code migration into `apps/agent` was already completed on July 16, but Agent remained hard to discover from Portal Home. This makes the existing integration visible without changing Vercel roots, worker deployment, secrets, or runtime boundaries.

## Validation

- compared branch against `main`: only `home/index.html` and `docs/future-portal-agent-monorepo.md` changed
- no Agent runtime or deployment code changed
- local CLI/browser validation was unavailable in this runtime, so this remains a draft pending normal preview/CI checks
