### PR TITLE
Audit live 3DVR server readiness

### DIFF
--- a/.github/workflows/server-readiness-audit.yml
+++ b/.github/workflows/server-readiness-audit.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 5
     env:
       RESULT_BRANCH: ${{ github.head_ref }}
+      DO_HOST: 167.172.193.194
     defaults:
       run:
         working-directory: apps/agent
@@ -40,8 +41,29 @@ jobs:
       - name: Install agent dependencies
         run: npm ci
 
+      - name: Probe DigitalOcean public surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - "$DO_HOST" <<'PY' > /tmp/server-audit-public.json
+          import json, socket, sys
+          host = sys.argv[1]
+          ports = {}
+          for port in (22, 80, 443, 4310):
+              sock = socket.socket()
+              sock.settimeout(4)
+              try:
+                  sock.connect((host, port))
+                  ports[str(port)] = True
+              except OSError:
+                  ports[str(port)] = False
+              finally:
+                  sock.close()
+          print(json.dumps({'host': host, 'ports': ports}))
+          PY
+          cat /tmp/server-audit-public.json
+
       - name: Probe managed and legacy workers
-        id: audit
         shell: bash
         run: |
           set -euo pipefail
@@ -74,8 +96,8 @@ jobs:
             cat "$outfile"
           }
 
-          probe_queue '3dvr-managed' 12 /tmp/server-audit-managed.json
-          probe_queue 'anonymous@3dvr' 20 /tmp/server-audit-legacy.json
+          probe_queue '3dvr-managed' 8 /tmp/server-audit-managed.json
+          probe_queue 'anonymous@3dvr' 12 /tmp/server-audit-legacy.json
 
       - name: Persist sanitized audit result
         if: always()
@@ -86,11 +108,16 @@ jobs:
           python3 - <<'PY'
           import datetime, json, os
 
-          def read_record(path):
+          def load_json_with_banner(path):
               try:
-                  record = json.load(open(path))
+                  text = open(path).read()
+                  start = text.find('{')
+                  return json.loads(text[start:]) if start >= 0 else {}
               except Exception:
-                  record = {}
+                  return {}
+
+          def read_record(path):
+              record = load_json_with_banner(path)
               try:
                   task_id = open(path + '.id').read().strip()
               except Exception:
@@ -103,8 +130,14 @@ jobs:
                   'error': record.get('error') or '',
               }
 
+          try:
+              public = json.load(open('/tmp/server-audit-public.json'))
+          except Exception:
+              public = {'host': os.environ.get('DO_HOST', ''), 'ports': {}}
+
           out = {
               'checkedAt': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+              'digitalOceanPublic': public,
               'managed': read_record('/tmp/server-audit-managed.json'),
               'legacy': read_record('/tmp/server-audit-legacy.json'),
           }
@@ -118,5 +151,5 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add ops/server-readiness-audit-result.json
           if git diff --cached --quiet; then exit 0; fi
-          git commit -m 'Record managed and legacy server readiness audit'
+          git commit -m 'Record server readiness audit'
           git push origin "HEAD:$RESULT_BRANCH"

--- a/.github/workflows/server-readiness-audit.yml
+++ b/.github/workflows/server-readiness-audit.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      THREEDVR_AGENT_OWNER_ALIAS: 3dvr-managed
       RESULT_BRANCH: ${{ github.head_ref }}
     defaults:
       run:
@@ -41,57 +40,73 @@ jobs:
       - name: Install agent dependencies
         run: npm ci
 
-      - name: Queue read-only server audit
+      - name: Probe managed and legacy workers
         id: audit
         shell: bash
         run: |
           set -euo pipefail
           task='printf "HOST=%s\n" "$(hostname -f 2>/dev/null || hostname)"; printf "IPS=%s\n" "$(hostname -I 2>/dev/null | xargs || true)"; echo "DISK_ROOT"; df -Pk / | tail -n 1; echo "INODES_ROOT"; df -Pi / | tail -n 1; echo "MEMORY_MB"; free -m | sed -n "1,2p"; echo "UPTIME"; uptime; echo "LARGEST_RUNTIME_DIRS_MB"; du -sm /opt/3dvr* /root/.3dvr /var/lib/3dvr-revenue /var/log 2>/dev/null | sort -nr | head -n 10 || true'
-          result="$(node thomas-agent/node/agent-task-queue.js enqueue --json --backend shell --risk read_only --approval-status not_required --requires shell --max-runtime-ms 60000 "$task")"
-          task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
-          echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
 
