### PR TITLE
Fix Vercel selective deploy schema limit

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
       "main": true
     }
   },
-  "ignoreCommand": "BASE=\"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\"; git diff --quiet \"$BASE\" HEAD -- . ':(exclude)apps/agent/**' ':(exclude)apps/companion/**' ':(exclude).github/**' ':(exclude)docs/**' ':(exclude)ops/**' ':(exclude)tests/**' ':(exclude)scripts/**' ':(exclude)README.md' ':(exclude)AGENTS.md'",
+  "ignoreCommand": "git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- . ':(exclude)apps/agent/**' ':(exclude)apps/companion/**' ':(exclude).github/**' ':(exclude)docs/**' ':(exclude)ops/**' ':(exclude)tests/**' ':(exclude)scripts/**' ':(exclude)*.md'",
   "crons": [
     { "path": "/api/growth/homepage-hero-cron", "schedule": "43 2 * * *" },
     { "path": "/api/money/autopilot-cron", "schedule": "17 16 * * 1-5" }


### PR DESCRIPTION
Follow-up to #1674. Vercel rejected the new `ignoreCommand` because it exceeded the 256-character schema limit. This shortens the command while preserving main-only native Git deployment and exclusions for Agent/Companion/CI/docs/ops/tests/scripts/Markdown-only churn. No deployment-trigger PR or German-worker path.