### PR TITLE
Deploy only main on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,11 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  },
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':(exclude)apps/agent/**' ':(exclude)apps/companion/**'",
   "redirects": [
     {


### PR DESCRIPTION
Disable automatic Vercel deployments for every Git branch except `main` using Vercel's `git.deploymentEnabled` branch rules. This prevents Companion/agent PR branches from consuming the daily deployment quota while preserving production deploys after merge. The existing path-based ignored-build command remains as defense in depth.