### PR TITLE
Deploy Operator founder context to production

### DIFF
--- a/workspace/.deploy-operator-context
+++ b/workspace/.deploy-operator-context
@@ -1,0 +1,2 @@
+Deploy production after merging the 3DVR Operator founder-context update.
+This marker is intentionally temporary and should not be merged into main.


### PR DESCRIPTION
Temporary same-repo deployment trigger for the merged Operator founder-context update.

Closed without merge: the deployment attempt was skipped/ignored and the current Vercel deployment circuit breaker requires us not to keep probing this blocked production path. Preserve `git.deploymentEnabled: false`; retry only with new positive reachability evidence or a materially different deployment path.