### PR TITLE
feat(agent): add Mobilerun demo receipts and latency

### DIFF
--- a/apps/agent/test/test_mobilerun_core_backend.py
+++ b/apps/agent/test/test_mobilerun_core_backend.py
@@ -28,6 +28,11 @@ def test_reports_device_status_without_broadening_authority():
     result = backend.execute(request())
     assert result.ok is True
     assert result.evidence["connected"] is True
+    assert result.evidence["backend"] == "mobilerun-core"
+    assert result.evidence["transport"] == "local-android-http"
+    assert result.evidence["round_trip_latency_ms"] >= 0
+    assert result.evidence["credentials_redacted"] is True
+    assert result.evidence["fallback_used"] is False
     assert backend.supports("device.status") is True
     assert backend.supports("shell.exec") is False
 
@@ -47,6 +52,9 @@ def test_returns_structured_unavailable_evidence():
     result = backend.execute(request())
     assert result.ok is False
     assert result.error_code == "backend_unavailable"
+    assert result.evidence["backend"] == "mobilerun-core"
+    assert result.evidence["credentials_redacted"] is True
+    assert result.evidence["round_trip_latency_ms"] >= 0
 
 
 def test_rejects_other_allowed_protocol_capabilities_in_first_slice():
@@ -74,6 +82,7 @@ def test_default_factory_passes_env_endpoint_and_token(monkeypatch):
     assert result.ok is True
     assert captured == {"base_url": "http://127.0.0.1:8080", "token": "secret-token"}
     assert "secret-token" not in repr(result.evidence)
+    assert result.evidence["credentials_redacted"] is True
 
 
 def test_default_factory_reports_missing_external_credentials(monkeypatch):
@@ -84,3 +93,4 @@ def test_default_factory_reports_missing_external_credentials(monkeypatch):
     assert result.ok is False
     assert result.error_code == "backend_unavailable"
     assert "not configured" in result.evidence["detail"]
+    assert result.evidence["credentials_redacted"] is True

--- a/apps/agent/thomas-agent/python/mobilerun_core_backend.py
+++ b/apps/agent/thomas-agent/python/mobilerun_core_backend.py
@@ -6,6 +6,7 @@ small and dependency-optional: importing it does not require mobilerun-core.
 
 from __future__ import annotations
 
+import time
 from typing import Any, Callable
 
 from companion_execution_backend import (
@@ -48,6 +49,18 @@ class MobilerunCoreBackend:
             self._device = self._device_factory()
         return self._device
 
+    @staticmethod
+    def _receipt(evidence: dict[str, Any], started_ns: int) -> dict[str, Any]:
+        """Attach demo-safe transport evidence without exposing credentials."""
+        return {
+            **evidence,
+            "backend": "mobilerun-core",
+            "transport": "local-android-http",
+            "round_trip_latency_ms": round((time.monotonic_ns() - started_ns) / 1_000_000, 3),
+            "credentials_redacted": True,
+            "fallback_used": False,
+        }
+
     def supports(self, capability: str) -> bool:
         if capability != "device.status":
             return False
@@ -66,6 +79,7 @@ class MobilerunCoreBackend:
                 ok=False,
                 error_code="unsupported_capability",
             )
+        started_ns = time.monotonic_ns()
         try:
             device = self._get_device()
             supports = getattr(device, "supports", None)
@@ -86,13 +100,13 @@ class MobilerunCoreBackend:
                 request_id=request.request_id,
                 capability=request.capability,
                 ok=True,
-                evidence=evidence,
+                evidence=self._receipt(evidence, started_ns),
             )
         except (RuntimeError, OSError) as error:
             return CompanionExecutionResult(
                 request_id=request.request_id,
                 capability=request.capability,
                 ok=False,
-                evidence={"backend": "mobilerun-core", "detail": str(error)},
+                evidence=self._receipt({"detail": str(error)}, started_ns),
                 error_code="backend_unavailable",
             )


### PR DESCRIPTION
## Summary
- attach deterministic demo-safe receipt fields to Mobilerun `device.status` results
- record round-trip latency using a monotonic clock
- explicitly mark credentials redacted and fallback unused
- preserve the existing read-only authority boundary
- cover success and unavailable-backend receipts in tests

## Why
This directly advances the v0.0.59 pre-demo freeze: receipts + latency visibility without broadening phone authority. A live endpoint/token is still required for the real-device proof; no credential enters Git.

## Validation
Focused deterministic tests are included; let repository CI validate the branch before merge.

Refs #1560 #1490