### PR TITLE
Make the free website offer actually free and live

### DIFF
--- a/free-page/app.js
+++ b/free-page/app.js
@@ -82,14 +82,11 @@ function putGun(node, payload) {
 }
 
 async function saveBriefToCrm(formData) {
-  const name = valueFor(formData, 'name', 'New business launch lead');
+  const name = valueFor(formData, 'name', 'New free website lead');
   const leadEmail = valueFor(formData, 'email', '');
-  const offer = valueFor(formData, 'offer', 'Needs a clear first website.');
-  const audience = valueFor(formData, 'audience', 'Not specified');
-  const action = valueFor(formData, 'action', 'Contact me');
-  const contact = valueFor(formData, 'contact', 'Will provide contact link.');
+  const offer = valueFor(formData, 'offer', 'Needs a simple first website.');
   const now = new Date().toISOString();
-  const id = `lead-free-page-${slug(leadEmail || name)}`;
+  const id = `lead-free-site-${slug(leadEmail || name)}`;
   const record = {
     id,
     recordType: 'person',
@@ -97,29 +94,29 @@ async function saveBriefToCrm(formData) {
     email: leadEmail,
     company: name,
     role: 'Founder / operator',
-    tags: ['free-page', 'homepage-concept', 'inbound'],
+    tags: ['free-site', 'inbound', 'automated-build'],
     status: 'new',
     warmth: 'warm',
     source: 'free-page',
-    offerAmount: '$300 Starter Microsite; ongoing support available',
-    nextBestAction: 'Review the brief and prepare the personalized homepage concept.',
+    offerAmount: 'Free one-page site on a 3DVR-hosted address; optional paid upgrades',
+    nextBestAction: 'Build and publish the smallest useful one-page website, then email the live URL.',
     nextFollowUp: now.slice(0, 10),
     activityCount: 1,
     created: now,
     updated: now,
-    notes: [`Inbound free-page brief`, `Offer/project: ${offer}`, `Audience: ${audience}`, `Main action: ${action}`, `Best contact link: ${contact}`].join('\n')
+    notes: [`Inbound free website request`, `Offer/project: ${offer}`].join('\n')
   };
   const touch = {
-    id: `touch-free-page-${slug(leadEmail || name)}-${Date.now()}`,
+    id: `touch-free-site-${slug(leadEmail || name)}-${Date.now()}`,
     recordId: id,
     contactName: name,
     contactEmail: leadEmail,
     type: 'inbound',
     channel: 'free-page',
     source: 'free-page',
-    summary: 'Inbound request for a free personalized homepage concept.',
-    outcome: 'Lead captured; concept requested.',
-    message: JSON.stringify({ name, email: leadEmail, offer, audience, action, contact }),
+    summary: 'Inbound request for a free live 3DVR-hosted website.',
+    outcome: 'Lead captured for automated build and email delivery.',
+    message: JSON.stringify({ name, email: leadEmail, offer }),
     created: now,
     updated: now
   };
@@ -131,25 +128,23 @@ async function saveBriefToCrm(formData) {
 }
 
 function buildMailto(formData) {
-  const name = valueFor(formData, 'name', 'A new 3DVR page');
-  const offer = valueFor(formData, 'offer', 'I want a clearer homepage concept for my business.');
-  const audience = valueFor(formData, 'audience', 'People who might hire, book, buy, or understand this.');
-  const action = valueFor(formData, 'action', 'Contact me');
-  const contact = valueFor(formData, 'contact', 'I will send the best contact link next.');
+  const name = valueFor(formData, 'name', 'A new 3DVR website');
+  const offer = valueFor(formData, 'offer', 'I need a simple website that explains what I do and how to contact me.');
   const leadEmail = valueFor(formData, 'email', '');
 
-  const subject = `Free homepage concept for ${name}`;
+  const subject = `Free 3DVR website request — ${name}`;
   const body = [
-    'I want a free personalized homepage concept.',
+    'I want a free live one-page website on a 3DVR-hosted address.',
     '',
     `Name/business: ${name}`,
-    `Offer/project: ${offer}`,
-    `Audience: ${audience}`,
-    `Main action button: ${action}`,
-    `Best contact link: ${contact}`,
-    `Best email for reply: ${leadEmail}`,
+    `Best email for the live link: ${leadEmail}`,
     '',
-    'If the direction works, I am open to finishing and publishing the page.'
+    'What the website should explain:',
+    offer,
+    '',
+    'Please build the smallest useful version and email me the live URL.',
+    '',
+    'Optional: I can reply with my current website, social profile, logo, photos, phone number, booking link, or other details if needed.'
   ].join('\n');
 
   return `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
@@ -158,7 +153,7 @@ function buildMailto(formData) {
 function trackLeadIntent() {
   if (typeof window.gtag === 'function') {
     window.gtag('event', 'generate_lead', {
-      method: 'mailto_brief'
+      method: 'free_live_site_email'
     });
   }
   return trackFirstPartyEvent('generate_lead');
@@ -168,8 +163,8 @@ trackFirstPartyEvent('page_view');
 
 shareButton?.addEventListener('click', async () => {
   const shareData = {
-    title: 'A free homepage concept from 3DVR',
-    text: 'Make your local business easier to understand and contact with a free homepage concept.',
+    title: 'Get a free live website from 3DVR',
+    text: '3DVR will build a simple one-page site, publish it on a 3DVR-hosted address, and email you the live link for free.',
     url: shareUrl
   };
   try {
@@ -200,7 +195,7 @@ if (form && mailtoLink && handoffCopy) {
     const formData = new FormData(form);
     const href = buildMailto(formData);
     mailtoLink.href = href;
-    handoffCopy.textContent = 'Your brief is saved to our follow-up desk. Review the email and send it to request your private preview.';
+    handoffCopy.textContent = 'Your request is in the 3DVR follow-up desk. Send the prepared email so the automated build queue can return a live site link.';
     await Promise.race([
       saveBriefToCrm(formData),
       trackLeadIntent(),

--- a/free-page/index.html
+++ b/free-page/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Get a clearer homepage concept | 3DVR</title>
-  <meta name="description" content="Get a personalized homepage concept for your local business at no cost, then finish and publish it when the direction feels right.">
+  <title>Get a free live website | 3DVR</title>
+  <meta name="description" content="Tell 3DVR what your business does and get a simple one-page website published free on a 3DVR-hosted address, with no card required.">
   <link rel="canonical" href="https://portal.3dvr.tech/free-page/">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-96XRKQ5L65"></script>
   <script>
@@ -27,56 +27,80 @@
       <span class="brand-mark">3D</span>
       <span>3DVR</span>
     </a>
-    <nav aria-label="Free page navigation">
-      <a href="../new-business-launch/">How it works</a>
-      <a href="#examples">Examples</a>
+    <nav aria-label="Free website navigation">
+      <a href="#how">How it works</a>
+      <a href="#examples">What you get</a>
       <a href="#brief">Start</a>
-      <a class="nav-pill" href="../billing/?plan=starter">Keep it live</a>
+      <a class="nav-pill" href="../billing/?plan=starter">Optional support</a>
     </nav>
   </header>
 
   <main>
     <section class="hero">
       <div class="hero-copy">
-        <p class="eyebrow">For local businesses with a page that could work harder</p>
-        <h1>Get a clearer homepage concept for free.</h1>
-        <p class="lead">Tell me what your business does. I’ll shape a simple homepage direction that makes your service, trust, and next step easier to understand. If it helps, I can finish and publish it for you.</p>
+        <p class="eyebrow">A real website, not a mockup</p>
+        <h1>Get a simple website live for free.</h1>
+        <p class="lead">Tell us what your business does. 3DVR will build a clean one-page site, publish it on a 3DVR-hosted address, and email you the live link. No card. No sales call required.</p>
         <div class="hero-actions">
-          <a class="button primary" href="#brief">Request my concept</a>
-          <a class="button secondary" href="#examples">See what’s included</a>
+          <a class="button primary" href="#brief">Get my free site</a>
+          <a class="button secondary" href="#how">How it works</a>
         </div>
       </div>
 
       <aside class="proof-card" aria-label="What is included">
-        <p class="card-kicker">Your free concept includes</p>
+        <p class="card-kicker">Your free site includes</p>
         <ul>
-          <li>A clearer headline for your main service</li>
-          <li>One obvious call, booking, or contact action</li>
-          <li>Simple proof points customers can scan</li>
-          <li>A shareable preview link for your team</li>
-          <li>No obligation to continue</li>
+          <li>A clear headline for what you do</li>
+          <li>Your main service or offer</li>
+          <li>One obvious contact or booking action</li>
+          <li>A mobile-friendly one-page design</li>
+          <li>A live 3DVR-hosted URL you can share</li>
         </ul>
       </aside>
     </section>
 
-    <section id="examples" class="examples" aria-labelledby="examples-heading">
+    <section id="how" class="examples" aria-labelledby="how-heading">
       <div class="section-heading">
-        <p class="eyebrow">What the concept fixes</p>
-        <h2 id="examples-heading">A homepage should help the right customer act.</h2>
+        <p class="eyebrow">One email in, live site out</p>
+        <h2 id="how-heading">Tell us → we build → you get the link.</h2>
       </div>
       <div class="example-grid">
         <div class="example-card dave">
-          <span>01 · Be understood</span>
+          <span>01 · Tell us</span>
+          <strong>Give us your business and offer.</strong>
+          <p>A few sentences are enough. If you already have a page or social profile, include the link.</p>
+        </div>
+        <div class="example-card donovan">
+          <span>02 · We publish</span>
+          <strong>3DVR makes the smallest useful site.</strong>
+          <p>We turn the information into a clean one-page website and put it live on a 3DVR-hosted address.</p>
+        </div>
+        <div class="example-card yours">
+          <span>03 · You use it</span>
+          <strong>We email you the live URL.</strong>
+          <p>Share it immediately. If you later want a custom domain, revisions, or ongoing help, that support is optional.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="examples" class="examples" aria-labelledby="examples-heading">
+      <div class="section-heading">
+        <p class="eyebrow">Built to be useful first</p>
+        <h2 id="examples-heading">A tiny site can still do the important job.</h2>
+      </div>
+      <div class="example-grid">
+        <div class="example-card dave">
+          <span>Be understood</span>
           <strong>Say what you do in one clear line.</strong>
           <p>Visitors should know who you help and why they should keep reading.</p>
         </div>
         <div class="example-card donovan">
-          <span>02 · Build trust</span>
+          <span>Build trust</span>
           <strong>Show the proof that matters.</strong>
           <p>Services, experience, location, reviews, or results—only what helps a decision.</p>
         </div>
         <div class="example-card yours">
-          <span>03 · Earn the next step</span>
+          <span>Earn the next step</span>
           <strong>Make contacting you easy.</strong>
           <p>One clear call, booking, quote, or inquiry path instead of a maze of links.</p>
         </div>
@@ -86,8 +110,8 @@
     <section id="brief" class="brief-section" aria-labelledby="brief-heading">
       <div>
         <p class="eyebrow">One-minute brief</p>
-        <h2 id="brief-heading">Tell me what customers should do.</h2>
-        <p class="section-copy">Three short answers are enough. I’ll reply with the concept and the next step.</p>
+        <h2 id="brief-heading">What should your website say?</h2>
+        <p class="section-copy">Give us the basics. The email it opens is also our automation trigger, so your request goes straight into the build queue.</p>
       </div>
 
       <form class="brief-card" id="freePageBrief">
@@ -96,55 +120,55 @@
           <input name="name" type="text" placeholder="Example: Dave AV, Rosa's Garden Care" autocomplete="organization" required>
         </label>
         <label>
-          Best email for the draft
+          Best email for the live link
           <input name="email" type="email" placeholder="you@example.com" autocomplete="email" required>
         </label>
         <label>
           What do you want customers to hire, book, buy, or understand?
-          <textarea name="offer" rows="4" placeholder="I do lighting for corporate events. I want people to see my work and email me for availability."></textarea>
+          <textarea name="offer" rows="4" placeholder="I do lighting for corporate events. I want people to see what I do and email me for availability." required></textarea>
         </label>
-        <button class="button primary wide" type="submit">Request the free concept</button>
+        <button class="button primary wide" type="submit">Request my free live site</button>
       </form>
     </section>
 
     <section class="handoff" aria-live="polite">
       <div>
-        <p class="eyebrow">Next step</p>
-        <h2>I’ll reply with a private preview.</h2>
-        <p id="handoffCopy">Review the email, send it, and I’ll shape the first direction for your business.</p>
+        <p class="eyebrow">Final step</p>
+        <h2>Send the email. We’ll return with the live site.</h2>
+        <p id="handoffCopy">Your request is also saved to the 3DVR follow-up desk. Send the prepared email and the automated build queue can pick it up.</p>
       </div>
-      <a id="mailtoLink" class="button secondary" href="mailto:3dvr.tech@gmail.com?subject=Free%203DVR%20page">Email 3DVR</a>
+      <a id="mailtoLink" class="button secondary" href="mailto:3dvr.tech@gmail.com?subject=Free%203DVR%20website">Email 3DVR</a>
     </section>
 
     <section class="keep-live">
       <div>
-        <p class="eyebrow">If the direction works</p>
-        <h2>Finish and publish the page for $300.</h2>
-        <p>The free concept is the first step. A finished Starter Microsite includes the live page, contact path, basic visuals, and one revision. Ongoing support is available when you need it.</p>
+        <p class="eyebrow">Free means free</p>
+        <h2>Keep the simple 3DVR-hosted site at no charge.</h2>
+        <p>If you later want a custom domain, additional pages, revisions, CRM, booking, payments, or ongoing human support, you can add only what is useful. The first simple site does not require an upgrade.</p>
       </div>
-      <a class="button primary" href="mailto:3dvr.tech@gmail.com?subject=Finish%20my%20homepage%20concept">Finish my page</a>
+      <a class="button primary" href="../billing/?plan=starter">See optional support</a>
     </section>
 
     <section class="share-card" aria-labelledby="share-heading">
       <div>
-        <p class="eyebrow">Know a business with a confusing homepage?</p>
-        <h2 id="share-heading">Give them a clearer first step.</h2>
-        <p>Share this with a local operator who could make it easier for customers to understand and get in touch.</p>
+        <p class="eyebrow">Know someone without a website?</p>
+        <h2 id="share-heading">Give them one for free.</h2>
+        <p>Share this with a local business, independent worker, artist, teacher, organizer, or friend who needs a simple place on the web.</p>
       </div>
       <div class="share-actions">
-        <button class="button primary" id="shareFreePage" type="button">Share the free page</button>
+        <button class="button primary" id="shareFreePage" type="button">Share the free website</button>
         <button class="button secondary" id="copyFreePage" type="button">Copy link</button>
         <p id="shareStatus" class="share-status" role="status" aria-live="polite"></p>
       </div>
     </section>
 
     <section class="operator-note">
-      <p>Already know what you want? Use the internal <a href="../launch-site/">3DVR Launch Site builder</a> to assemble the page faster.</p>
+      <p>3DVR favors open tools and simple pages that can grow with the owner instead of trapping them in a website subscription.</p>
     </section>
   </main>
 
   <footer>
-    <p>3DVR makes clear websites and simple systems for local businesses.</p>
+    <p>3DVR · A useful place on the web for everyone.</p>
   </footer>
 
   <script src="./app.js" type="module"></script>

--- a/free-sites/_template.html
+++ b/free-sites/_template.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{BUSINESS_NAME}}</title>
+  <meta name="description" content="{{META_DESCRIPTION}}">
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111d;
+      --card: rgba(255, 255, 255, 0.08);
+      --line: rgba(255, 255, 255, 0.16);
+      --text: #f7fbff;
+      --muted: #b9c6d4;
+      --accent: #69f0d2;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 15% 15%, rgba(48, 190, 170, 0.22), transparent 35%),
+        radial-gradient(circle at 85% 80%, rgba(74, 112, 255, 0.2), transparent 40%),
+        var(--bg);
+    }
+    a { color: inherit; }
+    main {
+      width: min(100% - 2rem, 920px);
+      margin: 0 auto;
+      padding: 5rem 0 3rem;
+    }
+    .eyebrow {
+      margin: 0 0 1rem;
+      color: var(--accent);
+      font-size: 0.82rem;
+      font-weight: 800;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+    h1 {
+      max-width: 13ch;
+      margin: 0;
+      font-size: clamp(3rem, 10vw, 6.5rem);
+      line-height: 0.95;
+      letter-spacing: -0.055em;
+    }
+    .lede {
+      max-width: 680px;
+      margin: 1.5rem 0 0;
+      color: var(--muted);
+      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+      line-height: 1.65;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.8rem;
+      margin-top: 2rem;
+    }
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 48px;
+      padding: 0.8rem 1.15rem;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      text-decoration: none;
+      font-weight: 800;
+    }
+    .button.primary {
+      border-color: transparent;
+      background: var(--accent);
+      color: #04110e;
+    }
+    .panel {
+      margin-top: 4rem;
+      padding: clamp(1.4rem, 4vw, 2.2rem);
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      background: var(--card);
+      backdrop-filter: blur(14px);
+    }
+    .panel h2 {
+      margin: 0 0 0.8rem;
+      font-size: clamp(1.8rem, 4vw, 2.5rem);
+    }
+    .panel p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.75;
+      white-space: pre-line;
+    }
+    footer {
+      width: min(100% - 2rem, 920px);
+      margin: 0 auto;
+      padding: 1rem 0 3rem;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+    footer a { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="eyebrow">{{EYEBROW}}</p>
+    <h1>{{BUSINESS_NAME}}</h1>
+    <p class="lede">{{TAGLINE}}</p>
+    <div class="actions">
+      <a class="button primary" href="{{PRIMARY_URL}}">{{PRIMARY_LABEL}}</a>
+      <a class="button" href="mailto:{{CONTACT_EMAIL}}">Email</a>
+    </div>
+
+    <section class="panel">
+      <h2>{{SECTION_HEADING}}</h2>
+      <p>{{SECTION_BODY}}</p>
+    </section>
+  </main>
+  <footer>
+    Free site hosted by <a href="https://3dvr.tech/">3DVR</a>. The owner can upgrade, move, or expand it anytime.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- turns `/free-page/` from a free concept + $300 publish offer into a free live one-page website offer
- tells requesters that 3DVR will build, publish, and email the live URL
- updates CRM metadata and the generated email so inbound requests enter an automated build queue
- adds a reusable text-first `free-sites/_template.html` for safe automated publishing
- keeps custom domains, revisions, extra pages, and ongoing support as optional paid upgrades

## Why
This is the campaign offer: give someone a useful place on the web first, then earn trust and optional paid work afterward. It also creates a deterministic template for the inbox automation to use.

## Safety / scope
No billing configuration changed. No existing customer site changed. The free site is intentionally simple and hosted on a 3DVR-owned address.