### PR TITLE
Fix stale Operator developer session proof

### DIFF
--- a/operator/forge.js
+++ b/operator/forge.js
@@ -101,14 +101,38 @@ async function waitForSea(user, waitMs = PROOF_WAIT_MS) {
   return user?._?.sea || null;
 }
 
-function readStoredPortalAuth() {
+function readStoredPortalIdentity() {
   const storage = globalThis.localStorage;
   if (storage?.getItem?.('signedIn') !== 'true') return null;
   const alias = normalizeText(storage.getItem('alias'), 200);
-  const password = normalizeText(storage.getItem('password'), 1000);
   const expectedPub = normalizeText(storage.getItem('userPubKey'), 500);
-  if (!alias || !password) return null;
-  return { alias, password, expectedPub };
+  if (!alias && !expectedPub) return null;
+  return { alias, expectedPub };
+}
+
+function readStoredPortalAuth() {
+  const identity = readStoredPortalIdentity();
+  if (!identity) return null;
+  const password = normalizeText(globalThis.localStorage?.getItem?.('password'), 1000);
+  if (!identity.alias || !password) return null;
+  return { ...identity, password };
+}
+
+export function developerIdentityMatches({
+  expectedAlias = '',
+  expectedPub = '',
+  actualAlias = '',
+  actualPub = ''
+} = {}) {
+  const wantedAlias = normalizeText(expectedAlias, 200).toLowerCase();
+  const wantedPub = normalizeText(expectedPub, 500);
+  const seenAlias = normalizeText(actualAlias, 200).toLowerCase();
+  const seenPub = normalizeText(actualPub, 500);
+  if (!seenPub) return false;
+  if (wantedPub && wantedPub !== seenPub) return false;
+  if (wantedAlias && seenAlias && wantedAlias !== seenAlias) return false;
+  if (!wantedPub && wantedAlias && !seenAlias) return false;
+  return true;
 }
 
 async function restoreStoredPortalSea(user) {
@@ -143,8 +167,23 @@ async function restoreStoredPortalSea(user) {
 }
 
 async function ensurePortalSea(user) {
+  const stored = readStoredPortalIdentity();
   const recalled = await waitForSea(user);
-  if (recalled && (user?.is?.pub || recalled.pub)) return recalled;
+  if (recalled) {
+    const actualPub = normalizeText(user?.is?.pub || recalled.pub, 500);
+    const actualAlias = normalizeText(user?.is?.alias, 200);
+    if (developerIdentityMatches({
+      expectedAlias: stored?.alias,
+      expectedPub: stored?.expectedPub,
+      actualAlias,
+      actualPub
+    })) {
+      return recalled;
+    }
+    try {
+      user?.leave?.();
+    } catch {}
+  }
   return restoreStoredPortalSea(user);
 }
 

--- a/tests/operator-developer-key-ui.test.js
+++ b/tests/operator-developer-key-ui.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 import { getStoredDeveloperKey } from '../operator/developer-key-ui.js';
+import { developerIdentityMatches } from '../operator/forge.js';
 
 function storage(values = {}) {
   return {
@@ -26,6 +27,27 @@ test('Operator developer proof can restore the existing Portal password session 
   assert.match(forge, /user\.auth\(stored\.alias, stored\.password/);
   assert.match(forge, /stored\.expectedPub && stored\.expectedPub !== actualPub/);
   assert.match(forge, /const sea = await ensurePortalSea\(context\.user\)/);
+});
+
+test('Operator refuses a stale recalled SEA identity before signing a developer proof', async () => {
+  assert.equal(developerIdentityMatches({
+    expectedAlias: 'tmsteph@3dvr',
+    expectedPub: 'current-pub',
+    actualAlias: 'other@3dvr',
+    actualPub: 'stale-pub'
+  }), false);
+
+  assert.equal(developerIdentityMatches({
+    expectedAlias: 'tmsteph@3dvr',
+    expectedPub: 'current-pub',
+    actualAlias: 'tmsteph@3dvr',
+    actualPub: 'current-pub'
+  }), true);
+
+  const forge = await readFile(new URL('../operator/forge.js', import.meta.url), 'utf8');
+  assert.match(forge, /const stored = readStoredPortalIdentity\(\)/);
+  assert.match(forge, /developerIdentityMatches\(\{/);
+  assert.match(forge, /user\?\.leave\?\.\(\)/);
 });
 
 test('a downgraded code suggestion offers the signed-in developer key for approval', async () => {


### PR DESCRIPTION
Operator could recall a stale GUN/SEA session and use that identity to sign developer proofs even when Portal localStorage showed a newer signed-in account/key. The server then correctly downgraded the code edit to a Forge suggestion.

This change:
- validates recalled SEA identity against the current Portal alias/public key
- discards a stale recalled session and re-authenticates with the current Portal password session
- adds regression coverage for stale-vs-current developer identities

This keeps exact key binding intact; it does not weaken developer authorization.