### PR TITLE
Approve tmsteph Portal key for Operator edits

### DIFF
--- a/apps/agent/test/operator-forge-auth.test.js
+++ b/apps/agent/test/operator-forge-auth.test.js
@@ -5,7 +5,10 @@ const path = require('node:path');
 const {
   authorizePortalOperatorTask,
   resolveRepoAlias,
+  BUILTIN_OPERATOR_DEVELOPER_BINDINGS,
 } = require('../thomas-agent/node/operator-forge-auth');
+
+const TMSTEPH_PUB = 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg';
 
 function validRecord(overrides = {}) {
   return {
@@ -32,6 +35,27 @@ function validProof(overrides = {}) {
     ...overrides,
   };
 }
+
+test('built-in worker policy binds tmsteph alias to the exact SEA public key', () => {
+  assert.equal(BUILTIN_OPERATOR_DEVELOPER_BINDINGS['tmsteph@3dvr'], TMSTEPH_PUB);
+});
+
+test('built-in tmsteph SEA binding authorizes an Operator edit request', async () => {
+  const portalRepo = path.resolve('/srv/3dvr-portal');
+  const result = await authorizePortalOperatorTask(validRecord({ authPub: TMSTEPH_PUB }), {
+    now: 1_001_000,
+    env: { THREEDVR_OPERATOR_PORTAL_REPO: portalRepo },
+    verifyImpl: async () => validProof({
+      alias: 'tmsteph@3dvr',
+      pub: TMSTEPH_PUB,
+    }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.repoPath, portalRepo);
+  assert.equal(result.identity.alias, 'tmsteph@3dvr');
+  assert.equal(result.identity.pub, TMSTEPH_PUB);
+});
 
 test('approved signed Operator request resolves only an allowlisted repo path', async () => {
   const portalRepo = path.resolve('/srv/3dvr-portal');
@@ -85,6 +109,20 @@ test('claiming an approved alias with a different SEA key is rejected', async ()
     },
     verifyImpl: async () => validProof({
       alias: '3dvr.tech@gmail.com',
+      pub: 'pub-evil',
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, '3DVR account is not approved for code edits');
+});
+
+test('claiming tmsteph alias with a different SEA key is rejected', async () => {
+  const result = await authorizePortalOperatorTask(validRecord({ authPub: 'pub-evil' }), {
+    now: 1_001_000,
+    env: {},
+    verifyImpl: async () => validProof({
+      alias: 'tmsteph@3dvr',
       pub: 'pub-evil',
     }),
   });

--- a/apps/agent/thomas-agent/node/operator-forge-auth.js
+++ b/apps/agent/thomas-agent/node/operator-forge-auth.js
@@ -1,6 +1,9 @@
 const path = require('node:path');
 
 const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
+  'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',
+});
 
 function normalizeText(value = '') {
   return String(value || '').trim();
@@ -32,10 +35,21 @@ function parseBindings(value = '') {
   return bindings;
 }
 
+function withBuiltinBindings(bindings) {
+  for (const [alias, pub] of Object.entries(BUILTIN_OPERATOR_DEVELOPER_BINDINGS)) {
+    const normalizedAlias = normalizeAlias(alias);
+    const normalizedPub = normalizeText(pub);
+    if (normalizedAlias && normalizedPub && !bindings.has(normalizedAlias)) {
+      bindings.set(normalizedAlias, normalizedPub);
+    }
+  }
+  return bindings;
+}
+
 function resolvePolicy(env = process.env) {
   return {
     pubs: new Set(listFromConfig(env.THREEDVR_OPERATOR_DEVELOPER_PUBS)),
-    bindings: parseBindings(env.THREEDVR_OPERATOR_DEVELOPER_BINDINGS),
+    bindings: withBuiltinBindings(parseBindings(env.THREEDVR_OPERATOR_DEVELOPER_BINDINGS)),
   };
 }
 
@@ -128,4 +142,5 @@ module.exports = {
   authorizePortalOperatorTask,
   resolvePolicy,
   resolveRepoAlias,
+  BUILTIN_OPERATOR_DEVELOPER_BINDINGS,
 };

--- a/src/operator/developer-access.js
+++ b/src/operator/developer-access.js
@@ -1,6 +1,9 @@
 import { resolveSeaAuthMaxAgeMs, verifySignedSeaPayload } from '../auth/sea.js';
 
 export const DEFAULT_OPERATOR_DEVELOPER_ALIAS = '3dvr.tech@gmail.com';
+export const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
+  'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',
+});
 
 function normalizeText(value = '') {
   return String(value || '').trim();
@@ -32,10 +35,21 @@ function parseBindings(value = '') {
   return bindings;
 }
 
+function withBuiltinBindings(bindings) {
+  for (const [alias, pub] of Object.entries(BUILTIN_OPERATOR_DEVELOPER_BINDINGS)) {
+    const normalizedAlias = normalizeAlias(alias);
+    const normalizedPub = normalizeText(pub);
+    if (normalizedAlias && normalizedPub && !bindings.has(normalizedAlias)) {
+      bindings.set(normalizedAlias, normalizedPub);
+    }
+  }
+  return bindings;
+}
+
 export function resolveOperatorDeveloperPolicy(config = process.env) {
   return {
     pubs: new Set(listFromConfig(config.THREEDVR_OPERATOR_DEVELOPER_PUBS)),
-    bindings: parseBindings(config.THREEDVR_OPERATOR_DEVELOPER_BINDINGS)
+    bindings: withBuiltinBindings(parseBindings(config.THREEDVR_OPERATOR_DEVELOPER_BINDINGS))
   };
 }
 

--- a/tests/operator-developer-access.test.js
+++ b/tests/operator-developer-access.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  BUILTIN_OPERATOR_DEVELOPER_BINDINGS,
   DEFAULT_OPERATOR_DEVELOPER_ALIAS,
   resolveOperatorDeveloperAccess,
   resolveOperatorDeveloperPolicy,
@@ -11,11 +12,31 @@ import {
   normalizeOperatorResult,
 } from '../src/operator/api.js';
 
-test('default operator developer policy does not trust an alias by itself', () => {
+const TMSTEPH_PUB = 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg';
+
+test('default operator developer policy trusts only the built-in exact SEA binding', () => {
   const policy = resolveOperatorDeveloperPolicy({});
   assert.equal(DEFAULT_OPERATOR_DEVELOPER_ALIAS, '3dvr.tech@gmail.com');
+  assert.equal(BUILTIN_OPERATOR_DEVELOPER_BINDINGS['tmsteph@3dvr'], TMSTEPH_PUB);
   assert.equal(policy.pubs.size, 0);
-  assert.equal(policy.bindings.size, 0);
+  assert.equal(policy.bindings.size, 1);
+  assert.equal(policy.bindings.get('tmsteph@3dvr'), TMSTEPH_PUB);
+});
+
+test('built-in tmsteph SEA public key receives native code edit permission', async () => {
+  const access = await resolveOperatorDeveloperAccess({ authPub: TMSTEPH_PUB, authProof: 'proof-1' }, {
+    config: {},
+    expectedOrigin: 'https://portal.3dvr.tech',
+    verify: async () => ({
+      ok: true,
+      identity: { alias: 'tmsteph@3dvr', pub: TMSTEPH_PUB },
+    }),
+  });
+
+  assert.equal(access.authenticated, true);
+  assert.equal(access.approved, true);
+  assert.equal(access.role, 'developer');
+  assert.deepEqual(access.permissions, ['suggest', 'edit']);
 });
 
 test('approved SEA public key receives native code edit permission', async () => {
@@ -44,6 +65,21 @@ test('claiming the maintainer alias with an unbound key remains a contributor', 
     verify: async () => ({
       ok: true,
       identity: { alias: '3dvr.tech@gmail.com', pub: 'pub-evil' },
+    }),
+  });
+
+  assert.equal(access.authenticated, true);
+  assert.equal(access.approved, false);
+  assert.equal(access.role, 'contributor');
+  assert.deepEqual(access.permissions, ['suggest']);
+});
+
+test('claiming tmsteph alias with a different SEA key remains a contributor', async () => {
+  const access = await resolveOperatorDeveloperAccess({ authPub: 'pub-evil', authProof: 'proof-evil' }, {
+    config: {},
+    verify: async () => ({
+      ok: true,
+      identity: { alias: 'tmsteph@3dvr', pub: 'pub-evil' },
     }),
   });
 


### PR DESCRIPTION
## What changed
- bind the exact `tmsteph@3dvr` SEA public key supplied from the signed-in Portal account
- apply the same binding in the Portal API authorization policy and the DigitalOcean Forge worker authorization policy
- keep username/alias-only trust disabled; a different SEA key claiming `tmsteph@3dvr` remains a contributor
- preserve environment-based developer overrides/additions
- add regression coverage on both the Portal and worker sides

This completes the developer approval flow without exposing or trusting any private key material.