### PR TITLE
Companion: harden authenticated relay client

### DIFF
--- a/apps/companion/lib/src/relay_client.dart
+++ b/apps/companion/lib/src/relay_client.dart
@@ -13,14 +13,16 @@ class RelayClient {
   RelayClient({
     required this.baseUri,
     required this.credentials,
-    HttpClient? httpClient,
+    RelayRequestSender? sender,
     DateTime Function()? clock,
-  })  : _httpClient = httpClient ?? HttpClient(),
-        _clock = clock ?? DateTime.now;
+  })  : _sender = sender ?? DartRelayRequestSender(),
+        _clock = clock ?? DateTime.now {
+    _requireSecureRelayUri(baseUri);
+  }
 
   final Uri baseUri;
   final RelayCredentialProvider credentials;
-  final HttpClient _httpClient;
+  final RelayRequestSender _sender;
   final DateTime Function() _clock;
 
   Future<RelayRoundTrip> invoke(RelayEnvelope envelope) async {
@@ -39,26 +41,37 @@ class RelayClient {
       throw const RelayClientException('relay credential unavailable');
     }
 
-    final startedAt = _clock().toUtc();
-    final request = await _httpClient.postUrl(baseUri.resolve('/v1/relay/invoke'));
-    request.headers.set(HttpHeaders.authorizationHeader, authorization);
-    request.headers.contentType = ContentType.json;
-    request.write(jsonEncode(<String, Object?>{
-      'requestId': envelope.requestId,
-      'capabilityId': envelope.capabilityId,
-      'expiresAt': envelope.expiresAt.toUtc().toIso8601String(),
-    }));
+    // Secure-store access is asynchronous. Do not let a request cross the
+    // network boundary if it expired while credentials were being loaded.
+    if (envelope.isExpired(_clock())) {
+      throw const RelayClientException('request expired');
+    }
 
-    final response = await request.close();
-    final body = await utf8.decoder.bind(response).join();
+    final startedAt = _clock().toUtc();
+    final response = await _sender.postJson(
+      baseUri.resolve('/v1/relay/invoke'),
+      authorization: authorization,
+      body: <String, Object?>{
+        'requestId': envelope.requestId,
+        'capabilityId': envelope.capabilityId,
+        'expiresAt': envelope.expiresAt.toUtc().toIso8601String(),
+      },
+    );
+
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw RelayClientException('relay returned HTTP ${response.statusCode}');
     }
 
-    final decoded = jsonDecode(body);
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } on FormatException {
+      throw const RelayClientException('relay returned malformed JSON');
+    }
     if (decoded is! Map<String, dynamic>) {
       throw const RelayClientException('relay returned malformed JSON');
     }
+
     final finishedAt = _clock().toUtc();
     return RelayRoundTrip(
       requestId: envelope.requestId,
@@ -68,6 +81,63 @@ class RelayClient {
     );
   }
 
+  void close() => _sender.close();
+}
+
+void _requireSecureRelayUri(Uri uri) {
+  final host = uri.host.toLowerCase();
+  final isLoopback = host == '127.0.0.1' || host == 'localhost' || host == '::1';
+  if (uri.scheme == 'https') return;
+  if (uri.scheme == 'http' && isLoopback) return;
+  throw ArgumentError.value(
+    uri,
+    'baseUri',
+    'relay endpoints must use HTTPS except for loopback development',
+  );
+}
+
+abstract interface class RelayRequestSender {
+  Future<RelayHttpResponse> postJson(
+    Uri uri, {
+    required String authorization,
+    required Map<String, Object?> body,
+  });
+
+  void close();
+}
+
+class RelayHttpResponse {
+  const RelayHttpResponse({required this.statusCode, required this.body});
+
+  final int statusCode;
+  final String body;
+}
+
+class DartRelayRequestSender implements RelayRequestSender {
+  DartRelayRequestSender({HttpClient? httpClient})
+      : _httpClient = httpClient ?? HttpClient();
+
+  final HttpClient _httpClient;
+
+  @override
+  Future<RelayHttpResponse> postJson(
+    Uri uri, {
+    required String authorization,
+    required Map<String, Object?> body,
+  }) async {
+    final request = await _httpClient.postUrl(uri);
+    request.headers.set(HttpHeaders.authorizationHeader, authorization);
+    request.headers.contentType = ContentType.json;
+    request.write(jsonEncode(body));
+
+    final response = await request.close();
+    return RelayHttpResponse(
+      statusCode: response.statusCode,
+      body: await utf8.decoder.bind(response).join(),
+    );
+  }
+
+  @override
   void close() => _httpClient.close(force: true);
 }
 