-          final=''
-          for attempt in $(seq 1 30); do
-            result="$(node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
-            status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
-            case "$status" in
-              completed|failed|skipped)
-                final="$result"
-                break
-                ;;
-            esac
-            sleep 4
-          done
+          probe_queue() {
+            owner="$1"
+            attempts="$2"
+            outfile="$3"
+            result="$(THREEDVR_AGENT_OWNER_ALIAS="$owner" node thomas-agent/node/agent-task-queue.js enqueue --json --backend shell --risk read_only --approval-status not_required --requires shell --max-runtime-ms 60000 "$task")"
+            task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
+            final=''
+            for attempt in $(seq 1 "$attempts"); do
+              result="$(THREEDVR_AGENT_OWNER_ALIAS="$owner" node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+              status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
+              case "$status" in
+                completed|failed|skipped)
+                  final="$result"
+                  break
+                  ;;
+              esac
+              sleep 4
+            done
+            if [ -z "$final" ]; then
+              final="$(THREEDVR_AGENT_OWNER_ALIAS="$owner" node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+            fi
+            printf '%s\n' "$final" > "$outfile"
+            printf '%s\n' "$task_id" > "${outfile}.id"
+            echo "=== $owner ==="
+            cat "$outfile"
+          }
 
-          if [ -z "$final" ]; then
-            final="$(node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
-          fi
-          printf '%s\n' "$final" > /tmp/server-audit-task.json
-          cat /tmp/server-audit-task.json
+          probe_queue '3dvr-managed' 12 /tmp/server-audit-managed.json
+          probe_queue 'anonymous@3dvr' 20 /tmp/server-audit-legacy.json
 
       - name: Persist sanitized audit result
         if: always()
         shell: bash
-        env:
-          TASK_ID: ${{ steps.audit.outputs.task_id }}
         run: |
           set -euo pipefail
           cd "$GITHUB_WORKSPACE"
           python3 - <<'PY'
           import datetime, json, os
-          src = '/tmp/server-audit-task.json'
-          try:
-              record = json.load(open(src))
-          except Exception:
-              record = {}
+
+          def read_record(path):
+              try:
+                  record = json.load(open(path))
+              except Exception:
+                  record = {}
+              try:
+                  task_id = open(path + '.id').read().strip()
+              except Exception:
+                  task_id = ''
+              return {
+                  'taskId': task_id or record.get('id') or '',
+                  'status': record.get('status') or 'unavailable',
+                  'workerDeviceId': record.get('workerDeviceId') or '',
+                  'resultSummary': record.get('resultSummary') or '',
+                  'error': record.get('error') or '',
+              }
+
           out = {
               'checkedAt': datetime.datetime.now(datetime.timezone.utc).isoformat(),
-              'taskId': os.environ.get('TASK_ID') or record.get('id') or '',
-              'status': record.get('status') or 'unavailable',
-              'workerDeviceId': record.get('workerDeviceId') or '',
-              'resultSummary': record.get('resultSummary') or '',
-              'error': record.get('error') or '',
+              'managed': read_record('/tmp/server-audit-managed.json'),
+              'legacy': read_record('/tmp/server-audit-legacy.json'),
           }
           os.makedirs('ops', exist_ok=True)
           with open('ops/server-readiness-audit-result.json', 'w') as f:
@@ -103,5 +118,5 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add ops/server-readiness-audit-result.json
           if git diff --cached --quiet; then exit 0; fi
-          git commit -m 'Record managed server readiness audit'
+          git commit -m 'Record managed and legacy server readiness audit'
           git push origin "HEAD:$RESULT_BRANCH"

--- a/.github/workflows/server-readiness-audit.yml
+++ b/.github/workflows/server-readiness-audit.yml
@@ -1,0 +1,107 @@
+name: Server Readiness Audit
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/server-readiness-audit.yml'
+      - 'ops/server-readiness-audit-trigger.txt'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: server-readiness-audit-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      THREEDVR_AGENT_OWNER_ALIAS: 3dvr-managed
+      RESULT_BRANCH: ${{ github.head_ref }}
+    defaults:
+      run:
+        working-directory: apps/agent
+    steps:
+      - name: Checkout audit branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.0
+          cache: npm
+          cache-dependency-path: apps/agent/package-lock.json
+
+      - name: Install agent dependencies
+        run: npm ci
+
+      - name: Queue read-only server audit
+        id: audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          task='printf "HOST=%s\n" "$(hostname -f 2>/dev/null || hostname)"; printf "IPS=%s\n" "$(hostname -I 2>/dev/null | xargs || true)"; echo "DISK_ROOT"; df -Pk / | tail -n 1; echo "INODES_ROOT"; df -Pi / | tail -n 1; echo "MEMORY_MB"; free -m | sed -n "1,2p"; echo "UPTIME"; uptime; echo "LARGEST_RUNTIME_DIRS_MB"; du -sm /opt/3dvr* /root/.3dvr /var/lib/3dvr-revenue /var/log 2>/dev/null | sort -nr | head -n 10 || true'
+          result="$(node thomas-agent/node/agent-task-queue.js enqueue --json --backend shell --risk read_only --approval-status not_required --requires shell --max-runtime-ms 60000 "$task")"
+          task_id="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task queue JSON payload missing');console.log(JSON.parse(s.slice(i)).id)})")"
+          echo "task_id=$task_id" >> "$GITHUB_OUTPUT"
+
+          final=''
+          for attempt in $(seq 1 30); do
+            result="$(node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+            status="$(printf '%s' "$result" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const i=s.indexOf('{');if(i<0)throw new Error('task status JSON payload missing');console.log(JSON.parse(s.slice(i)).status||'')})")"
+            case "$status" in
+              completed|failed|skipped)
+                final="$result"
+                break
+                ;;
+            esac
+            sleep 4
+          done
+
+          if [ -z "$final" ]; then
+            final="$(node thomas-agent/node/agent-task-queue.js status --id "$task_id" --json)"
+          fi
+          printf '%s\n' "$final" > /tmp/server-audit-task.json
+          cat /tmp/server-audit-task.json
+
+      - name: Persist sanitized audit result
+        if: always()
+        shell: bash
+        env:
+          TASK_ID: ${{ steps.audit.outputs.task_id }}
+        run: |
+          set -euo pipefail
+          cd "$GITHUB_WORKSPACE"
+          python3 - <<'PY'
+          import datetime, json, os
+          src = '/tmp/server-audit-task.json'
+          try:
+              record = json.load(open(src))
+          except Exception:
+              record = {}
+          out = {
+              'checkedAt': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+              'taskId': os.environ.get('TASK_ID') or record.get('id') or '',
+              'status': record.get('status') or 'unavailable',
+              'workerDeviceId': record.get('workerDeviceId') or '',
+              'resultSummary': record.get('resultSummary') or '',
+              'error': record.get('error') or '',
+          }
+          os.makedirs('ops', exist_ok=True)
+          with open('ops/server-readiness-audit-result.json', 'w') as f:
+              json.dump(out, f, indent=2)
+              f.write('\n')
+          PY
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add ops/server-readiness-audit-result.json
+          if git diff --cached --quiet; then exit 0; fi
+          git commit -m 'Record managed server readiness audit'
+          git push origin "HEAD:$RESULT_BRANCH"

