### PR TITLE
Companion: guard direct relay envelopes

### DIFF
--- a/apps/companion/lib/src/relay_envelope.dart
+++ b/apps/companion/lib/src/relay_envelope.dart
@@ -1,0 +1,53 @@
+const relayReadOnlyCapabilities = <String>{'health', 'device.status'};
+
+class RelayEnvelope {
+  const RelayEnvelope({
+    required this.requestId,
+    required this.capabilityId,
+    required this.expiresAt,
+  });
+
+  final String requestId;
+  final String capabilityId;
+  final DateTime expiresAt;
+
+  factory RelayEnvelope.fromJson(Map<String, Object?> json) {
+    final requestId = json['requestId'];
+    final capabilityId = json['capabilityId'];
+    final expiresAt = json['expiresAt'];
+    if (requestId is! String || requestId.trim().isEmpty) {
+      throw const FormatException('requestId is required');
+    }
+    if (capabilityId is! String ||
+        !relayReadOnlyCapabilities.contains(capabilityId)) {
+      throw const FormatException('unknown relay capability');
+    }
+    if (expiresAt is! String) {
+      throw const FormatException('expiresAt is required');
+    }
+    final parsedExpiry = DateTime.tryParse(expiresAt)?.toUtc();
+    if (parsedExpiry == null) {
+      throw const FormatException('expiresAt must be ISO-8601');
+    }
+    return RelayEnvelope(
+      requestId: requestId,
+      capabilityId: capabilityId,
+      expiresAt: parsedExpiry,
+    );
+  }
+
+  bool isExpired(DateTime now) => !expiresAt.isAfter(now.toUtc());
+}
+
+class RelayRequestGuard {
+  final Set<String> _seenRequestIds = <String>{};
+
+  void accept(RelayEnvelope envelope, DateTime now) {
+    if (envelope.isExpired(now)) {
+      throw const FormatException('relay request expired');
+    }
+    if (!_seenRequestIds.add(envelope.requestId)) {
+      throw const FormatException('duplicate relay request');
+    }
+  }
+}

--- a/apps/companion/test/relay_envelope_test.dart
+++ b/apps/companion/test/relay_envelope_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:three_dvr_companion/src/relay_envelope.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 17, 3);
+
+  RelayEnvelope envelope({
+    String requestId = 'req-1',
+    String capabilityId = 'health',
+    String expiresAt = '2026-08-17T03:01:00Z',
+  }) => RelayEnvelope.fromJson({
+    'requestId': requestId,
+    'capabilityId': capabilityId,
+    'expiresAt': expiresAt,
+  });
+
+  test('accepts only the initial read-only capabilities', () {
+    expect(envelope().capabilityId, 'health');
+    expect(envelope(capabilityId: 'device.status').capabilityId, 'device.status');
+    expect(
+      () => envelope(capabilityId: 'url.open'),
+      throwsFormatException,
+    );
+  });
+
+  test('rejects expired requests', () {
+    final guard = RelayRequestGuard();
+    expect(
+      () => guard.accept(envelope(expiresAt: '2026-08-17T02:59:59Z'), now),
+      throwsFormatException,
+    );
+  });
+
+  test('rejects duplicate request ids', () {
+    final guard = RelayRequestGuard();
+    final request = envelope();
+    guard.accept(request, now);
+    expect(() => guard.accept(request, now), throwsFormatException);
+  });
+
+  test('rejects malformed envelopes', () {
+    expect(
+      () => RelayEnvelope.fromJson({
+        'requestId': '',
+        'capabilityId': 'health',
+        'expiresAt': '2026-08-17T03:01:00Z',
+      }),
+      throwsFormatException,
+    );
+  });
+}

--- a/apps/companion/test/relay_envelope_test.dart
+++ b/apps/companion/test/relay_envelope_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:three_dvr_companion/src/relay_envelope.dart';
+import 'package:companion/src/relay_envelope.dart';
 
 void main() {
   final now = DateTime.utc(2026, 8, 17, 3);
@@ -17,10 +17,7 @@ void main() {
   test('accepts only the initial read-only capabilities', () {
     expect(envelope().capabilityId, 'health');
     expect(envelope(capabilityId: 'device.status').capabilityId, 'device.status');
-    expect(
-      () => envelope(capabilityId: 'url.open'),
-      throwsFormatException,
-    );
+    expect(() => envelope(capabilityId: 'url.open'), throwsFormatException);
   });
 
   test('rejects expired requests', () {


### PR DESCRIPTION
Advances #1491 with the safety boundary needed before authenticated relay I/O.

- accepts only `health` and `device.status`
- validates request IDs and ISO-8601 expiry
- rejects expired requests
- rejects duplicate request IDs
- keeps `url.open`, `app.open_known`, shell, selectors, and coordinates out of this slice
- adds deterministic Flutter tests

No credentials or network transport are added yet; this is the bounded envelope/deduplication layer the authenticated client will sit behind.