### PR TITLE
Companion: become an Android assistant

### DIFF
--- a/apps/companion/lib/main.dart
+++ b/apps/companion/lib/main.dart
@@ -36,6 +36,7 @@ class _CompanionHomeState extends State<CompanionHome> {
 
   Map<String, Object?> status = const {};
   Map<String, Object?> permissionState = const {};
+  Map<String, Object?> assistantState = const {};
   bool loading = true;
   String? bridgeError;
   String? persistentToken;
@@ -72,11 +73,7 @@ class _CompanionHomeState extends State<CompanionHome> {
         if (persistentToken == null) {
           throw StateError('Persistent Android bridge token unavailable');
         }
-        if (mounted) {
-          setState(() {
-            bridgeError = null;
-          });
-        }
+        if (mounted) setState(() => bridgeError = null);
         return;
       }
       await localServer.start();
@@ -93,11 +90,13 @@ class _CompanionHomeState extends State<CompanionHome> {
       final values = await Future.wait([
         bridge.getDeviceStatus(),
         bridge.getCapabilityStatus(),
+        if (Platform.isAndroid) bridge.getAssistantStatus() else Future.value(<String, Object?>{}),
       ]);
       if (!mounted) return;
       setState(() {
         status = values[0];
         permissionState = values[1];
+        assistantState = values[2];
         loading = false;
       });
     } catch (error) {
@@ -120,12 +119,27 @@ class _CompanionHomeState extends State<CompanionHome> {
     );
   }
 
+  Future<void> _requestAssistantRole() async {
+    final opened = await bridge.requestAssistantRole();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(opened
+            ? 'Choose 3DVR Companion as your assistant, then return here.'
+            : 'Android assistant role is unavailable on this device.'),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final capabilities = companionCapabilities
         .where((capability) => capability.platforms.contains(currentPlatform))
         .toList(growable: false);
     final endpoint = activeEndpoint;
+    final assistantHeld = assistantState['roleHeld'] == true;
+    final assistantAvailable = assistantState['roleAvailable'] == true;
+    final assistantActive = assistantState['voiceServiceActive'] == true;
 
     return Scaffold(
       appBar: AppBar(
@@ -164,6 +178,58 @@ class _CompanionHomeState extends State<CompanionHome> {
                     ),
             ),
           ),
+          if (Platform.isAndroid) ...[
+            const SizedBox(height: 12),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(assistantActive ? Icons.record_voice_over : Icons.mic_none),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            '3DVR Android assistant',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(assistantHeld
+                        ? '3DVR Companion is selected as the Android assistant.'
+                        : 'Make 3DVR the system assistant so Android can keep the voice interaction service available for hands-free use.'),
+                    const SizedBox(height: 12),
+                    if (assistantAvailable && !assistantHeld)
+                      FilledButton.icon(
+                        onPressed: _requestAssistantRole,
+                        icon: const Icon(Icons.assistant),
+                        label: const Text('Make 3DVR my assistant'),
+                      )
+                    else if (assistantHeld)
+                      const Row(
+                        children: [
+                          Icon(Icons.check_circle_outline),
+                          SizedBox(width: 8),
+                          Text('Assistant role enabled'),
+                        ],
+                      )
+                    else
+                      FilledButton.tonal(
+                        onPressed: bridge.openVoiceInputSettings,
+                        child: const Text('Open voice input settings'),
+                      ),
+                    const SizedBox(height: 8),
+                    Text('Voice service active: $assistantActive'),
+                    Text('Session service ready: ${assistantState['serviceReady'] == true}'),
+                  ],
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: 12),
           Card(
             child: Padding(

--- a/apps/companion/lib/src/platform_bridge.dart
+++ b/apps/companion/lib/src/platform_bridge.dart
@@ -58,6 +58,21 @@ class CompanionPlatformBridge {
     return result ?? const {};
   }
 
+  Future<Map<String, Object?>> getAssistantStatus() async {
+    final result = await _channel.invokeMapMethod<String, Object?>('assistantStatus');
+    return result ?? const {};
+  }
+
+  Future<bool> requestAssistantRole() async {
+    final result = await _channel.invokeMethod<bool>('requestAssistantRole');
+    return result ?? false;
+  }
+
+  Future<bool> openVoiceInputSettings() async {
+    final result = await _channel.invokeMethod<bool>('openVoiceInputSettings');
+    return result ?? false;
+  }
+
   Future<bool> openAccessibilitySettings() async {
     final result = await _channel.invokeMethod<bool>('openAccessibilitySettings');
     return result ?? false;

--- a/apps/companion/native-spec/android/CompanionVoiceInteractionService.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceInteractionService.kt
@@ -1,0 +1,31 @@
+package tech.threedvr.companion
+
+import android.os.Bundle
+import android.service.voice.VoiceInteractionService
+
+object CompanionAssistantState {
+    @Volatile var serviceReady: Boolean = false
+    @Volatile var lastSessionPreparedAt: Long? = null
+}
+
+/**
+ * Lightweight system-owned entry point for 3DVR as the selected Android assistant.
+ * Heavy audio/model work belongs in the session layer rather than this always-on
+ * service.
+ */
+class CompanionVoiceInteractionService : VoiceInteractionService() {
+    override fun onReady() {
+        super.onReady()
+        CompanionAssistantState.serviceReady = true
+    }
+
+    override fun onPrepareToShowSession(args: Bundle, flags: Int) {
+        CompanionAssistantState.lastSessionPreparedAt = System.currentTimeMillis()
+        super.onPrepareToShowSession(args, flags)
+    }
+
+    override fun onShutdown() {
+        CompanionAssistantState.serviceReady = false
+        super.onShutdown()
+    }
+}

--- a/apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt
@@ -1,0 +1,71 @@
+package tech.threedvr.companion
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Typeface
+import android.os.Bundle
+import android.service.voice.VoiceInteractionSession
+import android.view.Gravity
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+
+/**
+ * Minimal native assistant surface. This establishes the Android assistant/session
+ * contract now; realtime speech is connected in the next slice.
+ */
+class CompanionVoiceInteractionSession(
+    private val sessionContext: Context,
+) : VoiceInteractionSession(sessionContext) {
+
+    override fun onCreateContentView(): View {
+        val density = sessionContext.resources.displayMetrics.density
+        fun dp(value: Int): Int = (value * density).toInt()
+
+        return LinearLayout(sessionContext).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            setPadding(dp(24), dp(24), dp(24), dp(24))
+
+            addView(TextView(sessionContext).apply {
+                text = "3DVR"
+                textSize = 26f
+                setTypeface(typeface, Typeface.BOLD)
+            })
+            addView(TextView(sessionContext).apply {
+                text = "Assistant session ready"
+                textSize = 16f
+                setPadding(0, dp(8), 0, dp(16))
+            })
+            addView(TextView(sessionContext).apply {
+                text = "Voice conversation and device tools will run here."
+                textSize = 14f
+                gravity = Gravity.CENTER
+            })
+            addView(Button(sessionContext).apply {
+                text = "Open 3DVR Companion"
+                setOnClickListener {
+                    val intent = sessionContext.packageManager
+                        .getLaunchIntentForPackage(sessionContext.packageName)
+                        ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    if (intent != null) sessionContext.startActivity(intent)
+                }
+            }, LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply { topMargin = dp(16) })
+        }
+    }
+
+    override fun onShow(args: Bundle?, showFlags: Int) {
+        CompanionAssistantState.lastSessionPreparedAt = System.currentTimeMillis()
+        setKeepAwake(true)
+        super.onShow(args, showFlags)
+    }
+
+    override fun onHide() {
+        setKeepAwake(false)
+        super.onHide()
+    }
+}

--- a/apps/companion/native-spec/android/CompanionVoiceInteractionSessionService.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceInteractionSessionService.kt
@@ -1,0 +1,10 @@
+package tech.threedvr.companion
+
+import android.os.Bundle
+import android.service.voice.VoiceInteractionSession
+import android.service.voice.VoiceInteractionSessionService
+
+class CompanionVoiceInteractionSessionService : VoiceInteractionSessionService() {
+    override fun onNewSession(args: Bundle?): VoiceInteractionSession =
+        CompanionVoiceInteractionSession(this)
+}

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -1,11 +1,14 @@
 package tech.threedvr.companion
 
+import android.app.role.RoleManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.BatteryManager
 import android.os.Build
 import android.provider.Settings
+import android.service.voice.VoiceInteractionService
 import android.util.Base64
 import android.view.accessibility.AccessibilityManager
 import io.flutter.embedding.android.FlutterActivity
@@ -63,6 +66,12 @@ class MainActivity : FlutterActivity() {
                 when (call.method) {
                     "deviceStatus" -> result.success(deviceStatus())
                     "capabilityStatus" -> result.success(capabilityStatus())
+                    "assistantStatus" -> result.success(assistantStatus())
+                    "requestAssistantRole" -> result.success(requestAssistantRole())
+                    "openVoiceInputSettings" -> {
+                        startActivity(Intent(Settings.ACTION_VOICE_INPUT_SETTINGS))
+                        result.success(true)
+                    }
                     "bridgeToken" -> result.success(getOrCreateBridgeToken())
                     "notificationMetadata" -> result.success(NotificationMetadataStore.snapshot())
                     "messageNotifications" -> {
@@ -112,6 +121,38 @@ class MainActivity : FlutterActivity() {
         return created
     }
 
+    private fun assistantStatus(): Map<String, Any?> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return mapOf(
+                "roleAvailable" to false,
+                "roleHeld" to false,
+                "voiceServiceActive" to false,
+                "serviceReady" to false,
+            )
+        }
+        val roleManager = getSystemService(RoleManager::class.java)
+        val component = ComponentName(this, CompanionVoiceInteractionService::class.java)
+        return mapOf(
+            "roleAvailable" to roleManager.isRoleAvailable(RoleManager.ROLE_ASSISTANT),
+            "roleHeld" to roleManager.isRoleHeld(RoleManager.ROLE_ASSISTANT),
+            "voiceServiceActive" to VoiceInteractionService.isActiveService(this, component),
+            "serviceReady" to CompanionAssistantState.serviceReady,
+            "lastSessionPreparedAt" to CompanionAssistantState.lastSessionPreparedAt,
+        )
+    }
+
+    private fun requestAssistantRole(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return false
+        val roleManager = getSystemService(RoleManager::class.java)
+        if (!roleManager.isRoleAvailable(RoleManager.ROLE_ASSISTANT)) return false
+        if (roleManager.isRoleHeld(RoleManager.ROLE_ASSISTANT)) return true
+        startActivityForResult(
+            roleManager.createRequestRoleIntent(RoleManager.ROLE_ASSISTANT),
+            ASSISTANT_ROLE_REQUEST_CODE,
+        )
+        return true
+    }
+
     private fun deviceStatus(): Map<String, Any?> {
         val battery = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
         return mapOf(
@@ -125,20 +166,26 @@ class MainActivity : FlutterActivity() {
         )
     }
 
-    private fun capabilityStatus(): Map<String, Any> = mapOf(
-        "accessibilityEnabled" to isAccessibilityEnabled(),
-        "notificationAccessEnabled" to isNotificationAccessEnabled(),
-        "messageNotificationReadEnabled" to isNotificationAccessEnabled(),
-        "messageNotificationReplyEnabled" to isNotificationAccessEnabled(),
-        "messageHistoryEncryptedAtRest" to true,
-        "backgroundBridgeEnabled" to true,
-        "knownAppLaunchEnabled" to true,
-        "remoteKnownActionsEnabled" to false,
-        "persistentPairingEnabled" to true,
-        "relayCredentialsEncryptedAtRest" to true,
-        "directRelayEnabled" to true,
-        "directRelayReadOnly" to true,
-    )
+    private fun capabilityStatus(): Map<String, Any> {
+        val assistant = assistantStatus()
+        return mapOf(
+            "accessibilityEnabled" to isAccessibilityEnabled(),
+            "notificationAccessEnabled" to isNotificationAccessEnabled(),
+            "messageNotificationReadEnabled" to isNotificationAccessEnabled(),
+            "messageNotificationReplyEnabled" to isNotificationAccessEnabled(),
+            "messageHistoryEncryptedAtRest" to true,
+            "backgroundBridgeEnabled" to true,
+            "knownAppLaunchEnabled" to true,
+            "remoteKnownActionsEnabled" to false,
+            "persistentPairingEnabled" to true,
+            "relayCredentialsEncryptedAtRest" to true,
+            "directRelayEnabled" to true,
+            "directRelayReadOnly" to true,
+            "assistantRoleAvailable" to (assistant["roleAvailable"] == true),
+            "assistantRoleHeld" to (assistant["roleHeld"] == true),
+            "voiceInteractionServiceActive" to (assistant["voiceServiceActive"] == true),
+        )
+    }
 
     private fun openHttpUrl(raw: String): Boolean {
         val uri = runCatching { Uri.parse(raw) }.getOrNull() ?: return false
@@ -173,5 +220,9 @@ class MainActivity : FlutterActivity() {
     private fun isNotificationAccessEnabled(): Boolean {
         val enabled = Settings.Secure.getString(contentResolver, "enabled_notification_listeners") ?: return false
         return enabled.split(':').any { component -> component.startsWith("$packageName/") }
+    }
+
+    companion object {
+        private const val ASSISTANT_ROLE_REQUEST_CODE = 38474
     }
 }

--- a/apps/companion/native-spec/android/companion_voice_interaction_service.xml
+++ b/apps/companion/native-spec/android/companion_voice_interaction_service.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<voice-interaction-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:sessionService="tech.threedvr.companion.CompanionVoiceInteractionSessionService"
+    android:supportsAssist="true"
+    android:supportsLaunchVoiceAssistFromKeyguard="false"
+    android:supportsLocalInteraction="true" />

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -24,10 +24,11 @@ cp "$BACKUP/analysis_options.yaml" analysis_options.yaml
 
 KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
 mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
-for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt; do
+for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt CompanionVoiceInteractionService.kt CompanionVoiceInteractionSessionService.kt CompanionVoiceInteractionSession.kt; do
   cp "native-spec/android/$source" "$KOTLIN_DIR/$source"
 done
 cp native-spec/android/companion_accessibility_service.xml android/app/src/main/res/xml/companion_accessibility_service.xml
+cp native-spec/android/companion_voice_interaction_service.xml android/app/src/main/res/xml/companion_voice_interaction_service.xml
 
 cat > android/app/src/main/res/xml/companion_network_security_config.xml <<'XML'
 <?xml version="1.0" encoding="utf-8"?>
@@ -46,7 +47,7 @@ import plistlib
 import xml.etree.ElementTree as ET
 ANDROID='http://schemas.android.com/apk/res/android'; ET.register_namespace('android',ANDROID); a=lambda n:f'{{{ANDROID}}}{n}'
 manifest_path=Path('android/app/src/main/AndroidManifest.xml'); tree=ET.parse(manifest_path); root=tree.getroot()
-permissions=['android.permission.INTERNET','android.permission.FOREGROUND_SERVICE','android.permission.FOREGROUND_SERVICE_SPECIAL_USE','android.permission.POST_NOTIFICATIONS','android.permission.RECEIVE_BOOT_COMPLETED','android.permission.REQUEST_INSTALL_PACKAGES','android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION']
+permissions=['android.permission.INTERNET','android.permission.RECORD_AUDIO','android.permission.FOREGROUND_SERVICE','android.permission.FOREGROUND_SERVICE_SPECIAL_USE','android.permission.POST_NOTIFICATIONS','android.permission.RECEIVE_BOOT_COMPLETED','android.permission.REQUEST_INSTALL_PACKAGES','android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION']
 existing={n.get(a('name')) for n in root.findall('uses-permission')}
 for p in reversed(permissions):
     if p not in existing: root.insert(0,ET.Element('uses-permission',{a('name'):p}))
@@ -60,11 +61,14 @@ known={'com.openai.chatgpt','com.google.android.apps.maps','com.google.android.g
 existing_q={n.get(a('name')) for n in queries.findall('package')}
 for p in sorted(known):
     if p not in existing_q: ET.SubElement(queries,'package',{a('name'):p})
+if not any(i.find('action') is not None and i.find('action').get(a('name'))=='android.speech.RecognitionService' for i in queries.findall('intent')):
+    intent=ET.SubElement(queries,'intent'); ET.SubElement(intent,'action',{a('name'):'android.speech.RecognitionService'})
 app=root.find('application')
 if app is None: raise SystemExit('AndroidManifest.xml has no <application>')
 app.set(a('label'),'3DVR Companion'); app.set(a('networkSecurityConfig'),'@xml/companion_network_security_config')
+managed_services={'.CompanionAccessibilityService','.CompanionNotificationListener','.CompanionKeepAliveService','.CompanionVoiceInteractionService','.CompanionVoiceInteractionSessionService'}
 for service in list(app.findall('service')):
-    if service.get(a('name')) in {'.CompanionAccessibilityService','.CompanionNotificationListener','.CompanionKeepAliveService'}: app.remove(service)
+    if service.get(a('name')) in managed_services: app.remove(service)
 for receiver in list(app.findall('receiver')):
     if receiver.get(a('name')) in {'.CompanionStartupReceiver','.CompanionInstallResultReceiver'}: app.remove(receiver)
 for provider in list(app.findall('provider')):
@@ -74,6 +78,9 @@ access=ET.SubElement(app,'service',{a('name'):'.CompanionAccessibilityService',a
 f=ET.SubElement(access,'intent-filter'); ET.SubElement(f,'action',{a('name'):'android.accessibilityservice.AccessibilityService'}); ET.SubElement(access,'meta-data',{a('name'):'android.accessibilityservice',a('resource'):'@xml/companion_accessibility_service'})
 notification=ET.SubElement(app,'service',{a('name'):'.CompanionNotificationListener',a('permission'):'android.permission.BIND_NOTIFICATION_LISTENER_SERVICE',a('exported'):'false',a('label'):'3DVR Companion notifications'}); nf=ET.SubElement(notification,'intent-filter'); ET.SubElement(nf,'action',{a('name'):'android.service.notification.NotificationListenerService'})
 keep=ET.SubElement(app,'service',{a('name'):'.CompanionKeepAliveService',a('exported'):'false',a('foregroundServiceType'):'specialUse',a('stopWithTask'):'false'}); ET.SubElement(keep,'property',{a('name'):'android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE',a('value'):'Keeps the user-enabled local and authenticated remote 3DVR Companion bridges reachable while the app is backgrounded.'})
+voice=ET.SubElement(app,'service',{a('name'):'.CompanionVoiceInteractionService',a('label'):'3DVR Assistant',a('permission'):'android.permission.BIND_VOICE_INTERACTION',a('exported'):'true',a('process'):':assistant'})
+vf=ET.SubElement(voice,'intent-filter'); ET.SubElement(vf,'action',{a('name'):'android.service.voice.VoiceInteractionService'}); ET.SubElement(voice,'meta-data',{a('name'):'android.voice_interaction',a('resource'):'@xml/companion_voice_interaction_service'})
+ET.SubElement(app,'service',{a('name'):'.CompanionVoiceInteractionSessionService',a('permission'):'android.permission.BIND_VOICE_INTERACTION',a('exported'):'true',a('process'):':assistant_session'})
 startup=ET.SubElement(app,'receiver',{a('name'):'.CompanionStartupReceiver',a('enabled'):'true',a('exported'):'false'}); sf=ET.SubElement(startup,'intent-filter')
 for action in ('android.intent.action.BOOT_COMPLETED','android.intent.action.MY_PACKAGE_REPLACED'): ET.SubElement(sf,'action',{a('name'):action})
 ET.SubElement(app,'receiver',{a('name'):'.CompanionInstallResultReceiver',a('enabled'):'true',a('exported'):'false'})
@@ -110,5 +117,6 @@ echo "Android boot/package-replace recovery: wired"
 echo "Android self-update loopback: wired"
 echo "Android Shizuku/Sui privilege provider: wired"
 echo "Android relay credentials: Keystore-encrypted at rest"
-echo "Android direct relay: always-on read-only client wired"
+echo "Android direct relay: always-on client wired"
+echo "Android assistant role + VoiceInteractionService: wired"
 echo "iOS App Intent: staged in ios/CompanionNativeSpec (Xcode target wiring still required)"


### PR DESCRIPTION
## What changed
- adds a native `VoiceInteractionService`, `VoiceInteractionSessionService`, and minimal assistant session surface
- wires the services into the generated Android manifest using `BIND_VOICE_INTERACTION`
- adds the Android Assistant role request/status path to the existing Companion platform bridge
- adds a dashboard card to make 3DVR the selected Android assistant
- stages microphone permission and speech-recognition service visibility for the next realtime voice slice
- keeps the always-running interaction service lightweight and puts session UI in a separate process

## Why
This gives “Hey 3DVR” an OS-native Android assistant foundation rather than relying on a permanent foreground microphone service.

## Scope
This PR establishes assistant selection/session plumbing. It does not yet implement wake-word detection or OpenAI Realtime audio; those come after the assistant role compiles and runs on-device.