### PR TITLE
Add 3DVR Linen clothing page

### DIFF
--- a/linen/index.html
+++ b/linen/index.html
@@ -20,6 +20,7 @@
     </a>
     <nav aria-label="Page navigation">
       <a href="#pattern-001">Pattern 001</a>
+      <a href="#materials">Buy materials</a>
       <a href="#principles">Principles</a>
       <a href="#wardrobe">Wardrobe</a>
     </nav>
@@ -35,6 +36,7 @@
       </p>
       <div class="hero-actions">
         <a class="button primary" href="#pattern-001">Make the first pair</a>
+        <a class="button" href="#materials">Buy the materials</a>
         <a class="button" href="#principles">Why linen?</a>
       </div>
       <div class="material-line" aria-label="Material specification">
@@ -101,6 +103,52 @@
         <strong>Prototype rule:</strong>
         Make the first pair roomy. Wear them, wash them, mark what you would change, then update the pattern. The pattern grows from real bodies instead of forcing bodies into fixed sizing.
       </aside>
+    </section>
+
+    <section id="materials" class="section materials-section">
+      <div class="section-heading">
+        <p class="eyebrow">First-pair kit</p>
+        <h2>Buy only what you need.</h2>
+        <p>
+          The garment itself needs only linen cloth and linen thread. The drawstring is cut from the same cloth.
+          For a first adult prototype, about 3 yards of 58-inch-wide fabric is a useful starting estimate, but trace and measure your pieces before ordering when possible.
+        </p>
+      </div>
+
+      <div class="materials-grid">
+        <article class="material-card feature-card">
+          <span class="number">Fabric</span>
+          <h3>Natural 5.3 oz linen</h3>
+          <p>100% linen, 58 inches wide, medium weight. This is the baseline cloth for Pattern 001.</p>
+          <div class="buy-links">
+            <a class="button primary" href="https://fabrics-store.com/fabrics/linen-fabric-IL019-natural-middle/" target="_blank" rel="noopener noreferrer">Buy natural IL019</a>
+            <a class="text-link" href="https://fabrics-store.com/fabrics/linen-fabric-IL019-mix-natural-middle" target="_blank" rel="noopener noreferrer">Mix natural option</a>
+          </div>
+        </article>
+
+        <article class="material-card">
+          <span class="number">Thread</span>
+          <h3>100% linen sewing thread</h3>
+          <p>Fine 20x3 natural linen thread in a 100 m spool, suitable for hand and machine sewing of medium-coarse fabric.</p>
+          <div class="buy-links">
+            <a class="button primary" href="https://www.sartorbohemia.com/fine-linen-thread-20x3-100m-natural_z12500/" target="_blank" rel="noopener noreferrer">Buy natural linen thread</a>
+            <a class="text-link" href="https://www.sartorbohemia.com/linen-threads/" target="_blank" rel="noopener noreferrer">More linen thread colors</a>
+          </div>
+        </article>
+
+        <article class="material-card">
+          <span class="number">Drawstring</span>
+          <h3>Use the same fabric</h3>
+          <p>No elastic, cord, toggle, or purchased hardware is required. Cut a long strip from your linen, fold the raw edges inward, stitch, and knot the ends.</p>
+          <div class="buy-links">
+            <span class="no-buy">Nothing else to buy.</span>
+          </div>
+        </article>
+      </div>
+
+      <p class="purchase-note">
+        These are example sources, not affiliate links. Stock, pricing, finishes, and shipping can change; verify that the listing still says 100% linen before ordering.
+      </p>
     </section>
 
     <section id="principles" class="section principles-section">

