### PR TITLE
Add secret-free Mobilerun endpoint configuration

### DIFF
--- a/apps/agent/test/test_mobilerun_config.py
+++ b/apps/agent/test/test_mobilerun_config.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "thomas-agent", "python"))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from mobilerun_config import MobilerunConfig
+
+
+class MobilerunConfigTest(unittest.TestCase):
+    def test_loads_endpoint_and_token_without_exposing_token(self):
+        config = MobilerunConfig.from_env({
+            "THREEDVR_MOBILERUN_URL": "http://127.0.0.1:8080/",
+            "THREEDVR_MOBILERUN_TOKEN": "secret-token",
+        })
+        self.assertEqual(config.base_url, "http://127.0.0.1:8080")
+        self.assertEqual(config.token, "secret-token")
+        self.assertEqual(config.redacted(), {"base_url": "http://127.0.0.1:8080", "token": "[redacted]"})
+        self.assertNotIn("secret-token", repr(config.redacted()))
+
+    def test_rejects_missing_credentials(self):
+        with self.assertRaisesRegex(RuntimeError, "not configured"):
+            MobilerunConfig.from_env({})
+
+    def test_rejects_non_http_endpoint(self):
+        with self.assertRaisesRegex(RuntimeError, "http"):
+            MobilerunConfig.from_env({
+                "THREEDVR_MOBILERUN_URL": "file:///tmp/socket",
+                "THREEDVR_MOBILERUN_TOKEN": "secret-token",
+            })
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/agent/thomas-agent/python/mobilerun_config.py
+++ b/apps/agent/thomas-agent/python/mobilerun_config.py
@@ -1,0 +1,28 @@
+"""Environment-only configuration for the optional Mobilerun backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import environ
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class MobilerunConfig:
+    base_url: str
+    token: str
+
+    @classmethod
+    def from_env(cls, env=None) -> "MobilerunConfig":
+        values = environ if env is None else env
+        base_url = values.get("THREEDVR_MOBILERUN_URL", "").strip().rstrip("/")
+        token = values.get("THREEDVR_MOBILERUN_TOKEN", "").strip()
+        if not base_url or not token:
+            raise RuntimeError("Mobilerun endpoint credentials are not configured")
+        parsed = urlparse(base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise RuntimeError("Mobilerun endpoint URL must be http(s)")
+        return cls(base_url=base_url, token=token)
+
+    def redacted(self) -> dict[str, str]:
+        return {"base_url": self.base_url, "token": "[redacted]"}


### PR DESCRIPTION
## What changed

- adds environment-only `THREEDVR_MOBILERUN_URL` / `THREEDVR_MOBILERUN_TOKEN` configuration
- validates the endpoint before use
- keeps token redacted from configuration evidence
- adds deterministic tests for valid, missing, and invalid configuration

## Why

This advances #1490 without inventing or committing a live device credential. It creates the configuration boundary needed to exercise the already-merged read-only `device.status` Mobilerun adapter against `local-android-http` later.

## Safety

No network call, device action, shell, gesture, message, purchase, or secret is added in this slice. Live credentials remain outside Git.