### PR TITLE
Fix Git auth in free-site Actions fallback

### DIFF
--- a/apps/agent/thomas-agent/node/free-site-actions-runner.js
+++ b/apps/agent/thomas-agent/node/free-site-actions-runner.js
@@ -1,14 +1,31 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { runOnce } = require('./free-site-worker');
 
 const ROOT = path.join(__dirname, '..');
 const STATE_DIR = process.env.THREEDVR_AUTOPILOT_STATE_DIR || path.join(ROOT, 'state');
 const STATE_FILE = process.env.THREEDVR_FREE_SITE_STATE_FILE || path.join(STATE_DIR, 'free-site-worker-state.json');
 
+function configureGitHubAuth() {
+  if (!process.env.GH_TOKEN) throw new Error('GH_TOKEN is not configured for free-site publishing.');
+  const result = spawnSync('gh', ['auth', 'setup-git'], {
+    encoding: 'utf8',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || 'gh auth setup-git failed').trim());
+  }
+}
+
+function readState() {
+  if (!fs.existsSync(STATE_FILE)) return { messages: {} };
+  return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+}
+
 function finalizeExistingState() {
   if (!fs.existsSync(STATE_FILE)) return 0;
-  const state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+  const state = readState();
   let finalized = 0;
   for (const entry of Object.values(state.messages || {})) {
     if (entry?.status !== 'existing') continue;
@@ -25,7 +42,16 @@ function finalizeExistingState() {
   return finalized;
 }
 
+function failedRequestCount() {
+  const state = readState();
+  return Object.values(state.messages || {}).filter((entry) => entry?.status === 'failed').length;
+}
+
 async function main() {
+  // GitHub Actions checkout credentials only cover the portal checkout. Configure
+  // gh as git's credential helper so the bounded worker can clone/push 3dvr-web.
+  configureGitHubAuth();
+
   // GitHub Actions runners are ephemeral, so use two passes per cycle:
   // pass 1 discovers/publishes; pass 2 marks already-existing sites seen.
   // Then normalize those entries to processed so they cannot starve newer mail.
@@ -37,6 +63,9 @@ async function main() {
     console.log(`[free-site-actions-runner] cycle=${cycle} acted=${acted} finalized_existing=${finalized}`);
     if (acted === 0 && finalized === 0) break;
   }
+
+  const failed = failedRequestCount();
+  if (failed > 0) throw new Error(`Free-site worker left ${failed} request(s) in failed state.`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Configures `gh auth setup-git` before the bounded worker clones/pushes `tmsteph/3dvr-web`, and makes the Actions runner fail if any request remains in failed state. This fixes the observed `could not read Username for https://github.com` failure and removes the false-green recovery status.