### PR TITLE
Finalize existing free-site requests in one recovery run

### DIFF
--- a/.github/workflows/free-site-third-line-recovery.yml
+++ b/.github/workflows/free-site-third-line-recovery.yml
@@ -43,7 +43,15 @@ jobs:
       - name: Run established bounded free-site worker
         id: worker
         continue-on-error: true
-        run: node apps/agent/thomas-agent/node/free-site-worker.js
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A second pass is intentional: the first pass may discover a site
+          # that was fulfilled by another path and persist `existing` state.
+          # Reusing the same runner/state lets the bounded worker finalize that
+          # request (marking it seen) without generating or publishing again.
+          node apps/agent/thomas-agent/node/free-site-worker.js
+          node apps/agent/thomas-agent/node/free-site-worker.js
 
       - name: Publish third-line recovery status
         if: always()


### PR DESCRIPTION
Fixes the third-line fallback so it runs the established bounded worker twice on the same runner/state. This lets a request whose site was already fulfilled by another path be finalized (marked handled/seen) without generating or publishing a duplicate site. The German-worker hard-down circuit breaker and Vercel deployment guard are untouched.