### PR TITLE
Companion: enable bounded remote app and URL actions

### DIFF
--- a/apps/companion/native-spec/android/CompanionRemoteRelayClient.kt
+++ b/apps/companion/native-spec/android/CompanionRemoteRelayClient.kt
@@ -1,8 +1,11 @@
 package tech.threedvr.companion
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.BatteryManager
 import android.os.Build
+import android.provider.Settings
 import org.json.JSONObject
 import java.io.BufferedReader
 import java.io.InputStream
@@ -32,12 +35,13 @@ object CompanionRemoteRelayState {
 }
 
 /**
- * Owns Companion's direct read-only relay from the always-on foreground service.
+ * Owns Companion's direct relay from the always-on foreground service.
  *
- * The first live slice accepts only health and device.status. It never executes
- * shell commands, accessibility actions, app launches, URLs, messages, or other
- * mutating capabilities. Device credentials are ephemeral and encrypted at rest
- * by CompanionRelaySecretStore.
+ * Remote execution is deliberately capability-based rather than a shell. The
+ * currently admitted set is health, device.status, app.open_known, and url.open.
+ * App aliases are fixed locally and remote URLs must be clean HTTPS URLs.
+ * Accessibility, messages, arbitrary packages, Shizuku actions, and shell
+ * execution remain outside this direct-relay surface.
  */
 class CompanionRemoteRelayClient(context: Context) {
     private val appContext = context.applicationContext
@@ -76,15 +80,11 @@ class CompanionRemoteRelayClient(context: Context) {
                     failures = 0
                     continue
                 }
-                require(response.statusCode in 200..299) {
-                    "relay HTTP ${response.statusCode}"
-                }
+                require(response.statusCode in 200..299) { "relay HTTP ${response.statusCode}" }
 
                 val decoded = JSONObject(response.body)
                 val command = decoded.optJSONObject("command")
-                if (command != null) {
-                    handleCommand(credential, command)
-                }
+                if (command != null) handleCommand(credential, command)
 
                 CompanionRemoteRelayState.lastSuccessAt = System.currentTimeMillis()
                 CompanionRemoteRelayState.lastError = null
@@ -123,14 +123,8 @@ class CompanionRemoteRelayClient(context: Context) {
         }
 
         clearCredential()
-        val response = request(
-            method = "POST",
-            path = "/relay/v1/devices",
-            body = JSONObject().toString(),
-        )
-        require(response.statusCode in 200..299) {
-            "device bootstrap HTTP ${response.statusCode}"
-        }
+        val response = request(method = "POST", path = "/relay/v1/devices", body = JSONObject().toString())
+        require(response.statusCode in 200..299) { "device bootstrap HTTP ${response.statusCode}" }
         val decoded = JSONObject(response.body)
         val deviceId = decoded.optString("deviceId").trim()
         val token = decoded.optString("deviceToken").trim()
@@ -150,6 +144,7 @@ class CompanionRemoteRelayClient(context: Context) {
         val capabilityId = command.optString("capabilityId").trim()
         val expiresAt = command.optLong("expiresAt", 0L)
         if (requestId.length !in 16..86 || expiresAt <= System.currentTimeMillis()) return
+        val arguments = command.optJSONObject("arguments") ?: JSONObject()
 
         val result = when (capabilityId) {
             "health" -> CommandResult(
@@ -161,6 +156,8 @@ class CompanionRemoteRelayClient(context: Context) {
                 ),
             )
             "device.status" -> CommandResult(ok = true, data = deviceStatus())
+            "app.open_known" -> openKnownApp(arguments)
+            "url.open" -> openHttpsUrl(arguments)
             else -> CommandResult(ok = false, code = "unsupported_capability")
         }
 
@@ -180,9 +177,36 @@ class CompanionRemoteRelayClient(context: Context) {
             clearCredential()
             return
         }
-        require(response.statusCode in 200..299) {
-            "result HTTP ${response.statusCode}"
+        require(response.statusCode in 200..299) { "result HTTP ${response.statusCode}" }
+    }
+
+    private fun openKnownApp(arguments: JSONObject): CommandResult {
+        val alias = arguments.optString("alias").trim().lowercase()
+        if (alias !in ALLOWED_APP_ALIASES) return CommandResult(false, "unsupported_app_alias")
+
+        if (alias == "settings") {
+            appContext.startActivity(Intent(Settings.ACTION_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            return CommandResult(true, data = mapOf("opened" to true, "alias" to alias))
         }
+
+        val candidates = KNOWN_APPS[alias] ?: return CommandResult(false, "unsupported_app_alias")
+        for (packageName in candidates) {
+            val intent = appContext.packageManager.getLaunchIntentForPackage(packageName) ?: continue
+            appContext.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            return CommandResult(true, data = mapOf("opened" to true, "alias" to alias))
+        }
+        return CommandResult(false, "app_not_installed", mapOf("alias" to alias))
+    }
+
+    private fun openHttpsUrl(arguments: JSONObject): CommandResult {
+        val raw = arguments.optString("url").trim()
+        if (raw.isEmpty() || raw.length > 2048) return CommandResult(false, "invalid_url")
+        val uri = runCatching { Uri.parse(raw) }.getOrNull() ?: return CommandResult(false, "invalid_url")
+        if (uri.scheme != "https" || !uri.userInfo.isNullOrEmpty() || uri.host.isNullOrBlank()) {
+            return CommandResult(false, "invalid_url")
+        }
+        appContext.startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        return CommandResult(true, data = mapOf("opened" to true))
     }
 
     private fun deviceStatus(): Map<String, Any?> {
@@ -193,6 +217,7 @@ class CompanionRemoteRelayClient(context: Context) {
             "model" to Build.MODEL,
             "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY),
             "bridgeActive" to true,
+            "capabilities" to listOf("health", "device.status", "app.open_known", "url.open"),
         )
     }
 
@@ -269,14 +294,8 @@ class CompanionRemoteRelayClient(context: Context) {
         return if (message.isBlank()) name else "$name: $message"
     }
 
-    private data class DeviceCredential(
-        val deviceId: String,
-        val token: String,
-        val expiresAt: Long,
-    )
-
+    private data class DeviceCredential(val deviceId: String, val token: String, val expiresAt: Long)
     private data class HttpResponse(val statusCode: Int, val body: String)
-
     private data class CommandResult(
         val ok: Boolean,
         val code: String? = null,
@@ -285,6 +304,19 @@ class CompanionRemoteRelayClient(context: Context) {
 
     companion object {
         const val RELAY_BASE_URL = "https://gun-relay-3dvr.fly.dev"
+
+        private val ALLOWED_APP_ALIASES = setOf(
+            "settings", "chatgpt", "maps", "gmail", "chrome", "calendar", "camera", "messages",
+        )
+        private val KNOWN_APPS = mapOf(
+            "chatgpt" to listOf("com.openai.chatgpt"),
+            "maps" to listOf("com.google.android.apps.maps"),
+            "gmail" to listOf("com.google.android.gm"),
+            "chrome" to listOf("com.android.chrome"),
+            "calendar" to listOf("com.google.android.calendar", "com.samsung.android.calendar"),
+            "camera" to listOf("com.sec.android.app.camera", "com.google.android.GoogleCamera"),
+            "messages" to listOf("com.google.android.apps.messaging", "com.samsung.android.messaging", "com.android.mms"),
+        )
 
         private const val DEVICE_ID_KEY = "remote.device_id"
         private const val DEVICE_TOKEN_KEY = "remote.device_token"

--- a/src/device/companion-command-proxy.js
+++ b/src/device/companion-command-proxy.js
@@ -1,8 +1,23 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { verifySignedSeaPayload, resolveSeaAuthMaxAgeMs } from '../auth/sea.js';
 
 const RELAY_BASE_URL = 'https://gun-relay-3dvr.fly.dev';
-export const READ_ONLY_COMPANION_CAPABILITIES = new Set(['health', 'device.status']);
+export const REMOTE_COMPANION_CAPABILITIES = new Set([
+  'health',
+  'device.status',
+  'app.open_known',
+  'url.open',
+]);
+const ALLOWED_APP_ALIASES = new Set([
+  'settings',
+  'chatgpt',
+  'maps',
+  'gmail',
+  'chrome',
+  'calendar',
+  'camera',
+  'messages',
+]);
 const RESULT_TIMEOUT_MS = 10_000;
 const RESULT_POLL_MS = 400;
 const text = (value = '') => String(value || '').trim();
@@ -14,6 +29,40 @@ function requestOrigin(req) {
   const host = forwardedHost || text(req?.headers?.host || req?.headers?.Host);
   const scheme = proto || (host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https');
   return host ? `${scheme}://${host}` : '';
+}
+
+function normalizeArguments(capabilityId, value) {
+  const args = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  if (capabilityId === 'health' || capabilityId === 'device.status') {
+    if (Object.keys(args).length) throw new Error('capability does not accept arguments');
+    return {};
+  }
+  if (capabilityId === 'app.open_known') {
+    const alias = text(args.alias).toLowerCase();
+    if (!ALLOWED_APP_ALIASES.has(alias)) throw new Error('unsupported app alias');
+    return { alias };
+  }
+  if (capabilityId === 'url.open') {
+    const raw = text(args.url);
+    if (!raw || raw.length > 2048) throw new Error('valid https url required');
+    let parsed;
+    try { parsed = new URL(raw); } catch (_error) { throw new Error('valid https url required'); }
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+      throw new Error('valid https url required');
+    }
+    return { url: parsed.toString() };
+  }
+  throw new Error('capability is not enabled for remote invocation');
+}
+
+function argumentDigest(argumentsValue) {
+  const canonical = JSON.stringify(argumentsValue);
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 24);
+}
+
+export function companionSignedAction(mode, capabilityId, argumentsValue = {}) {
+  if (mode === 'devices') return 'devices';
+  return `invoke:${capabilityId}:${argumentDigest(argumentsValue)}`;
 }
 
 async function relayFetch(fetchImpl, token, path, options = {}) {
@@ -51,14 +100,14 @@ function chooseDevice(devices, requestedId) {
   return devices.length === 1 ? devices[0] : null;
 }
 
-async function invoke(fetchImpl, token, deviceId, capabilityId) {
+async function invoke(fetchImpl, token, deviceId, capabilityId, argumentsValue) {
   const queued = await relayFetch(fetchImpl, token, '/relay/v1/commands', {
     method: 'POST',
     body: JSON.stringify({
       requestId: `portal_${randomUUID().replaceAll('-', '')}`,
       deviceId,
       capabilityId,
-      arguments: {},
+      arguments: argumentsValue,
       ttlMs: 15_000,
     }),
   });
@@ -86,7 +135,19 @@ export function createCompanionCommandHandler(options = {}) {
     const body = req.body && typeof req.body === 'object' ? req.body : {};
     const mode = text(body.companionMode || body.commandMode || body.mode || body.action);
     const capabilityId = text(body.capabilityId);
-    const signedAction = mode === 'devices' ? 'devices' : `invoke:${capabilityId}`;
+    if (mode !== 'devices' && mode !== 'invoke') return res.status(400).json({ ok: false, error: 'unsupported mode' });
+    if (mode === 'invoke' && !REMOTE_COMPANION_CAPABILITIES.has(capabilityId)) {
+      return res.status(403).json({ ok: false, error: 'capability is not enabled for remote invocation' });
+    }
+
+    let argumentsValue = {};
+    try {
+      argumentsValue = mode === 'invoke' ? normalizeArguments(capabilityId, body.arguments) : {};
+    } catch (error) {
+      return res.status(400).json({ ok: false, error: error instanceof Error ? error.message : 'invalid arguments' });
+    }
+
+    const signedAction = companionSignedAction(mode, capabilityId, argumentsValue);
     const origin = text(body.origin || requestOrigin(req) || config.PORTAL_ORIGIN);
     const auth = await verifyAuth(body, {
       scope: 'companion-command',
@@ -101,18 +162,15 @@ export function createCompanionCommandHandler(options = {}) {
       },
     });
     if (!auth.ok || auth.identity?.action !== signedAction) {
-      return res.status(401).json({ ok: false, error: auth.reason || 'Companion action proof did not match this request.' });
+      return res.status(401).json({ ok: false, error: auth.reason || 'Companion action proof did not match this exact request.' });
     }
-    if (mode !== 'devices' && mode !== 'invoke') return res.status(400).json({ ok: false, error: 'unsupported mode' });
-    if (mode === 'invoke' && !READ_ONLY_COMPANION_CAPABILITIES.has(capabilityId)) {
-      return res.status(403).json({ ok: false, error: 'capability is not enabled for remote invocation' });
-    }
+
     const oidcToken = text(config.VERCEL_OIDC_TOKEN);
     if (!oidcToken) return res.status(503).json({ ok: false, error: 'Companion workload identity is unavailable' });
 
     try {
       const devices = await activeDevices(fetchImpl, oidcToken);
-      if (mode === 'devices') return res.status(200).json({ ok: true, devices, capabilities: [...READ_ONLY_COMPANION_CAPABILITIES] });
+      if (mode === 'devices') return res.status(200).json({ ok: true, devices, capabilities: [...REMOTE_COMPANION_CAPABILITIES] });
       const device = chooseDevice(devices, body.deviceId);
       if (!device) {
         return res.status(devices.length === 0 ? 503 : 409).json({
@@ -121,7 +179,7 @@ export function createCompanionCommandHandler(options = {}) {
           devices: devices.map(({ deviceId, expiresAt }) => ({ deviceId, expiresAt })),
         });
       }
-      const result = await invoke(fetchImpl, oidcToken, device.deviceId, capabilityId);
+      const result = await invoke(fetchImpl, oidcToken, device.deviceId, capabilityId, argumentsValue);
       return res.status(200).json({
         ok: Boolean(result.commandOk), deviceId: device.deviceId, capabilityId,
         code: result.code || null, data: result.data && typeof result.data === 'object' ? result.data : {},

--- a/tests/companion-command-api.test.js
+++ b/tests/companion-command-api.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createCompanionCommandHandler } from '../src/device/companion-command-proxy.js';
+import {
+  companionSignedAction,
+  createCompanionCommandHandler,
+} from '../src/device/companion-command-proxy.js';
 
 function createResponse() {
   return {
@@ -20,6 +23,8 @@ function mockJsonResponse(status, payload) {
   return { ok: status >= 200 && status < 300, status, async text() { return JSON.stringify(payload); } };
 }
 
+const signed = (capabilityId, args = {}) => companionSignedAction('invoke', capabilityId, args);
+
 test('requires a signed action proof before relay access', async () => {
   let networkCalls = 0;
   const handler = createCompanionCommandHandler({ config: { VERCEL_OIDC_TOKEN: 'oidc-token' }, fetchImpl: async () => { networkCalls += 1; throw new Error('should not call network'); }, verifyAuth: async () => ({ ok: false, reason: 'denied' }) });
@@ -30,18 +35,44 @@ test('requires a signed action proof before relay access', async () => {
 
 test('binds the signed proof to the requested capability', async () => {
   let networkCalls = 0;
-  const handler = createCompanionCommandHandler({ config: { VERCEL_OIDC_TOKEN: 'oidc-token' }, fetchImpl: async () => { networkCalls += 1; throw new Error('should not call network'); }, verifyAuth: acceptedAuth('invoke:health') });
+  const handler = createCompanionCommandHandler({ config: { VERCEL_OIDC_TOKEN: 'oidc-token' }, fetchImpl: async () => { networkCalls += 1; throw new Error('should not call network'); }, verifyAuth: acceptedAuth(signed('health')) });
   const res = createResponse();
   await handler(request({ mode: 'invoke', capabilityId: 'device.status' }), res);
   assert.equal(res.statusCode, 401); assert.equal(networkCalls, 0);
 });
 
-test('rejects mutating capabilities before relay access', async () => {
+test('binds the signed proof to exact remote action arguments', async () => {
   let networkCalls = 0;
-  const handler = createCompanionCommandHandler({ config: { VERCEL_OIDC_TOKEN: 'oidc-token' }, fetchImpl: async () => { networkCalls += 1; throw new Error('should not call network'); }, verifyAuth: acceptedAuth('invoke:ui.perform') });
+  const approvedArgs = { url: 'https://example.com/approved' };
+  const handler = createCompanionCommandHandler({
+    config: { VERCEL_OIDC_TOKEN: 'oidc-token' },
+    fetchImpl: async () => { networkCalls += 1; throw new Error('should not call network'); },
+    verifyAuth: acceptedAuth(signed('url.open', approvedArgs)),
+  });
+  const res = createResponse();
+  await handler(request({ mode: 'invoke', capabilityId: 'url.open', arguments: { url: 'https://example.com/changed' } }), res);
+  assert.equal(res.statusCode, 401); assert.equal(networkCalls, 0);
+});
+
+test('rejects high-risk capabilities before relay access', async () => {
+  let networkCalls = 0;
+  const handler = createCompanionCommandHandler({ config: { VERCEL_OIDC_TOKEN: 'oidc-token' }, fetchImpl: async () => { networkCalls += 1; throw new Error('should not call network'); }, verifyAuth: acceptedAuth('unused') });
   const res = createResponse();
   await handler(request({ mode: 'invoke', capabilityId: 'ui.perform' }), res);
   assert.equal(res.statusCode, 403); assert.equal(networkCalls, 0);
+});
+
+test('rejects arbitrary app aliases and insecure URLs before relay access', async () => {
+  for (const body of [
+    { mode: 'invoke', capabilityId: 'app.open_known', arguments: { alias: 'termux' } },
+    { mode: 'invoke', capabilityId: 'url.open', arguments: { url: 'http://example.com' } },
+  ]) {
+    let networkCalls = 0;
+    const handler = createCompanionCommandHandler({ config: { VERCEL_OIDC_TOKEN: 'oidc-token' }, fetchImpl: async () => { networkCalls += 1; throw new Error('should not call network'); }, verifyAuth: acceptedAuth('unused') });
+    const res = createResponse();
+    await handler(request(body), res);
+    assert.equal(res.statusCode, 400); assert.equal(networkCalls, 0);
+  }
 });
 
 test('requires Vercel workload identity after user authorization', async () => {
@@ -51,23 +82,24 @@ test('requires Vercel workload identity after user authorization', async () => {
   assert.equal(res.statusCode, 503); assert.match(res.body.error, /workload identity/i);
 });
 
-test('lists active Companion devices through the OIDC-authenticated relay', async () => {
+test('lists active Companion devices and admitted capabilities', async () => {
   const calls = [];
   const handler = createCompanionCommandHandler({ config: { VERCEL_OIDC_TOKEN: 'vercel-oidc-secret' }, verifyAuth: acceptedAuth('devices'), fetchImpl: async (url, options) => { calls.push({ url, options }); return mockJsonResponse(200, { ok: true, devices: [{ deviceId: 'device_abcdefghijklmnopqrstuv', expiresAt: 123456 }] }); } });
   const res = createResponse();
   await handler(request({ mode: 'devices' }), res);
-  assert.equal(res.statusCode, 200); assert.equal(res.body.devices.length, 1); assert.deepEqual(res.body.capabilities, ['health', 'device.status']);
+  assert.equal(res.statusCode, 200); assert.equal(res.body.devices.length, 1);
+  assert.deepEqual(res.body.capabilities, ['health', 'device.status', 'app.open_known', 'url.open']);
   assert.equal(calls[0].options.headers.authorization, 'Bearer vercel-oidc-secret'); assert.equal(JSON.stringify(res.body).includes('vercel-oidc-secret'), false);
 });
 
 test('invokes device.status on the sole connected phone and returns the result', async () => {
   const calls = [];
   const handler = createCompanionCommandHandler({
-    config: { VERCEL_OIDC_TOKEN: 'vercel-oidc-secret' }, verifyAuth: acceptedAuth('invoke:device.status'),
+    config: { VERCEL_OIDC_TOKEN: 'vercel-oidc-secret' }, verifyAuth: acceptedAuth(signed('device.status')),
     fetchImpl: async (url, options) => {
       calls.push({ url, options });
       if (url.endsWith('/relay/v1/devices')) return mockJsonResponse(200, { ok: true, devices: [{ deviceId: 'device_abcdefghijklmnopqrstuv', expiresAt: 999999 }] });
-      if (url.endsWith('/relay/v1/commands')) { const body = JSON.parse(options.body); assert.equal(body.deviceId, 'device_abcdefghijklmnopqrstuv'); assert.equal(body.capabilityId, 'device.status'); return mockJsonResponse(201, { ok: true, requestId: body.requestId }); }
+      if (url.endsWith('/relay/v1/commands')) { const body = JSON.parse(options.body); assert.equal(body.deviceId, 'device_abcdefghijklmnopqrstuv'); assert.equal(body.capabilityId, 'device.status'); assert.deepEqual(body.arguments, {}); return mockJsonResponse(201, { ok: true, requestId: body.requestId }); }
       if (url.includes('/relay/v1/results/')) return mockJsonResponse(200, { ok: true, commandOk: true, data: { model: 'SM-F936U1', batteryPercent: 67 }, completedAt: 123456 });
       throw new Error(`unexpected URL ${url}`);
     },
@@ -78,10 +110,26 @@ test('invokes device.status on the sole connected phone and returns the result',
   assert.deepEqual(res.body.data, { model: 'SM-F936U1', batteryPercent: 67 }); assert.equal(calls.length, 3);
 });
 
+test('forwards a normalized known-app action to the relay', async () => {
+  const args = { alias: 'maps' };
+  const handler = createCompanionCommandHandler({
+    config: { VERCEL_OIDC_TOKEN: 'vercel-oidc-secret' }, verifyAuth: acceptedAuth(signed('app.open_known', args)),
+    fetchImpl: async (url, options) => {
+      if (url.endsWith('/relay/v1/devices')) return mockJsonResponse(200, { ok: true, devices: [{ deviceId: 'device_abcdefghijklmnopqrstuv', expiresAt: 999999 }] });
+      if (url.endsWith('/relay/v1/commands')) { const body = JSON.parse(options.body); assert.deepEqual(body.arguments, args); return mockJsonResponse(201, { ok: true, requestId: body.requestId }); }
+      if (url.includes('/relay/v1/results/')) return mockJsonResponse(200, { ok: true, commandOk: true, data: { opened: true, alias: 'maps' }, completedAt: 123456 });
+      throw new Error(`unexpected URL ${url}`);
+    },
+  });
+  const res = createResponse();
+  await handler(request({ mode: 'invoke', capabilityId: 'app.open_known', arguments: args }), res);
+  assert.equal(res.statusCode, 200); assert.equal(res.body.ok, true); assert.equal(res.body.data.alias, 'maps');
+});
+
 test('does not guess when multiple Companion devices are connected', async () => {
   let commandPosted = false;
   const handler = createCompanionCommandHandler({
-    config: { VERCEL_OIDC_TOKEN: 'vercel-oidc-secret' }, verifyAuth: acceptedAuth('invoke:health'),
+    config: { VERCEL_OIDC_TOKEN: 'vercel-oidc-secret' }, verifyAuth: acceptedAuth(signed('health')),
     fetchImpl: async (url) => {
       if (url.endsWith('/relay/v1/devices')) return mockJsonResponse(200, { ok: true, devices: [{ deviceId: 'device_abcdefghijklmnopqrstuv', expiresAt: 1 }, { deviceId: 'device_zyxwvutsrqponmlkjihgfe', expiresAt: 2 }] });
       commandPosted = true; throw new Error('should not enqueue');


### PR DESCRIPTION
## What changed
- expands the canonical direct relay client to execute `app.open_known` and `url.open`
- keeps a fixed local app alias allowlist and clean HTTPS-only URL policy
- returns bounded results without echoing URL contents
- expands the Portal proxy to the same capability set
- binds the SEA proof to the exact normalized action arguments using a digest, preventing replay of an approval for a different URL/app
- adds focused tests for capability blocking, argument validation, exact request binding, and relay forwarding

## Still blocked
`ui.perform`, messages, arbitrary packages, shell, and Shizuku privilege actions are not admitted by this PR.