### PR TITLE
Make free-site fallbacks state-safe

### DIFF
--- a/.github/workflows/free-site-fast-lane.yml
+++ b/.github/workflows/free-site-fast-lane.yml
@@ -2,8 +2,6 @@ name: Free Site Fast Lane
 
 on:
   schedule:
-    # GitHub Actions scheduled workflows support a five-minute minimum cadence.
-    # Recovery trigger: 2026-08-21T09:46Z
     - cron: '*/5 * * * *'
   workflow_dispatch:
   push:
@@ -11,22 +9,27 @@ on:
       - main
     paths:
       - '.github/workflows/free-site-fast-lane.yml'
+      - 'apps/agent/thomas-agent/node/free-site-worker.js'
+      - 'apps/agent/thomas-agent/node/free-site-actions-runner.js'
 
 permissions:
   contents: read
 
 concurrency:
-  group: free-site-fast-lane
+  group: free-site-fulfillment
   cancel-in-progress: false
 
 jobs:
   fulfill:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       GMAIL_USER: ${{ secrets.GMAIL_USER }}
       GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
       GH_TOKEN: ${{ secrets.GH_PAT }}
+      THREEDVR_FREE_SITE_MAX_PER_RUN: '20'
+      THREEDVR_FREE_SITE_LOOKBACK_HOURS: '24'
+      THREEDVR_AUTOPILOT_STATE_DIR: ${{ runner.temp }}/3dvr-free-site-state
     steps:
       - name: Checkout portal
         uses: actions/checkout@v4
@@ -41,252 +44,13 @@ jobs:
       - name: Install agent dependencies
         run: npm --prefix apps/agent ci
 
