### PR TITLE
Polish portal spinner into a regal gold 3DVR coin

### DIFF
--- a/portal-swirl-logo.js
+++ b/portal-swirl-logo.js
@@ -1,72 +1,38 @@
 (() => {
   const THREE_CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
   const TAU = Math.PI * 2;
-  const BASE_FACE_SPIN = TAU / 5200;
-  const DRAG_WIND_FACTOR = 0.00012;
-  const MAX_EXTRA_SPIN = 0.035;
-  const PULL_WINDUP_FACTOR = 0.00007;
-  const MAX_PULL_WINDUP_SPIN = 0.012;
-  const SPIN_DECAY = 0.995;
-  const FLIP_DECAY = 0.965;
-  const MIN_FLIP_VELOCITY = 0.005;
-  const TILT_X_LIMIT = 0.52;
-  const TILT_Y_LIMIT = 0.68;
-  const PULL_TILT_GAIN = 0.0042;
-  const TWIST_LIMIT = 0.045;
-  const TWIST_FACTOR = 0.0012;
-  const FLIP_DISTANCE_THRESHOLD = 42;
-  const FLIP_DISTANCE_FULL_CHARGE = 110;
-  const FLIP_STREAK_REQUIRED = 4;
-  const FLIP_ENERGY_DECAY = 0.4;
-  const FLIP_STREAK_WINDOW = 3200;
-  const SWIPE_STREAK_MAX = 5;
-  const SWIPE_TILT_GAIN = 0.2;
-  const SWIPE_SPIN_GAIN = 0.12;
-  const HOLD_PAUSE_DELAY_MS = 260;
-  const QUICK_TAP_MAX_MS = 280;
-  const QUICK_TAP_PULL_DISTANCE = 72;
-  const TOUCH_RAMP_WINDOW = 2400;
-  const TOUCH_RAMP_MAX = 6;
-  const FIRST_TOUCH_SPIN_SCALE = 0.38;
-  const TOUCH_SPIN_GAIN = 0.18;
-  const FIRST_TOUCH_WOBBLE_SCALE = 0.48;
-  const TOUCH_WOBBLE_GAIN = 0.32;
-  const FIRST_TOUCH_FLIP_SCALE = 0.74;
-  const TOUCH_FLIP_GAIN = 0.16;
-  const TOUCH_INSTABILITY_IMPULSE = 0.012;
-  const TOUCH_INSTABILITY_DECAY = 0.985;
-  const MAX_TOUCH_INSTABILITY = 0.075;
-  const MAX_FLIP_ENERGY = 1.15;
-  const FLIP_IMPULSE_X = 0.22;
-  const FLIP_IMPULSE_Y = 0.26;
-  const FLIP_CROSS_IMPULSE = 0.055;
-  const FLIP_SPIN_BOOST = 0.006;
-  const FLIP_BUILD_SPIN_STEP = 0.0025;
-  const FLIP_BUILD_IMPULSE_STEP = 0.024;
-  const FLIP_BUILD_WOBBLE_STEP = 0.026;
-  const TARGET_SETTLE_BASE = 0.965;
-  const CURRENT_SETTLE_BASE = 0.9;
-  const FLIP_HOME_EASE = 0.075;
-  const UPRIGHT_TEXT_HOME_EASE = 0.12;
-  const GOOD_FACE_STEP = Math.PI;
-  const UPRIGHT_TEXT_STEP = TAU;
-  const DRAG_WOBBLE_FACTOR = 0.0009;
-  const DRAG_TWIST_WOBBLE_FACTOR = 0.00042;
-  const DRAG_WOBBLE_STREAK_GAIN = 0.48;
-  const FLIP_WOBBLE_IMPULSE = 0.075;
-  const WOBBLE_SPRING = 0.12;
-  const WOBBLE_DECAY = 0.89;
-  const MAX_WOBBLE = 0.18;
-  const MAX_WOBBLE_Z = 0.09;
-  const SPARK_BURST_MAX = 18;
-  const SPARK_LIFETIME_MS = 720;
   const ROOT_SELECTOR = '[data-portal-swirl-logo]';
   const CANVAS_SELECTOR = '[data-portal-swirl-canvas]';
 
+  const BASE_FACE_SPIN = TAU / 5200;
+  const DRAG_SPIN_GAIN = 0.00012;
+  const MAX_EXTRA_SPIN = 0.04;
+  const SPIN_DECAY = 0.994;
+  const TILT_X_LIMIT = 0.52;
+  const TILT_Y_LIMIT = 0.68;
+  const TILT_GAIN = 0.0042;
+  const WOBBLE_DECAY = 0.9;
+  const WOBBLE_SPRING = 0.115;
+  const MAX_WOBBLE = 0.2;
+  const HOLD_PAUSE_DELAY_MS = 260;
+  const QUICK_TAP_MAX_MS = 280;
+  const COMBO_WINDOW_MS = 2400;
+  const COMBO_MAX = 8;
+  const SPARK_LIFETIME_MS = 760;
+  const SPARK_BURST_MAX = 28;
+
+  const GOLD = {
+    highlight: '#fff8bf',
+    light: '#ffe66a',
+    mid: '#f7bf24',
+    deep: '#d68a04',
+    shadow: '#7a4300',
+    ink: '#6e3d00',
+    cream: '#fff3b0',
+  };
+
   const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
   const lerp = (from, to, amount) => from + (to - from) * amount;
-  const nearestGoodFaceAngle = (angle) => Math.round(angle / GOOD_FACE_STEP) * GOOD_FACE_STEP;
-  const nearestUprightTextAngle = (angle) => Math.round(angle / UPRIGHT_TEXT_STEP) * UPRIGHT_TEXT_STEP;
 
   function loadThree() {
     if (window.THREE) return Promise.resolve(window.THREE);
@@ -89,174 +55,245 @@
     });
   }
 
