### PR TITLE
Fix production deploy worker queue alias

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -32,6 +32,7 @@ env:
   VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
   VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  THREEDVR_AGENT_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed' }}
 
 jobs:
   deploy:


### PR DESCRIPTION
## What changed
- Route production deploy queue tasks through the same managed owner alias used by the German agent worker.
- Keep the repository variable override, with `3dvr-managed` as the existing fallback.

## Why
Production deploy run #12 queued successfully, but the task landed under `anonymous@3dvr` and remained `queued` for the full receipt window. The worker deployment workflow already uses `THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed'`; the Vercel production workflow was missing that wiring.

This unblocks deployment of the already-merged trailing-slash routing fix from PR #1630.

Stripe mode: no change.
Portal origin: no change.
Account linking: no change.