### PR TITLE
Add 3DVR Work Agent MVP shell

### DIFF
--- a/work-agent/README.md
+++ b/work-agent/README.md
@@ -1,0 +1,144 @@
+# 3DVR Work Agent
+
+A worker-owned freelance booking agent for AV technicians and stagehands.
+
+## First useful loop
+
+1. Worker signs in and connects their own email.
+2. Worker gives the agent a resume, experience, home market, minimum rate, and job rules.
+3. Agent reads availability from Google Calendar and employer schedule sources such as Encore.
+4. Agent finds relevant production companies and freelance calls.
+5. Agent drafts personalized outreach from the worker's own identity.
+6. Worker approves sends by default.
+7. Agent watches replies, summarizes opportunities, and prepares responses.
+8. Worker explicitly approves accepting work unless they later enable rule-based booking.
+9. Confirmed work becomes a busy block so the agent does not double-book.
+
+## MVP surfaces
+
+`/work-agent/` is the first onboarding shell. It currently supports:
+
+- worker profile and rate preferences
+- resume-file selection metadata
+- Google mail OAuth initiation
+- Google Calendar OAuth initiation
+- conservative outbound and booking policy controls
+- an Encore connector placeholder
+- an activity/audit placeholder
+
+The page intentionally stores only non-secret connection metadata in its own work-agent storage. It does not yet persist OAuth credentials for a background worker.
+
+## Existing 3DVR pieces to reuse
+
+- Portal OAuth already supports Google identity, mail, and calendar scopes.
+- The 3DVR agent already contains Gmail transport, inbox monitoring, and outreach sending code.
+- The agent architecture already defines tenant-scoped queues, task risk classes, approval gates, and dedicated handling for credential-heavy workloads.
+- GunJS remains the portal source of truth for owner-scoped product state once this shell moves beyond local prototype state.
+
+## Production boundary
+
+Do **not** make background email automation depend on browser `localStorage` tokens.
+
+Before a real worker can leave the page and have 3DVR continue acting for them, add a server-side credential connection layer that:
+
+- binds credentials to `provider + provider subject`, not just email
+- encrypts refresh tokens at rest
+- never returns stored refresh tokens to normal portal JavaScript
+- limits scopes to the exact connector capability
+- supports revoke/reconnect
+- writes an auditable connection record without secrets
+- keeps credential tasks on an isolated or dedicated worker path
+
+The existing portal OAuth response shape can bootstrap the UX, but long-lived worker credentials need a safer server-side storage flow.
+
+## Suggested owner-scoped data shape
+
+```text
+workAgent/<tenantId>/profile
+workAgent/<tenantId>/resume
+workAgent/<tenantId>/rules
+workAgent/<tenantId>/connections
+workAgent/<tenantId>/availability/sources
+workAgent/<tenantId>/availability/blocks
+workAgent/<tenantId>/companies
+workAgent/<tenantId>/outreach
+workAgent/<tenantId>/threads
+workAgent/<tenantId>/opportunities
+workAgent/<tenantId>/approvals
+workAgent/<tenantId>/activity
+```
+
+Example policy:
+
+```json
+{
+  "outboundMode": "draft",
+  "bookingMode": "ask",
+  "minimumDayRate": 400,
+  "markets": ["San Diego"],
+  "blockedCompanies": [],
+  "allowTravel": false
+}
+```
+
+## Availability contract
+
+Every connector should normalize into the same shape:
+
+```json
+{
+  "source": "encore|google-calendar|manual|iatse",
+  "externalId": "source-record-id",
+  "startsAt": "2026-09-01T08:00:00-07:00",
+  "endsAt": "2026-09-01T18:00:00-07:00",
+  "status": "busy|tentative|available",
+  "label": "Encore call",
+  "updatedAt": 1780000000000
+}
+```
+
+Outreach should only target days that remain open after all sources are merged.
+
+## Outreach state machine
+
+```text
+lead
+  -> drafted
+  -> awaiting_approval
+  -> sent
+  -> replied
+  -> negotiating
+  -> awaiting_booking_approval
+  -> booked | declined | closed
+```
+
+Each external action gets an activity record with actor, timestamp, target, source message, and approval reference.
+
+## Encore connector
+
+Treat Encore as an availability source, not the central account identity.
+
+Near-term implementation can reuse the browser/session automation already proven for the founder workflow, but the product connector should eventually expose a small normalized interface:
+
+```text
+connect()
+refreshSession()
+listSchedule(start, end)
+health()
+disconnect()
+```
+
+Store session secrets outside GunJS and outside normal portal browser storage.
+
+## Next build order
+
+1. Secure server-side OAuth credential storage for one test user.
+2. Resume upload + text extraction into an owner-scoped profile.
+3. Google Calendar availability normalization.
+4. Encore schedule normalization using the existing browser workflow.
+5. Company/lead records and draft-only outreach queue.
+6. Inbox reply watcher and opportunity extraction.
+7. Approval screen for send/reply/book actions.
+8. First end-to-end test: one worker, one open date, one company, one approved outreach email, one captured reply.
+
+The first revenue proof is not a fully autonomous agent. It is one additional AV worker getting one legitimate freelance opportunity through this loop.