--- a/ops/server-readiness-audit-result.json
+++ b/ops/server-readiness-audit-result.json
@@ -1,0 +1,8 @@
+{
+  "checkedAt": "2026-08-23T19:26:05.642125+00:00",
+  "taskId": "remote-task-d0fae135b2e6c65e6eb332cb",
+  "status": "unavailable",
+  "workerDeviceId": "",
+  "resultSummary": "",
+  "error": ""
+}

--- a/ops/server-readiness-audit-result.json
+++ b/ops/server-readiness-audit-result.json
@@ -1,8 +1,17 @@
 {
-  "checkedAt": "2026-08-23T19:26:05.642125+00:00",
-  "taskId": "remote-task-d0fae135b2e6c65e6eb332cb",
-  "status": "unavailable",
-  "workerDeviceId": "",
-  "resultSummary": "",
-  "error": ""
+  "checkedAt": "2026-08-23T19:29:41.858454+00:00",
+  "managed": {
+    "taskId": "remote-task-844228da4e662ae2dffa3a65",
+    "status": "unavailable",
+    "workerDeviceId": "",
+    "resultSummary": "",
+    "error": ""
+  },
+  "legacy": {
+    "taskId": "remote-task-dc7d9bef4897242d65ef8951",
+    "status": "unavailable",
+    "workerDeviceId": "",
+    "resultSummary": "",
+    "error": ""
+  }
 }

--- a/ops/server-readiness-audit-result.json
+++ b/ops/server-readiness-audit-result.json
@@ -1,15 +1,24 @@
 {
-  "checkedAt": "2026-08-23T19:29:41.858454+00:00",
+  "checkedAt": "2026-08-23T19:34:08.439472+00:00",
+  "digitalOceanPublic": {
+    "host": "167.172.193.194",
+    "ports": {
+      "22": true,
+      "80": true,
+      "443": true,
+      "4310": false
+    }
+  },
   "managed": {
-    "taskId": "remote-task-844228da4e662ae2dffa3a65",
-    "status": "unavailable",
+    "taskId": "remote-task-e1d8314de0ed255eb2301d45",
+    "status": "queued",
     "workerDeviceId": "",
     "resultSummary": "",
     "error": ""
   },
   "legacy": {
-    "taskId": "remote-task-dc7d9bef4897242d65ef8951",
-    "status": "unavailable",
+    "taskId": "remote-task-43a1b8411a1919f2fe8660cb",
+    "status": "queued",
     "workerDeviceId": "",
     "resultSummary": "",
     "error": ""

--- a/ops/server-readiness-audit-trigger.txt
+++ b/ops/server-readiness-audit-trigger.txt
@@ -1,0 +1,2 @@
+One-shot readiness audit requested 2026-08-23.
+Checks live managed worker hostname, root disk/inodes, memory, uptime, and largest 3DVR/runtime directories using the existing read-only agent queue.


### PR DESCRIPTION
One-shot read-only infrastructure audit using the existing managed 3DVR agent queue. Result: the DigitalOcean host at 167.172.193.194 is reachable on ports 22/80/443 (4310 is closed), but neither the `3dvr-managed` nor legacy `anonymous@3dvr` queue is currently being consumed. No worker claimed the disk-health task, so disk usage could not be measured remotely through the agent path. Diagnostic complete; closing without merging the temporary workflow.