--- a/apps/companion/test/relay_client_test.dart
+++ b/apps/companion/test/relay_client_test.dart
@@ -1,0 +1,239 @@
+import 'package:companion/src/relay_auth.dart';
+import 'package:companion/src/relay_client.dart';
+import 'package:companion/src/relay_envelope.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RelayClient endpoint security', () {
+    test('rejects cleartext remote relay endpoints', () {
+      expect(
+        () => RelayClient(
+          baseUri: Uri.parse('http://relay.3dvr.tech'),
+          credentials: _StaticCredentials(_validCredential()),
+          sender: _FakeSender(),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('allows HTTPS and loopback HTTP', () {
+      final https = RelayClient(
+        baseUri: Uri.parse('https://relay.3dvr.tech'),
+        credentials: _StaticCredentials(_validCredential()),
+        sender: _FakeSender(),
+      );
+      final loopback = RelayClient(
+        baseUri: Uri.parse('http://127.0.0.1:38473'),
+        credentials: _StaticCredentials(_validCredential()),
+        sender: _FakeSender(),
+      );
+      https.close();
+      loopback.close();
+    });
+  });
+
+  group('RelayClient request boundary', () {
+    test('rejects an expired request before network I/O', () async {
+      final sender = _FakeSender();
+      final now = DateTime.utc(2026, 8, 17, 18);
+      final client = RelayClient(
+        baseUri: Uri.parse('https://relay.3dvr.tech'),
+        credentials: _StaticCredentials(_validCredential()),
+        sender: sender,
+        clock: () => now,
+      );
+
+      await expectLater(
+        client.invoke(RelayEnvelope(
+          requestId: 'request-expired',
+          capabilityId: 'health',
+          expiresAt: now,
+        )),
+        throwsA(isA<RelayClientException>()),
+      );
+      expect(sender.calls, 0);
+    });
+
+    test('rechecks expiry after asynchronous credential loading', () async {
+      var now = DateTime.utc(2026, 8, 17, 18);
+      final sender = _FakeSender();
+      final credentials = _AdvancingCredentials(
+        credential: RelayCredential(
+          token: 'relay-secret-token',
+          expiresAt: now.add(const Duration(hours: 1)),
+        ),
+        onLoad: () => now = now.add(const Duration(seconds: 3)),
+      );
+      final client = RelayClient(
+        baseUri: Uri.parse('https://relay.3dvr.tech'),
+        credentials: credentials,
+        sender: sender,
+        clock: () => now,
+      );
+
+      await expectLater(
+        client.invoke(RelayEnvelope(
+          requestId: 'request-near-expiry',
+          capabilityId: 'device.status',
+          expiresAt: now.add(const Duration(seconds: 2)),
+        )),
+        throwsA(
+          isA<RelayClientException>().having(
+            (error) => error.message,
+            'message',
+            'request expired',
+          ),
+        ),
+      );
+      expect(sender.calls, 0);
+    });
+
+    test('places credential only in the Authorization header', () async {
+      final now = DateTime.utc(2026, 8, 17, 18);
+      final sender = _FakeSender(
+        response: const RelayHttpResponse(statusCode: 200, body: '{"ok":true}'),
+      );
+      final client = RelayClient(
+        baseUri: Uri.parse('https://relay.3dvr.tech'),
+        credentials: _StaticCredentials(RelayCredential(
+          token: 'relay-secret-token',
+          expiresAt: now.add(const Duration(hours: 1)),
+        )),
+        sender: sender,
+        clock: () => now,
+      );
+
+      final result = await client.invoke(RelayEnvelope(
+        requestId: 'request-header-test',
+        capabilityId: 'health',
+        expiresAt: now.add(const Duration(minutes: 1)),
+      ));
+
+      expect(result.payload['ok'], true);
+      expect(sender.authorization, 'Bearer relay-secret-token');
+      expect(sender.body.toString(), isNot(contains('relay-secret-token')));
+      expect(sender.uri.toString(), 'https://relay.3dvr.tech/v1/relay/invoke');
+    });
+
+    test('normalizes malformed successful JSON into RelayClientException', () async {
+      final now = DateTime.utc(2026, 8, 17, 18);
+      final client = RelayClient(
+        baseUri: Uri.parse('https://relay.3dvr.tech'),
+        credentials: _StaticCredentials(RelayCredential(
+          token: 'relay-secret-token',
+          expiresAt: now.add(const Duration(hours: 1)),
+        )),
+        sender: _FakeSender(
+          response: const RelayHttpResponse(statusCode: 200, body: '<html>bad gateway</html>'),
+        ),
+        clock: () => now,
+      );
+
+      await expectLater(
+        client.invoke(RelayEnvelope(
+          requestId: 'request-bad-json',
+          capabilityId: 'health',
+          expiresAt: now.add(const Duration(minutes: 1)),
+        )),
+        throwsA(
+          isA<RelayClientException>().having(
+            (error) => error.message,
+            'message',
+            'relay returned malformed JSON',
+          ),
+        ),
+      );
+    });
+
+    test('normalizes non-success HTTP responses without echoing response data', () async {
+      final now = DateTime.utc(2026, 8, 17, 18);
+      final client = RelayClient(
+        baseUri: Uri.parse('https://relay.3dvr.tech'),
+        credentials: _StaticCredentials(RelayCredential(
+          token: 'relay-secret-token',
+          expiresAt: now.add(const Duration(hours: 1)),
+        )),
+        sender: _FakeSender(
+          response: const RelayHttpResponse(
+            statusCode: 503,
+            body: 'upstream accidentally echoed relay-secret-token',
+          ),
+        ),
+        clock: () => now,
+      );
+
+      await expectLater(
+        client.invoke(RelayEnvelope(
+          requestId: 'request-http-failure',
+          capabilityId: 'health',
+          expiresAt: now.add(const Duration(minutes: 1)),
+        )),
+        throwsA(
+          isA<RelayClientException>()
+              .having((error) => error.message, 'message', 'relay returned HTTP 503')
+              .having((error) => error.toString(), 'redaction', isNot(contains('relay-secret-token'))),
+        ),
+      );
+    });
+  });
+}
+
+RelayCredential _validCredential() => RelayCredential(
+      token: 'relay-secret-token',
+      expiresAt: DateTime.utc(2099),
+    );
+
+class _StaticCredentials implements RelayCredentialProvider {
+  _StaticCredentials(this.credential);
+
+  final RelayCredential? credential;
+
+  @override
+  Future<RelayCredential?> load() async => credential;
+
+  @override
+  Future<void> clear() async {}
+}
+
+class _AdvancingCredentials extends _StaticCredentials {
+  _AdvancingCredentials({
+    required RelayCredential credential,
+    required this.onLoad,
+  }) : super(credential);
+
+  final void Function() onLoad;
+
+  @override
+  Future<RelayCredential?> load() async {
+    onLoad();
+    return credential;
+  }
+}
+
+class _FakeSender implements RelayRequestSender {
+  _FakeSender({
+    this.response = const RelayHttpResponse(statusCode: 200, body: '{"ok":true}'),
+  });
+
+  final RelayHttpResponse response;
+  int calls = 0;
+  Uri? uri;
+  String? authorization;
+  Map<String, Object?> body = const {};
+
+  @override
+  Future<RelayHttpResponse> postJson(
+    Uri uri, {
+    required String authorization,
+    required Map<String, Object?> body,
+  }) async {
+    calls += 1;
+    this.uri = uri;
+    this.authorization = authorization;
+    this.body = Map<String, Object?>.from(body);
+    return response;
+  }
+
+  @override
+  void close() {}
+}


### PR DESCRIPTION
## What changed
- require HTTPS for remote relay endpoints, with loopback HTTP allowed only for local development
- recheck command expiry after asynchronous secure credential loading
- normalize malformed successful responses into redacted `RelayClientException`
- isolate HTTP I/O behind a tiny injectable sender boundary
- add focused tests for endpoint security, pre-network expiry rejection, credential/header placement, malformed JSON, and HTTP failures

## Why
Addresses the valid Codex review findings on #1532 before expanding the relay beyond read-only capabilities.

## Safety
No new device capabilities, no shell, no arbitrary selectors/coordinates, no credential values in logs/results, and Termux fallback remains unchanged.