### PR TITLE
fix: deploy portal to the Vercel project that owns the domain

### DIFF
--- a/.github/workflows/vercel-dev-preview.yml
+++ b/.github/workflows/vercel-dev-preview.yml
@@ -16,9 +16,11 @@ on:
         required: false
         default: 'false'
 
+# Use the same long-lived project that owns portal.3dvr.tech. Public Vercel
+# project/team IDs are explicit so previews do not drift to a duplicate project.
 env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
+  VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   VERCEL_DEV_ALIAS: ${{ secrets.VERCEL_DEV_ALIAS }}
 
@@ -33,11 +35,11 @@ jobs:
         id: config
         shell: bash
         run: |
-          if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID" ] && [ -n "$VERCEL_PROJECT_ID" ]; then
+          if [ -n "$VERCEL_TOKEN" ]; then
             echo "can_deploy=true" >> "$GITHUB_OUTPUT"
           else
             echo "can_deploy=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping Vercel Dev Preview because one or more Vercel secrets are not configured."
+            echo "::notice::Skipping Vercel Dev Preview because VERCEL_TOKEN is not configured for this event."
           fi
 
       - name: Checkout repository
@@ -48,7 +50,7 @@ jobs:
         if: ${{ steps.config.outputs.can_deploy == 'true' }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -17,9 +17,11 @@ concurrency:
   group: vercel-production-prebuilt
   cancel-in-progress: true
 
+# portal.3dvr.tech is attached to this long-lived Vercel project. Keep these
+# public IDs explicit so deployment cannot silently drift to a duplicate project.
 env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
+  VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 jobs:
@@ -31,8 +33,8 @@ jobs:
       - name: Check Vercel production configuration
         shell: bash
         run: |
-          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
-            echo "::error::Missing Vercel production deployment secrets."
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::Missing VERCEL_TOKEN production deployment secret."
             exit 1
           fi
 
@@ -70,6 +72,7 @@ jobs:
             echo "Deployment: $DEPLOY_URL"
             echo "Commit: $GITHUB_SHA"
             echo "Environment: production"
+            echo "Project: $VERCEL_PROJECT_ID"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify production routes

--- a/tests/workspace-sync.test.js
+++ b/tests/workspace-sync.test.js
@@ -34,12 +34,21 @@ test('relay timeout never auto-saves empty startup state', async () => {
   assert.doesNotMatch(timeoutBlock, /\bsave\s*\(/, 'timeout must not overwrite unknown remote state');
 });
 
-test('production workflow deploys and verifies workspace changes', async () => {
+test('production workflow deploys workspace to the portal Vercel project', async () => {
   const workflow = await read('.github/workflows/vercel-production-prebuilt.yml');
 
   assert.match(workflow, /- "workspace\/\*\*"/);
+  assert.match(workflow, /VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z/);
+  assert.match(workflow, /VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch/);
   assert.match(workflow, /\$\{\{ steps\.deploy\.outputs\.url \}\}\/workspace\//);
   assert.match(workflow, /<title>3DVR Workspace<\/title>/);
+});
+
+test('preview workflow targets the same portal Vercel project', async () => {
+  const workflow = await read('.github/workflows/vercel-dev-preview.yml');
+
+  assert.match(workflow, /VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z/);
+  assert.match(workflow, /VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch/);
 });
 
 test('workspace and Codex Cloud link to each other', async () => {


### PR DESCRIPTION
## Fix

The portal had two Vercel projects named `3dvr-portal`. `portal.3dvr.tech` belongs to the long-lived project under `tmstephs-projects`, while our Actions config could drift to the newer duplicate under the `3dvr` team.

This change pins both production and preview Actions to the Vercel team/project that actually owns `portal.3dvr.tech`:

- Org: `team_xxJGO7S7h1ZP4BHidYV0CX9Z`
- Project: `prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch`

Only `VERCEL_TOKEN` remains secret.

It also adds regression checks so the Workspace deploy cannot silently drift back to the duplicate project.

## Why now

PR #1623 merged the new `/workspace/`, but the live route stayed 404. The merged commit's Vercel status showed build-rate-limit failures on the Git integration, and inspection showed our newer duplicate project does not own the production portal domain. The prebuilt GitHub Action should target the real portal project directly and avoid relying on the duplicate auto-build path.
