### PR TITLE
Run corrected DigitalOcean recovery probe

### DIFF
--- a/ops/do-host-recovery-result.json
+++ b/ops/do-host-recovery-result.json
@@ -1,0 +1,12 @@
+{
+  "checkedAt": "2026-08-23T00:45:54.994452+00:00",
+  "sshKeyPresent": false,
+  "doTokenPresent": false,
+  "apiMatchedKnownHost": false,
+  "powerAction": "unavailable",
+  "port22": true,
+  "port80": true,
+  "port443": true,
+  "port4310": false,
+  "sshAuthenticated": false
+}

--- a/ops/do-host-recovery-trigger.txt
+++ b/ops/do-host-recovery-trigger.txt
@@ -1,0 +1,1 @@
+Run corrected DigitalOcean preview-host recovery probe.


### PR DESCRIPTION
Fresh one-shot trigger based on the corrected recovery workflow now on main. No production code change; sanitized result is written back to this branch.