### PR TITLE
Make Vercel deploys truly main-only

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -1,13 +1,16 @@
-name: Vercel Production Fallback
+name: Vercel Production
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: vercel-production-fallback
+  group: vercel-production-main
   cancel-in-progress: true
 
 env:
@@ -17,7 +20,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy canonical production fallback
+    name: Deploy canonical production
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "*": false,
-      "main": true
-    }
+    "deploymentEnabled": false
   },
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [
     { "path": "/api/growth/homepage-hero-cron", "schedule": "43 2 * * *" },
     { "path": "/api/money/autopilot-cron", "schedule": "17 16 * * 1-5" }


### PR DESCRIPTION
Disable native Vercel Git deployments so feature-branch commits stop creating canceled deployment records. Use the production GitHub Action on pushes to `main`, while keeping previews opt-in through the existing labeled/manual preview workflow.