### PR TITLE
Production refresh for simplified portal home

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -1,5 +1,6 @@
 name: Vercel Production Prebuilt
 
+# Manual production refresh for the simplified Operator-first portal home.
 on:
   push:
     branches:


### PR DESCRIPTION
Manual production deployment lane for the simplified Operator-first homepage.

Closed without merging: Workspace Tests, Playwright Checks, and Vercel Dev Preview passed, but Vercel Production Prebuilt failed. The latest German-worker recovery probe (#1670) also produced no positive deployment evidence. Per the deployment circuit breaker, do not create/retry another production branch or recovery trigger until there is materially new reachability evidence or a different repair path. Production remains on the prior deployment.