### PR TITLE
Add Human Value Network page

### DIFF
--- a/human-value-network/app.js
+++ b/human-value-network/app.js
@@ -1,0 +1,104 @@
+const form = document.getElementById('nicheForm');
+const clearButton = document.getElementById('clearNiche');
+const valueMap = document.getElementById('valueMap');
+const valueMapBody = document.getElementById('valueMapBody');
+const copyButton = document.getElementById('copyValueMap');
+
+const fields = ['asked', 'learned', 'energy', 'teach', 'problem'];
+const labels = {
+  asked: 'People already trust me for',
+  learned: 'Hard-earned knowledge',
+  energy: 'Energy / curiosity',
+  teach: 'Something I can teach now',
+  problem: 'A problem I keep noticing'
+};
+
+const storageKey = '3dvr-human-value-network';
+
+function getValues() {
+  return Object.fromEntries(fields.map((name) => [name, form.elements[name].value.trim()]));
+}
+
+function saveDraft() {
+  localStorage.setItem(storageKey, JSON.stringify(getValues()));
+}
+
+function restoreDraft() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    fields.forEach((name) => {
+      if (saved[name]) form.elements[name].value = saved[name];
+    });
+  } catch {
+    localStorage.removeItem(storageKey);
+  }
+}
+
+function buildMap(values) {
+  const entries = fields.filter((name) => values[name]);
+  valueMapBody.innerHTML = '';
+
+  const dl = document.createElement('dl');
+  entries.forEach((name) => {
+    const wrapper = document.createElement('div');
+    const dt = document.createElement('dt');
+    const dd = document.createElement('dd');
+    dt.textContent = labels[name];
+    dd.textContent = values[name];
+    wrapper.append(dt, dd);
+    dl.append(wrapper);
+  });
+
+  const experiment = document.createElement('p');
+  experiment.innerHTML = '<strong>Next experiment:</strong> Pick one person with a real need and offer one small useful outcome. Learn from the exchange before trying to build a whole business.';
+
+  valueMapBody.append(dl, experiment);
+}
+
+function mapAsText() {
+  const values = getValues();
+  const lines = ['3DVR HUMAN VALUE MAP', ''];
+  fields.forEach((name) => {
+    if (values[name]) lines.push(`${labels[name]}:\n${values[name]}\n`);
+  });
+  lines.push('Next experiment: Pick one person with a real need and offer one small useful outcome. Learn from the exchange before building a whole business.');
+  return lines.join('\n');
+}
+
+form.addEventListener('input', saveDraft);
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const values = getValues();
+  if (!fields.some((name) => values[name])) {
+    form.elements.asked.focus();
+    return;
+  }
+
+  buildMap(values);
+  valueMap.hidden = false;
+  valueMap.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+
+clearButton.addEventListener('click', () => {
+  form.reset();
+  valueMap.hidden = true;
+  valueMapBody.innerHTML = '';
+  localStorage.removeItem(storageKey);
+  form.elements.asked.focus();
+});
+
+copyButton.addEventListener('click', async () => {
+  const original = copyButton.textContent;
+  try {
+    await navigator.clipboard.writeText(mapAsText());
+    copyButton.textContent = 'Copied';
+  } catch {
+    copyButton.textContent = 'Select and copy instead';
+  }
+  window.setTimeout(() => {
+    copyButton.textContent = original;
+  }, 1800);
+});
+
+restoreDraft();