--- a/linen/index.html
+++ b/linen/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>3DVR Linen — Clothing Humans Can Make</title>
+  <meta name="description" content="3DVR Linen is an open-source clothing project built around simple, repairable garments made from linen, starting with drawstring pants and no elastic.">
+  <meta name="theme-color" content="#efe7d3">
+  <link rel="stylesheet" href="./styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script defer src="/issue-launcher.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <a class="brand" href="../index.html" aria-label="Back to 3DVR Portal">
+      <span class="brand-mark" aria-hidden="true">3dvr</span>
+      <span>linen</span>
+    </a>
+    <nav aria-label="Page navigation">
+      <a href="#pattern-001">Pattern 001</a>
+      <a href="#principles">Principles</a>
+      <a href="#wardrobe">Wardrobe</a>
+    </nav>
+  </header>
+
+  <main id="main">
+    <section class="hero">
+      <p class="eyebrow">Open-source clothing</p>
+      <h1>Clothing humans can make.</h1>
+      <p class="lede">
+        A small wardrobe made from one ancient material: linen. Simple cuts, natural fibers,
+        visible repair, local sewing, and patterns anyone can copy or improve.
+      </p>
+      <div class="hero-actions">
+        <a class="button primary" href="#pattern-001">Make the first pair</a>
+        <a class="button" href="#principles">Why linen?</a>
+      </div>
+      <div class="material-line" aria-label="Material specification">
+        <span>100% linen fabric</span>
+        <span>linen thread</span>
+        <span>linen drawstring</span>
+        <span>no elastic</span>
+        <span>no plastic hardware</span>
+      </div>
+    </section>
+
+    <section id="pattern-001" class="section pattern-section">
+      <div class="section-heading">
+        <p class="eyebrow">Pattern 001</p>
+        <h2>Everyday drawstring pants</h2>
+        <p>
+          Start with the easiest useful garment: relaxed pants with a linen drawstring and a simple casing.
+          The first version deliberately uses a pair of loose pants you already like as the pattern.
+        </p>
+      </div>
+
+      <div class="pattern-grid">
+        <article class="card feature-card">
+          <span class="number">01</span>
+          <h3>Choose the linen</h3>
+          <p>Use medium-weight 100% linen, roughly 5–7 oz/yd², for a first everyday pair.</p>
+          <p class="note"><strong>Before cutting:</strong> wash and dry the fabric the way you plan to care for the finished pants.</p>
+        </article>
+
+        <article class="card">
+          <span class="number">02</span>
+          <h3>Trace a pair that fits</h3>
+          <p>Fold a loose pair of pants in half. Trace the front and back leg shapes onto paper or directly onto folded linen.</p>
+          <p>Add about 5/8 in (1.5 cm) around sewn edges and extra height at the waist for the drawstring casing.</p>
+        </article>
+
+        <article class="card">
+          <span class="number">03</span>
+          <h3>Sew the legs</h3>
+          <p>Sew each front to its matching back along the outer and inner leg seams. Finish raw edges with a flat-felled, French, or turned-and-stitched seam.</p>
+        </article>
+
+        <article class="card">
+          <span class="number">04</span>
+          <h3>Join the rise</h3>
+          <p>Turn one leg right-side out, place it inside the other leg, match the crotch curve, and sew the full rise as one continuous seam.</p>
+        </article>
+
+        <article class="card">
+          <span class="number">05</span>
+          <h3>Build the linen casing</h3>
+          <p>Fold the waist edge inward twice to create a casing wide enough for the drawstring. Leave a small opening at the front.</p>
+          <p>For an all-fiber version, hand-stitch the opening like a buttonhole instead of adding a metal eyelet.</p>
+        </article>
+
+        <article class="card">
+          <span class="number">06</span>
+          <h3>Make the drawstring</h3>
+          <p>Cut a long linen strip, fold the raw edges inward, fold again, and stitch it into a narrow cord. Feed it through the casing and knot the ends.</p>
+        </article>
+      </div>
+
+      <aside class="prototype-note">
+        <strong>Prototype rule:</strong>
+        Make the first pair roomy. Wear them, wash them, mark what you would change, then update the pattern. The pattern grows from real bodies instead of forcing bodies into fixed sizing.
+      </aside>
+    </section>
+
+    <section id="principles" class="section principles-section">
+      <div class="section-heading">
+        <p class="eyebrow">The system</p>
+        <h2>Less fashion. More human infrastructure.</h2>
+      </div>
+      <div class="principles-grid">
+        <article>
+          <h3>Natural first</h3>
+          <p>Prefer linen and other simple natural materials over complex blends and hidden synthetics.</p>
+        </article>
+        <article>
+          <h3>Repair forever</h3>
+          <p>Construction should be understandable enough that the owner can patch, resew, resize, or reuse the cloth.</p>
+        </article>
+        <article>
+          <h3>Open patterns</h3>
+          <p>Patterns are instructions, not secrets. Copy them, adapt them, teach them, and improve them.</p>
+        </article>
+        <article>
+          <h3>Local skill</h3>
+          <p>A garment can be made at home, by a neighborhood tailor, or by a small local sewing circle.</p>
+        </article>
+        <article>
+          <h3>Few good pieces</h3>
+          <p>Build a small wardrobe where the same pieces work at home, at work, outdoors, and while traveling.</p>
+        </article>
+        <article>
+          <h3>Designed to evolve</h3>
+          <p>Every repair and modification can become knowledge for the next version of the pattern.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="wardrobe" class="section wardrobe-section">
+      <div class="section-heading">
+        <p class="eyebrow">Roadmap</p>
+        <h2>The tiny linen wardrobe</h2>
+      </div>
+      <div class="wardrobe-list">
+        <div><span>001</span><strong>Drawstring pants</strong><em>Start here</em></div>
+        <div><span>002</span><strong>Relaxed shirt</strong><em>Next</em></div>
+        <div><span>003</span><strong>Drawstring shorts</strong><em>Planned</em></div>
+        <div><span>004</span><strong>Overshirt / work jacket</strong><em>Planned</em></div>
+        <div><span>005</span><strong>Simple robe / dress</strong><em>Planned</em></div>
+        <div><span>006</span><strong>Kids' basics</strong><em>Planned</em></div>
+      </div>
+    </section>
+
+    <section class="manifesto">
+      <p>Grow fiber. Weave cloth. Share patterns. Sew locally. Repair what breaks.</p>
+      <h2>Build the future from things we can understand.</h2>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../index.html">3DVR Portal</a>
+    <span>·</span>
+    <span>3DVR Linen</span>
+    <span>·</span>
+    <span>Open, repairable, human-scale clothing.</span>
+  </footer>
+</body>
+</html>

