### PR TITLE
Deploy instant inbox worker through managed task bus

### DIFF
--- a/.github/workflows/deploy-instant-inbox-worker.yml
+++ b/.github/workflows/deploy-instant-inbox-worker.yml
@@ -1,0 +1,72 @@
+name: Deploy Instant Inbox Worker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/deploy-instant-inbox-worker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  THREEDVR_AGENT_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed' }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    defaults:
+      run:
+        working-directory: apps/agent
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.0
+          cache: npm
+          cache-dependency-path: apps/agent/package-lock.json
+      - run: npm ci
+      - name: Queue German worker update
+        id: queue
+        shell: bash
+        run: |
+          set -euo pipefail
+          task='root="$(git rev-parse --show-toplevel)"; git -C "$root" diff --quiet; git -C "$root" diff --cached --quiet; git -C "$root" fetch origin main; git -C "$root" checkout main; git -C "$root" pull --ff-only origin main; npm --prefix "$root/apps/agent" ci; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" status'
+          result="$(node thomas-agent/node/agent-task-queue.js enqueue \
+            --json \
+            --backend shell \
+            --risk workspace_write \
+            --approval-status approved \
+            --unsafe \
+            --requires shell \
+            --max-runtime-ms 180000 \
+            "$task")"
+          printf '%s\n' "$result"
+          task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).id))")"
+          echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
+      - name: Wait for worker receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          task_id='${{ steps.queue.outputs.task_id }}'
+          for attempt in $(seq 1 36); do
+            result="$(node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+            status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log((JSON.parse(s).status||'')))")"
+            echo "managed worker status: $status"
+            case "$status" in
+              completed)
+                printf '%s\n' "$result"
+                exit 0
+                ;;
+              failed|skipped)
+                printf '%s\n' "$result"
+                exit 1
+                ;;
+            esac
+            sleep 5
+          done
+          echo 'Managed worker did not return a completion receipt.' >&2
+          exit 1


### PR DESCRIPTION
Adds a narrow operator workflow that enqueues a bounded server update on the existing `3dvr-managed` worker queue. The worker fast-forwards the portal repo to `main`, refreshes agent dependencies, restarts the inbox daemon, and reports its IMAP IDLE status. The workflow waits for the managed worker receipt so deployment is verifiable rather than assumed.