--- a/human-value-network/index.html
+++ b/human-value-network/index.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Human Value Network | 3DVR</title>
+  <meta name="description" content="Discover your unique skill stack, turn it into useful value, and build a people-powered economy through skill-sharing, direct exchange, and collaboration.">
+  <meta name="theme-color" content="#07120f">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script defer src="app.js"></script>
+</head>
+<body class="theme-dark value-page">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+
+  <div class="value-shell">
+    <header class="value-nav">
+      <a class="brand-link" href="../index.html">3DVR</a>
+      <nav aria-label="Human Value Network navigation">
+        <a href="../purpose-movement/">Purpose</a>
+        <a href="#path">The path</a>
+        <a href="#niche-lab">Find your niche</a>
+        <a href="../launch-room/">Launch Room</a>
+      </nav>
+    </header>
+
+    <main id="mainContent">
+      <section class="hero" aria-labelledby="hero-title">
+        <p class="eyebrow">Human Value Network</p>
+        <h1 id="hero-title">We already have what we need. We have each other.</h1>
+        <p class="hero-copy">
+          Every human carries a one-of-one combination of skills, experience, curiosity, relationships,
+          taste, struggle, and perspective. 3DVR helps people recognize that value, shape it into something
+          useful, and exchange it directly with other people.
+        </p>
+        <div class="hero-actions">
+          <a class="button button--primary" href="#niche-lab">Find your value</a>
+          <a class="button" href="#economy">See the network</a>
+        </div>
+        <p class="hero-note">
+          This is not about hating large companies. It is about remembering that they are not the only place
+          value can come from.
+        </p>
+      </section>
+
+      <section class="statement" aria-labelledby="statement-title">
+        <p class="eyebrow">The idea</p>
+        <h2 id="statement-title">Build an economy we would rather live in.</h2>
+        <p>
+          Buy from people you know. Share skills. Teach each other. Start tiny businesses. Build open tools.
+          Form teams around real needs. Use large systems when they help, not because we forgot we have alternatives.
+        </p>
+        <blockquote>
+          <strong>Don’t just buy differently. Build differently.</strong>
+        </blockquote>
+      </section>
+
+      <section class="skill-stack" aria-labelledby="skill-stack-title">
+        <div class="section-heading">
+          <p class="eyebrow">Your value is combinational</p>
+          <h2 id="skill-stack-title">Nobody else has your exact stack.</h2>
+          <p>Your niche is often hiding where ordinary-looking parts of your life overlap.</p>
+        </div>
+        <div class="stack-grid">
+          <article><span>01</span><h3>Skills</h3><p>Things you can do, fix, explain, organize, make, perform, or improve.</p></article>
+          <article><span>02</span><h3>Experience</h3><p>Jobs, places, communities, mistakes, responsibilities, and seasons you have lived through.</p></article>
+          <article><span>03</span><h3>Curiosity</h3><p>The subjects you keep returning to when nobody is assigning homework.</p></article>
+          <article><span>04</span><h3>Perspective</h3><p>The connections you notice because your path through life has been different.</p></article>
+          <article><span>05</span><h3>Relationships</h3><p>The people and communities whose needs you understand from the inside.</p></article>
+          <article><span>06</span><h3>Care</h3><p>The problems you cannot quite stop caring about. That attention is information.</p></article>
+        </div>
+      </section>
+
+      <section class="resistance" aria-labelledby="resistance-title">
+        <div class="section-heading">
+          <p class="eyebrow">Why this is hard</p>
+          <h2 id="resistance-title">Finding your worth is not just a business exercise.</h2>
+          <p>People often have to untangle years of messages about who they are allowed to become.</p>
+        </div>
+        <div class="resistance-grid">
+          <article><h3>Family scripts</h3><p>“Be realistic.” “That isn’t a real job.” “Why can’t you just do what everyone else does?”</p></article>
+          <article><h3>Marketing scripts</h3><p>Being trained to see yourself primarily as a consumer instead of a capable creator.</p></article>
+          <article><h3>Credential scripts</h3><p>Believing value only counts after an institution gives you permission to offer it.</p></article>
+          <article><h3>Self-worth</h3><p>Learning to charge, ask, share, teach, and be visible without pretending to be someone else.</p></article>
+          <article><h3>Teamwork</h3><p>Learning where your strengths end and another person’s begin, then building together.</p></article>
+          <article><h3>Fear of judgment</h3><p>Making the first public signal before you feel completely ready.</p></article>
+        </div>
+      </section>
+
+      <section id="path" class="path-section" aria-labelledby="path-title">
+        <div class="section-heading">
+          <p class="eyebrow">The 3DVR path</p>
+          <h2 id="path-title">Worth becomes freedom through practice.</h2>
+        </div>
+        <ol class="path-list">
+          <li><span>Notice</span><p>Pay attention to what you know, what people ask you for, and what problems keep pulling at you.</p></li>
+          <li><span>Name</span><p>Describe your unusual combination clearly enough that another human can recognize it.</p></li>
+          <li><span>Package</span><p>Turn one small piece of that value into a service, lesson, product, tool, event, or contribution.</p></li>
+          <li><span>Signal</span><p>Tell real people what you are exploring. Ask who needs it. Listen before scaling.</p></li>
+          <li><span>Exchange</span><p>Sell it, barter it, trade skills, contribute it openly, or combine it with someone else’s work.</p></li>
+          <li><span>Teach</span><p>Document what you learn so another person can gain the capability too.</p></li>
+          <li><span>Network</span><p>Connect useful people until a resilient local and online economy starts to emerge.</p></li>
+        </ol>
+      </section>
+
+      <section id="economy" class="economy" aria-labelledby="economy-title">
+        <div class="section-heading">
+          <p class="eyebrow">People-powered economy</p>
+          <h2 id="economy-title">Keep more value moving between humans.</h2>
+          <p>The network gets stronger each time one person’s capability unlocks another person’s next step.</p>
+        </div>
+        <div class="loop" aria-label="Human value exchange loop">
+          <span>discover</span><b>→</b><span>offer</span><b>→</b><span>exchange</span><b>→</b><span>learn</span><b>→</b><span>teach</span><b>→</b><span>collaborate</span>
+        </div>
+        <div class="economy-grid">
+          <article><h3>Buy from ourselves</h3><p>When a friend, neighbor, independent builder, or small team can solve the need well, give them the opportunity.</p></article>
+          <article><h3>Skill-share</h3><p>Trade capabilities when money is scarce. A website can become photography. Childcare can become repair. Knowledge can become momentum.</p></article>
+          <article><h3>Open what we can</h3><p>Shared code, documentation, templates, knowledge, and standards reduce dependence by making capability reusable.</p></article>
+          <article><h3>Build teams, not heroes</h3><p>No one has to know everything. A healthy network makes specialization a strength instead of a weakness.</p></article>
+        </div>
+      </section>
+
+      <section id="niche-lab" class="niche-lab" aria-labelledby="niche-title">
+        <div class="section-heading">
+          <p class="eyebrow">Niche Lab</p>
+          <h2 id="niche-title">Find the value hiding in your life.</h2>
+          <p>Answer fast. Do not try to sound impressive. The useful pattern is usually already there.</p>
+        </div>
+
+        <form id="nicheForm" class="niche-form">
+          <label>
+            <span>What do people already ask you for help with?</span>
+            <textarea name="asked" rows="3" placeholder="Troubleshooting gear, listening, cooking, organizing a crew, fixing bikes..."></textarea>
+          </label>
+          <label>
+            <span>What have you learned the hard way?</span>
+            <textarea name="learned" rows="3" placeholder="Things work, school, family, failure, travel, caregiving, or rebuilding taught you."></textarea>
+          </label>
+          <label>
+            <span>What can you happily talk about or practice for hours?</span>
+            <textarea name="energy" rows="3" placeholder="The topic that gives you energy instead of draining it."></textarea>
+          </label>
+          <label>
+            <span>What could you teach someone in 30 minutes?</span>
+            <textarea name="teach" rows="3" placeholder="One useful outcome another person could leave with today."></textarea>
+          </label>
+          <label>
+            <span>What problem around you do you keep noticing?</span>
+            <textarea name="problem" rows="3" placeholder="Something inefficient, unfair, confusing, expensive, lonely, ugly, or missing."></textarea>
+          </label>
+
+          <div class="form-actions">
+            <button class="button button--primary" type="submit">Build my value map</button>
+            <button class="button" type="button" id="clearNiche">Clear</button>
+          </div>
+        </form>
+
+        <section class="value-map" id="valueMap" aria-live="polite" hidden>
+          <p class="eyebrow">Your first signal</p>
+          <h3>You do not need the perfect niche. You need a useful experiment.</h3>
+          <div id="valueMapBody"></div>
+          <div class="form-actions">
+            <button class="button" type="button" id="copyValueMap">Copy value map</button>
+            <a class="button button--primary" href="../launch-room/">Take it to Launch Room</a>
+          </div>
+        </section>
+      </section>
+
+      <section class="closing" aria-labelledby="closing-title">
+        <p class="eyebrow">The bigger vision</p>
+        <h2 id="closing-title">A world full of capable people who know they matter.</h2>
+        <p>
+          3DVR can help people move from consumer to creator, isolated skill-holder to collaborator,
+          employee-only identity to multidimensional builder, and vague self-doubt to visible evidence of value.
+        </p>
+        <blockquote><strong>Find your worth. Find your niche. Help each other build.</strong></blockquote>
+        <div class="hero-actions">
+          <a class="button button--primary" href="../launch-room/">Launch something small</a>
+          <a class="button" href="../community/index.html">Find your people</a>
+          <a class="button" href="../purpose-movement/">Explore your purpose</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <span>3DVR.Tech — Build the future together.</span>
+      <a href="../index.html">Back to Portal</a>
+    </footer>
+  </div>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/human-value-network/styles.css
+++ b/human-value-network/styles.css
@@ -1,0 +1,428 @@
+body.value-page {
+  --page-background: radial-gradient(120% 100% at 20% 0%, #14352d 0%, #07120f 48%, #030706 100%);
+  --surface: rgba(10, 28, 23, 0.72);
+  --surface-alt: rgba(14, 39, 32, 0.86);
+  --surface-border: rgba(110, 231, 183, 0.18);
+  --color-text: #ecfdf5;
+  --color-text-muted: #a7c7bb;
+  --accent: #6ee7b7;
+  --accent-strong: #a7f3d0;
+  --accent-contrast: #052018;
+  background: var(--page-background);
+}
+
+.value-page::before {
+  background: radial-gradient(circle, rgba(52, 211, 153, 0.24), transparent 62%);
+}
+
+.value-page::after {
+  background: radial-gradient(circle, rgba(20, 184, 166, 0.2), transparent 62%);
+}
+
+.value-shell {
+  position: relative;
+  z-index: 1;
+  width: min(1160px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1rem 0 4rem;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  z-index: 1000;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  background: #ecfdf5;
+  color: #052018;
+}
+
+.value-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 0;
+}
+
+.value-nav nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.65rem;
+}
+
+.value-nav a {
+  color: #d1fae5;
+}
+
+.value-nav nav a {
+  padding: 0.55rem 0.85rem;
+  border: 1px solid rgba(110, 231, 183, 0.18);
+  border-radius: 999px;
+  background: rgba(6, 20, 16, 0.46);
+}
+
+.brand-link {
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+main {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hero,
+.statement,
+.skill-stack,
+.resistance,
+.path-section,
+.economy,
+.niche-lab,
+.closing {
+  border: 1px solid var(--surface-border);
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(15, 43, 35, 0.84), rgba(4, 14, 11, 0.88));
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.28);
+}
+
+.hero {
+  padding: clamp(2rem, 6vw, 5.5rem);
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.hero h1,
+section h2 {
+  margin: 0;
+  max-width: 16ch;
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+}
+
+.hero h1 {
+  font-size: clamp(3rem, 9vw, 7.2rem);
+}
+
+section h2 {
+  font-size: clamp(2rem, 5vw, 4.6rem);
+}
+
+.hero-copy {
+  max-width: 760px;
+  margin: 1.6rem 0 0;
+  font-size: clamp(1.05rem, 2vw, 1.35rem);
+  color: #c8e7dc;
+}
+
+.hero-note {
+  max-width: 680px;
+  margin-top: 2rem;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.8rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.hero-actions,
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 0.72rem 1.1rem;
+  border: 1px solid rgba(167, 243, 208, 0.24);
+  border-radius: 999px;
+  background: rgba(16, 59, 47, 0.72);
+  color: #ecfdf5;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.button:hover,
+.button:focus-visible {
+  color: #fff;
+  border-color: rgba(167, 243, 208, 0.54);
+  transform: translateY(-1px);
+}
+
+.button--primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: transparent;
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  color: #03120d;
+  background: var(--accent-strong);
+}
+
+.statement,
+.skill-stack,
+.resistance,
+.path-section,
+.economy,
+.niche-lab,
+.closing {
+  padding: clamp(1.5rem, 5vw, 4.5rem);
+}
+
+.statement p,
+.section-heading p,
+.closing > p:not(.eyebrow) {
+  max-width: 760px;
+  color: var(--color-text-muted);
+  font-size: 1.08rem;
+}
+
+blockquote {
+  margin: 2rem 0 0;
+  padding: 1.25rem 1.4rem;
+  border-left: 3px solid var(--accent);
+  background: rgba(110, 231, 183, 0.06);
+  border-radius: 0 16px 16px 0;
+  font-size: clamp(1.25rem, 3vw, 2rem);
+}
+
+.stack-grid,
+.resistance-grid,
+.economy-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.stack-grid article,
+.resistance-grid article,
+.economy-grid article {
+  padding: 1.35rem;
+  border: 1px solid rgba(110, 231, 183, 0.14);
+  border-radius: 18px;
+  background: rgba(2, 11, 8, 0.32);
+}
+
+.stack-grid span {
+  display: inline-flex;
+  min-width: 2.3rem;
+  min-height: 2.3rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(110, 231, 183, 0.1);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+article h3 {
+  margin: 0.8rem 0 0.35rem;
+  font-size: 1.15rem;
+}
+
+article p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.path-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.path-list li {
+  display: grid;
+  grid-template-columns: minmax(90px, 0.32fr) 1fr;
+  gap: 1rem;
+  align-items: baseline;
+  padding: 1rem 0;
+  border-bottom: 1px solid rgba(110, 231, 183, 0.13);
+}
+
+.path-list span {
+  color: var(--accent);
+  font-size: 1.25rem;
+  font-weight: 800;
+}
+
+.path-list p {
+  margin: 0;
+  color: #c8e7dc;
+}
+
+.loop {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+  margin: 2rem 0;
+}
+
+.loop span {
+  padding: 0.65rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(110, 231, 183, 0.1);
+  border: 1px solid rgba(110, 231, 183, 0.16);
+  font-weight: 700;
+}
+
+.loop b {
+  color: var(--accent);
+}
+
+.niche-form {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.niche-form label {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.niche-form label > span {
+  font-weight: 700;
+}
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 96px;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(110, 231, 183, 0.2);
+  border-radius: 14px;
+  background: rgba(2, 9, 7, 0.56);
+  color: #ecfdf5;
+  font: inherit;
+}
+
+textarea:focus {
+  outline: 2px solid rgba(110, 231, 183, 0.52);
+  outline-offset: 2px;
+}
+
+.value-map {
+  margin-top: 2rem;
+  padding: 1.4rem;
+  border: 1px solid rgba(110, 231, 183, 0.3);
+  border-radius: 20px;
+  background: rgba(22, 78, 60, 0.2);
+}
+
+.value-map h3 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+}
+
+.value-map dl {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+}
+
+.value-map dt {
+  font-weight: 800;
+  color: var(--accent);
+}
+
+.value-map dd {
+  margin: 0.2rem 0 0;
+  color: #d6efe6;
+  white-space: pre-wrap;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 2rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+footer a {
+  color: var(--accent);
+}
+
+@media (max-width: 760px) {
+  .value-shell {
+    width: min(100% - 1rem, 1160px);
+    padding-top: 0.4rem;
+  }
+
+  .value-nav {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 0.75rem 0;
+  }
+
+  .value-nav nav {
+    justify-content: flex-start;
+    width: 100%;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 0.25rem;
+  }
+
+  .value-nav nav a {
+    white-space: nowrap;
+  }
+
+  .hero,
+  .statement,
+  .skill-stack,
+  .resistance,
+  .path-section,
+  .economy,
+  .niche-lab,
+  .closing {
+    border-radius: 20px;
+  }
+
+  .hero {
+    min-height: 62vh;
+  }
+
+  .stack-grid,
+  .resistance-grid,
+  .economy-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .path-list li {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+
+  footer {
+    flex-direction: column;
+  }
+}

--- a/tests/human-value-network.test.js
+++ b/tests/human-value-network.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('human value network page ships the skill-sharing journey', async () => {
+  const html = await readFile(new URL('../human-value-network/index.html', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../human-value-network/styles.css', import.meta.url), 'utf8');
+  const app = await readFile(new URL('../human-value-network/app.js', import.meta.url), 'utf8');
+
+  assert.match(html, /We already have what we need\. We have each other\./);
+  assert.match(html, /Nobody else has your exact stack/);
+  assert.match(html, /Build an economy we would rather live in/);
+  assert.match(html, /Buy from ourselves/);
+  assert.match(html, /Skill-share/);
+  assert.match(html, /id="niche-lab"/);
+  assert.match(html, /Build my value map/);
+  assert.match(html, /href="..\/launch-room\/"/);
+  assert.match(html, /href="..\/community\/index\.html"/);
+
+  assert.match(css, /\.value-shell/);
+  assert.match(css, /\.niche-form/);
+  assert.match(css, /@media \(max-width: 760px\)/);
+
+  assert.match(app, /3dvr-human-value-network/);
+  assert.match(app, /navigator\.clipboard\.writeText/);
+  assert.match(app, /localStorage\.setItem/);
+});


### PR DESCRIPTION
## What changed
- adds a new `/human-value-network/` landing page for the people-powered 3DVR economy idea
- frames independence as building alternatives, not simply opposing large companies
- explains unique skill stacks, family/marketing/credential resistance, skill-sharing, direct exchange, and collaborative networks
- adds an interactive Niche Lab that saves answers locally and generates a copyable human value map
- links the journey onward to Launch Room, Community, and Purpose Movement
- adds a smoke test for the page, responsive styles, local storage, and clipboard behavior

## Why
3DVR needs a clear page for helping people recognize their worth, find a niche, and turn individual capability into mutual economic resilience.

## Validation
The branch diff is additive-only: four new files and no existing portal behavior changed. The test follows the existing static page-test pattern in the repo.