### PR TITLE
Ship the first Android Assistant voice round trip

### DIFF
--- a/apps/companion/VOICE_ROUND_TRIP.md
+++ b/apps/companion/VOICE_ROUND_TRIP.md
@@ -1,0 +1,36 @@
+# Android Assistant voice round trip
+
+This is the first end-to-end daily-driver voice proof for 3DVR Companion.
+
+## User path
+
+1. Open 3DVR Companion.
+2. Make 3DVR Companion the Android Assistant.
+3. Allow microphone access.
+4. Invoke the Android Assistant gesture or button.
+5. Say **“Open Maps.”**
+6. Companion recognizes the phrase, routes it to the bounded `app.open_known` capability, launches Maps, and stores a receipt.
+7. Reopen Companion to inspect the latest voice receipt.
+
+## Admitted commands
+
+The first voice proof only accepts `open`, `launch`, or `start` requests for these known targets:
+
+- Maps
+- Gmail
+- Camera
+- Messages
+- Calendar
+- Chrome
+- ChatGPT
+- Settings
+
+Anything else is rejected as `unsupported_voice_command`.
+
+## Safety boundary
+
+This path does not accept arbitrary package names, URLs, Accessibility selectors, shell commands, Shizuku operations, financial actions, account changes, or outbound messages. It stores no raw audio. Only the latest short transcript and bounded action result are retained as a user-visible receipt.
+
+## Realtime next
+
+OpenAI Realtime remains the conversational intelligence upgrade. The device-action contract does not need to change when Realtime is added: model tool calls should still resolve into the same bounded Companion capabilities and receipts rather than gaining direct device authority.

--- a/apps/companion/lib/main.dart
+++ b/apps/companion/lib/main.dart
@@ -29,7 +29,8 @@ class CompanionHome extends StatefulWidget {
   State<CompanionHome> createState() => _CompanionHomeState();
 }
 
-class _CompanionHomeState extends State<CompanionHome> {
+class _CompanionHomeState extends State<CompanionHome>
+    with WidgetsBindingObserver {
   final CompanionPlatformBridge bridge = const CompanionPlatformBridge();
   late final LocalCompanionServer localServer = LocalCompanionServer(bridge: bridge);
   static final Uri androidNativeEndpoint = Uri.parse('http://127.0.0.1:38473');
@@ -38,6 +39,7 @@ class _CompanionHomeState extends State<CompanionHome> {
   Map<String, Object?> permissionState = const {};
   Map<String, Object?> assistantState = const {};
   Map<String, Object?> voiceAuthorizationState = const {};
+  Map<String, Object?> voiceReceipt = const {};
   bool loading = true;
   bool preparingVoice = false;
   String? bridgeError;
@@ -58,14 +60,21 @@ class _CompanionHomeState extends State<CompanionHome> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     refresh();
     _startLocalBridge();
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     if (!Platform.isAndroid) localServer.stop();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) refresh();
   }
 
   Future<void> _startLocalBridge() async {
@@ -93,12 +102,14 @@ class _CompanionHomeState extends State<CompanionHome> {
         bridge.getDeviceStatus(),
         bridge.getCapabilityStatus(),
         if (Platform.isAndroid) bridge.getAssistantStatus() else Future.value(<String, Object?>{}),
+        if (Platform.isAndroid) bridge.getVoiceReceipt() else Future.value(<String, Object?>{}),
       ]);
       if (!mounted) return;
       setState(() {
         status = values[0];
         permissionState = values[1];
         assistantState = values[2];
+        voiceReceipt = values[3];
         loading = false;
       });
     } catch (error) {
@@ -129,6 +140,18 @@ class _CompanionHomeState extends State<CompanionHome> {
         content: Text(opened
             ? 'Choose 3DVR Companion as your assistant, then return here.'
             : 'Android assistant role is unavailable on this device.'),
+      ),
+    );
+  }
+
+  Future<void> _requestMicrophonePermission() async {
+    final opened = await bridge.requestMicrophonePermission();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(opened
+            ? 'Allow microphone access in the Android prompt.'
+            : 'Microphone permission could not be requested.'),
       ),
     );
   }
