### PR TITLE
Make 3DVR machine previews functional and verified

### DIFF
--- a/.github/workflows/machine-preview-tests.yml
+++ b/.github/workflows/machine-preview-tests.yml
@@ -1,0 +1,31 @@
+name: Machine Preview Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/preview-server.mjs'
+      - 'scripts/ops/start-machine-preview.sh'
+      - 'tests/machine-preview-server.test.js'
+      - '.github/workflows/machine-preview.yml'
+      - '.github/workflows/machine-preview-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Check preview scripts
+        run: |
+          node --check scripts/preview-server.mjs
+          bash -n scripts/ops/start-machine-preview.sh
+      - name: Run preview server regression test
+        run: node --test tests/machine-preview-server.test.js

--- a/.github/workflows/machine-preview.yml
+++ b/.github/workflows/machine-preview.yml
@@ -70,7 +70,7 @@ jobs:
             task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
             echo "Queued task: $task_id"
 
-            for attempt in $(seq 1 40); do
+            for attempt in $(seq 1 24); do
               result="$(THREEDVR_AGENT_OWNER_ALIAS="$alias" node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
               status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
               echo "Remote preview status: $status"
@@ -108,6 +108,57 @@ jobs:
           echo "::warning::Managed queue did not publish the preview; trying the legacy German worker queue once."
           run_queue 'anonymous@3dvr'
 
+      - name: Verify public preview from outside the machine
+        id: verify
+        if: steps.remote.outcome == 'success'
+        shell: bash
+        env:
+          PREVIEW_URL: ${{ steps.remote.outputs.preview_url }}
+          PREVIEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [ -n "$PREVIEW_URL" ]
+
+          curl -fsS \
+            --retry 10 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            --connect-timeout 5 \
+            --max-time 10 \
+            "$PREVIEW_URL/__3dvr-preview" > /tmp/3dvr-preview-health.json
+
+          HEALTH_FILE=/tmp/3dvr-preview-health.json EXPECTED_SHA="$PREVIEW_SHA" node - <<'NODE'
+          const { readFileSync } = require('node:fs');
+          const health = JSON.parse(readFileSync(process.env.HEALTH_FILE, 'utf8'));
+          if (!health.ok || health.sha !== process.env.EXPECTED_SHA) {
+            throw new Error(`Preview health mismatch: expected ${process.env.EXPECTED_SHA}, got ${health.sha || 'none'}`);
+          }
+          NODE
+
+          curl -fsS \
+            --retry 5 \
+            --retry-delay 1 \
+            --retry-all-errors \
+            --connect-timeout 5 \
+            --max-time 10 \
+            "$PREVIEW_URL/" > /tmp/3dvr-preview-home.html
+          grep -Fq 'home-operator.js' /tmp/3dvr-preview-home.html
+
+          curl -fsS \
+            --retry 5 \
+            --retry-delay 1 \
+            --retry-all-errors \
+            --connect-timeout 5 \
+            --max-time 10 \
+            "$PREVIEW_URL/home-operator.js" > /dev/null
+
+          operator_options_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+            --connect-timeout 5 \
+            --max-time 10 \
+            -X OPTIONS \
+            "$PREVIEW_URL/api/openai-site?provider=operator")"
+          [ "$operator_options_status" = '204' ]
+
       - name: Publish preview status
         if: always()
         shell: bash
