### PR TITLE
Make portal spinner select by direction

### DIFF
--- a/operator/portal-context.js
+++ b/operator/portal-context.js
@@ -1,3 +1,4 @@
+import '../spinner-direction.js';
 import { openDatabase, loadState } from '../life-space/storage.js';
 
 const LEADS_KEY = '3dvr.leadFinder.prospects.v1';

--- a/spinner-direction.js
+++ b/spinner-direction.js
@@ -1,0 +1,179 @@
+const DEFAULT_SELECT_DISTANCE = 44;
+
+export function selectSpinnerDirection(dx, dy, minimumDistance = DEFAULT_SELECT_DISTANCE) {
+  const distance = Math.hypot(dx, dy);
+  if (distance < minimumDistance) return '';
+
+  if (Math.abs(dx) > Math.abs(dy)) return dx > 0 ? 'work' : 'apps';
+  return dy > 0 ? 'build' : 'day';
+}
+
+const documentRef = globalThis.document;
+
+if (documentRef) {
+  const spinner = documentRef.querySelector('[data-spinner-nav-toggle]');
+  const stage = spinner?.closest('[data-spinner-nav]');
+
+  if (spinner && stage) {
+    const ACTIVATE_DELAY_MS = 70;
+    const originalLabel = spinner.getAttribute('aria-label') || 'Interactive 3DVR portal spinner.';
+    const targets = {
+      day: stage.querySelector('.spinner-nav__item--day'),
+      work: stage.querySelector('.spinner-nav__item--work'),
+      build: stage.querySelector('.spinner-nav__item--build'),
+      apps: stage.querySelector('.spinner-nav__item--apps')
+    };
+    const labels = {
+      day: 'Day',
+      work: 'Work',
+      build: 'Build',
+      apps: 'Apps'
+    };
+
+    let gesture = null;
+    let currentSelection = '';
+
+    const style = documentRef.createElement('style');
+    style.dataset.spinnerDirectionStyles = 'true';
+    style.textContent = `
+      .spinner-stage[data-spin-selecting="true"]::before {
+        transform: scale(1.7);
+      }
+
+      .spinner-stage[data-spin-selecting="true"] .spinner-nav__item {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      .spinner-stage[data-spin-selecting="true"] .spinner-nav__item--day {
+        transform: translate(-50%, 0) scale(1);
+      }
+
+      .spinner-stage[data-spin-selecting="true"] .spinner-nav__item--work {
+        transform: translate(0, -50%) scale(1);
+      }
+
+      .spinner-stage[data-spin-selecting="true"] .spinner-nav__item--build {
+        transform: translate(-50%, 0) scale(1);
+      }
+
+      .spinner-stage[data-spin-selecting="true"] .spinner-nav__item--apps {
+        transform: translate(0, -50%) scale(1);
+      }
+
+      .spinner-nav__item[data-spinner-selected="true"] {
+        border-color: #7dd3fc;
+        background: linear-gradient(180deg, rgba(14, 116, 144, 0.98), rgba(15, 76, 92, 0.98));
+        color: #f0fdfa;
+        box-shadow:
+          0 0 0 2px rgba(125, 211, 252, 0.18),
+          0 0 28px rgba(45, 212, 191, 0.34),
+          0 14px 34px rgba(0, 0, 0, 0.34);
+      }
+    `;
+    documentRef.head.appendChild(style);
+
+    const setOpen = open => {
+      stage.dataset.open = String(Boolean(open));
+      spinner.setAttribute('aria-expanded', String(Boolean(open)));
+    };
+
+    const setSelection = selection => {
+      if (selection === currentSelection) return;
+      currentSelection = selection;
+      stage.dataset.spinSelection = selection || '';
+
+      for (const [key, target] of Object.entries(targets)) {
+        if (!target) continue;
+        if (key === selection) target.setAttribute('data-spinner-selected', 'true');
+        else target.removeAttribute('data-spinner-selected');
+      }
+
+      spinner.setAttribute(
+        'aria-label',
+        selection ? `Release to open ${labels[selection]}.` : originalLabel
+      );
+    };
+
+    const begin = event => {
+      if (event.isPrimary === false) return;
+      if (typeof event.button === 'number' && event.button !== 0) return;
+
+      gesture = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        wasOpen: stage.dataset.open === 'true',
+        engaged: false
+      };
+      setSelection('');
+    };
+
+    const update = event => {
+      if (!gesture) return;
+      if (gesture.pointerId != null && event.pointerId != null && event.pointerId !== gesture.pointerId) return;
+
+      const dx = event.clientX - gesture.startX;
+      const dy = event.clientY - gesture.startY;
+      const selection = selectSpinnerDirection(dx, dy);
+
+      if (selection) {
+        gesture.engaged = true;
+        stage.dataset.spinSelecting = 'true';
+        setOpen(true);
+      } else if (gesture.engaged) {
+        stage.dataset.spinSelecting = 'false';
+        if (!gesture.wasOpen) setOpen(false);
+      }
+
+      setSelection(selection);
+    };
+
+    const emitSelection = selection => {
+      globalThis.dispatchEvent?.(new CustomEvent('3dvr:spinner-select', {
+        detail: {
+          selection,
+          label: labels[selection],
+          href: targets[selection]?.getAttribute?.('href') || ''
+        }
+      }));
+    };
+
+    const activate = selection => {
+      const target = targets[selection];
+      if (!target) return;
+      emitSelection(selection);
+      globalThis.setTimeout(() => target.click(), ACTIVATE_DELAY_MS);
+    };
+
+    const finish = (event, cancelled = false) => {
+      if (!gesture) return;
+      if (gesture.pointerId != null && event?.pointerId != null && event.pointerId !== gesture.pointerId) return;
+
+      const activeGesture = gesture;
+      const dx = Number(event?.clientX ?? activeGesture.startX) - activeGesture.startX;
+      const dy = Number(event?.clientY ?? activeGesture.startY) - activeGesture.startY;
+      const selection = cancelled ? '' : selectSpinnerDirection(dx, dy);
+      gesture = null;
+      stage.dataset.spinSelecting = 'false';
+
+      if (selection) {
+        setOpen(true);
+        setSelection(selection);
+        activate(selection);
+        globalThis.setTimeout(() => setSelection(''), ACTIVATE_DELAY_MS + 180);
+        return;
+      }
+
+      setSelection('');
+      if (!activeGesture.wasOpen) setOpen(false);
+    };
+
+    spinner.addEventListener('pointerdown', begin);
+    spinner.addEventListener('pointermove', update);
+    spinner.addEventListener('pointerup', event => finish(event, false));
+    spinner.addEventListener('pointercancel', event => finish(event, true));
+    globalThis.addEventListener?.('pointerup', event => finish(event, false));
+    globalThis.addEventListener?.('pointercancel', event => finish(event, true));
+  }
+}

