### PR TITLE
Align the whole free-site funnel

### DIFF
--- a/free-page/preview/index.html
+++ b/free-page/preview/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Your homepage concept | 3DVR</title>
+  <title>Your website direction | 3DVR</title>
   <meta name="robots" content="noindex,nofollow">
   <meta name="description" content="A private one-page website direction prepared by 3DVR.">
   <link rel="stylesheet" href="./styles.css">
@@ -19,13 +19,13 @@
 
   <main>
     <section class="intro">
-      <p class="eyebrow">A free homepage concept for <span data-business>your business</span></p>
+      <p class="eyebrow">A free website direction for <span data-business>your business</span></p>
       <h1>Make <span data-business>your business</span> easier to understand and contact.</h1>
-      <p>I made this first direction to show how your main service, proof, and next step could work together on one clear page.</p>
+      <p>This first direction shows how your main service, proof, and next step can work together on one clear page.</p>
     </section>
 
     <section class="browser" aria-label="Website direction preview">
-      <div class="browser-bar" aria-hidden="true"><i></i><i></i><i></i><span data-host>your-business.com</span></div>
+      <div class="browser-bar" aria-hidden="true"><i></i><i></i><i></i><span data-host>your-business.3dvr.tech</span></div>
       <div class="mock-site">
         <nav><strong data-business>Your business</strong><span>Services&nbsp;&nbsp; About&nbsp;&nbsp; Contact</span></nav>
         <div class="mock-hero">
@@ -42,22 +42,22 @@
       </div>
     </section>
 
-    <section class="notice-grid" aria-label="What this concept improves">
+    <section class="notice-grid" aria-label="What this direction improves">
       <article><p class="eyebrow">What I’m improving</p><h2>Clarity</h2><p data-observation>Visitors should understand your main service without hunting through the page.</p></article>
       <article><p class="eyebrow">What happens next</p><h2>Action</h2><p data-next-step>The page points the right customer to one simple call, booking, or contact step.</p></article>
     </section>
 
     <section class="claim-card">
       <div>
-        <p class="eyebrow">Want the finished page?</p>
-        <h2>I can finish and publish this direction for $300.</h2>
-        <p id="contactNote">Reply to Thomas to adjust the copy, colors, or next step. The concept is free; publishing the finished Starter Microsite is optional.</p>
+        <p class="eyebrow">Want this live?</p>
+        <h2>3DVR can publish the simple one-page version for free.</h2>
+        <p id="contactNote">Reply to Thomas with factual corrections or missing contact details. The simple 3DVR-hosted site is free to keep; custom domains, extra pages, revisions, integrations, and ongoing support are optional upgrades.</p>
       </div>
-      <a class="claim-button" id="claimButton" href="mailto:3dvr.tech@gmail.com">Reply about my page</a>
+      <a class="claim-button" id="claimButton" href="mailto:3dvr.tech@gmail.com">Reply about my site</a>
     </section>
   </main>
 
-  <footer>Business offer from <a href="https://3dvr.tech">3dvr.tech</a></footer>
+  <footer>Free website offer from <a href="https://3dvr.tech">3dvr.tech</a></footer>
   <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/new-business-launch/index.html
+++ b/new-business-launch/index.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Launch Your Business Online | 3DVR</title>
-  <meta name="description" content="Get a clear first website for your new business, then keep it live with practical monthly help from 3DVR.">
+  <meta name="description" content="Get a simple one-page website published free on a 3DVR-hosted address, then add practical support only when you want it.">
   <link rel="canonical" href="https://portal.3dvr.tech/new-business-launch/">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Launch Your Business Online | 3DVR">
-  <meta property="og:description" content="Get a clear first website for your new business, then keep it live with practical monthly help from 3DVR.">
+  <meta property="og:description" content="Get a simple one-page website published free on a 3DVR-hosted address, then add practical support only when you want it.">
   <meta property="og:url" content="https://portal.3dvr.tech/new-business-launch/">
   <meta name="twitter:card" content="summary">
   <script type="application/ld+json">
@@ -18,12 +18,13 @@
       "name": "3DVR New Business Launch",
       "provider": {"@type": "Organization", "name": "3DVR", "url": "https://3dvr.tech/"},
       "areaServed": "Worldwide",
