### PR TITLE
Companion: own read-only relay from Android foreground service

### DIFF
--- a/apps/companion/native-spec/android/CompanionKeepAliveService.kt
+++ b/apps/companion/native-spec/android/CompanionKeepAliveService.kt
@@ -15,19 +15,27 @@ class CompanionKeepAliveService : Service() {
         private const val notificationId = 38473
     }
 
+    private var remoteRelay: CompanionRemoteRelayClient? = null
+
     override fun onCreate() {
         super.onCreate()
         createChannel()
         startForeground(notificationId, buildNotification())
         CompanionNativeBridgeServer.ensureStarted(this)
+        remoteRelay = CompanionRemoteRelayClient(this).also { it.start() }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         CompanionNativeBridgeServer.ensureStarted(this)
+        if (remoteRelay == null) {
+            remoteRelay = CompanionRemoteRelayClient(this).also { it.start() }
+        }
         return START_STICKY
     }
 
     override fun onDestroy() {
+        remoteRelay?.stop()
+        remoteRelay = null
         CompanionNativeBridgeServer.stop()
         super.onDestroy()
     }
@@ -41,7 +49,7 @@ class CompanionKeepAliveService : Service() {
             "3DVR Companion bridge",
             NotificationManager.IMPORTANCE_LOW,
         ).apply {
-            description = "Keeps the local Companion control bridge available while the app is in the background."
+            description = "Keeps the local and authenticated remote Companion bridges available while the app is in the background."
             setShowBadge(false)
         }
         getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
@@ -63,7 +71,7 @@ class CompanionKeepAliveService : Service() {
         }
         return builder
             .setContentTitle("3DVR Companion active")
-            .setContentText("Always-on local assistant bridge")
+            .setContentText("Always-on local + secure relay assistant bridge")
             .setSmallIcon(android.R.drawable.stat_notify_sync_noanim)
             .setOngoing(true)
             .setContentIntent(pendingIntent)

