### PR TITLE
Retry spinner production deploy

### DIFF
--- a/spinner-production-retry.txt
+++ b/spinner-production-retry.txt
@@ -1,0 +1,1 @@
+Retry native Vercel production deployment for interactive portal spinner after build-rate-limit rejection.


### PR DESCRIPTION
No product-code change. This creates a small deployment-trigger file so Vercel retries the already-merged interactive spinner after the previous production build was rejected by Vercel's build-rate limit.