### PR TITLE
Companion: encrypt relay credentials with Android Keystore

### DIFF
--- a/apps/companion/native-spec/android/CompanionRelaySecretStore.kt
+++ b/apps/companion/native-spec/android/CompanionRelaySecretStore.kt
@@ -1,0 +1,65 @@
+package tech.threedvr.companion
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.nio.charset.StandardCharsets
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class CompanionRelaySecretStore(private val context: Context) {
+    private val prefs = context.getSharedPreferences("companion_relay_secrets_v1", Context.MODE_PRIVATE)
+    private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+
+    fun read(key: String): String? {
+        val encoded = prefs.getString(key, null) ?: return null
+        return runCatching {
+            val packed = Base64.decode(encoded, Base64.NO_WRAP)
+            require(packed.size > IV_BYTES)
+            val iv = packed.copyOfRange(0, IV_BYTES)
+            val ciphertext = packed.copyOfRange(IV_BYTES, packed.size)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, secretKey(), GCMParameterSpec(TAG_BITS, iv))
+            String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8)
+        }.getOrNull()
+    }
+
+    fun write(key: String, value: String) {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey())
+        val ciphertext = cipher.doFinal(value.toByteArray(StandardCharsets.UTF_8))
+        val packed = cipher.iv + ciphertext
+        prefs.edit().putString(key, Base64.encodeToString(packed, Base64.NO_WRAP)).apply()
+    }
+
+    fun delete(key: String) {
+        prefs.edit().remove(key).apply()
+    }
+
+    private fun secretKey(): SecretKey {
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(true)
+                .build(),
+        )
+        return generator.generateKey()
+    }
+
+    companion object {
+        private const val KEY_ALIAS = "3dvr_companion_relay_secret_v1"
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val IV_BYTES = 12
+        private const val TAG_BITS = 128
+    }
+}

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -15,6 +15,7 @@ import java.security.SecureRandom
 
 class MainActivity : FlutterActivity() {
     private val channelName = "tech.3dvr.companion/platform"
+    private val relaySecretsChannelName = "tech.threedvr.companion/relay_secrets"
     private val bridgePrefs = "companion_local_bridge"
     private val bridgeTokenKey = "bearer_token_v1"
 
@@ -32,6 +33,31 @@ class MainActivity : FlutterActivity() {
         super.configureFlutterEngine(flutterEngine)
         startKeepAliveService()
         MessageNotificationStore.initialize(this)
+        val relaySecretStore = CompanionRelaySecretStore(this)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, relaySecretsChannelName)
+            .setMethodCallHandler { call, result ->
+                val key = call.argument<String>("key")?.trim().orEmpty()
+                if (key.isEmpty()) {
+                    result.error("invalid_key", "Relay secret key is required.", null)
+                    return@setMethodCallHandler
+                }
+                when (call.method) {
+                    "read" -> result.success(relaySecretStore.read(key))
+                    "write" -> {
+                        val value = call.argument<String>("value")
+                        if (value == null) result.error("invalid_value", "Relay secret value is required.", null)
+                        else {
+                            relaySecretStore.write(key, value)
+                            result.success(null)
+                        }
+                    }
+                    "delete" -> {
+                        relaySecretStore.delete(key)
+                        result.success(null)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
             .setMethodCallHandler { call, result ->
                 when (call.method) {
@@ -72,89 +98,58 @@ class MainActivity : FlutterActivity() {
 
     private fun startKeepAliveService() {
         val intent = Intent(this, CompanionKeepAliveService::class.java)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startForegroundService(intent)
-        } else {
-            startService(intent)
-        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) startForegroundService(intent) else startService(intent)
     }
 
     private fun getOrCreateBridgeToken(): String {
         val prefs = getSharedPreferences(bridgePrefs, Context.MODE_PRIVATE)
         val existing = prefs.getString(bridgeTokenKey, null)
         if (!existing.isNullOrBlank()) return existing
-
         val bytes = ByteArray(32)
         SecureRandom().nextBytes(bytes)
-        val created = Base64.encodeToString(
-            bytes,
-            Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING,
-        )
+        val created = Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
         prefs.edit().putString(bridgeTokenKey, created).apply()
         return created
     }
 
     private fun deviceStatus(): Map<String, Any?> {
         val battery = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
-        return mapOf(
-            "sdk" to Build.VERSION.SDK_INT,
-            "manufacturer" to Build.MANUFACTURER,
-            "model" to Build.MODEL,
-            "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY),
-        )
+        return mapOf("sdk" to Build.VERSION.SDK_INT, "manufacturer" to Build.MANUFACTURER, "model" to Build.MODEL, "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY))
     }
 
     private fun capabilityStatus(): Map<String, Any> = mapOf(
-        "accessibilityEnabled" to isAccessibilityEnabled(),
-        "notificationAccessEnabled" to isNotificationAccessEnabled(),
-        "messageNotificationReadEnabled" to isNotificationAccessEnabled(),
-        "messageNotificationReplyEnabled" to isNotificationAccessEnabled(),
-        "messageHistoryEncryptedAtRest" to true,
-        "backgroundBridgeEnabled" to true,
-        "knownAppLaunchEnabled" to true,
-        "remoteKnownActionsEnabled" to false,
-        "persistentPairingEnabled" to true,
+        "accessibilityEnabled" to isAccessibilityEnabled(), "notificationAccessEnabled" to isNotificationAccessEnabled(),
+        "messageNotificationReadEnabled" to isNotificationAccessEnabled(), "messageNotificationReplyEnabled" to isNotificationAccessEnabled(),
+        "messageHistoryEncryptedAtRest" to true, "backgroundBridgeEnabled" to true, "knownAppLaunchEnabled" to true,
+        "remoteKnownActionsEnabled" to false, "persistentPairingEnabled" to true, "relayCredentialsEncryptedAtRest" to true,
     )
 
     private fun openHttpUrl(raw: String): Boolean {
         val uri = runCatching { Uri.parse(raw) }.getOrNull() ?: return false
         if (uri.scheme != "https" && uri.scheme != "http") return false
-        startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
-        return true
+        startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)); return true
     }
 
     private fun openKnownApp(rawAlias: String): Boolean {
         val alias = rawAlias.trim().lowercase()
-        if (alias == "settings") {
-            startActivity(Intent(Settings.ACTION_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
-            return true
-        }
+        if (alias == "settings") { startActivity(Intent(Settings.ACTION_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)); return true }
         val candidates = knownApps[alias] ?: return false
         for (packageName in candidates) {
             val launchIntent = packageManager.getLaunchIntentForPackage(packageName) ?: continue
-            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            startActivity(launchIntent)
-            return true
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK); startActivity(launchIntent); return true
         }
         return false
     }
 
     private fun isAccessibilityEnabled(): Boolean {
-        val manager = getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
-            ?: return false
-        return manager.getEnabledAccessibilityServiceList(
-            android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_ALL_MASK,
-        ).any { info ->
-            info.resolveInfo.serviceInfo.packageName == packageName &&
-                info.resolveInfo.serviceInfo.name.endsWith("CompanionAccessibilityService")
+        val manager = getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager ?: return false
+        return manager.getEnabledAccessibilityServiceList(android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_ALL_MASK).any { info ->
+            info.resolveInfo.serviceInfo.packageName == packageName && info.resolveInfo.serviceInfo.name.endsWith("CompanionAccessibilityService")
         }
     }
 
     private fun isNotificationAccessEnabled(): Boolean {
-        val enabled = Settings.Secure.getString(
-            contentResolver,
-            "enabled_notification_listeners",
-        ) ?: return false
+        val enabled = Settings.Secure.getString(contentResolver, "enabled_notification_listeners") ?: return false
         return enabled.split(':').any { component -> component.startsWith("$packageName/") }
     }
 }

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -4,26 +4,17 @@ set -euo pipefail
 APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$APP_DIR"
 
-command -v flutter >/dev/null 2>&1 || {
-  echo "flutter is required"
-  exit 1
-}
+command -v flutter >/dev/null 2>&1 || { echo "flutter is required"; exit 1; }
 
 BACKUP="$(mktemp -d)"
 trap 'rm -rf "$BACKUP"' EXIT
-
 cp -R lib "$BACKUP/lib"
 cp -R test "$BACKUP/test"
 cp pubspec.yaml "$BACKUP/pubspec.yaml"
 cp README.md "$BACKUP/README.md"
 cp analysis_options.yaml "$BACKUP/analysis_options.yaml"
 
-flutter create \
-  --org tech.threedvr \
-  --project-name companion \
-  --platforms=android,ios \
-  .
-
+flutter create --org tech.threedvr --project-name companion --platforms=android,ios .
 rm -rf lib test
 cp -R "$BACKUP/lib" lib
 cp -R "$BACKUP/test" test
@@ -33,16 +24,10 @@ cp "$BACKUP/analysis_options.yaml" analysis_options.yaml
 
 KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
 mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
-cp native-spec/android/MainActivity.kt "$KOTLIN_DIR/MainActivity.kt"
-cp native-spec/android/CompanionAccessibilityService.kt "$KOTLIN_DIR/CompanionAccessibilityService.kt"
-cp native-spec/android/CompanionNotificationListener.kt "$KOTLIN_DIR/CompanionNotificationListener.kt"
-cp native-spec/android/CompanionKeepAliveService.kt "$KOTLIN_DIR/CompanionKeepAliveService.kt"
-cp native-spec/android/CompanionNativeBridgeServer.kt "$KOTLIN_DIR/CompanionNativeBridgeServer.kt"
-cp native-spec/android/CompanionStartupReceiver.kt "$KOTLIN_DIR/CompanionStartupReceiver.kt"
-cp native-spec/android/CompanionSelfUpdater.kt "$KOTLIN_DIR/CompanionSelfUpdater.kt"
-cp native-spec/android/CompanionShizuku.kt "$KOTLIN_DIR/CompanionShizuku.kt"
-cp native-spec/android/companion_accessibility_service.xml \
-  android/app/src/main/res/xml/companion_accessibility_service.xml
+for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt; do
+  cp "native-spec/android/$source" "$KOTLIN_DIR/$source"
+done
+cp native-spec/android/companion_accessibility_service.xml android/app/src/main/res/xml/companion_accessibility_service.xml
 
 cat > android/app/src/main/res/xml/companion_network_security_config.xml <<'XML'
 <?xml version="1.0" encoding="utf-8"?>
@@ -59,192 +44,58 @@ python3 <<'PY'
 from pathlib import Path
 import plistlib
 import xml.etree.ElementTree as ET
-
-ANDROID = 'http://schemas.android.com/apk/res/android'
-ET.register_namespace('android', ANDROID)
-a = lambda name: f'{{{ANDROID}}}{name}'
-
-manifest_path = Path('android/app/src/main/AndroidManifest.xml')
-tree = ET.parse(manifest_path)
-root = tree.getroot()
-
-permissions = [
-    'android.permission.INTERNET',
-    'android.permission.FOREGROUND_SERVICE',
-    'android.permission.FOREGROUND_SERVICE_SPECIAL_USE',
-    'android.permission.POST_NOTIFICATIONS',
-    'android.permission.RECEIVE_BOOT_COMPLETED',
-    'android.permission.REQUEST_INSTALL_PACKAGES',
-    'android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION',
-]
-existing_permissions = {
-    node.get(a('name')) for node in root.findall('uses-permission')
-}
-for permission in reversed(permissions):
-    if permission not in existing_permissions:
-        root.insert(0, ET.Element('uses-permission', {a('name'): permission}))
-
-queries = root.find('queries')
+ANDROID='http://schemas.android.com/apk/res/android'; ET.register_namespace('android',ANDROID); a=lambda n:f'{{{ANDROID}}}{n}'
+manifest_path=Path('android/app/src/main/AndroidManifest.xml'); tree=ET.parse(manifest_path); root=tree.getroot()
+permissions=['android.permission.INTERNET','android.permission.FOREGROUND_SERVICE','android.permission.FOREGROUND_SERVICE_SPECIAL_USE','android.permission.POST_NOTIFICATIONS','android.permission.RECEIVE_BOOT_COMPLETED','android.permission.REQUEST_INSTALL_PACKAGES','android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION']
+existing={n.get(a('name')) for n in root.findall('uses-permission')}
+for p in reversed(permissions):
+    if p not in existing: root.insert(0,ET.Element('uses-permission',{a('name'):p}))
+queries=root.find('queries')
 if queries is None:
-    queries = ET.Element('queries')
-    insert_at = 0
-    for index, child in enumerate(list(root)):
-        if child.tag == 'uses-permission':
-            insert_at = index + 1
-    root.insert(insert_at, queries)
-known_packages = {
-    'com.openai.chatgpt',
-    'com.google.android.apps.maps',
-    'com.google.android.gm',
-    'com.android.chrome',
-    'com.termux',
-    'com.google.android.calendar',
-    'com.samsung.android.calendar',
-    'com.sec.android.app.camera',
-    'com.google.android.GoogleCamera',
-    'com.google.android.apps.messaging',
-    'com.samsung.android.messaging',
-    'com.android.mms',
-    'moe.shizuku.privileged.api',
-}
-existing_queries = {node.get(a('name')) for node in queries.findall('package')}
-for package in sorted(known_packages):
-    if package not in existing_queries:
-        ET.SubElement(queries, 'package', {a('name'): package})
-
-app = root.find('application')
-if app is None:
-    raise SystemExit('AndroidManifest.xml has no <application>')
-app.set(a('label'), '3DVR Companion')
-app.set(a('networkSecurityConfig'), '@xml/companion_network_security_config')
-
+    queries=ET.Element('queries'); insert_at=0
+    for i,c in enumerate(list(root)):
+        if c.tag=='uses-permission': insert_at=i+1
+    root.insert(insert_at,queries)
+known={'com.openai.chatgpt','com.google.android.apps.maps','com.google.android.gm','com.android.chrome','com.termux','com.google.android.calendar','com.samsung.android.calendar','com.sec.android.app.camera','com.google.android.GoogleCamera','com.google.android.apps.messaging','com.samsung.android.messaging','com.android.mms','moe.shizuku.privileged.api'}
+existing_q={n.get(a('name')) for n in queries.findall('package')}
+for p in sorted(known):
+    if p not in existing_q: ET.SubElement(queries,'package',{a('name'):p})
+app=root.find('application')
+if app is None: raise SystemExit('AndroidManifest.xml has no <application>')
+app.set(a('label'),'3DVR Companion'); app.set(a('networkSecurityConfig'),'@xml/companion_network_security_config')
 for service in list(app.findall('service')):
-    if service.get(a('name')) in {
-        '.CompanionAccessibilityService',
-        '.CompanionNotificationListener',
-        '.CompanionKeepAliveService',
-    }:
-        app.remove(service)
+    if service.get(a('name')) in {'.CompanionAccessibilityService','.CompanionNotificationListener','.CompanionKeepAliveService'}: app.remove(service)
 for receiver in list(app.findall('receiver')):
-    if receiver.get(a('name')) in {
-        '.CompanionStartupReceiver',
-        '.CompanionInstallResultReceiver',
-    }:
-        app.remove(receiver)
+    if receiver.get(a('name')) in {'.CompanionStartupReceiver','.CompanionInstallResultReceiver'}: app.remove(receiver)
 for provider in list(app.findall('provider')):
-    if provider.get(a('name')) == 'rikka.shizuku.ShizukuProvider':
-        app.remove(provider)
-
-ET.SubElement(app, 'provider', {
-    a('name'): 'rikka.shizuku.ShizukuProvider',
-    a('authorities'): '${applicationId}.shizuku',
-    a('multiprocess'): 'false',
-    a('enabled'): 'true',
-    a('exported'): 'true',
-    a('permission'): 'android.permission.INTERACT_ACROSS_USERS_FULL',
-})
-
-accessibility = ET.SubElement(app, 'service', {
-    a('name'): '.CompanionAccessibilityService',
-    a('permission'): 'android.permission.BIND_ACCESSIBILITY_SERVICE',
-    a('exported'): 'true',
-    a('label'): '3DVR Companion accessibility',
-})
-intent_filter = ET.SubElement(accessibility, 'intent-filter')
-ET.SubElement(intent_filter, 'action', {
-    a('name'): 'android.accessibilityservice.AccessibilityService',
-})
-ET.SubElement(accessibility, 'meta-data', {
-    a('name'): 'android.accessibilityservice',
-    a('resource'): '@xml/companion_accessibility_service',
-})
-
-notification = ET.SubElement(app, 'service', {
-    a('name'): '.CompanionNotificationListener',
-    a('permission'): 'android.permission.BIND_NOTIFICATION_LISTENER_SERVICE',
-    a('exported'): 'false',
-    a('label'): '3DVR Companion notifications',
-})
-notification_filter = ET.SubElement(notification, 'intent-filter')
-ET.SubElement(notification_filter, 'action', {
-    a('name'): 'android.service.notification.NotificationListenerService',
-})
-
-keepalive = ET.SubElement(app, 'service', {
-    a('name'): '.CompanionKeepAliveService',
-    a('exported'): 'false',
-    a('foregroundServiceType'): 'specialUse',
-    a('stopWithTask'): 'false',
-})
-ET.SubElement(keepalive, 'property', {
-    a('name'): 'android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE',
-    a('value'): 'Keeps the user-enabled local 3DVR Companion bridge reachable while the app is backgrounded.',
-})
-
-startup = ET.SubElement(app, 'receiver', {
-    a('name'): '.CompanionStartupReceiver',
-    a('enabled'): 'true',
-    a('exported'): 'false',
-})
-startup_filter = ET.SubElement(startup, 'intent-filter')
-for action in (
-    'android.intent.action.BOOT_COMPLETED',
-    'android.intent.action.MY_PACKAGE_REPLACED',
-):
-    ET.SubElement(startup_filter, 'action', {a('name'): action})
-
-ET.SubElement(app, 'receiver', {
-    a('name'): '.CompanionInstallResultReceiver',
-    a('enabled'): 'true',
-    a('exported'): 'false',
-})
-
-ET.indent(tree, space='    ')
-tree.write(manifest_path, encoding='utf-8', xml_declaration=True)
-
-strings_path = Path('android/app/src/main/res/values/strings.xml')
-if strings_path.exists():
-    strings_tree = ET.parse(strings_path)
-    strings_root = strings_tree.getroot()
-else:
-    strings_path.parent.mkdir(parents=True, exist_ok=True)
-    strings_root = ET.Element('resources')
-    strings_tree = ET.ElementTree(strings_root)
-
-for node in list(strings_root.findall('string')):
-    if node.get('name') == 'companion_accessibility_description':
-        strings_root.remove(node)
-entry = ET.SubElement(strings_root, 'string', {'name': 'companion_accessibility_description'})
-entry.text = 'Lets 3DVR Companion inspect and control the screen when you enable full phone control.'
-ET.indent(strings_tree, space='    ')
-strings_tree.write(strings_path, encoding='utf-8', xml_declaration=True)
-
-# Shizuku 13.1.x requires core library desugaring when minSdk is 23.
-gradle_path = Path('android/app/build.gradle.kts')
-gradle = gradle_path.read_text(encoding='utf-8')
-if 'isCoreLibraryDesugaringEnabled = true' not in gradle:
-    gradle = gradle.replace(
-        'compileOptions {',
-        'compileOptions {\n        isCoreLibraryDesugaringEnabled = true',
-        1,
-    )
-if 'dev.rikka.shizuku:api:13.1.5' not in gradle:
-    gradle += '''\n\ndependencies {\n    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")\n    implementation("dev.rikka.shizuku:api:13.1.5")\n    implementation("dev.rikka.shizuku:provider:13.1.5")\n}\n'''
-gradle_path.write_text(gradle, encoding='utf-8')
-
-plist_path = Path('ios/Runner/Info.plist')
-with plist_path.open('rb') as handle:
-    plist = plistlib.load(handle)
-plist['CFBundleDisplayName'] = '3DVR Companion'
-plist['CFBundleName'] = '3DVR Companion'
-with plist_path.open('wb') as handle:
-    plistlib.dump(plist, handle)
+    if provider.get(a('name'))=='rikka.shizuku.ShizukuProvider': app.remove(provider)
+ET.SubElement(app,'provider',{a('name'):'rikka.shizuku.ShizukuProvider',a('authorities'):'${applicationId}.shizuku',a('multiprocess'):'false',a('enabled'):'true',a('exported'):'true',a('permission'):'android.permission.INTERACT_ACROSS_USERS_FULL'})
+access=ET.SubElement(app,'service',{a('name'):'.CompanionAccessibilityService',a('permission'):'android.permission.BIND_ACCESSIBILITY_SERVICE',a('exported'):'true',a('label'):'3DVR Companion accessibility'})
+f=ET.SubElement(access,'intent-filter'); ET.SubElement(f,'action',{a('name'):'android.accessibilityservice.AccessibilityService'}); ET.SubElement(access,'meta-data',{a('name'):'android.accessibilityservice',a('resource'):'@xml/companion_accessibility_service'})
+notification=ET.SubElement(app,'service',{a('name'):'.CompanionNotificationListener',a('permission'):'android.permission.BIND_NOTIFICATION_LISTENER_SERVICE',a('exported'):'false',a('label'):'3DVR Companion notifications'}); nf=ET.SubElement(notification,'intent-filter'); ET.SubElement(nf,'action',{a('name'):'android.service.notification.NotificationListenerService'})
+keep=ET.SubElement(app,'service',{a('name'):'.CompanionKeepAliveService',a('exported'):'false',a('foregroundServiceType'):'specialUse',a('stopWithTask'):'false'}); ET.SubElement(keep,'property',{a('name'):'android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE',a('value'):'Keeps the user-enabled local 3DVR Companion bridge reachable while the app is backgrounded.'})
+startup=ET.SubElement(app,'receiver',{a('name'):'.CompanionStartupReceiver',a('enabled'):'true',a('exported'):'false'}); sf=ET.SubElement(startup,'intent-filter')
+for action in ('android.intent.action.BOOT_COMPLETED','android.intent.action.MY_PACKAGE_REPLACED'): ET.SubElement(sf,'action',{a('name'):action})
+ET.SubElement(app,'receiver',{a('name'):'.CompanionInstallResultReceiver',a('enabled'):'true',a('exported'):'false'})
+ET.indent(tree,space='    '); tree.write(manifest_path,encoding='utf-8',xml_declaration=True)
+strings_path=Path('android/app/src/main/res/values/strings.xml')
+if strings_path.exists(): st=ET.parse(strings_path); sr=st.getroot()
+else: strings_path.parent.mkdir(parents=True,exist_ok=True); sr=ET.Element('resources'); st=ET.ElementTree(sr)
+for n in list(sr.findall('string')):
+    if n.get('name')=='companion_accessibility_description': sr.remove(n)
+e=ET.SubElement(sr,'string',{'name':'companion_accessibility_description'}); e.text='Lets 3DVR Companion inspect and control the screen when you enable full phone control.'; ET.indent(st,space='    '); st.write(strings_path,encoding='utf-8',xml_declaration=True)
+gradle_path=Path('android/app/build.gradle.kts'); gradle=gradle_path.read_text()
+if 'isCoreLibraryDesugaringEnabled = true' not in gradle: gradle=gradle.replace('compileOptions {','compileOptions {\n        isCoreLibraryDesugaringEnabled = true',1)
+if 'dev.rikka.shizuku:api:13.1.5' not in gradle: gradle+='''\n\ndependencies {\n    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")\n    implementation("dev.rikka.shizuku:api:13.1.5")\n    implementation("dev.rikka.shizuku:provider:13.1.5")\n}\n'''
+gradle_path.write_text(gradle)
+plist_path=Path('ios/Runner/Info.plist')
+with plist_path.open('rb') as h: plist=plistlib.load(h)
+plist['CFBundleDisplayName']='3DVR Companion'; plist['CFBundleName']='3DVR Companion'
+with plist_path.open('wb') as h: plistlib.dump(plist,h)
 PY
 
 mkdir -p ios/CompanionNativeSpec
-cp native-spec/ios/OpenCompanionDashboardIntent.swift \
-  ios/CompanionNativeSpec/OpenCompanionDashboardIntent.swift
-
+cp native-spec/ios/OpenCompanionDashboardIntent.swift ios/CompanionNativeSpec/OpenCompanionDashboardIntent.swift
 flutter pub get
 dart format lib test
 flutter analyze
@@ -258,4 +109,5 @@ echo "Android always-on native bridge: wired"
 echo "Android boot/package-replace recovery: wired"
 echo "Android self-update loopback: wired"
 echo "Android Shizuku/Sui privilege provider: wired"
+echo "Android relay credentials: Keystore-encrypted at rest"
 echo "iOS App Intent: staged in ios/CompanionNativeSpec (Xcode target wiring still required)"


### PR DESCRIPTION
## What changed

- implements the native `relay_secrets` MethodChannel staged in #1527
- encrypts relay secret values with AES-GCM using a non-exportable Android Keystore key
- stores only IV+ciphertext in private app preferences
- wires read/write/delete without logging secret values
- makes the scaffold copy the Keystore implementation into generated Android builds

## Scope / safety

This is storage only. It adds no relay network connection and no new execution capabilities. `health` / `device.status` remain the only allowed direct-relay envelopes, and Termux remains unchanged as fallback.

## Validation

Fresh Companion Android CI is required before merge, especially Kotlin compilation through the generated scaffold.