@@ -115,16 +166,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PREVIEW_URL: ${{ steps.remote.outputs.preview_url }}
           REMOTE_OUTCOME: ${{ steps.remote.outcome }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
           PREVIEW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           state=failure
           description='3DVR machine preview failed'
           target_url=''
-          if [ "$REMOTE_OUTCOME" = success ] && [ -n "$PREVIEW_URL" ]; then
+          if [ "$REMOTE_OUTCOME" = success ] && [ "$VERIFY_OUTCOME" = success ] && [ -n "$PREVIEW_URL" ]; then
             state=success
-            description='3DVR machine preview ready'
+            description='3DVR machine preview ready and externally verified'
             target_url="$PREVIEW_URL"
+          elif [ "$REMOTE_OUTCOME" = success ]; then
+            description='3DVR machine preview tunnel failed external verification'
           fi
 
           payload="$(STATE="$state" DESCRIPTION="$description" TARGET_URL="$target_url" node -e 'const p={state:process.env.STATE,context:"3DVR Machine Preview",description:process.env.DESCRIPTION};if(process.env.TARGET_URL)p.target_url=process.env.TARGET_URL;process.stdout.write(JSON.stringify(p))')"
@@ -144,6 +198,7 @@ jobs:
               echo "Ref: $GITHUB_REF_NAME"
               echo "SHA: $PREVIEW_SHA"
               echo "Queue: ${{ steps.remote.outputs.queue_alias }}"
+              echo 'Verification: external health + homepage + Operator route'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/scripts/ops/start-machine-preview.sh
+++ b/scripts/ops/start-machine-preview.sh
@@ -57,7 +57,14 @@ cat > "$base/server-run.sh" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 cd '$release'
-exec env HOST=127.0.0.1 PORT='$port' node scripts/dev-server.mjs >>'$base/server.log' 2>&1
+exec env \
+  HOST=127.0.0.1 \
+  PORT='$port' \
+  PREVIEW_ROOT='$release' \
+  PREVIEW_REF='$ref' \
+  PREVIEW_SHA='$sha' \
+  PREVIEW_PRODUCTION_ORIGIN='https://portal.3dvr.tech' \
+  node --max-old-space-size=96 scripts/preview-server.mjs >>'$base/server.log' 2>&1
 EOF
 chmod +x "$base/server-run.sh"
 
@@ -77,7 +84,8 @@ start_process "$server_session" "$base/server-run.sh" "$base/server.pid"
 
 server_ready=false
 for _ in $(seq 1 20); do
-  if curl -fsS "http://127.0.0.1:$port/" >/dev/null 2>&1; then
+  health="$(curl -fsS "http://127.0.0.1:$port/__3dvr-preview" 2>/dev/null || true)"
+  if printf '%s' "$health" | grep -Fq "\"sha\":\"$sha\""; then
     server_ready=true
     break
   fi
@@ -85,7 +93,7 @@ for _ in $(seq 1 20); do
 done
 
 if [ "$server_ready" != true ]; then
-  echo "Preview server did not become ready." >&2
+  echo "Preview server did not become ready for $sha." >&2
   tail -n 80 "$base/server.log" >&2 || true
   exit 3
 fi

--- a/scripts/preview-server.mjs
+++ b/scripts/preview-server.mjs
@@ -1,0 +1,236 @@
+import { createServer } from 'node:http';
+import { access, readFile, stat } from 'node:fs/promises';
+import { extname, join, normalize, resolve } from 'node:path';
+
+const PORT = Number(process.env.PORT || 4310);
+const HOST = process.env.HOST || '127.0.0.1';
+const ROOT = resolve(process.env.PREVIEW_ROOT || process.cwd());
+const PREVIEW_SHA = String(process.env.PREVIEW_SHA || '').trim();
+const PREVIEW_REF = String(process.env.PREVIEW_REF || '').trim();
+const PRODUCTION_ORIGIN = String(process.env.PREVIEW_PRODUCTION_ORIGIN || 'https://portal.3dvr.tech').replace(/\/+$/, '');
+
+const MIME_TYPES = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.htm', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.webmanifest', 'application/manifest+json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.gif', 'image/gif'],
+  ['.webp', 'image/webp'],
+  ['.ico', 'image/x-icon'],
+  ['.woff', 'font/woff'],
+  ['.woff2', 'font/woff2'],
+  ['.txt', 'text/plain; charset=utf-8']
+]);
+
+function setPreviewHeaders(res) {
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('X-3DVR-Preview-Sha', PREVIEW_SHA);
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+}
+
+function json(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  setPreviewHeaders(res);
+  res.end(JSON.stringify(payload));
+}
+
+function safePath(pathname) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(pathname || '/');
+  } catch {
+    return null;
+  }
+
+  const clean = decoded
+    .replace(/^\/+/, '')
+    .replace(/\.\.(\/|\\|$)/g, '');
+  const candidate = normalize(join(ROOT, clean || 'index.html'));
+  return candidate.startsWith(ROOT) ? candidate : null;
+}
+
+async function findFile(pathname) {
+  const candidate = safePath(pathname === '/' ? '/index.html' : pathname);
+  if (!candidate) return null;
+
+  try {
+    const fileStat = await stat(candidate);
+    if (fileStat.isDirectory()) {
+      const indexPath = join(candidate, 'index.html');
+      await access(indexPath);
+      return {
+        path: indexPath,
+        redirect: pathname.endsWith('/') ? null : `${pathname}/`
+      };
+    }
+    return { path: candidate, redirect: null };
+  } catch {
+    const indexPath = join(candidate, 'index.html');
+    try {
+      await access(indexPath);
+      return {
+        path: indexPath,
+        redirect: pathname.endsWith('/') ? null : `${pathname}/`
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function readRequestBody(req, maxBytes = 1024 * 1024) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > maxBytes) {
+      const error = new Error('Preview request body too large');
+      error.statusCode = 413;
+      throw error;
+    }
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+function isOperatorApi(url) {
+  return url.pathname === '/api/openai-site' && url.searchParams.get('provider') === 'operator';
+}
+
+async function proxyOperatorApi(req, res, url) {
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    setPreviewHeaders(res);
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    json(res, 405, { error: 'Method Not Allowed' });
+    return;
+  }
+
+  let body;
+  try {
+    body = await readRequestBody(req);
+  } catch (error) {
+    json(res, error?.statusCode || 400, { error: error?.message || 'Invalid request body' });
+    return;
+  }
+
+  const upstreamUrl = new URL('/api/openai-site', `${PRODUCTION_ORIGIN}/`);
+  upstreamUrl.search = url.search;
+
+  let upstream;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': req.headers['content-type'] || 'application/json',
+        'Accept': req.headers.accept || 'application/json'
+      },
+      body
+    });
+  } catch (error) {
+    json(res, 502, { error: 'Production Operator API unavailable', detail: error?.message || String(error) });
+    return;
+  }
+
+  res.statusCode = upstream.status;
+  for (const headerName of ['content-type', 'cache-control']) {
+    const value = upstream.headers.get(headerName);
+    if (value) res.setHeader(headerName, value);
+  }
+  setPreviewHeaders(res);
+
+  if (!upstream.body) {
+    res.end();
+    return;
+  }
+
+  try {
+    const reader = upstream.body.getReader();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      res.write(Buffer.from(value));
+    }
+    res.end();
+  } catch (error) {
+    if (!res.headersSent) {
+      json(res, 502, { error: 'Failed while streaming Operator response' });
+    } else {
+      res.destroy(error);
+    }
+  }
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url || '/', `http://${req.headers.host || `${HOST}:${PORT}`}`);
+
+  if (url.pathname === '/__3dvr-preview') {
+    json(res, 200, {
+      ok: true,
+      sha: PREVIEW_SHA,
+      ref: PREVIEW_REF,
+      productionApi: PRODUCTION_ORIGIN
+    });
+    return;
+  }
+
+  if (url.pathname.startsWith('/api/')) {
+    if (isOperatorApi(url)) {
+      await proxyOperatorApi(req, res, url);
+      return;
+    }
+    json(res, 404, { error: 'API route is not enabled in machine previews' });
+    return;
+  }
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    json(res, 405, { error: 'Method Not Allowed' });
+    return;
+  }
+
+  const found = await findFile(url.pathname);
+  if (!found) {
+    res.statusCode = 404;
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    setPreviewHeaders(res);
+    res.end('Not found');
+    return;
+  }
+
+  if (found.redirect) {
+    res.statusCode = 308;
+    res.setHeader('Location', `${found.redirect}${url.search}`);
+    setPreviewHeaders(res);
+    res.end();
+    return;
+  }
+
+  try {
+    const body = await readFile(found.path);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', MIME_TYPES.get(extname(found.path).toLowerCase()) || 'application/octet-stream');
+    setPreviewHeaders(res);
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (error) {
+    json(res, 500, { error: error?.message || 'Failed to read preview file' });
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`3DVR preview ${PREVIEW_SHA || 'unknown'} running at http://${HOST}:${PORT}`);
+});

