### PR TITLE
Fix linen fabric shopping link

### DIFF
--- a/linen/index.html
+++ b/linen/index.html
@@ -116,18 +116,17 @@
         <h2>Buy only what you need.</h2>
         <p>
           The garment itself needs only linen cloth and linen thread. The drawstring is cut from the same cloth.
-          For a first adult prototype, about 3 yards of 58-inch-wide fabric is a useful starting estimate, but trace and measure your pieces before ordering when possible.
+          For a first adult prototype, about 3 yards of 52–58-inch-wide fabric is a useful starting estimate, but trace and measure your pieces before ordering when possible.
         </p>
       </div>
 
       <div class="materials-grid">
         <article class="material-card feature-card">
           <span class="number">Fabric</span>
-          <h3>Natural 5.3 oz linen</h3>
-          <p>100% linen, 58 inches wide, medium weight. This is the baseline cloth for Pattern 001.</p>
+          <h3>Natural medium-weight linen</h3>
+          <p>100% pure linen twill, 5.83 oz/yd² and 52 inches wide. Choose the Natural (light) color for an undyed-looking first pair.</p>
           <div class="buy-links">
-            <a class="button primary" href="https://fabrics-store.com/fabrics/linen-fabric-IL019-natural-middle/" target="_blank" rel="noopener noreferrer">Buy natural IL019</a>
-            <a class="text-link" href="https://fabrics-store.com/fabrics/linen-fabric-IL019-mix-natural-middle" target="_blank" rel="noopener noreferrer">Mix natural option</a>
+            <a class="button primary" href="https://www.thelinenlab.com/products/classic-linen-twill-fabric-100-pure-linen-medium-weight" target="_blank" rel="noopener noreferrer">Buy natural linen</a>
           </div>
         </article>
 


### PR DESCRIPTION
Replace the flaky Fabrics-Store purchase link with a currently live, in-stock 100% linen twill option from The Linen Lab (5.83 oz/yd², Natural light available).