--- a/linen/styles.css
+++ b/linen/styles.css
@@ -1,0 +1,253 @@
+:root {
+  --paper: #f4eedf;
+  --paper-deep: #e8dcc3;
+  --ink: #2d342b;
+  --muted: #667064;
+  --moss: #52644d;
+  --moss-dark: #394735;
+  --line: rgba(45, 52, 43, 0.18);
+  --white: rgba(255, 255, 255, 0.46);
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at 18% 8%, rgba(255,255,255,.65), transparent 28rem),
+    linear-gradient(180deg, var(--paper), #eee5d3 58%, #e5d8bd);
+  color: var(--ink);
+  font-family: Georgia, 'Times New Roman', serif;
+  line-height: 1.6;
+}
+a { color: inherit; }
+.skip-link {
+  position: fixed;
+  left: 1rem;
+  top: -5rem;
+  z-index: 10;
+  background: var(--ink);
+  color: white;
+  padding: .7rem 1rem;
+}
+.skip-link:focus { top: 1rem; }
+
+.site-header,
+main,
+footer {
+  width: min(1120px, calc(100% - 2rem));
+  margin-inline: auto;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding: 1.25rem 0;
+  border-bottom: 1px solid var(--line);
+}
+.brand {
+  display: inline-flex;
+  align-items: baseline;
+  gap: .55rem;
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+.brand-mark {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .8rem;
+  letter-spacing: .12em;
+  text-transform: lowercase;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: .22rem .48rem;
+}
+nav { display: flex; flex-wrap: wrap; gap: 1rem; }
+nav a {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .88rem;
+  text-decoration: none;
+  color: var(--muted);
+}
+nav a:hover, nav a:focus { color: var(--ink); text-decoration: underline; }
+
+.hero {
+  min-height: 72vh;
+  display: grid;
+  align-content: center;
+  padding: clamp(4rem, 9vw, 8rem) 0;
+  border-bottom: 1px solid var(--line);
+}
+.eyebrow {
+  margin: 0 0 .7rem;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .78rem;
+  font-weight: 800;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--moss);
+}
+h1, h2, h3 { margin-top: 0; line-height: 1.05; }
+h1 {
+  max-width: 12ch;
+  margin-bottom: 1.2rem;
+  font-size: clamp(3.6rem, 11vw, 8.2rem);
+  font-weight: 500;
+  letter-spacing: -.055em;
+}
+.lede {
+  max-width: 760px;
+  margin: 0;
+  font-size: clamp(1.2rem, 2.7vw, 1.75rem);
+  color: var(--muted);
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  margin-top: 2rem;
+}
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: .7rem 1rem;
+  border: 1px solid var(--moss);
+  border-radius: 999px;
+  color: var(--moss-dark);
+  font-family: Arial, Helvetica, sans-serif;
+  font-weight: 700;
+  text-decoration: none;
+}
+.button.primary { background: var(--moss-dark); color: #f7f1e5; }
+.material-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .55rem;
+  margin-top: 2.5rem;
+}
+.material-line span {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: .38rem .7rem;
+  background: rgba(255,255,255,.2);
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .8rem;
+}
+
+.section { padding: clamp(4rem, 8vw, 7rem) 0; border-bottom: 1px solid var(--line); }
+.section-heading { max-width: 760px; margin-bottom: 2.2rem; }
+.section-heading h2,
+.manifesto h2 {
+  margin-bottom: 1rem;
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  font-weight: 500;
+  letter-spacing: -.04em;
+}
+.section-heading > p:last-child { color: var(--muted); font-size: 1.1rem; }
+
+.pattern-grid,
+.principles-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+.card,
+.principles-grid article {
+  min-height: 250px;
+  padding: 1.35rem;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--white);
+  backdrop-filter: blur(7px);
+}
+.card h3,
+.principles-grid h3 { margin: .85rem 0 .7rem; font-size: 1.45rem; }
+.card p,
+.principles-grid p { color: var(--muted); }
+.feature-card { background: rgba(82,100,77,.11); }
+.number {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .78rem;
+  letter-spacing: .1em;
+  color: var(--moss);
+}
+.note { padding-top: .7rem; border-top: 1px solid var(--line); }
+.prototype-note {
+  margin-top: 1rem;
+  padding: 1.15rem 1.25rem;
+  border-left: 4px solid var(--moss);
+  background: rgba(82,100,77,.08);
+  font-size: 1.05rem;
+}
+
+.principles-grid article { min-height: 190px; }
+.principles-grid h3 { margin-top: 0; }
+
+.wardrobe-list { border-top: 1px solid var(--line); }
+.wardrobe-list div {
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.05rem 0;
+  border-bottom: 1px solid var(--line);
+}
+.wardrobe-list span,
+.wardrobe-list em {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .82rem;
+  color: var(--muted);
+  font-style: normal;
+}
+.wardrobe-list strong { font-size: 1.18rem; }
+
+.manifesto {
+  padding: clamp(5rem, 11vw, 9rem) 0;
+  text-align: center;
+}
+.manifesto p {
+  margin: 0 auto 1rem;
+  max-width: 850px;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .9rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--moss);
+}
+.manifesto h2 { max-width: 850px; margin-inline: auto; }
+
+footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: .6rem;
+  padding: 2rem 0 3rem;
+  border-top: 1px solid var(--line);
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .82rem;
+  color: var(--muted);
+}
+
+@media (max-width: 850px) {
+  .pattern-grid,
+  .principles-grid { grid-template-columns: 1fr 1fr; }
+  .site-header { align-items: flex-start; }
+  nav { justify-content: flex-end; }
+}
+
+@media (max-width: 620px) {
+  .site-header { display: block; }
+  nav { margin-top: .9rem; justify-content: flex-start; gap: .8rem; }
+  .hero { min-height: auto; }
+  h1 { font-size: clamp(3.4rem, 17vw, 5.5rem); }
+  .pattern-grid,
+  .principles-grid { grid-template-columns: 1fr; }
+  .card,
+  .principles-grid article { min-height: auto; }
+  .wardrobe-list div { grid-template-columns: 3rem 1fr; }
+  .wardrobe-list em { grid-column: 2; }
+}

