### PR TITLE
Fix homepage Operator developer auth and busy-state UX

### DIFF
--- a/home-operator.js
+++ b/home-operator.js
@@ -1,5 +1,6 @@
 import { runOperatorAction } from './operator/actions.js';
 import { collectPortalContext } from './operator/portal-context.js';
+import { createOperatorDeveloperProof } from './operator/forge.js';
 
 const ACCOUNT_SCORE_PREFIX = '3dvr:score:';
 
@@ -222,6 +223,7 @@ if (form && input && submit && status && result && reply && followUps && actionL
   const makeConversationId = () => globalThis.crypto?.randomUUID?.()
     || `conversation-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const now = () => new Date().toISOString();
+  const idlePlaceholder = input.getAttribute('placeholder') || 'Ask Operator…';
 
   let history = [];
   let homeConversationId = '';
@@ -455,6 +457,7 @@ if (form && input && submit && status && result && reply && followUps && actionL
   const setBusy = busy => {
     submit.disabled = busy;
     input.disabled = busy;
+    input.placeholder = busy ? 'Operator is working on this page…' : idlePlaceholder;
     submit.dataset.busy = String(busy);
     submit.setAttribute('aria-label', busy ? 'Operator is working' : 'Send to Operator');
     form.setAttribute('aria-busy', String(busy));
@@ -492,13 +495,16 @@ if (form && input && submit && status && result && reply && followUps && actionL
     persistHistory();
     input.value = '';
     setBusy(true);
-    status.textContent = 'Operator is working on this page…';
+    status.textContent = '';
 
     try {
-      const portalContext = await collectPortalContext();
+      const [portalContext, developerAuth] = await Promise.all([
+        collectPortalContext(),
+        createOperatorDeveloperProof()
+      ]);
       portalContext.page = collectPageContext();
 
-      const response = await requestOperator({ prompt, history: prior, portalContext });
+      const response = await requestOperator({ prompt, history: prior, portalContext, developerAuth });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Operator request failed.');
 

--- a/operator/forge.js
+++ b/operator/forge.js
@@ -139,7 +139,7 @@ async function signedPortalProof(scope, action, extra = {}, options = {}) {
 }
 
 export async function createOperatorDeveloperProof() {
-  return signedPortalProof('operator-developer-access', 'operator-chat', {}, { loadRuntime: false });
+  return signedPortalProof('operator-developer-access', 'operator-chat');
 }
 
 export async function saveCodeSuggestion(action = {}) {

--- a/operator/forge.js
+++ b/operator/forge.js
@@ -139,6 +139,8 @@ async function signedPortalProof(scope, action, extra = {}, options = {}) {
 }
 
 export async function createOperatorDeveloperProof() {
+  const signedIn = globalThis.localStorage?.getItem?.('signedIn') === 'true';
+  if (!signedIn) return null;
   return signedPortalProof('operator-developer-access', 'operator-chat');
 }
 

--- a/tests/home-operator-bar.test.js
+++ b/tests/home-operator-bar.test.js
@@ -17,3 +17,20 @@ test('homepage embeds a context-aware Operator bar', async () => {
   assert.match(client, /runOperatorAction/);
   assert.match(client, /provider=operator/);
 });
+
+test('homepage Operator sends the signed developer proof used by full Operator', async () => {
+  const client = await read('home-operator.js');
+
+  assert.match(client, /createOperatorDeveloperProof/);
+  assert.match(client, /const \[portalContext, developerAuth\] = await Promise\.all/);
+  assert.match(client, /createOperatorDeveloperProof\(\)/);
+  assert.match(client, /requestOperator\(\{ prompt, history: prior, portalContext, developerAuth \}\)/);
+});
+
+test('homepage busy state lives in the Operator input instead of the status line', async () => {
+  const client = await read('home-operator.js');
+
+  assert.match(client, /input\.placeholder = busy \? 'Operator is working on this page…' : idlePlaceholder/);
+  assert.match(client, /setBusy\(true\);\n\s*status\.textContent = '';/);
+  assert.doesNotMatch(client, /status\.textContent = 'Operator is working on this page…'/);
+});


### PR DESCRIPTION
## What changed
- send the same signed 3DVR developer proof from homepage Operator that full Operator already sends
- keep code-edit authorization tied to the existing SEA verification path
- show “Operator is working on this page…” inside the Operator input placeholder instead of the status text below it
- add regression coverage for both behaviors

This fixes the homepage path where approved developer accounts were always treated as contributors because no developer proof was included.