### PR TITLE
Probe existing Codex terminal authentication

### DIFF
--- a/ops/codex-auth-probe-result.json
+++ b/ops/codex-auth-probe-result.json
@@ -1,0 +1,7 @@
+{
+  "combinedAuthSecretPresent": false,
+  "usernameSecretPresent": false,
+  "passwordSecretPresent": false,
+  "authenticatedHttpCode": "000",
+  "authenticated": false
+}

--- a/ops/codex-auth-probe-trigger.txt
+++ b/ops/codex-auth-probe-trigger.txt
@@ -1,0 +1,1 @@
+Check whether existing repository secrets can authenticate to Codex Cloud.


### PR DESCRIPTION
One-shot sanitized check for repository secrets that can authenticate to the documented Codex Cloud Basic-auth endpoint. No credential values are logged or persisted.