### PR TITLE
Recover Operator developer proof from Portal login

### DIFF
--- a/operator/actions.js
+++ b/operator/actions.js
@@ -1,5 +1,6 @@
 import './home-busy-state.js';
 import './network-resilience.js';
+import './forge-link-label.js';
 import { revealDeveloperKeyButton } from './developer-key-ui.js';
 import { openDatabase, loadState, saveState } from '../life-space/storage.js';
 import { normalizeProspect } from '../lead-finder/core.js';

--- a/operator/actions.js
+++ b/operator/actions.js
@@ -1,5 +1,6 @@
 import './home-busy-state.js';
 import './network-resilience.js';
+import { revealDeveloperKeyButton } from './developer-key-ui.js';
 import { openDatabase, loadState, saveState } from '../life-space/storage.js';
 import { normalizeProspect } from '../lead-finder/core.js';
 
@@ -43,7 +44,9 @@ export async function runOperatorAction(action = {}) {
   }
   if (action.type === 'suggest_code_change') {
     const { saveCodeSuggestion } = await import('./forge.js');
-    return saveCodeSuggestion(action);
+    const outcome = await saveCodeSuggestion(action);
+    revealDeveloperKeyButton();
+    return outcome;
   }
   if (action.type === 'request_code_change') {
     const { queueCodeChange } = await import('./forge.js');

--- a/operator/developer-key-ui.js
+++ b/operator/developer-key-ui.js
@@ -1,0 +1,82 @@
+function readStorageValue(storage, key) {
+  try {
+    return String(storage?.getItem?.(key) || '').trim();
+  } catch {
+    return '';
+  }
+}
+
+export function getStoredDeveloperKey(storage = globalThis.localStorage) {
+  if (readStorageValue(storage, 'signedIn') !== 'true') return '';
+  return readStorageValue(storage, 'userPubKey');
+}
+
+function copyWithFallback(text, documentObj) {
+  const area = documentObj.createElement('textarea');
+  area.value = text;
+  area.setAttribute('readonly', '');
+  area.style.position = 'fixed';
+  area.style.opacity = '0';
+  documentObj.body.appendChild(area);
+  area.select();
+  const copied = documentObj.execCommand?.('copy') !== false;
+  area.remove();
+  return copied;
+}
+
+export function revealDeveloperKeyButton({
+  storage = globalThis.localStorage,
+  documentObj = globalThis.document,
+  navigatorObj = globalThis.navigator
+} = {}) {
+  const pub = getStoredDeveloperKey(storage);
+  if (!pub || !documentObj?.createElement) return null;
+
+  const existing = documentObj.querySelector('[data-operator-developer-key]');
+  if (existing) {
+    existing.hidden = false;
+    existing.dataset.operatorDeveloperKey = pub;
+    return existing;
+  }
+
+  const anchor = documentObj.querySelector('#homeOperatorStatus')
+    || documentObj.querySelector('#operator-status')
+    || documentObj.querySelector('#homeOperatorResult')
+    || documentObj.querySelector('#operator-form');
+  if (!anchor) return null;
+
+  const button = documentObj.createElement('button');
+  button.type = 'button';
+  button.dataset.operatorDeveloperKey = pub;
+  button.textContent = 'Copy developer key';
+  button.setAttribute('aria-label', 'Copy public developer key for approval');
+  button.style.marginLeft = '8px';
+  button.style.border = '1px solid currentColor';
+  button.style.borderRadius = '999px';
+  button.style.padding = '4px 9px';
+  button.style.background = 'transparent';
+  button.style.color = 'inherit';
+  button.style.font = 'inherit';
+  button.style.cursor = 'pointer';
+
+  button.addEventListener('click', async () => {
+    let copied = false;
+    try {
+      if (navigatorObj?.clipboard?.writeText) {
+        await navigatorObj.clipboard.writeText(pub);
+        copied = true;
+      } else {
+        copied = copyWithFallback(pub, documentObj);
+      }
+    } catch {
+      copied = copyWithFallback(pub, documentObj);
+    }
+
+    const prior = button.textContent;
+    button.textContent = copied ? 'Developer key copied' : 'Copy developer key';
+    if (copied) setTimeout(() => { button.textContent = prior; }, 1800);
+  });
+
+  anchor.insertAdjacentElement?.('afterend', button);
+  return button;
+}

--- a/operator/forge-link-label.js
+++ b/operator/forge-link-label.js
@@ -1,0 +1,40 @@
+function labelForgeLink(anchor) {
+  if (!anchor?.getAttribute) return;
+  const href = anchor.getAttribute('href') || '';
+  if (!href.includes('/forge/record.html?')) return;
+
+  let kind = '';
+  try {
+    const url = new URL(href, globalThis.location?.origin || 'https://portal.3dvr.tech');
+    kind = url.searchParams.get('kind') || '';
+  } catch {
+    return;
+  }
+
+  if (kind === 'suggestion') anchor.textContent = 'Open Forge suggestion →';
+  if (kind === 'edit') anchor.textContent = 'Open Forge edit →';
+}
+
+export function installForgeLinkLabels(documentObj = globalThis.document) {
+  if (!documentObj?.querySelectorAll || typeof globalThis.MutationObserver !== 'function') return null;
+  if (documentObj.documentElement?.dataset?.forgeLinkLabelsInstalled === 'true') return null;
+  if (documentObj.documentElement) documentObj.documentElement.dataset.forgeLinkLabelsInstalled = 'true';
+
+  const scan = root => {
+    if (root?.matches?.('a[href*="/forge/record.html?"]')) labelForgeLink(root);
+    root?.querySelectorAll?.('a[href*="/forge/record.html?"]').forEach(labelForgeLink);
+  };
+
+  scan(documentObj);
+  const observer = new MutationObserver(records => {
+    records.forEach(record => record.addedNodes.forEach(node => {
+      if (node?.nodeType === 1) scan(node);
+    }));
+  });
+  observer.observe(documentObj.body || documentObj.documentElement, { childList: true, subtree: true });
+  return observer;
+}
+
+installForgeLinkLabels();
+
+export { labelForgeLink };

--- a/operator/forge.js
+++ b/operator/forge.js
@@ -1,5 +1,6 @@
 const FORGE_ROOT = '3dvr-portal';
 const PROOF_WAIT_MS = 900;
+const AUTH_WAIT_MS = 2600;
 const WRITE_TIMEOUT_MS = 3500;
 const DEFAULT_PEERS = [
   'wss://gun-relay-3dvr.fly.dev/gun',
@@ -91,13 +92,60 @@ async function getGunContext({ loadRuntime = true } = {}) {
   return { gun: gunInstance, user: gunUser };
 }
 
-async function waitForSea(user) {
-  const deadline = Date.now() + PROOF_WAIT_MS;
+async function waitForSea(user, waitMs = PROOF_WAIT_MS) {
+  const deadline = Date.now() + waitMs;
   while (Date.now() < deadline) {
     if (user?._?.sea && (user?.is?.pub || user._.sea.pub)) return user._.sea;
     await new Promise(resolve => setTimeout(resolve, 50));
   }
   return user?._?.sea || null;
+}
+
+function readStoredPortalAuth() {
+  const storage = globalThis.localStorage;
+  if (storage?.getItem?.('signedIn') !== 'true') return null;
+  const alias = normalizeText(storage.getItem('alias'), 200);
+  const password = normalizeText(storage.getItem('password'), 1000);
+  const expectedPub = normalizeText(storage.getItem('userPubKey'), 500);
+  if (!alias || !password) return null;
+  return { alias, password, expectedPub };
+}
+
+async function restoreStoredPortalSea(user) {
+  const stored = readStoredPortalAuth();
+  if (!stored || typeof user?.auth !== 'function') return null;
+
+  const authenticated = await new Promise(resolve => {
+    let settled = false;
+    const finish = value => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(false), AUTH_WAIT_MS);
+
+    try {
+      user.auth(stored.alias, stored.password, ack => {
+        if (ack?.err) return finish(false);
+        const actualPub = normalizeText(user?.is?.pub || user?._?.sea?.pub, 500);
+        if (!actualPub) return finish(false);
+        if (stored.expectedPub && stored.expectedPub !== actualPub) return finish(false);
+        finish(true);
+      });
+    } catch {
+      finish(false);
+    }
+  });
+
+  if (!authenticated) return null;
+  return waitForSea(user, AUTH_WAIT_MS);
+}
+
+async function ensurePortalSea(user) {
+  const recalled = await waitForSea(user);
+  if (recalled && (user?.is?.pub || recalled.pub)) return recalled;
+  return restoreStoredPortalSea(user);
 }
 
 function writeGun(node, value) {
@@ -121,7 +169,7 @@ function writeGun(node, value) {
 async function signedPortalProof(scope, action, extra = {}, options = {}) {
   const context = await getGunContext(options);
   if (!context || !globalThis.Gun?.SEA?.sign) return null;
-  const sea = await waitForSea(context.user);
+  const sea = await ensurePortalSea(context.user);
   const pub = normalizeText(context.user?.is?.pub || sea?.pub, 500);
   if (!sea || !pub) return null;
   const alias = normalizeText(context.user?.is?.alias || globalThis.localStorage?.getItem?.('alias'), 200);

--- a/tests/operator-developer-key-ui.test.js
+++ b/tests/operator-developer-key-ui.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { getStoredDeveloperKey } from '../operator/developer-key-ui.js';
+
+function storage(values = {}) {
+  return {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(values, key) ? values[key] : null;
+    }
+  };
+}
+
+test('developer key UI only exposes the signed-in account public key', () => {
+  assert.equal(getStoredDeveloperKey(storage({ signedIn: 'false', userPubKey: 'pub-1' })), '');
+  assert.equal(getStoredDeveloperKey(storage({ signedIn: 'true', userPubKey: '  pub-1  ' })), 'pub-1');
+});
+
+test('Operator developer proof can restore the existing Portal password session safely', async () => {
+  const forge = await readFile(new URL('../operator/forge.js', import.meta.url), 'utf8');
+
+  assert.match(forge, /storage\.getItem\('alias'\)/);
+  assert.match(forge, /storage\.getItem\('password'\)/);
+  assert.match(forge, /storage\.getItem\('userPubKey'\)/);
+  assert.match(forge, /user\.auth\(stored\.alias, stored\.password/);
+  assert.match(forge, /stored\.expectedPub && stored\.expectedPub !== actualPub/);
+  assert.match(forge, /const sea = await ensurePortalSea\(context\.user\)/);
+});
+
+test('a downgraded code suggestion offers the signed-in developer key for approval', async () => {
+  const actions = await readFile(new URL('../operator/actions.js', import.meta.url), 'utf8');
+
+  assert.match(actions, /revealDeveloperKeyButton/);
+  assert.match(actions, /const outcome = await saveCodeSuggestion\(action\)/);
+  assert.match(actions, /revealDeveloperKeyButton\(\)/);
+});

--- a/tests/operator-forge-link-label.test.js
+++ b/tests/operator-forge-link-label.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { labelForgeLink } from '../operator/forge-link-label.js';
+
+function anchor(href) {
+  return {
+    textContent: 'Open workspace →',
+    getAttribute(name) {
+      return name === 'href' ? href : '';
+    }
+  };
+}
+
+test('Forge suggestion links are labeled as suggestions', () => {
+  const link = anchor('/forge/record.html?kind=suggestion&id=suggestion-1');
+  labelForgeLink(link);
+  assert.equal(link.textContent, 'Open Forge suggestion →');
+});
+
+test('Forge edit links are labeled as edits', () => {
+  const link = anchor('/forge/record.html?kind=edit&id=operator-task-1');
+  labelForgeLink(link);
+  assert.equal(link.textContent, 'Open Forge edit →');
+});


### PR DESCRIPTION
## What changed
- recover the signed Portal SEA session when Operator needs a developer proof but GUN recall has not populated the keypair yet
- re-authenticate locally from the Portal's existing stored alias/password, then require the authenticated SEA public key to match the stored `userPubKey`
- when an authenticated code request is still downgraded to a Forge suggestion, show a **Copy developer key** control using only the public key so the exact account can be approved without trusting the username alone
- add regression coverage for the public-key UI and proof recovery path

This is aimed at the current production behavior where the signed-in `tmsteph` account still receives suggestion-only responses.