### PR TITLE
Run DigitalOcean preview recovery probe

### DIFF
--- a/ops/do-host-recovery-result.json
+++ b/ops/do-host-recovery-result.json
@@ -1,0 +1,12 @@
+{
+  "checkedAt": "2026-08-23T00:45:21.668010+00:00",
+  "sshKeyPresent": false,
+  "doTokenPresent": false,
+  "apiMatchedKnownHost": false,
+  "powerAction": "unavailable",
+  "port22": true,
+  "port80": true,
+  "port443": true,
+  "port4310": false,
+  "sshAuthenticated": false
+}

--- a/ops/do-host-recovery-trigger.txt
+++ b/ops/do-host-recovery-trigger.txt
@@ -1,1 +1,2 @@
 One-shot DigitalOcean preview host recovery probe.
+Synchronize after recovery workflow registration.

--- a/ops/do-host-recovery-trigger.txt
+++ b/ops/do-host-recovery-trigger.txt
@@ -1,2 +1,3 @@
 One-shot DigitalOcean preview host recovery probe.
 Synchronize after recovery workflow registration.
+Run with corrected probe workflow.

--- a/ops/do-host-recovery-trigger.txt
+++ b/ops/do-host-recovery-trigger.txt
@@ -1,0 +1,1 @@
+One-shot DigitalOcean preview host recovery probe.


### PR DESCRIPTION
One-shot same-repo trigger for the sanitized DigitalOcean preview-host recovery workflow. No production code changes; result is written back to this branch.