### PR TITLE
Add optional bounded Mobilerun core backend

### DIFF
--- a/apps/agent/test/test_mobilerun_core_backend.py
+++ b/apps/agent/test/test_mobilerun_core_backend.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "thomas-agent" / "python"))
+
+from companion_execution_backend import CompanionExecutionRequest
+from mobilerun_core_backend import MobilerunCoreBackend
+
+
+class FakeDevice:
+    def __init__(self, supported=True):
+        self.supported = supported
+
+    def supports(self, capability):
+        return self.supported and capability == "device.status"
+
+    def status(self):
+        return {"connected": True, "transport": "local-android-http"}
+
+
+def request(capability="device.status"):
+    return CompanionExecutionRequest("req-1", capability, 9999999999999)
+
+
+def test_reports_device_status_without_broadening_authority():
+    backend = MobilerunCoreBackend(lambda: FakeDevice())
+    result = backend.execute(request())
+    assert result.ok is True
+    assert result.evidence["connected"] is True
+    assert backend.supports("device.status") is True
+    assert backend.supports("shell.exec") is False
+
+
+def test_returns_structured_unsupported_evidence():
+    backend = MobilerunCoreBackend(lambda: FakeDevice(False))
+    result = backend.execute(request())
+    assert result.ok is False
+    assert result.error_code == "unsupported_capability"
+
+
+def test_returns_structured_unavailable_evidence():
+    def unavailable():
+        raise RuntimeError("mobilerun-core is unavailable")
+
+    backend = MobilerunCoreBackend(unavailable)
+    result = backend.execute(request())
+    assert result.ok is False
+    assert result.error_code == "backend_unavailable"
+
+
+def test_rejects_other_allowed_protocol_capabilities_in_first_slice():
+    backend = MobilerunCoreBackend(lambda: FakeDevice())
+    result = backend.execute(request("ui.snapshot"))
+    assert result.ok is False
+    assert result.error_code == "unsupported_capability"

--- a/apps/agent/thomas-agent/python/mobilerun_core_backend.py
+++ b/apps/agent/thomas-agent/python/mobilerun_core_backend.py
@@ -1,0 +1,84 @@
+"""Optional Mobilerun mechanics backend for 3DVR Companion.
+
+3DVR remains the policy/identity/audit boundary. This adapter is deliberately
+small and dependency-optional: importing it does not require mobilerun-core.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from companion_execution_backend import (
+    CompanionExecutionRequest,
+    CompanionExecutionResult,
+)
+
+
+class MobilerunCoreBackend:
+    """Bounded adapter around an injected Mobilerun Device-like object."""
+
+    def __init__(self, device_factory: Callable[[], Any] | None = None) -> None:
+        self._device_factory = device_factory or self._default_device_factory
+        self._device: Any | None = None
+
+    @staticmethod
+    def _default_device_factory() -> Any:
+        try:
+            from mobilerun import Mobilerun  # type: ignore
+        except ImportError as error:
+            raise RuntimeError("mobilerun-core is unavailable") from error
+        return Mobilerun().device
+
+    def _get_device(self) -> Any:
+        if self._device is None:
+            self._device = self._device_factory()
+        return self._device
+
+    def supports(self, capability: str) -> bool:
+        if capability != "device.status":
+            return False
+        try:
+            device = self._get_device()
+            supports = getattr(device, "supports", None)
+            return bool(supports(capability)) if callable(supports) else True
+        except (RuntimeError, OSError):
+            return False
+
+    def execute(self, request: CompanionExecutionRequest) -> CompanionExecutionResult:
+        if request.capability != "device.status":
+            return CompanionExecutionResult(
+                request_id=request.request_id,
+                capability=request.capability,
+                ok=False,
+                error_code="unsupported_capability",
+            )
+        try:
+            device = self._get_device()
+            supports = getattr(device, "supports", None)
+            if callable(supports) and not supports("device.status"):
+                return CompanionExecutionResult(
+                    request_id=request.request_id,
+                    capability=request.capability,
+                    ok=False,
+                    error_code="unsupported_capability",
+                )
+            status = getattr(device, "status", None)
+            evidence = status() if callable(status) else status
+            if evidence is None:
+                evidence = {"available": True}
+            elif not isinstance(evidence, dict):
+                evidence = {"status": evidence}
+            return CompanionExecutionResult(
+                request_id=request.request_id,
+                capability=request.capability,
+                ok=True,
+                evidence=evidence,
+            )
+        except (RuntimeError, OSError) as error:
+            return CompanionExecutionResult(
+                request_id=request.request_id,
+                capability=request.capability,
+                ok=False,
+                evidence={"backend": "mobilerun-core", "detail": str(error)},
+                error_code="backend_unavailable",
+            )


### PR DESCRIPTION
## What changed

- adds dependency-optional Python `MobilerunCoreBackend`
- first slice exposes only `device.status`
- capability discovery is checked when available
- absent backend/capability returns structured evidence rather than broad fallback authority
- deterministic fake-device tests cover success, unavailable, unsupported, and authority boundaries

## Boundaries

3DVR still owns identity, policy, approvals, expiry, dedupe, risk and audit. This does not add arbitrary shell, gestures, prompts, messages, purchases, deletions, Android APK dependencies, or credentials to Git.

## Next

After CI, connect configuration to `local-android-http` with URL/token supplied outside Git, then map approved app launch and sanitized UI snapshot only after deterministic evidence.