### PR TITLE
Link Operator Forge actions to exact records

### DIFF
--- a/forge/record.html
+++ b/forge/record.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Forge item | 3DVR</title>
+  <meta name="theme-color" content="#111827">
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="../index-style.css">
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="/gun-init.js"></script>
+  <style>
+    :root { color-scheme: dark; }
+    body { min-height: 100vh; background: #0d1117; color: #e6edf3; }
+    .record-shell { width: min(100% - 32px, 760px); margin: 0 auto; padding: 24px 0 48px; }
+    .record-nav { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+    .record-nav a { color: #c9d1d9; text-decoration: none; font-weight: 700; }
+    .record-nav a:first-child { margin-right: auto; }
+    .record-card { border: 1px solid #30363d; border-radius: 20px; background: rgba(22, 27, 34, 0.92); padding: 22px; box-shadow: 0 22px 54px rgba(0,0,0,.24); }
+    .record-eyebrow { margin: 0 0 8px; color: #79c0ff; font-size: .78rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+    .record-title { margin: 0; font-size: clamp(1.45rem, 6vw, 2.2rem); line-height: 1.1; }
+    .record-meta { display: flex; flex-wrap: wrap; gap: 8px; margin: 16px 0 22px; }
+    .record-meta span { border: 1px solid #30363d; border-radius: 999px; padding: 6px 10px; color: #8b949e; font-size: .85rem; }
+    .record-status { color: #aff5b4 !important; border-color: rgba(46,160,67,.45) !important; }
+    .record-section { margin-top: 22px; }
+    .record-section h2 { margin: 0 0 8px; font-size: .92rem; color: #8b949e; text-transform: uppercase; letter-spacing: .06em; }
+    .record-section p, .record-section pre { margin: 0; line-height: 1.65; white-space: pre-wrap; overflow-wrap: anywhere; }
+    .record-error { color: #ffb4b4; }
+    .record-loading { color: #8b949e; }
+    .record-id { margin-top: 24px; color: #6e7681; font: 12px ui-monospace, SFMono-Regular, Consolas, monospace; overflow-wrap: anywhere; }
+    [hidden] { display: none !important; }
+  </style>
+</head>
+<body>
+  <main class="record-shell">
+    <nav class="record-nav" aria-label="Forge item navigation">
+      <a href="/forge/">← Forge</a>
+      <a href="/operator/">Operator</a>
+      <a href="/">Portal</a>
+    </nav>
+
+    <article class="record-card" aria-live="polite">
+      <p class="record-eyebrow" data-record-kind>Forge item</p>
+      <h1 class="record-title" data-record-title>Loading…</h1>
+      <p class="record-loading" data-record-loading>Opening this Forge record.</p>
+
+      <div data-record-content hidden>
+        <div class="record-meta">
+          <span class="record-status" data-record-status></span>
+          <span data-record-repo></span>
+          <span data-record-created></span>
+        </div>
+
+        <section class="record-section">
+          <h2 data-record-body-label>Request</h2>
+          <p data-record-body></p>
+        </section>
+
+        <section class="record-section" data-record-result-section hidden>
+          <h2>Result</h2>
+          <p data-record-result></p>
+        </section>
+
+        <section class="record-section" data-record-error-section hidden>
+          <h2>Error</h2>
+          <p class="record-error" data-record-error></p>
+        </section>
+
+        <p class="record-id" data-record-id></p>
+      </div>
+    </article>
+  </main>
+
+  <script type="module" src="record.js"></script>
+</body>
+</html>

--- a/forge/record.js
+++ b/forge/record.js
@@ -1,0 +1,94 @@
+const params = new URLSearchParams(window.location.search);
+const kind = params.get('kind') === 'edit' ? 'edit' : params.get('kind') === 'suggestion' ? 'suggestion' : '';
+const id = String(params.get('id') || '').trim();
+
+const refs = {
+  kind: document.querySelector('[data-record-kind]'),
+  title: document.querySelector('[data-record-title]'),
+  loading: document.querySelector('[data-record-loading]'),
+  content: document.querySelector('[data-record-content]'),
+  status: document.querySelector('[data-record-status]'),
+  repo: document.querySelector('[data-record-repo]'),
+  created: document.querySelector('[data-record-created]'),
+  bodyLabel: document.querySelector('[data-record-body-label]'),
+  body: document.querySelector('[data-record-body]'),
+  resultSection: document.querySelector('[data-record-result-section]'),
+  result: document.querySelector('[data-record-result]'),
+  errorSection: document.querySelector('[data-record-error-section]'),
+  error: document.querySelector('[data-record-error]'),
+  id: document.querySelector('[data-record-id]'),
+};
+
+function clean(value = '', max = 6000) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function safeDate(value) {
+  const date = new Date(value || '');
+  return Number.isNaN(date.getTime()) ? '' : date.toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function showError(message) {
+  refs.kind.textContent = 'Forge item';
+  refs.title.textContent = 'Could not open this item';
+  refs.loading.textContent = message;
+  refs.loading.classList.add('record-error');
+  refs.content.hidden = true;
+}
+
+function renderRecord(record = {}) {
+  const isEdit = kind === 'edit';
+  const title = clean(record.title, 240) || (isEdit ? 'Operator code edit' : 'Operator suggestion');
+  const body = clean(isEdit ? record.task : record.text);
+  const status = clean(record.status, 80) || (isEdit ? 'queued' : 'open');
+  const repo = clean(record.repo, 120) || 'portal';
+  const created = safeDate(record.createdAt || record.updatedAt);
+  const result = clean(record.resultSummary);
+  const error = clean(record.error);
+
+  document.title = `${title} | 3DVR Forge`;
+  refs.kind.textContent = isEdit ? 'Forge edit' : 'Forge suggestion';
+  refs.title.textContent = title;
+  refs.status.textContent = status;
+  refs.repo.textContent = repo;
+  refs.created.textContent = created || 'Date unavailable';
+  refs.bodyLabel.textContent = isEdit ? 'Edit request' : 'Suggestion';
+  refs.body.textContent = body || 'No request text was stored.';
+  refs.result.textContent = result;
+  refs.resultSection.hidden = !result;
+  refs.error.textContent = error;
+  refs.errorSection.hidden = !error;
+  refs.id.textContent = `ID: ${id}`;
+  refs.loading.hidden = true;
+  refs.content.hidden = false;
+}
+
+if (!kind || !id) {
+  showError('This link is missing a valid Forge record type or ID.');
+} else if (!window.Gun) {
+  showError('Forge sync is unavailable in this browser.');
+} else {
+  const gun = window.Gun({ peers: window.__GUN_PEERS__ || ['wss://gun-relay-3dvr.fly.dev/gun'] });
+  const collection = kind === 'edit' ? 'editRequests' : 'suggestions';
+  const node = gun.get('3dvr-portal').get('forge').get(collection).get(id);
+  let resolved = false;
+
+  const timer = window.setTimeout(() => {
+    if (!resolved) showError('This Forge item did not load. It may still be syncing; try opening the link again.');
+  }, 5000);
+
+  node.once(record => {
+    resolved = true;
+    window.clearTimeout(timer);
+    if (!record || typeof record !== 'object' || (!record.id && !record.title && !record.status)) {
+      showError('This Forge item could not be found.');
+      return;
+    }
+    renderRecord(record);
+  });
+
+  node.on(record => {
+    if (!record || typeof record !== 'object') return;
+    renderRecord(record);
+  });
+}

--- a/operator/forge.js
+++ b/operator/forge.js
@@ -23,6 +23,11 @@ function makeId(prefix) {
   return `${prefix}-${globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(16).slice(2)}`}`;
 }
 
+function forgeRecordUrl(kind, id) {
+  const params = new URLSearchParams({ kind, id });
+  return `/forge/record.html?${params.toString()}`;
+}
+
 function loadScript(src) {
   if (typeof document === 'undefined') return Promise.reject(new Error('Browser script loading is unavailable.'));
   const existing = document.querySelector(`script[src="${src}"]`);
@@ -162,7 +167,11 @@ export async function saveCodeSuggestion(action = {}) {
     source: 'portal-operator'
   };
   await writeGun(context.gun.get(FORGE_ROOT).get('forge').get('suggestions').get(id), record);
-  return { message: 'Saved as a 3DVR Forge suggestion.' };
+  return {
+    message: 'Saved as a 3DVR Forge suggestion.',
+    url: forgeRecordUrl('suggestion', id),
+    label: 'Forge suggestion'
+  };
 }
 
 export async function queueCodeChange(action = {}) {
@@ -203,5 +212,9 @@ export async function queueCodeChange(action = {}) {
     authPub: proof.authPub
   };
   await writeGun(context.gun.get(FORGE_ROOT).get('forge').get('editRequests').get(id), record);
-  return { message: `Queued an approved developer edit for ${repo}.` };
+  return {
+    message: `Queued an approved developer edit for ${repo}.`,
+    url: forgeRecordUrl('edit', id),
+    label: 'Forge edit'
+  };
 }

--- a/tests/forge-record-deep-links.test.js
+++ b/tests/forge-record-deep-links.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('Operator Forge actions return links to the exact stored record', async () => {
+  const forge = await read('operator/forge.js');
+
+  assert.match(forge, /forgeRecordUrl\('suggestion', id\)/);
+  assert.match(forge, /forgeRecordUrl\('edit', id\)/);
+  assert.match(forge, /label: 'Forge suggestion'/);
+  assert.match(forge, /label: 'Forge edit'/);
+  assert.match(forge, /\/forge\/record\.html/);
+});
+
+test('Forge record page opens only safe display fields from the requested record', async () => {
+  const page = await read('forge/record.html');
+  const client = await read('forge/record.js');
+
+  assert.match(page, /data-record-status/);
+  assert.match(page, /record\.js/);
+  assert.match(client, /kind === 'edit' \? 'editRequests' : 'suggestions'/);
+  assert.match(client, /record\.resultSummary/);
+  assert.match(client, /record\.error/);
+  assert.doesNotMatch(client, /authProof/);
+  assert.doesNotMatch(client, /authPub/);
+});


### PR DESCRIPTION
## What changed
- return a direct deep link whenever Operator saves a Forge suggestion or queues an approved code edit
- add a dedicated Forge record page that opens the exact suggestion/edit by stable ID
- show live status, repo, request text, result summary, and errors
- keep signed SEA proof/auth fields out of the record viewer
- add regression tests for exact-record links and safe rendering

This makes “Saved as a 3DVR Forge suggestion” / queued edit outcomes immediately inspectable instead of dropping users at a generic workspace.