### PR TITLE
Restore native Vercel auto-deploys

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -1,63 +1,32 @@
-name: Vercel Production Prebuilt
+name: Vercel Production Fallback
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/vercel-production-prebuilt.yml"
-      - "scripts/vercel/deploy-production-worker.sh"
-      - "index.html"
-      - "workspace/**"
-      - "codex-cloud/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/vercel-production-prebuilt.yml"
-      - "scripts/vercel/deploy-production-worker.sh"
-      - "index.html"
-      - "workspace/**"
-      - "codex-cloud/**"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: vercel-production-prebuilt
+  group: vercel-production-fallback
   cancel-in-progress: true
 
-# portal.3dvr.tech is attached to this long-lived Vercel project. Keep these
-# public IDs explicit so deployment cannot silently drift to a duplicate project.
 env:
   VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
   VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-  THREEDVR_AGENT_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed' }}
 
 jobs:
   deploy:
-    name: Build production artifact and deploy
-    # Agent-compatible manual deploy lane: only same-repo deploy/production-* PRs
-    # may use the pull_request trigger. Ordinary PRs and forks cannot deploy.
-    if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.pull_request.head.repo.full_name == github.repository &&
-       startsWith(github.head_ref, 'deploy/production-'))
+    name: Manual direct Vercel deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
-      - name: Detect deployment path
-        id: config
+      - name: Require direct Vercel credentials
         shell: bash
         run: |
-          if [ -n "$VERCEL_TOKEN" ]; then
-            echo "local_vercel=true" >> "$GITHUB_OUTPUT"
-            echo "Using repository VERCEL_TOKEN for a prebuilt GitHub-hosted deploy."
-          else
-            echo "local_vercel=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::VERCEL_TOKEN is not configured in Actions; using the existing German worker as the credential boundary."
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::VERCEL_TOKEN is not configured. Native Vercel Git deployment remains the normal production path."
+            exit 1
           fi
 
       - name: Checkout repository
@@ -69,128 +38,35 @@ jobs:
           node-version: 22.22.0
           cache: npm
 
-      - name: Install dependencies for local deploy
-        if: ${{ steps.config.outputs.local_vercel == 'true' }}
+      - name: Install dependencies
         run: npm ci
 
       - name: Install Vercel CLI
-        if: ${{ steps.config.outputs.local_vercel == 'true' }}
         run: npm install --global vercel
 
       - name: Pull production environment
-        if: ${{ steps.config.outputs.local_vercel == 'true' }}
         run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
-      - name: Build production artifact locally
-        if: ${{ steps.config.outputs.local_vercel == 'true' }}
+      - name: Build production artifact
         run: vercel build --prod --token="$VERCEL_TOKEN"
 
-      - name: Deploy prebuilt artifact from GitHub runner
-        if: ${{ steps.config.outputs.local_vercel == 'true' }}
-        id: local_deploy
+      - name: Deploy production artifact
+        id: deploy
         shell: bash
         run: |
           DEPLOY_URL="$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN" --yes)"
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "Production URL: $DEPLOY_URL"
 
-      - name: Install German-worker queue dependencies
-        if: ${{ steps.config.outputs.local_vercel != 'true' }}
-        run: npm --prefix apps/agent ci
-
-      - name: Queue prebuilt deploy on German worker
-        if: ${{ steps.config.outputs.local_vercel != 'true' }}
-        id: remote_queue
-        shell: bash
-        run: |
-          set -euo pipefail
-          script_ref="${GITHUB_HEAD_REF:-main}"
-          printf -v quoted_ref '%q' "$script_ref"
-          task="git fetch origin $quoted_ref && git show FETCH_HEAD:scripts/vercel/deploy-production-worker.sh | bash"
-          result="$(node apps/agent/thomas-agent/node/agent-task-queue.js enqueue \
-            --json \
-            --backend shell \
-            --risk workspace_write \
-            --approval-status approved \
-            --unsafe \
-            --requires shell \
-            --max-runtime-ms 600000 \
-            "$task")"
-          printf '%s\n' "$result"
-          task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
-          echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for German worker deploy receipt
-        if: ${{ steps.config.outputs.local_vercel != 'true' }}
-        id: remote_deploy
-        shell: bash
-        run: |
-          set -euo pipefail
-          task_id='${{ steps.remote_queue.outputs.task_id }}'
-          for attempt in $(seq 1 120); do
-            if ! result="$(node apps/agent/thomas-agent/node/agent-task-queue.js status --id "$task_id" --json 2>/tmp/3dvr-task-status.err)"; then
-              echo "::warning::Transient task status read failed; retrying ($attempt/120)."
-              sleep 2
-              continue
-            fi
-            if ! status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)process.exit(2);console.log((JSON.parse(s.slice(i)).status||''))})")"; then
-              echo "::warning::Task status payload was incomplete; retrying ($attempt/120)."
-              sleep 2
-              continue
-            fi
-            echo "German production deploy status: $status"
-            case "$status" in
-              completed)
-                printf '%s\n' "$result"
-                exit 0
-                ;;
-              failed|skipped)
-                printf '%s\n' "$result"
-                exit 1
-                ;;
-            esac
-            sleep 5
-          done
-          echo 'German worker did not return a production deploy receipt.' >&2
-          exit 1
-
-      - name: Verify production routes
+      - name: Verify production homepage
         shell: bash
         env:
-          LOCAL_DEPLOY_URL: ${{ steps.local_deploy.outputs.url }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
         run: |
-          set -euo pipefail
-          BASE_URL="${LOCAL_DEPLOY_URL:-https://portal.3dvr.tech}"
-
           curl --fail --silent --show-error --location \
             --retry 8 --retry-delay 3 --retry-all-errors \
-            "$BASE_URL/" \
+            "$DEPLOY_URL/" \
             --output /tmp/portal-home.html
           grep -q '<title>3DVR Portal</title>' /tmp/portal-home.html
           grep -q 'id="home-title">What do you want to do?' /tmp/portal-home.html
-          echo "3DVR Portal homepage verified."
-
-          curl --fail --silent --show-error --location \
-            --retry 8 --retry-delay 3 --retry-all-errors \
-            "$BASE_URL/context-hq/" \
-            --output /tmp/context-hq.html
-          grep -q '<title>Context HQ | 3DVR Portal</title>' /tmp/context-hq.html
-          echo "Context HQ production route verified."
-
-          curl --fail --silent --show-error --location \
-            --retry 8 --retry-delay 3 --retry-all-errors \
-            "$BASE_URL/workspace/" \
-            --output /tmp/workspace.html
-          grep -q '<title>3DVR Workspace</title>' /tmp/workspace.html
-          grep -q './main.js' /tmp/workspace.html
-          echo "3DVR Workspace production route verified."
-
-          {
-            echo "## Vercel Production Prebuilt"
-            echo
-            echo "Commit: $GITHUB_SHA"
-            echo "Environment: production"
-            echo "Project: $VERCEL_PROJECT_ID"
-            echo "Verified: $BASE_URL/"
-            echo "Verified: $BASE_URL/workspace/"
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "3DVR Portal production homepage verified."

--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": true
   },
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':(exclude)apps/agent/**' ':(exclude)apps/companion/**'",
-  "redirects": [
-    {
-      "source": "/",
-      "has": [{ "type": "host", "value": "wenzo.3dvr.tech" }],
-      "destination": "/wenzo/",
-      "permanent": false
-    }
-  ],
   "crons": [
     { "path": "/api/growth/homepage-hero-cron", "schedule": "43 2 * * *" },
     { "path": "/api/money/autopilot-cron", "schedule": "17 16 * * 1-5" }
@@ -57,6 +49,7 @@
     { "source": "/video/index.html", "destination": "/portal.3dvr.tech/video/index.html" }
   ],
   "redirects": [
+    { "source": "/", "has": [{ "type": "host", "value": "wenzo.3dvr.tech" }], "destination": "/wenzo/", "permanent": false },
     {
       "source": "/:path((?!api(?:/|$)|webhooks(?:/|$))(?!.*\\.[^/]+$).*[^/])",
       "has": [{ "type": "header", "key": "accept", "value": ".*text/html.*" }],


### PR DESCRIPTION
Superseded: `main` independently removed `git.deploymentEnabled: false`, and Vercel immediately resumed native Git deployments. Closing this PR to avoid reintroducing a redundant config block. A smaller follow-up keeps only the deployment-workflow cleanup.