--- a/work-agent/app.js
+++ b/work-agent/app.js
@@ -1,0 +1,166 @@
+(function initWorkAgent() {
+  const PROFILE_KEY = '3dvr.workAgent.profile';
+  const RULES_KEY = '3dvr.workAgent.rules';
+  const CONNECTIONS_KEY = '3dvr.workAgent.connections';
+  const RESUME_KEY = '3dvr.workAgent.resume';
+
+  const $ = id => document.getElementById(id);
+
+  function readJson(key, fallback) {
+    try {
+      const value = localStorage.getItem(key);
+      return value ? JSON.parse(value) : fallback;
+    } catch (_err) {
+      return fallback;
+    }
+  }
+
+  function writeJson(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+
+  function setStatus(id, text) {
+    const target = $(id);
+    if (target) target.textContent = text;
+  }
+
+  function loadProfile() {
+    const profile = readJson(PROFILE_KEY, {});
+    $('name').value = profile.name || '';
+    $('roles').value = profile.roles || '';
+    $('market').value = profile.market || '';
+    $('minimum-rate').value = profile.minimumRate || '';
+    $('notes').value = profile.notes || '';
+  }
+
+  function saveProfile() {
+    writeJson(PROFILE_KEY, {
+      name: $('name').value.trim(),
+      roles: $('roles').value.trim(),
+      market: $('market').value.trim(),
+      minimumRate: $('minimum-rate').value.trim(),
+      notes: $('notes').value.trim(),
+      updatedAt: Date.now(),
+    });
+    setStatus('profile-status', 'Profile saved on this device.');
+  }
+
+  function loadRules() {
+    const rules = readJson(RULES_KEY, {});
+    $('outbound-mode').value = rules.outboundMode || 'draft';
+    $('booking-mode').value = rules.bookingMode || 'ask';
+  }
+
+  function saveRules() {
+    writeJson(RULES_KEY, {
+      outboundMode: $('outbound-mode').value,
+      bookingMode: $('booking-mode').value,
+      updatedAt: Date.now(),
+    });
+    setStatus('rules-status', 'Agent rules saved.');
+  }
+
+  function handleResume(event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) {
+      localStorage.removeItem(RESUME_KEY);
+      setStatus('resume-status', 'No resume selected yet.');
+      return;
+    }
+
+    writeJson(RESUME_KEY, {
+      name: file.name,
+      size: file.size,
+      type: file.type,
+      selectedAt: Date.now(),
+    });
+    setStatus('resume-status', `${file.name} selected. Secure upload is not enabled yet.`);
+  }
+
+  function loadResume() {
+    const resume = readJson(RESUME_KEY, null);
+    if (resume && resume.name) {
+      setStatus('resume-status', `${resume.name} was selected previously. Choose it again when secure upload is available.`);
+    }
+  }
+
+  function readConnections() {
+    return readJson(CONNECTIONS_KEY, {});
+  }
+
+  function saveConnectionMetadata(result) {
+    if (!result || !result.ok || !result.provider || !result.connection) return;
+    const scopeKey = result.connection.scopeKey || result.scopeKey || 'identity';
+    if (scopeKey !== 'mail' && scopeKey !== 'gmail' && scopeKey !== 'calendar') return;
+
+    const connections = readConnections();
+    const key = scopeKey === 'gmail' ? 'mail' : scopeKey;
+    connections[key] = {
+      provider: result.provider,
+      email: result.connection.email || (result.identity && result.identity.email) || '',
+      displayName: result.connection.displayName || (result.identity && result.identity.displayName) || '',
+      scopeKey: key,
+      linkedAt: result.connection.linkedAt || Date.now(),
+    };
+    writeJson(CONNECTIONS_KEY, connections);
+  }
+
+  function consumeOAuthResult() {
+    if (!window.PortalOAuth || typeof window.PortalOAuth.consumePendingResult !== 'function') return;
+    const result = window.PortalOAuth.consumePendingResult();
+    if (!result) return;
+
+    if (result.ok) {
+      saveConnectionMetadata(result);
+      return;
+    }
+
+    const message = result.error || 'OAuth connection failed.';
+    setStatus('mail-detail', message);
+    setStatus('calendar-detail', message);
+  }
+
+  function renderConnections() {
+    const connections = readConnections();
+    const mail = connections.mail;
+    const calendar = connections.calendar;
+
+    if (mail) {
+      $('mail-pill').textContent = 'Connected';
+      $('mail-pill').classList.add('connected');
+      setStatus('mail-detail', mail.email ? `Connected as ${mail.email}.` : 'Google mail connected.');
+      $('connect-mail').textContent = 'Reconnect Gmail';
+    }
+
+    if (calendar) {
+      $('calendar-pill').textContent = 'Connected';
+      $('calendar-pill').classList.add('connected');
+      setStatus('calendar-detail', calendar.email ? `Connected as ${calendar.email}.` : 'Google Calendar connected.');
+      $('connect-calendar').textContent = 'Reconnect calendar';
+    }
+  }
+
+  function beginOAuth(scopeKey) {
+    if (!window.PortalOAuth || typeof window.PortalOAuth.begin !== 'function') {
+      window.alert('Portal OAuth is unavailable.');
+      return;
+    }
+    window.PortalOAuth.begin('google', {
+      intent: 'connect',
+      scopeKey,
+      returnTo: '/work-agent/',
+    });
+  }
+
+  $('save-profile').addEventListener('click', saveProfile);
+  $('save-rules').addEventListener('click', saveRules);
+  $('resume').addEventListener('change', handleResume);
+  $('connect-mail').addEventListener('click', () => beginOAuth('mail'));
+  $('connect-calendar').addEventListener('click', () => beginOAuth('calendar'));
+
+  loadProfile();
+  loadRules();
+  loadResume();
+  consumeOAuthResult();
+  renderConnections();
+})();

