### PR TITLE
feat: seed 3DVR Computing family

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,2 +1,3 @@
 apps/agent/
 apps/companion/
+apps/computing/

--- a/apps/computing/README.md
+++ b/apps/computing/README.md
@@ -1,0 +1,43 @@
+# 3DVR Computing
+
+3DVR Computing is the incubator for an open, agent-native family of computing products. The first shared primitive is deliberately small: a capability contract that lets the same 3DVR Agent request actions from a browser, Debian system, or Android device while preserving user authority and an audit receipt.
+
+This lives inside `3dvr-portal` only while the contract is young. The platform pieces should remain independently releasable so they can move into dedicated repositories as they mature.
+
+## Family
+
+- **3DVR Agent** — intent, planning, policy, approvals, and receipts.
+- **3DVR Browser** — Chromium/Brave-derived browser surface with agent tools exposed as explicit capabilities.
+- **3DVR Desktop** — Debian-based desktop where system actions are exposed through narrow adapters instead of unrestricted shell access.
+- **3DVR Mobile** — Android/AOSP-compatible surface that grows from the existing Companion bridge.
+- **3DVR Shell** — one user-facing command surface across the family.
+
+## Contract v0
+
+Every device action is named as a capability such as `browser.open` or `os.notify`.
+
+A policy returns one of three decisions:
+
+- `allow` — execute through the registered adapter.
+- `ask` — return `needs_approval` without executing.
+- `deny` — return `blocked` without executing.
+
+Every request returns a receipt. This makes automation observable before we add broader OS authority.
+
+## Run it
+
+```sh
+npm --prefix apps/computing test
+npm --prefix apps/computing run demo
+```
+
+The demo uses mock adapters so it is safe to run anywhere. Real Debian, Android, and browser adapters can implement the same contract without changing the policy layer.
+
+## First vertical slices
+
+1. Connect the existing Android Companion bridge to this capability contract.
+2. Add a Debian adapter for a tiny allowlist: notifications, opening URLs, and launching approved apps.
+3. Add a Chromium/Brave development shell exposing navigation, tabs, downloads, and page actions through explicit browser capabilities.
+4. Persist approval choices and receipts through the existing Agent/Portal identity and event systems.
+
+The rule is simple: **the agent may become powerful without becoming invisible.**

--- a/apps/computing/bin/3dvr-computing.mjs
+++ b/apps/computing/bin/3dvr-computing.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { createMockAdapters } from '../src/adapters/mock.mjs';
+import { createPolicy } from '../src/policy.mjs';
+import { createRuntime } from '../src/runtime.mjs';
+
+const command = process.argv[2] ?? 'demo';
+
+if (command !== 'demo') {
+  console.error('Usage: node bin/3dvr-computing.mjs demo');
+  process.exitCode = 1;
+} else {
+  const runtime = createRuntime({
+    policy: createPolicy({
+      'browser.open': 'allow',
+      'os.notify': 'ask'
+    }),
+    adapters: createMockAdapters()
+  });
+
+  console.log('3DVR Computing capabilities:');
+  for (const capability of runtime.listCapabilities()) {
+    console.log(`- ${capability}`);
+  }
+
+  const browserReceipt = await runtime.request('browser.open', {
+    url: 'https://3dvr.tech'
+  });
+  const notifyReceipt = await runtime.request('os.notify', {
+    title: '3DVR Computing',
+    body: 'The same capability contract can power Debian, Android, and the browser.'
+  });
+
+  console.log('\nReceipts:');
+  console.log(JSON.stringify([browserReceipt, notifyReceipt], null, 2));
+}

