### PR TITLE
Add adaptive live draft awareness to Operator

### DIFF
--- a/operator/index.html
+++ b/operator/index.html
@@ -11,6 +11,7 @@
   <script src="/gun-init.js"></script>
   <script src="/auth-identity.js"></script>
   <script type="module" src="app.js"></script>
+  <script type="module" src="live-awareness.js"></script>
 </head>
 <body>
   <main>

--- a/operator/live-awareness.js
+++ b/operator/live-awareness.js
@@ -1,0 +1,330 @@
+const STORAGE_KEY = '3dvr.operator.live-draft-awareness.v1';
+const DEFAULT_DELAY_MS = 3600;
+const MIN_DELAY_MS = 1800;
+const MAX_DELAY_MS = 12000;
+const MIN_DRAFT_CHARS = 12;
+const MAX_IDLE_RECHECKS = 2;
+
+export function clampDraftDelay(value, fallback = DEFAULT_DELAY_MS) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.max(MIN_DELAY_MS, Math.min(MAX_DELAY_MS, Math.round(parsed || fallback)));
+}
+
+export function changedDraftCharacters(previous = '', current = '') {
+  const before = String(previous);
+  const after = String(current);
+  if (before === after) return 0;
+
+  let prefix = 0;
+  const prefixLimit = Math.min(before.length, after.length);
+  while (prefix < prefixLimit && before[prefix] === after[prefix]) prefix += 1;
+
+  let suffix = 0;
+  const suffixLimit = Math.min(before.length - prefix, after.length - prefix);
+  while (
+    suffix < suffixLimit
+    && before[before.length - 1 - suffix] === after[after.length - 1 - suffix]
+  ) suffix += 1;
+
+  return (before.length - prefix - suffix) + (after.length - prefix - suffix);
+}
+
+export function shouldObserveDraft({ draft = '', lastObserved = '', forceIdle = false } = {}) {
+  const text = String(draft).trim();
+  if (text.length < MIN_DRAFT_CHARS) return false;
+  if (forceIdle) return text === String(lastObserved).trim();
+  if (!lastObserved) return true;
+  if (text === String(lastObserved).trim()) return false;
+
+  const changed = changedDraftCharacters(lastObserved, text);
+  return changed >= 8 || Math.abs(text.length - String(lastObserved).trim().length) >= 8 || /[.!?…]\s*$/.test(text);
+}
+
+function readEnabled() {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function writeEnabled(enabled) {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(Boolean(enabled)));
+  } catch {
+    // Live awareness is optional; a blocked localStorage should not affect chat.
+  }
+}
+
+function recentVisibleHistory() {
+  const messages = Array.from(document.querySelectorAll('#operator-log article.message'))
+    .slice(-6)
+    .map(article => ({
+      role: article.classList.contains('assistant') ? 'assistant' : 'user',
+      content: article.querySelector('p')?.textContent?.trim() || ''
+    }))
+    .filter(item => item.content);
+
+  if (messages.length) return messages;
+
+  const homeReply = document.querySelector('#homeOperatorReply')?.textContent?.trim();
+  return homeReply ? [{ role: 'assistant', content: homeReply }] : [];
+}
+
+function installStyles() {
+  if (document.querySelector('#operator-live-awareness-style')) return;
+  const style = document.createElement('style');
+  style.id = 'operator-live-awareness-style';
+  style.textContent = `
+    .operator-live-awareness {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 28px;
+      padding: 3px 8px;
+      border: 1px solid rgba(125, 211, 252, 0.24);
+      border-radius: 999px;
+      background: rgba(8, 18, 31, 0.72);
+      color: #a7b6c9;
+      font: inherit;
+      font-size: 0.76rem;
+      cursor: pointer;
+    }
+
+    .operator-live-awareness[aria-pressed="true"] {
+      border-color: rgba(103, 232, 249, 0.52);
+      color: #d7fbff;
+      box-shadow: inset 0 0 0 1px rgba(103, 232, 249, 0.08);
+    }
+
+    .operator-live-awareness__dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: currentColor;
+      opacity: 0.5;
+    }
+
+    .operator-live-awareness[aria-pressed="true"] .operator-live-awareness__dot {
+      opacity: 1;
+      box-shadow: 0 0 8px rgba(103, 232, 249, 0.65);
+    }
+
+    .operator-live-awareness-status {
+      max-width: 230px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export function attachLiveDraftAwareness({
+  input,
+  form,
+  statusTarget,
+  request = globalThis.fetch
+} = {}) {
+  if (!input || !form || typeof request !== 'function') return null;
+
+  installStyles();
+
+  const footer = form.querySelector(':scope > div > span') || form.querySelector('span') || form;
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'operator-live-awareness';
+  toggle.title = 'When enabled, unsent draft text may be sent to Operator while you type. Draft checks can never take actions.';
+  toggle.innerHTML = '<span class="operator-live-awareness__dot" aria-hidden="true"></span><span>Live awareness</span>';
+
+  const liveStatus = document.createElement('small');
+  liveStatus.className = 'operator-live-awareness-status';
+  liveStatus.setAttribute('role', 'status');
+  liveStatus.hidden = true;
+
+  footer.append(toggle, liveStatus);
+
+  let enabled = readEnabled();
+  let timer = null;
+  let inFlight = false;
+  let lastObserved = '';
+  let previousValue = input.value || '';
+  let startedAt = 0;
+  let lastInputAt = 0;
+  let editCount = 0;
+  let deletedChars = 0;
+  let pauseCount = 0;
+  let idleRechecks = 0;
+  let nextDelayMs = DEFAULT_DELAY_MS;
+  let previousSummary = '';
+
+  const renderToggle = () => {
+    toggle.setAttribute('aria-pressed', String(enabled));
+    toggle.setAttribute('aria-label', enabled ? 'Disable live draft awareness' : 'Enable live draft awareness');
+    if (!enabled) {
+      liveStatus.hidden = true;
+      if (statusTarget?.dataset?.liveAwareness === 'true') {
+        statusTarget.textContent = 'Ready';
+        delete statusTarget.dataset.liveAwareness;
+      }
+    }
+  };
+
+  const setListeningStatus = message => {
+    liveStatus.hidden = false;
+    liveStatus.textContent = message;
+    if (statusTarget && !/Working|Try again/i.test(statusTarget.textContent || '')) {
+      statusTarget.textContent = message;
+      statusTarget.dataset.liveAwareness = 'true';
+    }
+  };
+
+  const clearTimer = () => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+  };
+
+  const schedule = (delay = nextDelayMs, { forceIdle = false } = {}) => {
+    clearTimer();
+    if (!enabled || document.hidden) return;
+    const draft = input.value.trim();
+    if (!shouldObserveDraft({ draft, lastObserved, forceIdle })) return;
+    timer = setTimeout(() => observe({ forceIdle }), Math.max(MIN_DELAY_MS, delay));
+  };
+
+  const observe = async ({ forceIdle = false } = {}) => {
+    clearTimer();
+    if (!enabled || document.hidden || inFlight) return;
+
+    const draft = input.value.trim();
+    if (!shouldObserveDraft({ draft, lastObserved, forceIdle })) return;
+
+    const observedDraft = draft;
+    const observedAt = Date.now();
+    pauseCount += 1;
+    inFlight = true;
+    setListeningStatus('Operator is listening…');
+
+    try {
+      const response = await request('/api/openai-site?provider=operator', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          draft: true,
+          prompt: observedDraft,
+          history: recentVisibleHistory(),
+          previousDraftSummary: previousSummary,
+          draftSignals: {
+            elapsedMs: startedAt ? observedAt - startedAt : 0,
+            pauseMs: lastInputAt ? observedAt - lastInputAt : 0,
+            editCount,
+            deletedChars,
+            pauseCount,
+            characterCount: observedDraft.length
+          }
+        })
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Draft awareness unavailable.');
+
+      const awareness = data.draftAwareness || {};
+      if (input.value.trim() !== observedDraft) {
+        idleRechecks = 0;
+        schedule(DEFAULT_DELAY_MS);
+        return;
+      }
+
+      lastObserved = observedDraft;
+      previousSummary = String(awareness.summary || '').trim().slice(0, 180);
+      nextDelayMs = clampDraftDelay(awareness.checkAgainMs);
+      setListeningStatus(awareness.ready ? 'Following · waiting for Send' : 'Following your thought…');
+      if (previousSummary) liveStatus.title = previousSummary;
+
+      if (nextDelayMs > 0 && idleRechecks < MAX_IDLE_RECHECKS) {
+        idleRechecks += 1;
+        schedule(nextDelayMs, { forceIdle: true });
+      }
+    } catch {
+      liveStatus.hidden = false;
+      liveStatus.textContent = 'Live awareness paused';
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  const onInput = () => {
+    const value = input.value;
+    const timestamp = Date.now();
+    if (!startedAt && value.trim()) startedAt = timestamp;
+    if (value.length < previousValue.length) deletedChars += previousValue.length - value.length;
+    if (value !== previousValue) editCount += 1;
+    previousValue = value;
+    lastInputAt = timestamp;
+    idleRechecks = 0;
+
+    if (!value.trim()) {
+      clearTimer();
+      lastObserved = '';
+      previousSummary = '';
+      nextDelayMs = DEFAULT_DELAY_MS;
+      startedAt = 0;
+      editCount = 0;
+      deletedChars = 0;
+      pauseCount = 0;
+      if (enabled) setListeningStatus('Live awareness on');
+      return;
+    }
+
+    if (enabled) schedule(/[.!?…]\s*$/.test(value) ? 2200 : nextDelayMs);
+  };
+
+  toggle.addEventListener('click', () => {
+    enabled = !enabled;
+    writeEnabled(enabled);
+    renderToggle();
+    if (enabled) {
+      setListeningStatus('Live awareness on');
+      onInput();
+    } else {
+      clearTimer();
+    }
+  });
+
+  input.addEventListener('input', onInput, { passive: true });
+  form.addEventListener('submit', () => clearTimer());
+  document.addEventListener('visibilitychange', () => {
+    clearTimer();
+    if (!document.hidden && enabled && input.value.trim()) schedule();
+  });
+  window.addEventListener('beforeunload', clearTimer, { once: true });
+
+  renderToggle();
+  if (enabled) {
+    setListeningStatus('Live awareness on');
+    if (input.value.trim()) onInput();
+  }
+
+  return {
+    isEnabled: () => enabled,
+    checkNow: () => observe(),
+    disable: () => {
+      enabled = false;
+      writeEnabled(false);
+      clearTimer();
+      renderToggle();
+    }
+  };
+}
+
+if (typeof document !== 'undefined') {
+  const input = document.querySelector('#operator-input');
+  const form = document.querySelector('#operator-form');
+  if (input && form) {
+    attachLiveDraftAwareness({
+      input,
+      form,
+      statusTarget: document.querySelector('#operator-status')
+    });
+  }
+}

--- a/src/operator/api.js
+++ b/src/operator/api.js
@@ -1,5 +1,11 @@
 import { buildOperatorOwnerContext } from './context.js';
 import { resolveOperatorDeveloperAccess } from './developer-access.js';
+import {
+  buildOperatorDraftRequest,
+  DEFAULT_OPERATOR_DRAFT_GATEWAY_MODEL,
+  DEFAULT_OPERATOR_DRAFT_MODEL,
+  normalizeOperatorDraftAwareness
+} from './draft-awareness.js';
 
 export const DEFAULT_OPERATOR_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_OPERATOR_GATEWAY_MODEL = 'openai/gpt-5.4-mini';
@@ -156,13 +162,36 @@ export function createOperatorHandler(options = {}) {
     const prompt = clean(req.body?.prompt, 2000);
     if (!prompt) return res.status(400).json({ error: 'Tell the operator what you need.' });
     try {
+      const useGateway = !apiKey && Boolean(gatewayToken);
+      const requestEndpoint = useGateway ? endpoint : 'https://api.openai.com/v1/responses';
+
+      if (req.body?.draft === true) {
+        const draftModel = options.draftModel
+          || process.env.OPENAI_OPERATOR_DRAFT_MODEL
+          || (useGateway ? DEFAULT_OPERATOR_DRAFT_GATEWAY_MODEL : DEFAULT_OPERATOR_DRAFT_MODEL);
+        const response = await fetchImpl(requestEndpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authorizationToken}` },
+          body: JSON.stringify(buildOperatorDraftRequest({
+            prompt,
+            history: req.body?.history,
+            draftSignals: req.body?.draftSignals,
+            previousDraftSummary: req.body?.previousDraftSummary,
+            model: draftModel
+          }))
+        });
+        if (!response.ok) return res.status(response.status).json({ error: await readUpstreamError(response) });
+        const raw = outputText(await response.json());
+        return res.status(200).json({
+          draftAwareness: normalizeOperatorDraftAwareness(JSON.parse(raw))
+        });
+      }
+
       const developerAuth = req.body?.developerAuth || req.body?.portalContext?.developerAuth || {};
       const developerAccess = await resolveOperatorDeveloperAccess(developerAuth, {
         config: options.config || process.env,
         expectedOrigin: requestOrigin(req)
       });
