### PR TITLE
Fix free-site Actions state path

### DIFF
--- a/.github/workflows/free-site-fast-lane.yml
+++ b/.github/workflows/free-site-fast-lane.yml
@@ -29,7 +29,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       THREEDVR_FREE_SITE_MAX_PER_RUN: '20'
       THREEDVR_FREE_SITE_LOOKBACK_HOURS: '24'
-      THREEDVR_AUTOPILOT_STATE_DIR: ${{ runner.temp }}/3dvr-free-site-state
+      THREEDVR_AUTOPILOT_STATE_DIR: /tmp/3dvr-free-site-state
     steps:
       - name: Checkout portal
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
       - name: Restore fulfillment state
         uses: actions/cache@v4
         with:
-          path: ${{ runner.temp }}/3dvr-free-site-state
+          path: /tmp/3dvr-free-site-state
           key: free-site-worker-state-${{ github.run_id }}
           restore-keys: |
             free-site-worker-state-

--- a/.github/workflows/free-site-third-line-recovery.yml
+++ b/.github/workflows/free-site-third-line-recovery.yml
@@ -23,11 +23,11 @@ jobs:
     timeout-minutes: 20
     env:
       GMAIL_USER: ${{ secrets.GMAIL_USER }}
-      GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+      GMAIL_APP_PASSWORD: ${{ secrets.GH_PAT }}
       GH_TOKEN: ${{ secrets.GH_PAT }}
       THREEDVR_FREE_SITE_MAX_PER_RUN: '20'
       THREEDVR_FREE_SITE_LOOKBACK_HOURS: '24'
-      THREEDVR_AUTOPILOT_STATE_DIR: ${{ runner.temp }}/3dvr-free-site-state
+      THREEDVR_AUTOPILOT_STATE_DIR: /tmp/3dvr-free-site-state
     steps:
       - name: Checkout portal
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
       - name: Restore fulfillment state
         uses: actions/cache@v4
         with:
-          path: ${{ runner.temp }}/3dvr-free-site-state
+          path: /tmp/3dvr-free-site-state
           key: free-site-worker-state-${{ github.run_id }}
           restore-keys: |
             free-site-worker-state-

--- a/.github/workflows/free-site-third-line-recovery.yml
+++ b/.github/workflows/free-site-third-line-recovery.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 20
     env:
       GMAIL_USER: ${{ secrets.GMAIL_USER }}
-      GMAIL_APP_PASSWORD: ${{ secrets.GH_PAT }}
+      GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
       GH_TOKEN: ${{ secrets.GH_PAT }}
       THREEDVR_FREE_SITE_MAX_PER_RUN: '20'
       THREEDVR_FREE_SITE_LOOKBACK_HOURS: '24'


### PR DESCRIPTION
Uses a fixed ephemeral /tmp path for free-site fallback state/cache so GitHub can validate and start the workflows before a runner context exists. No change to the German IMAP-IDLE primary, mailbox authority, or Vercel deployment policy.