--- a/work-agent/index.html
+++ b/work-agent/index.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="3DVR Work Agent helps freelance AV workers find and manage work around their existing schedule." />
+  <title>3DVR Work Agent</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #06111f;
+      --panel: rgba(11, 28, 49, 0.92);
+      --panel-soft: rgba(18, 41, 69, 0.7);
+      --text: #f7fbff;
+      --muted: rgba(247, 251, 255, 0.68);
+      --border: rgba(255, 255, 255, 0.12);
+      --accent: #f0c75e;
+      --accent-text: #211a09;
+      --good: #90e0a8;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100dvh;
+      font-family: "Segoe UI", system-ui, sans-serif;
+      background: radial-gradient(circle at top, #12365d 0%, var(--bg) 52%, #02070d 100%);
+      color: var(--text);
+    }
+
+    main {
+      width: min(100% - 32px, 920px);
+      margin: 0 auto;
+      padding: 36px 0 72px;
+    }
+
+    header {
+      display: grid;
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+
+    .eyebrow {
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+
+    h1,
+    h2,
+    p {
+      margin: 0;
+    }
+
+    h1 {
+      font-size: clamp(2rem, 8vw, 3.5rem);
+      line-height: 1;
+    }
+
+    header p {
+      max-width: 680px;
+      color: var(--muted);
+      line-height: 1.6;
+    }
+
+    .grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .card {
+      display: grid;
+      gap: 16px;
+      padding: 20px;
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      background: var(--panel);
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.24);
+    }
+
+    .card.wide {
+      grid-column: 1 / -1;
+    }
+
+    .card h2 {
+      font-size: 1.12rem;
+    }
+
+    .card p,
+    .helper,
+    .status {
+      color: var(--muted);
+      font-size: 0.92rem;
+      line-height: 1.5;
+    }
+
+    label {
+      display: grid;
+      gap: 7px;
+      color: var(--muted);
+      font-size: 0.84rem;
+    }
+
+    input,
+    textarea,
+    select {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: rgba(0, 0, 0, 0.2);
+      color: var(--text);
+      padding: 12px 13px;
+      font: inherit;
+    }
+
+    textarea {
+      min-height: 88px;
+      resize: vertical;
+    }
+
+    button,
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 14px;
+      background: var(--panel-soft);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    button.primary {
+      border-color: transparent;
+      background: var(--accent);
+      color: var(--accent-text);
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .connection {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.025);
+    }
+
+    .connection strong {
+      display: block;
+      margin-bottom: 3px;
+    }
+
+    .pill {
+      display: inline-flex;
+      border-radius: 999px;
+      padding: 5px 9px;
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--muted);
+      font-size: 0.75rem;
+      white-space: nowrap;
+    }
+
+    .pill.connected {
+      background: rgba(144, 224, 168, 0.14);
+      color: var(--good);
+    }
+
+    .activity {
+      display: grid;
+      gap: 10px;
+    }
+
+    .activity-item {
+      padding: 14px;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
+    @media (max-width: 720px) {
+      main {
+        width: min(100% - 24px, 920px);
+        padding-top: 24px;
+      }
+
+      .grid {
+        grid-template-columns: 1fr;
+      }
+
+      .card.wide {
+        grid-column: auto;
+      }
+
+      .connection {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+
+      .connection button {
+        width: 100%;
+      }
+    }
+  </style>
+  <script src="/oauth.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script defer src="/work-agent/app.js"></script>
+</head>
+<body>
+  <main>
+    <header>
+      <span class="eyebrow">3DVR Work Agent</span>
+      <h1>Your freelance booking agent.</h1>
+      <p>Give the agent your experience, availability, and rules. It can find AV work, prepare outreach, watch replies, and eventually handle routine booking while keeping you in control.</p>
+    </header>
+
+    <section class="grid" aria-label="Work agent setup">
+      <article class="card">
+        <div>
+          <h2>1. Worker profile</h2>
+          <p>Enough context to represent you accurately.</p>
+        </div>
+        <label>
+          Name
+          <input id="name" autocomplete="name" placeholder="Your name" />
+        </label>
+        <label>
+          Main roles
+          <input id="roles" placeholder="A1, A2, stagehand, video, lighting" />
+        </label>
+        <label>
+          Home market
+          <input id="market" placeholder="San Diego, CA" />
+        </label>
+        <label>
+          Minimum day rate
+          <input id="minimum-rate" inputmode="numeric" placeholder="$400" />
+        </label>
+        <label>
+          Notes for your agent
+          <textarea id="notes" placeholder="Touring experience, preferred clients, travel limits, union notes, specialties..."></textarea>
+        </label>
+        <button id="save-profile" class="primary" type="button">Save profile</button>
+        <p id="profile-status" class="status" aria-live="polite"></p>
+      </article>
+
+      <article class="card">
+        <div>
+          <h2>2. Resume</h2>
+          <p>Your resume becomes source material for personalized outreach.</p>
+        </div>
+        <label>
+          Resume file
+          <input id="resume" type="file" accept=".pdf,.doc,.docx,.txt" />
+        </label>
+        <p id="resume-status" class="status">No resume selected yet.</p>
+        <p class="helper">This first shell only records the selected filename. Secure upload and resume parsing are the next backend step.</p>
+      </article>
+
+      <article class="card wide">
+        <div>
+          <h2>3. Connections</h2>
+          <p>Use the worker's own accounts. The agent should never impersonate a shared 3DVR mailbox.</p>
+        </div>
+
+        <div class="connection">
+          <div>
+            <strong>Google email</strong>
+            <span id="mail-detail" class="helper">Required to send outreach and read replies.</span>
+          </div>
+          <span id="mail-pill" class="pill">Not connected</span>
+          <button id="connect-mail" type="button">Connect Gmail</button>
+        </div>
+
+        <div class="connection">
+          <div>
+            <strong>Google Calendar</strong>
+            <span id="calendar-detail" class="helper">Adds a second source of truth for open days.</span>
+          </div>
+          <span id="calendar-pill" class="pill">Not connected</span>
+          <button id="connect-calendar" type="button">Connect calendar</button>
+        </div>
+
+        <div class="connection">
+          <div>
+            <strong>Encore schedule</strong>
+            <span class="helper">Read the worker's employer schedule so the agent only chases work on genuinely open days.</span>
+          </div>
+          <span class="pill">Connector next</span>
+          <button type="button" disabled>Connect Encore</button>
+        </div>
+      </article>
+
+      <article class="card">
+        <div>
+          <h2>4. Agent rules</h2>
+          <p>Start conservative. Automation can increase after trust is earned.</p>
+        </div>
+        <label>
+          Outbound mode
+          <select id="outbound-mode">
+            <option value="draft">Draft everything for approval</option>
+            <option value="approved">Auto-send only pre-approved outreach</option>
+            <option value="routine">Handle routine outreach and replies</option>
+          </select>
+        </label>
+        <label>
+          Booking authority
+          <select id="booking-mode">
+            <option value="ask">Always ask before accepting work</option>
+            <option value="rules">Accept only when job matches my rules</option>
+          </select>
+        </label>
+        <button id="save-rules" class="primary" type="button">Save rules</button>
+        <p id="rules-status" class="status" aria-live="polite"></p>
+      </article>
+
+      <article class="card">
+        <div>
+          <h2>Agent activity</h2>
+          <p>A simple audit trail for what the agent found, drafted, sent, or needs approved.</p>
+        </div>
+        <div class="activity">
+          <div class="activity-item">No outreach yet. Finish the setup, then the first backend worker can begin with draft-only prospecting.</div>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## What this adds
- `/work-agent/` onboarding shell for freelance AV workers
- profile, market, role, rate, and agent-rule inputs
- resume selection placeholder
- Google Gmail and Calendar OAuth entry points using existing portal OAuth
- Encore schedule connector placeholder
- activity/audit placeholder
- architecture notes for secure credential storage, normalized availability, outreach states, and the first end-to-end revenue proof

## Why
This turns the founder's existing freelance-booking workflow into the first reusable product surface: a worker-owned agent that can represent AV technicians from their own email, work around employer schedules, and keep consequential sends/bookings behind approval gates.

## Security boundary
This PR intentionally does not persist OAuth secrets for background workers. Production automation needs encrypted server-side token storage tied to provider subject/tenant identity before we enable unattended email activity.

## Account-linking impact
Adds no new provider or OAuth endpoint. It reuses existing Google `mail` and `calendar` scopes from the portal OAuth flow. Work-agent connection metadata is prototype-local only.

## Verification
- Confirmed branch files exist and use absolute script paths so `/work-agent` vs `/work-agent/` does not break assets.
- No Stripe or billing changes.

## Next slice
Secure one test user's Google credential server-side, then normalize Calendar + Encore availability and queue draft-only outreach.