### PR TITLE
Self-heal OpenClaw on German worker deploy

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -84,7 +84,7 @@ jobs:
           # The task worker is executing this command, so never stop its own
           # tmux session here. The queue wrapper reloads config every poll,
           # allowing the live worker to adopt updated owner/runtime settings.
-          task='root="$(git rev-parse --show-toplevel)"; git -C "$root" diff --quiet; git -C "$root" diff --cached --quiet; git -C "$root" fetch origin main; git -C "$root" checkout main; git -C "$root" pull --ff-only origin main; npm --prefix "$root/apps/agent" ci; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" status'
+          task='root="$(git rev-parse --show-toplevel)"; git -C "$root" diff --quiet; git -C "$root" diff --cached --quiet; git -C "$root" fetch origin main; git -C "$root" checkout main; git -C "$root" pull --ff-only origin main; npm --prefix "$root/apps/agent" ci; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" start; bash "$root/apps/agent/thomas-agent/scripts/ask-openclaw-health"; "$root/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" status'
           result="$(node thomas-agent/node/agent-task-queue.js enqueue \
             --json \
             --backend shell \
@@ -135,7 +135,7 @@ jobs:
           description='German agent stack update failed'
           if [ "$QUEUE_OUTCOME" = success ] && [ "$REMOTE_OUTCOME" = success ]; then
             state=success
-            description='German agent stack alive: worker, router, inbox, autopilot, heartbeat'
+            description='German agent stack alive: worker, router, inbox, autopilot, heartbeat, OpenClaw'
           fi
           curl -fsS \
             -X POST \

--- a/apps/agent/thomas-agent/scripts/ask-openclaw-health
+++ b/apps/agent/thomas-agent/scripts/ask-openclaw-health
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="${THREEDVR_CONFIG_FILE:-$HOME/.3dvr/config/env}"
+if [ -f "$CONFIG_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$CONFIG_FILE"
+  set +a
+fi
+
+if ! command -v openclaw >/dev/null 2>&1; then
+  echo '[openclaw-health] openclaw CLI is not installed or not on PATH.' >&2
+  exit 1
+fi
+
+probe_gateway() {
+  openclaw gateway status --require-rpc --json >/tmp/3dvr-openclaw-gateway-status.json 2>/tmp/3dvr-openclaw-gateway-status.err
+}
+
+probe_channels() {
+  openclaw channels status --probe >/tmp/3dvr-openclaw-channels-status.txt 2>/tmp/3dvr-openclaw-channels-status.err
+}
+
+healthy=true
+if ! probe_gateway; then
+  echo '[openclaw-health] gateway RPC probe failed.' >&2
+  healthy=false
+fi
+if ! probe_channels; then
+  echo '[openclaw-health] channel probe failed.' >&2
+  healthy=false
+fi
+
+if [ "$healthy" = false ]; then
+  echo '[openclaw-health] restarting managed OpenClaw gateway...'
+  openclaw gateway restart --wait 30s --json
+fi
+
+# Always show a compact post-check and fail if the runtime is still unhealthy.
+openclaw gateway status --require-rpc --json
+openclaw channels status --probe
+
+echo '[openclaw-health] gateway and channel probes passed.'


### PR DESCRIPTION
Adds a bounded OpenClaw health probe to the German worker deployment path.

- Probe gateway RPC and configured channels.
- Restart the managed OpenClaw gateway only when a probe fails.
- Re-probe after restart and fail the deployment if OpenClaw is still unhealthy.
- Keep existing 3DVR worker/router/inbox/autopilot checks intact.

This targets the current symptom where the 3DVR worker can be alive while the OpenClaw chat runtime stops responding.