### PR TITLE
Add safe trigger hook for German worker recovery

### DIFF
--- a/.github/workflows/german-worker-legacy-recovery.yml
+++ b/.github/workflows/german-worker-legacy-recovery.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - '.github/workflows/german-worker-legacy-recovery.yml'
+      - 'ops/german-worker-recovery-trigger.txt'
 
 permissions:
   contents: read

--- a/ops/german-worker-recovery-trigger.txt
+++ b/ops/german-worker-recovery-trigger.txt
@@ -1,0 +1,2 @@
+2026-08-21T07:46:44Z
+Reason: hourly free-site reliability fallback re-probe after failed German worker recovery status.


### PR DESCRIPTION
Adds a narrow ops marker path that can retrigger the existing bounded German worker recovery workflow without editing workflow logic on every reliability pass. Includes one marker update to re-probe the currently failing primary worker. No mailbox, fulfillment, or authority changes.