### PR TITLE
Companion: own direct-relay reconnect lifecycle

### DIFF
--- a/apps/companion/lib/src/relay_lifecycle.dart
+++ b/apps/companion/lib/src/relay_lifecycle.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'command_transport.dart';
+import 'relay_backoff.dart';
+
+/// Owns the direct-relay connection lifecycle without broadening Companion's
+/// execution capabilities. Android foreground-service wiring can drive this
+/// controller while the existing Termux transport remains an independent
+/// fallback.
+class RelayLifecycleController {
+  RelayLifecycleController({
+    required Future<void> Function() connect,
+    required Future<void> Function() disconnect,
+    RelayBackoff? backoff,
+    Future<void> Function(Duration)? delay,
+  })  : _connect = connect,
+        _disconnect = disconnect,
+        _backoff = backoff ?? RelayBackoff(),
+        _delay = delay ?? Future<void>.delayed;
+
+  final Future<void> Function() _connect;
+  final Future<void> Function() _disconnect;
+  final RelayBackoff _backoff;
+  final Future<void> Function(Duration) _delay;
+  final _states = StreamController<TransportState>.broadcast();
+
+  bool _running = false;
+  int _attempt = 0;
+
+  Stream<TransportState> get states => _states.stream;
+  bool get isRunning => _running;
+
+  Future<void> start() async {
+    if (_running) return;
+    _running = true;
+    _attempt = 0;
+    await _connectUntilStopped();
+  }
+
+  Future<void> stop() async {
+    if (!_running) return;
+    _running = false;
+    await _disconnect();
+    _emit(const TransportState(status: TransportStatus.stopped));
+  }
+
+  Future<void> _connectUntilStopped() async {
+    while (_running) {
+      _emit(const TransportState(status: TransportStatus.connecting));
+      try {
+        await _connect();
+        if (!_running) return;
+        _attempt = 0;
+        _emit(const TransportState(status: TransportStatus.connected));
+        return;
+      } catch (_) {
+        if (!_running) return;
+        final retryAfter = _backoff.delayForAttempt(_attempt++);
+        _emit(TransportState(
+          status: TransportStatus.backingOff,
+          detail: 'relay connection failed',
+          retryAfter: retryAfter,
+        ));
+        await _delay(retryAfter);
+      }
+    }
+  }
+
+  /// Called by the foreground service when an established relay connection is
+  /// lost. Reconnect remains bounded by [RelayBackoff].
+  Future<void> connectionLost() async {
+    if (!_running) return;
+    await _disconnect();
+    await _connectUntilStopped();
+  }
+
+  void _emit(TransportState state) {
+    if (!_states.isClosed) _states.add(state);
+  }
+
+  Future<void> dispose() async {
+    if (_running) await stop();
+    await _states.close();
+  }
+}

--- a/apps/companion/test/relay_lifecycle_test.dart
+++ b/apps/companion/test/relay_lifecycle_test.dart
@@ -1,0 +1,74 @@
+import 'dart:math';
+
+import 'package:companion/src/command_transport.dart';
+import 'package:companion/src/relay_backoff.dart';
+import 'package:companion/src/relay_lifecycle.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('connects after bounded retry and emits deterministic lifecycle', () async {
+    var connects = 0;
+    final delays = <Duration>[];
+    final controller = RelayLifecycleController(
+      connect: () async {
+        connects += 1;
+        if (connects == 1) throw StateError('offline');
+      },
+      disconnect: () async {},
+      backoff: RelayBackoff(
+        base: const Duration(milliseconds: 10),
+        cap: const Duration(milliseconds: 10),
+        random: Random(1),
+      ),
+      delay: (duration) async => delays.add(duration),
+    );
+    final statuses = <TransportStatus>[];
+    final subscription = controller.states.listen((state) => statuses.add(state.status));
+
+    await controller.start();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(connects, 2);
+    expect(delays, hasLength(1));
+    expect(statuses, [
+      TransportStatus.connecting,
+      TransportStatus.backingOff,
+      TransportStatus.connecting,
+      TransportStatus.connected,
+    ]);
+
+    await controller.stop();
+    await subscription.cancel();
+    await controller.dispose();
+  });
+
+  test('start is idempotent while connected', () async {
+    var connects = 0;
+    final controller = RelayLifecycleController(
+      connect: () async => connects += 1,
+      disconnect: () async {},
+    );
+
+    await controller.start();
+    await controller.start();
+
+    expect(connects, 1);
+    await controller.dispose();
+  });
+
+  test('connection loss reconnects without enabling command capabilities', () async {
+    var connects = 0;
+    var disconnects = 0;
+    final controller = RelayLifecycleController(
+      connect: () async => connects += 1,
+      disconnect: () async => disconnects += 1,
+    );
+
+    await controller.start();
+    await controller.connectionLost();
+
+    expect(connects, 2);
+    expect(disconnects, 1);
+    await controller.dispose();
+  });
+}


### PR DESCRIPTION
## What changed

- adds a deterministic direct-relay lifecycle controller for foreground-service ownership
- models connecting → connected → bounded backoff/reconnect using the existing RelayBackoff primitive
- keeps start idempotent and supports explicit connection-loss recovery
- adds focused lifecycle tests

## Safety / scope

- no new execution capabilities
- no shell, selectors, coordinates, message sends, or app launches
- no credentials or endpoint secrets in Git
- Termux fallback remains unchanged

## Why

This is the next bounded slice of #1491: establish reliable foreground-service connection ownership before wiring the private endpoint and attempting real read-only health/device.status round trips.

Fresh Companion CI is required before merge.