-      const useGateway = !apiKey && Boolean(gatewayToken);
-      const requestEndpoint = useGateway ? endpoint : 'https://api.openai.com/v1/responses';
       const model = options.model || process.env.OPENAI_OPERATOR_MODEL || (useGateway ? DEFAULT_OPERATOR_GATEWAY_MODEL : DEFAULT_OPERATOR_MODEL);
       const response = await fetchImpl(requestEndpoint, {
         method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authorizationToken}` },

--- a/src/operator/draft-awareness.js
+++ b/src/operator/draft-awareness.js
@@ -1,0 +1,90 @@
+export const DEFAULT_OPERATOR_DRAFT_MODEL = 'gpt-4.1-mini';
+export const DEFAULT_OPERATOR_DRAFT_GATEWAY_MODEL = 'openai/gpt-4.1-mini';
+
+const DRAFT_RESPONSE_SCHEMA = {
+  name: 'portal_operator_draft_awareness',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['summary', 'ready', 'checkAgainMs'],
+    properties: {
+      summary: { type: 'string' },
+      ready: { type: 'boolean' },
+      checkAgainMs: { type: 'integer', minimum: 0, maximum: 12000 }
+    }
+  }
+};
+
+const clean = (value, max = 3000) => String(value || '').trim().slice(0, max);
+const boundedNumber = (value, min, max, fallback = 0) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(min, Math.min(max, Math.round(parsed))) : fallback;
+};
+
+export function normalizeDraftSignals(value = {}) {
+  return {
+    elapsedMs: boundedNumber(value?.elapsedMs, 0, 300000),
+    pauseMs: boundedNumber(value?.pauseMs, 0, 120000),
+    editCount: boundedNumber(value?.editCount, 0, 1000),
+    deletedChars: boundedNumber(value?.deletedChars, 0, 10000),
+    pauseCount: boundedNumber(value?.pauseCount, 0, 100),
+    characterCount: boundedNumber(value?.characterCount, 0, 4000)
+  };
+}
+
+export function buildOperatorDraftRequest({
+  prompt,
+  history = [],
+  draftSignals = {},
+  previousDraftSummary = '',
+  model = DEFAULT_OPERATOR_DRAFT_MODEL
+} = {}) {
+  const messages = (Array.isArray(history) ? history : [])
+    .slice(-4)
+    .map(item => ({
+      role: item?.role === 'assistant' ? 'assistant' : 'user',
+      content: clean(item?.content, 700)
+    }))
+    .filter(item => item.content);
+
+  const signals = normalizeDraftSignals(draftSignals);
+  const previousSummary = clean(previousDraftSummary, 180);
+  messages.push({
+    role: 'user',
+    content: [
+      'UNSENT_DRAFT_BEGIN',
+      clean(prompt, 2000),
+      'UNSENT_DRAFT_END',
+      `UI_SIGNALS ${JSON.stringify(signals)}`,
+      previousSummary ? `PREVIOUS_DRAFT_SUMMARY ${previousSummary}` : ''
+    ].filter(Boolean).join('\n')
+  });
+
+  return {
+    model,
+    store: false,
+    instructions: [
+      'You are a private pre-send awareness process for the 3DVR Operator.',
+      'The text marked UNSENT_DRAFT is not a sent message. Never answer it, never take an action, and never claim anything happened.',
+      'Infer only enough to help the eventual Operator understand what the user may be trying to say.',
+      'Treat typing cadence, edits, deletions, and pauses as weak interface signals. Do not infer emotions, diagnoses, intent to act, or other sensitive mental states from them.',
+      'summary must be a short neutral description of the likely topic or direction, not advice and not a reply to the user.',
+      'ready should be true only when the draft appears coherent enough that another idle check is unlikely to add useful context before Send.',
+      'checkAgainMs controls whether the system should look again if the user remains idle: use 0 when it should wait for another edit or Send; otherwise choose 2000 to 12000 milliseconds.',
+      'Prefer fewer checks. A long pause can justify one later recheck, but repeated unchanged checks usually should stop.',
+      'Return only the requested JSON.'
+    ].join(' '),
+    input: messages,
+    text: { format: { type: 'json_schema', ...DRAFT_RESPONSE_SCHEMA } }
+  };
+}
+
+export function normalizeOperatorDraftAwareness(value = {}) {
+  const requestedDelay = boundedNumber(value?.checkAgainMs, 0, 12000);
+  return {
+    summary: clean(value?.summary, 180),
+    ready: value?.ready === true,
+    checkAgainMs: requestedDelay > 0 && requestedDelay < 2000 ? 2000 : requestedDelay
+  };
+}

--- a/tests/operator-draft-awareness.test.js
+++ b/tests/operator-draft-awareness.test.js
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildOperatorDraftRequest,
+  DEFAULT_OPERATOR_DRAFT_MODEL,
+  normalizeDraftSignals,
+  normalizeOperatorDraftAwareness
+} from '../src/operator/draft-awareness.js';
+import {
+  changedDraftCharacters,
+  clampDraftDelay,
+  shouldObserveDraft
+} from '../operator/live-awareness.js';
+
+test('draft awareness uses a small stateless request with no action contract', () => {
+  const request = buildOperatorDraftRequest({
+    prompt: 'I think we should maybe change the portal home page',
+    history: [{ role: 'assistant', content: 'What do you want to work on next?' }],
+    draftSignals: { elapsedMs: 8000, pauseMs: 3200, editCount: 4, deletedChars: 12, pauseCount: 1, characterCount: 52 }
+  });
+
+  assert.equal(request.model, DEFAULT_OPERATOR_DRAFT_MODEL);
+  assert.equal(request.store, false);
+  assert.equal(request.text.format.name, 'portal_operator_draft_awareness');
+  assert.match(request.instructions, /Never answer it, never take an action/i);
+  assert.match(request.instructions, /weak interface signals/i);
+  assert.doesNotMatch(request.instructions, /request_code_change/);
+  assert.match(request.input.at(-1).content, /UNSENT_DRAFT_BEGIN/);
+  assert.match(request.input.at(-1).content, /"pauseMs":3200/);
+});
+
+test('draft signals and requested intervals are bounded', () => {
+  assert.deepEqual(normalizeDraftSignals({
+    elapsedMs: 9999999,
+    pauseMs: -20,
+    editCount: 99999,
+    deletedChars: 99999,
+    pauseCount: 999,
+    characterCount: 99999
+  }), {
+    elapsedMs: 300000,
+    pauseMs: 0,
+    editCount: 1000,
+    deletedChars: 10000,
+    pauseCount: 100,
+    characterCount: 4000
+  });
+
+  assert.deepEqual(normalizeOperatorDraftAwareness({
+    summary: '  thinking about portal changes  ',
+    ready: true,
+    checkAgainMs: 500
+  }), {
+    summary: 'thinking about portal changes',
+    ready: true,
+    checkAgainMs: 2000
+  });
+
+  assert.equal(clampDraftDelay(500), 1800);
+  assert.equal(clampDraftDelay(90000), 12000);
+  assert.equal(clampDraftDelay(0), 0);
+});
+
+test('client only observes meaningful drafts and edits', () => {
+  assert.equal(shouldObserveDraft({ draft: 'too short' }), false);
+  assert.equal(shouldObserveDraft({ draft: 'This is long enough to observe.' }), true);
+  assert.equal(shouldObserveDraft({
+    draft: 'This is long enough to observe.',
+    lastObserved: 'This is long enough to observe.'
+  }), false);
+  assert.equal(shouldObserveDraft({
+    draft: 'This is long enough to observe!',
+    lastObserved: 'This is long enough to observe.'
+  }), true);
+  assert.equal(shouldObserveDraft({
+    draft: 'This is long enough to observe.',
+    lastObserved: 'This is long enough to observe.',
+    forceIdle: true
+  }), true);
+  assert.ok(changedDraftCharacters('hello world', 'hello there') >= 8);
+});


### PR DESCRIPTION
Adds an opt-in live draft awareness layer to full Operator.

- observes only meaningful unsent edits after a pause
- lets the lightweight draft model choose whether/when to recheck
- caps unchanged idle rechecks at two
- uses `gpt-4.1-mini` / gateway equivalent with `store:false`
- sends no portal snapshot or developer auth for draft checks
- draft checks cannot take actions
- adds unit coverage for client heuristics and server safeguards

Live awareness is off by default and can be enabled from the Operator composer.