### PR TITLE
Companion: add Android-local relay credential provider boundary

### DIFF
--- a/apps/companion/lib/src/local_relay_credentials.dart
+++ b/apps/companion/lib/src/local_relay_credentials.dart
@@ -1,0 +1,44 @@
+import 'relay_auth.dart';
+
+/// Minimal Android-local credential storage boundary for the direct relay.
+///
+/// The backing store is intentionally abstract: production Android code should
+/// bind this to encrypted device-local storage (for example Keystore-backed
+/// storage), while tests can use an in-memory implementation. Token values must
+/// never be written to Git, logs, analytics, crash reports, or relay envelopes.
+abstract interface class RelaySecretStore {
+  Future<String?> read(String key);
+  Future<void> write(String key, String value);
+  Future<void> delete(String key);
+}
+
+class LocalRelayCredentialProvider implements RelayCredentialProvider {
+  LocalRelayCredentialProvider(this.store);
+
+  final RelaySecretStore store;
+
+  static const _tokenKey = 'relay.token';
+  static const _expiresAtKey = 'relay.expires_at';
+
+  @override
+  Future<RelayCredential?> load() async {
+    final token = await store.read(_tokenKey);
+    final expiresRaw = await store.read(_expiresAtKey);
+    if (token == null || token.isEmpty || expiresRaw == null) return null;
+
+    final expiresAt = DateTime.tryParse(expiresRaw)?.toUtc();
+    if (expiresAt == null) return null;
+    return RelayCredential(token: token, expiresAt: expiresAt);
+  }
+
+  Future<void> save(RelayCredential credential) async {
+    await store.write(_tokenKey, credential.token);
+    await store.write(_expiresAtKey, credential.expiresAt.toUtc().toIso8601String());
+  }
+
+  @override
+  Future<void> clear() async {
+    await store.delete(_tokenKey);
+    await store.delete(_expiresAtKey);
+  }
+}

--- a/apps/companion/test/local_relay_credentials_test.dart
+++ b/apps/companion/test/local_relay_credentials_test.dart
@@ -1,0 +1,63 @@
+import 'package:companion/src/local_relay_credentials.dart';
+import 'package:companion/src/relay_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MemorySecretStore implements RelaySecretStore {
+  final values = <String, String>{};
+
+  @override
+  Future<String?> read(String key) async => values[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    values.remove(key);
+  }
+}
+
+void main() {
+  test('credential provider persists and loads token plus expiry', () async {
+    final store = MemorySecretStore();
+    final provider = LocalRelayCredentialProvider(store);
+    final credential = RelayCredential(
+      token: 'secret-value',
+      expiresAt: DateTime.utc(2026, 8, 17, 12),
+    );
+
+    await provider.save(credential);
+    final loaded = await provider.load();
+
+    expect(loaded?.token, 'secret-value');
+    expect(loaded?.expiresAt, DateTime.utc(2026, 8, 17, 12));
+    expect(loaded.toString(), contains('<redacted>'));
+    expect(loaded.toString(), isNot(contains('secret-value')));
+  });
+
+  test('missing or malformed local state returns no credential', () async {
+    final store = MemorySecretStore();
+    final provider = LocalRelayCredentialProvider(store);
+
+    expect(await provider.load(), isNull);
+    store.values['relay.token'] = 'secret-value';
+    store.values['relay.expires_at'] = 'not-a-date';
+    expect(await provider.load(), isNull);
+  });
+
+  test('clear removes all relay credential material', () async {
+    final store = MemorySecretStore();
+    final provider = LocalRelayCredentialProvider(store);
+    await provider.save(RelayCredential(
+      token: 'secret-value',
+      expiresAt: DateTime.utc(2026, 8, 17, 12),
+    ));
+
+    await provider.clear();
+
+    expect(await provider.load(), isNull);
+    expect(store.values, isEmpty);
+  });
+}


### PR DESCRIPTION
## What changed

- adds a device-local relay credential provider behind the existing #1522 auth boundary
- keeps the secret-store backend abstract so Android can bind it to Keystore-backed/encrypted storage without leaking credentials into Git or logs
- stores only token + ISO expiry through the secret-store interface
- adds deterministic save/load/malformed-state/clear/redaction tests

## Safety

No relay network connection is added here. No credential values are committed. No execution capability changes. Termux fallback is untouched.

## Next

Bind `RelaySecretStore` to Android secure storage, then use this provider for authenticated read-only `health` / `device.status` relay I/O under #1491.