### PR TITLE
Recover German worker for Operator production deploy

### DIFF
--- a/ops/german-worker-recovery-trigger.txt
+++ b/ops/german-worker-recovery-trigger.txt
@@ -1,2 +1,2 @@
-2026-08-21T07:46:44Z
-Reason: hourly free-site reliability fallback re-probe after failed German worker recovery status.
+2026-08-22T04:10:00Z
+Reason: recover managed task worker so Operator portal-context production deployment can complete.


### PR DESCRIPTION
Activate the existing German-worker recovery workflow so the queued Operator production deployment can complete. This only updates the dedicated recovery trigger marker.