### PR TITLE
Deploy restored portal spinner

### DIFF
--- a/spinner-production-retry.txt
+++ b/spinner-production-retry.txt
@@ -1,1 +1,1 @@
-Owner PR trigger for the canonical production lane: publish the restored interactive spinner and inline Operator from current main to portal.3dvr.tech.
+Owner PR trigger for the canonical production lane: publish the restored interactive spinner and inline Operator from current main to portal.3dvr.tech. Synchronize trigger 2.

--- a/spinner-production-retry.txt
+++ b/spinner-production-retry.txt
@@ -1,1 +1,1 @@
-Owner PR trigger for the canonical production lane: publish the restored interactive spinner and inline Operator from current main to portal.3dvr.tech. Synchronize trigger 2.
+Owner PR trigger for the canonical production lane: publish the restored interactive spinner and inline Operator from current main to portal.3dvr.tech. Synchronize trigger 3 via registered CI.

--- a/spinner-production-retry.txt
+++ b/spinner-production-retry.txt
@@ -1,1 +1,1 @@
-Trigger the canonical GitHub Actions production lane so portal.3dvr.tech receives the restored interactive spinner and inline Operator from main.
+Owner PR trigger for the canonical production lane: publish the restored interactive spinner and inline Operator from current main to portal.3dvr.tech.


### PR DESCRIPTION
Owner-only production trigger. Deploy current main through the canonical prebuilt Vercel lane and verify the interactive spinner plus inline Operator at portal.3dvr.tech.