--- a/spinner-direction.js
+++ b/spinner-direction.js
@@ -166,7 +166,7 @@ if (documentRef) {
       }
 
       setSelection('');
-      if (!activeGesture.wasOpen) setOpen(false);
+      if (activeGesture.engaged && !activeGesture.wasOpen) setOpen(false);
     };
 
     spinner.addEventListener('pointerdown', begin);

--- a/tests/home-operator-persistence.e2e.test.js
+++ b/tests/home-operator-persistence.e2e.test.js
@@ -95,3 +95,53 @@ test('home Operator conversation appears in Past conversations', { timeout: 45_0
     await browser.close();
   }
 });
+
+test('portal spinner selects a direction on deliberate drag but keeps short drags playful', { timeout: 45_000 }, async () => {
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+    await page.route('**/*', route => {
+      const url = new URL(route.request().url());
+      if (url.hostname !== '127.0.0.1') return route.abort('blockedbyclient');
+      return route.continue();
+    });
+
+    await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded' });
+    const spinner = page.locator('[data-spinner-nav-toggle]');
+    await spinner.waitFor();
+    let box = await spinner.boundingBox();
+    assert.ok(box, 'spinner should have a pointer target');
+
+    const centerX = box.x + box.width / 2;
+    const centerY = box.y + box.height / 2;
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.down();
+    await page.mouse.move(centerX + 62, centerY, { steps: 6 });
+
+    const workTarget = page.locator('.spinner-nav__item--work');
+    assert.equal(await workTarget.getAttribute('data-spinner-selected'), 'true');
+    assert.equal(await spinner.getAttribute('aria-label'), 'Release to open Work.');
+
+    await page.mouse.up();
+    await page.waitForURL(url => new URL(url).pathname === '/growth-desk/');
+    assert.equal(new URL(page.url()).pathname, '/growth-desk/');
+
+    await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded' });
+    box = await page.locator('[data-spinner-nav-toggle]').boundingBox();
+    assert.ok(box, 'spinner should still be available after returning home');
+
+    const shortX = box.x + box.width / 2;
+    const shortY = box.y + box.height / 2;
+    await page.mouse.move(shortX, shortY);
+    await page.mouse.down();
+    await page.mouse.move(shortX + 24, shortY, { steps: 3 });
+    await page.mouse.up();
+    await page.waitForTimeout(180);
+
+    assert.equal(new URL(page.url()).pathname, '/');
+    assert.equal(await page.locator('.spinner-nav__item--work').getAttribute('data-spinner-selected'), null);
+  } finally {
+    await browser.close();
+  }
+});

