### PR TITLE
Companion: add one-time phone proof for Realtime voice

### DIFF
--- a/apps/companion/lib/src/platform_bridge.dart
+++ b/apps/companion/lib/src/platform_bridge.dart
@@ -63,6 +63,11 @@ class CompanionPlatformBridge {
     return result ?? const {};
   }
 
+  Future<Map<String, Object?>> beginVoiceAuthorization() async {
+    final result = await _channel.invokeMapMethod<String, Object?>('beginVoiceAuthorization');
+    return result ?? const {};
+  }
+
   Future<bool> requestAssistantRole() async {
     final result = await _channel.invokeMethod<bool>('requestAssistantRole');
     return result ?? false;

--- a/apps/companion/native-spec/android/CompanionRemoteRelayClient.kt
+++ b/apps/companion/native-spec/android/CompanionRemoteRelayClient.kt
@@ -38,14 +38,16 @@ object CompanionRemoteRelayState {
  * Owns Companion's direct relay from the always-on foreground service.
  *
  * Remote execution is deliberately capability-based rather than a shell. The
- * currently admitted set is health, device.status, app.open_known, and url.open.
- * App aliases are fixed locally and remote URLs must be clean HTTPS URLs.
+ * user-facing admitted set is health, device.status, app.open_known, and
+ * url.open. `voice.authorize` is an internal one-time proof-of-possession
+ * challenge used only to bootstrap a locally initiated Realtime voice session.
  * Accessibility, messages, arbitrary packages, Shizuku actions, and shell
  * execution remain outside this direct-relay surface.
  */
 class CompanionRemoteRelayClient(context: Context) {
     private val appContext = context.applicationContext
     private val secretStore = CompanionRelaySecretStore(appContext)
+    private val voiceAuthorizationStore = CompanionVoiceAuthorizationStore(appContext)
     private val executor = Executors.newSingleThreadExecutor()
     private val running = AtomicBoolean(false)
 
@@ -158,6 +160,7 @@ class CompanionRemoteRelayClient(context: Context) {
             "device.status" -> CommandResult(ok = true, data = deviceStatus())
             "app.open_known" -> openKnownApp(arguments)
             "url.open" -> openHttpsUrl(arguments)
+            "voice.authorize" -> authorizeVoice(arguments)
             else -> CommandResult(ok = false, code = "unsupported_capability")
         }
 
@@ -178,6 +181,19 @@ class CompanionRemoteRelayClient(context: Context) {
             return
         }
         require(response.statusCode in 200..299) { "result HTTP ${response.statusCode}" }
+    }
+
+    private fun authorizeVoice(arguments: JSONObject): CommandResult {
+        val nonce = arguments.optString("nonce").trim()
+        if (!VOICE_NONCE_RE.matches(nonce)) {
+            return CommandResult(false, "invalid_voice_nonce")
+        }
+        val authorized = voiceAuthorizationStore.consume(nonce)
+        return if (authorized) {
+            CommandResult(true, data = mapOf("authorized" to true))
+        } else {
+            CommandResult(false, "voice_authorization_rejected")
+        }
     }
 
     private fun openKnownApp(arguments: JSONObject): CommandResult {
@@ -305,6 +321,7 @@ class CompanionRemoteRelayClient(context: Context) {
     companion object {
         const val RELAY_BASE_URL = "https://gun-relay-3dvr.fly.dev"
 
+        private val VOICE_NONCE_RE = Regex("^[A-Za-z0-9_-]{24,128}$")
         private val ALLOWED_APP_ALIASES = setOf(
             "settings", "chatgpt", "maps", "gmail", "chrome", "calendar", "camera", "messages",
         )

--- a/apps/companion/native-spec/android/CompanionVoiceAuthorizationStore.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceAuthorizationStore.kt
@@ -1,0 +1,66 @@
+package tech.threedvr.companion
+
+import android.content.Context
+import android.util.Base64
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+/**
+ * One-use proof that a Realtime voice session was initiated locally on this phone.
+ *
+ * The opaque nonce may cross the Flutter/Portal boundary, but the relay bearer
+ * credential never does. A matching relay challenge consumes the nonce.
+ */
+class CompanionVoiceAuthorizationStore(context: Context) {
+    private val appContext = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun issue(now: Long = System.currentTimeMillis()): VoiceAuthorization {
+        val bytes = ByteArray(24)
+        SecureRandom().nextBytes(bytes)
+        val nonce = Base64.encodeToString(
+            bytes,
+            Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING,
+        )
+        val expiresAt = now + TTL_MS
+        prefs.edit()
+            .putString(KEY_NONCE, nonce)
+            .putLong(KEY_EXPIRES_AT, expiresAt)
+            .apply()
+        return VoiceAuthorization(nonce, expiresAt)
+    }
+
+    fun consume(candidate: String, now: Long = System.currentTimeMillis()): Boolean {
+        val expected = prefs.getString(KEY_NONCE, null)
+        val expiresAt = prefs.getLong(KEY_EXPIRES_AT, 0L)
+        if (expected.isNullOrBlank() || expiresAt <= now) {
+            clear()
+            return false
+        }
+        if (!secureEquals(expected, candidate)) return false
+        clear()
+        return true
+    }
+
+    fun clear() {
+        prefs.edit().remove(KEY_NONCE).remove(KEY_EXPIRES_AT).apply()
+    }
+
+    private fun secureEquals(left: String, right: String): Boolean {
+        val leftBytes = left.toByteArray(Charsets.UTF_8)
+        val rightBytes = right.toByteArray(Charsets.UTF_8)
+        return MessageDigest.isEqual(leftBytes, rightBytes)
+    }
+
+    data class VoiceAuthorization(
+        val nonce: String,
+        val expiresAt: Long,
+    )
+
+    companion object {
+        private const val PREFS_NAME = "companion_voice_authorization"
+        private const val KEY_NONCE = "pending_nonce"
+        private const val KEY_EXPIRES_AT = "pending_expires_at"
+        const val TTL_MS = 30_000L
+    }
+}

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -37,6 +37,7 @@ class MainActivity : FlutterActivity() {
         startKeepAliveService()
         MessageNotificationStore.initialize(this)
         val relaySecretStore = CompanionRelaySecretStore(this)
+        val voiceAuthorizationStore = CompanionVoiceAuthorizationStore(this)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, relaySecretsChannelName)
             .setMethodCallHandler { call, result ->
                 val key = call.argument<String>("key")?.trim().orEmpty()
@@ -68,6 +69,7 @@ class MainActivity : FlutterActivity() {
                     "capabilityStatus" -> result.success(capabilityStatus())
                     "assistantStatus" -> result.success(assistantStatus())
                     "requestAssistantRole" -> result.success(requestAssistantRole())
+                    "beginVoiceAuthorization" -> result.success(beginVoiceAuthorization(voiceAuthorizationStore))
                     "openVoiceInputSettings" -> {
                         startActivity(Intent(Settings.ACTION_VOICE_INPUT_SETTINGS))
                         result.success(true)
@@ -119,6 +121,26 @@ class MainActivity : FlutterActivity() {
         val created = Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
         prefs.edit().putString(bridgeTokenKey, created).apply()
         return created
+    }
+
+    private fun beginVoiceAuthorization(
+        store: CompanionVoiceAuthorizationStore,
+    ): Map<String, Any?> {
+        val deviceId = CompanionRemoteRelayState.deviceId
+        if (CompanionRemoteRelayState.status != "connected" || deviceId.isNullOrBlank()) {
+            store.clear()
+            return mapOf(
+                "ok" to false,
+                "error" to "direct relay is not connected",
+            )
+        }
+        val authorization = store.issue()
+        return mapOf(
+            "ok" to true,
+            "deviceId" to deviceId,
+            "nonce" to authorization.nonce,
+            "expiresAt" to authorization.expiresAt,
+        )
     }
 
     private fun assistantStatus(): Map<String, Any?> {
@@ -176,11 +198,12 @@ class MainActivity : FlutterActivity() {
             "messageHistoryEncryptedAtRest" to true,
             "backgroundBridgeEnabled" to true,
             "knownAppLaunchEnabled" to true,
-            "remoteKnownActionsEnabled" to false,
+            "remoteKnownActionsEnabled" to true,
             "persistentPairingEnabled" to true,
             "relayCredentialsEncryptedAtRest" to true,
             "directRelayEnabled" to true,
-            "directRelayReadOnly" to true,
+            "directRelayReadOnly" to false,
+            "voiceProofEnabled" to true,
             "assistantRoleAvailable" to (assistant["roleAvailable"] == true),
             "assistantRoleHeld" to (assistant["roleHeld"] == true),
             "voiceInteractionServiceActive" to (assistant["voiceServiceActive"] == true),

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -24,7 +24,7 @@ cp "$BACKUP/analysis_options.yaml" analysis_options.yaml
 
 KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
 mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
-for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt CompanionVoiceInteractionService.kt CompanionVoiceInteractionSessionService.kt CompanionVoiceInteractionSession.kt; do
+for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt CompanionVoiceAuthorizationStore.kt CompanionVoiceInteractionService.kt CompanionVoiceInteractionSessionService.kt CompanionVoiceInteractionSession.kt; do
   cp "native-spec/android/$source" "$KOTLIN_DIR/$source"
 done
 cp native-spec/android/companion_accessibility_service.xml android/app/src/main/res/xml/companion_accessibility_service.xml
@@ -118,5 +118,6 @@ echo "Android self-update loopback: wired"
 echo "Android Shizuku/Sui privilege provider: wired"
 echo "Android relay credentials: Keystore-encrypted at rest"
 echo "Android direct relay: always-on client wired"
+echo "Android one-time voice proof: wired"
 echo "Android assistant role + VoiceInteractionService: wired"
 echo "iOS App Intent: staged in ios/CompanionNativeSpec (Xcode target wiring still required)"


### PR DESCRIPTION
## What changed
- adds a 30-second one-use native voice authorization nonce store
- exposes only the opaque nonce + device id to Flutter; the relay bearer remains in Android secure storage
- consumes the nonce only when the authenticated direct relay returns a matching `voice.authorize` challenge
- adds `beginVoiceAuthorization` to the platform bridge
- fixes dashboard capability truth: remote known actions are enabled and the direct relay is no longer read-only
- wires the new native store into generated Android builds

## Security
The nonce is one-use, short-lived, generated with `SecureRandom`, and compared with `MessageDigest.isEqual`. Mismatched challenges do not consume the valid pending nonce. Successful relay results report only `authorized: true`, not the nonce.