### PR TITLE
fix(companion): remove false positive from receipt secret scan

### DIFF
--- a/apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt
+++ b/apps/companion/native-spec/android/CompanionVoiceReceiptStore.kt
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets
 
 /**
  * Stores only the latest bounded voice action receipt for user-visible audit.
- * No raw audio is stored, and receipts intentionally avoid secrets or tokens.
+ * No raw audio is stored, and receipts contain only bounded action evidence.
  *
  * The Assistant session runs in a separate Android process, so this uses an
  * app-private AtomicFile instead of SharedPreferences to keep cross-process


### PR DESCRIPTION
## Summary
- removes credential-related words from the receipt-store comment that trip the focused source scan
- keeps the runtime receipt schema and authority unchanged
- preserves the test's useful guard against credential-bearing code entering the receipt store

Follow-up reliability fix for the review finding after #1579.