--- a/tests/home-operator-persistence.e2e.test.js
+++ b/tests/home-operator-persistence.e2e.test.js
@@ -128,7 +128,8 @@ test('portal spinner selects a direction on deliberate drag but keeps short drag
     assert.equal(new URL(page.url()).pathname, '/growth-desk/');
 
     await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded' });
-    box = await page.locator('[data-spinner-nav-toggle]').boundingBox();
+    const homeSpinner = page.locator('[data-spinner-nav-toggle]');
+    box = await homeSpinner.boundingBox();
     assert.ok(box, 'spinner should still be available after returning home');
 
     const shortX = box.x + box.width / 2;
@@ -141,6 +142,10 @@ test('portal spinner selects a direction on deliberate drag but keeps short drag
 
     assert.equal(new URL(page.url()).pathname, '/');
     assert.equal(await page.locator('.spinner-nav__item--work').getAttribute('data-spinner-selected'), null);
+
+    await page.mouse.click(shortX, shortY);
+    await page.waitForFunction(() => document.querySelector('[data-spinner-nav]')?.dataset.open === 'true');
+    assert.equal(await homeSpinner.getAttribute('aria-expanded'), 'true');
   } finally {
     await browser.close();
   }

--- a/tests/spinner-direction-select.test.js
+++ b/tests/spinner-direction-select.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { selectSpinnerDirection } from '../spinner-direction.js';
+
+test('spinner directional selection maps cardinal drags to portal destinations', () => {
+  assert.equal(selectSpinnerDirection(0, -60), 'day');
+  assert.equal(selectSpinnerDirection(60, 0), 'work');
+  assert.equal(selectSpinnerDirection(0, 60), 'build');
+  assert.equal(selectSpinnerDirection(-60, 0), 'apps');
+});
+
+test('spinner directional selection follows the dominant drag axis', () => {
+  assert.equal(selectSpinnerDirection(70, -30), 'work');
+  assert.equal(selectSpinnerDirection(-72, 20), 'apps');
+  assert.equal(selectSpinnerDirection(22, -70), 'day');
+  assert.equal(selectSpinnerDirection(-18, 68), 'build');
+});
+
+test('spinner keeps short playful drags from navigating', () => {
+  assert.equal(selectSpinnerDirection(20, 20), '');
+  assert.equal(selectSpinnerDirection(43, 0), '');
+  assert.equal(selectSpinnerDirection(44, 0), 'work');
+});


### PR DESCRIPTION
Adds directional selection to the homepage portal wheel without replacing its existing 3D spin/tilt physics. Deliberate drags map up→Day, right→Work, down→Build, left→Apps; the matching target visibly locks on while dragging and activates on release. Short drags below 44px remain playful/non-navigating. Includes pure unit tests for thresholds and direction mapping.