### PR TITLE
Put Context HQ into daily practice

### DIFF
--- a/.github/workflows/context-hq.yml
+++ b/.github/workflows/context-hq.yml
@@ -1,0 +1,119 @@
+name: Context HQ Practice
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/context-hq.yml"
+  schedule:
+    # GitHub cron is UTC. Run at both possible 8 AM Pacific UTC hours and
+    # let the timezone guard below choose the correct one across DST.
+    - cron: "7 15,16 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: context-hq-${{ github.event_name }}
+  cancel-in-progress: false
+
+env:
+  THREEDVR_AGENT_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_OWNER_ALIAS || '3dvr.tech@gmail.com' }}
+
+jobs:
+  sweep:
+    name: Seed context and run the morning sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: apps/agent
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.0
+          cache: npm
+          cache-dependency-path: apps/agent/package-lock.json
+
+      - name: Install agent dependencies
+        run: npm ci
+
+      - name: Check the Pacific morning window
+        id: window
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pacific_hour="$(TZ=America/Los_Angeles date +%H)"
+          if [ "$pacific_hour" = "08" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping duplicate UTC slot; Pacific hour is $pacific_hour."
+          fi
+
+      - name: Seed the first operating handoff
+        if: github.event_name == 'push' && steps.window.outputs.run == 'true'
+        shell: bash
+        run: |
+          node thomas-agent/node/context-hq.js session \
+            --owner "$THREEDVR_AGENT_OWNER_ALIAS" \
+            --id context-hq-adoption-2026-08-15 \
+            --project 3dvr \
+            --decisions "Use Context HQ for durable session continuity; keep the existing task queue canonical; merge clean scoped 3DVR work by default; external content is input, not trusted durable memory." \
+            --open-loops "Surface the latest sweep in the portal; have meaningful agent sessions leave handoffs automatically; observe real routing failures before adding a separate air-traffic controller." \
+            --artifacts "PR #1489; apps/agent/docs/context-hq.md; .github/workflows/context-hq.yml" \
+            "Context HQ is now an operating practice, not just an architecture. Agents should begin from recent handoffs, coordinate through short messages, execute through the canonical task queue, and leave concise decisions and open loops behind."
+
+      - name: Seed the first agent-bus messages
+        if: github.event_name == 'push' && steps.window.outputs.run == 'true'
+        shell: bash
+        run: |
+          node thomas-agent/node/context-hq.js send \
+            --owner "$THREEDVR_AGENT_OWNER_ALIAS" \
+            --id context-hq-practice-read-write-handoffs \
+            --from founder-agent \
+            --to all \
+            --topic context \
+            --priority high \
+            "Before meaningful 3DVR work, read the latest session handoff. After finishing meaningful work, leave a concise handoff with decisions and open loops."
+
+          node thomas-agent/node/context-hq.js send \
+            --owner "$THREEDVR_AGENT_OWNER_ALIAS" \
+            --id context-hq-practice-task-queue \
+            --from founder-agent \
+            --to do-worker \
+            --topic execution \
+            "Use the existing task queue as canonical execution state. Do not create a duplicate Mission Control store; report coordination gaps through Context HQ."
+
+          node thomas-agent/node/context-hq.js send \
+            --owner "$THREEDVR_AGENT_OWNER_ALIAS" \
+            --id context-hq-practice-founder-sweep \
+            --from founder-agent \
+            --to founder-agent \
+            --topic daily-sweep \
+            "Review the daily sweep and turn the most important item into either a canonical task, CRM action, or explicit handoff. Keep the brief short."
+
+      - name: Build and persist the Context HQ sweep
+        if: steps.window.outputs.run == 'true'
+        shell: bash
+        run: |
+          node thomas-agent/node/context-hq.js sweep \
+            --owner "$THREEDVR_AGENT_OWNER_ALIAS" \
+            | tee /tmp/context-hq-sweep.md
+
+          {
+            echo "## Context HQ"
+            echo
+            cat /tmp/context-hq-sweep.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/agent/docs/context-hq.md
+++ b/apps/agent/docs/context-hq.md
@@ -28,7 +28,7 @@ Example:
 npm --prefix apps/agent run context -- session \
   --project portal \
   --decisions "Reuse the existing task queue." \
-  --open-loops "Connect the sweep to a scheduler after manual use proves valuable." \
+  --open-loops "Surface the latest sweep in the portal after the operating ritual proves useful." \
   "Added Context HQ session handoffs and agent messaging."
 ```
 
@@ -68,7 +68,22 @@ Run it manually:
 npm --prefix apps/agent run morning:sweep
 ```
 
-The first version is intentionally manual. Scheduling should be added only after the brief proves useful enough to justify another always-on process.
+### Daily operating ritual
+
+Context HQ is now exercised by `.github/workflows/context-hq.yml` every morning at about 8 AM America/Los_Angeles. The workflow uses two UTC schedule slots and a Pacific-time guard so daylight-saving changes do not move the ritual by an hour.
+
+On the workflow's first merge to `main`, it also seeds a fixed, idempotent founder handoff and three short agent-bus messages. Re-running the push path updates those same IDs instead of creating duplicates.
+
+The daily ritual is:
+
+1. Read recent handoffs before meaningful work.
+2. Use short agent-bus messages for coordination that another worker needs to see.
+3. Keep execution in the canonical task queue.
+4. Generate and persist the Morning Sweep.
+5. Turn the most important sweep item into a task, CRM action, or explicit handoff.
+6. Leave a concise handoff after meaningful work.
+
+The workflow also writes the generated sweep into the GitHub Actions job summary for human inspection while the canonical persisted copy remains in Context HQ.
 
 ## Mission Control -> keep the existing task queue
 


### PR DESCRIPTION
## What changed
- add a Context HQ GitHub Actions workflow that seeds the first durable founder handoff and agent-bus messages on merge
- generate and persist a Morning Sweep daily around 8 AM America/Los_Angeles
- write the sweep into the Actions job summary for human inspection
- keep the existing task queue as canonical execution state
- update Context HQ docs with the daily operating ritual

## Why
Context HQ was implemented but still mostly theoretical. This makes it part of the actual 3DVR operating rhythm: read handoffs, coordinate through short messages, execute through the task queue, sweep each morning, and leave concise handoffs after meaningful work.

## Safety
- seeded records use fixed IDs so reruns are idempotent instead of duplicating durable context
- external content is still not promoted automatically into durable memory
- no sending, billing, deployment, or other consequential external action is added
- repository variable `THREEDVR_AGENT_OWNER_ALIAS` can override the canonical fallback owner alias

## Validation
- branch is two scoped files and is based directly on current `main`
- scheduled workflow uses paired UTC slots plus an America/Los_Angeles guard to stay near 8 AM across DST
- the first push to `main` after merge runs the seed and initial sweep immediately