### PR TITLE
Link free-site recovery status to workflow run

### DIFF
--- a/.github/workflows/free-site-third-line-recovery.yml
+++ b/.github/workflows/free-site-third-line-recovery.yml
@@ -69,10 +69,11 @@ jobs:
             state=failure
             description='Third-line free-site worker failed'
           fi
+          target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           curl -fsS -X POST \
             -H "Authorization: Bearer $STATUS_TOKEN" \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
-            -d "{\"state\":\"$state\",\"context\":\"3DVR Free Site Third-Line\",\"description\":\"$description\"}"
+            -d "{\"state\":\"$state\",\"context\":\"3DVR Free Site Third-Line\",\"description\":\"$description\",\"target_url\":\"$target_url\"}"
           [ "$state" = success ]


### PR DESCRIPTION
Adds the exact GitHub Actions run URL to the third-line recovery commit status so per-request fulfillment failures can be diagnosed without weakening mailbox or deployment safeguards.