@@ -177,6 +200,7 @@ class _CompanionHomeState extends State<CompanionHome> {
     final bridgeReady = bridgeError == null && endpoint != null;
     final accessibilityEnabled = permissionState['accessibilityEnabled'] == true;
     final notificationAccessEnabled = permissionState['notificationAccessEnabled'] == true;
+    final microphoneGranted = permissionState['microphoneGranted'] == true;
     final voiceAuthorizationReady = voiceAuthorizationState['ok'] == true;
 
     return Scaffold(
@@ -225,14 +249,23 @@ class _CompanionHomeState extends State<CompanionHome> {
                     _readinessRow('Local bridge', bridgeReady),
                     _readinessRow('Direct relay', relayConnected),
                     _readinessRow('Android assistant', assistantHeld),
+                    _readinessRow('Microphone access', microphoneGranted),
                     _readinessRow('Voice service', assistantActive),
                     _readinessRow('Session service', assistantServiceReady),
                     _readinessRow('Accessibility control', accessibilityEnabled),
                     _readinessRow('Notification access', notificationAccessEnabled),
                     _readinessRow('One-time voice authorization', voiceAuthorizationReady),
+                    if (!microphoneGranted) ...[
+                      const SizedBox(height: 12),
+                      FilledButton.tonalIcon(
+                        onPressed: _requestMicrophonePermission,
+                        icon: const Icon(Icons.mic_none),
+                        label: const Text('Allow microphone'),
+                      ),
+                    ],
                     const SizedBox(height: 12),
                     FilledButton.icon(
-                      onPressed: relayConnected && assistantHeld && !preparingVoice
+                      onPressed: relayConnected && assistantHeld && microphoneGranted && !preparingVoice
                           ? _prepareVoiceSession
                           : null,
                       icon: preparingVoice
@@ -242,15 +275,65 @@ class _CompanionHomeState extends State<CompanionHome> {
                               child: CircularProgressIndicator(strokeWidth: 2),
                             )
                           : const Icon(Icons.mic),
-                      label: Text(preparingVoice ? 'Preparing…' : 'Prepare voice session'),
+                      label: Text(preparingVoice ? 'Preparing…' : 'Prepare Realtime voice'),
                     ),
-                    if (!relayConnected || !assistantHeld) ...[
+                    if (!relayConnected || !assistantHeld || !microphoneGranted) ...[
                       const SizedBox(height: 8),
                       Text(
                         !relayConnected
-                            ? 'Connect the direct relay before preparing a voice session.'
-                            : 'Select 3DVR Companion as the Android assistant before preparing voice.',
+                            ? 'Connect the direct relay before preparing a Realtime voice session.'
+                            : !assistantHeld
+                                ? 'Select 3DVR Companion as the Android assistant before preparing voice.'
+                                : 'Allow microphone access before preparing voice.',
                       ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.record_voice_over),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            'Voice round trip',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    const Text(
+                      'Invoke 3DVR as the Android Assistant and say “Open Maps”. The first release path only admits known app launches.',
+                    ),
+                    const SizedBox(height: 12),
+                    if (!assistantHeld)
+                      const Text('First make 3DVR Companion your Android assistant.')
+                    else if (!microphoneGranted)
+                      const Text('First allow microphone access above.')
+                    else
+                      const Text('Ready to test. Invoke your Android Assistant gesture or button and speak a supported command.'),
+                    if (voiceReceipt.isNotEmpty) ...[
+                      const Divider(height: 28),
+                      Text('Last voice receipt', style: Theme.of(context).textTheme.titleSmall),
+                      const SizedBox(height: 6),
+                      Text('Heard: ${voiceReceipt['transcript'] ?? ''}'),
+                      Text('Capability: ${voiceReceipt['capability'] ?? ''}'),
+                      Text('Target: ${voiceReceipt['target'] ?? ''}'),
+                      Text('Result: ${voiceReceipt['ok'] == true ? 'success' : 'blocked/failed'}'),
+                      Text('Code: ${voiceReceipt['code'] ?? ''}'),
+                      if (voiceReceipt['timestamp'] is num)
+                        Text(
+                          'At: ${DateTime.fromMillisecondsSinceEpoch((voiceReceipt['timestamp'] as num).toInt()).toLocal()}',
+                        ),
                     ],
                   ],
                 ),

--- a/apps/companion/lib/src/platform_bridge.dart
+++ b/apps/companion/lib/src/platform_bridge.dart
@@ -63,6 +63,11 @@ class CompanionPlatformBridge {
     return result ?? const {};
   }
 
+  Future<Map<String, Object?>> getVoiceReceipt() async {
+    final result = await _channel.invokeMapMethod<String, Object?>('voiceReceipt');
+    return result ?? const {};
+  }
+
   Future<Map<String, Object?>> beginVoiceAuthorization() async {
     final result = await _channel.invokeMapMethod<String, Object?>('beginVoiceAuthorization');
     return result ?? const {};
@@ -70,6 +75,11 @@ class CompanionPlatformBridge {
 
   Future<bool> requestAssistantRole() async {
     final result = await _channel.invokeMethod<bool>('requestAssistantRole');
+    return result ?? false;
+  }
+
+  Future<bool> requestMicrophonePermission() async {
+    final result = await _channel.invokeMethod<bool>('requestMicrophonePermission');
     return result ?? false;
   }
 

--- a/apps/companion/native-spec/android/CompanionAssistantStateStore.kt
+++ b/apps/companion/native-spec/android/CompanionAssistantStateStore.kt
@@ -1,0 +1,65 @@
+package tech.threedvr.companion
+
+import android.content.Context
+import android.util.AtomicFile
+import org.json.JSONObject
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+/**
+ * Cross-process readiness state for Android's VoiceInteractionService and
+ * VoiceInteractionSession. Android runs those components in dedicated
+ * processes, so ordinary Kotlin object fields are not shared with MainActivity.
+ */
+object CompanionAssistantStateStore {
+    private const val SERVICE_FILE = "companion_assistant_service.json"
+    private const val SESSION_FILE = "companion_assistant_session.json"
+
+    fun setServiceReady(context: Context, ready: Boolean) {
+        writeJson(
+            atomicFile(context, SERVICE_FILE),
+            JSONObject().apply {
+                put("serviceReady", ready)
+                put("updatedAt", System.currentTimeMillis())
+            },
+        )
+    }
+
+    fun markSessionPrepared(context: Context) {
+        writeJson(
+            atomicFile(context, SESSION_FILE),
+            JSONObject().apply {
+                put("lastSessionPreparedAt", System.currentTimeMillis())
+            },
+        )
+    }
+
+    fun snapshot(context: Context): Map<String, Any?> {
+        val service = readJson(atomicFile(context, SERVICE_FILE))
+        val session = readJson(atomicFile(context, SESSION_FILE))
+        return mapOf(
+            "serviceReady" to (service?.optBoolean("serviceReady", false) ?: false),
+            "serviceUpdatedAt" to service?.optLong("updatedAt", 0L)?.takeIf { it > 0L },
+            "lastSessionPreparedAt" to session?.optLong("lastSessionPreparedAt", 0L)?.takeIf { it > 0L },
+        )
+    }
+
+    private fun atomicFile(context: Context, name: String): AtomicFile =
+        AtomicFile(File(context.filesDir, name))
+
+    private fun writeJson(file: AtomicFile, payload: JSONObject) {
+        val output = runCatching { file.startWrite() }.getOrNull() ?: return
+        try {
+            output.write(payload.toString().toByteArray(StandardCharsets.UTF_8))
+            output.flush()
+            file.finishWrite(output)
+        } catch (_: Exception) {
+            file.failWrite(output)
+        }
+    }
+
+    private fun readJson(file: AtomicFile): JSONObject? {
+        val bytes = runCatching { file.readFully() }.getOrNull() ?: return null
+        return runCatching { JSONObject(String(bytes, StandardCharsets.UTF_8)) }.getOrNull()
+    }
+}

--- a/apps/companion/native-spec/android/CompanionVoiceCommandRouter.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceCommandRouter.kt
@@ -1,0 +1,91 @@
+package tech.threedvr.companion
+
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+
+/**
+ * Tiny, explicit voice command router for the first Assistant round-trip.
+ *
+ * This is intentionally not a general natural-language executor. It only
+ * recognizes a small set of "open known app" requests and maps them to the
+ * same bounded app aliases admitted by Companion's remote relay.
+ */
+object CompanionVoiceCommandRouter {
+    data class Route(
+        val capabilityId: String,
+        val alias: String,
+    )
+
+    data class Execution(
+        val ok: Boolean,
+        val code: String,
+        val alias: String,
+    )
+
+    private val commandPatterns = linkedMapOf(
+        "maps" to Regex("\\b(?:open|launch|start)\\s+(?:my\\s+)?(?:google\\s+)?maps\\b"),
+        "gmail" to Regex("\\b(?:open|launch|start)\\s+(?:my\\s+)?gmail\\b"),
+        "camera" to Regex("\\b(?:open|launch|start)\\s+(?:my\\s+)?camera\\b"),
+        "messages" to Regex("\\b(?:open|launch|start)\\s+(?:my\\s+)?(?:text\\s+)?messages\\b"),
+        "calendar" to Regex("\\b(?:open|launch|start)\\s+(?:my\\s+)?calendar\\b"),
+        "chrome" to Regex("\\b(?:open|launch|start)\\s+(?:google\\s+)?chrome\\b"),
+        "chatgpt" to Regex("\\b(?:open|launch|start)\\s+(?:the\\s+)?chat\\s*gpt\\b"),
+        "settings" to Regex("\\b(?:open|launch|start)\\s+(?:my\\s+)?settings\\b"),
+    )
+
+    private val knownApps = mapOf(
+        "maps" to listOf("com.google.android.apps.maps"),
+        "gmail" to listOf("com.google.android.gm"),
+        "camera" to listOf("com.sec.android.app.camera", "com.google.android.GoogleCamera"),
+        "messages" to listOf("com.google.android.apps.messaging", "com.samsung.android.messaging", "com.android.mms"),
+        "calendar" to listOf("com.google.android.calendar", "com.samsung.android.calendar"),
+        "chrome" to listOf("com.android.chrome"),
+        "chatgpt" to listOf("com.openai.chatgpt"),
+    )
+
+    fun route(rawTranscript: String): Route? {
+        val normalized = rawTranscript
+            .lowercase()
+            .replace(Regex("[^a-z0-9 ]"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+        if (normalized.isBlank() || normalized.length > 240) return null
+
+        val alias = commandPatterns.entries
+            .firstOrNull { (_, pattern) -> pattern.containsMatchIn(normalized) }
+            ?.key
+            ?: return null
+        return Route(capabilityId = "app.open_known", alias = alias)
+    }
+
+    fun execute(context: Context, route: Route): Execution {
+        if (route.capabilityId != "app.open_known") {
+            return Execution(false, "unsupported_capability", route.alias)
+        }
+
+        if (route.alias == "settings") {
+            return try {
+                context.startActivity(
+                    Intent(Settings.ACTION_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                )
+                Execution(true, "opened", route.alias)
+            } catch (_: Exception) {
+                Execution(false, "launch_failed", route.alias)
+            }
+        }
+
+        val candidates = knownApps[route.alias]
+            ?: return Execution(false, "unsupported_app_alias", route.alias)
+        for (packageName in candidates) {
+            val intent = context.packageManager.getLaunchIntentForPackage(packageName) ?: continue
+            return try {
+                context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+                Execution(true, "opened", route.alias)
+            } catch (_: Exception) {
+                Execution(false, "launch_failed", route.alias)
+            }
+        }
+        return Execution(false, "app_not_installed", route.alias)
+    }
+}

--- a/apps/companion/native-spec/android/CompanionVoiceInteractionService.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceInteractionService.kt
@@ -3,11 +3,6 @@ package tech.threedvr.companion
 import android.os.Bundle
 import android.service.voice.VoiceInteractionService
 
-object CompanionAssistantState {
-    @Volatile var serviceReady: Boolean = false
-    @Volatile var lastSessionPreparedAt: Long? = null
-}
-
 /**
  * Lightweight system-owned entry point for 3DVR as the selected Android assistant.
  * Heavy audio/model work belongs in the session layer rather than this always-on
@@ -16,16 +11,16 @@ object CompanionAssistantState {
 class CompanionVoiceInteractionService : VoiceInteractionService() {
     override fun onReady() {
         super.onReady()
-        CompanionAssistantState.serviceReady = true
+        CompanionAssistantStateStore.setServiceReady(this, true)
     }
 
     override fun onPrepareToShowSession(args: Bundle, flags: Int) {
-        CompanionAssistantState.lastSessionPreparedAt = System.currentTimeMillis()
+        CompanionAssistantStateStore.markSessionPrepared(this)
         super.onPrepareToShowSession(args, flags)
     }
 
     override fun onShutdown() {
-        CompanionAssistantState.serviceReady = false
+        CompanionAssistantStateStore.setServiceReady(this, false)
         super.onShutdown()
     }
 }

--- a/apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt
@@ -1,10 +1,17 @@
 package tech.threedvr.companion
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Typeface
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.service.voice.VoiceInteractionSession
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
 import android.view.Gravity
 import android.view.View
 import android.widget.Button
@@ -12,16 +19,48 @@ import android.widget.LinearLayout
 import android.widget.TextView
 
 /**
- * Minimal native assistant surface. This establishes the Android assistant/session
- * contract now; realtime speech is connected in the next slice.
+ * Native Android Assistant surface for the first real voice -> capability ->
+ * phone-action round trip.
+ *
+ * Recognition is local to the user-invoked Assistant session. The transcript is
+ * routed only through CompanionVoiceCommandRouter's explicit known-app allow
+ * list; no arbitrary package, shell, Accessibility selector, or URL is accepted.
  */
 class CompanionVoiceInteractionSession(
     private val sessionContext: Context,
 ) : VoiceInteractionSession(sessionContext) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var speechRecognizer: SpeechRecognizer? = null
+    private var statusView: TextView? = null
+    private var transcriptView: TextView? = null
+    private var listenButton: Button? = null
+    private var listening = false
 
     override fun onCreateContentView(): View {
         val density = sessionContext.resources.displayMetrics.density
         fun dp(value: Int): Int = (value * density).toInt()
+
+        val status = TextView(sessionContext).apply {
+            text = "Assistant session ready"
+            textSize = 16f
+            gravity = Gravity.CENTER
+            setPadding(0, dp(8), 0, dp(8))
+        }
+        statusView = status
+
+        val transcript = TextView(sessionContext).apply {
+            text = "Try: “Open Maps”"
+            textSize = 14f
+            gravity = Gravity.CENTER
+            setPadding(0, 0, 0, dp(16))
+        }
+        transcriptView = transcript
+
+        val listen = Button(sessionContext).apply {
+            text = "Listen"
+            setOnClickListener { startListening() }
+        }
+        listenButton = listen
 
         return LinearLayout(sessionContext).apply {
             orientation = LinearLayout.VERTICAL
@@ -33,39 +72,180 @@ class CompanionVoiceInteractionSession(
                 textSize = 26f
                 setTypeface(typeface, Typeface.BOLD)
             })
-            addView(TextView(sessionContext).apply {
-                text = "Assistant session ready"
-                textSize = 16f
-                setPadding(0, dp(8), 0, dp(16))
-            })
-            addView(TextView(sessionContext).apply {
-                text = "Voice conversation and device tools will run here."
-                textSize = 14f
-                gravity = Gravity.CENTER
-            })
+            addView(status)
+            addView(transcript)
+            addView(listen, LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ))
             addView(Button(sessionContext).apply {
                 text = "Open 3DVR Companion"
-                setOnClickListener {
-                    val intent = sessionContext.packageManager
-                        .getLaunchIntentForPackage(sessionContext.packageName)
-                        ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    if (intent != null) sessionContext.startActivity(intent)
-                }
+                setOnClickListener { openCompanion() }
             }, LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT,
-            ).apply { topMargin = dp(16) })
+            ).apply { topMargin = dp(10) })
         }
     }
 
     override fun onShow(args: Bundle?, showFlags: Int) {
+        super.onShow(args, showFlags)
         CompanionAssistantState.lastSessionPreparedAt = System.currentTimeMillis()
         setKeepAwake(true)
-        super.onShow(args, showFlags)
+        mainHandler.postDelayed({ startListening() }, 300L)
     }
 
     override fun onHide() {
+        stopListening()
         setKeepAwake(false)
         super.onHide()
+    }
+
+    override fun onDestroy() {
+        mainHandler.removeCallbacksAndMessages(null)
+        speechRecognizer?.destroy()
+        speechRecognizer = null
+        super.onDestroy()
+    }
+
+    private fun startListening() {
+        if (listening) return
+        if (sessionContext.checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+            statusView?.text = "Microphone permission is required"
+            transcriptView?.text = "Open 3DVR Companion, allow microphone access, then invoke the Assistant again."
+            listenButton?.isEnabled = false
+            return
+        }
+        if (!SpeechRecognizer.isRecognitionAvailable(sessionContext)) {
+            statusView?.text = "Speech recognition is unavailable"
+            transcriptView?.text = "Android does not currently expose a recognition service on this device."
+            return
+        }
+
+        if (speechRecognizer == null) {
+            speechRecognizer = SpeechRecognizer.createSpeechRecognizer(sessionContext).also { recognizer ->
+                recognizer.setRecognitionListener(object : RecognitionListener {
+                    override fun onReadyForSpeech(params: Bundle?) {
+                        listening = true
+                        statusView?.text = "Listening…"
+                        listenButton?.isEnabled = false
+                    }
+
+                    override fun onBeginningOfSpeech() {
+                        statusView?.text = "I hear you…"
+                    }
+
+                    override fun onRmsChanged(rmsdB: Float) = Unit
+                    override fun onBufferReceived(buffer: ByteArray?) = Unit
+                    override fun onEndOfSpeech() {
+                        statusView?.text = "Working…"
+                    }
+
+                    override fun onError(error: Int) {
+                        listening = false
+                        listenButton?.isEnabled = true
+                        statusView?.text = when (error) {
+                            SpeechRecognizer.ERROR_NO_MATCH -> "I didn't catch a supported command"
+                            SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "I didn't hear anything"
+                            SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "Microphone permission is required"
+                            else -> "Speech recognition stopped"
+                        }
+                        transcriptView?.text = "Try: “Open Maps” or “Open Camera”."
+                    }
+
+                    override fun onResults(results: Bundle?) {
+                        listening = false
+                        listenButton?.isEnabled = true
+                        val transcript = results
+                            ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                            ?.firstOrNull()
+                            ?.trim()
+                            .orEmpty()
+                        handleTranscript(transcript)
+                    }
+
+                    override fun onPartialResults(partialResults: Bundle?) {
+                        val partial = partialResults
+                            ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                            ?.firstOrNull()
+                            ?.trim()
+                            .orEmpty()
+                        if (partial.isNotBlank()) transcriptView?.text = "Heard: $partial"
+                    }
+
+                    override fun onEvent(eventType: Int, params: Bundle?) = Unit
+                })
+            }
+        }
+
+        statusView?.text = "Starting microphone…"
+        transcriptView?.text = "Say: “Open Maps”"
+        listenButton?.isEnabled = false
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+            putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
+            putExtra(RecognizerIntent.EXTRA_PROMPT, "Tell 3DVR what known app to open")
+        }
+        try {
+            speechRecognizer?.startListening(intent)
+        } catch (_: Exception) {
+            listening = false
+            listenButton?.isEnabled = true
+            statusView?.text = "Unable to start speech recognition"
+            transcriptView?.text = "Try again, or open Companion to check readiness."
+        }
+    }
+
+    private fun stopListening() {
+        if (!listening) return
+        runCatching { speechRecognizer?.cancel() }
+        listening = false
+        listenButton?.isEnabled = true
+    }
+
+    private fun handleTranscript(transcript: String) {
+        if (transcript.isBlank()) {
+            statusView?.text = "I didn't catch that"
+            transcriptView?.text = "Try: “Open Maps”"
+            return
+        }
+        transcriptView?.text = "Heard: $transcript"
+        val route = CompanionVoiceCommandRouter.route(transcript)
+        if (route == null) {
+            CompanionVoiceReceiptStore.record(
+                sessionContext,
+                transcript = transcript,
+                capability = "voice.command",
+                target = "",
+                ok = false,
+                code = "unsupported_voice_command",
+            )
+            statusView?.text = "That command is outside the safe voice set"
+            transcriptView?.text = "Try open Maps, Gmail, Camera, Messages, Calendar, Chrome, ChatGPT, or Settings."
+            return
+        }
+
+        val execution = CompanionVoiceCommandRouter.execute(sessionContext, route)
+        CompanionVoiceReceiptStore.record(
+            sessionContext,
+            transcript = transcript,
+            capability = route.capabilityId,
+            target = route.alias,
+            ok = execution.ok,
+            code = execution.code,
+        )
+        statusView?.text = if (execution.ok) {
+            "Opening ${route.alias.replaceFirstChar { it.uppercase() }}"
+        } else {
+            "Could not open ${route.alias}: ${execution.code}"
+        }
+    }
+
+    private fun openCompanion() {
+        val intent = sessionContext.packageManager
+            .getLaunchIntentForPackage(sessionContext.packageName)
+            ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        if (intent != null) sessionContext.startActivity(intent)
     }
 }

--- a/apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt
@@ -90,7 +90,7 @@ class CompanionVoiceInteractionSession(
 
     override fun onShow(args: Bundle?, showFlags: Int) {
         super.onShow(args, showFlags)
-        CompanionAssistantState.lastSessionPreparedAt = System.currentTimeMillis()
+        CompanionAssistantStateStore.markSessionPrepared(sessionContext)
         setKeepAwake(true)
         mainHandler.postDelayed({ startListening() }, 300L)
     }

--- a/apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt
@@ -1,0 +1,50 @@
+package tech.threedvr.companion
+
+import android.content.Context
+
+/**
+ * Stores only the latest bounded voice action receipt for user-visible audit.
+ * No raw audio is stored, and receipts intentionally avoid secrets or tokens.
+ */
+object CompanionVoiceReceiptStore {
+    private const val PREFS = "companion_voice_receipt"
+    private const val KEY_TIMESTAMP = "timestamp"
+    private const val KEY_TRANSCRIPT = "transcript"
+    private const val KEY_CAPABILITY = "capability"
+    private const val KEY_TARGET = "target"
+    private const val KEY_OK = "ok"
+    private const val KEY_CODE = "code"
+
+    fun record(
+        context: Context,
+        transcript: String,
+        capability: String,
+        target: String,
+        ok: Boolean,
+        code: String,
+    ) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putLong(KEY_TIMESTAMP, System.currentTimeMillis())
+            .putString(KEY_TRANSCRIPT, transcript.take(240))
+            .putString(KEY_CAPABILITY, capability.take(80))
+            .putString(KEY_TARGET, target.take(120))
+            .putBoolean(KEY_OK, ok)
+            .putString(KEY_CODE, code.take(120))
+            .apply()
+    }
+
+    fun snapshot(context: Context): Map<String, Any?> {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val timestamp = prefs.getLong(KEY_TIMESTAMP, 0L)
+        if (timestamp <= 0L) return emptyMap()
+        return mapOf(
+            "timestamp" to timestamp,
+            "transcript" to prefs.getString(KEY_TRANSCRIPT, "").orEmpty(),
+            "capability" to prefs.getString(KEY_CAPABILITY, "").orEmpty(),
+            "target" to prefs.getString(KEY_TARGET, "").orEmpty(),
+            "ok" to prefs.getBoolean(KEY_OK, false),
+            "code" to prefs.getString(KEY_CODE, "").orEmpty(),
+        )
+    }
+}

--- a/apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt
@@ -1,19 +1,21 @@
 package tech.threedvr.companion
 
 import android.content.Context
+import android.util.AtomicFile
+import org.json.JSONObject
+import java.io.File
+import java.nio.charset.StandardCharsets
 
 /**
  * Stores only the latest bounded voice action receipt for user-visible audit.
  * No raw audio is stored, and receipts intentionally avoid secrets or tokens.
+ *
+ * The Assistant session runs in a separate Android process, so this uses an
+ * app-private AtomicFile instead of SharedPreferences to keep cross-process
+ * reads deterministic.
  */
 object CompanionVoiceReceiptStore {
-    private const val PREFS = "companion_voice_receipt"
-    private const val KEY_TIMESTAMP = "timestamp"
-    private const val KEY_TRANSCRIPT = "transcript"
-    private const val KEY_CAPABILITY = "capability"
-    private const val KEY_TARGET = "target"
-    private const val KEY_OK = "ok"
-    private const val KEY_CODE = "code"
+    private const val FILE_NAME = "companion_voice_receipt.json"
 
     fun record(
         context: Context,
@@ -23,28 +25,42 @@ object CompanionVoiceReceiptStore {
         ok: Boolean,
         code: String,
     ) {
-        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit()
-            .putLong(KEY_TIMESTAMP, System.currentTimeMillis())
-            .putString(KEY_TRANSCRIPT, transcript.take(240))
-            .putString(KEY_CAPABILITY, capability.take(80))
-            .putString(KEY_TARGET, target.take(120))
-            .putBoolean(KEY_OK, ok)
-            .putString(KEY_CODE, code.take(120))
-            .apply()
+        val payload = JSONObject().apply {
+            put("timestamp", System.currentTimeMillis())
+            put("transcript", transcript.take(240))
+            put("capability", capability.take(80))
+            put("target", target.take(120))
+            put("ok", ok)
+            put("code", code.take(120))
+        }
+        val atomicFile = atomicFile(context)
+        val output = runCatching { atomicFile.startWrite() }.getOrNull() ?: return
+        try {
+            output.write(payload.toString().toByteArray(StandardCharsets.UTF_8))
+            output.flush()
+            atomicFile.finishWrite(output)
+        } catch (_: Exception) {
+            atomicFile.failWrite(output)
+        }
     }
 
     fun snapshot(context: Context): Map<String, Any?> {
-        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-        val timestamp = prefs.getLong(KEY_TIMESTAMP, 0L)
+        val bytes = runCatching { atomicFile(context).readFully() }.getOrNull() ?: return emptyMap()
+        val payload = runCatching {
+            JSONObject(String(bytes, StandardCharsets.UTF_8))
+        }.getOrNull() ?: return emptyMap()
+        val timestamp = payload.optLong("timestamp", 0L)
         if (timestamp <= 0L) return emptyMap()
         return mapOf(
             "timestamp" to timestamp,
-            "transcript" to prefs.getString(KEY_TRANSCRIPT, "").orEmpty(),
-            "capability" to prefs.getString(KEY_CAPABILITY, "").orEmpty(),
-            "target" to prefs.getString(KEY_TARGET, "").orEmpty(),
-            "ok" to prefs.getBoolean(KEY_OK, false),
-            "code" to prefs.getString(KEY_CODE, "").orEmpty(),
+            "transcript" to payload.optString("transcript"),
+            "capability" to payload.optString("capability"),
+            "target" to payload.optString("target"),
+            "ok" to payload.optBoolean("ok", false),
+            "code" to payload.optString("code"),
         )
     }
+
+    private fun atomicFile(context: Context): AtomicFile =
+        AtomicFile(File(context.filesDir, FILE_NAME))
 }

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -158,12 +158,14 @@ class MainActivity : FlutterActivity() {
         }
         val roleManager = getSystemService(RoleManager::class.java)
         val component = ComponentName(this, CompanionVoiceInteractionService::class.java)
+        val persistedState = CompanionAssistantStateStore.snapshot(this)
         return mapOf(
             "roleAvailable" to roleManager.isRoleAvailable(RoleManager.ROLE_ASSISTANT),
             "roleHeld" to roleManager.isRoleHeld(RoleManager.ROLE_ASSISTANT),
             "voiceServiceActive" to VoiceInteractionService.isActiveService(this, component),
-            "serviceReady" to CompanionAssistantState.serviceReady,
-            "lastSessionPreparedAt" to CompanionAssistantState.lastSessionPreparedAt,
+            "serviceReady" to (persistedState["serviceReady"] == true),
+            "serviceUpdatedAt" to persistedState["serviceUpdatedAt"],
+            "lastSessionPreparedAt" to persistedState["lastSessionPreparedAt"],
         )
     }
 

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -1,9 +1,11 @@
 package tech.threedvr.companion
 
+import android.Manifest
 import android.app.role.RoleManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.BatteryManager
 import android.os.Build
@@ -68,7 +70,9 @@ class MainActivity : FlutterActivity() {
                     "deviceStatus" -> result.success(deviceStatus())
                     "capabilityStatus" -> result.success(capabilityStatus())
                     "assistantStatus" -> result.success(assistantStatus())
+                    "voiceReceipt" -> result.success(CompanionVoiceReceiptStore.snapshot(this))
                     "requestAssistantRole" -> result.success(requestAssistantRole())
+                    "requestMicrophonePermission" -> result.success(requestMicrophonePermission())
                     "beginVoiceAuthorization" -> result.success(beginVoiceAuthorization(voiceAuthorizationStore))
                     "openVoiceInputSettings" -> {
                         startActivity(Intent(Settings.ACTION_VOICE_INPUT_SETTINGS))
@@ -175,6 +179,18 @@ class MainActivity : FlutterActivity() {
         return true
     }
 
+    private fun hasMicrophonePermission(): Boolean =
+        checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+
+    private fun requestMicrophonePermission(): Boolean {
+        if (hasMicrophonePermission()) return true
+        requestPermissions(
+            arrayOf(Manifest.permission.RECORD_AUDIO),
+            MICROPHONE_PERMISSION_REQUEST_CODE,
+        )
+        return true
+    }
+
     private fun deviceStatus(): Map<String, Any?> {
         val battery = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
         return mapOf(
@@ -193,6 +209,7 @@ class MainActivity : FlutterActivity() {
         return mapOf(
             "accessibilityEnabled" to isAccessibilityEnabled(),
             "notificationAccessEnabled" to isNotificationAccessEnabled(),
+            "microphoneGranted" to hasMicrophonePermission(),
             "messageNotificationReadEnabled" to isNotificationAccessEnabled(),
             "messageNotificationReplyEnabled" to isNotificationAccessEnabled(),
             "messageHistoryEncryptedAtRest" to true,
@@ -247,5 +264,6 @@ class MainActivity : FlutterActivity() {
 
     companion object {
         private const val ASSISTANT_ROLE_REQUEST_CODE = 38474
+        private const val MICROPHONE_PERMISSION_REQUEST_CODE = 38475
     }
 }

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -24,7 +24,7 @@ cp "$BACKUP/analysis_options.yaml" analysis_options.yaml
 
 KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
 mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
-for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt CompanionVoiceAuthorizationStore.kt CompanionVoiceReceiptStore.kt CompanionVoiceCommandRouter.kt CompanionVoiceInteractionService.kt CompanionVoiceInteractionSessionService.kt CompanionVoiceInteractionSession.kt; do
+for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt CompanionVoiceAuthorizationStore.kt CompanionVoiceReceiptStore.kt CompanionAssistantStateStore.kt CompanionVoiceCommandRouter.kt CompanionVoiceInteractionService.kt CompanionVoiceInteractionSessionService.kt CompanionVoiceInteractionSession.kt; do
   cp "native-spec/android/$source" "$KOTLIN_DIR/$source"
 done
 cp native-spec/android/companion_accessibility_service.xml android/app/src/main/res/xml/companion_accessibility_service.xml

--- a/apps/companion/scaffold.sh
+++ b/apps/companion/scaffold.sh
@@ -24,7 +24,7 @@ cp "$BACKUP/analysis_options.yaml" analysis_options.yaml
 
 KOTLIN_DIR="android/app/src/main/kotlin/tech/threedvr/companion"
 mkdir -p "$KOTLIN_DIR" android/app/src/main/res/xml
-for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt CompanionVoiceAuthorizationStore.kt CompanionVoiceInteractionService.kt CompanionVoiceInteractionSessionService.kt CompanionVoiceInteractionSession.kt; do
+for source in MainActivity.kt CompanionAccessibilityService.kt CompanionNotificationListener.kt CompanionKeepAliveService.kt CompanionNativeBridgeServer.kt CompanionStartupReceiver.kt CompanionSelfUpdater.kt CompanionShizuku.kt CompanionRelaySecretStore.kt CompanionRemoteRelayClient.kt CompanionVoiceAuthorizationStore.kt CompanionVoiceReceiptStore.kt CompanionVoiceCommandRouter.kt CompanionVoiceInteractionService.kt CompanionVoiceInteractionSessionService.kt CompanionVoiceInteractionSession.kt; do
   cp "native-spec/android/$source" "$KOTLIN_DIR/$source"
 done
 cp native-spec/android/companion_accessibility_service.xml android/app/src/main/res/xml/companion_accessibility_service.xml
@@ -120,4 +120,5 @@ echo "Android relay credentials: Keystore-encrypted at rest"
 echo "Android direct relay: always-on client wired"
 echo "Android one-time voice proof: wired"
 echo "Android assistant role + VoiceInteractionService: wired"
+echo "Android bounded voice app-launch round trip: wired"
 echo "iOS App Intent: staged in ios/CompanionNativeSpec (Xcode target wiring still required)"

--- a/tests/companion-voice-round-trip.test.js
+++ b/tests/companion-voice-round-trip.test.js
@@ -6,6 +6,8 @@ const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf
 
 const router = read('apps/companion/native-spec/android/CompanionVoiceCommandRouter.kt');
 const session = read('apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt');
+const service = read('apps/companion/native-spec/android/CompanionVoiceInteractionService.kt');
+const assistantState = read('apps/companion/native-spec/android/CompanionAssistantStateStore.kt');
 const activity = read('apps/companion/native-spec/android/MainActivity.kt');
 const scaffold = read('apps/companion/scaffold.sh');
 const dashboard = read('apps/companion/lib/main.dart');
@@ -27,6 +29,15 @@ test('Android Assistant recognizes speech and records a visible receipt', () => 
   assert.doesNotMatch(session, /Runtime\.getRuntime|ProcessBuilder|\bexec\s*\(/);
 });
 
+test('assistant readiness survives Android process boundaries', () => {
+  assert.match(assistantState, /AtomicFile/);
+  assert.match(service, /CompanionAssistantStateStore\.setServiceReady/);
+  assert.match(session, /CompanionAssistantStateStore\.markSessionPrepared/);
+  assert.match(activity, /CompanionAssistantStateStore\.snapshot/);
+  assert.doesNotMatch(service, /CompanionAssistantState\./);
+  assert.doesNotMatch(session, /CompanionAssistantState\./);
+});
+
 test('microphone consent and receipt are exposed to the Companion dashboard', () => {
   assert.match(activity, /"microphoneGranted" to hasMicrophonePermission\(\)/);
   assert.match(activity, /"requestMicrophonePermission"/);
@@ -38,6 +49,7 @@ test('microphone consent and receipt are exposed to the Companion dashboard', ()
 
 test('fresh Android scaffolds include the voice sources and record-audio permission', () => {
   assert.match(scaffold, /CompanionVoiceReceiptStore\.kt/);
+  assert.match(scaffold, /CompanionAssistantStateStore\.kt/);
   assert.match(scaffold, /CompanionVoiceCommandRouter\.kt/);
   assert.match(scaffold, /android\.permission\.RECORD_AUDIO/);
 });

--- a/tests/companion-voice-round-trip.test.js
+++ b/tests/companion-voice-round-trip.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const router = read('apps/companion/native-spec/android/CompanionVoiceCommandRouter.kt');
+const session = read('apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt');
+const activity = read('apps/companion/native-spec/android/MainActivity.kt');
+const scaffold = read('apps/companion/scaffold.sh');
+const dashboard = read('apps/companion/lib/main.dart');
+
+test('voice round trip is constrained to the known app capability', () => {
+  assert.match(router, /capabilityId = "app\.open_known"/);
+  for (const alias of ['maps', 'gmail', 'camera', 'messages', 'calendar', 'chrome', 'chatgpt', 'settings']) {
+    assert.match(router, new RegExp(`"${alias}"`));
+  }
+  assert.doesNotMatch(router, /"termux"/);
+  assert.doesNotMatch(router, /Runtime\.getRuntime|ProcessBuilder|\bexec\s*\(/);
+});
+
+test('Android Assistant recognizes speech and records a visible receipt', () => {
+  assert.match(session, /SpeechRecognizer\.createSpeechRecognizer/);
+  assert.match(session, /CompanionVoiceCommandRouter\.route/);
+  assert.match(session, /CompanionVoiceCommandRouter\.execute/);
+  assert.match(session, /CompanionVoiceReceiptStore\.record/);
+  assert.doesNotMatch(session, /Runtime\.getRuntime|ProcessBuilder|\bexec\s*\(/);
+});
+
+test('microphone consent and receipt are exposed to the Companion dashboard', () => {
+  assert.match(activity, /"microphoneGranted" to hasMicrophonePermission\(\)/);
+  assert.match(activity, /"requestMicrophonePermission"/);
+  assert.match(activity, /"voiceReceipt"/);
+  assert.match(dashboard, /Allow microphone/);
+  assert.match(dashboard, /Last voice receipt/);
+  assert.match(dashboard, /say “Open Maps”/);
+});
+
+test('fresh Android scaffolds include the voice sources and record-audio permission', () => {
+  assert.match(scaffold, /CompanionVoiceReceiptStore\.kt/);
+  assert.match(scaffold, /CompanionVoiceCommandRouter\.kt/);
+  assert.match(scaffold, /android\.permission\.RECORD_AUDIO/);
+});


### PR DESCRIPTION
## What changed

- make the Android Assistant session automatically listen with `SpeechRecognizer`
- route only a tiny known-app voice set into the bounded `app.open_known` capability
- support Maps, Gmail, Camera, Messages, Calendar, Chrome, ChatGPT, and Settings
- persist the latest short transcript + capability + target + result as a user-visible voice receipt
- expose microphone consent and the latest receipt in the Companion readiness dashboard
- include the new native sources in fresh Android scaffolds
- add a source-level contract test that rejects shell/Termux drift in this voice path

## Why

v0.0.59 needs one real spoken request → bounded phone action → visible receipt before adding more subsystems. This proves that loop without making OpenAI Realtime a release blocker.

## Safety

This path does not accept arbitrary package names, URLs, Accessibility selectors, shell commands, Shizuku operations, financial actions, account changes, or outbound messages. Raw audio is not stored. Unsupported speech is rejected rather than guessed.

## Demo

1. Make 3DVR Companion the Android Assistant.
2. Allow microphone access.
3. Invoke the Android Assistant gesture/button.
4. Say **“Open Maps.”**
5. Reopen Companion to inspect the voice receipt.

OpenAI Realtime remains the next intelligence layer; its future tool calls should resolve into these same bounded capability contracts rather than gaining direct device authority.

Part of #1564.