-  function makeFaceTexture(THREE, mirrored = false) {
-    const textureCanvas = document.createElement('canvas');
+  function makeGoldFaceTexture(THREE, mirrored = false) {
+    const canvas = document.createElement('canvas');
     const size = 1024;
-    textureCanvas.width = size;
-    textureCanvas.height = size;
-    const context = textureCanvas.getContext('2d');
+    canvas.width = size;
+    canvas.height = size;
+    const context = canvas.getContext('2d');
     const center = size / 2;
-    const radius = size * 0.45;
+    const radius = size * 0.475;
 
-    const shell = context.createRadialGradient(center, center, radius * 0.08, center, center, size * 0.66);
-    shell.addColorStop(0, '#9de7f8');
-    shell.addColorStop(0.28, '#2aa7bf');
-    shell.addColorStop(0.62, '#0f766e');
-    shell.addColorStop(1, '#07111f');
+    context.clearRect(0, 0, size, size);
+
+    const shell = context.createRadialGradient(
+      center - radius * 0.28,
+      center - radius * 0.34,
+      radius * 0.03,
+      center,
+      center,
+      radius * 1.05,
+    );
+    shell.addColorStop(0, GOLD.highlight);
+    shell.addColorStop(0.16, GOLD.light);
+    shell.addColorStop(0.48, GOLD.mid);
+    shell.addColorStop(0.78, GOLD.deep);
+    shell.addColorStop(1, GOLD.shadow);
     context.fillStyle = shell;
     context.fillRect(0, 0, size, size);
 
     context.save();
     context.translate(center, center);
     if (mirrored) context.scale(-1, 1);
+
+    for (let ray = 0; ray < 72; ray += 1) {
+      const angle = (ray / 72) * TAU;
+      const inner = radius * 0.38;
+      const outer = radius * 0.88;
+      context.beginPath();
+      context.moveTo(Math.cos(angle) * inner, Math.sin(angle) * inner);
+      context.lineTo(Math.cos(angle) * outer, Math.sin(angle) * outer);
+      context.strokeStyle = ray % 2
+        ? 'rgba(255, 247, 180, 0.045)'
+        : 'rgba(112, 61, 0, 0.035)';
+      context.lineWidth = 5;
+      context.stroke();
+    }
+
     for (let arm = 0; arm < 7; arm += 1) {
       context.save();
       context.rotate((arm / 7) * TAU);
-      const gradient = context.createLinearGradient(0, 0, radius, radius * 0.32);
-      gradient.addColorStop(0, 'rgba(226, 246, 252, 0.58)');
-      gradient.addColorStop(0.5, 'rgba(125, 211, 252, 0.42)');
-      gradient.addColorStop(1, 'rgba(251, 191, 36, 0.24)');
+      const gradient = context.createLinearGradient(0, 0, radius, radius * 0.25);
+      gradient.addColorStop(0, 'rgba(255, 255, 224, 0.56)');
+      gradient.addColorStop(0.45, 'rgba(255, 225, 90, 0.42)');
+      gradient.addColorStop(1, 'rgba(125, 67, 0, 0.24)');
       context.strokeStyle = gradient;
-      context.lineWidth = 38;
+      context.lineWidth = 34;
       context.lineCap = 'round';
       context.beginPath();
-      for (let index = 0; index <= 88; index += 1) {
-        const progress = index / 88;
-        const angle = progress * TAU * 1.04;
-        const r = radius * (0.13 + progress * 0.72);
+      for (let index = 0; index <= 80; index += 1) {
+        const progress = index / 80;
+        const angle = progress * TAU * 0.94;
+        const r = radius * (0.12 + progress * 0.68);
         const x = Math.cos(angle) * r;
-        const y = Math.sin(angle) * r * 0.72;
+        const y = Math.sin(angle) * r * 0.76;
         if (index === 0) context.moveTo(x, y);
         else context.lineTo(x, y);
       }
       context.stroke();
       context.restore();
     }
-    context.restore();
 
     context.beginPath();
-    context.arc(center, center, radius * 0.97, 0, TAU);
-    context.strokeStyle = '#d8fff7';
-    context.lineWidth = 30;
+    context.arc(0, 0, radius * 0.9, 0, TAU);
+    context.strokeStyle = 'rgba(255, 250, 196, 0.9)';
+    context.lineWidth = 24;
     context.stroke();
 
     context.beginPath();
-    context.arc(center, center, radius * 0.74, 0, TAU);
-    context.strokeStyle = 'rgba(254, 215, 170, 0.74)';
+    context.arc(0, 0, radius * 0.79, 0, TAU);
+    context.strokeStyle = 'rgba(119, 63, 0, 0.34)';
+    context.lineWidth = 10;
+    context.stroke();
+
+    const centerMedallion = context.createRadialGradient(
+      -radius * 0.09,
+      -radius * 0.12,
+      radius * 0.02,
+      0,
+      0,
+      radius * 0.38,
+    );
+    centerMedallion.addColorStop(0, '#fffbd4');
+    centerMedallion.addColorStop(0.34, '#ffdd51');
+    centerMedallion.addColorStop(0.75, '#efa916');
+    centerMedallion.addColorStop(1, '#b76b00');
+    context.beginPath();
+    context.arc(0, 0, radius * 0.37, 0, TAU);
+    context.fillStyle = centerMedallion;
+    context.fill();
+    context.strokeStyle = 'rgba(255, 246, 174, 0.84)';
     context.lineWidth = 12;
     context.stroke();
 
-    context.beginPath();
-    context.arc(center, center, radius * 0.36, 0, TAU);
-    context.fillStyle = 'rgba(2, 6, 23, 0.72)';
-    context.fill();
-    context.strokeStyle = 'rgba(186, 230, 253, 0.38)';
-    context.lineWidth = 8;
-    context.stroke();
+    context.restore();
 
-    const texture = new THREE.CanvasTexture(textureCanvas);
+    const texture = new THREE.CanvasTexture(canvas);
     texture.center.set(0.5, 0.5);
     texture.anisotropy = 8;
     texture.needsUpdate = true;
     return texture;
   }
 
-  function makeTextTexture(THREE, mirrored = false) {
-    const textureCanvas = document.createElement('canvas');
+  function makeTextTexture(THREE) {
+    const canvas = document.createElement('canvas');
     const size = 1024;
-    textureCanvas.width = size;
-    textureCanvas.height = size;
-    const context = textureCanvas.getContext('2d');
+    canvas.width = size;
+    canvas.height = size;
+    const context = canvas.getContext('2d');
     const center = size / 2;
 
     context.clearRect(0, 0, size, size);
-    context.save();
-    context.translate(center, center);
-    if (mirrored) context.scale(-1, 1);
     context.textAlign = 'center';
     context.textBaseline = 'middle';
-    context.shadowColor = 'rgba(0, 0, 0, 0.55)';
-    context.shadowBlur = 28;
-    context.fillStyle = '#ffffff';
-    context.font = '900 142px Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
-    context.fillText('3dvr', 0, -22);
-    context.fillStyle = '#ccfbf1';
-    context.font = '850 82px Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
-    context.fillText('portal', 0, 104);
-    context.restore();
 
-    const texture = new THREE.CanvasTexture(textureCanvas);
+    context.shadowColor = 'rgba(91, 48, 0, 0.62)';
+    context.shadowBlur = 24;
+    context.shadowOffsetY = 14;
+    context.lineJoin = 'round';
+    context.lineWidth = 18;
+    context.strokeStyle = '#8a4c00';
+    context.fillStyle = '#fff7bf';
+    context.font = '950 178px Inter, ui-sans-serif, system-ui, sans-serif';
+    context.strokeText('3DVR', center, center - 26);
+    context.fillText('3DVR', center, center - 26);
+
+    context.shadowBlur = 14;
+    context.shadowOffsetY = 8;
+    context.lineWidth = 10;
+    context.strokeStyle = '#9b5900';
+    context.fillStyle = '#ffe174';
+    context.font = '900 72px Inter, ui-sans-serif, system-ui, sans-serif';
+    context.strokeText('PORTAL', center, center + 126);
+    context.fillText('PORTAL', center, center + 126);
+
+    const texture = new THREE.CanvasTexture(canvas);
     texture.anisotropy = 8;
     texture.needsUpdate = true;
     return texture;
   }
 
-  function createPortalToken(THREE) {
+  function createPortalCoin(THREE) {
     const group = new THREE.Group();
-    const frontFaceTexture = makeFaceTexture(THREE, false);
-    const backFaceTexture = makeFaceTexture(THREE, true);
-    const sideMaterial = new THREE.MeshStandardMaterial({
-      color: 0x0f8f8f,
-      metalness: 0.68,
-      roughness: 0.26,
+    const frontFaceTexture = makeGoldFaceTexture(THREE, false);
+    const backFaceTexture = makeGoldFaceTexture(THREE, true);
+
+    const edgeMaterial = new THREE.MeshStandardMaterial({
+      color: 0xd88c08,
+      metalness: 0.94,
+      roughness: 0.16,
     });
-    const frontMaterial = new THREE.MeshStandardMaterial({
+
+    const faceMaterialFront = new THREE.MeshStandardMaterial({
       map: frontFaceTexture,
-      metalness: 0.4,
-      roughness: 0.22,
+      color: 0xffffff,
+      metalness: 0.78,
+      roughness: 0.2,
     });
-    const backMaterial = new THREE.MeshStandardMaterial({
+
+    const faceMaterialBack = new THREE.MeshStandardMaterial({
       map: backFaceTexture,
-      metalness: 0.42,
-      roughness: 0.26,
+      color: 0xffffff,
+      metalness: 0.8,
+      roughness: 0.22,
     });
 
     const body = new THREE.Mesh(
       new THREE.CylinderGeometry(1.45, 1.45, 0.34, 128, 1, false),
-      [sideMaterial, frontMaterial, backMaterial],
+      [edgeMaterial, faceMaterialFront, faceMaterialBack],
     );
     body.rotation.x = Math.PI / 2;
     group.add(body);
 
     const rimMaterial = new THREE.MeshStandardMaterial({
-      color: 0xfed7aa,
-      metalness: 0.82,
-      roughness: 0.18,
+      color: 0xffd23f,
+      metalness: 0.98,
+      roughness: 0.1,
     });
-    const frontRim = new THREE.Mesh(new THREE.TorusGeometry(1.47, 0.04, 16, 128), rimMaterial);
-    frontRim.position.z = 0.185;
+
+    const rimGeometry = new THREE.TorusGeometry(1.46, 0.055, 18, 128);
+    const frontRim = new THREE.Mesh(rimGeometry, rimMaterial);
+    frontRim.position.z = 0.19;
     group.add(frontRim);
 
     const backRim = frontRim.clone();
-    backRim.position.z = -0.185;
+    backRim.position.z = -0.19;
     group.add(backRim);
 
-    const textGeometry = new THREE.PlaneGeometry(2.22, 2.22);
-    const frontText = new THREE.Mesh(
-      textGeometry,
-      new THREE.MeshBasicMaterial({
-        map: makeTextTexture(THREE, false),
-        transparent: true,
-        depthWrite: false,
-      }),
-    );
-    frontText.position.z = 0.225;
+    const innerRingGeometry = new THREE.TorusGeometry(1.16, 0.018, 10, 128);
+    const innerRingMaterial = new THREE.MeshStandardMaterial({
+      color: 0xffef8b,
+      metalness: 0.95,
+      roughness: 0.12,
+    });
+    const frontInnerRing = new THREE.Mesh(innerRingGeometry, innerRingMaterial);
+    frontInnerRing.position.z = 0.205;
+    group.add(frontInnerRing);
+    const backInnerRing = frontInnerRing.clone();
+    backInnerRing.position.z = -0.205;
+    group.add(backInnerRing);
+
+    const reedMaterial = new THREE.MeshStandardMaterial({
+      color: 0xffc62e,
+      metalness: 0.92,
+      roughness: 0.21,
+    });
+    for (let index = 0; index < 36; index += 1) {
+      const angle = (index / 36) * TAU;
+      const reed = new THREE.Mesh(new THREE.BoxGeometry(0.018, 0.2, 0.045), reedMaterial);
+      reed.position.set(Math.cos(angle) * 1.455, Math.sin(angle) * 1.455, 0);
+      reed.rotation.z = angle;
+      group.add(reed);
+    }
+
+    const textTexture = makeTextTexture(THREE);
+    const textMaterial = new THREE.MeshBasicMaterial({
+      map: textTexture,
+      transparent: true,
+      depthWrite: false,
+      opacity: 0.98,
+    });
+    const textGeometry = new THREE.PlaneGeometry(2.2, 2.2);
+    const frontText = new THREE.Mesh(textGeometry, textMaterial);
+    frontText.position.z = 0.23;
     group.add(frontText);
 
-    const backText = new THREE.Mesh(
-      textGeometry,
-      new THREE.MeshBasicMaterial({
-        map: makeTextTexture(THREE, false),
-        transparent: true,
-        depthWrite: false,
-      }),
-    );
-    backText.position.z = -0.225;
+    const backText = new THREE.Mesh(textGeometry, textMaterial.clone());
+    backText.position.z = -0.23;
     backText.rotation.y = Math.PI;
     group.add(backText);
 
     group.userData.faceTextures = [frontFaceTexture, backFaceTexture];
-
     return group;
   }
 
@@ -264,7 +301,7 @@
     const canvas = root.querySelector(CANVAS_SELECTOR);
     if (!canvas) return null;
 
-    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
     const state = {
       ready: false,
       mode: 'initializing',
@@ -273,56 +310,41 @@
       pointerMoved: false,
       lastX: 0,
       lastY: 0,
-      dragDX: 0,
-      dragDY: 0,
       gestureDX: 0,
       gestureDY: 0,
       dragStartedAt: 0,
       lastPointerDownDuration: 0,
-      lastTapStimulatedAt: 0,
       holdPauseTimer: 0,
       lastTimestamp: 0,
       faceSpin: 0,
       extraFaceSpin: 0,
-      pullWindupSpin: 0,
       targetX: 0,
       targetY: 0,
       targetZ: 0,
       currentX: 0,
       currentY: 0,
       currentZ: 0,
-      flipX: 0,
-      flipY: 0,
-      flipVelocityX: 0,
-      flipVelocityY: 0,
-      flipStreakAxis: '',
-      flipStreakDirection: 0,
-      flipStreakCount: 0,
-      flipStreakEnergy: 0,
-      lastFlipGestureAt: 0,
-      swipeStreakAxis: '',
-      swipeStreakDirection: 0,
-      swipeStreakCount: 0,
-      lastSwipeAt: 0,
-      touchRampCount: 0,
-      lastTouchRampAt: 0,
-      touchInstability: 0,
       wobbleX: 0,
       wobbleY: 0,
       wobbleZ: 0,
       wobbleVelocityX: 0,
       wobbleVelocityY: 0,
       wobbleVelocityZ: 0,
+      comboCount: 0,
+      lastMagicAt: 0,
+      magicLevel: 0,
       renderer: null,
       scene: null,
       camera: null,
       token: null,
       fallbackContext: null,
       sparkLayer: null,
+      halo: null,
       frame: 0,
     };
 
     const getRect = () => root.getBoundingClientRect();
+    const now = () => window.performance?.now?.() ?? Date.now();
 
     const resize = () => {
       const rect = getRect();
@@ -345,53 +367,29 @@
       }
     };
 
-    const getPointer = (event) => {
-      const rect = getRect();
-      return {
-        x: event.clientX - rect.left,
-        y: event.clientY - rect.top,
-        rect,
-      };
-    };
-
-    const capturePointer = (event) => {
-      if (event.pointerId == null || !root.setPointerCapture) return;
-      try {
-        root.setPointerCapture(event.pointerId);
-      } catch {
-        // Synthetic smoke-test events and older browsers can reject capture.
-      }
-    };
-
-    const releasePointer = (event) => {
-      if (event.pointerId == null || !root.releasePointerCapture) return;
-      try {
-        root.releasePointerCapture(event.pointerId);
-      } catch {
-        // Pointer capture is optional; release behavior should never block settling.
-      }
-    };
-
-    const setPaused = (paused) => {
+    const setPaused = paused => {
       state.paused = Boolean(paused);
       root.dataset.logoPaused = String(state.paused);
     };
 
-    const clearHoldPauseTimer = () => {
-      if (!state.holdPauseTimer) return;
-      window.clearTimeout(state.holdPauseTimer);
-      state.holdPauseTimer = 0;
+    const capturePointer = event => {
+      if (event.pointerId == null || !root.setPointerCapture) return;
+      try { root.setPointerCapture(event.pointerId); } catch {}
     };
 
-    const ensureSparkLayer = () => {
+    const releasePointer = event => {
+      if (event.pointerId == null || !root.releasePointerCapture) return;
+      try { root.releasePointerCapture(event.pointerId); } catch {}
+    };
+
+    const ensureMagicLayer = () => {
       if (state.sparkLayer) return state.sparkLayer;
       const layer = document.createElement('span');
       layer.setAttribute('aria-hidden', 'true');
       Object.assign(layer.style, {
         position: 'absolute',
-        inset: '-10%',
-        overflow: 'hidden',
-        borderRadius: '50%',
+        inset: '-18%',
+        overflow: 'visible',
         pointerEvents: 'none',
         zIndex: '3',
       });
@@ -400,302 +398,184 @@
       return layer;
     };
 
-    const spawnSparks = (count = 6, intensity = 1) => {
-      const layer = ensureSparkLayer();
+    const ensureHalo = () => {
+      if (state.halo) return state.halo;
+      const halo = document.createElement('span');
+      halo.setAttribute('aria-hidden', 'true');
+      Object.assign(halo.style, {
+        position: 'absolute',
+        inset: '7%',
+        borderRadius: '50%',
+        border: '2px solid rgba(255, 228, 103, 0.7)',
+        boxShadow: '0 0 24px rgba(255, 199, 50, 0.28), inset 0 0 20px rgba(255, 239, 151, 0.2)',
+        opacity: '0',
+        transform: 'scale(0.82)',
+        transition: 'transform 420ms cubic-bezier(.16,1,.3,1), opacity 420ms ease-out',
+        pointerEvents: 'none',
+        zIndex: '1',
+      });
+      root.appendChild(halo);
+      state.halo = halo;
+      return halo;
+    };
+
+    const pulseHalo = (strength = 1) => {
+      if (reducedMotion) return;
+      const halo = ensureHalo();
+      halo.style.opacity = String(clamp(0.28 + strength * 0.15, 0, 0.82));
+      halo.style.transform = `scale(${0.9 + strength * 0.09})`;
+      window.setTimeout(() => {
+        halo.style.opacity = '0';
+        halo.style.transform = 'scale(1.42)';
+      }, 30);
+    };
+
+    const spawnSparks = (count = 7, intensity = 1, stars = false) => {
+      if (reducedMotion) return;
+      const layer = ensureMagicLayer();
       const rect = getRect();
       const size = Math.max(2, Math.min(rect.width, rect.height));
       const burstCount = Math.min(count, SPARK_BURST_MAX);
 
       for (let index = 0; index < burstCount; index += 1) {
         const spark = document.createElement('span');
-        spark.dataset.portalSpark = 'true';
         const angle = Math.random() * TAU;
-        const distance = size * (0.18 + Math.random() * 0.24) * intensity;
-        const sparkSize = 2 + Math.random() * 3.5 * intensity;
-        const hue = 38 + Math.random() * 34;
+        const distance = size * (0.18 + Math.random() * 0.36) * intensity;
+        const sparkSize = 2.5 + Math.random() * 4 * intensity;
+        const lifetime = SPARK_LIFETIME_MS + Math.random() * 180;
+        spark.dataset.portalSpark = 'true';
+        spark.textContent = stars && index % 3 === 0 ? '✦' : '';
         Object.assign(spark.style, {
           position: 'absolute',
           left: '50%',
           top: '50%',
-          width: `${sparkSize}px`,
-          height: `${sparkSize}px`,
+          width: stars && index % 3 === 0 ? 'auto' : `${sparkSize}px`,
+          height: stars && index % 3 === 0 ? 'auto' : `${sparkSize}px`,
           borderRadius: '999px',
-          background: `hsl(${hue} 95% 64%)`,
-          boxShadow: `0 0 ${8 + sparkSize * 2}px hsl(${hue} 95% 58% / 0.8)`,
-          opacity: '0.9',
-          transform: 'translate(-50%, -50%) scale(0.8)',
-          transition: `transform ${SPARK_LIFETIME_MS}ms cubic-bezier(0.16, 1, 0.3, 1), opacity ${SPARK_LIFETIME_MS}ms ease-out`,
+          background: stars && index % 3 === 0 ? 'transparent' : GOLD.light,
+          color: GOLD.highlight,
+          fontSize: `${8 + sparkSize * 2}px`,
+          lineHeight: '1',
+          textShadow: '0 0 9px rgba(255, 214, 65, 0.9)',
+          boxShadow: stars && index % 3 === 0 ? 'none' : `0 0 ${9 + sparkSize * 2}px rgba(255, 196, 34, 0.9)`,
+          opacity: '0.96',
+          transform: 'translate(-50%, -50%) scale(0.75) rotate(0deg)',
+          transition: `transform ${lifetime}ms cubic-bezier(.16,1,.3,1), opacity ${lifetime}ms ease-out`,
         });
         layer.appendChild(spark);
         window.requestAnimationFrame(() => {
-          spark.style.transform = `translate(calc(-50% + ${Math.cos(angle) * distance}px), calc(-50% + ${Math.sin(angle) * distance}px)) scale(0.18)`;
+          spark.style.transform = `translate(calc(-50% + ${Math.cos(angle) * distance}px), calc(-50% + ${Math.sin(angle) * distance}px)) scale(0.12) rotate(${120 + Math.random() * 260}deg)`;
           spark.style.opacity = '0';
         });
-        window.setTimeout(() => spark.remove(), SPARK_LIFETIME_MS + 80);
+        window.setTimeout(() => spark.remove(), lifetime + 100);
       }
     };
 
-    const getGesture = () => {
-      const absX = Math.abs(state.gestureDX);
-      const absY = Math.abs(state.gestureDY);
-      const axis = absX >= absY ? 'y' : 'x';
-      const distance = Math.max(absX, absY);
-      const direction = axis === 'y' ? Math.sign(state.gestureDX) : Math.sign(state.gestureDY);
-
-      return { axis, direction, distance };
-    };
-
-    const getActiveSwipeStreakCount = () => {
-      const { axis, direction, distance } = getGesture();
-      if (!direction || distance < 8) return state.swipeStreakCount;
-
-      return state.swipeStreakAxis === axis && state.swipeStreakDirection === direction
-        ? state.swipeStreakCount
-        : 0;
-    };
-
-    const getSwipeBoost = () => 1 + Math.min(getActiveSwipeStreakCount(), SWIPE_STREAK_MAX) * SWIPE_TILT_GAIN;
-    const getSpinBoost = () => 1 + Math.min(getActiveSwipeStreakCount(), SWIPE_STREAK_MAX) * SWIPE_SPIN_GAIN;
-    const getTouchRampLevel = () => Math.max(0, state.touchRampCount - 1);
-    const getTouchSpinScale = () => FIRST_TOUCH_SPIN_SCALE + getTouchRampLevel() * TOUCH_SPIN_GAIN;
-    const getTouchWobbleScale = () => FIRST_TOUCH_WOBBLE_SCALE + getTouchRampLevel() * TOUCH_WOBBLE_GAIN;
-    const getTouchFlipScale = () =>
-      state.touchRampCount > 0 ? FIRST_TOUCH_FLIP_SCALE + getTouchRampLevel() * TOUCH_FLIP_GAIN : 1;
-
-    const updateSwipeStreak = ({ axis, direction, distance }) => {
-      if (!direction || distance < FLIP_DISTANCE_THRESHOLD) {
-        state.swipeStreakCount = 0;
-        return;
-      }
-
-      const now = window.performance?.now?.() ?? Date.now();
-      const sameSwipe =
-        state.swipeStreakAxis === axis &&
-        state.swipeStreakDirection === direction &&
-        now - state.lastSwipeAt < FLIP_STREAK_WINDOW;
-
-      state.swipeStreakAxis = axis;
-      state.swipeStreakDirection = direction;
-      state.swipeStreakCount = sameSwipe ? Math.min(state.swipeStreakCount + 1, SWIPE_STREAK_MAX) : 1;
-      state.lastSwipeAt = now;
-    };
-
-    const updateTouchRamp = () => {
-      const now = window.performance?.now?.() ?? Date.now();
-      const recentTouch = state.lastTouchRampAt > 0 && now - state.lastTouchRampAt < TOUCH_RAMP_WINDOW;
-      state.touchRampCount = recentTouch ? Math.min(state.touchRampCount + 1, TOUCH_RAMP_MAX) : 1;
-      state.lastTouchRampAt = now;
-
-      const rampLevel = getTouchRampLevel();
-      if (rampLevel <= 0) return;
-
-      const jitterSign = Math.sin(now * 0.019) >= 0 ? 1 : -1;
-      const instabilityImpulse = rampLevel * TOUCH_INSTABILITY_IMPULSE;
-      state.touchInstability = clamp(
-        state.touchInstability + instabilityImpulse,
-        0,
-        MAX_TOUCH_INSTABILITY,
-      );
-      state.wobbleVelocityX += jitterSign * instabilityImpulse;
-      state.wobbleVelocityY -= jitterSign * instabilityImpulse * 0.74;
-      state.wobbleVelocityZ += jitterSign * instabilityImpulse * 0.42;
-    };
-
-    const setTiltFromPointer = (event, dx = 0, dy = 0) => {
-      const point = getPointer(event);
-      const centerX = point.rect.width / 2;
-      const centerY = point.rect.height / 2;
-      const tiltBoost = getSwipeBoost();
-      const pointerTiltY = clamp((point.x - centerX) / centerX, -1, 1) * TILT_Y_LIMIT;
-      const pointerTiltX = clamp((point.y - centerY) / centerY, -1, 1) * TILT_X_LIMIT;
-      const pullTiltY = state.gestureDX * PULL_TILT_GAIN;
-      const pullTiltX = state.gestureDY * PULL_TILT_GAIN;
-      state.targetY = clamp((pointerTiltY + pullTiltY) * tiltBoost, -TILT_Y_LIMIT, TILT_Y_LIMIT);
-      state.targetX = clamp((pointerTiltX + pullTiltX) * tiltBoost, -TILT_X_LIMIT, TILT_X_LIMIT);
-      state.targetZ = clamp((dx - dy) * TWIST_FACTOR, -TWIST_LIMIT, TWIST_LIMIT);
-    };
-
-    const registerFlipGesture = (axis, direction, distance) => {
-      if (!direction || distance < FLIP_DISTANCE_THRESHOLD) {
-        state.flipStreakEnergy *= FLIP_ENERGY_DECAY;
-        state.flipStreakCount = 0;
-        return;
-      }
-
-      const now = window.performance?.now?.() ?? Date.now();
-      const sameGesture =
-        state.flipStreakAxis === axis &&
-        state.flipStreakDirection === direction &&
-        now - state.lastFlipGestureAt < FLIP_STREAK_WINDOW;
-      const energyGain = clamp(
-        (distance - FLIP_DISTANCE_THRESHOLD) / FLIP_DISTANCE_FULL_CHARGE,
-        0.16,
-        0.36,
-      );
-
-      state.flipStreakEnergy = sameGesture
-        ? clamp(state.flipStreakEnergy + energyGain, 0, MAX_FLIP_ENERGY)
-        : energyGain;
-      state.flipStreakCount = sameGesture ? state.flipStreakCount + 1 : 1;
-      state.flipStreakAxis = axis;
-      state.flipStreakDirection = direction;
-      state.lastFlipGestureAt = now;
-
-      const buildLevel = Math.min(state.flipStreakCount, FLIP_STREAK_REQUIRED);
-      const buildScale = (1 + clamp(state.flipStreakEnergy, 0, MAX_FLIP_ENERGY) * 0.28) * getTouchFlipScale();
-      const buildTilt = FLIP_BUILD_IMPULSE_STEP * buildLevel * buildScale;
-      const buildWobble = FLIP_BUILD_WOBBLE_STEP * buildLevel * buildScale;
-
-      if (axis === 'y') {
-        state.targetY = clamp(state.targetY + direction * buildTilt, -TILT_Y_LIMIT, TILT_Y_LIMIT);
-        state.wobbleVelocityY += direction * buildWobble;
-      } else {
-        state.targetX = clamp(state.targetX + direction * buildTilt, -TILT_X_LIMIT, TILT_X_LIMIT);
-        state.wobbleVelocityX += direction * buildWobble;
-      }
-      state.extraFaceSpin = clamp(
-        state.extraFaceSpin + FLIP_BUILD_SPIN_STEP * buildLevel * buildScale,
-        -MAX_EXTRA_SPIN,
-        MAX_EXTRA_SPIN,
-      );
-
-      if (state.flipStreakCount < FLIP_STREAK_REQUIRED) return;
-
-      const impulseScale = (1 + clamp(state.flipStreakEnergy, 0, MAX_FLIP_ENERGY) * 0.35) * getTouchFlipScale();
-      const wobbleSign = Math.sin(now * 0.017 + (axis === 'y' ? 0 : 1.7)) >= 0 ? 1 : -1;
-      if (axis === 'y') {
-        state.flipVelocityY += direction * FLIP_IMPULSE_Y * impulseScale;
-        state.flipVelocityX += wobbleSign * FLIP_CROSS_IMPULSE * impulseScale;
-        state.wobbleVelocityX += wobbleSign * FLIP_WOBBLE_IMPULSE * impulseScale;
-        state.wobbleVelocityY += direction * FLIP_WOBBLE_IMPULSE * 0.55 * impulseScale;
-      } else {
-        state.flipVelocityX += direction * FLIP_IMPULSE_X * impulseScale;
-        state.flipVelocityY += wobbleSign * FLIP_CROSS_IMPULSE * impulseScale;
-        state.wobbleVelocityY += wobbleSign * FLIP_WOBBLE_IMPULSE * impulseScale;
-        state.wobbleVelocityX += direction * FLIP_WOBBLE_IMPULSE * 0.55 * impulseScale;
-      }
-      state.wobbleVelocityZ += wobbleSign * FLIP_WOBBLE_IMPULSE * 0.5 * impulseScale;
-      state.extraFaceSpin = clamp(
-        state.extraFaceSpin + FLIP_SPIN_BOOST * impulseScale,
-        -MAX_EXTRA_SPIN,
-        MAX_EXTRA_SPIN,
-      );
-      spawnSparks(12, 1.15);
-      state.flipStreakCount = 0;
-      state.flipStreakEnergy = 0;
-    };
-
-    const addDirectionalFlipImpulse = ({ axis, direction, distance }) => {
-      registerFlipGesture(axis, direction, distance);
-    };
-
-    const stimulateQuickTap = () => {
-      const now = window.performance?.now?.() ?? Date.now();
-      state.lastTapStimulatedAt = now;
-      const gesture = {
-        axis: 'y',
-        direction: 1,
-        distance: QUICK_TAP_PULL_DISTANCE,
+    const emitMagic = (type, detail = {}) => {
+      const payload = {
+        type,
+        combo: state.comboCount,
+        level: state.magicLevel,
+        ...detail,
       };
-      updateSwipeStreak(gesture);
-      addDirectionalFlipImpulse(gesture);
-      state.extraFaceSpin = clamp(
-        state.extraFaceSpin + QUICK_TAP_PULL_DISTANCE * 0.00018 * getSpinBoost() * getTouchSpinScale(),
-        -MAX_EXTRA_SPIN,
-        MAX_EXTRA_SPIN,
-      );
-      state.wobbleVelocityY += FLIP_BUILD_WOBBLE_STEP * getTouchWobbleScale();
-      spawnSparks(5, 0.74);
+      root.dispatchEvent(new CustomEvent('3dvr:coin-interact', { bubbles: true, detail: payload }));
+      window.dispatchEvent(new CustomEvent(`3dvr:coin-${type}`, { detail: payload }));
     };
 
-    const startDrag = (event) => {
-      const point = getPointer(event);
+    const stimulateTap = () => {
+      const timestamp = now();
+      state.comboCount = timestamp - state.lastMagicAt < COMBO_WINDOW_MS
+        ? Math.min(state.comboCount + 1, COMBO_MAX)
+        : 1;
+      state.lastMagicAt = timestamp;
+      state.magicLevel = Math.max(state.magicLevel, state.comboCount >= 5 ? 2 : state.comboCount >= 3 ? 1 : 0);
+
+      const comboBoost = 1 + Math.max(0, state.comboCount - 1) * 0.16;
+      state.extraFaceSpin = clamp(state.extraFaceSpin + 0.012 * comboBoost, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
+      state.wobbleVelocityY += 0.045 * comboBoost;
+      state.wobbleVelocityX -= 0.02 * comboBoost;
+
+      spawnSparks(5 + state.comboCount * 2, 0.72 + state.comboCount * 0.06, state.comboCount >= 3);
+      pulseHalo(0.65 + state.comboCount * 0.12);
+      emitMagic('tap', { count: state.comboCount });
+
+      if (state.comboCount === 3) {
+        state.extraFaceSpin = clamp(state.extraFaceSpin + 0.013, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
+        emitMagic('combo', { milestone: 3 });
+      }
+
+      if (state.comboCount === 5) {
+        state.extraFaceSpin = clamp(state.extraFaceSpin + 0.02, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
+        state.wobbleVelocityZ += 0.09;
+        spawnSparks(24, 1.22, true);
+        emitMagic('powerup', { milestone: 5, charged: true });
+      }
+    };
+
+    const startDrag = event => {
+      const rect = getRect();
       state.dragging = true;
-      clearHoldPauseTimer();
-      state.holdPauseTimer = window.setTimeout(() => {
-        if (state.dragging && !state.pointerMoved) setPaused(true);
-        state.holdPauseTimer = 0;
-      }, HOLD_PAUSE_DELAY_MS);
       state.pointerMoved = false;
-      state.lastX = point.x;
-      state.lastY = point.y;
-      state.dragDX = 0;
-      state.dragDY = 0;
+      state.lastX = event.clientX - rect.left;
+      state.lastY = event.clientY - rect.top;
       state.gestureDX = 0;
       state.gestureDY = 0;
-      state.dragStartedAt = window.performance?.now?.() ?? Date.now();
-      state.pullWindupSpin = 0;
-      updateTouchRamp();
+      state.dragStartedAt = now();
+      window.clearTimeout(state.holdPauseTimer);
+      state.holdPauseTimer = window.setTimeout(() => {
+        if (state.dragging && !state.pointerMoved) setPaused(true);
+      }, HOLD_PAUSE_DELAY_MS);
       capturePointer(event);
       event.preventDefault();
     };
 
-    const drag = (event) => {
+    const drag = event => {
       if (!state.dragging) return;
-      const point = getPointer(event);
-      const dx = point.x - state.lastX;
-      const dy = point.y - state.lastY;
+      const rect = getRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      const dx = x - state.lastX;
+      const dy = y - state.lastY;
       const distance = Math.hypot(dx, dy);
+
       if (distance > 3) {
-        clearHoldPauseTimer();
-        if (state.paused) setPaused(false);
         state.pointerMoved = true;
+        window.clearTimeout(state.holdPauseTimer);
+        setPaused(false);
       }
-      state.lastX = point.x;
-      state.lastY = point.y;
-      state.dragDX = dx;
-      state.dragDY = dy;
+
+      state.lastX = x;
+      state.lastY = y;
       state.gestureDX += dx;
       state.gestureDY += dy;
-      const touchSpinScale = getTouchSpinScale();
-      state.pullWindupSpin = clamp(
-        state.pullWindupSpin + distance * PULL_WINDUP_FACTOR * getSpinBoost() * touchSpinScale,
-        0,
-        MAX_PULL_WINDUP_SPIN,
-      );
-      state.extraFaceSpin = clamp(
-        state.extraFaceSpin + distance * DRAG_WIND_FACTOR * getSpinBoost() * touchSpinScale,
-        -MAX_EXTRA_SPIN,
-        MAX_EXTRA_SPIN,
-      );
-      const wobbleMultiplier =
-        (1 + Math.min(state.flipStreakCount, 3) * DRAG_WOBBLE_STREAK_GAIN) * getTouchWobbleScale();
-      state.wobbleVelocityY += dx * DRAG_WOBBLE_FACTOR * wobbleMultiplier;
-      state.wobbleVelocityX += dy * DRAG_WOBBLE_FACTOR * wobbleMultiplier;
-      state.wobbleVelocityZ += (dx - dy) * DRAG_TWIST_WOBBLE_FACTOR * wobbleMultiplier;
-      state.wobbleVelocityX += state.touchInstability * Math.sign(dy || dx || 1) * 0.12;
-      state.wobbleVelocityZ += state.touchInstability * Math.sign(dx - dy || 1) * 0.08;
-      setTiltFromPointer(event, dx, dy);
+      state.extraFaceSpin = clamp(state.extraFaceSpin + distance * DRAG_SPIN_GAIN, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
+      state.targetY = clamp(state.gestureDX * TILT_GAIN, -TILT_Y_LIMIT, TILT_Y_LIMIT);
+      state.targetX = clamp(state.gestureDY * TILT_GAIN, -TILT_X_LIMIT, TILT_X_LIMIT);
+      state.targetZ = clamp((state.gestureDX - state.gestureDY) * 0.00075, -0.08, 0.08);
+      state.wobbleVelocityX += dy * 0.00072;
+      state.wobbleVelocityY += dx * 0.00072;
+      state.wobbleVelocityZ += (dx - dy) * 0.00028;
       event.preventDefault();
     };
 
     const endDrag = (event = {}) => {
       if (!state.dragging) return;
       state.dragging = false;
-      clearHoldPauseTimer();
+      window.clearTimeout(state.holdPauseTimer);
       releasePointer(event);
+      state.lastPointerDownDuration = now() - state.dragStartedAt;
 
-      const wasTap = !state.pointerMoved && Math.hypot(state.gestureDX, state.gestureDY) < 6;
-      const now = window.performance?.now?.() ?? Date.now();
-      state.lastPointerDownDuration = now - state.dragStartedAt;
-      if (wasTap) {
-        if (state.lastPointerDownDuration <= QUICK_TAP_MAX_MS) {
-          stimulateQuickTap();
-        }
-        setPaused(false);
-        return;
+      const distance = Math.hypot(state.gestureDX, state.gestureDY);
+      if (!state.pointerMoved && distance < 6 && state.lastPointerDownDuration <= QUICK_TAP_MAX_MS) {
+        stimulateTap();
+      } else if (distance >= 18) {
+        state.extraFaceSpin = clamp(state.extraFaceSpin + Math.min(distance, 180) * 0.00022, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
+        state.wobbleVelocityX += clamp(state.gestureDY * 0.0004, -0.07, 0.07);
+        state.wobbleVelocityY += clamp(state.gestureDX * 0.0004, -0.07, 0.07);
+        spawnSparks(Math.min(14, 5 + Math.round(distance / 22)), 0.85, false);
+        emitMagic('spin', { distance: Math.round(distance) });
       }
 
-      const gesture = getGesture();
-      updateSwipeStreak(gesture);
-      addDirectionalFlipImpulse(gesture);
-      state.extraFaceSpin = clamp(
-        state.extraFaceSpin +
-          Math.hypot(state.dragDX, state.dragDY) * 0.00035 * getSpinBoost() * getTouchSpinScale(),
-        -MAX_EXTRA_SPIN,
-        MAX_EXTRA_SPIN,
-      );
-      spawnSparks(7, 0.88);
       setPaused(false);
     };
 
@@ -708,36 +588,33 @@
       root.addEventListener('lostpointercapture', endDrag);
       window.addEventListener('pointerup', endDrag);
       window.addEventListener('pointercancel', endDrag);
-      root.addEventListener('click', (event) => {
-        const now = window.performance?.now?.() ?? Date.now();
-        if (state.dragging || state.lastPointerDownDuration > QUICK_TAP_MAX_MS) return;
-        if (now - state.lastTapStimulatedAt < 160) return;
-        stimulateQuickTap();
-        setPaused(false);
-        event.preventDefault();
-      });
 
-      root.addEventListener('keydown', (event) => {
+      root.addEventListener('keydown', event => {
         if (event.key === ' ') {
           if (!event.repeat) setPaused(true);
           event.preventDefault();
-        } else if (event.key === 'ArrowRight') {
-          setPaused(false);
-          state.extraFaceSpin = clamp(state.extraFaceSpin + 0.012, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
-          registerFlipGesture('y', 1, FLIP_DISTANCE_FULL_CHARGE);
+          return;
+        }
+
+        if (event.key === 'Enter') {
+          stimulateTap();
           event.preventDefault();
-        } else if (event.key === 'ArrowLeft') {
+          return;
+        }
+
+        if (event.key.startsWith('Arrow')) {
           setPaused(false);
-          state.extraFaceSpin = clamp(state.extraFaceSpin + 0.008, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
-          registerFlipGesture('y', -1, FLIP_DISTANCE_FULL_CHARGE);
-          event.preventDefault();
-        } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-          setPaused(false);
-          registerFlipGesture('x', event.key === 'ArrowUp' ? -1 : 1, FLIP_DISTANCE_FULL_CHARGE);
+          const horizontal = event.key === 'ArrowRight' ? 1 : event.key === 'ArrowLeft' ? -1 : 0;
+          const vertical = event.key === 'ArrowDown' ? 1 : event.key === 'ArrowUp' ? -1 : 0;
+          state.targetY = clamp(state.targetY + horizontal * 0.28, -TILT_Y_LIMIT, TILT_Y_LIMIT);
+          state.targetX = clamp(state.targetX + vertical * 0.24, -TILT_X_LIMIT, TILT_X_LIMIT);
+          state.extraFaceSpin = clamp(state.extraFaceSpin + 0.01, -MAX_EXTRA_SPIN, MAX_EXTRA_SPIN);
+          spawnSparks(5, 0.65, false);
           event.preventDefault();
         }
       });
-      root.addEventListener('keyup', (event) => {
+
+      root.addEventListener('keyup', event => {
         if (event.key === ' ') {
           setPaused(false);
           event.preventDefault();
@@ -748,17 +625,15 @@
     const drawFallback = () => {
       const context = state.fallbackContext;
       if (!context) return;
-
       const rect = getRect();
       const width = Math.max(1, rect.width);
       const height = Math.max(1, rect.height);
-      const centerX = width / 2;
-      const centerY = height / 2;
       const size = Math.min(width, height);
       const radius = size * 0.42;
-      const surfaceY = state.currentY + state.flipY + state.wobbleY;
-      const tiltScaleX = Math.max(0.2, Math.abs(Math.cos(surfaceY)) * 0.76 + 0.24);
-      const tiltScaleY = Math.max(0.52, Math.cos(state.currentX + state.flipX + state.wobbleX) * 0.2 + 0.78);
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const tiltScaleX = Math.max(0.2, Math.abs(Math.cos(state.currentY + state.wobbleY)) * 0.78 + 0.22);
+      const tiltScaleY = Math.max(0.54, Math.cos(state.currentX + state.wobbleX) * 0.18 + 0.8);
 
       context.clearRect(0, 0, width, height);
       context.save();
@@ -766,138 +641,107 @@
       context.rotate(state.currentZ + state.wobbleZ);
       context.scale(tiltScaleX, tiltScaleY);
 
-      const faceGradient = context.createRadialGradient(0, 0, radius * 0.08, 0, 0, radius);
-      faceGradient.addColorStop(0, '#9de7f8');
-      faceGradient.addColorStop(0.28, '#2aa7bf');
-      faceGradient.addColorStop(0.62, '#0f766e');
-      faceGradient.addColorStop(1, '#07111f');
+      const face = context.createRadialGradient(-radius * 0.28, -radius * 0.34, radius * 0.03, 0, 0, radius);
+      face.addColorStop(0, GOLD.highlight);
+      face.addColorStop(0.18, GOLD.light);
+      face.addColorStop(0.52, GOLD.mid);
+      face.addColorStop(0.8, GOLD.deep);
+      face.addColorStop(1, GOLD.shadow);
       context.beginPath();
       context.arc(0, 0, radius, 0, TAU);
-      context.fillStyle = faceGradient;
+      context.fillStyle = face;
       context.fill();
 
-      for (let arm = 0; arm < 7; arm += 1) {
-        context.save();
-        context.rotate((arm / 7) * TAU + state.faceSpin * 0.7);
-        context.beginPath();
-        for (let index = 0; index <= 58; index += 1) {
-          const progress = index / 58;
-          const angle = progress * TAU * 1.05;
-          const r = radius * (0.12 + progress * 0.72);
-          const x = Math.cos(angle) * r;
-          const y = Math.sin(angle) * r * 0.72;
-          if (index === 0) context.moveTo(x, y);
-          else context.lineTo(x, y);
-        }
-        context.strokeStyle = 'rgba(186, 230, 253, 0.38)';
-        context.lineWidth = Math.max(4, radius * 0.066);
-        context.lineCap = 'round';
-        context.stroke();
-        context.restore();
-      }
-
-      context.lineWidth = Math.max(7, size * 0.04);
-      context.strokeStyle = '#d8fff7';
-      context.beginPath();
-      context.arc(0, 0, radius, 0, TAU);
+      context.lineWidth = Math.max(7, size * 0.035);
+      context.strokeStyle = GOLD.cream;
       context.stroke();
 
       context.lineWidth = Math.max(3, size * 0.012);
-      context.strokeStyle = 'rgba(254, 215, 170, 0.74)';
+      context.strokeStyle = 'rgba(118, 62, 0, 0.42)';
       context.beginPath();
-      context.arc(0, 0, radius * 0.74, 0, TAU);
+      context.arc(0, 0, radius * 0.79, 0, TAU);
       context.stroke();
 
-      context.beginPath();
-      context.arc(0, 0, radius * 0.36, 0, TAU);
-      context.fillStyle = 'rgba(2, 6, 23, 0.72)';
-      context.fill();
-
+      context.shadowColor = 'rgba(90, 48, 0, 0.55)';
+      context.shadowBlur = size * 0.025;
+      context.shadowOffsetY = size * 0.012;
       context.textAlign = 'center';
       context.textBaseline = 'middle';
-      context.shadowColor = 'rgba(0, 0, 0, 0.45)';
-      context.shadowBlur = size * 0.03;
-      context.fillStyle = '#ffffff';
-      context.font = `900 ${Math.max(18, size * 0.15)}px Inter, system-ui, sans-serif`;
-      context.fillText('3dvr', 0, -size * 0.02);
-      context.fillStyle = '#ccfbf1';
-      context.font = `800 ${Math.max(11, size * 0.085)}px Inter, system-ui, sans-serif`;
-      context.fillText('portal', 0, size * 0.12);
+      context.lineJoin = 'round';
+      context.lineWidth = Math.max(3, size * 0.014);
+      context.strokeStyle = '#884a00';
+      context.fillStyle = '#fff7bd';
+      context.font = `950 ${Math.max(20, size * 0.15)}px Inter, system-ui, sans-serif`;
+      context.strokeText('3DVR', 0, -size * 0.02);
+      context.fillText('3DVR', 0, -size * 0.02);
+      context.lineWidth = Math.max(2, size * 0.008);
+      context.font = `900 ${Math.max(11, size * 0.062)}px Inter, system-ui, sans-serif`;
+      context.fillStyle = '#ffe174';
+      context.strokeText('PORTAL', 0, size * 0.12);
+      context.fillText('PORTAL', 0, size * 0.12);
       context.restore();
     };
 
     const render = () => {
-      const rotationX = state.currentX + state.flipX + state.wobbleX;
-      const rotationY = state.currentY + state.flipY + state.wobbleY;
-      const rotationZ = state.currentZ + state.wobbleZ;
-
       if (state.renderer && state.scene && state.camera && state.token) {
-        state.token.rotation.set(rotationX, rotationY, rotationZ);
+        state.token.rotation.set(
+          state.currentX + state.wobbleX,
+          state.currentY + state.wobbleY,
+          state.currentZ + state.wobbleZ,
+        );
         for (const texture of state.token.userData.faceTextures || []) {
           texture.rotation = state.faceSpin;
         }
         state.renderer.render(state.scene, state.camera);
         return;
       }
-
       drawFallback();
     };
 
     const animate = (timestamp = 0) => {
       state.frame = window.requestAnimationFrame(animate);
-      const rawElapsed = state.lastTimestamp ? Math.min(timestamp - state.lastTimestamp, 250) : 16.67;
-      const spinElapsed = Math.min(rawElapsed, 64);
+      const elapsed = state.lastTimestamp ? Math.min(timestamp - state.lastTimestamp, 64) : 16.67;
       state.lastTimestamp = timestamp;
-      const frames = rawElapsed / 16.67;
-      const targetSettle = 1 - Math.pow(TARGET_SETTLE_BASE, frames);
-      const currentSettle = 1 - Math.pow(CURRENT_SETTLE_BASE, frames);
+      const frames = elapsed / 16.67;
 
       if (!state.dragging) {
-        state.targetX = lerp(state.targetX, 0, targetSettle);
-        state.targetY = lerp(state.targetY, 0, targetSettle);
-        state.targetZ = lerp(state.targetZ, 0, targetSettle);
-        state.pullWindupSpin = lerp(state.pullWindupSpin, 0, currentSettle);
+        state.targetX = lerp(state.targetX, 0, 1 - Math.pow(0.965, frames));
+        state.targetY = lerp(state.targetY, 0, 1 - Math.pow(0.965, frames));
+        state.targetZ = lerp(state.targetZ, 0, 1 - Math.pow(0.955, frames));
         state.extraFaceSpin *= Math.pow(SPIN_DECAY, frames);
       }
 
-      state.currentX = lerp(state.currentX, state.targetX, currentSettle);
-      state.currentY = lerp(state.currentY, state.targetY, currentSettle);
-      state.currentZ = lerp(state.currentZ, state.targetZ, currentSettle);
-      state.flipX += state.flipVelocityX * frames;
-      state.flipY += state.flipVelocityY * frames;
-      state.flipVelocityX *= Math.pow(FLIP_DECAY, frames);
-      state.flipVelocityY *= Math.pow(FLIP_DECAY, frames);
+      state.currentX = lerp(state.currentX, state.targetX, 1 - Math.pow(0.9, frames));
+      state.currentY = lerp(state.currentY, state.targetY, 1 - Math.pow(0.9, frames));
+      state.currentZ = lerp(state.currentZ, state.targetZ, 1 - Math.pow(0.9, frames));
+
       state.wobbleVelocityX += -state.wobbleX * WOBBLE_SPRING * frames;
       state.wobbleVelocityY += -state.wobbleY * WOBBLE_SPRING * frames;
       state.wobbleVelocityZ += -state.wobbleZ * WOBBLE_SPRING * frames;
-      state.touchInstability *= Math.pow(TOUCH_INSTABILITY_DECAY, frames);
       state.wobbleVelocityX *= Math.pow(WOBBLE_DECAY, frames);
       state.wobbleVelocityY *= Math.pow(WOBBLE_DECAY, frames);
       state.wobbleVelocityZ *= Math.pow(WOBBLE_DECAY, frames);
       state.wobbleX = clamp(state.wobbleX + state.wobbleVelocityX * frames, -MAX_WOBBLE, MAX_WOBBLE);
       state.wobbleY = clamp(state.wobbleY + state.wobbleVelocityY * frames, -MAX_WOBBLE, MAX_WOBBLE);
-      state.wobbleZ = clamp(state.wobbleZ + state.wobbleVelocityZ * frames, -MAX_WOBBLE_Z, MAX_WOBBLE_Z);
+      state.wobbleZ = clamp(state.wobbleZ + state.wobbleVelocityZ * frames, -MAX_WOBBLE * 0.6, MAX_WOBBLE * 0.6);
 
-      if (Math.abs(state.flipVelocityX) < MIN_FLIP_VELOCITY) {
-        state.flipVelocityX = 0;
-        state.flipX = lerp(state.flipX, nearestUprightTextAngle(state.flipX), UPRIGHT_TEXT_HOME_EASE);
-      }
-      if (Math.abs(state.flipVelocityY) < MIN_FLIP_VELOCITY) {
-        state.flipVelocityY = 0;
-        state.flipY = lerp(state.flipY, nearestGoodFaceAngle(state.flipY), FLIP_HOME_EASE);
+      if (!state.paused && !reducedMotion) {
+        state.faceSpin += (BASE_FACE_SPIN + state.extraFaceSpin) * elapsed;
       }
 
-      const baseSpin = state.paused ? 0 : reducedMotion ? BASE_FACE_SPIN * 0.28 : BASE_FACE_SPIN;
-      const extraSpin = state.paused || state.dragging ? 0 : state.extraFaceSpin;
-      const pullWindupSpin = state.dragging ? state.pullWindupSpin : 0;
-      state.faceSpin += (baseSpin + extraSpin + pullWindupSpin) * spinElapsed;
+      if (state.comboCount && now() - state.lastMagicAt > COMBO_WINDOW_MS) {
+        state.comboCount = 0;
+        state.magicLevel = 0;
+      }
+
       render();
     };
 
-    const markReady = (mode) => {
+    const markReady = mode => {
       state.ready = true;
       state.mode = mode;
       root.dataset.logoReady = 'true';
+      root.dataset.coinFinish = 'regal-gold';
       window.__portalSwirlLogo = {
         ready: true,
         mode,
@@ -907,33 +751,23 @@
           paused: state.paused,
           faceSpin: state.faceSpin,
           extraFaceSpin: state.extraFaceSpin,
-          pullWindupSpin: state.pullWindupSpin,
           targetX: state.targetX,
           targetY: state.targetY,
           targetZ: state.targetZ,
           currentX: state.currentX,
           currentY: state.currentY,
           currentZ: state.currentZ,
-          flipX: state.flipX,
-          flipY: state.flipY,
-          flipVelocityX: state.flipVelocityX,
-          flipVelocityY: state.flipVelocityY,
-          swipeStreakCount: state.swipeStreakCount,
-          swipeStreakAxis: state.swipeStreakAxis,
-          swipeStreakDirection: state.swipeStreakDirection,
-          touchRampCount: state.touchRampCount,
-          touchInstability: state.touchInstability,
-          flipStreakCount: state.flipStreakCount,
-          flipStreakEnergy: state.flipStreakEnergy,
           wobbleX: state.wobbleX,
           wobbleY: state.wobbleY,
           wobbleZ: state.wobbleZ,
+          comboCount: state.comboCount,
+          magicLevel: state.magicLevel,
         }),
       };
     };
 
-    const initFallback = (error) => {
-      console.warn('3dvr portal Three.js logo fallback active:', error);
+    const initFallback = error => {
+      console.warn('3dvr portal Three.js coin fallback active:', error);
       state.fallbackContext = canvas.getContext('2d');
       if (!state.fallbackContext) {
         window.__portalSwirlLogo = { ready: false };
@@ -954,21 +788,36 @@
           alpha: true,
           powerPreference: 'high-performance',
         });
+        renderer.outputEncoding = THREE.sRGBEncoding;
+        renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        renderer.toneMappingExposure = 1.14;
+
         const scene = new THREE.Scene();
         const camera = new THREE.PerspectiveCamera(38, 1, 0.1, 100);
         camera.position.set(0, 0, 5);
 
-        const token = createPortalToken(THREE);
+        const token = createPortalCoin(THREE);
+        token.rotation.x = -0.08;
+        token.rotation.y = 0.1;
         scene.add(token);
-        scene.add(new THREE.AmbientLight(0xe2fff8, 0.72));
 
-        const key = new THREE.DirectionalLight(0xffffff, 1.35);
-        key.position.set(2.5, 2.8, 4.5);
+        scene.add(new THREE.HemisphereLight(0xfff7d6, 0x5c2f00, 0.95));
+
+        const key = new THREE.DirectionalLight(0xfff5d0, 1.95);
+        key.position.set(2.8, 3.4, 4.8);
         scene.add(key);
 
-        const fill = new THREE.DirectionalLight(0x99f6e4, 0.62);
-        fill.position.set(-3, -1.5, 2);
+        const fill = new THREE.DirectionalLight(0xffad2f, 0.88);
+        fill.position.set(-3.2, -1.2, 2.2);
         scene.add(fill);
+
+        const coolRim = new THREE.DirectionalLight(0xb9e9ff, 0.48);
+        coolRim.position.set(-2.5, 3.2, -2.8);
+        scene.add(coolRim);
+
+        const sparkle = new THREE.PointLight(0xffdd69, 0.72, 9);
+        sparkle.position.set(0.6, -2.2, 3.6);
+        scene.add(sparkle);
 
         state.renderer = renderer;
         state.scene = scene;


### PR DESCRIPTION
## What changed
- Re-art-directs the interactive 3DVR spinner as a bright polished gold coin rather than teal/bronze.
- Adds layered gold highlights, engraved rings, a reeded edge, embossed-style 3DVR PORTAL lettering, and warmer premium lighting.
- Keeps drag/tap/keyboard interaction and the separate directional navigation layer.
- Adds playful tap-combo feedback: gold sparks, star bursts, halo pulses, and a 5-tap power-up moment.
- Emits reusable `3dvr:coin-interact`, `3dvr:coin-tap`, `3dvr:coin-spin`, `3dvr:coin-combo`, and `3dvr:coin-powerup` events so future portal worlds, sounds, achievements, or navigation can hook into the coin without coupling game logic to the renderer.
- Keeps a polished gold canvas fallback and respects reduced-motion preferences.

## Intent
Mario-coin-like readability and delight, but with an original 3DVR identity rather than copied artwork.

Draft for visual/interaction review before merging to `main` and triggering production.