### PR TITLE
Probe current 3DVR machine control surfaces

### DIFF
--- a/ops/machine-control-probe-result.json
+++ b/ops/machine-control-probe-result.json
@@ -1,0 +1,30 @@
+{
+  "runnersApi": false,
+  "runnerCount": 0,
+  "onlineRunnerCount": 0,
+  "runnerLabels": [],
+  "codexDnsIp": "167.233.174.20",
+  "surfaces": [
+    {
+      "name": "do_http",
+      "httpCode": "200",
+      "server": "Caddy",
+      "authScheme": "",
+      "location": ""
+    },
+    {
+      "name": "do_https",
+      "httpCode": "000",
+      "server": "",
+      "authScheme": "",
+      "location": ""
+    },
+    {
+      "name": "codex_https",
+      "httpCode": "401",
+      "server": "Caddy",
+      "authScheme": "Basic",
+      "location": ""
+    }
+  ]
+}

--- a/ops/machine-control-probe-trigger.txt
+++ b/ops/machine-control-probe-trigger.txt
@@ -1,0 +1,1 @@
+Probe current 3DVR machine control surfaces.


### PR DESCRIPTION
One-shot sanitized probe for registered self-hosted runners and the currently documented DigitalOcean/Codex HTTPS surfaces. No production code changes.