### PR TITLE
Make homepage Operator busy text visibly replace input

### DIFF
--- a/operator/actions.js
+++ b/operator/actions.js
@@ -1,3 +1,4 @@
+import './home-busy-state.js';
 import { openDatabase, loadState, saveState } from '../life-space/storage.js';
 import { normalizeProspect } from '../lead-finder/core.js';
 

--- a/operator/home-busy-state.js
+++ b/operator/home-busy-state.js
@@ -1,0 +1,40 @@
+const BUSY_TEXT = 'Operator is working on this page…';
+const IDLE_LABEL = 'Ask Operator anything';
+
+function installHomeOperatorBusyText() {
+  if (typeof document === 'undefined' || typeof MutationObserver === 'undefined') return;
+
+  const form = document.querySelector('#homeOperatorForm');
+  const input = document.querySelector('#homeOperatorInput');
+  if (!form || !input || input.dataset.busyTextInstalled === 'true') return;
+
+  input.dataset.busyTextInstalled = 'true';
+
+  const sync = () => {
+    const busy = form.getAttribute('aria-busy') === 'true';
+
+    if (busy) {
+      input.dataset.operatorBusyText = 'true';
+      input.value = BUSY_TEXT;
+      input.setAttribute('aria-label', BUSY_TEXT.replace(/…$/, ''));
+      return;
+    }
+
+    if (input.dataset.operatorBusyText === 'true') {
+      input.value = '';
+      delete input.dataset.operatorBusyText;
+      input.setAttribute('aria-label', IDLE_LABEL);
+    }
+  };
+
+  new MutationObserver(sync).observe(form, {
+    attributes: true,
+    attributeFilter: ['aria-busy']
+  });
+
+  sync();
+}
+
+installHomeOperatorBusyText();
+
+export { BUSY_TEXT, installHomeOperatorBusyText };

--- a/tests/home-operator-bar.test.js
+++ b/tests/home-operator-bar.test.js
@@ -29,8 +29,15 @@ test('homepage Operator sends the signed developer proof used by full Operator',
 
 test('homepage busy state lives in the Operator input instead of the status line', async () => {
   const client = await read('home-operator.js');
+  const actions = await read('operator/actions.js');
+  const busyUi = await read('operator/home-busy-state.js');
 
   assert.match(client, /input\.placeholder = busy \? 'Operator is working on this page…' : idlePlaceholder/);
   assert.match(client, /setBusy\(true\);\n\s*status\.textContent = '';/);
   assert.doesNotMatch(client, /status\.textContent = 'Operator is working on this page…'/);
+  assert.match(actions, /import '\.\/home-busy-state\.js';/);
+  assert.match(busyUi, /input\.value = BUSY_TEXT/);
+  assert.match(busyUi, /const BUSY_TEXT = 'Operator is working on this page…'/);
+  assert.match(busyUi, /form\.getAttribute\('aria-busy'\) === 'true'/);
+  assert.match(busyUi, /input\.value = '';/);
 });


### PR DESCRIPTION
## What changed
- make `Operator is working on this page…` the actual visible input value while homepage Operator is busy
- keep the field locked by the existing busy state, then restore the normal empty `Ask Operator…` input afterward
- mirror the form's `aria-busy` state so this works consistently on mobile browsers instead of relying only on disabled-input placeholder rendering
- add regression coverage for the visible busy value

This addresses the live UX issue where the busy message still appeared not to replace `Ask Operator…` in the box.