### PR TITLE
Inspect public DigitalOcean Caddy surface

### DIFF
--- a/ops/do-public-edge-probe-result.json
+++ b/ops/do-public-edge-probe-result.json
@@ -1,0 +1,8 @@
+{
+  "url": "http://167.172.193.194/",
+  "title": "3DVR Static Test",
+  "visibleText": "3DVR Static Test 3DVR self-hosting test Static site is live. This page is served from /var/www/3dvr-test on the DigitalOcean server, through Caddy, without Vercel.",
+  "localLinks": [],
+  "optionsCode": "405",
+  "allowHeader": "GET, HEAD"
+}

--- a/ops/do-public-edge-probe-trigger.txt
+++ b/ops/do-public-edge-probe-trigger.txt
@@ -1,0 +1,1 @@
+Inspect the public Caddy surface on the current DigitalOcean host.


### PR DESCRIPTION
One-shot read-only probe of the public HTTP edge: title, visible text, local links, and OPTIONS/Allow metadata. No writes to the server.