### PR TITLE
Expose the full living 3DVR runtime

### DIFF
--- a/alive/index.html
+++ b/alive/index.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>3DVR Alive</title>
+  <meta name="description" content="Live pulse and organ status for the 3DVR agent runtime." />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07110d;
+      --panel: rgba(12, 29, 22, .9);
+      --line: rgba(171, 255, 206, .14);
+      --text: #ebfff2;
+      --muted: #9bc4aa;
+      --alive: #73f59f;
+      --warn: #ffd36d;
+      --down: #ff7d7d;
+      --unknown: #9ba7a0;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at 50% 0%, rgba(75, 220, 132, .16), transparent 38rem),
+        var(--bg);
+      color: var(--text);
+    }
+    main { width: min(920px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 64px; }
+    a { color: var(--alive); }
+    .eyebrow { color: var(--muted); letter-spacing: .14em; text-transform: uppercase; font-size: .76rem; }
+    h1 { margin: 8px 0 6px; font-size: clamp(2.3rem, 8vw, 5rem); line-height: .95; }
+    .lede { margin: 0; color: var(--muted); max-width: 42rem; }
+    .pulse-panel {
+      margin-top: 28px;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 18px;
+      align-items: center;
+      padding: 22px;
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      background: var(--panel);
+    }
+    .pulse {
+      width: 64px;
+      height: 64px;
+      border-radius: 50%;
+      background: var(--unknown);
+      box-shadow: 0 0 0 0 rgba(115, 245, 159, .4);
+    }
+    .pulse.alive { background: var(--alive); animation: beat 1.8s infinite; }
+    .pulse.degraded { background: var(--warn); animation: beat 2.8s infinite; }
+    .pulse.offline { background: var(--down); }
+    @keyframes beat {
+      0%, 100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(115, 245, 159, .36); }
+      18% { transform: scale(1.08); box-shadow: 0 0 0 13px rgba(115, 245, 159, 0); }
+      32% { transform: scale(1); }
+    }
+    .state { font-size: 1.55rem; font-weight: 760; }
+    .meta { margin-top: 5px; color: var(--muted); font-size: .92rem; }
+    .organs { margin-top: 18px; display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 12px; }
+    .organ { padding: 16px; border: 1px solid var(--line); border-radius: 16px; background: var(--panel); }
+    .organ-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+    .organ h2 { margin: 0; font-size: 1rem; }
+    .dot { width: 10px; height: 10px; border-radius: 50%; background: var(--unknown); }
+    .dot.up { background: var(--alive); box-shadow: 0 0 14px rgba(115,245,159,.55); }
+    .dot.down { background: var(--down); }
+    .organ-state { margin-top: 12px; color: var(--muted); font-size: .86rem; word-break: break-word; }
+    .details { margin-top: 18px; padding: 18px; border: 1px solid var(--line); border-radius: 16px; background: var(--panel); }
+    .details dl { margin: 0; display: grid; grid-template-columns: max-content 1fr; gap: 8px 14px; }
+    .details dt { color: var(--muted); }
+    .details dd { margin: 0; word-break: break-word; }
+    footer { margin-top: 24px; color: var(--muted); font-size: .86rem; display: flex; gap: 16px; flex-wrap: wrap; }
+    @media (max-width: 520px) {
+      main { padding-top: 28px; }
+      .pulse-panel { grid-template-columns: 1fr; }
+      .details dl { grid-template-columns: 1fr; gap: 3px; }
+      .details dd { margin-bottom: 8px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="eyebrow">Open Personal Computing · live runtime</div>
+    <h1>3DVR Alive</h1>
+    <p class="lede">A real-time view of the agent's pulse. Green means recent heartbeat data says every required organ is running.</p>
+
+    <section class="pulse-panel" aria-live="polite">
+      <div id="pulse" class="pulse" aria-hidden="true"></div>
+      <div>
+        <div id="overall-state" class="state">Connecting…</div>
+        <div id="overall-meta" class="meta">Waiting for the first heartbeat.</div>
+      </div>
+    </section>
+
+    <section class="organs" aria-label="Agent organs">
+      <article class="organ" data-organ="inbox"><div class="organ-top"><h2>Inbox</h2><span class="dot"></span></div><div class="organ-state">Unknown</div></article>
+      <article class="organ" data-organ="outreach"><div class="organ-top"><h2>Outreach</h2><span class="dot"></span></div><div class="organ-state">Unknown</div></article>
+      <article class="organ" data-organ="worker"><div class="organ-top"><h2>Task worker</h2><span class="dot"></span></div><div class="organ-state">Unknown</div></article>
+      <article class="organ" data-organ="router"><div class="organ-top"><h2>Context router</h2><span class="dot"></span></div><div class="organ-state">Unknown</div></article>
+      <article class="organ" data-organ="supervisor"><div class="organ-top"><h2>Supervisor</h2><span class="dot"></span></div><div class="organ-state">Unknown</div></article>
+    </section>
+
+    <section class="details">
+      <dl>
+        <dt>Owner</dt><dd id="owner">--</dd>
+        <dt>Host</dt><dd id="host">--</dd>
+        <dt>Last beat</dt><dd id="last-beat">--</dd>
+        <dt>Heartbeat age</dt><dd id="beat-age">--</dd>
+        <dt>Process</dt><dd id="process">--</dd>
+      </dl>
+    </section>
+
+    <footer>
+      <span>Owner can be changed with <code>?owner=alias</code>.</span>
+      <a href="/admin/">Agent Ops</a>
+      <a href="/context-hq/">Context HQ</a>
+    </footer>
+  </main>
+
+  <script>
+    const params = new URLSearchParams(location.search);
+    const ownerAlias = params.get('owner') || '3dvr-managed';
+    const STALE_AFTER_MS = 180000;
+    const gun = Gun({
+      peers: window.__GUN_PEERS__ || [
+        'wss://relay.3dvr.tech/gun',
+        'wss://gun-relay-3dvr.fly.dev/gun'
+      ]
+    });
+    const runtimeNode = gun.get('3dvr-portal').get('agentOps').get(ownerAlias).get('runtime');
+    const snapshot = { ownerAlias };
+    const organs = ['inbox', 'outreach', 'worker', 'router', 'supervisor'];
+
+    const byId = id => document.getElementById(id);
+
+    function formatAge(ms) {
+      if (!Number.isFinite(ms) || ms < 0) return 'unknown';
+      const seconds = Math.floor(ms / 1000);
+      if (seconds < 60) return `${seconds}s`;
+      const minutes = Math.floor(seconds / 60);
+      if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+      return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+    }
+
+    function renderOrgan(name) {
+      const card = document.querySelector(`[data-organ="${name}"]`);
+      if (!card) return;
+      const value = snapshot[name];
+      const dot = card.querySelector('.dot');
+      const text = card.querySelector('.organ-state');
+      dot.className = 'dot';
+      if (!value || typeof value !== 'object') {
+        text.textContent = 'Unknown';
+        return;
+      }
+      dot.classList.add(value.running ? 'up' : 'down');
+      text.textContent = `${value.running ? 'Running' : 'Stopped'}${value.session ? ` · ${value.session}` : ''}`;
+    }
+
+    function render() {
+      const beatAt = Date.parse(snapshot.lastBeatAt || '');
+      const age = Number.isFinite(beatAt) ? Date.now() - beatAt : Infinity;
+      const stale = age > STALE_AFTER_MS;
+      const reported = String(snapshot.status || '').toLowerCase();
+      const allOrgansUp = organs.every(name => snapshot[name] && snapshot[name].running === true);
+      let state = 'UNKNOWN';
+      let pulseClass = '';
+      if (stale && Number.isFinite(beatAt)) {
+        state = 'OFFLINE';
+        pulseClass = 'offline';
+      } else if (!stale && reported === 'running' && allOrgansUp) {
+        state = 'ALIVE';
+        pulseClass = 'alive';
+      } else if (!stale && Number.isFinite(beatAt)) {
+        state = 'DEGRADED';
+        pulseClass = 'degraded';
+      }
+
+      byId('pulse').className = `pulse ${pulseClass}`.trim();
+      byId('overall-state').textContent = state;
+      byId('overall-meta').textContent = state === 'ALIVE'
+        ? 'Every required organ is reporting healthy.'
+        : state === 'OFFLINE'
+          ? 'Heartbeat data is stale. The runtime may be unreachable.'
+          : state === 'DEGRADED'
+            ? 'A recent heartbeat exists, but one or more organs are unhealthy.'
+            : 'Waiting for a usable runtime heartbeat.';
+      byId('owner').textContent = snapshot.ownerAlias || ownerAlias;
+      byId('host').textContent = snapshot.hostName || '--';
+      byId('last-beat').textContent = Number.isFinite(beatAt) ? new Date(beatAt).toLocaleString() : '--';
+      byId('beat-age').textContent = Number.isFinite(age) ? formatAge(age) : '--';
+      byId('process').textContent = snapshot.pid ? `PID ${snapshot.pid}${snapshot.startedAt ? ` · since ${new Date(snapshot.startedAt).toLocaleString()}` : ''}` : '--';
+      organs.forEach(renderOrgan);
+    }
+
+    runtimeNode.on(data => {
+      if (data && typeof data === 'object') Object.assign(snapshot, data);
+      render();
+    });
+    organs.forEach(name => {
+      runtimeNode.get(name).on(data => {
+        if (data && typeof data === 'object') snapshot[name] = data;
+        render();
+      });
+    });
+    setInterval(render, 5000);
+    render();
+  </script>
+</body>
+</html>

--- a/apps/agent/test/agent-heartbeat.test.js
+++ b/apps/agent/test/agent-heartbeat.test.js
@@ -37,6 +37,7 @@ exit 1
     THREEDVR_AUTOPILOT_TMUX_SESSION: process.env.THREEDVR_AUTOPILOT_TMUX_SESSION,
     THREEDVR_AGENT_WORKER_TMUX_SESSION: process.env.THREEDVR_AGENT_WORKER_TMUX_SESSION,
     THREEDVR_CONTEXT_TASK_ROUTER_TMUX_SESSION: process.env.THREEDVR_CONTEXT_TASK_ROUTER_TMUX_SESSION,
+    THREEDVR_AGENT_SUPERVISOR_TMUX_SESSION: process.env.THREEDVR_AGENT_SUPERVISOR_TMUX_SESSION,
     THREEDVR_LEADS_FILE: process.env.THREEDVR_LEADS_FILE,
     THREEDVR_OUTREACH_LOG_FILE: process.env.THREEDVR_OUTREACH_LOG_FILE,
     THREEDVR_INBOX_STATE_FILE: process.env.THREEDVR_INBOX_STATE_FILE,
@@ -57,10 +58,11 @@ exit 1
     process.env.THREEDVR_AUTOPILOT_TMUX_SESSION = 'beat-outreach';
     process.env.THREEDVR_AGENT_WORKER_TMUX_SESSION = 'beat-worker';
     process.env.THREEDVR_CONTEXT_TASK_ROUTER_TMUX_SESSION = 'beat-router';
+    process.env.THREEDVR_AGENT_SUPERVISOR_TMUX_SESSION = 'beat-supervisor';
     process.env.THREEDVR_LEADS_FILE = leadsFile;
     process.env.THREEDVR_OUTREACH_LOG_FILE = outreachLogFile;
     process.env.THREEDVR_INBOX_STATE_FILE = inboxStateFile;
-    process.env.FAKE_TMUX_RUNNING_SESSIONS = 'beat-inbox,beat-outreach,beat-worker,beat-router';
+    process.env.FAKE_TMUX_RUNNING_SESSIONS = 'beat-inbox,beat-outreach,beat-worker,beat-router,beat-supervisor';
 
     const heartbeat = loadHeartbeatModule();
 
@@ -72,6 +74,7 @@ exit 1
     assert.equal(running.outreach.running, true);
     assert.equal(running.worker.running, true);
     assert.equal(running.router.running, true);
+    assert.equal(running.supervisor.running, true);
     assert.equal(running.sales.ownerAlias, 'ops@3dvr');
     assert.equal(running.sales.leads.statusCounts.new, 1);
     assert.match(running.startedAt, /^\d{4}-\d{2}-\d{2}T/);
@@ -84,20 +87,23 @@ exit 1
     assert.match(runningSummary, /Outreach: running \(beat-outreach\)/);
     assert.match(runningSummary, /Task worker: running \(beat-worker\)/);
     assert.match(runningSummary, /Context router: running \(beat-router\)/);
+    assert.match(runningSummary, /Supervisor: running \(beat-supervisor\)/);
     assert.match(runningSummary, /Sales: new=1, contacted=0, replied=0, failed=0, manual=0, today=0/);
 
-    process.env.FAKE_TMUX_RUNNING_SESSIONS = 'beat-inbox,beat-worker';
+    process.env.FAKE_TMUX_RUNNING_SESSIONS = 'beat-inbox,beat-worker,beat-supervisor';
     const degraded = heartbeat.getRuntimeSnapshot();
     assert.equal(degraded.status, 'degraded');
     assert.equal(degraded.inbox.running, true);
     assert.equal(degraded.outreach.running, false);
     assert.equal(degraded.worker.running, true);
     assert.equal(degraded.router.running, false);
+    assert.equal(degraded.supervisor.running, true);
 
     const degradedSummary = heartbeat.summarizeRuntime(degraded);
     assert.match(degradedSummary, /Status: degraded/);
     assert.match(degradedSummary, /Outreach: stopped \(beat-outreach\)/);
     assert.match(degradedSummary, /Context router: stopped \(beat-router\)/);
+    assert.match(degradedSummary, /Supervisor: running \(beat-supervisor\)/);
   } finally {
     process.env.PATH = originalEnv.PATH;
     process.env.THREEDVR_AGENT_OWNER_ALIAS = originalEnv.THREEDVR_AGENT_OWNER_ALIAS;
@@ -105,6 +111,7 @@ exit 1
     process.env.THREEDVR_AUTOPILOT_TMUX_SESSION = originalEnv.THREEDVR_AUTOPILOT_TMUX_SESSION;
     process.env.THREEDVR_AGENT_WORKER_TMUX_SESSION = originalEnv.THREEDVR_AGENT_WORKER_TMUX_SESSION;
     process.env.THREEDVR_CONTEXT_TASK_ROUTER_TMUX_SESSION = originalEnv.THREEDVR_CONTEXT_TASK_ROUTER_TMUX_SESSION;
+    process.env.THREEDVR_AGENT_SUPERVISOR_TMUX_SESSION = originalEnv.THREEDVR_AGENT_SUPERVISOR_TMUX_SESSION;
     process.env.THREEDVR_LEADS_FILE = originalEnv.THREEDVR_LEADS_FILE;
     process.env.THREEDVR_OUTREACH_LOG_FILE = originalEnv.THREEDVR_OUTREACH_LOG_FILE;
     process.env.THREEDVR_INBOX_STATE_FILE = originalEnv.THREEDVR_INBOX_STATE_FILE;

--- a/apps/agent/thomas-agent/node/agent-heartbeat.js
+++ b/apps/agent/thomas-agent/node/agent-heartbeat.js
@@ -8,6 +8,7 @@ const INBOX_SESSION = process.env.THREEDVR_INBOX_TMUX_SESSION || '3dvr-inbox';
 const OUTREACH_SESSION = process.env.THREEDVR_AUTOPILOT_TMUX_SESSION || '3dvr-autopilot';
 const TASK_WORKER_SESSION = process.env.THREEDVR_AGENT_WORKER_TMUX_SESSION || '3dvr-worker';
 const CONTEXT_ROUTER_SESSION = process.env.THREEDVR_CONTEXT_TASK_ROUTER_TMUX_SESSION || '3dvr-context-router';
+const SUPERVISOR_SESSION = process.env.THREEDVR_AGENT_SUPERVISOR_TMUX_SESSION || '3dvr-supervisor';
 const HEARTBEAT_INTERVAL_SECONDS = Number(process.env.THREEDVR_AGENT_HEARTBEAT_INTERVAL_SECONDS || 60);
 const HEARTBEAT_WRITE_TIMEOUT_MS = Number(process.env.THREEDVR_AGENT_HEARTBEAT_WRITE_TIMEOUT_MS || 10000);
 const HEARTBEAT_FLUSH_MS = Number(process.env.THREEDVR_AGENT_HEARTBEAT_FLUSH_MS || 1000);
@@ -38,7 +39,8 @@ function getRuntimeSnapshot() {
   const outreachRunning = isSessionRunning(OUTREACH_SESSION);
   const workerRunning = isSessionRunning(TASK_WORKER_SESSION);
   const routerRunning = isSessionRunning(CONTEXT_ROUTER_SESSION);
-  const status = inboxRunning && outreachRunning && workerRunning && routerRunning ? 'running' : 'degraded';
+  const supervisorRunning = isSessionRunning(SUPERVISOR_SESSION);
+  const status = inboxRunning && outreachRunning && workerRunning && routerRunning && supervisorRunning ? 'running' : 'degraded';
   let sales = {};
   try {
     sales = gunSafe(compactRuntimeSales(buildSalesSummary({ ownerAlias: OWNER_ALIAS, recentLimit: 3 })));
@@ -72,6 +74,10 @@ function getRuntimeSnapshot() {
     router: {
       session: CONTEXT_ROUTER_SESSION,
       running: routerRunning,
+    },
+    supervisor: {
+      session: SUPERVISOR_SESSION,
+      running: supervisorRunning,
     },
     sales,
   };
@@ -107,6 +113,7 @@ function summarizeRuntime(runtime = {}) {
   const outreach = runtime.outreach && typeof runtime.outreach === 'object' ? runtime.outreach : {};
   const worker = runtime.worker && typeof runtime.worker === 'object' ? runtime.worker : {};
   const router = runtime.router && typeof runtime.router === 'object' ? runtime.router : {};
+  const supervisor = runtime.supervisor && typeof runtime.supervisor === 'object' ? runtime.supervisor : {};
   const sales = runtime.sales && typeof runtime.sales === 'object' ? runtime.sales : {};
   const leads = sales.leads && typeof sales.leads === 'object' ? sales.leads : {};
   const leadCounts = leads.statusCounts && typeof leads.statusCounts === 'object' ? leads.statusCounts : {};
@@ -119,7 +126,8 @@ function summarizeRuntime(runtime = {}) {
     `Inbox: ${inbox.running ? 'running' : 'stopped'} (${normalizeText(inbox.session) || INBOX_SESSION})`,
     `Outreach: ${outreach.running ? 'running' : 'stopped'} (${normalizeText(outreach.session) || OUTREACH_SESSION})`,
     `Task worker: ${worker.running ? 'running' : 'stopped'} (${normalizeText(worker.session) || TASK_WORKER_SESSION})`,
-    `Context router: ${router.running ? 'running' : 'stopped'} (${normalizeText(router.session) || CONTEXT_ROUTER_SESSION})`
+    `Context router: ${router.running ? 'running' : 'stopped'} (${normalizeText(router.session) || CONTEXT_ROUTER_SESSION})`,
+    `Supervisor: ${supervisor.running ? 'running' : 'stopped'} (${normalizeText(supervisor.session) || SUPERVISOR_SESSION})`
   ];
   if (sales.generatedAt) {
     lines.push(`Sales: new=${leadCounts.new || 0}, contacted=${leadCounts.contacted || 0}, replied=${leadCounts.replied || 0}, failed=${leadCounts.failed || 0}, manual=${leads.manualReview || 0}, today=${outreachCounts.contactedToday || 0}`);
@@ -143,6 +151,7 @@ async function writeHeartbeat() {
       outreach: snapshot.outreach,
       worker: snapshot.worker,
       router: snapshot.router,
+      supervisor: snapshot.supervisor,
       startedAt: snapshot.startedAt,
       sales: snapshot.sales,
     },
@@ -174,6 +183,7 @@ async function writeHeartbeat() {
     putGun(node.get('outreach'), snapshot.outreach, { timeoutMs: HEARTBEAT_WRITE_TIMEOUT_MS }),
     putGun(node.get('worker'), snapshot.worker, { timeoutMs: HEARTBEAT_WRITE_TIMEOUT_MS }),
     putGun(node.get('router'), snapshot.router, { timeoutMs: HEARTBEAT_WRITE_TIMEOUT_MS }),
+    putGun(node.get('supervisor'), snapshot.supervisor, { timeoutMs: HEARTBEAT_WRITE_TIMEOUT_MS }),
     putGun(salesNode, {
       ownerAlias: snapshot.sales.ownerAlias,
       hostName: snapshot.sales.hostName,
@@ -199,11 +209,12 @@ async function readHeartbeat() {
   const scalarKeys = ['ownerAlias', 'service', 'status', 'hostName', 'pid', 'startedAt', 'lastBeatAt'];
   const salesNode = node.get('sales');
   const salesLeadsNode = salesNode.get('leads');
-  const [inbox, outreach, worker, router, sales, salesLeads, salesStatusCounts, salesRouteCounts, salesOutreach, salesInbox, scalarValues] = await Promise.all([
+  const [inbox, outreach, worker, router, supervisor, sales, salesLeads, salesStatusCounts, salesRouteCounts, salesOutreach, salesInbox, scalarValues] = await Promise.all([
     onceGun(node.get('inbox')).catch(() => null),
     onceGun(node.get('outreach')).catch(() => null),
     onceGun(node.get('worker')).catch(() => null),
     onceGun(node.get('router')).catch(() => null),
+    onceGun(node.get('supervisor')).catch(() => null),
     onceGun(salesNode).catch(() => null),
     onceGun(salesLeadsNode).catch(() => null),
     onceGun(salesLeadsNode.get('statusCounts')).catch(() => null),
@@ -222,6 +233,7 @@ async function readHeartbeat() {
   if (outreach && typeof outreach === 'object') runtime.outreach = outreach;
   if (worker && typeof worker === 'object') runtime.worker = worker;
   if (router && typeof router === 'object') runtime.router = router;
+  if (supervisor && typeof supervisor === 'object') runtime.supervisor = supervisor;
   if (sales && typeof sales === 'object') runtime.sales = sales;
   if (!runtime.sales || typeof runtime.sales !== 'object') runtime.sales = {};
   if (salesLeads && typeof salesLeads === 'object') runtime.sales.leads = salesLeads;

--- a/scripts/playwright/smoke.mjs
+++ b/scripts/playwright/smoke.mjs
@@ -42,6 +42,35 @@ function resolveSafePath(pathname) {
   return absolutePath;
 }
 
+function isTransientNavigationError(error) {
+  const message = String(error?.message || error || '');
+  return /execution context was destroyed|most likely because of a navigation|frame was detached/i.test(message);
+}
+
+async function readLandingSnapshot(page) {
+  const landingTitle = page.locator('#landing-title');
+  let lastError;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      await page.waitForLoadState('domcontentloaded');
+      await landingTitle.waitFor({ state: 'visible', timeout: 10000 });
+      const [pageTitle, heading] = await Promise.all([
+        page.title(),
+        landingTitle.innerText(),
+      ]);
+      return { pageTitle, heading: heading.trim() };
+    } catch (error) {
+      lastError = error;
+      if (!isTransientNavigationError(error) || attempt === 2) throw error;
+      await page.waitForLoadState('domcontentloaded').catch(() => {});
+      await delay(100);
+    }
+  }
+
+  throw lastError;
+}
+
 let browser;
 const server = createServer(async (request, response) => {
   try {
@@ -86,9 +115,7 @@ try {
   const response = await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
   assert(response && response.ok(), `Expected ${baseUrl} to return 2xx/3xx`);
 
-  await page.waitForSelector('#landing-title', { timeout: 10000 });
-  const pageTitle = await page.title();
-  const heading = (await page.locator('#landing-title').innerText()).trim();
+  const { pageTitle, heading } = await readLandingSnapshot(page);
 
   assert.equal(pageTitle, '3DVR Portal');
   assert.match(heading, /Welcome to the 3DVR Portal|Choose your path into the portal|Get in, get moving\.|One system\. Any device\.|One portal\. Fast access\.|Find your purpose\. Organize your life\. Launch your world\./i);

--- a/tests/alive-dashboard.test.js
+++ b/tests/alive-dashboard.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test('alive dashboard exposes the complete runtime organism', async () => {
+  const pageUrl = new URL('../alive/index.html', import.meta.url);
+  assert.equal(await fileExists(pageUrl), true, 'alive/index.html should exist');
+
+  const html = await readFile(pageUrl, 'utf8');
+  assert.match(html, /3DVR Alive/);
+  assert.match(html, /data-organ="inbox"/);
+  assert.match(html, /data-organ="outreach"/);
+  assert.match(html, /data-organ="worker"/);
+  assert.match(html, /data-organ="router"/);
+  assert.match(html, /data-organ="supervisor"/);
+  assert.match(html, /STALE_AFTER_MS = 180000/);
+  assert.match(html, /state = 'ALIVE'/);
+  assert.match(html, /state = 'DEGRADED'/);
+  assert.match(html, /state = 'OFFLINE'/);
+  assert.match(html, /gun\.get\('3dvr-portal'\)\.get\('agentOps'\)\.get\(ownerAlias\)\.get\('runtime'\)/);
+  assert.match(html, /runtimeNode\.get\(name\)\.on/);
+  assert.match(html, /href="\/admin\/"/);
+  assert.match(html, /href="\/context-hq\/"/);
+});


### PR DESCRIPTION
Make runtime health include the self-healing supervisor and add a standalone `/alive/` dashboard backed by the same GUN runtime data.

The page shows inbox, outreach, task worker, Context router, and supervisor independently. Overall state is ALIVE only when heartbeat data is fresh and every required organ is running; stale data becomes OFFLINE after three minutes, and partial health becomes DEGRADED.

Includes heartbeat test updates plus a static dashboard test.