### PR TITLE
Retry transient Operator fetch failures

### DIFF
--- a/operator/actions.js
+++ b/operator/actions.js
@@ -1,4 +1,5 @@
 import './home-busy-state.js';
+import './network-resilience.js';
 import { openDatabase, loadState, saveState } from '../life-space/storage.js';
 import { normalizeProspect } from '../lead-finder/core.js';
 

--- a/operator/network-resilience.js
+++ b/operator/network-resilience.js
@@ -1,0 +1,60 @@
+const INSTALL_KEY = '__3dvrOperatorFetchRetryInstalled';
+const RETRY_DELAY_MS = 650;
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function operatorRequestUrl(input) {
+  const raw = typeof input === 'string' ? input : input?.url || '';
+  if (!raw) return null;
+  try {
+    return new URL(raw, globalThis.location?.href || 'https://portal.3dvr.tech/');
+  } catch {
+    return null;
+  }
+}
+
+function isOperatorApiRequest(input) {
+  const url = operatorRequestUrl(input);
+  if (!url) return false;
+  const currentOrigin = globalThis.location?.origin || url.origin;
+  return url.origin === currentOrigin
+    && url.pathname === '/api/openai-site'
+    && url.searchParams.get('provider') === 'operator';
+}
+
+function requestMethod(input, init = {}) {
+  return String(init?.method || input?.method || 'GET').toUpperCase();
+}
+
+export function installOperatorFetchRetry(target = globalThis) {
+  if (!target?.fetch || target[INSTALL_KEY]) return;
+
+  const originalFetch = target.fetch.bind(target);
+  target[INSTALL_KEY] = true;
+
+  target.fetch = async (input, init) => {
+    try {
+      return await originalFetch(input, init);
+    } catch (error) {
+      const retryable = isOperatorApiRequest(input)
+        && requestMethod(input, init) === 'POST';
+      if (!retryable) throw error;
+
+      await sleep(RETRY_DELAY_MS);
+      try {
+        return await originalFetch(input, init);
+      } catch (retryError) {
+        const message = target.navigator?.onLine === false
+          ? 'You appear to be offline. Reconnect and try Operator again.'
+          : 'Connection to Operator was interrupted. Please try again.';
+        const wrapped = new TypeError(message);
+        wrapped.cause = retryError;
+        throw wrapped;
+      }
+    }
+  };
+}
+
+installOperatorFetchRetry();

--- a/tests/operator-network-resilience.test.js
+++ b/tests/operator-network-resilience.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('Operator retries browser-level fetch failures once without retrying HTTP responses', async () => {
+  const actions = await read('operator/actions.js');
+  const network = await read('operator/network-resilience.js');
+
+  assert.match(actions, /import '\.\/network-resilience\.js';/);
+  assert.match(network, /url\.pathname === '\/api\/openai-site'/);
+  assert.match(network, /url\.searchParams\.get\('provider'\) === 'operator'/);
+  assert.match(network, /requestMethod\(input, init\) === 'POST'/);
+  assert.match(network, /return await originalFetch\(input, init\);/);
+  assert.match(network, /await sleep\(RETRY_DELAY_MS\);/);
+  assert.match(network, /return await originalFetch\(input, init\);/g);
+  assert.match(network, /Connection to Operator was interrupted\. Please try again\./);
+  assert.doesNotMatch(network, /response\.status/);
+});


### PR DESCRIPTION
## What changed
- add one automatic retry for browser-level `fetch()` failures on Operator POST requests
- apply it to both the homepage Operator bar and full Operator via their shared action module
- do not retry HTTP 4xx/5xx responses, so real server errors stay visible
- replace raw repeated `Failed to fetch` with a clearer connection/offline message after the retry is exhausted
- add regression coverage

The production logs showed the failed request never reached `/api/openai-site`, while nearby successful Operator calls returned 200. This hardens the client transport layer without duplicating Forge actions, which only run after a successful Operator response.