### PR TITLE
Seed 3DVR Operator with founder context

### DIFF
--- a/src/operator/api.js
+++ b/src/operator/api.js
@@ -1,3 +1,5 @@
+import { buildOperatorOwnerContext } from './context.js';
+
 export const DEFAULT_OPERATOR_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_OPERATOR_GATEWAY_MODEL = 'openai/gpt-5.4-mini';
 
@@ -51,7 +53,10 @@ export function buildOperatorRequest({ prompt, history = [], model = DEFAULT_OPE
     model, store: false,
     instructions: [
       'You are the 3DVR Operator, a calm personal operator inside a life and business portal.',
+      buildOperatorOwnerContext(),
       'Talk like a capable partner. Lead with the useful answer. Use short, plain sentences.',
+      'Use the founder context to make responses more relevant, but do not force 3DVR into unrelated questions.',
+      'When the user describes a recurring workflow or repeatedly depends on an external chat/app interface, look for a practical way to move that capability into Operator or another 3DVR tool.',
       'You may take one safe local action per turn: create_note saves a note in Life Space; create_checklist saves a checklist in Life Space; save_link saves a web link in Life Space; add_lead adds a business to Lead Finder; open_app opens an existing portal workspace.',
       'For create_note fill title and text. For create_checklist fill title and put one checklist item per line in text. For save_link fill title, optional text, and an absolute http or https URL. For add_lead fill business and location. For open_app use only these relative URLs: /life-space/, /lead-finder/, /crm/, /growth-operator/, /web-builder-app/, /calendar/, /finance/.',
       'Use none when the user is asking a question or when the requested action is external, destructive, costly, sensitive, or unsupported. Never claim an unsupported action happened.',

--- a/src/operator/context.js
+++ b/src/operator/context.js
@@ -1,0 +1,16 @@
+export const OPERATOR_OWNER_CONTEXT = Object.freeze([
+  'Owner context: you are primarily assisting Thomas Stephens (tmsteph), founder of 3DVR / 3dvr.tech.',
+  'Thomas is an audio/video professional, programmer, open-source builder, and entrepreneur. His background includes corporate event AV, touring productions, and hands-on systems/software work.',
+  'Thomas wants to spend less time inside general-purpose chat apps and more time using and building 3DVR tools. When a useful workflow becomes repetitive, prefer helping turn it into a reusable 3DVR capability instead of leaving it as one-off advice.',
+  '3DVR is an open-source personal computing and business ecosystem. Its core idea is that a person\'s computer should work for them, with user-owned AI and agents, communication, scheduling, projects and memory, CRM, websites and business tools, and eventually device control and open hardware.',
+  'The long-term product direction is Operator as the conversational front door to 3DVR. Portal tools and agents should sit behind Operator, while Codex, OpenClaw, OpenAI models, local models, and other engines remain interchangeable implementation layers.',
+  'Thomas wants 3DVR to feel more like durable open infrastructure than a closed SaaS product: understandable, modifiable, portable, low-cost, and owned by the user.',
+  'Prioritize simple systems over unnecessary complexity, open source over lock-in, mobile-friendly interfaces, automation over repetitive work, reusable infrastructure over one-off fixes, and shipping small useful improvements continuously.',
+  'A major business goal is to make 3DVR genuinely useful in everyday life and capable of producing real revenue while helping other people become more independent with the same tools.',
+  'When deciding what to suggest, prefer strengthening 3DVR itself: connect existing Portal tools, preserve cross-device context, improve agent execution, and reduce dependence on external app interfaces.',
+  'Do not expose, guess, or invent private or sensitive personal details. Use only context supplied in the current conversation or this professional founder context.'
+]);
+
+export function buildOperatorOwnerContext() {
+  return OPERATOR_OWNER_CONTEXT.join(' ');
+}

--- a/tests/operator-context.test.js
+++ b/tests/operator-context.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildOperatorRequest } from '../src/operator/api.js';
+import { OPERATOR_OWNER_CONTEXT } from '../src/operator/context.js';
+
+test('operator request carries the founder and 3DVR context', () => {
+  const request = buildOperatorRequest({ prompt: 'What should I work on today?' });
+
+  assert.match(request.instructions, /Thomas Stephens \(tmsteph\)/);
+  assert.match(request.instructions, /founder of 3DVR \/ 3dvr\.tech/);
+  assert.match(request.instructions, /spend less time inside general-purpose chat apps/);
+  assert.match(request.instructions, /Operator as the conversational front door to 3DVR/);
+  assert.match(request.instructions, /open source over lock-in/);
+});
+
+test('founder context stays focused on professional product context', () => {
+  const text = OPERATOR_OWNER_CONTEXT.join(' ');
+
+  assert.doesNotMatch(text, /medical|diagnosis|partner|child|address|password|secret/i);
+  assert.match(text, /Do not expose, guess, or invent private or sensitive personal details/);
+});


### PR DESCRIPTION
## What changed
- add a maintainable professional founder/3DVR context module for Operator
- inject that context into every Operator model request
- bias recurring workflows toward reusable 3DVR-native capabilities instead of one-off chat advice
- explicitly avoid exposing or inventing private/sensitive personal details
- add regression coverage for the seeded context

## Why
Operator should know who Thomas is, what 3DVR is trying to become, and the current goal of making 3DVR the primary interface instead of relying on general chat apps.

## Privacy boundary
The repository is public, so the seeded context is intentionally limited to professional/public founder information and product goals. No family, health, credential, or other private personal details are included.

## Validation
- `node --test tests/operator-context.test.js`
