### PR TITLE
Make 3DVR discoverable as an open-source CRM

### DIFF
--- a/open-source-crm/index.html
+++ b/open-source-crm/index.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>3DVR — Open Source CRM, Contacts, Calendar & Notes</title>
+  <meta name="description" content="3DVR is an open-source CRM and all-in-one business workspace with contacts, calendar, notes, follow-ups, messaging, billing, projects, and more. Built in the open under GPLv3.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <link rel="canonical" href="https://portal.3dvr.tech/open-source-crm/">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-logo.svg">
+  <meta name="theme-color" content="#0d1117">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="3DVR">
+  <meta property="og:title" content="3DVR — Open Source CRM, Contacts, Calendar & Notes">
+  <meta property="og:description" content="An open-source CRM and all-in-one workspace for contacts, calendar, notes, follow-ups, messaging, billing, projects, and more.">
+  <meta property="og:url" content="https://portal.3dvr.tech/open-source-crm/">
+  <meta property="og:image" content="https://portal.3dvr.tech/icons/icon-512.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="3DVR — Open Source CRM, Contacts, Calendar & Notes">
+  <meta name="twitter:description" content="Open-source CRM + contacts + calendar + notes + business workspace.">
+  <meta name="twitter:image" content="https://portal.3dvr.tech/icons/icon-512.png">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "3DVR Portal",
+    "alternateName": "3DVR",
+    "url": "https://portal.3dvr.tech/open-source-crm/",
+    "applicationCategory": "BusinessApplication",
+    "applicationSubCategory": "Customer Relationship Management",
+    "operatingSystem": "Web",
+    "description": "Open-source CRM and all-in-one business workspace with contacts, calendar, notes, follow-ups, messaging, billing, projects, and more.",
+    "isAccessibleForFree": true,
+    "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "author": {
+      "@type": "Organization",
+      "name": "3DVR",
+      "url": "https://3dvr.tech/"
+    },
+    "sameAs": [
+      "https://github.com/tmsteph/3dvr-portal"
+    ]
+  }
+  </script>
+
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0d1117;
+      --panel: #161b22;
+      --panel-2: #0f1723;
+      --text: #e6edf3;
+      --muted: #9da7b3;
+      --line: #30363d;
+      --blue: #58a6ff;
+      --teal: #39d0c3;
+      --green: #56d364;
+      --max: 1100px;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+    }
+    a { color: var(--blue); }
+    a:hover { color: #8bc3ff; }
+    .shell { width: min(calc(100% - 32px), var(--max)); margin: 0 auto; }
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      border-bottom: 1px solid rgba(255,255,255,.08);
+      background: rgba(13,17,23,.92);
+      backdrop-filter: blur(14px);
+    }
+    nav {
+      min-height: 64px;
+      display: flex;
+      gap: 18px;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      padding: 10px 0;
+    }
+    .brand {
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: -.02em;
+    }
+    .nav-links { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; }
+    .nav-links a { color: var(--muted); text-decoration: none; font-weight: 650; }
+    .nav-links a:hover { color: var(--text); }
+    .hero { padding: 86px 0 58px; }
+    .eyebrow {
+      color: var(--teal);
+      font-size: .83rem;
+      font-weight: 800;
+      letter-spacing: .16em;
+      text-transform: uppercase;
+    }
+    h1, h2, h3 { line-height: 1.12; letter-spacing: -.03em; }
+    h1 { max-width: 900px; margin: 14px 0 20px; font-size: clamp(2.6rem, 7vw, 5.7rem); }
+    h2 { font-size: clamp(2rem, 4vw, 3.3rem); margin: 0 0 18px; }
+    h3 { font-size: 1.22rem; margin: 0 0 8px; }
+    .lede { max-width: 800px; color: var(--muted); font-size: clamp(1.1rem, 2vw, 1.32rem); }
+    .actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 30px; }
+    .button {
+      min-height: 46px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 10px 16px;
+      border: 1px solid rgba(88,166,255,.45);
+      border-radius: 999px;
+      background: #10233d;
+      color: #e8f3ff;
+      text-decoration: none;
+      font-weight: 800;
+    }
+    .button.secondary { background: transparent; border-color: var(--line); }
+    .proof {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 44px;
+    }
+    .proof div, .card {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: linear-gradient(180deg, var(--panel), var(--panel-2));
+    }
+    .proof div { padding: 18px; }
+    .proof strong { display: block; font-size: 1.04rem; }
+    .proof span { color: var(--muted); font-size: .92rem; }
+    section { padding: 58px 0; }
+    .section-intro { max-width: 760px; color: var(--muted); margin-bottom: 26px; }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+    .card { padding: 24px; }
+    .card p { color: var(--muted); margin: 0 0 12px; }
+    .card ul { margin: 0; padding-left: 20px; color: #c8d1da; }
+    .card li + li { margin-top: 5px; }
+    .pill {
+      display: inline-block;
+      margin-bottom: 14px;
+      padding: 4px 9px;
+      border: 1px solid rgba(57,208,195,.35);
+      border-radius: 999px;
+      color: var(--teal);
+      font-size: .8rem;
+      font-weight: 750;
+    }
+    .manifesto {
+      border: 1px solid rgba(86,211,100,.25);
+      border-radius: 24px;
+      padding: clamp(24px, 5vw, 44px);
+      background: linear-gradient(145deg, rgba(86,211,100,.07), rgba(88,166,255,.06));
+    }
+    .manifesto p { max-width: 820px; color: #c8d1da; font-size: 1.08rem; }
+    .faq details {
+      border-top: 1px solid var(--line);
+      padding: 18px 0;
+    }
+    .faq details:last-child { border-bottom: 1px solid var(--line); }
+    .faq summary { cursor: pointer; font-weight: 800; }
+    .faq p { color: var(--muted); max-width: 820px; }
+    footer { border-top: 1px solid var(--line); margin-top: 40px; padding: 34px 0 52px; color: var(--muted); }
+    .footer-links { display: flex; gap: 16px; flex-wrap: wrap; margin-top: 10px; }
+    @media (max-width: 760px) {
+      .proof, .grid { grid-template-columns: 1fr; }
+      .hero { padding-top: 54px; }
+      nav { align-items: flex-start; }
+    }
+  </style>
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <header>
+    <nav class="shell" aria-label="Primary navigation">
+      <a class="brand" href="/">3dvr portal</a>
+      <div class="nav-links">
+        <a href="#features">Features</a>
+        <a href="#open-source">Open source</a>
+        <a href="#faq">FAQ</a>
+        <a href="https://github.com/tmsteph/3dvr-portal">GitHub</a>
+      </div>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero shell">
+      <span class="eyebrow">Open-source business software</span>
+      <h1>An open-source CRM, contacts, calendar, notes — and the rest of your work.</h1>
+      <p class="lede">
+        3DVR is a growing all-in-one workspace for people who would rather own their tools than stitch together another pile of closed SaaS apps. Keep relationships, schedules, notes, follow-ups, projects, communication, billing, and daily direction in one open system.
+      </p>
+      <div class="actions">
+        <a class="button" href="/">Open 3DVR Portal</a>
+        <a class="button secondary" href="https://github.com/tmsteph/3dvr-portal">View the GPLv3 source</a>
+      </div>
+
+      <div class="proof" aria-label="3DVR core product areas">
+        <div><strong>CRM</strong><span>Leads, people, status, follow-ups and relationship context.</span></div>
+        <div><strong>Contacts</strong><span>Import, search, organize, back up and connect people to CRM context.</span></div>
+        <div><strong>Calendar</strong><span>Local-first scheduling with optional Google and Outlook sync.</span></div>
+        <div><strong>Notes + workspace</strong><span>Life Space for notes, links, files, photos and sketches.</span></div>
+      </div>
+    </section>
+
+    <section id="features" class="shell">
+      <span class="eyebrow">One system, many jobs</span>
+      <h2>The everyday tools should know about each other.</h2>
+      <p class="section-intro">
+        3DVR treats CRM, contacts, calendar and notes as parts of the same human workflow instead of separate subscriptions. Start with the piece you need and let the portal grow with you.
+      </p>
+
+      <div class="grid">
+        <article class="card">
+          <span class="pill">Open-source CRM</span>
+          <h3>Track relationships without turning people into rows.</h3>
+          <p>Use CRM context for leads, prospects, active relationships, follow-ups and the work connected to each person.</p>
+          <ul>
+            <li>Lead and relationship status</li>
+            <li>Follow-up dates and reminders</li>
+            <li>Linked contact records</li>
+            <li>Searchable customer context</li>
+          </ul>
+          <p><a href="/crm/">Open the CRM →</a></p>
+        </article>
+
+        <article class="card">
+          <span class="pill">Contacts</span>
+          <h3>A contact book that belongs inside the workflow.</h3>
+          <p>Bring people in from your phone or existing services, then connect those records to the work you are actually doing.</p>
+          <ul>
+            <li>Android contact picker</li>
+            <li>VCF and CSV import</li>
+            <li>Google and Microsoft contact import</li>
+            <li>JSON and CSV backup</li>
+          </ul>
+          <p><a href="/contacts/">Open Contacts →</a></p>
+        </article>
+
+        <article class="card">
+          <span class="pill">Calendar</span>
+          <h3>Plan locally. Sync outward only when it helps.</h3>
+          <p>The Calendar Hub saves events locally first and lets you connect external calendars when you choose.</p>
+          <ul>
+            <li>Monthly schedule view</li>
+            <li>Fast event capture</li>
+            <li>Recurring weekly events</li>
+            <li>Optional Google and Outlook sync</li>
+          </ul>
+          <p><a href="/calendar/">Open Calendar →</a></p>
+        </article>
+
+        <article class="card">
+          <span class="pill">Notes + Life Space</span>
+          <h3>Keep the messy thinking next to the structured work.</h3>
+          <p>Life Space gives ideas and context somewhere to live before they become a task, project, customer conversation or plan.</p>
+          <ul>
+            <li>Notes and freeform context</li>
+            <li>Links and files</li>
+            <li>Photos and sketches</li>
+            <li>A bridge from life context into action</li>
+          </ul>
+          <p><a href="/life-space/">Open Life Space →</a></p>
+        </article>
+
+        <article class="card">
+          <span class="pill">Business workspace</span>
+          <h3>Go beyond CRM when the work grows.</h3>
+          <p>3DVR Portal also connects the surrounding parts of running a small organization or independent practice.</p>
+          <ul>
+            <li>Projects and action systems</li>
+            <li>Messaging and community spaces</li>
+            <li>Billing and plan management</li>
+            <li>Finance and profitability tools</li>
+          </ul>
+          <p><a href="/">Browse the portal →</a></p>
+        </article>
+
+        <article class="card">
+          <span class="pill">Installable web apps</span>
+          <h3>Use the browser as the universal client.</h3>
+          <p>The portal is built as a web-first system with installable PWA experiences for core tools such as Contacts and Calendar.</p>
+          <ul>
+            <li>Works across modern browsers</li>
+            <li>Installable PWA surfaces</li>
+            <li>Offline-friendly workflows where supported</li>
+            <li>Open code you can inspect and change</li>
+          </ul>
+          <p><a href="https://github.com/tmsteph/3dvr-portal">Explore the source →</a></p>
+        </article>
+      </div>
+    </section>
+
+    <section id="open-source" class="shell">
+      <div class="manifesto">
+        <span class="eyebrow">Built in the open</span>
+        <h2>Your business operating system should be inspectable.</h2>
+        <p>
+          3DVR Portal is released under the GNU General Public License v3.0. The goal is bigger than replacing one CRM: build a trustworthy, open ecosystem for the ordinary software people use to organize relationships, work and life.
+        </p>
+        <div class="actions">
+          <a class="button" href="https://github.com/tmsteph/3dvr-portal">Read the source on GitHub</a>
+          <a class="button secondary" href="https://github.com/tmsteph/3dvr-portal/blob/main/LICENSE">Read the GPLv3 license</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="shell faq">
+      <span class="eyebrow">Questions</span>
+      <h2>What is 3DVR?</h2>
+
+      <details open>
+        <summary>Is 3DVR an open-source CRM?</summary>
+        <p>Yes. The 3DVR Portal repository is public and licensed under GPLv3. CRM is one core workspace inside a larger open-source portal that also includes contacts, calendar, notes and other business tools.</p>
+      </details>
+
+      <details>
+        <summary>Is it only a CRM?</summary>
+        <p>No. The bigger idea is an open business and personal operating system: CRM, contacts, calendar, notes, communication, projects, billing, finance and other connected workflows in one portal.</p>
+      </details>
+
+      <details>
+        <summary>Can I import my existing contacts?</summary>
+        <p>Yes. The Contacts workspace supports VCF and CSV imports, Android's contact picker where available, plus Google and Microsoft contact imports.</p>
+      </details>
+
+      <details>
+        <summary>Does the calendar require Google Calendar?</summary>
+        <p>No. Calendar events can live locally first. Google and Outlook sync are optional connections when you want them.</p>
+      </details>
+
+      <details>
+        <summary>Where is the source code?</summary>
+        <p>The source is public on GitHub in the <a href="https://github.com/tmsteph/3dvr-portal">tmsteph/3dvr-portal</a> repository.</p>
+      </details>
+    </section>
+  </main>
+
+  <footer>
+    <div class="shell">
+      <strong>3DVR — Build the future in the open.</strong>
+      <div class="footer-links">
+        <a href="https://3dvr.tech/">3dvr.tech</a>
+        <a href="/">Portal</a>
+        <a href="https://github.com/tmsteph/3dvr-portal">GitHub</a>
+        <a href="/sitemap.xml">Sitemap</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,10 +1,8 @@
 User-agent: *
 Allow: /
 Disallow: /billing/
-Disallow: /crm/
 Disallow: /admin/
 Disallow: /finance/
-Disallow: /contacts/
 Disallow: /sign-in.html
 Disallow: /free-trial.html
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://portal.3dvr.tech/</loc></url>
+  <url><loc>https://portal.3dvr.tech/open-source-crm/</loc><lastmod>2026-08-16</lastmod></url>
   <url><loc>https://portal.3dvr.tech/free-page/</loc></url>
   <url><loc>https://portal.3dvr.tech/new-business-launch/</loc></url>
   <url><loc>https://portal.3dvr.tech/av-operator/</loc></url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,6 +2,10 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://portal.3dvr.tech/</loc></url>
   <url><loc>https://portal.3dvr.tech/open-source-crm/</loc><lastmod>2026-08-16</lastmod></url>
+  <url><loc>https://portal.3dvr.tech/crm/</loc></url>
+  <url><loc>https://portal.3dvr.tech/contacts/</loc></url>
+  <url><loc>https://portal.3dvr.tech/calendar/</loc></url>
+  <url><loc>https://portal.3dvr.tech/life-space/</loc></url>
   <url><loc>https://portal.3dvr.tech/free-page/</loc></url>
   <url><loc>https://portal.3dvr.tech/new-business-launch/</loc></url>
   <url><loc>https://portal.3dvr.tech/av-operator/</loc></url>


### PR DESCRIPTION
## What changed
- added a crawlable `/open-source-crm/` product landing page targeting open-source CRM, contacts, calendar, notes, and business OS searches
- added canonical, description, Open Graph/Twitter metadata, and `SoftwareApplication` JSON-LD
- removed the robots.txt crawl blocks for the public CRM and Contacts app shells while keeping admin, billing, finance, and sign-in blocked
- added the SEO landing page plus CRM, Contacts, Calendar, and Life Space to the sitemap

## Why
The portal homepage currently has a generic `3DVR Portal` title and the core CRM/Contacts routes were not crawlable. Google therefore had very little public text connecting 3DVR to the product categories people might search for.

## Validation
- branch compares cleanly against `main`
- only `open-source-crm/index.html`, `robots.txt`, and `sitemap.xml` are changed
- the landing page uses plain semantic HTML and no build-time dependencies
