### PR TITLE
Recover German worker for portal home deploy

### DIFF
--- a/ops/german-worker-recovery-trigger.txt
+++ b/ops/german-worker-recovery-trigger.txt
@@ -1,2 +1,2 @@
-2026-08-22T04:10:00Z
-Reason: recover managed task worker so Operator portal-context production deployment can complete.
+2026-08-22T04:37:00Z
+Reason: recover managed task worker so simplified Operator-first portal homepage production deployment can complete.


### PR DESCRIPTION
Refresh the existing German-worker recovery trigger so the queued production deployment for the simplified portal homepage can be consumed. This uses the repo's existing managed-queue probe and legacy fallback recovery path.