### PR TITLE
Companion: add direct-relay credential boundary

### DIFF
--- a/apps/companion/lib/src/relay_auth.dart
+++ b/apps/companion/lib/src/relay_auth.dart
@@ -1,0 +1,39 @@
+/// Authentication boundary for Companion's direct relay.
+///
+/// Credentials must come from Android-local secure configuration. Implementations
+/// must not persist or emit token values through Git, analytics, crash reports,
+/// logs, or command/result envelopes.
+abstract interface class RelayCredentialProvider {
+  Future<RelayCredential?> load();
+
+  Future<void> clear();
+}
+
+class RelayCredential {
+  const RelayCredential({
+    required this.token,
+    required this.expiresAt,
+  });
+
+  final String token;
+  final DateTime expiresAt;
+
+  bool isUsableAt(DateTime now) =>
+      token.isNotEmpty && now.toUtc().isBefore(expiresAt.toUtc());
+
+  @override
+  String toString() => 'RelayCredential(<redacted>, expiresAt: $expiresAt)';
+}
+
+/// Returns only a bearer header value for a currently usable credential.
+/// Callers should treat the returned string as sensitive and never log it.
+Future<String?> relayAuthorizationHeader(
+  RelayCredentialProvider provider, {
+  DateTime Function()? clock,
+}) async {
+  final credential = await provider.load();
+  if (credential == null) return null;
+  final now = (clock ?? DateTime.now)().toUtc();
+  if (!credential.isUsableAt(now)) return null;
+  return 'Bearer ${credential.token}';
+}

--- a/apps/companion/test/relay_auth_test.dart
+++ b/apps/companion/test/relay_auth_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:threedvr_companion/src/relay_auth.dart';
+import 'package:companion/src/relay_auth.dart';
 
 class MemoryCredentials implements RelayCredentialProvider {
   MemoryCredentials(this.value);

--- a/apps/companion/test/relay_auth_test.dart
+++ b/apps/companion/test/relay_auth_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:threedvr_companion/src/relay_auth.dart';
+
+class MemoryCredentials implements RelayCredentialProvider {
+  MemoryCredentials(this.value);
+
+  RelayCredential? value;
+
+  @override
+  Future<RelayCredential?> load() async => value;
+
+  @override
+  Future<void> clear() async => value = null;
+}
+
+void main() {
+  final now = DateTime.utc(2026, 8, 17, 5);
+
+  test('missing credential does not produce authorization', () async {
+    final provider = MemoryCredentials(null);
+    expect(await relayAuthorizationHeader(provider, clock: () => now), isNull);
+  });
+
+  test('expired credential does not produce authorization', () async {
+    final provider = MemoryCredentials(
+      RelayCredential(token: 'secret', expiresAt: now.subtract(const Duration(seconds: 1))),
+    );
+    expect(await relayAuthorizationHeader(provider, clock: () => now), isNull);
+  });
+
+  test('usable credential produces bearer authorization', () async {
+    final provider = MemoryCredentials(
+      RelayCredential(token: 'secret', expiresAt: now.add(const Duration(minutes: 5))),
+    );
+    expect(
+      await relayAuthorizationHeader(provider, clock: () => now),
+      'Bearer secret',
+    );
+  });
+
+  test('credential string representation never reveals token', () {
+    final credential = RelayCredential(
+      token: 'do-not-log-me',
+      expiresAt: now.add(const Duration(minutes: 5)),
+    );
+    expect(credential.toString(), isNot(contains('do-not-log-me')));
+    expect(credential.toString(), contains('<redacted>'));
+  });
+}


### PR DESCRIPTION
## What changed

- adds an explicit credential-provider boundary for the Companion direct relay
- rejects missing, empty, and expired credentials before producing authorization
- redacts credential values from string representations
- adds deterministic tests for missing, expired, valid, and log-redaction behavior

## Safety / scope

This does **not** connect to a relay yet and does not add a secret to Git. It creates the narrow seam the Android-local secure credential implementation and authenticated relay client can depend on next. Termux fallback is untouched.

Part of #1491.

## Next slice

Wire an Android-local secure provider + relay client behind this boundary, then prove read-only `health` / `device.status` round trips through the already-merged envelope guard.