-      "description": "A clear first website and practical monthly support for new businesses, side hustles, and solo operators.",
+      "description": "A free simple one-page website on a 3DVR-hosted address with optional paid support for new businesses, side hustles, and solo operators.",
       "offers": {
         "@type": "OfferCatalog",
-        "name": "3DVR support lanes",
+        "name": "3DVR launch and support lanes",
         "itemListElement": [
-          {"@type": "Offer", "name": "Keep it live", "price": "5", "priceCurrency": "USD", "url": "https://portal.3dvr.tech/billing/?plan=starter"},
+          {"@type": "Offer", "name": "Free one-page website", "price": "0", "priceCurrency": "USD", "url": "https://portal.3dvr.tech/free-page/"},
+          {"@type": "Offer", "name": "Light support", "price": "5", "priceCurrency": "USD", "url": "https://portal.3dvr.tech/billing/?plan=starter"},
           {"@type": "Offer", "name": "Launch help", "price": "20", "priceCurrency": "USD", "url": "https://portal.3dvr.tech/billing/?plan=pro"},
           {"@type": "Offer", "name": "Build momentum", "price": "50", "priceCurrency": "USD", "url": "https://portal.3dvr.tech/billing/?plan=builder"},
           {"@type": "Offer", "name": "Embedded support", "price": "200", "priceCurrency": "USD", "url": "https://portal.3dvr.tech/billing/?plan=embedded"}
@@ -53,8 +54,8 @@
     <a class="brand" href="../"><span class="brand-mark">3D</span><span>3DVR</span></a>
     <nav aria-label="Launch navigation">
       <a href="#how">How it works</a>
-      <a href="#plans">Plans</a>
-      <a class="nav-pill" href="../free-page/#brief">Start free</a>
+      <a href="#plans">Optional support</a>
+      <a class="nav-pill" href="../free-page/#brief">Get a free website</a>
     </nav>
   </header>
 
@@ -63,19 +64,19 @@
       <div class="hero-copy">
         <p class="eyebrow">For new businesses, side hustles, and solo operators</p>
         <h1>Help people trust and hire your new business.</h1>
-        <p class="lead">Tell us what you do. We’ll make a clear first web page with one clear next step. If you like it, keep it live and get help each month.</p>
+        <p class="lead">Tell us what you do. We’ll build a clear one-page website, publish it on a 3DVR-hosted address, and email you the live link for free. Add paid support later only if it helps.</p>
         <div class="hero-actions">
-          <a class="button primary" href="../free-page/#brief">Get a free first draft</a>
-          <a class="button secondary" href="#plans">See the monthly path</a>
+          <a class="button primary" href="../free-page/#brief">Get my free website</a>
+          <a class="button secondary" href="#plans">See optional support</a>
         </div>
       </div>
       <aside class="proof-card" aria-label="What you get">
         <p class="card-kicker">Your first launch kit</p>
         <ul>
           <li>One clear offer and title</li>
-          <li>A simple home on the web</li>
-          <li>A way to call, book, pay, or connect</li>
-          <li>A page you can send to people</li>
+          <li>A simple live home on the web</li>
+          <li>A way to call, book, or connect</li>
+          <li>A 3DVR-hosted page you can share</li>
         </ul>
       </aside>
     </section>
@@ -87,20 +88,20 @@
       </div>
       <div class="example-grid">
         <div class="example-card dave"><span>1. Tell us</span><strong>What do you do?</strong><p>One service, product, project, or skill is enough.</p></div>
-        <div class="example-card donovan"><span>2. See it</span><strong>Get a first draft</strong><p>Review a focused page before deciding what comes next.</p></div>
-        <div class="example-card yours"><span>3. Keep moving</span><strong>Choose support</strong><p>Keep it live, improve it monthly, or get a deeper operating lane.</p></div>
+        <div class="example-card donovan"><span>2. We publish</span><strong>Get a live first site</strong><p>3DVR makes the smallest useful page and puts it online on a 3DVR-hosted address.</p></div>
+        <div class="example-card yours"><span>3. Keep moving</span><strong>Use it or add support</strong><p>Keep the simple site free, or add custom domains, revisions, integrations, and ongoing help when useful.</p></div>
       </div>
     </section>
 
     <section id="plans" class="keep-live">
       <div>
-        <p class="eyebrow">Simple monthly path</p>
-        <h2>Pay for help, not a huge tool pile.</h2>
-        <p><strong>$5/mo</strong> keeps your page live. <strong>$20/mo</strong> adds launch help and updates. <strong>$50/mo</strong> adds help with leads and follow-up. Teams can use the <strong>$200/mo</strong> plan for deeper help. You can pay in the secure portal.</p>
+        <p class="eyebrow">Free site, optional support</p>
+        <h2>Pay for help, not basic hosting.</h2>
+        <p>Your simple one-page 3DVR-hosted site stays free. <strong>$5/mo</strong> adds light support and small updates. <strong>$20/mo</strong> adds launch help. <strong>$50/mo</strong> adds a stronger business-building support lane. Teams can use the <strong>$200/mo</strong> plan for deeper help.</p>
         <p class="checkout-proof"><strong>Real checkout proof:</strong> a customer paid the first $20 invoice and now has an active $20/month 3DVR subscription. That confirms the checkout and billing path work; it does not promise a particular business outcome.</p>
       </div>
       <div class="hero-actions">
-        <a class="button primary" href="../free-page/#brief">Start with the free draft</a>
+        <a class="button primary" href="../free-page/#brief">Get the free site</a>
         <a class="button secondary" href="../billing/?plan=pro">Continue to $20 checkout</a>
       </div>
     </section>
@@ -108,10 +109,10 @@
     <section class="subscription-path" aria-labelledby="subscription-heading">
       <div class="section-heading">
         <p class="eyebrow">Choose the next useful step</p>
-        <h2 id="subscription-heading">Start small. Pay for more help later.</h2>
+        <h2 id="subscription-heading">The site is free. Support is optional.</h2>
       </div>
       <div class="subscription-grid">
-        <article class="subscription-card"><small>Keep it live</small><h3>$5 / month</h3><p>Keep your first page online and request small updates.</p><a class="button secondary" href="../billing/?plan=starter">Continue to $5 checkout</a></article>
+        <article class="subscription-card"><small>Light support</small><h3>$5 / month</h3><p>Request small updates and get a little ongoing help while the free site stays online either way.</p><a class="button secondary" href="../billing/?plan=starter">Continue to $5 checkout</a></article>
         <article class="subscription-card recommended"><small>Best launch lane</small><h3>$20 / month</h3><p>Get launch help, ongoing updates, and a clearer next step.</p><a class="button primary" href="../billing/?plan=pro">Continue to $20 checkout</a></article>
         <article class="subscription-card"><small>Build momentum</small><h3>$50 / month</h3><p>Use a stronger support lane for active business building.</p><a class="button secondary" href="../billing/?plan=builder">Continue to $50 checkout</a></article>
         <article class="subscription-card"><small>Embedded support</small><h3>$200 / month</h3><p>Reserve deeper planning and execution support for a real team.</p><a class="button secondary" href="../billing/?plan=embedded">Continue to $200 checkout</a></article>

--- a/tests/free-page-offer.test.js
+++ b/tests/free-page-offer.test.js
@@ -6,17 +6,21 @@ const html = await readFile(new URL('../free-page/index.html', import.meta.url),
 const script = await readFile(new URL('../free-page/app.js', import.meta.url), 'utf8');
 const previewHtml = await readFile(new URL('../free-page/preview/index.html', import.meta.url), 'utf8');
 const previewScript = await readFile(new URL('../free-page/preview/app.js', import.meta.url), 'utf8');
+const launchHtml = await readFile(new URL('../new-business-launch/index.html', import.meta.url), 'utf8');
+const templateHtml = await readFile(new URL('../free-sites/_template.html', import.meta.url), 'utf8');
 const styles = await readFile(new URL('../free-page/styles.css', import.meta.url), 'utf8');
 const previewStyles = await readFile(new URL('../free-page/preview/styles.css', import.meta.url), 'utf8');
 
-test('free page offer presents the personalized homepage concept', () => {
-  assert.match(html, /Get a clearer homepage concept for free/);
-  assert.match(html, /Finish and publish the page for \$300/);
-  assert.match(html, /Request the free concept/);
+test('free page offer promises a real free live website', () => {
+  assert.match(html, /Get a simple website live for free/);
+  assert.match(html, /publish it on a 3DVR-hosted address/);
+  assert.match(html, /email you the live link/);
+  assert.match(html, /Request my free live site/);
+  assert.match(html, /Keep the simple 3DVR-hosted site at no charge/);
+  assert.doesNotMatch(html, /Finish and publish the page for \$300/);
   assert.match(html, /3dvr\.tech@gmail\.com/);
   assert.match(html, /name="email" type="email"[^>]*required/);
-  assert.match(html, /A homepage should help the right customer act/);
-  assert.match(html, /\.\.\/launch-site\//);
+  assert.match(html, /A tiny site can still do the important job/);
   assert.match(html, /<script defer src="\/_vercel\/insights\/script\.js"><\/script>/);
   assert.match(html, /googletagmanager\.com\/gtag\/js\?id=G-96XRKQ5L65/);
   assert.match(html, /gtag\('config', 'G-96XRKQ5L65'\)/);
@@ -24,10 +28,12 @@ test('free page offer presents the personalized homepage concept', () => {
   assert.match(html, /\.\.\/gun-init\.js/);
 });
 
-test('personalized preview is noindex, safely client-rendered, and tracks explicit funnel events', () => {
+test('personalized preview is noindex and agrees the simple hosted site is free', () => {
   assert.match(previewHtml, /noindex,nofollow/);
-  assert.match(previewHtml, /finish and publish this direction for \$300/i);
-  assert.match(previewHtml, /Reply about my page/);
+  assert.match(previewHtml, /publish the simple one-page version for free/i);
+  assert.match(previewHtml, /simple 3DVR-hosted site is free to keep/i);
+  assert.doesNotMatch(previewHtml, /publish this direction for \$300/i);
+  assert.match(previewHtml, /Reply about my site/);
   assert.match(previewHtml, /class="brand" href="\.\.\/"[^>]*><span>3dvr<\/span><\/a>/);
   assert.match(previewHtml, /id="contactButton"/);
   assert.match(previewHtml, /data-business/);
@@ -38,8 +44,32 @@ test('personalized preview is noindex, safely client-rendered, and tracks explic
   assert.match(previewScript, /mailto:\$\{contactEmail\}/);
   assert.doesNotMatch(previewScript, /searchParams\.get\('email'\)/);
   assert.doesNotMatch(previewScript, /innerHTML/);
-  assert.match(previewHtml, /Business offer from/);
-  assert.doesNotMatch(previewHtml, /Advertisement from/);
+  assert.match(previewHtml, /Free website offer from/);
+});
+
+test('new business launch keeps basic hosting free and sells support separately', () => {
+  assert.match(launchHtml, /publish it on a 3DVR-hosted address.*live link for free/s);
+  assert.match(launchHtml, /simple one-page 3DVR-hosted site stays free/i);
+  assert.match(launchHtml, /Pay for help, not basic hosting/);
+  assert.match(launchHtml, /Light support/);
+  assert.doesNotMatch(launchHtml, /\$5\/mo<\/strong> keeps your page live/);
+  assert.match(launchHtml, /"Free one-page website", "price": "0"/);
+});
+
+test('free site automation has a deterministic reusable template', () => {
+  for (const placeholder of [
+    '{{BUSINESS_NAME}}',
+    '{{META_DESCRIPTION}}',
+    '{{TAGLINE}}',
+    '{{PRIMARY_URL}}',
+    '{{PRIMARY_LABEL}}',
+    '{{CONTACT_EMAIL}}',
+    '{{SECTION_HEADING}}',
+    '{{SECTION_BODY}}'
+  ]) {
+    assert.match(templateHtml, new RegExp(placeholder.replace(/[{}]/g, '\\$&')));
+  }
+  assert.match(templateHtml, /Free site hosted by/);
 });
 
 test('free page layouts contain folded-phone overflow guards', () => {
@@ -51,17 +81,17 @@ test('free page layouts contain folded-phone overflow guards', () => {
   }
 });
 
-test('free page brief builds an email handoff without backend dependencies', () => {
+test('free page brief routes inbound email into the live-site build queue', () => {
   assert.match(script, /mailto:/);
-  assert.match(script, /Free homepage concept/);
+  assert.match(script, /Free 3DVR website request/);
   assert.match(script, /3dvr\.tech@gmail\.com/);
-  assert.match(script, /finishing and publishing the page/);
+  assert.match(script, /build the smallest useful version and email me the live URL/i);
   assert.match(script, /gtag\('event', 'generate_lead'/);
-  assert.match(script, /method: 'mailto_brief'/);
+  assert.match(script, /method: 'free_live_site_email'/);
   assert.match(script, /trackFirstPartyEvent\('page_view'\)/);
   assert.match(script, /trackFirstPartyEvent\('generate_lead'\)/);
   assert.match(script, /saveBriefToCrm/);
   assert.match(script, /3dvr-crm/);
   assert.match(script, /crm-touch-log/);
-  assert.match(script, /Lead captured; concept requested/);
+  assert.match(script, /Lead captured for automated build and email delivery/);
 });


### PR DESCRIPTION
## What changed
- removes the old `$300` publish promise from the personalized preview
- makes `/new-business-launch/` explicit that the basic 3DVR-hosted one-page site stays free
- reframes `$5+` plans as optional support rather than required hosting
- updates structured offer data to include the $0 website
- rewrites the focused contract tests for the new live-site offer and reusable template

## Why
The campaign should make one promise everywhere: the simple one-page site is free to build, publish, and keep on a 3DVR-hosted address; paid help is optional.

## Deployment note
Vercel is currently over the free-plan daily deployment limit, so this PR is code alignment now and will be included in the next successful production deployment.