### PR TITLE
Companion: stage Android secure-store platform boundary

### DIFF
--- a/apps/companion/lib/src/platform_relay_secret_store.dart
+++ b/apps/companion/lib/src/platform_relay_secret_store.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/services.dart';
+
+import 'local_relay_credentials.dart';
+
+/// Device-local secret store backed by the native Companion platform bridge.
+///
+/// Native Android owns encryption/key material. Dart only sends the storage key
+/// and secret value across the in-process MethodChannel; values must never be
+/// logged, surfaced in analytics, or included in relay envelopes.
+class PlatformRelaySecretStore implements RelaySecretStore {
+  PlatformRelaySecretStore({MethodChannel? channel})
+      : _channel = channel ?? const MethodChannel('tech.threedvr.companion/relay_secrets');
+
+  final MethodChannel _channel;
+
+  @override
+  Future<String?> read(String key) async {
+    return _channel.invokeMethod<String>('read', {'key': key});
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    await _channel.invokeMethod<void>('write', {'key': key, 'value': value});
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    await _channel.invokeMethod<void>('delete', {'key': key});
+  }
+}

--- a/apps/companion/test/platform_relay_secret_store_test.dart
+++ b/apps/companion/test/platform_relay_secret_store_test.dart
@@ -1,0 +1,47 @@
+import 'package:companion/src/platform_relay_secret_store.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('test/relay_secrets');
+  final values = <String, String>{};
+
+  setUp(() async {
+    values.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      final args = Map<String, dynamic>.from(call.arguments as Map);
+      final key = args['key'] as String;
+      switch (call.method) {
+        case 'read':
+          return values[key];
+        case 'write':
+          values[key] = args['value'] as String;
+          return null;
+        case 'delete':
+          values.remove(key);
+          return null;
+        default:
+          throw PlatformException(code: 'unsupported');
+      }
+    });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('save/read/delete operations stay behind the platform channel', () async {
+    final store = PlatformRelaySecretStore(channel: channel);
+    expect(await store.read('relay.token'), isNull);
+
+    await store.write('relay.token', 'secret-value');
+    expect(await store.read('relay.token'), 'secret-value');
+
+    await store.delete('relay.token');
+    expect(await store.read('relay.token'), isNull);
+  });
+}


### PR DESCRIPTION
## What changed

- adds a `PlatformRelaySecretStore` implementation behind the existing `RelaySecretStore` interface
- uses a dedicated in-process MethodChannel so Dart never owns Android encryption/key material
- adds deterministic read/write/delete channel tests

## Safety / scope

This is deliberately the smallest next slice for #1491. It does **not** add relay networking, credentials, shell/UI execution, new capabilities, or change the Termux fallback. Secret values are not committed or logged.

## Next

Once green, implement the Android native side with Keystore-backed encrypted storage, then connect authenticated read-only `health` / `device.status` relay I/O.