### PR TITLE
Restore main-only Vercel Git deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
   },
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [


### PR DESCRIPTION
The quota guard changed `git.deploymentEnabled` to boolean `false`, which disables every automatic Git deployment including `main`. Restore the branch map that keeps feature branches disabled while allowing `main` production deploys. Keep the existing ignoreCommand as a second guard against non-main builds.