### PR TITLE
Hard-stop Vercel builds outside main

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
       "main": true
     }
   },
-  "ignoreCommand": "git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- . ':(exclude)apps/agent/**' ':(exclude)apps/companion/**' ':(exclude).github/**' ':(exclude)docs/**' ':(exclude)ops/**' ':(exclude)tests/**' ':(exclude)scripts/**' ':(exclude)*.md'",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != main ] || git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- . ':(exclude)apps/agent/**' ':(exclude)apps/companion/**' ':(exclude).github/**' ':(exclude)docs/**' ':(exclude)ops/**' ':(exclude)tests/**' ':(exclude)scripts/**' ':(exclude)*.md'",
   "crons": [
     { "path": "/api/growth/homepage-hero-cron", "schedule": "43 2 * * *" },
     { "path": "/api/money/autopilot-cron", "schedule": "17 16 * * 1-5" }

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
       "main": true
     }
   },
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != main ] || git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- . ':(exclude)apps/agent/**' ':(exclude)apps/companion/**' ':(exclude).github/**' ':(exclude)docs/**' ':(exclude)ops/**' ':(exclude)tests/**' ':(exclude)scripts/**' ':(exclude)*.md'",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != main ] || git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- . ':(exclude)apps/agent/**' ':(exclude)apps/companion/**' ':(exclude).github/**' ':(exclude)docs/**' ':(exclude)ops/**' ':(exclude)tests/**' ':(exclude)*.md'",
   "crons": [
     { "path": "/api/growth/homepage-hero-cron", "schedule": "43 2 * * *" },
     { "path": "/api/money/autopilot-cron", "schedule": "17 16 * * 1-5" }


### PR DESCRIPTION
The selective deploy config still allowed Vercel's Git integration to attempt PR deployments, and recent PRs hit the Hobby 100-deploy/day limit despite `deploymentEnabled` policy. Add a defense-in-depth `ignoreCommand` guard: any ref other than `main` exits successfully before a build starts; `main` keeps the existing non-web churn filter. This does not create or trigger a deployment and keeps explicit preview workflow as the only PR preview path.