### PR TITLE
Fix static pages without trailing slashes

### DIFF
--- a/tests/trailing-slash-routing.test.js
+++ b/tests/trailing-slash-routing.test.js
@@ -14,9 +14,10 @@ describe('static page URL routing', () => {
   it('canonicalizes extensionless HTML navigations to a trailing slash', async () => {
     const config = JSON.parse(await readProjectFile('vercel.json'));
     const redirects = Array.isArray(config.redirects) ? config.redirects : [];
+    const expectedSource = '/:path((?!api(?:/|$)|webhooks(?:/|$))(?!.*\\.[^/]+$).*[^/])';
 
     const rule = redirects.find((redirect) =>
-      redirect.source === '/:path((?!api(?:/|$)|webhooks(?:/|$))(?!.*\\.[^/]+$).+[^/])'
+      redirect.source === expectedSource
       && redirect.destination === '/:path/'
       && redirect.permanent === true
     );
@@ -25,6 +26,15 @@ describe('static page URL routing', () => {
     assert.deepEqual(rule.has, [
       { type: 'header', key: 'accept', value: '.*text/html.*' }
     ]);
+
+    const routePattern = new RegExp(`^${expectedSource.slice('/:path('.length, -1)}$`);
+    assert.equal(routePattern.test('calendar'), true);
+    assert.equal(routePattern.test('x'), true);
+    assert.equal(routePattern.test('tools/editor'), true);
+    assert.equal(routePattern.test('api/calendar'), false);
+    assert.equal(routePattern.test('webhooks/stripe'), false);
+    assert.equal(routePattern.test('calendar/app.js'), false);
+    assert.equal(routePattern.test('calendar/'), false);
   });
 
   it('keeps directory-local assets relative to the canonical page URL', async () => {

--- a/tests/trailing-slash-routing.test.js
+++ b/tests/trailing-slash-routing.test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+
+const readProjectFile = async (path) =>
+  readFile(resolve(projectRoot, path), 'utf8');
+
+describe('static page URL routing', () => {
+  it('canonicalizes extensionless HTML navigations to a trailing slash', async () => {
+    const config = JSON.parse(await readProjectFile('vercel.json'));
+    const redirects = Array.isArray(config.redirects) ? config.redirects : [];
+
+    const rule = redirects.find((redirect) =>
+      redirect.source === '/:path((?!api(?:/|$)|webhooks(?:/|$))(?!.*\\.[^/]+$).+[^/])'
+      && redirect.destination === '/:path/'
+      && redirect.permanent === true
+    );
+
+    assert.ok(rule);
+    assert.deepEqual(rule.has, [
+      { type: 'header', key: 'accept', value: '.*text/html.*' }
+    ]);
+  });
+
+  it('keeps directory-local assets relative to the canonical page URL', async () => {
+    const calendarHtml = await readProjectFile('calendar/index.html');
+
+    assert.match(calendarHtml, /href="\.\/calendar\.css"/);
+    assert.match(calendarHtml, /src="\.\/pwa-install\.js"/);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,12 @@
     { "source": "/video/index.html", "destination": "/portal.3dvr.tech/video/index.html" }
   ],
   "redirects": [
+    {
+      "source": "/:path((?!api(?:/|$)|webhooks(?:/|$))(?!.*\\.[^/]+$).+[^/])",
+      "has": [{ "type": "header", "key": "accept", "value": ".*text/html.*" }],
+      "destination": "/:path/",
+      "permanent": true
+    },
     { "source": "/", "has": [{ "type": "host", "value": "crm.3dvr.tech" }], "destination": "/crm/", "permanent": false },
     { "source": "/", "has": [{ "type": "host", "value": "danny.3dvr.tech" }], "destination": "/danny/", "permanent": false },
     { "source": "/", "has": [{ "type": "host", "value": "thomas-av.3dvr.tech" }], "destination": "/thomas-av/", "permanent": false },

--- a/vercel.json
+++ b/vercel.json
@@ -58,7 +58,7 @@
   ],
   "redirects": [
     {
-      "source": "/:path((?!api(?:/|$)|webhooks(?:/|$))(?!.*\\.[^/]+$).+[^/])",
+      "source": "/:path((?!api(?:/|$)|webhooks(?:/|$))(?!.*\\.[^/]+$).*[^/])",
       "has": [{ "type": "header", "key": "accept", "value": ".*text/html.*" }],
       "destination": "/:path/",
       "permanent": true


### PR DESCRIPTION
## What changed
- Redirect extensionless HTML navigations like `/calendar` to `/calendar/` before relative CSS/JS are resolved.
- Leave `/api/*`, `/webhooks/*`, and file-extension URLs alone.
- Add a regression test around the Vercel routing rule and representative relative assets.

## Why
Many portal pages are directory-based static apps that intentionally use `./...` assets. Vercel currently serves both `/page` and `/page/` without canonicalizing, so `/page` makes the browser resolve those assets from the wrong directory.

## Risk
Low and scoped to browser HTML navigations. API/webhook paths are explicitly excluded; static asset requests do not match the HTML `Accept` condition.

Stripe mode: no change.
Portal origin: no change.
Account linking: no change.