### PR TITLE
Probe Caddy admin reachability

### DIFF
--- a/ops/caddy-admin-probe-result.json
+++ b/ops/caddy-admin-probe-result.json
@@ -1,0 +1,6 @@
+{
+  "port2019": false,
+  "configHttpCode": "000",
+  "topLevelKeys": [],
+  "httpServers": []
+}

--- a/ops/caddy-admin-probe-trigger.txt
+++ b/ops/caddy-admin-probe-trigger.txt
@@ -1,0 +1,1 @@
+Read-only probe of Caddy admin reachability.


### PR DESCRIPTION
One-shot read-only probe of the DigitalOcean Caddy admin API. It records only port reachability, HTTP status, top-level config keys, listen addresses, and route counts.