### PR TITLE
Deploy trailing-slash routing fix to production

### DIFF
--- a/workspace/deploy-production-trailing-slash.md
+++ b/workspace/deploy-production-trailing-slash.md
@@ -1,0 +1,5 @@
+# Production deploy trigger
+
+Deploy current `main` after the trailing-slash routing fix and production worker owner-alias fix.
+
+This file exists only to activate the guarded `deploy/production-*` pull-request lane. Do not merge this marker into `main`.


### PR DESCRIPTION
Production deployment trigger for the trailing-slash routing fix. CLOSED UNMERGED under the Vercel deployment circuit breaker: this marker is stale, intentionally must not land on main, and the production lane has since shown no new positive worker/deployment reachability evidence. Do not recreate/retry this deploy trigger until there is materially different reachability evidence or a different repair path.

Expected eventual production verification remains: requesting `/calendar` as HTML redirects to `/calendar/`, and `/calendar/` loads local CSS/JS normally.

Stripe mode: no change. Portal origin: no change. Account linking: no change.