### PR TITLE
Add printable Pattern 001 PDF

### DIFF
--- a/linen/3dvr-linen-pattern-001-drawstring-pants.pdf
+++ b/linen/3dvr-linen-pattern-001-drawstring-pants.pdf
@@ -1,0 +1,153 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 7 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://fabrics-store.com/fabrics/linen-fabric-IL019-natural-middle/)
+>> /Border [ 0 0 0 ] /Rect [ 56.4 360.7875 351.6915 375.7875 ] /Subtype /Link /Type /Annot
+>>
+endobj
+5 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.sartorbohemia.com/fine-linen-thread-20x3-100m-natural_z12500/)
+>> /Border [ 0 0 0 ] /Rect [ 56.4 337.7875 390.51 352.7875 ] /Subtype /Link /Type /Annot
+>>
+endobj
+6 0 obj
+<<
+/Annots [ 4 0 R 5 0 R ] /Contents 14 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+8 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/PageMode /UseNone /Pages 13 0 R /Type /Catalog
+>>
+endobj
+12 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260819223559+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260819223559+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+13 0 obj
+<<
+/Count 4 /Kids [ 6 0 R 8 0 R 9 0 R 10 0 R ] /Type /Pages
+>>
+endobj
+14 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1802
+>>
+stream
+Gatm;bAu>q']&X:m\Vd4C=*1Z:05]XR:KPu'!(E>)jl4.VBhjc:_`$WHN6mLXB='KO\?r)JF9u:Hb_&J?fq>@)ktpt3]Uci3)+#'iZP,?)82LZI6.dn,gFeoJg.LM.*/_S@AL)f>5.=s^W?gX>12d!;39m"NtMf*\-P(uC!(Fd^:_MR,_XgK#Z>Cc8Js_JQ^TOeHMH9igH?(-lTlL*S>?qPO!M'9\BB3cSOB%Pd(5oJo_+n1FB5fTV(mB2`^gOR6\]O:_goFna]FqD[">bU6tsHsr'ngVE@ko%nn0pj\=E[T@l[L>)sa"">,B32?4_gl8D0#l+[oH(aXN!\SV&_6@B]0Uo69B,i-k]#'0ZE%/<)GT!=o2;#;ZL<n+m3<I"TM2;kq\`nhc/A313r+#QMH2GMf6':W8dZC9d&_Y1i3$7P%>cR1I&I9t*,$F2ifVF*>%X8Wc,;of,LTo#SkuY2QV'3UBOF5W9pjC.[Nm1TD<3/P;s7Mr(%ndSqaI8J6//Y$Eq:XO[EC/!@=(9N<-4X(^JD1`(JL&m???BW(Q3<rJ-/NKKuoPJ9l<W2k@K-(r#T?jNhjW>T`j(:`Z2BW[R#eP])m<*0+Y@Rk#_kt5C%a9I/!.+i;!C0B(cGIeDeB<D4t+BgY"6Qeq.V?5,5Am.(Q/.1gkQR'bedr1eq'IVQ\(^NLVVehLc,VCtYc$5&MMJ6lC^8=7F_2$,;`J&sU/RegEj,!HG5#f+LF"gQ^*b72R8+2.L@.[bE)<2;.-n)M+ojnfP-'C^)gMUA7Vtr&-jFk0qZDFJY8lt*T6QZE;CF9M-hgF]3bHKFD:bp<erB+4Y06t_/0b\9mA2>TS>8.=dHjnAN1T?Qg)b"g4FD`&XPO3]qX)=ou!<XErZtl>,DHg6Nqpb1_Nh/(+ob<g!MJfJAhdLL#FF,[:BP`#q/('Z<b^K]OY1:Wc:/srR,DKo/2O?(1g"*Ipd&`5>/%?\kn*<,A"C5t(FM#Qc41hdl`02+SGC(^m]&QS)rt6)nTgd\-'^6__j8C#7Rm!tc^PBd?O2q2?(4M<uQAo$$^Y6JO^8pkGEHF_6G:,M#n/rc#KPU?FEl!"6>e@O(X)r!oDA"jpCUt/Orc[O*M"1eO^l!KKJBrV@#:Vg$R]<OZD@s!*eN5jfPC-WCja=_@VR#Y"Q6S5\?'CX.CBI>*N&'^Qm#Efe%9Z:H*>rOdfIlM&-G63E,tlq=Q%U"=JSc^9lr[VnY,f?5!]h"k>&$`Xe;=,,Ua9/,2jm\($`.Mk@D=BKh5Pt,"&h@oRGIs7??=IgT&jtQgh7MTIJ]$E"1L/-ngm'^E=ap4^mG!pcbaU*^Rp5UWRZt]N-2pk1JhC=(M9X8%B@*)C(aM<0P'\'Q*Ce:!D>]ZT?gCcNNl"+Gp,!qUf5po5:cXS6Tt@'DHffZ0mFs!k'&(O3Occm"6b9/N,9!:9.-ouHT(MbmB7HIh/N*i%X$O#&P\PXQH8MPQ,qX/hB:8tj%6)Lk>!j$ICK8!84R"QCGe5$Y#aRUbjt%>\XsCYd.kEfNW#!SA6DD%MJc1\Mu/OtS`;a-g1^^[Nt$e8[S.RLiYuB3Fn<kYi/ecNK:d;le:'2t*QIgk/S@sS%-dbJ@ckNeZ:bP\Lg306=,RPWC$)jD$MmmW(/c5NRh`muX8PWEJIWK>NDaBV4LqM@VgP@nI\>*+j_2tUl[RNk&#l))B:M.\k79B;_-K2sKf:JBh=0,d=\;W<Dnl$;[<U3CekIk9U#gKTIc:gW_HeFpO=a*$O4uJ3V]nI[<Hto.GR=Q,qX<jNp583_LlVH>7MTs"~>endstream
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1589
+>>
+stream
+Gb"/&gN)%,&:N/3m%]ba@05B[0qQseG*87MdIa:'"%7\Q@u=)K15c+GB0f+OAN@1\Sp$tE>7r5eG0aL?@Nd2;^C6arMWf(Q(KZcqU1m%O(,8P@dSJ?6?P?9^BqB&PL#tT4Gnqcjr*n*/h'r&.Kd(H7H9DjCSh$@naPnCA,goY#3IUZ?X-3fuFWjXd;3FO6_iKO9::BG/f$7d#E\&$3/sK%$n0?%W/_8&rqB/W]!iT1BVLSOB"21g@gX6W)hXnMSJ/ClUqA]h;MPd"ZqO.R0MU8>!EW/t\HaBrP%Mo'K-gXp4:mafXLujMb,I95P,RG1d+RGB_PraX;O_2uW=,Ktq-7[7USpftmRMamCF(=Ic%A)-_D>>u<^B<I:N&5l>$sABs7"S6*r#NUK!gY@gbc+rQ`3HW)[\X.b[dU/4Bka#n3_-?\eCXrT*SE)]f@d^-WAdr%)_:C2SkM5DR43'QZYSSqDjsrsDofPf+]m'N2c[W!lRZ.b:-BY>>'O+PIuE-@m[TdPOo[$4UV*S\`RZmckANE8fVT5k]-ek-P4.0>L%3P.UZoU6[EnC!7V(Si6f+NW<WJ:bdKVpb`V\-FO$>?W58(,[KqBF"Vh#(@1$5to16oc]bC#[P-]k^:"Y[j`4CUcd^(-0KU)6UN-OG_$>4IA?UVK_BZuocr`oR"@EI.7Sp<!fLdm1JOfnWBGjk^RUKnb\rfLll=P!pkR%!B]3W=%9Z<5=;8L\Kbo(n*</OS1!7@2-%GB0_*I9#1bW1I)E()p6\*9Ol<9QXnm7Ungtqdo"P6Eo8*pr?:$$grY0^j%lFfQA::%X0)NKf!R*sOag[o3&*OX#DI*YF%S'*/d0d=&k/R#?,$HSc&,3D\;fHl)=Ib`^U'Dqm!N5'natb1:?<0Udi:M1#%:1(=UmWgodCE7KaNKCC[IJF)qp[jlY1)!`Nh]X1NuKO)UG\W<TAR-28J[cC<24AX[A4I9S\:lP]Cb7q'a3D5u@W+V&j8(UUK8.Mmd2L=",a@]Hnm-8>4+@Q2HPOj-%aLmoAD_XW#71,P5som7M%kma!;ln*lnOl(HFgEQFLu1j@`NE=:l``cg8-.WlFg\#YH0CauW"Q5t('+o2WdFRB9-oU=sm\irft!W=ZObtqEP[?[0U])5%Ha66Nh]eK;\jme/<X667?k?'o3\K1BdB-5$^`%R*sKXA)p!]G_d7I0lo1d$!_IbbDQR2K6>\\UtI1UF6/+7^<jLNdW)]n<Ob"1#SEm@mrOAsQ+tn;;7"=.n8-Xs(Jqa*Z#'c:#QrA,L^iO;\S^RPV:ZDS*K[gU^VKn/+0Db>$ekBj0LP"e4/krAA0Sc)0ei1T3,N*fl[?$iRriHtW?d/kDjW"+BrVeMO_nGd'&Q.=4rXjGk>VBB&i#C<[JTEbTOIb\ZCf9pA$&Zg/J(,?NUYg$I6"478Xsh;I\VE8S35n'7Pe:uEr=@I4VQC9@"NIHpJ/Ltq"t>B**sL)C>H)=1d`mo*am-PWhYE56mG@Jn87S6Oa6GH@/k?!h)VL7fF!Y[grs/=%9s2/dK,Td=XmW]NM]<1K>cE2,1K6jD"eq,Ql\jl(o_j!:;>hu+Kh-i~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1531
+>>
+stream
+Gau0B9lo&I&A@C2m&c9u_$%R"A(+KGA=QC5CO2t$J4PK*9EGP,7AG@)"X(pqA6ZJegEVP#^tlI1D]_4f_LLjcb7<J/">7\.."fVMBM;m&>f*+s_7'FoOu,rpOFk)/+F+_M'MLYdrp:EWaU/5A_X)Y8Z92b^!KtDj`.4X4_s-[d0:\S$(mYs`Kas91iig+2iG,SgT=aIX=\+S%8^%Q3;]tKUa]r#>9/l'_7$\BPh8(!/j1ioZfdNh-"J:@TdNHJaina?bd!%2>$BoNIphgA/&f0Z>;*Kh?!l$Pe?R0&=42ljjAI,R-*'#iKj,=%J&H]ms.<<E$@7J%<k_h.t(:b%qG86]T=h+Nen:"_J&?:=gY3mT"8=_$<eF_T)%O-CR4B#A@bm4/o*W5p@T2hAcJE^OeJU.lFXY2VL4RhtcK6ok@YRI>K=:uE&-K4_F/TrX4GXRIS4p".R9cOHC#0)<EReQ!71/ALO4WN6YaIr#+7O5`Qpu18r/LlXJil=W&B!ejjMKt,E1l6B9VkUiW9DJ]plp8(AUFa5nUs*2U7bg9oBZ=,^.*Ee*J16%"\H9I_[Y/"];$qeW=ek1Lf,sY>$.QagYD.F3%?Gkc]eCH$2A2'uUs<=D*k`.c$/9F<#^d=F''r4PMVa",T)4t^=0f.A'*j7RJ+7.#E.f+-i<2@.7_roo[U>P1HN!3@k!RG9ps-5g@Hp_=VQk'kbaZ'4lF,sE&Yk@m]LTmc#mmSPL;]u`I*-5nA[kN\S+/):BOiRh+`r\ug;rPn/9+^\*/h.qf0G2W9;0_lBe0s%X_M)R\*s(B1^f[b"*Q;j11K@:W-S_=0C*nq#"huQU)4(lFFD/!0qu4-#HO_b0U;D[*b0:riB)KYp9CH708%g0im,]dPc]VH?5coP<!+]*AIitOhD8@($Z_jDQ3A0:7X1&f7]*rn^$MW`qIq'7b>'StkODH7o8QqUL;rr6$!Y[q2dSG[qW/#f_0-2/8!#(f>9QE<^\"I[kFg`df'a1bP9h8J[?@*de'rG#lCA^`p.3iI]>cmZm`H2u?Q8!HGR*#+%l7)*@hhE-M(AAbf%/k2NQ0-Ln&hr9&^]Z:lUReW%<e'['tpf]7#<a8WNgT;5sEJU'13j#Wp/\s2W=7G5d)(f#6D/3f[3C$XfVHa&B70h/2c4U`sAKS>G)L+H9#j(aPpC_jI)'TXI/e%STi9aa66a!Br`&a'\(?!QjUd]WJOrc@!\&VDgFc0=a@U];%"AEUg0Q_mek?jBt%`O[iQrD]Z!g?D4CS/3io?9-qj*d]-m6A^cf9IFdH\Slp*5"E\AHlL7Pp-s-B>eGF/FdF1rm7Re94P@p$2<E\KiKCo]d3e`!H^k`DrEfZ+KdIMa):0CEHO3)r$@*UK`,<4/:#Y]WO!fb?TjpJ#=h+LL)J/Ib)9#An__69,?K!fmX<hcmQVd\amc&mM8R4+dk)F,&[#[Va)lbbSP)M*ni9S*K:YV=>J<;*+%m!OPg+:Z*=S'!?$::Rj&hZBY]*GEtEKo%OcdWS/-g%"81srucO~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1234
+>>
+stream
+GauHJbAu>q']&(*m\UXV,JsZZcH`PmFuid)Z)1Z71*)1(,U=YOP)s8:l[&Uplro\iG<1m]OT_>(caaSEE!l*TrHD*PrA:4K&LT2E1*[jFLaMTTQc\1S!R'LK91!*5kWZqj1l=;9o0MDdS_uG@/uV]*HTPVLQAI:BQ:?-BLa@nnEr,8U<lY6bL,ho*VE!PEqj31X#@$qjoBsUVcEWm.@4ldkbh_:.\]%ad7IMgcQiV>((ZEW2+6^CU<(!!/QI`&G&-Is%]7BDnC%?s)Dk5k--GkFm.!r0RQ?,LBUW%^*#lE-Y*2Zs@@Ssbqn2,u":.tcj#eh:`&l2p?'KX]E,=*Mm'Lh4&?JJ`7@d9+?.bP91QJL.9l+69+Sba.Q!shKpC'Zq7nHK0F*4TW,3qbNSa%H*%)ljmX9d?]R9c?sYl8usuZ9XFmf3<!dmV&U-;lcM@B%^VJ>2@C/i2s9M<fq4@buCaThAHF3*l`BI0%u:hG(OHCm\tr>JL'+h!t,4&-iA4rH/r,*T&oVRhT5+Fba)6tV-K4PdE3hEeU]9:B%=OUJP!L8r6`pUs7O6a5"Z9_M"Ai4QEI0J]o2GRQZhmS`]2;jK^h"WqIK=m>3_'G:B4%O1BI@j[9+uY<39GNKXI659&'"FJ8of\J<P\YDib^>RXIuu_Ve,7`hrO2/Ep'SSksfP$Pb&)"mMGjNO7G8(946(2=jb;&7s7WE*YD<]5[^_(MEua6LUpp81f!'G=N@Zj`INF'6o]mhSYa8rdXXYEJI9F'qLr-c.t30,77emQb7FqGio?3:ZIoV+]:E.I_b)h?.^IoHE4g>YdlL<(e`%Yd@69<H@o./Y23uTTrGTCq,<[roaA+-d+YGI,rCFhQ\ED`-#egjrVim<Y9seu+o%)Y!tD/g#(_8SL>fMVbO;sT$pK*Z=Lk!WYeM*1T]2AsXb:tKoYAB7HoeHehLXR=_MgJRUW?f8Id9!7=('@IpK$hbJrF?Z4]MI+$3rkIWAb?Ef\>ro`M'Fs2ZA-dPpV_!?EJ(mm'HX9]?b#TkPG[[Pa8gg(@EY3A*H>^0*;u#+ce=hU5Ol/A#CunE2\^HSVE;,/:2/IZCNPZ0%u,PTeC-eRA;H^e9U<(p0)Tm7c@S-pIhnul3\QF!FqrmT/m^ahKf&T2d#F;b[jjCX6lhj*`9\6/I]rd\<lEDEp\o)fq:@0,<7Sb5p<.k;aY`lbVhQI=d!K!K-%lc"I$"=e'=Z'5@oucA,~>endstream
+endobj
+xref
+0 18
+0000000000 65535 f 
+0000000061 00000 n 
+0000000112 00000 n 
+0000000219 00000 n 
+0000000331 00000 n 
+0000000547 00000 n 
+0000000766 00000 n 
+0000000985 00000 n 
+0000001094 00000 n 
+0000001289 00000 n 
+0000001484 00000 n 
+0000001680 00000 n 
+0000001750 00000 n 
+0000002031 00000 n 
+0000002110 00000 n 
+0000004004 00000 n 
+0000005685 00000 n 
+0000007308 00000 n 
+trailer
+<<
+/ID 
+[<7f82ec49a9bb347a6e2b0c406b93c6f6><7f82ec49a9bb347a6e2b0c406b93c6f6>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 12 0 R
+/Root 11 0 R
+/Size 18
+>>
+startxref
+8634
+%%EOF

--- a/linen/index.html
+++ b/linen/index.html
@@ -20,6 +20,7 @@
     </a>
     <nav aria-label="Page navigation">
       <a href="#pattern-001">Pattern 001</a>
+      <a href="./3dvr-linen-pattern-001-drawstring-pants.pdf">Download PDF</a>
       <a href="#materials">Buy materials</a>
       <a href="#principles">Principles</a>
       <a href="#wardrobe">Wardrobe</a>
@@ -35,7 +36,8 @@
         visible repair, local sewing, and patterns anyone can copy or improve.
       </p>
       <div class="hero-actions">
-        <a class="button primary" href="#pattern-001">Make the first pair</a>
+        <a class="button primary" href="./3dvr-linen-pattern-001-drawstring-pants.pdf">Download Pattern 001 PDF</a>
+        <a class="button" href="#pattern-001">Make the first pair</a>
         <a class="button" href="#materials">Buy the materials</a>
         <a class="button" href="#principles">Why linen?</a>
       </div>
@@ -55,6 +57,9 @@
         <p>
           Start with the easiest useful garment: relaxed pants with a linen drawstring and a simple casing.
           The first version deliberately uses a pair of loose pants you already like as the pattern.
+        </p>
+        <p>
+          <a class="button primary" href="./3dvr-linen-pattern-001-drawstring-pants.pdf">Download the printable v0.1 pattern guide</a>
         </p>
       </div>
 


### PR DESCRIPTION
## What changed
- added a 4-page printable Pattern 001 guide for the all-linen drawstring pants
- embedded the linen fabric and linen thread purchase links in the PDF
- added a print calibration box and tracing/assembly diagrams
- linked the PDF prominently from `/linen/`

## Validation
- rendered all four PDF pages at 160 DPI and visually checked the result
- purchase links are clickable in the PDF
- garment construction remains linen cloth + linen thread + linen drawstring, with no elastic or plastic hardware