### PR TITLE
Restore main-only Vercel production after Operator auth merge

### DIFF
--- a/operator/developer-key-ui.js
+++ b/operator/developer-key-ui.js
@@ -60,16 +60,19 @@ export function revealDeveloperKeyButton({
   button.style.cursor = 'pointer';
 
   button.addEventListener('click', async () => {
+    const currentPub = String(button.dataset.operatorDeveloperKey || getStoredDeveloperKey(storage) || '').trim();
+    if (!currentPub) return;
+
     let copied = false;
     try {
       if (navigatorObj?.clipboard?.writeText) {
-        await navigatorObj.clipboard.writeText(pub);
+        await navigatorObj.clipboard.writeText(currentPub);
         copied = true;
       } else {
-        copied = copyWithFallback(pub, documentObj);
+        copied = copyWithFallback(currentPub, documentObj);
       }
     } catch {
-      copied = copyWithFallback(pub, documentObj);
+      copied = copyWithFallback(currentPub, documentObj);
     }
 
     const prior = button.textContent;

--- a/tests/operator-developer-key-ui.test.js
+++ b/tests/operator-developer-key-ui.test.js
@@ -35,3 +35,12 @@ test('a downgraded code suggestion offers the signed-in developer key for approv
   assert.match(actions, /const outcome = await saveCodeSuggestion\(action\)/);
   assert.match(actions, /revealDeveloperKeyButton\(\)/);
 });
+
+test('developer key copy reads the refreshed button key instead of a stale closure', async () => {
+  const ui = await readFile(new URL('../operator/developer-key-ui.js', import.meta.url), 'utf8');
+
+  assert.match(ui, /button\.dataset\.operatorDeveloperKey = pub/);
+  assert.match(ui, /const currentPub = String\(button\.dataset\.operatorDeveloperKey \|\| getStoredDeveloperKey\(storage\)/);
+  assert.match(ui, /writeText\(currentPub\)/);
+  assert.doesNotMatch(ui, /writeText\(pub\)/);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
   },
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [
     { "path": "/api/growth/homepage-hero-cron", "schedule": "43 2 * * *" },
     { "path": "/api/money/autopilot-cron", "schedule": "17 16 * * 1-5" }


### PR DESCRIPTION
## What changed
- restore the intended Vercel Git policy: build `main` for production, skip every non-main branch
- keep the GitHub Actions Vercel workflow as a manual fallback only
- fix the #1730 review issue so **Copy developer key** always copies the currently displayed account key rather than a stale key after an account switch
- add regression coverage for refreshed developer-key copying

The Operator auth fix in #1730 merged successfully, but a concurrent main update left `vercel.json` at `deploymentEnabled: false`, so that merge never reached production. This restores the already-tested main-only policy without reopening preview/branch builds.