--- a/tests/machine-preview-server.test.js
+++ b/tests/machine-preview-server.test.js
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const previewServer = join(repoRoot, 'scripts', 'preview-server.mjs');
+
+async function listen(server) {
+  await new Promise((resolveListen, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  return server.address().port;
+}
+
+async function getFreePort() {
+  const server = createServer();
+  const port = await listen(server);
+  await new Promise(resolveClose => server.close(resolveClose));
+  return port;
+}
+
+async function waitFor(url, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise(resolveWait => setTimeout(resolveWait, 50));
+  }
+  throw lastError || new Error(`Timed out waiting for ${url}`);
+}
+
+test('machine preview serves branch files and only proxies Operator API', async t => {
+  const root = await mkdtemp(join(tmpdir(), '3dvr-preview-'));
+  await writeFile(join(root, 'index.html'), '<!doctype html><script src="/home-operator.js"></script>');
+  await writeFile(join(root, 'home-operator.js'), 'window.previewLoaded = true;');
+
+  const upstreamRequests = [];
+  const upstream = createServer(async (req, res) => {
+    const body = [];
+    for await (const chunk of req) body.push(chunk);
+    upstreamRequests.push({ url: req.url, method: req.method, body: Buffer.concat(body).toString('utf8') });
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify({ reply: 'preview operator ok' }));
+  });
+  const upstreamPort = await listen(upstream);
+  t.after(() => new Promise(resolveClose => upstream.close(resolveClose)));
+
+  const port = await getFreePort();
+  const sha = 'preview-test-sha';
+  const child = spawn(process.execPath, [previewServer], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      PORT: String(port),
+      PREVIEW_ROOT: root,
+      PREVIEW_SHA: sha,
+      PREVIEW_REF: 'machine-preview/test',
+      PREVIEW_PRODUCTION_ORIGIN: `http://127.0.0.1:${upstreamPort}`
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  t.after(async () => {
+    child.kill('SIGTERM');
+    await Promise.race([
+      new Promise(resolveExit => child.once('exit', resolveExit)),
+      new Promise(resolveTimeout => setTimeout(resolveTimeout, 1000))
+    ]);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const base = `http://127.0.0.1:${port}`;
+  const healthResponse = await waitFor(`${base}/__3dvr-preview`);
+  const health = await healthResponse.json();
+  assert.equal(health.ok, true);
+  assert.equal(health.sha, sha);
+  assert.equal(health.ref, 'machine-preview/test');
+
+  const home = await fetch(`${base}/`);
+  assert.equal(home.status, 200);
+  assert.match(await home.text(), /home-operator\.js/);
+  assert.equal(home.headers.get('x-3dvr-preview-sha'), sha);
+
+  const staticJs = await fetch(`${base}/home-operator.js`);
+  assert.equal(staticJs.status, 200);
+  assert.match(await staticJs.text(), /previewLoaded/);
+
+  const options = await fetch(`${base}/api/openai-site?provider=operator`, { method: 'OPTIONS' });
+  assert.equal(options.status, 204);
+
+  const operator = await fetch(`${base}/api/openai-site?provider=operator`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt: 'hello preview' })
+  });
+  assert.equal(operator.status, 200);
+  assert.deepEqual(await operator.json(), { reply: 'preview operator ok' });
+  assert.equal(upstreamRequests.length, 1);
+  assert.equal(upstreamRequests[0].method, 'POST');
+  assert.equal(upstreamRequests[0].url, '/api/openai-site?provider=operator');
+  assert.match(upstreamRequests[0].body, /hello preview/);
+
+  const blockedApi = await fetch(`${base}/api/session`);
+  assert.equal(blockedApi.status, 404);
+  assert.match((await blockedApi.json()).error, /not enabled/i);
+
+  const blockedPost = await fetch(`${base}/`, { method: 'POST' });
+  assert.equal(blockedPost.status, 405);
+});


### PR DESCRIPTION
Fixes the two issues found in review of the low-load machine preview lane.

- Adds a dedicated `scripts/preview-server.mjs` instead of using the generic static dev server.
- Keeps the preview snapshot static/low-load, but proxies only `/api/openai-site?provider=operator` to production so the homepage Operator still works.
- All other `/api/**` routes stay blocked in machine previews.
- Adds `/__3dvr-preview` with ref/SHA evidence.
- Keeps Node memory capped at 96 MB on the machine.
- Requires the GitHub runner to fetch the public Cloudflare tunnel, validate the exact SHA, load the homepage and JS, and verify the Operator route before posting a green preview status.
- Adds a focused regression test and syntax checks.

This does not restore the currently unreachable German worker; it makes the preview lane correct once a machine path is available again.