### PR TITLE
Restore native Vercel production until CI token exists

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -1,16 +1,13 @@
-name: Vercel Production
+name: Vercel Production Fallback
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: vercel-production-main
+  group: vercel-production-fallback
   cancel-in-progress: true
 
 env:
@@ -20,7 +17,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy canonical production
+    name: Deploy canonical production fallback
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
   },
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [
     { "path": "/api/growth/homepage-hero-cron", "schedule": "43 2 * * *" },
     { "path": "/api/money/autopilot-cron", "schedule": "17 16 * * 1-5" }


### PR DESCRIPTION
Restore the previously working native Vercel Git path for `main` and return the token-dependent GitHub Actions deploy to manual fallback only. This avoids leaving production deploys disabled while `VERCEL_TOKEN` is not configured in GitHub. Preview workflow remains opt-in.