### PR TITLE
Add legacy bootstrap fallback for German worker queue

### DIFF
--- a/.github/workflows/german-worker-legacy-recovery.yml
+++ b/.github/workflows/german-worker-legacy-recovery.yml
@@ -1,0 +1,100 @@
+name: Recover German Worker Queue
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/german-worker-legacy-recovery.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    defaults:
+      run:
+        working-directory: apps/agent
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.0
+          cache: npm
+          cache-dependency-path: apps/agent/package-lock.json
+
+      - name: Install agent dependencies
+        run: npm ci
+
+      - name: Probe managed worker queue
+        id: managed_probe
+        continue-on-error: true
+        shell: bash
+        env:
+          THREEDVR_AGENT_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed' }}
+        run: |
+          set -euo pipefail
+          task='root="$(git rev-parse --show-toplevel)"; "$root/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" status; bash "$root/apps/agent/thomas-agent/scripts/ask-openclaw-health"'
+          result="$(node thomas-agent/node/agent-task-queue.js enqueue --json --backend shell --risk workspace_write --approval-status approved --unsafe --requires shell --max-runtime-ms 90000 "$task")"
+          task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
+          for attempt in $(seq 1 12); do
+            result="$(node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+            status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
+            case "$status" in
+              completed) exit 0 ;;
+              failed|skipped) exit 1 ;;
+            esac
+            sleep 5
+          done
+          exit 1
+
+      - name: Bootstrap through legacy queue
+        id: legacy_bootstrap
+        if: steps.managed_probe.outcome != 'success'
+        shell: bash
+        env:
+          THREEDVR_AGENT_OWNER_ALIAS: anonymous@3dvr
+        run: |
+          set -euo pipefail
+          task='root="$(git rev-parse --show-toplevel)"; git -C "$root" diff --quiet; git -C "$root" diff --cached --quiet; git -C "$root" fetch origin main; git -C "$root" checkout main; git -C "$root" pull --ff-only origin main; npm --prefix "$root/apps/agent" ci; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" stop || true; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" start; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" start; bash "$root/apps/agent/thomas-agent/scripts/ask-openclaw-health"; "$root/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-context-task-router-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-autopilot-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-agent-heartbeat-daemon" status'
+          result="$(node thomas-agent/node/agent-task-queue.js enqueue --json --backend shell --risk workspace_write --approval-status approved --unsafe --requires shell --max-runtime-ms 180000 "$task")"
+          task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
+          for attempt in $(seq 1 36); do
+            result="$(THREEDVR_AGENT_OWNER_ALIAS=anonymous@3dvr node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+            status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
+            case "$status" in
+              completed) exit 0 ;;
+              failed|skipped) printf '%s\n' "$result"; exit 1 ;;
+            esac
+            sleep 5
+          done
+          echo 'Legacy German worker queue did not return a completion receipt.' >&2
+          exit 1
+
+      - name: Verify worker migrated to managed queue
+        if: steps.managed_probe.outcome != 'success' && steps.legacy_bootstrap.outcome == 'success'
+        shell: bash
+        env:
+          THREEDVR_AGENT_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed' }}
+        run: |
+          set -euo pipefail
+          task='root="$(git rev-parse --show-toplevel)"; "$root/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon" status; "$root/apps/agent/thomas-agent/scripts/ask-inbox-daemon" status'
+          result="$(node thomas-agent/node/agent-task-queue.js enqueue --json --backend shell --risk workspace_write --approval-status approved --unsafe --requires shell --max-runtime-ms 60000 "$task")"
+          task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
+          for attempt in $(seq 1 18); do
+            result="$(node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+            status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
+            case "$status" in
+              completed) exit 0 ;;
+              failed|skipped) exit 1 ;;
+            esac
+            sleep 5
+          done
+          echo 'German worker did not migrate to the managed queue.' >&2
+          exit 1


### PR DESCRIPTION
## What changed
- add a bounded recovery workflow for the German worker
- probe the current managed queue first
- only if that probe fails, enqueue the same safe stack refresh through the legacy `anonymous@3dvr` owner alias
- after legacy recovery, verify that the worker has migrated back to the managed queue

## Why
The latest German-worker status shows the managed queue accepted work but no completion receipt arrived. Earlier deployments indicate an old long-lived worker may still be polling the legacy owner alias. This provides an out-of-band-compatible bootstrap without replacing the IMAP-IDLE primary path or the five-minute free-site fallback.

## Safety
No mailbox behavior, free-site authority, or outbound messaging policy changes. The workflow preserves the existing bounded stack health checks and does not stop the worker daemon that executes its own task.