### PR TITLE
Define bounded Companion execution backend contract

### DIFF
--- a/apps/agent/test/test_companion_execution_backend.py
+++ b/apps/agent/test/test_companion_execution_backend.py
@@ -1,0 +1,49 @@
+import pathlib
+import sys
+import time
+import unittest
+
+PYTHON_ROOT = pathlib.Path(__file__).resolve().parents[1] / "thomas-agent" / "python"
+sys.path.insert(0, str(PYTHON_ROOT))
+
+from companion_execution_backend import (  # noqa: E402
+    CompanionExecutionRequest,
+)
+
+
+class CompanionExecutionRequestTests(unittest.TestCase):
+    def setUp(self):
+        self.now = int(time.time() * 1000)
+
+    def request(self, capability="device.status", arguments=None):
+        return CompanionExecutionRequest(
+            request_id="req-1",
+            capability=capability,
+            expires_at_ms=self.now + 30_000,
+            arguments=arguments or {},
+        )
+
+    def test_read_only_status_is_allowed(self):
+        self.request().validate(self.now)
+
+    def test_unknown_capability_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "unsupported backend capability"):
+            self.request("shell.exec").validate(self.now)
+
+    def test_expired_request_is_rejected(self):
+        request = CompanionExecutionRequest("req-1", "device.status", self.now - 1)
+        with self.assertRaisesRegex(ValueError, "expired"):
+            request.validate(self.now)
+
+    def test_known_app_launch_requires_explicit_app_id(self):
+        with self.assertRaisesRegex(ValueError, "approved app_id"):
+            self.request("app.open_known").validate(self.now)
+        self.request("app.open_known", {"app_id": "settings"}).validate(self.now)
+
+    def test_free_form_gestures_are_not_in_contract(self):
+        with self.assertRaises(ValueError):
+            self.request("ui.tap", {"x": 10, "y": 20}).validate(self.now)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/agent/thomas-agent/python/companion_execution_backend.py
+++ b/apps/agent/thomas-agent/python/companion_execution_backend.py
@@ -1,0 +1,56 @@
+"""Bounded execution-backend contract for 3DVR Companion.
+
+Backends receive already-authorized named capabilities. They are not policy engines and
+must not accept arbitrary shell commands, free-form prompts, or unrestricted gestures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol
+
+
+ALLOWED_BACKEND_CAPABILITIES = frozenset({
+    "device.status",
+    "app.open_known",
+    "ui.snapshot",
+})
+
+
+@dataclass(frozen=True)
+class CompanionExecutionRequest:
+    request_id: str
+    capability: str
+    expires_at_ms: int
+    arguments: Mapping[str, Any] = field(default_factory=dict)
+
+    def validate(self, now_ms: int) -> None:
+        if not self.request_id.strip():
+            raise ValueError("request_id is required")
+        if self.capability not in ALLOWED_BACKEND_CAPABILITIES:
+            raise ValueError(f"unsupported backend capability: {self.capability}")
+        if self.expires_at_ms <= now_ms:
+            raise ValueError("request has expired")
+        if self.capability == "app.open_known":
+            app_id = self.arguments.get("app_id")
+            if not isinstance(app_id, str) or not app_id.strip():
+                raise ValueError("app.open_known requires an approved app_id")
+
+
+@dataclass(frozen=True)
+class CompanionExecutionResult:
+    request_id: str
+    capability: str
+    ok: bool
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+    error_code: str | None = None
+
+
+class CompanionExecutionBackend(Protocol):
+    """Mechanics-only backend behind 3DVR policy, approval, expiry, and audit."""
+
+    def supports(self, capability: str) -> bool:
+        ...
+
+    def execute(self, request: CompanionExecutionRequest) -> CompanionExecutionResult:
+        ...


### PR DESCRIPTION
## What changed

- defines a Python-side `CompanionExecutionBackend` protocol for optional execution adapters such as `mobilerun-core`
- constrains the first contract to `device.status`, approved `app.open_known`, and sanitized `ui.snapshot`
- validates request IDs, expiry, capability IDs, and explicit approved app IDs before a backend can execute
- adds focused tests proving arbitrary shell and free-form gesture capabilities are outside the contract

## Why

This is the first executable slice of #1490. 3DVR keeps policy, approvals, identity, expiry, dedupe, and audit above the backend boundary. Mobilerun can later provide device mechanics without becoming the autonomous policy layer.

## Safety

No Mobilerun dependency, device credential, network connection, APK change, shell execution, messages, purchases, deletions, or unrestricted tap/type behavior is added here.

## Validation

Fresh repository CI required before merge.