### PR TITLE
Retry German worker deployment after self-safe fixes

### DIFF
--- a/apps/agent/ops/german-worker-redeploy-2026-08-20.txt
+++ b/apps/agent/ops/german-worker-redeploy-2026-08-20.txt
@@ -1,0 +1,2 @@
+German worker redeploy trigger after self-safe queue/config fixes.
+Purpose: exercise the repaired main-branch Agent Checks deployment path and restore the primary IMAP-IDLE free-site worker.


### PR DESCRIPTION
Triggers the existing Agent Checks deployment path once after the managed-worker config/self-safe fixes landed. No runtime logic changes; this is only to exercise the repaired deploy and restore the primary IMAP-IDLE free-site worker.