### PR TITLE
Make portal spinner safer to play with

### DIFF
--- a/spinner-direction.js
+++ b/spinner-direction.js
@@ -1,4 +1,9 @@
 const DEFAULT_SELECT_DISTANCE = 44;
+const DEFAULT_MENU_DISTANCE = 18;
+const DEFAULT_HOLD_TO_ACTIVATE_MS = 650;
+const DEFAULT_STRONG_FLICK_DISTANCE = 150;
+const DEFAULT_STRONG_FLICK_MAX_MS = 190;
+const DEFAULT_STRONG_FLICK_SPEED = 0.9;
 
 export function selectSpinnerDirection(dx, dy, minimumDistance = DEFAULT_SELECT_DISTANCE) {
   const distance = Math.hypot(dx, dy);
@@ -6,6 +11,47 @@ export function selectSpinnerDirection(dx, dy, minimumDistance = DEFAULT_SELECT_
 
   if (Math.abs(dx) > Math.abs(dy)) return dx > 0 ? 'work' : 'apps';
   return dy > 0 ? 'build' : 'day';
+}
+
+export function classifySpinnerRelease({
+  dx = 0,
+  dy = 0,
+  durationMs = 0,
+  selectionHeldMs = 0,
+  cancelled = false
+} = {}, {
+  menuDistance = DEFAULT_MENU_DISTANCE,
+  selectDistance = DEFAULT_SELECT_DISTANCE,
+  holdToActivateMs = DEFAULT_HOLD_TO_ACTIVATE_MS,
+  strongFlickDistance = DEFAULT_STRONG_FLICK_DISTANCE,
+  strongFlickMaxMs = DEFAULT_STRONG_FLICK_MAX_MS,
+  strongFlickSpeed = DEFAULT_STRONG_FLICK_SPEED
+} = {}) {
+  const distance = Math.hypot(dx, dy);
+  const selection = cancelled ? '' : selectSpinnerDirection(dx, dy, selectDistance);
+  const speed = distance / Math.max(1, durationMs);
+
+  if (cancelled || distance < menuDistance) {
+    return { action: 'none', selection: '', reason: cancelled ? 'cancelled' : 'tiny', distance, speed };
+  }
+
+  if (!selection) {
+    return { action: 'menu', selection: '', reason: 'spin', distance, speed };
+  }
+
+  if (selectionHeldMs >= holdToActivateMs) {
+    return { action: 'activate', selection, reason: 'hold', distance, speed };
+  }
+
+  if (
+    distance >= strongFlickDistance
+    && durationMs <= strongFlickMaxMs
+    && speed >= strongFlickSpeed
+  ) {
+    return { action: 'activate', selection, reason: 'flick', distance, speed };
+  }
+
+  return { action: 'menu', selection, reason: 'spin', distance, speed };
 }
 
 const documentRef = globalThis.document;
@@ -16,6 +62,7 @@ if (documentRef) {
 
   if (spinner && stage) {
     const ACTIVATE_DELAY_MS = 70;
+    const SELECTION_FLASH_MS = 420;
     const originalLabel = spinner.getAttribute('aria-label') || 'Interactive 3DVR portal spinner.';
     const targets = {
       day: stage.querySelector('.spinner-nav__item--day'),
@@ -32,6 +79,10 @@ if (documentRef) {
 
     let gesture = null;
     let currentSelection = '';
+    let armed = false;
+    let armTimer = 0;
+
+    const now = () => globalThis.performance?.now?.() ?? Date.now();
 
     const style = documentRef.createElement('style');
     style.dataset.spinnerDirectionStyles = 'true';
@@ -63,11 +114,20 @@ if (documentRef) {
 
       .spinner-nav__item[data-spinner-selected="true"] {
         border-color: #7dd3fc;
-        background: linear-gradient(180deg, rgba(14, 116, 144, 0.98), rgba(15, 76, 92, 0.98));
+        background: linear-gradient(180deg, rgba(15, 76, 92, 0.98), rgba(13, 45, 63, 0.98));
         color: #f0fdfa;
         box-shadow:
-          0 0 0 2px rgba(125, 211, 252, 0.18),
-          0 0 28px rgba(45, 212, 191, 0.34),
+          0 0 0 2px rgba(125, 211, 252, 0.14),
+          0 0 22px rgba(45, 212, 191, 0.24),
+          0 14px 34px rgba(0, 0, 0, 0.34);
+      }
+
+      .spinner-nav__item[data-spinner-armed="true"] {
+        border-color: #fcd34d;
+        background: linear-gradient(180deg, rgba(14, 116, 144, 0.98), rgba(15, 76, 92, 0.98));
+        box-shadow:
+          0 0 0 3px rgba(252, 211, 77, 0.18),
+          0 0 34px rgba(45, 212, 191, 0.42),
           0 14px 34px rgba(0, 0, 0, 0.34);
       }
     `;
@@ -78,10 +138,52 @@ if (documentRef) {
       spinner.setAttribute('aria-expanded', String(Boolean(open)));
     };
 
+    const clearArmTimer = () => {
+      if (!armTimer) return;
+      globalThis.clearTimeout(armTimer);
+      armTimer = 0;
+    };
+
+    const updateAria = () => {
+      if (!currentSelection) {
+        spinner.setAttribute('aria-label', originalLabel);
+        return;
+      }
+
+      spinner.setAttribute(
+        'aria-label',
+        armed
+          ? `Release to open ${labels[currentSelection]}.`
+          : `${labels[currentSelection]} selected. Release for menu, or hold to open.`
+      );
+    };
+
+    const setArmed = value => {
+      armed = Boolean(value && currentSelection);
+      stage.dataset.spinArmed = String(armed);
+      for (const [key, target] of Object.entries(targets)) {
+        if (!target) continue;
+        if (armed && key === currentSelection) target.setAttribute('data-spinner-armed', 'true');
+        else target.removeAttribute('data-spinner-armed');
+      }
+      updateAria();
+    };
+
+    const scheduleArm = selection => {
+      clearArmTimer();
+      if (!selection || !gesture) return;
+      armTimer = globalThis.setTimeout(() => {
+        armTimer = 0;
+        if (!gesture || gesture.selection !== selection || currentSelection !== selection) return;
+        setArmed(true);
+      }, DEFAULT_HOLD_TO_ACTIVATE_MS);
+    };
+
     const setSelection = selection => {
       if (selection === currentSelection) return;
       currentSelection = selection;
       stage.dataset.spinSelection = selection || '';
+      setArmed(false);
 
       for (const [key, target] of Object.entries(targets)) {
         if (!target) continue;
@@ -89,22 +191,29 @@ if (documentRef) {
         else target.removeAttribute('data-spinner-selected');
       }
 
-      spinner.setAttribute(
-        'aria-label',
-        selection ? `Release to open ${labels[selection]}.` : originalLabel
-      );
+      if (gesture) {
+        gesture.selection = selection;
+        gesture.selectionSince = selection ? now() : 0;
+      }
+      scheduleArm(selection);
+      updateAria();
     };
 
     const begin = event => {
       if (event.isPrimary === false) return;
       if (typeof event.button === 'number' && event.button !== 0) return;
 
+      clearArmTimer();
+      setArmed(false);
       gesture = {
         pointerId: event.pointerId,
         startX: event.clientX,
         startY: event.clientY,
+        startedAt: now(),
         wasOpen: stage.dataset.open === 'true',
-        engaged: false
+        engaged: false,
+        selection: '',
+        selectionSince: 0
       };
       setSelection('');
     };
@@ -115,34 +224,33 @@ if (documentRef) {
 
       const dx = event.clientX - gesture.startX;
       const dy = event.clientY - gesture.startY;
+      const distance = Math.hypot(dx, dy);
       const selection = selectSpinnerDirection(dx, dy);
 
-      if (selection) {
+      if (distance >= DEFAULT_MENU_DISTANCE) {
         gesture.engaged = true;
         stage.dataset.spinSelecting = 'true';
         setOpen(true);
-      } else if (gesture.engaged) {
-        stage.dataset.spinSelecting = 'false';
-        if (!gesture.wasOpen) setOpen(false);
       }
 
       setSelection(selection);
     };
 
-    const emitSelection = selection => {
+    const emitSelection = (selection, reason) => {
       globalThis.dispatchEvent?.(new CustomEvent('3dvr:spinner-select', {
         detail: {
           selection,
           label: labels[selection],
-          href: targets[selection]?.getAttribute?.('href') || ''
+          href: targets[selection]?.getAttribute?.('href') || '',
+          reason
         }
       }));
     };
 
-    const activate = selection => {
+    const activate = (selection, reason) => {
       const target = targets[selection];
       if (!target) return;
-      emitSelection(selection);
+      emitSelection(selection, reason);
       globalThis.setTimeout(() => target.click(), ACTIVATE_DELAY_MS);
     };
 
@@ -151,22 +259,48 @@ if (documentRef) {
       if (gesture.pointerId != null && event?.pointerId != null && event.pointerId !== gesture.pointerId) return;
 
       const activeGesture = gesture;
+      const endedAt = now();
       const dx = Number(event?.clientX ?? activeGesture.startX) - activeGesture.startX;
       const dy = Number(event?.clientY ?? activeGesture.startY) - activeGesture.startY;
-      const selection = cancelled ? '' : selectSpinnerDirection(dx, dy);
-      gesture = null;
-      stage.dataset.spinSelecting = 'false';
+      const releaseSelection = cancelled ? '' : selectSpinnerDirection(dx, dy);
+      const selectionHeldMs = releaseSelection
+        && activeGesture.selection === releaseSelection
+        && activeGesture.selectionSince
+        ? endedAt - activeGesture.selectionSince
+        : 0;
+      const result = classifySpinnerRelease({
+        dx,
+        dy,
+        durationMs: endedAt - activeGesture.startedAt,
+        selectionHeldMs,
+        cancelled
+      });
 
-      if (selection) {
+      gesture = null;
+      clearArmTimer();
+      stage.dataset.spinSelecting = 'false';
+      setArmed(false);
+
+      if (result.action === 'activate' && result.selection) {
         setOpen(true);
-        setSelection(selection);
-        activate(selection);
-        globalThis.setTimeout(() => setSelection(''), ACTIVATE_DELAY_MS + 180);
+        setSelection(result.selection);
+        setArmed(true);
+        activate(result.selection, result.reason);
+        globalThis.setTimeout(() => {
+          setArmed(false);
+          setSelection('');
+        }, ACTIVATE_DELAY_MS + 180);
+        return;
+      }
+
+      if (result.action === 'menu') {
+        setOpen(true);
+        setSelection(result.selection);
+        globalThis.setTimeout(() => setSelection(''), SELECTION_FLASH_MS);
         return;
       }
 
       setSelection('');
-      if (activeGesture.engaged && !activeGesture.wasOpen) setOpen(false);
     };
 
     spinner.addEventListener('pointerdown', begin);

--- a/tests/home-operator-persistence.e2e.test.js
+++ b/tests/home-operator-persistence.e2e.test.js
@@ -96,7 +96,7 @@ test('home Operator conversation appears in Past conversations', { timeout: 45_0
   }
 });
 
-test('portal spinner selects a direction on deliberate drag but keeps short drags playful', { timeout: 45_000 }, async () => {
+test('portal spinner opens menu on normal spins and only activates after an intentional hold', { timeout: 45_000 }, async () => {
   const browser = await chromium.launch({ headless: true });
 
   try {
@@ -108,44 +108,66 @@ test('portal spinner selects a direction on deliberate drag but keeps short drag
     });
 
     await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded' });
-    const spinner = page.locator('[data-spinner-nav-toggle]');
+    let spinner = page.locator('[data-spinner-nav-toggle]');
     await spinner.waitFor();
     let box = await spinner.boundingBox();
     assert.ok(box, 'spinner should have a pointer target');
 
-    const centerX = box.x + box.width / 2;
-    const centerY = box.y + box.height / 2;
+    let centerX = box.x + box.width / 2;
+    let centerY = box.y + box.height / 2;
     await page.mouse.move(centerX, centerY);
     await page.mouse.down();
     await page.mouse.move(centerX + 62, centerY, { steps: 6 });
 
-    const workTarget = page.locator('.spinner-nav__item--work');
+    let workTarget = page.locator('.spinner-nav__item--work');
     assert.equal(await workTarget.getAttribute('data-spinner-selected'), 'true');
-    assert.equal(await spinner.getAttribute('aria-label'), 'Release to open Work.');
+    assert.equal(await spinner.getAttribute('aria-label'), 'Work selected. Release for menu, or hold to open.');
 
+    await page.mouse.up();
+    await page.waitForTimeout(160);
+    assert.equal(new URL(page.url()).pathname, '/');
+    assert.equal(await page.locator('[data-spinner-nav]').getAttribute('data-open'), 'true');
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    spinner = page.locator('[data-spinner-nav-toggle]');
+    box = await spinner.boundingBox();
+    assert.ok(box, 'spinner should still be available for a hold gesture');
+    centerX = box.x + box.width / 2;
+    centerY = box.y + box.height / 2;
+
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.down();
+    await page.mouse.move(centerX + 70, centerY, { steps: 6 });
+    workTarget = page.locator('.spinner-nav__item--work');
+    await page.waitForFunction(() => document.querySelector('.spinner-nav__item--work')?.dataset.spinnerArmed === 'true');
+    assert.equal(await spinner.getAttribute('aria-label'), 'Release to open Work.');
     await page.mouse.up();
     await page.waitForURL(url => new URL(url).pathname === '/growth-desk/');
-    assert.equal(new URL(page.url()).pathname, '/growth-desk/');
 
     await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded' });
-    const homeSpinner = page.locator('[data-spinner-nav-toggle]');
-    box = await homeSpinner.boundingBox();
-    assert.ok(box, 'spinner should still be available after returning home');
+    spinner = page.locator('[data-spinner-nav-toggle]');
+    box = await spinner.boundingBox();
+    assert.ok(box, 'spinner should still be available after navigation');
+    centerX = box.x + box.width / 2;
+    centerY = box.y + box.height / 2;
 
-    const shortX = box.x + box.width / 2;
-    const shortY = box.y + box.height / 2;
-    await page.mouse.move(shortX, shortY);
+    await page.mouse.move(centerX, centerY);
     await page.mouse.down();
-    await page.mouse.move(shortX + 24, shortY, { steps: 3 });
+    await page.mouse.move(centerX + 24, centerY, { steps: 3 });
     await page.mouse.up();
-    await page.waitForTimeout(180);
-
+    await page.waitForTimeout(120);
     assert.equal(new URL(page.url()).pathname, '/');
-    assert.equal(await page.locator('.spinner-nav__item--work').getAttribute('data-spinner-selected'), null);
+    assert.equal(await page.locator('[data-spinner-nav]').getAttribute('data-open'), 'true');
 
-    await page.mouse.click(shortX, shortY);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    spinner = page.locator('[data-spinner-nav-toggle]');
+    box = await spinner.boundingBox();
+    assert.ok(box, 'spinner should remain tappable');
+    centerX = box.x + box.width / 2;
+    centerY = box.y + box.height / 2;
+    await page.mouse.click(centerX, centerY);
     await page.waitForFunction(() => document.querySelector('[data-spinner-nav]')?.dataset.open === 'true');
-    assert.equal(await homeSpinner.getAttribute('aria-expanded'), 'true');
+    assert.equal(await spinner.getAttribute('aria-expanded'), 'true');
   } finally {
     await browser.close();
   }

--- a/tests/spinner-direction-select.test.js
+++ b/tests/spinner-direction-select.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { selectSpinnerDirection } from '../spinner-direction.js';
+import { classifySpinnerRelease, selectSpinnerDirection } from '../spinner-direction.js';
 
 test('spinner directional selection maps cardinal drags to portal destinations', () => {
   assert.equal(selectSpinnerDirection(0, -60), 'day');
@@ -16,8 +16,56 @@ test('spinner directional selection follows the dominant drag axis', () => {
   assert.equal(selectSpinnerDirection(-18, 68), 'build');
 });
 
-test('spinner keeps short playful drags from navigating', () => {
-  assert.equal(selectSpinnerDirection(20, 20), '');
-  assert.equal(selectSpinnerDirection(43, 0), '');
-  assert.equal(selectSpinnerDirection(44, 0), 'work');
+test('normal spins open the menu instead of navigating', () => {
+  assert.deepEqual(
+    classifySpinnerRelease({ dx: 62, dy: 0, durationMs: 260, selectionHeldMs: 80 }),
+    { action: 'menu', selection: 'work', reason: 'spin', distance: 62, speed: 62 / 260 }
+  );
+  assert.equal(classifySpinnerRelease({ dx: 24, dy: 0, durationMs: 140 }).action, 'menu');
+  assert.equal(classifySpinnerRelease({ dx: 10, dy: 0, durationMs: 120 }).action, 'none');
+});
+
+test('holding one direction deliberately arms app activation', () => {
+  const result = classifySpinnerRelease({
+    dx: 68,
+    dy: 0,
+    durationMs: 820,
+    selectionHeldMs: 690
+  });
+  assert.equal(result.action, 'activate');
+  assert.equal(result.selection, 'work');
+  assert.equal(result.reason, 'hold');
+
+  assert.equal(classifySpinnerRelease({
+    dx: 68,
+    dy: 0,
+    durationMs: 700,
+    selectionHeldMs: 520
+  }).action, 'menu');
+});
+
+test('only a very strong fast flick activates immediately', () => {
+  const strong = classifySpinnerRelease({
+    dx: 160,
+    dy: 0,
+    durationMs: 160,
+    selectionHeldMs: 20
+  });
+  assert.equal(strong.action, 'activate');
+  assert.equal(strong.reason, 'flick');
+  assert.equal(strong.selection, 'work');
+
+  assert.equal(classifySpinnerRelease({
+    dx: 160,
+    dy: 0,
+    durationMs: 420,
+    selectionHeldMs: 20
+  }).action, 'menu');
+
+  assert.equal(classifySpinnerRelease({
+    dx: 120,
+    dy: 0,
+    durationMs: 120,
+    selectionHeldMs: 20
+  }).action, 'menu');
 });


### PR DESCRIPTION
Changes spinner navigation so ordinary spins open the four-choice menu instead of immediately navigating. A direction only activates on release after being held steady for ~650ms, or via an intentionally extreme flick (>=150px, <=190ms, >=0.9 px/ms). Adds a distinct armed visual state and updates browser coverage so casual spins stay on the homepage.