### PR TITLE
Add low-load 3DVR machine previews

### DIFF
--- a/.github/workflows/machine-preview.yml
+++ b/.github/workflows/machine-preview.yml
@@ -3,6 +3,7 @@ name: 3DVR Machine Preview
 on:
   push:
     branches:
+      - main
       - 'machine-preview/**'
   workflow_dispatch:
 
@@ -20,6 +21,7 @@ env:
 jobs:
   preview:
     name: Publish machine preview
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/heads/machine-preview/') || contains(github.event.head_commit.message, '[machine-preview]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 8
     defaults:

--- a/.github/workflows/machine-preview.yml
+++ b/.github/workflows/machine-preview.yml
@@ -1,0 +1,150 @@
+name: 3DVR Machine Preview
+
+on:
+  push:
+    branches:
+      - 'machine-preview/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: 3dvr-machine-preview
+  cancel-in-progress: true
+
+env:
+  MANAGED_OWNER_ALIAS: ${{ vars.THREEDVR_AGENT_TASK_OWNER_ALIAS || '3dvr-managed' }}
+
+jobs:
+  preview:
+    name: Publish machine preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    defaults:
+      run:
+        working-directory: apps/agent
+
+    steps:
+      - name: Checkout preview ref
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.0
+          cache: npm
+          cache-dependency-path: apps/agent/package-lock.json
+
+      - name: Install queue client
+        run: npm ci
+
+      - name: Queue low-load preview on 3DVR machine
+        id: remote
+        shell: bash
+        env:
+          PREVIEW_REF: ${{ github.ref_name }}
+          PREVIEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          printf -v task 'root="$(git rev-parse --show-toplevel)"; git -C "$root" fetch --force origin %q; script="$(mktemp)"; git -C "$root" show %q:scripts/ops/start-machine-preview.sh > "$script"; chmod +x "$script"; "$script" "$root" %q %q 4310; rm -f "$script"' \
+            "$PREVIEW_REF" "$PREVIEW_SHA" "$PREVIEW_REF" "$PREVIEW_SHA"
+
+          run_queue() {
+            local alias="$1"
+            local result task_id status summary preview_url
+
+            echo "Trying preview queue: $alias"
+            result="$(THREEDVR_AGENT_OWNER_ALIAS="$alias" node thomas-agent/node/agent-task-queue.js enqueue \
+              --json \
+              --backend shell \
+              --risk workspace_write \
+              --approval-status approved \
+              --unsafe \
+              --requires shell \
+              --max-runtime-ms 180000 \
+              "$task")"
+
+            task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
+            echo "Queued task: $task_id"
+
+            for attempt in $(seq 1 40); do
+              result="$(THREEDVR_AGENT_OWNER_ALIAS="$alias" node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+              status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
+              echo "Remote preview status: $status"
+
+              case "$status" in
+                completed)
+                  summary="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');process.stdout.write(JSON.parse(s.slice(i)).resultSummary||'')})")"
+                  printf '%s\n' "$summary"
+                  preview_url="$(printf '%s\n' "$summary" | sed -n 's/^PREVIEW_URL=//p' | head -n 1)"
+                  if [ -z "$preview_url" ]; then
+                    echo "Completed task did not return PREVIEW_URL." >&2
+                    return 1
+                  fi
+                  echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+                  echo "queue_alias=$alias" >> "$GITHUB_OUTPUT"
+                  echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
+                  return 0
+                  ;;
+                failed|skipped)
+                  printf '%s\n' "$result" >&2
+                  return 1
+                  ;;
+              esac
+              sleep 5
+            done
+
+            echo "Preview task timed out on queue $alias." >&2
+            return 1
+          }
+
+          if run_queue "$MANAGED_OWNER_ALIAS"; then
+            exit 0
+          fi
+
+          echo "::warning::Managed queue did not publish the preview; trying the legacy German worker queue once."
+          run_queue 'anonymous@3dvr'
+
+      - name: Publish preview status
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: ${{ steps.remote.outputs.preview_url }}
+          REMOTE_OUTCOME: ${{ steps.remote.outcome }}
+          PREVIEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          state=failure
+          description='3DVR machine preview failed'
+          target_url=''
+          if [ "$REMOTE_OUTCOME" = success ] && [ -n "$PREVIEW_URL" ]; then
+            state=success
+            description='3DVR machine preview ready'
+            target_url="$PREVIEW_URL"
+          fi
+
+          payload="$(STATE="$state" DESCRIPTION="$description" TARGET_URL="$target_url" node -e 'const p={state:process.env.STATE,context:"3DVR Machine Preview",description:process.env.DESCRIPTION};if(process.env.TARGET_URL)p.target_url=process.env.TARGET_URL;process.stdout.write(JSON.stringify(p))')"
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$PREVIEW_SHA" \
+            -d "$payload"
+
+          if [ "$state" = success ]; then
+            {
+              echo '## 3DVR Machine Preview'
+              echo
+              echo "Preview: $PREVIEW_URL"
+              echo
+              echo "Ref: $GITHUB_REF_NAME"
+              echo "SHA: $PREVIEW_SHA"
+              echo "Queue: ${{ steps.remote.outputs.queue_alias }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          [ "$state" = success ]

--- a/.github/workflows/machine-preview.yml
+++ b/.github/workflows/machine-preview.yml
@@ -30,6 +30,20 @@ jobs:
       - name: Checkout preview ref
         uses: actions/checkout@v4
 
+      - name: Mark preview pending
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$PREVIEW_SHA" \
+            -d '{"state":"pending","context":"3DVR Machine Preview","description":"Waiting for 3DVR machine preview"}'
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -70,7 +84,7 @@ jobs:
             task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
             echo "Queued task: $task_id"
 
-            for attempt in $(seq 1 40); do
+            for attempt in $(seq 1 18); do
               result="$(THREEDVR_AGENT_OWNER_ALIAS="$alias" node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
               status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
               echo "Remote preview status: $status"

--- a/ops/machine-preview-trigger.txt
+++ b/ops/machine-preview-trigger.txt
@@ -1,2 +1,0 @@
-Machine preview trigger for the homepage Operator history fix.
-Ref: machine-preview/operator-history

--- a/ops/machine-preview-trigger.txt
+++ b/ops/machine-preview-trigger.txt
@@ -1,0 +1,2 @@
+Machine preview trigger for the homepage Operator history fix.
+Ref: machine-preview/operator-history

--- a/scripts/ops/start-machine-preview.sh
+++ b/scripts/ops/start-machine-preview.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="${1:-}"
+ref="${2:-}"
+sha="${3:-}"
+port="${4:-4310}"
+
+if [ -z "$root" ] || [ ! -d "$root/.git" ]; then
+  echo "A valid 3DVR repository root is required." >&2
+  exit 2
+fi
+if [ -z "$ref" ] || [ -z "$sha" ]; then
+  echo "Usage: start-machine-preview.sh <repo-root> <ref> <sha> [port]" >&2
+  exit 2
+fi
+
+base="${THREEDVR_MACHINE_PREVIEW_DIR:-$HOME/.cache/3dvr-machine-preview}"
+release="$base/release"
+bin_dir="$base/bin"
+server_session="3dvr-machine-preview-server"
+tunnel_session="3dvr-machine-preview-tunnel"
+
+mkdir -p "$base" "$bin_dir"
+
+stop_slot() {
+  if command -v tmux >/dev/null 2>&1; then
+    tmux kill-session -t "$server_session" 2>/dev/null || true
+    tmux kill-session -t "$tunnel_session" 2>/dev/null || true
+  fi
+  for pid_file in "$base/server.pid" "$base/tunnel.pid"; do
+    if [ -f "$pid_file" ]; then
+      pid="$(cat "$pid_file" 2>/dev/null || true)"
+      if [ -n "$pid" ]; then
+        kill "$pid" 2>/dev/null || true
+      fi
+      rm -f "$pid_file"
+    fi
+  done
+}
+
+stop_slot
+rm -rf "$release"
+mkdir -p "$release"
+
+# Fetch only the requested ref, then export a clean tracked snapshot. Using
+# git archive keeps .git, local .env files, and other server-only state out of
+# the public preview tree.
+git -C "$root" fetch --force origin "$ref"
+git -C "$root" cat-file -e "$sha^{commit}"
+git -C "$root" archive "$sha" | tar -x -C "$release"
+
+: > "$base/server.log"
+: > "$base/tunnel.log"
+
+cat > "$base/server-run.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+cd '$release'
+exec env HOST=127.0.0.1 PORT='$port' node scripts/dev-server.mjs >>'$base/server.log' 2>&1
+EOF
+chmod +x "$base/server-run.sh"
+
+start_process() {
+  local session="$1"
+  local command_file="$2"
+  local pid_file="$3"
+  if command -v tmux >/dev/null 2>&1; then
+    tmux new-session -d -s "$session" "$command_file"
+  else
+    nohup "$command_file" >/dev/null 2>&1 </dev/null &
+    echo $! > "$pid_file"
+  fi
+}
+
+start_process "$server_session" "$base/server-run.sh" "$base/server.pid"
+
+server_ready=false
+for _ in $(seq 1 20); do
+  if curl -fsS "http://127.0.0.1:$port/" >/dev/null 2>&1; then
+    server_ready=true
+    break
+  fi
+  sleep 0.5
+done
+
+if [ "$server_ready" != true ]; then
+  echo "Preview server did not become ready." >&2
+  tail -n 80 "$base/server.log" >&2 || true
+  exit 3
+fi
+
+cloudflared="$(command -v cloudflared || true)"
+if [ -z "$cloudflared" ]; then
+  cloudflared="$bin_dir/cloudflared"
+  if [ ! -x "$cloudflared" ]; then
+    case "$(uname -m)" in
+      x86_64|amd64) cf_arch=amd64 ;;
+      aarch64|arm64) cf_arch=arm64 ;;
+      *) echo "Unsupported architecture for cloudflared: $(uname -m)" >&2; exit 4 ;;
+    esac
+    url="https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$cf_arch"
+    tmp="$cloudflared.tmp"
+    if command -v curl >/dev/null 2>&1; then
+      curl -fsSL --retry 3 --connect-timeout 10 "$url" -o "$tmp"
+    elif command -v wget >/dev/null 2>&1; then
+      wget -qO "$tmp" "$url"
+    else
+      echo "Neither curl nor wget is available to install cloudflared." >&2
+      exit 4
+    fi
+    chmod +x "$tmp"
+    mv "$tmp" "$cloudflared"
+  fi
+fi
+
+cat > "$base/tunnel-run.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec '$cloudflared' tunnel --no-autoupdate --url 'http://127.0.0.1:$port' >>'$base/tunnel.log' 2>&1
+EOF
+chmod +x "$base/tunnel-run.sh"
+start_process "$tunnel_session" "$base/tunnel-run.sh" "$base/tunnel.pid"
+
+preview_url=""
+for _ in $(seq 1 40); do
+  preview_url="$(grep -Eo 'https://[-a-z0-9]+\.trycloudflare\.com' "$base/tunnel.log" | tail -n 1 || true)"
+  if [ -n "$preview_url" ]; then
+    break
+  fi
+  sleep 0.5
+done
+
+if [ -z "$preview_url" ]; then
+  echo "Cloudflare preview tunnel did not publish a URL." >&2
+  tail -n 100 "$base/tunnel.log" >&2 || true
+  exit 5
+fi
+
+cat > "$base/current.env" <<EOF
+PREVIEW_URL=$preview_url
+PREVIEW_REF=$ref
+PREVIEW_SHA=$sha
+PREVIEW_PORT=$port
+EOF
+
+printf 'PREVIEW_URL=%s\n' "$preview_url"
+printf 'PREVIEW_REF=%s\n' "$ref"
+printf 'PREVIEW_SHA=%s\n' "$sha"
+printf 'PREVIEW_PORT=%s\n' "$port"
+printf 'PREVIEW_HOST=%s\n' "$(hostname)"
+printf 'LOAD=%s\n' "$(cut -d ' ' -f 1-3 /proc/loadavg 2>/dev/null || true)"
+printf 'MEMORY=%s\n' "$(free -h 2>/dev/null | awk '/^Mem:/{print $3 "/" $2}' || true)"


### PR DESCRIPTION
Superseded: current `main` independently landed the canonical low-load `machine-preview/**` workflow and preview runner in commit `b51e2a28021cbc631acc1c055742bdb57cd87380`. Closing this duplicate rather than merging an older-base copy.