### PR TITLE
Companion: add bounded relay reconnect backoff

### DIFF
--- a/apps/companion/lib/src/relay_backoff.dart
+++ b/apps/companion/lib/src/relay_backoff.dart
@@ -1,0 +1,26 @@
+import 'dart:math';
+
+class RelayBackoff {
+  RelayBackoff({
+    this.base = const Duration(seconds: 1),
+    this.cap = const Duration(seconds: 30),
+    Random? random,
+  }) : _random = random ?? Random();
+
+  final Duration base;
+  final Duration cap;
+  final Random _random;
+
+  Duration delayForAttempt(int attempt) {
+    if (attempt < 0) {
+      throw ArgumentError.value(attempt, 'attempt', 'must be >= 0');
+    }
+
+    var milliseconds = base.inMilliseconds;
+    for (var i = 0; i < attempt && milliseconds < cap.inMilliseconds; i++) {
+      milliseconds = min(milliseconds * 2, cap.inMilliseconds);
+    }
+
+    return Duration(milliseconds: _random.nextInt(milliseconds + 1));
+  }
+}

--- a/apps/companion/test/relay_backoff_test.dart
+++ b/apps/companion/test/relay_backoff_test.dart
@@ -1,0 +1,29 @@
+import 'dart:math';
+
+import 'package:companion/src/relay_backoff.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('relay backoff stays bounded and deterministic with a seeded random', () {
+    final backoff = RelayBackoff(
+      base: const Duration(seconds: 1),
+      cap: const Duration(seconds: 8),
+      random: Random(7),
+    );
+
+    final delays = List.generate(8, backoff.delayForAttempt);
+
+    expect(delays[0], lessThanOrEqualTo(const Duration(seconds: 1)));
+    expect(delays[1], lessThanOrEqualTo(const Duration(seconds: 2)));
+    expect(delays[2], lessThanOrEqualTo(const Duration(seconds: 4)));
+    for (final delay in delays.skip(3)) {
+      expect(delay, lessThanOrEqualTo(const Duration(seconds: 8)));
+      expect(delay, greaterThanOrEqualTo(Duration.zero));
+    }
+  });
+
+  test('relay backoff rejects negative attempts', () {
+    final backoff = RelayBackoff(random: Random(1));
+    expect(() => backoff.delayForAttempt(-1), throwsArgumentError);
+  });
+}


### PR DESCRIPTION
Advances #1491 with the first executable relay-client primitive behind the merged transport boundary.

- capped exponential reconnect delay with jitter
- deterministic testability via injected Random
- hard 30-second default cap
- no execution capabilities, shell, selectors, coordinates, credentials, or Termux changes

This keeps reconnect policy isolated and testable before adding authenticated relay I/O.