### PR TITLE
feat(companion): standardize native voice demo receipt

### DIFF
--- a/apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt
@@ -32,6 +32,10 @@ object CompanionVoiceReceiptStore {
             put("target", target.take(120))
             put("ok", ok)
             put("code", code.take(120))
+            put("backend", "companion-native")
+            put("transport", "android-assistant")
+            put("credentialsRedacted", true)
+            put("fallbackUsed", false)
         }
         val atomicFile = atomicFile(context)
         val output = runCatching { atomicFile.startWrite() }.getOrNull() ?: return
@@ -58,6 +62,10 @@ object CompanionVoiceReceiptStore {
             "target" to payload.optString("target"),
             "ok" to payload.optBoolean("ok", false),
             "code" to payload.optString("code"),
+            "backend" to payload.optString("backend", "companion-native"),
+            "transport" to payload.optString("transport", "android-assistant"),
+            "credentialsRedacted" to payload.optBoolean("credentialsRedacted", true),
+            "fallbackUsed" to payload.optBoolean("fallbackUsed", false),
         )
     }
 

--- a/tests/companion-voice-round-trip.test.js
+++ b/tests/companion-voice-round-trip.test.js
@@ -8,6 +8,7 @@ const router = read('apps/companion/native-spec/android/CompanionVoiceCommandRou
 const session = read('apps/companion/native-spec/android/CompanionVoiceInteractionSession.kt');
 const service = read('apps/companion/native-spec/android/CompanionVoiceInteractionService.kt');
 const assistantState = read('apps/companion/native-spec/android/CompanionAssistantStateStore.kt');
+const receiptStore = read('apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt');
 const activity = read('apps/companion/native-spec/android/MainActivity.kt');
 const scaffold = read('apps/companion/scaffold.sh');
 const dashboard = read('apps/companion/lib/main.dart');
@@ -27,6 +28,14 @@ test('Android Assistant recognizes speech and records a visible receipt', () => 
   assert.match(session, /CompanionVoiceCommandRouter\.execute/);
   assert.match(session, /CompanionVoiceReceiptStore\.record/);
   assert.doesNotMatch(session, /Runtime\.getRuntime|ProcessBuilder|\bexec\s*\(/);
+});
+
+test('native voice receipt carries standardized demo-safe evidence', () => {
+  assert.match(receiptStore, /put\("backend", "companion-native"\)/);
+  assert.match(receiptStore, /put\("transport", "android-assistant"\)/);
+  assert.match(receiptStore, /put\("credentialsRedacted", true\)/);
+  assert.match(receiptStore, /put\("fallbackUsed", false\)/);
+  assert.doesNotMatch(receiptStore, /token|bearer|authorization/i);
 });
 
 test('assistant readiness survives Android process boundaries', () => {


### PR DESCRIPTION
## What
Adds the same demo-safe evidence vocabulary to the native Android Assistant voice receipt used for bounded `app.open_known` actions:
- backend: `companion-native`
- transport: `android-assistant`
- credentials redacted: true
- fallback used: false

Adds a source-level contract test ensuring those fields remain present and that the receipt store does not drift into token/bearer/authorization handling.

## Why
v0.0.59's Thursday demo gate requires both the read-only Mobilerun proof and the bounded native app action to produce understandable, redacted receipts. Mobilerun already has this evidence; this aligns the native voice path without broadening authority.

## Safety
No new capability, network path, credential, shell access, gesture authority, or outbound action. Existing known-app voice allowlist is unchanged.

Refs #1560