### PR TITLE
Fix managed worker config loading

### DIFF
--- a/apps/agent/test/agent-worker-daemon.test.js
+++ b/apps/agent/test/agent-worker-daemon.test.js
@@ -10,6 +10,6 @@ test('agent worker daemon reloads the selected 3DVR config inside its worker ses
 
   assert.match(script, /CONFIG_FILE="\$\{THREEDVR_CONFIG_FILE:-\$HOME\/\.3dvr\/config\/env\}"/);
   assert.match(script, /export THREEDVR_CONFIG_FILE=\$config_file_q/);
-  assert.match(script, /if \[ -f \\"\\\$THREEDVR_CONFIG_FILE\\" \]; then set -a; \. \\"\\\$THREEDVR_CONFIG_FILE\\"; set \+a; fi/);
+  assert.ok(script.includes('if [ -f \\"\\$THREEDVR_CONFIG_FILE\\" ]; then set -a; . \\"\\$THREEDVR_CONFIG_FILE\\"; set +a; fi;'));
   assert.match(script, /ask-agent-queue\\" run-once/);
 });

--- a/apps/agent/test/agent-worker-daemon.test.js
+++ b/apps/agent/test/agent-worker-daemon.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { readFile } = require('node:fs/promises');
+const path = require('node:path');
+
+const workerDaemon = path.join(__dirname, '..', 'thomas-agent', 'scripts', 'ask-agent-worker-daemon');
+
+test('agent worker daemon reloads the selected 3DVR config inside its worker session', async () => {
+  const script = await readFile(workerDaemon, 'utf8');
+
+  assert.match(script, /CONFIG_FILE="\$\{THREEDVR_CONFIG_FILE:-\$HOME\/\.3dvr\/config\/env\}"/);
+  assert.match(script, /export THREEDVR_CONFIG_FILE=\$config_file_q/);
+  assert.match(script, /if \[ -f \\"\\\$THREEDVR_CONFIG_FILE\\" \]; then set -a; \. \\"\\\$THREEDVR_CONFIG_FILE\\"; set \+a; fi/);
+  assert.match(script, /ask-agent-queue\\" run-once/);
+});

--- a/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon
+++ b/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon
@@ -3,6 +3,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_FILE="${THREEDVR_CONFIG_FILE:-$HOME/.3dvr/config/env}"
+
+if [ -f "$CONFIG_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$CONFIG_FILE"
+  set +a
+fi
+
 STATE_DIR="${THREEDVR_AUTOPILOT_STATE_DIR:-$ROOT/state}"
 PID_FILE="$STATE_DIR/agent-worker.pid"
 LOG_FILE="$STATE_DIR/agent-worker.log"
@@ -28,7 +37,11 @@ case "${1:-}" in
       echo "Agent worker already running in tmux session $TMUX_SESSION."
       exit 0
     fi
-    worker_loop="cd \"$ROOT\" && while true; do \"$SCRIPT_DIR/ask-agent-queue\" run-once >>\"$LOG_FILE\" 2>&1; sleep \"$INTERVAL_SECONDS\"; done"
+    # tmux can retain an older environment than the invoking shell. Load the
+    # selected 3DVR config inside the session so the managed worker always uses
+    # the current owner alias, queue settings, and backend configuration.
+    printf -v config_file_q '%q' "$CONFIG_FILE"
+    worker_loop="unset THREEDVR_ENV_LOADED; export THREEDVR_CONFIG_FILE=$config_file_q; if [ -f \"\$THREEDVR_CONFIG_FILE\" ]; then set -a; . \"\$THREEDVR_CONFIG_FILE\"; set +a; fi; cd \"$ROOT\" && while true; do \"$SCRIPT_DIR/ask-agent-queue\" run-once >>\"$LOG_FILE\" 2>&1; sleep \"$INTERVAL_SECONDS\"; done"
     if command -v tmux >/dev/null 2>&1; then
       tmux new-session -d -s "$TMUX_SESSION" "$worker_loop"
       echo "Started agent worker in tmux session $TMUX_SESSION. Log: $LOG_FILE"


### PR DESCRIPTION
The German worker deployment is still reporting failure on current `main` even after the task-queue JSON parser fix.

This addresses a concrete runtime reliability gap in the managed worker daemon:

- load `~/.3dvr/config/env` when the worker daemon starts
- explicitly reload that selected config inside the tmux worker session, matching the inbox-daemon pattern
- prevents a stale tmux environment from leaving the worker on the default `anonymous@3dvr` owner queue instead of the configured managed queue
- adds a focused regression test so the config reload cannot disappear silently

This is intentionally narrow: no new server authority, no new external-write capability, and no change to task risk/approval policy.

Next after green CI: merge, let the main-branch Agent Checks deployment run again, and inspect the `3DVR German Worker` status before touching the free-site fulfillment logic.