--- a/apps/computing/package.json
+++ b/apps/computing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@3dvr/computing",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Shared capability and permission contract for the 3DVR computing family.",
+  "scripts": {
+    "demo": "node bin/3dvr-computing.mjs demo",
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/apps/computing/platforms/android.md
+++ b/apps/computing/platforms/android.md
@@ -1,0 +1,7 @@
+# 3DVR Mobile — Android/AOSP track
+
+The existing 3DVR Companion is the bridgehead. It should become an Android adapter for the same capability names used by Debian and the browser.
+
+Prefer Android platform APIs and explicit app integrations over simulated taps. Accessibility automation should be a fallback for capabilities that apps do not expose directly.
+
+The long-term product can graduate from Companion app -> launcher/system integration -> AOSP-derived image while keeping the capability and permission contract stable.

--- a/apps/computing/platforms/browser.md
+++ b/apps/computing/platforms/browser.md
@@ -1,0 +1,16 @@
+# 3DVR Browser — Chromium/Brave track
+
+Compatibility comes first, so the initial browser should build on Chromium/Brave rather than a new rendering engine.
+
+The 3DVR layer should expose browser actions as explicit capabilities, for example:
+
+- `browser.open`
+- `browser.tab.create`
+- `browser.tab.close`
+- `browser.page.read`
+- `browser.page.act`
+- `browser.download`
+
+Page-level actions should inherit the same permission model and receipt format as OS actions. The browser is therefore a peer adapter to Debian and Android, not a separate automation universe.
+
+Start with a development shell or extension/protocol adapter. Fork browser chrome only after the capability contract and user experience prove useful.

--- a/apps/computing/platforms/debian.md
+++ b/apps/computing/platforms/debian.md
@@ -1,0 +1,14 @@
+# 3DVR Desktop — Debian track
+
+Start from Debian rather than replacing the Linux ecosystem. The 3DVR-specific layer belongs above the kernel, drivers, systemd, desktop stack, and package manager.
+
+The first adapter should expose a tiny allowlist through the shared capability contract:
+
+- `os.notify`
+- `browser.open`
+- `app.launch`
+- `file.reveal`
+
+Arbitrary shell execution is intentionally not part of v0. Higher-risk capabilities can be added later with explicit policy, previews, and receipts.
+
+Longer term, this track can become a reproducible Debian image plus 3DVR session/launcher packages rather than a hard fork of Debian itself.

--- a/apps/computing/src/adapters/mock.mjs
+++ b/apps/computing/src/adapters/mock.mjs
@@ -1,0 +1,14 @@
+export function createMockAdapters() {
+  return {
+    'browser.open': async ({ url }) => ({
+      opened: url,
+      adapter: 'mock-browser'
+    }),
+    'os.notify': async ({ title, body }) => ({
+      delivered: true,
+      title,
+      body,
+      adapter: 'mock-os'
+    })
+  };
+}

--- a/apps/computing/src/policy.mjs
+++ b/apps/computing/src/policy.mjs
@@ -1,0 +1,13 @@
+export const DECISIONS = Object.freeze({
+  ALLOW: 'allow',
+  ASK: 'ask',
+  DENY: 'deny'
+});
+
+export function createPolicy(rules = {}) {
+  return {
+    decide(capability) {
+      return rules[capability] ?? DECISIONS.ASK;
+    }
+  };
+}

--- a/apps/computing/src/runtime.mjs
+++ b/apps/computing/src/runtime.mjs
@@ -1,0 +1,58 @@
+import { DECISIONS } from './policy.mjs';
+
+export function createRuntime({ policy, adapters = {}, clock = () => new Date() }) {
+  if (!policy?.decide) {
+    throw new TypeError('policy.decide is required');
+  }
+
+  return {
+    listCapabilities() {
+      return Object.keys(adapters).sort();
+    },
+
+    async request(capability, input = {}) {
+      const requestedAt = clock().toISOString();
+      const decision = policy.decide(capability, input);
+      const baseReceipt = {
+        capability,
+        decision,
+        input,
+        requestedAt
+      };
+
+      if (decision === DECISIONS.DENY) {
+        return { ...baseReceipt, status: 'blocked' };
+      }
+
+      if (decision !== DECISIONS.ALLOW) {
+        return { ...baseReceipt, status: 'needs_approval' };
+      }
+
+      const execute = adapters[capability];
+      if (!execute) {
+        return {
+          ...baseReceipt,
+          status: 'unavailable',
+          error: 'No adapter registered for capability.'
+        };
+      }
+
+      try {
+        const result = await execute(input);
+        return {
+          ...baseReceipt,
+          status: 'executed',
+          completedAt: clock().toISOString(),
+          result
+        };
+      } catch (error) {
+        return {
+          ...baseReceipt,
+          status: 'failed',
+          completedAt: clock().toISOString(),
+          error: error instanceof Error ? error.message : String(error)
+        };
+      }
+    }
+  };
+}

--- a/apps/computing/test/runtime.test.mjs
+++ b/apps/computing/test/runtime.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createPolicy } from '../src/policy.mjs';
+import { createRuntime } from '../src/runtime.mjs';
+
+test('unknown capabilities require approval by default', async () => {
+  const runtime = createRuntime({
+    policy: createPolicy(),
+    adapters: {
+      'browser.open': async () => ({ opened: true })
+    }
+  });
+
+  const receipt = await runtime.request('browser.open', { url: 'https://3dvr.tech' });
+
+  assert.equal(receipt.decision, 'ask');
+  assert.equal(receipt.status, 'needs_approval');
+});
+
+test('denied capabilities never execute adapters', async () => {
+  let executed = false;
+  const runtime = createRuntime({
+    policy: createPolicy({ 'os.notify': 'deny' }),
+    adapters: {
+      'os.notify': async () => {
+        executed = true;
+      }
+    }
+  });
+
+  const receipt = await runtime.request('os.notify', { title: 'nope' });
+
+  assert.equal(receipt.status, 'blocked');
+  assert.equal(executed, false);
+});
+
+test('allowed capabilities execute and return a receipt', async () => {
+  const runtime = createRuntime({
+    policy: createPolicy({ 'browser.open': 'allow' }),
+    adapters: {
+      'browser.open': async ({ url }) => ({ opened: url })
+    }
+  });
+
+  const receipt = await runtime.request('browser.open', { url: 'https://3dvr.tech' });
+
+  assert.equal(receipt.status, 'executed');
+  assert.deepEqual(receipt.result, { opened: 'https://3dvr.tech' });
+  assert.ok(receipt.requestedAt);
+  assert.ok(receipt.completedAt);
+});


### PR DESCRIPTION
## What this starts

Seeds the shared contract for an open, agent-native 3DVR computing family spanning Debian/Desktop, Android/Mobile, and a Chromium/Brave-derived browser.

## Included
- `apps/computing` incubator with a capability runtime
- explicit `allow` / `ask` / `deny` policy decisions
- receipts for every requested action
- mock browser + OS adapters and runnable demo
- focused tests for approval, denial, and execution paths
- platform notes for Debian, Android/AOSP, and Chromium/Brave
- Vercel exclusion so the incubator is not shipped with the portal website

## Verification

- `node --test apps/computing/test/*.test.mjs` — 3/3 passing locally
- `node apps/computing/bin/3dvr-computing.mjs demo` — browser action executes under allow policy; OS notification returns `needs_approval` under ask policy

## Scope

This intentionally does not fork Debian, AOSP, or Chromium yet. It establishes the stable permission/capability seam first so the existing Agent and Companion can connect to real platform adapters without giving the agent invisible unrestricted authority.

No Stripe, billing, portal-origin, or account-linking impact.