-      - name: Find one unread free-site request
-        id: request
-        shell: bash
-        run: |
-          node <<'NODE'
-          const fs = require('fs');
-          const { ImapFlow } = require('./apps/agent/node_modules/imapflow');
-
-          const user = process.env.GMAIL_USER || '3dvr.tech@gmail.com';
-          const pass = process.env.GMAIL_APP_PASSWORD || '';
-          if (!pass) throw new Error('GMAIL_APP_PASSWORD is not configured');
-
-          function cleanBody(source) {
-            let body = String(source || '');
-            const split = body.search(/\r?\n\r?\n/);
-            if (split >= 0) body = body.slice(split).replace(/^\r?\n\r?\n/, '');
-            body = body
-              .replace(/=\r?\n/g, '')
-              .replace(/=20/g, ' ')
-              .replace(/=3D/gi, '=')
-              .replace(/<br\s*\/?>/gi, '\n')
-              .replace(/<[^>]+>/g, ' ')
-              .replace(/^--[-A-Za-z0-9_=.]+.*$/gm, ' ')
-              .replace(/^Content-(Type|Transfer-Encoding|Disposition):.*$/gim, ' ')
-              .replace(/\s+/g, ' ')
-              .trim();
-            return body.slice(0, 3000);
-          }
-
-          function looksLikeRequest(subject, body) {
-            const text = `${subject}\n${body}`.toLowerCase();
-            return /\b(website|web site|free site|free website)\b/.test(text)
-              && !/\b(unsubscribe|newsletter|receipt|invoice)\b/.test(text);
-          }
-
-          (async () => {
-            const client = new ImapFlow({
-              host: 'imap.gmail.com',
-              port: 993,
-              secure: true,
-              auth: { user, pass },
-              logger: false,
-            });
-
-            await client.connect();
-            const lock = await client.getMailboxLock('INBOX');
-            let found = null;
-            try {
-              const uids = await client.search({ seen: false });
-              for (const uid of uids.slice(-25).reverse()) {
-                for await (const message of client.fetch(uid, { uid: true, envelope: true, source: true }, { uid: true })) {
-                  const from = String(message.envelope?.from?.[0]?.address || '').toLowerCase();
-                  const subject = String(message.envelope?.subject || '').trim();
-                  if (!from || from === user.toLowerCase() || /(^|[._-])(no-?reply|mailer-daemon)@/i.test(from)) continue;
-                  const body = cleanBody(message.source ? message.source.toString('utf8') : '');
-                  if (!looksLikeRequest(subject, body)) continue;
-                  found = {
-                    uid: message.uid,
-                    from,
-                    subject,
-                    messageId: String(message.envelope?.messageId || ''),
-                    body,
-                  };
-                  break;
-                }
-                if (found) break;
-              }
-            } finally {
-              lock.release();
-              await client.logout();
-            }
-
-            if (!found) {
-              fs.appendFileSync(process.env.GITHUB_OUTPUT, 'found=false\n');
-              console.log('No unread free-site request found.');
-              return;
-            }
-
-            fs.writeFileSync('/tmp/free-site-request.json', JSON.stringify(found));
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'found=true\n');
-            console.log('Found one unread free-site request.');
-          })().catch(error => {
-            console.error(error);
-            process.exitCode = 1;
-          });
-          NODE
-
-      - name: Generate the one-page site
-        if: steps.request.outputs.found == 'true'
-        id: site
-        shell: bash
-        run: |
-          node <<'NODE'
-          const fs = require('fs');
-
-          function slugify(value) {
-            return String(value || '')
-              .toLowerCase()
-              .normalize('NFKD')
-              .replace(/[^a-z0-9]+/g, '-')
-              .replace(/^-+|-+$/g, '')
-              .slice(0, 48) || `site-${Date.now()}`;
-          }
-
-          function topicFromRequest(request) {
-            const text = `${request.subject}\n${request.body}`;
-            const about = text.match(/\babout\s+([A-Za-z0-9][A-Za-z0-9 &'._-]{1,80})/i);
-            if (about) return about[1].replace(/[.!?].*$/, '').trim();
-            const subject = String(request.subject || '').trim();
-            if (subject && !/^(website|free website|make me a website)$/i.test(subject)) return subject;
-            return 'Free Website';
-          }
-
-          (async () => {
-            const request = JSON.parse(fs.readFileSync('/tmp/free-site-request.json', 'utf8'));
-            const topic = topicFromRequest(request);
-            const prompt = [
-              'Build a polished, simple, mobile-friendly one-page website for a free 3DVR site request.',
-              'Use only facts supplied by the requester or safe general knowledge for a generic topic.',
-              'Do not invent reviews, credentials, addresses, prices, guarantees, or personal claims.',
-              'Do not use external scripts, external images, analytics, trackers, or forms.',
-              'Keep it concise and useful. Include a small footer that says: Free site hosted by 3DVR, linking to https://3dvr.tech/.',
-              `Suggested topic/title: ${topic}`,
-              `Requester subject: ${request.subject}`,
-              `Requester message: ${request.body}`,
-            ].join('\n');
-
-            const response = await fetch('https://portal.3dvr.tech/api/openai-site', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ prompt, model: 'gpt-4.1-mini' }),
-            });
-            const payload = await response.json();
-            if (!response.ok || !payload?.html) {
-              throw new Error(payload?.error || `site generator returned ${response.status}`);
-            }
-
-            const title = String(payload.title || topic || 'Free Website').trim();
-            const slug = slugify(topic || title);
-            fs.writeFileSync('/tmp/generated-site.html', payload.html);
-            fs.writeFileSync('/tmp/site-meta.json', JSON.stringify({ slug, title }));
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `slug=${slug}\n`);
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `url=https://3dvr.tech/free-sites/${slug}/\n`);
-          })().catch(error => {
-            console.error(error);
-            process.exitCode = 1;
-          });
-          NODE
-
-      - name: Checkout 3dvr-web
-        if: steps.request.outputs.found == 'true'
-        uses: actions/checkout@v4
+      - name: Restore fulfillment state
+        uses: actions/cache@v4
         with:
-          repository: tmsteph/3dvr-web
-          token: ${{ secrets.GH_PAT }}
-          path: web
-          fetch-depth: 0
+          path: ${{ runner.temp }}/3dvr-free-site-state
+          key: free-site-worker-state-${{ github.run_id }}
+          restore-keys: |
+            free-site-worker-state-
 
