### PR TITLE
Retrigger free-site fast lane for missed request recovery

### DIFF
--- a/.github/workflows/free-site-fast-lane.yml
+++ b/.github/workflows/free-site-fast-lane.yml
@@ -3,6 +3,7 @@ name: Free Site Fast Lane
 on:
   schedule:
     # GitHub Actions scheduled workflows support a five-minute minimum cadence.
+    # Recovery trigger: 2026-08-21T09:46Z
     - cron: '*/5 * * * *'
   workflow_dispatch:
   push:


### PR DESCRIPTION
The canonical mailbox health receipt reports at least one unread genuine free-site request while the German primary worker remains unhealthy and no newer 3dvr-web fulfillment PR exists. This intentionally makes a comment-only change to the existing five-minute fallback workflow so the push-to-main trigger immediately exercises the established bounded fulfillment path. No fulfillment authority or mailbox policy changes.