--- a/apps/companion/native-spec/android/CompanionRemoteRelayClient.kt
+++ b/apps/companion/native-spec/android/CompanionRemoteRelayClient.kt
@@ -1,0 +1,301 @@
+package tech.threedvr.companion
+
+import android.content.Context
+import android.os.BatteryManager
+import android.os.Build
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.net.ssl.HttpsURLConnection
+
+object CompanionRemoteRelayState {
+    @Volatile var status: String = "stopped"
+    @Volatile var deviceId: String? = null
+    @Volatile var credentialExpiresAt: Long? = null
+    @Volatile var lastSuccessAt: Long? = null
+    @Volatile var lastError: String? = null
+
+    fun snapshot(): Map<String, Any?> = mapOf(
+        "status" to status,
+        "deviceId" to deviceId,
+        "credentialExpiresAt" to credentialExpiresAt,
+        "lastSuccessAt" to lastSuccessAt,
+        "lastError" to lastError,
+        "relay" to CompanionRemoteRelayClient.RELAY_BASE_URL,
+    )
+}
+
+/**
+ * Owns Companion's direct read-only relay from the always-on foreground service.
+ *
+ * The first live slice accepts only health and device.status. It never executes
+ * shell commands, accessibility actions, app launches, URLs, messages, or other
+ * mutating capabilities. Device credentials are ephemeral and encrypted at rest
+ * by CompanionRelaySecretStore.
+ */
+class CompanionRemoteRelayClient(context: Context) {
+    private val appContext = context.applicationContext
+    private val secretStore = CompanionRelaySecretStore(appContext)
+    private val executor = Executors.newSingleThreadExecutor()
+    private val running = AtomicBoolean(false)
+
+    fun start() {
+        if (!running.compareAndSet(false, true)) return
+        CompanionRemoteRelayState.status = "connecting"
+        executor.execute { runLoop() }
+    }
+
+    fun stop() {
+        running.set(false)
+        executor.shutdownNow()
+        CompanionRemoteRelayState.status = "stopped"
+    }
+
+    private fun runLoop() {
+        var failures = 0
+        while (running.get()) {
+            try {
+                val credential = ensureCredential()
+                CompanionRemoteRelayState.deviceId = credential.deviceId
+                CompanionRemoteRelayState.credentialExpiresAt = credential.expiresAt
+                CompanionRemoteRelayState.status = "connected"
+
+                val response = request(
+                    method = "GET",
+                    path = "/relay/v1/devices/${credential.deviceId}/commands/next",
+                    credential = credential,
+                )
+                if (response.statusCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                    clearCredential()
+                    failures = 0
+                    continue
+                }
+                require(response.statusCode in 200..299) {
+                    "relay HTTP ${response.statusCode}"
+                }
+
+                val decoded = JSONObject(response.body)
+                val command = decoded.optJSONObject("command")
+                if (command != null) {
+                    handleCommand(credential, command)
+                }
+
+                CompanionRemoteRelayState.lastSuccessAt = System.currentTimeMillis()
+                CompanionRemoteRelayState.lastError = null
+                failures = 0
+                sleepInterruptibly(POLL_INTERVAL_MS)
+            } catch (error: InterruptedException) {
+                Thread.currentThread().interrupt()
+                break
+            } catch (error: Exception) {
+                CompanionRemoteRelayState.status = "backing-off"
+                CompanionRemoteRelayState.lastError = safeError(error)
+                failures = (failures + 1).coerceAtMost(8)
+                val delay = (BASE_BACKOFF_MS shl (failures - 1)).coerceAtMost(MAX_BACKOFF_MS)
+                try {
+                    sleepInterruptibly(delay)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    break
+                }
+            }
+        }
+    }
+
+    private fun ensureCredential(): DeviceCredential {
+        val now = System.currentTimeMillis()
+        val storedId = secretStore.read(DEVICE_ID_KEY)
+        val storedToken = secretStore.read(DEVICE_TOKEN_KEY)
+        val storedExpiry = secretStore.read(DEVICE_EXPIRES_KEY)?.toLongOrNull()
+        if (
+            !storedId.isNullOrBlank() &&
+            !storedToken.isNullOrBlank() &&
+            storedExpiry != null &&
+            storedExpiry > now + CREDENTIAL_REFRESH_MARGIN_MS
+        ) {
+            return DeviceCredential(storedId, storedToken, storedExpiry)
+        }
+
+        clearCredential()
+        val response = request(
+            method = "POST",
+            path = "/relay/v1/devices",
+            body = JSONObject().toString(),
+        )
+        require(response.statusCode in 200..299) {
+            "device bootstrap HTTP ${response.statusCode}"
+        }
+        val decoded = JSONObject(response.body)
+        val deviceId = decoded.optString("deviceId").trim()
+        val token = decoded.optString("deviceToken").trim()
+        val expiresAt = decoded.optLong("expiresAt", 0L)
+        require(deviceId.length in 22..86 && token.length in 32..128 && expiresAt > now) {
+            "relay returned invalid device credential"
+        }
+
+        secretStore.write(DEVICE_ID_KEY, deviceId)
+        secretStore.write(DEVICE_TOKEN_KEY, token)
+        secretStore.write(DEVICE_EXPIRES_KEY, expiresAt.toString())
+        return DeviceCredential(deviceId, token, expiresAt)
+    }
+
+    private fun handleCommand(credential: DeviceCredential, command: JSONObject) {
+        val requestId = command.optString("requestId").trim()
+        val capabilityId = command.optString("capabilityId").trim()
+        val expiresAt = command.optLong("expiresAt", 0L)
+        if (requestId.length !in 16..86 || expiresAt <= System.currentTimeMillis()) return
+
+        val result = when (capabilityId) {
+            "health" -> CommandResult(
+                ok = true,
+                data = mapOf(
+                    "transport" to "direct-relay",
+                    "alwaysOn" to true,
+                    "sdk" to Build.VERSION.SDK_INT,
+                ),
+            )
+            "device.status" -> CommandResult(ok = true, data = deviceStatus())
+            else -> CommandResult(ok = false, code = "unsupported_capability")
+        }
+
+        val resultJson = JSONObject().apply {
+            put("requestId", requestId)
+            put("ok", result.ok)
+            result.code?.let { put("code", it) }
+            put("data", JSONObject(result.data))
+        }
+        val response = request(
+            method = "POST",
+            path = "/relay/v1/devices/${credential.deviceId}/results",
+            body = resultJson.toString(),
+            credential = credential,
+        )
+        if (response.statusCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+            clearCredential()
+            return
+        }
+        require(response.statusCode in 200..299) {
+            "result HTTP ${response.statusCode}"
+        }
+    }
+
+    private fun deviceStatus(): Map<String, Any?> {
+        val battery = appContext.getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
+        return mapOf(
+            "sdk" to Build.VERSION.SDK_INT,
+            "manufacturer" to Build.MANUFACTURER,
+            "model" to Build.MODEL,
+            "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY),
+            "bridgeActive" to true,
+        )
+    }
+
+    private fun request(
+        method: String,
+        path: String,
+        body: String? = null,
+        credential: DeviceCredential? = null,
+    ): HttpResponse {
+        require(path.startsWith('/'))
+        val connection = URL(RELAY_BASE_URL + path).openConnection() as HttpsURLConnection
+        connection.requestMethod = method
+        connection.connectTimeout = CONNECT_TIMEOUT_MS
+        connection.readTimeout = READ_TIMEOUT_MS
+        connection.useCaches = false
+        connection.setRequestProperty("Accept", "application/json")
+        connection.setRequestProperty("User-Agent", "3DVR-Companion-Android")
+        credential?.let {
+            connection.setRequestProperty("Authorization", "Bearer ${it.token}")
+            connection.setRequestProperty("X-3DVR-Device", it.deviceId)
+        }
+        if (body != null) {
+            val bytes = body.toByteArray(StandardCharsets.UTF_8)
+            require(bytes.size <= MAX_BODY_BYTES)
+            connection.doOutput = true
+            connection.setRequestProperty("Content-Type", "application/json")
+            connection.setFixedLengthStreamingMode(bytes.size)
+            connection.outputStream.use { it.write(bytes) }
+        }
+
+        val status = connection.responseCode
+        val input = if (status in 200..299) connection.inputStream else connection.errorStream
+        val responseBody = readLimited(input)
+        connection.disconnect()
+        return HttpResponse(status, responseBody)
+    }
+
+    private fun readLimited(input: InputStream?): String {
+        if (input == null) return ""
+        val reader = BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8))
+        val result = StringBuilder()
+        val buffer = CharArray(2048)
+        var total = 0
+        reader.use {
+            while (true) {
+                val count = it.read(buffer)
+                if (count < 0) break
+                total += count
+                require(total <= MAX_RESPONSE_CHARS) { "relay response too large" }
+                result.append(buffer, 0, count)
+            }
+        }
+        return result.toString()
+    }
+
+    private fun clearCredential() {
+        secretStore.delete(DEVICE_ID_KEY)
+        secretStore.delete(DEVICE_TOKEN_KEY)
+        secretStore.delete(DEVICE_EXPIRES_KEY)
+        CompanionRemoteRelayState.deviceId = null
+        CompanionRemoteRelayState.credentialExpiresAt = null
+    }
+
+    private fun sleepInterruptibly(milliseconds: Long) {
+        if (!running.get()) return
+        Thread.sleep(milliseconds)
+    }
+
+    private fun safeError(error: Exception): String {
+        val name = error::class.java.simpleName.ifBlank { "RelayError" }
+        val message = error.message.orEmpty()
+            .replace(Regex("Bearer\\s+[^\\s]+", RegexOption.IGNORE_CASE), "Bearer <redacted>")
+            .take(160)
+        return if (message.isBlank()) name else "$name: $message"
+    }
+
+    private data class DeviceCredential(
+        val deviceId: String,
+        val token: String,
+        val expiresAt: Long,
+    )
+
+    private data class HttpResponse(val statusCode: Int, val body: String)
+
+    private data class CommandResult(
+        val ok: Boolean,
+        val code: String? = null,
+        val data: Map<String, Any?> = emptyMap(),
+    )
+
+    companion object {
+        const val RELAY_BASE_URL = "https://gun-relay-3dvr.fly.dev"
+
+        private const val DEVICE_ID_KEY = "remote.device_id"
+        private const val DEVICE_TOKEN_KEY = "remote.device_token"
+        private const val DEVICE_EXPIRES_KEY = "remote.expires_at"
+        private const val CREDENTIAL_REFRESH_MARGIN_MS = 60_000L
+        private const val POLL_INTERVAL_MS = 2_000L
+        private const val BASE_BACKOFF_MS = 1_000L
+        private const val MAX_BACKOFF_MS = 30_000L
+        private const val CONNECT_TIMEOUT_MS = 10_000
+        private const val READ_TIMEOUT_MS = 15_000
+        private const val MAX_BODY_BYTES = 32 * 1024
+        private const val MAX_RESPONSE_CHARS = 64 * 1024
+    }
+}

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -114,29 +114,51 @@ class MainActivity : FlutterActivity() {
 
     private fun deviceStatus(): Map<String, Any?> {
         val battery = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
-        return mapOf("sdk" to Build.VERSION.SDK_INT, "manufacturer" to Build.MANUFACTURER, "model" to Build.MODEL, "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY))
+        return mapOf(
+            "sdk" to Build.VERSION.SDK_INT,
+            "manufacturer" to Build.MANUFACTURER,
+            "model" to Build.MODEL,
+            "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY),
+            "relayStatus" to CompanionRemoteRelayState.status,
+            "relayDeviceId" to CompanionRemoteRelayState.deviceId,
+            "relayLastSuccessAt" to CompanionRemoteRelayState.lastSuccessAt,
+        )
     }
 
     private fun capabilityStatus(): Map<String, Any> = mapOf(
-        "accessibilityEnabled" to isAccessibilityEnabled(), "notificationAccessEnabled" to isNotificationAccessEnabled(),
-        "messageNotificationReadEnabled" to isNotificationAccessEnabled(), "messageNotificationReplyEnabled" to isNotificationAccessEnabled(),
-        "messageHistoryEncryptedAtRest" to true, "backgroundBridgeEnabled" to true, "knownAppLaunchEnabled" to true,
-        "remoteKnownActionsEnabled" to false, "persistentPairingEnabled" to true, "relayCredentialsEncryptedAtRest" to true,
+        "accessibilityEnabled" to isAccessibilityEnabled(),
+        "notificationAccessEnabled" to isNotificationAccessEnabled(),
+        "messageNotificationReadEnabled" to isNotificationAccessEnabled(),
+        "messageNotificationReplyEnabled" to isNotificationAccessEnabled(),
+        "messageHistoryEncryptedAtRest" to true,
+        "backgroundBridgeEnabled" to true,
+        "knownAppLaunchEnabled" to true,
+        "remoteKnownActionsEnabled" to false,
+        "persistentPairingEnabled" to true,
+        "relayCredentialsEncryptedAtRest" to true,
+        "directRelayEnabled" to true,
+        "directRelayReadOnly" to true,
     )
 
     private fun openHttpUrl(raw: String): Boolean {
         val uri = runCatching { Uri.parse(raw) }.getOrNull() ?: return false
         if (uri.scheme != "https" && uri.scheme != "http") return false
-        startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)); return true
+        startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        return true
     }
 
     private fun openKnownApp(rawAlias: String): Boolean {
         val alias = rawAlias.trim().lowercase()
-        if (alias == "settings") { startActivity(Intent(Settings.ACTION_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)); return true }
+        if (alias == "settings") {
+            startActivity(Intent(Settings.ACTION_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            return true
+        }
         val candidates = knownApps[alias] ?: return false
         for (packageName in candidates) {
             val launchIntent = packageManager.getLaunchIntentForPackage(packageName) ?: continue
-            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK); startActivity(launchIntent); return true
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(launchIntent)
+            return true
         }
         return false
     }

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -24,7 +24,7 @@ cp "$BACKUP/analysis_options.yaml" analysis_options.yaml
 
 KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
 mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
-for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt; do
+for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt; do
   cp "native-spec/android/$source" "$KOTLIN_DIR/$source"
 done
 cp native-spec/android/companion_accessibility_service.xml android/app/src/main/res/xml/companion_accessibility_service.xml
@@ -73,7 +73,7 @@ ET.SubElement(app,'provider',{a('name'):'rikka.shizuku.ShizukuProvider',a('autho
 access=ET.SubElement(app,'service',{a('name'):'.CompanionAccessibilityService',a('permission'):'android.permission.BIND_ACCESSIBILITY_SERVICE',a('exported'):'true',a('label'):'3DVR Companion accessibility'})
 f=ET.SubElement(access,'intent-filter'); ET.SubElement(f,'action',{a('name'):'android.accessibilityservice.AccessibilityService'}); ET.SubElement(access,'meta-data',{a('name'):'android.accessibilityservice',a('resource'):'@xml/companion_accessibility_service'})
 notification=ET.SubElement(app,'service',{a('name'):'.CompanionNotificationListener',a('permission'):'android.permission.BIND_NOTIFICATION_LISTENER_SERVICE',a('exported'):'false',a('label'):'3DVR Companion notifications'}); nf=ET.SubElement(notification,'intent-filter'); ET.SubElement(nf,'action',{a('name'):'android.service.notification.NotificationListenerService'})
-keep=ET.SubElement(app,'service',{a('name'):'.CompanionKeepAliveService',a('exported'):'false',a('foregroundServiceType'):'specialUse',a('stopWithTask'):'false'}); ET.SubElement(keep,'property',{a('name'):'android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE',a('value'):'Keeps the user-enabled local 3DVR Companion bridge reachable while the app is backgrounded.'})
+keep=ET.SubElement(app,'service',{a('name'):'.CompanionKeepAliveService',a('exported'):'false',a('foregroundServiceType'):'specialUse',a('stopWithTask'):'false'}); ET.SubElement(keep,'property',{a('name'):'android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE',a('value'):'Keeps the user-enabled local and authenticated remote 3DVR Companion bridges reachable while the app is backgrounded.'})
 startup=ET.SubElement(app,'receiver',{a('name'):'.CompanionStartupReceiver',a('enabled'):'true',a('exported'):'false'}); sf=ET.SubElement(startup,'intent-filter')
 for action in ('android.intent.action.BOOT_COMPLETED','android.intent.action.MY_PACKAGE_REPLACED'): ET.SubElement(sf,'action',{a('name'):action})
 ET.SubElement(app,'receiver',{a('name'):'.CompanionInstallResultReceiver',a('enabled'):'true',a('exported'):'false'})
@@ -110,4 +110,5 @@ echo "Android boot/package-replace recovery: wired"
 echo "Android self-update loopback: wired"
 echo "Android Shizuku/Sui privilege provider: wired"
 echo "Android relay credentials: Keystore-encrypted at rest"
+echo "Android direct relay: always-on read-only client wired"
 echo "iOS App Intent: staged in ios/CompanionNativeSpec (Xcode target wiring still required)"


### PR DESCRIPTION
## What changed
- adds a native Android direct-relay client owned by the existing always-on foreground service
- bootstraps short-lived device credentials from the existing Fly relay and stores them encrypted with the Android Keystore-backed relay secret store
- polls the device-specific command queue with bounded reconnect/backoff
- executes only `health` and `device.status` in this first slice
- posts bounded results back to the relay
- automatically refreshes credentials on expiry/401
- exposes non-secret relay status/device id in the Companion dashboard
- keeps the existing localhost/Termux bridge unchanged as fallback

## Safety
No shell, Accessibility execution, app launch, URL open, message send, or other mutating remote capability is admitted by this slice. Bearer credentials are never returned to Flutter or logs.

## Endpoint
Uses the existing production relay at `https://gun-relay-3dvr.fly.dev`.