-      - name: Publish through a narrow PR
-        if: steps.request.outputs.found == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          slug='${{ steps.site.outputs.slug }}'
-          branch="free-site/${slug}-${GITHUB_RUN_ID}"
-          cd web
-          git checkout -b "$branch" origin/main
-          mkdir -p "free-sites/$slug"
-          cp /tmp/generated-site.html "free-sites/$slug/index.html"
-          git config user.name '3DVR Free Site Worker'
-          git config user.email '3dvr.tech@gmail.com'
-          git add -- "free-sites/$slug/index.html"
-          git commit -m "Add free ${slug} site"
-          git push origin "$branch"
-          pr_url="$(gh pr create --repo tmsteph/3dvr-web --base main --head "$branch" --title "Add free ${slug} site" --body 'Automated fulfillment of a genuine inbound free-site request. The page is generated from the requester text with no invented business claims.')"
-          gh pr merge "$pr_url" --repo tmsteph/3dvr-web --squash --delete-branch=false
-
-      - name: Verify production and reply
-        if: steps.request.outputs.found == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          site_url='${{ steps.site.outputs.url }}'
-          live=false
-          for _ in $(seq 1 30); do
-            code="$(curl -L -sS -o /tmp/live-site.html -w '%{http_code}' "$site_url" || true)"
-            if [ "$code" = '200' ] && grep -qi '<html' /tmp/live-site.html; then
-              live=true
-              break
-            fi
-            sleep 10
-          done
-          if [ "$live" != 'true' ]; then
-            echo "Site did not become live before timeout: $site_url" >&2
-            exit 1
-          fi
-
-          SITE_URL="$site_url" node <<'NODE'
-          const fs = require('fs');
-          const { ImapFlow } = require('./apps/agent/node_modules/imapflow');
-          const nodemailer = require('./apps/agent/node_modules/nodemailer');
-
-          const request = JSON.parse(fs.readFileSync('/tmp/free-site-request.json', 'utf8'));
-          const user = process.env.GMAIL_USER || '3dvr.tech@gmail.com';
-          const pass = process.env.GMAIL_APP_PASSWORD || '';
-          const siteUrl = process.env.SITE_URL;
-          if (!pass) throw new Error('GMAIL_APP_PASSWORD is not configured');
-
-          (async () => {
-            const transporter = nodemailer.createTransport({ service: 'gmail', auth: { user, pass } });
-            await transporter.sendMail({
-              from: `3DVR <${user}>`,
-              to: request.from,
-              subject: `Re: ${request.subject || 'Your free website'}`,
-              text: [
-                'Your free site is live:',
-                siteUrl,
-                '',
-                'The simple site is free to keep on the 3DVR-hosted address. Reply with any factual corrections you want changed.',
-                '',
-                'Custom domains, more pages, revisions, integrations, and ongoing support are optional upgrades.',
-                '',
-                'If you know someone else who needs a simple site, share https://3dvr.tech/free-sites/.'
-              ].join('\n'),
-              inReplyTo: request.messageId || undefined,
-              references: request.messageId ? [request.messageId] : undefined,
-            });
-
-            const client = new ImapFlow({
-              host: 'imap.gmail.com',
-              port: 993,
-              secure: true,
-              auth: { user, pass },
-              logger: false,
-            });
-            await client.connect();
-            const lock = await client.getMailboxLock('INBOX');
-            try {
-              await client.messageFlagsAdd(request.uid, ['\\Seen'], { uid: true });
-            } finally {
-              lock.release();
-              await client.logout();
-            }
-            console.log(`Fulfilled ${siteUrl}`);
-          })().catch(error => {
-            console.error(error);
-            process.exitCode = 1;
-          });
-          NODE
+      - name: Run bounded free-site fulfillment
+        run: node apps/agent/thomas-agent/node/free-site-actions-runner.js

--- a/.github/workflows/free-site-third-line-recovery.yml
+++ b/.github/workflows/free-site-third-line-recovery.yml
@@ -6,15 +6,15 @@ on:
       - main
     paths:
       - '.github/workflows/free-site-third-line-recovery.yml'
+      - 'apps/agent/thomas-agent/node/free-site-actions-runner.js'
   workflow_dispatch:
 