--- a/linen/styles.css
+++ b/linen/styles.css
@@ -150,13 +150,15 @@ h1 {
 .section-heading > p:last-child { color: var(--muted); font-size: 1.1rem; }
 
 .pattern-grid,
-.principles-grid {
+.principles-grid,
+.materials-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
 }
 .card,
-.principles-grid article {
+.principles-grid article,
+.material-card {
   min-height: 250px;
   padding: 1.35rem;
   border: 1px solid var(--line);
@@ -165,9 +167,11 @@ h1 {
   backdrop-filter: blur(7px);
 }
 .card h3,
-.principles-grid h3 { margin: .85rem 0 .7rem; font-size: 1.45rem; }
+.principles-grid h3,
+.material-card h3 { margin: .85rem 0 .7rem; font-size: 1.45rem; }
 .card p,
-.principles-grid p { color: var(--muted); }
+.principles-grid p,
+.material-card p { color: var(--muted); }
 .feature-card { background: rgba(82,100,77,.11); }
 .number {
   font-family: Arial, Helvetica, sans-serif;
@@ -182,6 +186,43 @@ h1 {
   border-left: 4px solid var(--moss);
   background: rgba(82,100,77,.08);
   font-size: 1.05rem;
+}
+
+.materials-section { background: rgba(255,255,255,.12); }
+.material-card {
+  display: flex;
+  flex-direction: column;
+}
+.material-card p { flex: 1; }
+.buy-links {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: .75rem;
+  margin-top: 1rem;
+}
+.buy-links .button { width: 100%; }
+.text-link {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .86rem;
+  font-weight: 700;
+  color: var(--moss-dark);
+}
+.no-buy {
+  display: inline-block;
+  padding: .62rem .8rem;
+  border: 1px dashed var(--moss);
+  border-radius: 999px;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .86rem;
+  font-weight: 700;
+  color: var(--moss-dark);
+}
+.purchase-note {
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: .82rem;
 }
 
 .principles-grid article { min-height: 190px; }
@@ -234,7 +275,8 @@ footer {
 
 @media (max-width: 850px) {
   .pattern-grid,
-  .principles-grid { grid-template-columns: 1fr 1fr; }
+  .principles-grid,
+  .materials-grid { grid-template-columns: 1fr 1fr; }
   .site-header { align-items: flex-start; }
   nav { justify-content: flex-end; }
 }
@@ -245,9 +287,11 @@ footer {
   .hero { min-height: auto; }
   h1 { font-size: clamp(3.4rem, 17vw, 5.5rem); }
   .pattern-grid,
-  .principles-grid { grid-template-columns: 1fr; }
+  .principles-grid,
+  .materials-grid { grid-template-columns: 1fr; }
   .card,
-  .principles-grid article { min-height: auto; }
+  .principles-grid article,
+  .material-card { min-height: auto; }
   .wardrobe-list div { grid-template-columns: 3rem 1fr; }
   .wardrobe-list em { grid-column: 2; }
 }


### PR DESCRIPTION
## What changed
- added `/linen/` as a standalone 3DVR Linen page
- introduced the “Clothing humans can make” positioning
- added Pattern 001: all-linen drawstring pants with no elastic or plastic hardware
- documented a trace-and-sew first-pair method, repair-first principles, and a tiny wardrobe roadmap
- added a responsive natural-fiber-inspired visual design

## Why
Start an open-source clothing system around simple, understandable garments that can be made and repaired locally.

## Validation
- branch is 2 commits ahead of `main`
- only `linen/index.html` and `linen/styles.css` are added
- page includes Vercel Insights and the shared issue launcher