### PR TITLE
Publish German worker recovery receipts

### DIFF
--- a/.github/workflows/german-worker-legacy-recovery.yml
+++ b/.github/workflows/german-worker-legacy-recovery.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   recover:
@@ -57,6 +58,7 @@ jobs:
       - name: Bootstrap through legacy queue
         id: legacy_bootstrap
         if: steps.managed_probe.outcome != 'success'
+        continue-on-error: true
         shell: bash
         env:
           THREEDVR_AGENT_OWNER_ALIAS: anonymous@3dvr
@@ -70,15 +72,16 @@ jobs:
             status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
             case "$status" in
               completed) exit 0 ;;
-              failed|skipped) printf '%s\n' "$result"; exit 1 ;;
+              failed|skipped) exit 1 ;;
             esac
             sleep 5
           done
-          echo 'Legacy German worker queue did not return a completion receipt.' >&2
           exit 1
 
       - name: Verify worker migrated to managed queue
+        id: managed_verify
         if: steps.managed_probe.outcome != 'success' && steps.legacy_bootstrap.outcome == 'success'
+        continue-on-error: true
         shell: bash
         env:
           THREEDVR_AGENT_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed' }}
@@ -96,5 +99,35 @@ jobs:
             esac
             sleep 5
           done
-          echo 'German worker did not migrate to the managed queue.' >&2
           exit 1
+
+      - name: Publish recovery status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANAGED_OUTCOME: ${{ steps.managed_probe.outcome }}
+          LEGACY_OUTCOME: ${{ steps.legacy_bootstrap.outcome }}
+          VERIFY_OUTCOME: ${{ steps.managed_verify.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          state=failure
+          description='German worker recovery failed'
+          if [ "$MANAGED_OUTCOME" = success ]; then
+            state=success
+            description='German worker managed queue healthy'
+          elif [ "$LEGACY_OUTCOME" = success ] && [ "$VERIFY_OUTCOME" = success ]; then
+            state=success
+            description='German worker recovered through legacy queue and migrated to managed queue'
+          elif [ "$LEGACY_OUTCOME" != success ]; then
+            description='German worker unavailable on managed and legacy queues'
+          else
+            description='Legacy worker answered but did not migrate to managed queue'
+          fi
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+            -d "{\"state\":\"$state\",\"context\":\"3DVR German Worker Recovery\",\"description\":\"$description\"}"
+          [ "$state" = success ]


### PR DESCRIPTION
Adds a compact commit status for the recovery workflow so reliability checks can see whether the managed queue is healthy, legacy bootstrap recovered it, or both paths failed. No fulfillment or mailbox behavior changes.