### PR TITLE
Persist instant inbox deployment receipts

### DIFF
--- a/.github/workflows/deploy-instant-inbox-worker.yml
+++ b/.github/workflows/deploy-instant-inbox-worker.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   THREEDVR_AGENT_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed' }}
@@ -52,6 +52,24 @@ jobs:
         run: |
           set -euo pipefail
           task_id='${{ steps.queue.outputs.task_id }}'
+
+          write_receipt() {
+            receipt_status="$1"
+            cd "$GITHUB_WORKSPACE"
+            git config user.name '3DVR Actions'
+            git config user.email '3dvr.tech@gmail.com'
+            git fetch origin main
+            git checkout -B ops/instant-inbox-runtime-receipt origin/main
+            mkdir -p ops/tmp
+            printf '{"status":"%s","task_id":"%s","recorded_at":"%s"}\n' \
+              "$receipt_status" "$task_id" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              > ops/tmp/instant-inbox-deploy-receipt.json
+            git add -- ops/tmp/instant-inbox-deploy-receipt.json
+            git commit -m "ops: record instant inbox deployment $receipt_status" || true
+            git push --force origin HEAD:ops/instant-inbox-runtime-receipt
+            cd "$GITHUB_WORKSPACE/apps/agent"
+          }
+
           for attempt in $(seq 1 36); do
             result="$(node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
             status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log((JSON.parse(s).status||'')))")"
@@ -59,14 +77,17 @@ jobs:
             case "$status" in
               completed)
                 printf '%s\n' "$result"
+                write_receipt completed
                 exit 0
                 ;;
               failed|skipped)
                 printf '%s\n' "$result"
+                write_receipt "$status"
                 exit 1
                 ;;
             esac
             sleep 5
           done
+          write_receipt timeout
           echo 'Managed worker did not return a completion receipt.' >&2
           exit 1


### PR DESCRIPTION
Makes the managed German-worker deployment verifiable. The operator workflow now writes only a sanitized completed/failed/skipped/timeout receipt to a dedicated branch after the remote task returns, without exposing server output or credentials.