### PR TITLE
Wire Mobilerun external config into read-only transport

### DIFF
--- a/apps/agent/test/test_mobilerun_core_backend.py
+++ b/apps/agent/test/test_mobilerun_core_backend.py
@@ -1,4 +1,5 @@
 import sys
+import types
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "thomas-agent" / "python"))
@@ -53,3 +54,33 @@ def test_rejects_other_allowed_protocol_capabilities_in_first_slice():
     result = backend.execute(request("ui.snapshot"))
     assert result.ok is False
     assert result.error_code == "unsupported_capability"
+
+
+def test_default_factory_passes_env_endpoint_and_token(monkeypatch):
+    captured = {}
+
+    class FakeMobilerun:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.device = FakeDevice()
+
+    monkeypatch.setenv("THREEDVR_MOBILERUN_URL", "http://127.0.0.1:8080/")
+    monkeypatch.setenv("THREEDVR_MOBILERUN_TOKEN", "secret-token")
+    monkeypatch.setitem(sys.modules, "mobilerun", types.SimpleNamespace(Mobilerun=FakeMobilerun))
+
+    backend = MobilerunCoreBackend()
+    result = backend.execute(request())
+
+    assert result.ok is True
+    assert captured == {"base_url": "http://127.0.0.1:8080", "token": "secret-token"}
+    assert "secret-token" not in repr(result.evidence)
+
+
+def test_default_factory_reports_missing_external_credentials(monkeypatch):
+    monkeypatch.delenv("THREEDVR_MOBILERUN_URL", raising=False)
+    monkeypatch.delenv("THREEDVR_MOBILERUN_TOKEN", raising=False)
+    backend = MobilerunCoreBackend()
+    result = backend.execute(request())
+    assert result.ok is False
+    assert result.error_code == "backend_unavailable"
+    assert "not configured" in result.evidence["detail"]

--- a/apps/agent/thomas-agent/python/mobilerun_core_backend.py
+++ b/apps/agent/thomas-agent/python/mobilerun_core_backend.py
@@ -12,6 +12,7 @@ from companion_execution_backend import (
     CompanionExecutionRequest,
     CompanionExecutionResult,
 )
+from mobilerun_config import MobilerunConfig
 
 
 class MobilerunCoreBackend:
@@ -23,11 +24,24 @@ class MobilerunCoreBackend:
 
     @staticmethod
     def _default_device_factory() -> Any:
+        config = MobilerunConfig.from_env()
         try:
             from mobilerun import Mobilerun  # type: ignore
         except ImportError as error:
             raise RuntimeError("mobilerun-core is unavailable") from error
-        return Mobilerun().device
+
+        # Keep endpoint credentials outside Git and pass them only to the
+        # mechanics client. Supporting both common constructor spellings keeps
+        # this boundary tolerant of mobilerun-core API evolution without
+        # broadening 3DVR's authority.
+        try:
+            client = Mobilerun(base_url=config.base_url, token=config.token)
+        except TypeError:
+            try:
+                client = Mobilerun(url=config.base_url, token=config.token)
+            except TypeError as error:
+                raise RuntimeError("mobilerun-core endpoint configuration is unsupported") from error
+        return client.device
 
     def _get_device(self) -> Any:
         if self._device is None:


### PR DESCRIPTION
## What changed

- wires `THREEDVR_MOBILERUN_URL` + `THREEDVR_MOBILERUN_TOKEN` into the default optional Mobilerun client
- keeps credentials environment-only and out of evidence/logs
- supports bounded constructor compatibility without expanding authority
- adds deterministic tests for config-to-client wiring and missing credentials

## Authority boundary

Still only `device.status`. No shell, free-form prompts, messages, purchases, unrestricted gestures, app launch, or UI snapshot authority is added here.

## Next

Fresh CI, then a real read-only `device.status` proof when an external endpoint/token is available.