### PR TITLE
Work Agent: encrypted tenant credential store

### DIFF
--- a/apps/agent/thomas-agent/node/work-agent-credential-store.js
+++ b/apps/agent/thomas-agent/node/work-agent-credential-store.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+function masterKey(value = process.env.WORK_AGENT_CREDENTIAL_KEY) {
+  if (!value) throw new Error('WORK_AGENT_CREDENTIAL_KEY is required');
+  const key = Buffer.from(value, 'base64');
+  if (key.length !== 32) throw new Error('WORK_AGENT_CREDENTIAL_KEY must be 32 bytes base64');
+  return key;
+}
+
+function opaqueSubject(subject) {
+  return crypto.createHash('sha256').update(String(subject)).digest('hex');
+}
+
+function recordId({ tenantId, provider, subject }) {
+  if (!tenantId || !provider || !subject) throw new Error('tenantId, provider, and subject are required');
+  return crypto.createHash('sha256').update(`${tenantId}\0${provider}\0${subject}`).digest('hex');
+}
+
+function encrypt(refreshToken, key) {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(String(refreshToken), 'utf8'), cipher.final()]);
+  return { iv: iv.toString('base64'), ciphertext: ciphertext.toString('base64'), tag: cipher.getAuthTag().toString('base64') };
+}
+
+function decrypt(secret, key) {
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(secret.iv, 'base64'));
+  decipher.setAuthTag(Buffer.from(secret.tag, 'base64'));
+  return Buffer.concat([decipher.update(Buffer.from(secret.ciphertext, 'base64')), decipher.final()]).toString('utf8');
+}
+
+class WorkAgentCredentialStore {
+  constructor({ file, key } = {}) {
+    this.file = file || process.env.WORK_AGENT_CREDENTIAL_FILE || path.join(process.env.HOME || '.', '.3dvr', 'work-agent-credentials.json');
+    this.key = masterKey(key);
+  }
+
+  _read() {
+    try { return JSON.parse(fs.readFileSync(this.file, 'utf8')); }
+    catch (error) { if (error.code === 'ENOENT') return { version: 1, records: {} }; throw error; }
+  }
+
+  _write(data) {
+    fs.mkdirSync(path.dirname(this.file), { recursive: true, mode: 0o700 });
+    const tmp = `${this.file}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+    fs.renameSync(tmp, this.file);
+    fs.chmodSync(this.file, 0o600);
+  }
+
+  put({ tenantId, provider, subject, refreshToken, email, displayLabel, scopeKey, scopes = [] }) {
+    if (!refreshToken) throw new Error('refreshToken is required');
+    const data = this._read();
+    const id = recordId({ tenantId, provider, subject });
+    const now = new Date().toISOString();
+    const previous = data.records[id];
+    data.records[id] = {
+      tenantId, provider, subjectOpaque: opaqueSubject(subject), email, displayLabel, scopeKey, scopes,
+      connectedAt: previous?.connectedAt || now, updatedAt: now, revokedAt: null, status: 'connected',
+      secret: encrypt(refreshToken, this.key)
+    };
+    this._write(data);
+    return this.status({ tenantId, provider, subject });
+  }
+
+  getRefreshToken({ tenantId, provider, subject }) {
+    const record = this._read().records[recordId({ tenantId, provider, subject })];
+    if (!record || record.status !== 'connected' || !record.secret) return null;
+    return decrypt(record.secret, this.key);
+  }
+
+  status({ tenantId, provider, subject }) {
+    const record = this._read().records[recordId({ tenantId, provider, subject })];
+    if (!record) return null;
+    const { secret, tenantId: _tenant, ...safe } = record;
+    return safe;
+  }
+
+  revoke({ tenantId, provider, subject }) {
+    const data = this._read();
+    const id = recordId({ tenantId, provider, subject });
+    const record = data.records[id];
+    if (!record) return null;
+    delete record.secret;
+    record.status = 'revoked';
+    record.revokedAt = record.updatedAt = new Date().toISOString();
+    this._write(data);
+    return this.status({ tenantId, provider, subject });
+  }
+}
+
+module.exports = { WorkAgentCredentialStore, recordId, opaqueSubject };

--- a/apps/agent/thomas-agent/node/work-agent-credential-store.test.js
+++ b/apps/agent/thomas-agent/node/work-agent-credential-store.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { WorkAgentCredentialStore } = require('./work-agent-credential-store');
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-cred-'));
+const file = path.join(dir, 'credentials.json');
+const key = crypto.randomBytes(32).toString('base64');
+const store = new WorkAgentCredentialStore({ file, key });
+
+store.put({ tenantId: 'a', provider: 'google', subject: 'same-sub', refreshToken: 'secret-a', email: 'a@example.test', scopes: ['calendar.readonly'] });
+store.put({ tenantId: 'b', provider: 'google', subject: 'same-sub', refreshToken: 'secret-b', email: 'b@example.test' });
+assert.equal(store.getRefreshToken({ tenantId: 'a', provider: 'google', subject: 'same-sub' }), 'secret-a');
+assert.equal(store.getRefreshToken({ tenantId: 'b', provider: 'google', subject: 'same-sub' }), 'secret-b');
+
+const disk = fs.readFileSync(file, 'utf8');
+assert(!disk.includes('secret-a'));
+assert(!disk.includes('secret-b'));
+const status = store.status({ tenantId: 'a', provider: 'google', subject: 'same-sub' });
+assert(!('secret' in status));
+assert(!('refreshToken' in status));
+
+store.revoke({ tenantId: 'a', provider: 'google', subject: 'same-sub' });
+assert.equal(store.getRefreshToken({ tenantId: 'a', provider: 'google', subject: 'same-sub' }), null);
+assert.equal(store.status({ tenantId: 'a', provider: 'google', subject: 'same-sub' }).status, 'revoked');
+
+assert.throws(() => new WorkAgentCredentialStore({ file: path.join(dir, 'bad'), key: '' }), /required/);
+assert.throws(() => new WorkAgentCredentialStore({ file, key: crypto.randomBytes(32).toString('base64') }).getRefreshToken({ tenantId: 'b', provider: 'google', subject: 'same-sub' }));
+
+fs.rmSync(dir, { recursive: true, force: true });
+console.log('work-agent credential store tests passed');


### PR DESCRIPTION
Implements the bounded credential-store core from #1656 without changing the existing founder OAuth path or Vercel deployment settings.

- AES-256-GCM refresh-token encryption with required 32-byte environment key
- tenant + provider + provider-subject record isolation
- safe status serialization with no token material
- explicit revoke destroys usable encrypted refresh material
- atomic 0600 file persistence for the isolated worker path
- tests cover ciphertext-at-rest, tenant isolation, wrong/missing key, safe status, and revoke

This deliberately does not enable Gmail/Calendar reads or outbound actions yet. Closes the storage-core portion of #1656.