### PR TITLE
Persist home Operator conversations

### DIFF
--- a/home-operator.js
+++ b/home-operator.js
@@ -11,7 +11,93 @@ const followUps = document.querySelector('#homeOperatorFollowUps');
 const actionLink = document.querySelector('#homeOperatorAction');
 
 if (form && input && submit && status && result && reply && followUps && actionLink) {
+  const LEGACY_KEY = '3dvr.operator.history.v1';
+  const BASE_KEY = '3dvr.operator.conversations.v2';
+  const identity = window.AuthIdentity?.readSharedIdentity?.() || {};
+  const accountKey = localStorage.getItem('signedIn') === 'true'
+    ? String(localStorage.getItem('userPubKey') || identity.alias || localStorage.getItem('alias') || '').trim().toLowerCase()
+    : '';
+  const conversationStoreKey = accountKey
+    ? `${BASE_KEY}.account.${encodeURIComponent(accountKey)}`
+    : BASE_KEY;
+  const makeConversationId = () => globalThis.crypto?.randomUUID?.()
+    || `conversation-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const now = () => new Date().toISOString();
+
   let history = [];
+  let homeConversationId = '';
+  let homeConversationCreatedAt = '';
+
+  const readConversationStore = () => {
+    let store = { activeId: '', conversations: [] };
+
+    try {
+      const savedRaw = localStorage.getItem(conversationStoreKey)
+        || (conversationStoreKey !== BASE_KEY ? localStorage.getItem(BASE_KEY) : '')
+        || '';
+      const saved = JSON.parse(savedRaw || 'null');
+      if (saved && Array.isArray(saved.conversations)) {
+        store = {
+          activeId: String(saved.activeId || ''),
+          conversations: saved.conversations
+        };
+      } else {
+        const legacy = JSON.parse(localStorage.getItem(LEGACY_KEY) || '[]');
+        if (Array.isArray(legacy) && legacy.length) {
+          const migratedAt = now();
+          store = {
+            activeId: makeConversationId(),
+            conversations: [{
+              id: makeConversationId(),
+              createdAt: migratedAt,
+              updatedAt: migratedAt,
+              messages: legacy
+            }]
+          };
+          store.activeId = store.conversations[0].id;
+        }
+      }
+    } catch {
+      // A damaged local cache should never stop Operator from answering.
+    }
+
+    return store;
+  };
+
+  const persistHistory = () => {
+    if (!history.length) return;
+
+    if (!homeConversationId) {
+      homeConversationId = makeConversationId();
+      homeConversationCreatedAt = now();
+    }
+
+    const store = readConversationStore();
+    const updatedAt = now();
+    let conversation = store.conversations.find(item => item.id === homeConversationId);
+
+    if (!conversation) {
+      conversation = {
+        id: homeConversationId,
+        createdAt: homeConversationCreatedAt || updatedAt,
+        updatedAt,
+        messages: []
+      };
+      store.conversations.push(conversation);
+    }
+
+    conversation.messages = history.slice(-40);
+    conversation.updatedAt = updatedAt;
+    store.activeId = homeConversationId;
+    store.conversations = store.conversations
+      .filter(item => Array.isArray(item.messages) && item.messages.length)
+      .sort((a, b) => String(b.updatedAt || '').localeCompare(String(a.updatedAt || '')))
+      .slice(0, 50);
+
+    localStorage.setItem(conversationStoreKey, JSON.stringify(store));
+    if (conversationStoreKey !== BASE_KEY) localStorage.removeItem(BASE_KEY);
+    localStorage.removeItem(LEGACY_KEY);
+  };
 
   const installSubmitLoader = () => {
     if (submit.querySelector('.operator-submit__portal')) return;
@@ -157,6 +243,7 @@ if (form && input && submit && status && result && reply && followUps && actionL
 
     const prior = history.slice(-12);
     history.push({ role: 'user', content: prompt });
+    persistHistory();
     input.value = '';
     setBusy(true);
     status.textContent = 'Operator is working on this page…';
@@ -175,17 +262,27 @@ if (form && input && submit && status && result && reply && followUps && actionL
       }
 
       const message = [data.reply, outcome?.message].filter(Boolean).join('\n\n');
-      history.push({ role: 'assistant', content: message });
+      const suggestions = Array.isArray(data.suggestions) ? data.suggestions : [];
       const lifeSpaceActions = new Set(['create_note', 'create_checklist', 'save_link']);
-      const label = lifeSpaceActions.has(data.action?.type)
-        ? 'Open Life Space'
+      const storedActionLabel = lifeSpaceActions.has(data.action?.type)
+        ? 'Life Space'
         : data.action?.type === 'add_lead'
-          ? 'Open Lead Finder'
-          : 'Open workspace';
+          ? 'Lead Finder'
+          : 'workspace';
+      const label = storedActionLabel === 'workspace' ? 'Open workspace' : `Open ${storedActionLabel}`;
+
+      history.push({
+        role: 'assistant',
+        content: message,
+        suggestions,
+        actionUrl: outcome?.url || '',
+        actionLabel: storedActionLabel
+      });
+      persistHistory();
 
       renderResponse({
         message,
-        suggestions: Array.isArray(data.suggestions) ? data.suggestions : [],
+        suggestions,
         url: outcome?.url || '',
         label
       });
@@ -193,6 +290,7 @@ if (form && input && submit && status && result && reply && followUps && actionL
     } catch (error) {
       const message = `I could not finish that: ${error.message}`;
       history.push({ role: 'assistant', content: message });
+      persistHistory();
       renderResponse({ message });
       status.textContent = 'Operator needs another try.';
     } finally {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "playwright:verify:chrome-safari": "sh scripts/playwright/run-in-linux.sh playwright:verify:chrome-safari:linux",
     "vercel:alias-staging": "sh scripts/vercel/alias-staging-domains.sh",
     "playwright:ux:linux": "npm run playwright:install:linux && node scripts/playwright/ux-pass.mjs",
-    "playwright:ux": "sh scripts/playwright/run-in-linux.sh playwright:ux-pass.mjs"
+    "playwright:ux": "sh scripts/playwright/run-in-linux.sh playwright:ux:linux"
   },
   "dependencies": {
     "gun": "^0.2020.1241",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "playwright:install": "sh scripts/playwright/run-install.sh",
     "playwright:e2e:flaky:tests": "node --test tests/contacts-identity.e2e.test.js tests/billing-flow.e2e.test.js",
     "playwright:e2e:flaky:linux": "npm run playwright:install:linux && npm run playwright:e2e:flaky:tests",
-    "playwright:e2e:tests": "node --test tests/contacts-identity.e2e.test.js tests/contacts-score.e2e.test.js tests/crm-contacts-import.e2e.test.js tests/billing-flow.e2e.test.js tests/finance.e2e.test.js tests/sales-training-queue.e2e.test.js tests/sales-research-calendar.e2e.test.js",
+    "playwright:e2e:tests": "node --test tests/contacts-identity.e2e.test.js tests/contacts-score.e2e.test.js tests/crm-contacts-import.e2e.test.js tests/billing-flow.e2e.test.js tests/finance.e2e.test.js tests/home-operator-persistence.e2e.test.js tests/sales-training-queue.e2e.test.js tests/sales-research-calendar.e2e.test.js",
     "playwright:e2e:linux": "npm run playwright:install:linux && npm run playwright:e2e:tests",
     "playwright:e2e": "sh scripts/playwright/run-e2e.sh",
     "playwright:user-stories:tests": "node --test tests/crm-contacts-import.e2e.test.js tests/sales-research-calendar.e2e.test.js",
@@ -53,7 +53,7 @@
     "playwright:verify:chrome-safari": "sh scripts/playwright/run-in-linux.sh playwright:verify:chrome-safari:linux",
     "vercel:alias-staging": "sh scripts/vercel/alias-staging-domains.sh",
     "playwright:ux:linux": "npm run playwright:install:linux && node scripts/playwright/ux-pass.mjs",
-    "playwright:ux": "sh scripts/playwright/run-in-linux.sh playwright:ux:linux"
+    "playwright:ux": "sh scripts/playwright/run-in-linux.sh playwright:ux-pass.mjs"
   },
   "dependencies": {
     "gun": "^0.2020.1241",

--- a/tests/home-operator-persistence.e2e.test.js
+++ b/tests/home-operator-persistence.e2e.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { chromium } from 'playwright';
+
+const PORTAL_ORIGIN = process.env.PORTAL_ORIGIN || 'http://127.0.0.1:3011';
+
+test('home Operator conversation appears in Past conversations', async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  const prompt = 'Remember this homepage conversation for later.';
+  const responseText = 'This homepage conversation is saved.';
+
+  await page.route('**/api/openai-site?provider=operator', async route => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        reply: responseText,
+        suggestions: ['Continue this saved conversation.'],
+        action: { type: 'none' }
+      })
+    });
+  });
+
+  await page.goto(`${PORTAL_ORIGIN}/`);
+  await page.getByLabel('Ask Operator anything').fill(prompt);
+  await page.getByRole('button', { name: 'Send to Operator' }).click();
+  await page.getByText(responseText).waitFor();
+
+  const saved = await page.evaluate(() => JSON.parse(localStorage.getItem('3dvr.operator.conversations.v2') || 'null'));
+  assert.ok(saved, 'home Operator should create the shared conversation store');
+  assert.equal(saved.conversations.length, 1);
+  assert.equal(saved.conversations[0].messages[0].content, prompt);
+  assert.equal(saved.conversations[0].messages[1].content, responseText);
+  assert.equal(saved.activeId, saved.conversations[0].id);
+
+  await page.goto(`${PORTAL_ORIGIN}/operator/`);
+  await page.getByRole('button', { name: 'Past conversations' }).click();
+  const savedConversation = page.getByRole('button', { name: new RegExp(prompt.slice(0, 30)) });
+  await savedConversation.waitFor();
+  await savedConversation.click();
+  await page.locator('#operator-log').getByText(prompt).waitFor();
+  await page.locator('#operator-log').getByText(responseText).waitFor();
+
+  await browser.close();
+});

--- a/tests/home-operator-persistence.e2e.test.js
+++ b/tests/home-operator-persistence.e2e.test.js
@@ -27,7 +27,7 @@ before(async () => {
       const requestUrl = new URL(req.url, `http://${req.headers.host}`);
       let filePath = resolve(projectRoot, `.${requestUrl.pathname}`);
       if (requestUrl.pathname === '/' || requestUrl.pathname.endsWith('/')) {
-        filePath = resolve(filePath, requestUrl.pathname === '/' ? 'index.html' : 'index.html');
+        filePath = resolve(filePath, 'index.html');
       }
       const data = await readFile(filePath);
       const type = MIME_TYPES[extname(filePath).toLowerCase()] || 'application/octet-stream';

--- a/tests/home-operator-persistence.e2e.test.js
+++ b/tests/home-operator-persistence.e2e.test.js
@@ -1,8 +1,52 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import { after, before, test } from 'node:test';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { dirname, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
 
-const PORTAL_ORIGIN = process.env.PORTAL_ORIGIN || 'http://127.0.0.1:3011';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+const MIME_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.webmanifest': 'application/manifest+json'
+};
+
+let server;
+let baseUrl;
+
+before(async () => {
+  server = createServer(async (req, res) => {
+    try {
+      const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+      let filePath = resolve(projectRoot, `.${requestUrl.pathname}`);
+      if (requestUrl.pathname === '/' || requestUrl.pathname.endsWith('/')) {
+        filePath = resolve(filePath, requestUrl.pathname === '/' ? 'index.html' : 'index.html');
+      }
+      const data = await readFile(filePath);
+      const type = MIME_TYPES[extname(filePath).toLowerCase()] || 'application/octet-stream';
+      res.writeHead(200, { 'content-type': type });
+      res.end(data);
+    } catch {
+      res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Not found');
+    }
+  });
+
+  await new Promise(resolveServer => server.listen(0, '127.0.0.1', resolveServer));
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+after(async () => {
+  if (server) await new Promise(resolveServer => server.close(resolveServer));
+});
 
 test('home Operator conversation appears in Past conversations', { timeout: 45_000 }, async () => {
   const browser = await chromium.launch({ headless: true });
@@ -12,6 +56,11 @@ test('home Operator conversation appears in Past conversations', { timeout: 45_0
     const prompt = 'Remember this homepage conversation for later.';
     const responseText = 'This homepage conversation is saved.';
 
+    await page.route('**/*', route => {
+      const url = new URL(route.request().url());
+      if (url.hostname !== '127.0.0.1') return route.abort('blockedbyclient');
+      return route.continue();
+    });
     await page.route('**/api/openai-site?provider=operator', async route => {
       await route.fulfill({
         contentType: 'application/json',
@@ -23,7 +72,7 @@ test('home Operator conversation appears in Past conversations', { timeout: 45_0
       });
     });
 
-    await page.goto(`${PORTAL_ORIGIN}/`);
+    await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded' });
     await page.getByLabel('Ask Operator anything').fill(prompt);
     await page.getByRole('button', { name: 'Send to Operator' }).click();
     await page.getByText(responseText).waitFor();
@@ -35,7 +84,7 @@ test('home Operator conversation appears in Past conversations', { timeout: 45_0
     assert.equal(saved.conversations[0].messages[1].content, responseText);
     assert.equal(saved.activeId, saved.conversations[0].id);
 
-    await page.goto(`${PORTAL_ORIGIN}/operator/`);
+    await page.goto(`${baseUrl}/operator/`, { waitUntil: 'domcontentloaded' });
     await page.getByRole('button', { name: 'Past conversations' }).click();
     const savedConversation = page.getByRole('button', { name: new RegExp(prompt.slice(0, 30)) });
     await savedConversation.waitFor();

--- a/tests/home-operator-persistence.e2e.test.js
+++ b/tests/home-operator-persistence.e2e.test.js
@@ -4,42 +4,45 @@ import { chromium } from 'playwright';
 
 const PORTAL_ORIGIN = process.env.PORTAL_ORIGIN || 'http://127.0.0.1:3011';
 
-test('home Operator conversation appears in Past conversations', async () => {
+test('home Operator conversation appears in Past conversations', { timeout: 45_000 }, async () => {
   const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
-  const prompt = 'Remember this homepage conversation for later.';
-  const responseText = 'This homepage conversation is saved.';
 
-  await page.route('**/api/openai-site?provider=operator', async route => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify({
-        reply: responseText,
-        suggestions: ['Continue this saved conversation.'],
-        action: { type: 'none' }
-      })
+  try {
+    const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+    const prompt = 'Remember this homepage conversation for later.';
+    const responseText = 'This homepage conversation is saved.';
+
+    await page.route('**/api/openai-site?provider=operator', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reply: responseText,
+          suggestions: ['Continue this saved conversation.'],
+          action: { type: 'none' }
+        })
+      });
     });
-  });
 
-  await page.goto(`${PORTAL_ORIGIN}/`);
-  await page.getByLabel('Ask Operator anything').fill(prompt);
-  await page.getByRole('button', { name: 'Send to Operator' }).click();
-  await page.getByText(responseText).waitFor();
+    await page.goto(`${PORTAL_ORIGIN}/`);
+    await page.getByLabel('Ask Operator anything').fill(prompt);
+    await page.getByRole('button', { name: 'Send to Operator' }).click();
+    await page.getByText(responseText).waitFor();
 
-  const saved = await page.evaluate(() => JSON.parse(localStorage.getItem('3dvr.operator.conversations.v2') || 'null'));
-  assert.ok(saved, 'home Operator should create the shared conversation store');
-  assert.equal(saved.conversations.length, 1);
-  assert.equal(saved.conversations[0].messages[0].content, prompt);
-  assert.equal(saved.conversations[0].messages[1].content, responseText);
-  assert.equal(saved.activeId, saved.conversations[0].id);
+    const saved = await page.evaluate(() => JSON.parse(localStorage.getItem('3dvr.operator.conversations.v2') || 'null'));
+    assert.ok(saved, 'home Operator should create the shared conversation store');
+    assert.equal(saved.conversations.length, 1);
+    assert.equal(saved.conversations[0].messages[0].content, prompt);
+    assert.equal(saved.conversations[0].messages[1].content, responseText);
+    assert.equal(saved.activeId, saved.conversations[0].id);
 
-  await page.goto(`${PORTAL_ORIGIN}/operator/`);
-  await page.getByRole('button', { name: 'Past conversations' }).click();
-  const savedConversation = page.getByRole('button', { name: new RegExp(prompt.slice(0, 30)) });
-  await savedConversation.waitFor();
-  await savedConversation.click();
-  await page.locator('#operator-log').getByText(prompt).waitFor();
-  await page.locator('#operator-log').getByText(responseText).waitFor();
-
-  await browser.close();
+    await page.goto(`${PORTAL_ORIGIN}/operator/`);
+    await page.getByRole('button', { name: 'Past conversations' }).click();
+    const savedConversation = page.getByRole('button', { name: new RegExp(prompt.slice(0, 30)) });
+    await savedConversation.waitFor();
+    await savedConversation.click();
+    await page.locator('#operator-log').getByText(prompt).waitFor();
+    await page.locator('#operator-log').getByText(responseText).waitFor();
+  } finally {
+    await browser.close();
+  }
 });


### PR DESCRIPTION
Fix the homepage Operator so conversations started from `/` are saved into the same `3dvr.operator.conversations.v2` store used by `/operator/`. User messages are persisted immediately, replies retain suggestions/action metadata, account-scoped caches follow the existing naming convention, and legacy history is preserved during migration. Adds an E2E regression that sends from the homepage and verifies the thread appears under Past conversations in full Operator.