-# Recovery trigger: 2026-08-21T17:54Z
 permissions:
   contents: read
   statuses: write
 
 concurrency:
-  group: free-site-third-line-recovery
+  group: free-site-fulfillment
   cancel-in-progress: false
 
 jobs:
@@ -25,8 +25,9 @@ jobs:
       GMAIL_USER: ${{ secrets.GMAIL_USER }}
       GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
       GH_TOKEN: ${{ secrets.GH_PAT }}
-      THREEDVR_FREE_SITE_MAX_PER_RUN: '3'
+      THREEDVR_FREE_SITE_MAX_PER_RUN: '20'
       THREEDVR_FREE_SITE_LOOKBACK_HOURS: '24'
+      THREEDVR_AUTOPILOT_STATE_DIR: ${{ runner.temp }}/3dvr-free-site-state
     steps:
       - name: Checkout portal
         uses: actions/checkout@v4
@@ -41,18 +42,18 @@ jobs:
       - name: Install agent dependencies
         run: npm --prefix apps/agent ci
 
+      - name: Restore fulfillment state
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/3dvr-free-site-state
+          key: free-site-worker-state-${{ github.run_id }}
+          restore-keys: |
+            free-site-worker-state-
+
       - name: Run established bounded free-site worker
         id: worker
         continue-on-error: true
-        shell: bash
-        run: |
-          set -euo pipefail
-          # A second pass is intentional: the first pass may discover a site
-          # that was fulfilled by another path and persist `existing` state.
-          # Reusing the same runner/state lets the bounded worker finalize that
-          # request (marking it seen) without generating or publishing again.
-          node apps/agent/thomas-agent/node/free-site-worker.js
-          node apps/agent/thomas-agent/node/free-site-worker.js
+        run: node apps/agent/thomas-agent/node/free-site-actions-runner.js
 
       - name: Publish third-line recovery status
         if: always()

--- a/apps/agent/thomas-agent/node/free-site-actions-runner.js
+++ b/apps/agent/thomas-agent/node/free-site-actions-runner.js
@@ -1,0 +1,45 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { runOnce } = require('./free-site-worker');
+
+const ROOT = path.join(__dirname, '..');
+const STATE_DIR = process.env.THREEDVR_AUTOPILOT_STATE_DIR || path.join(ROOT, 'state');
+const STATE_FILE = process.env.THREEDVR_FREE_SITE_STATE_FILE || path.join(STATE_DIR, 'free-site-worker-state.json');
+
+function finalizeExistingState() {
+  if (!fs.existsSync(STATE_FILE)) return 0;
+  const state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+  let finalized = 0;
+  for (const entry of Object.values(state.messages || {})) {
+    if (entry?.status !== 'existing') continue;
+    entry.status = 'processed';
+    entry.completedAt = new Date().toISOString();
+    entry.existingSite = true;
+    finalized += 1;
+  }
+  if (!finalized) return 0;
+  fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
+  const tmp = `${STATE_FILE}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  fs.renameSync(tmp, STATE_FILE);
+  return finalized;
+}
+
+async function main() {
+  // GitHub Actions runners are ephemeral, so use two passes per cycle:
+  // pass 1 discovers/publishes; pass 2 marks already-existing sites seen.
+  // Then normalize those entries to processed so they cannot starve newer mail.
+  for (let cycle = 1; cycle <= 3; cycle += 1) {
+    const first = await runOnce();
+    const second = await runOnce();
+    const finalized = finalizeExistingState();
+    const acted = Number(first?.acted || 0) + Number(second?.acted || 0);
+    console.log(`[free-site-actions-runner] cycle=${cycle} acted=${acted} finalized_existing=${finalized}`);
+    if (acted === 0 && finalized === 0) break;
+  }
+}
+
+main().catch((error) => {
+  console.error(error?.stack || error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
Unifies the five-minute and third-line fallbacks on the established bounded free-site worker, persists worker state across ephemeral GitHub Actions runners, shares one fulfillment concurrency group, and prevents already-existing sites from starving newer inbound requests. The German IMAP-IDLE primary is unchanged.