### PR TITLE
Stop standalone Contacts Vercel deployment churn

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -9,11 +9,9 @@ on:
       - 'apps/agent/**'
       - 'apps/companion/**'
       - '.github/**'
-      - 'docs/**'
       - 'ops/**'
       - 'tests/**'
       - 'scripts/**'
-      - '**/*.md'
 
 permissions:
   contents: read

--- a/contacts/vercel.json
+++ b/contacts/vercel.json
@@ -1,4 +1,7 @@
 {
+  "git": {
+    "deploymentEnabled": false
+  },
   "headers": [
     {
       "source": "/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|woff2?)",
@@ -40,6 +43,5 @@
         }
       ]
     }
-  ],
-  "ignoreCommand": "sh ./ignore-build.sh"
+  ]
 }

--- a/contacts/vercel.json
+++ b/contacts/vercel.json
@@ -43,5 +43,6 @@
         }
       ]
     }
-  ]
+  ],
+  "ignoreCommand": "sh ./ignore-build.sh"
 }

--- a/tests/contacts-vercel-deploy-policy.test.js
+++ b/tests/contacts-vercel-deploy-policy.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const config = JSON.parse(
+  await readFile(new URL('../contacts/vercel.json', import.meta.url), 'utf8')
+);
+
+test('standalone Contacts cannot auto-deploy from Git pushes', () => {
+  assert.equal(config.git?.deploymentEnabled, false);
+});


### PR DESCRIPTION
The standalone `3dvr-portal-contacts` Vercel project is also linked to this repository and has been attempting deployments on routine PR activity, contributing to the Hobby 100-deployment limit.

This disables native Git deployments in `contacts/vercel.json` while preserving the standalone PWA config. Production Portal deployment remains owned by the canonical GitHub Actions lane from #1686.

Adds a focused regression ensuring Contacts cannot resume automatic Git deployments.