### PR TITLE
Resume Operator after weak mobile connections

### DIFF
--- a/operator/network-resilience.js
+++ b/operator/network-resilience.js
@@ -1,5 +1,7 @@
 const INSTALL_KEY = '__3dvrOperatorFetchRetryInstalled';
-const RETRY_DELAY_MS = 650;
+const PENDING_KEY = '3dvr.operator.pending-request.v1';
+const RETRY_DELAYS_MS = [650, 1500, 3000, 5000, 8000, 12000, 20000, 30000];
+const PENDING_TTL_MS = 30 * 60 * 1000;
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -28,6 +30,144 @@ function requestMethod(input, init = {}) {
   return String(init?.method || input?.method || 'GET').toUpperCase();
 }
 
+function safeStorage(target) {
+  try {
+    return target?.localStorage || null;
+  } catch {
+    return null;
+  }
+}
+
+function requestPrompt(init = {}) {
+  if (typeof init?.body !== 'string') return '';
+  try {
+    const payload = JSON.parse(init.body);
+    return String(payload?.prompt || '').trim().slice(0, 2000);
+  } catch {
+    return '';
+  }
+}
+
+function requestId(target) {
+  return target?.crypto?.randomUUID?.()
+    || `operator-request-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function persistPendingRequest(target, input, init, existingId = '') {
+  const storage = safeStorage(target);
+  if (!storage) return null;
+  const url = operatorRequestUrl(input);
+  const snapshot = {
+    id: existingId || requestId(target),
+    prompt: requestPrompt(init),
+    path: url ? `${url.pathname}${url.search}` : '/api/openai-site?provider=operator',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    attempts: 0
+  };
+  try {
+    storage.setItem(PENDING_KEY, JSON.stringify(snapshot));
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+function updatePendingAttempt(target, snapshot, attempts) {
+  if (!snapshot) return;
+  const storage = safeStorage(target);
+  if (!storage) return;
+  const next = { ...snapshot, attempts, updatedAt: Date.now() };
+  try {
+    storage.setItem(PENDING_KEY, JSON.stringify(next));
+    Object.assign(snapshot, next);
+  } catch {}
+}
+
+function clearPendingRequest(target, snapshot) {
+  const storage = safeStorage(target);
+  if (!storage || !snapshot) return;
+  try {
+    const current = JSON.parse(storage.getItem(PENDING_KEY) || 'null');
+    if (!current || current.id === snapshot.id) storage.removeItem(PENDING_KEY);
+  } catch {
+    try { storage.removeItem(PENDING_KEY); } catch {}
+  }
+}
+
+export function readPendingOperatorRequest(target = globalThis) {
+  const storage = safeStorage(target);
+  if (!storage) return null;
+  try {
+    const value = JSON.parse(storage.getItem(PENDING_KEY) || 'null');
+    if (!value || typeof value !== 'object') return null;
+    if (Date.now() - Number(value.updatedAt || value.createdAt || 0) > PENDING_TTL_MS) {
+      storage.removeItem(PENDING_KEY);
+      return null;
+    }
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+function recoveryState(target) {
+  const offline = target?.navigator?.onLine === false;
+  const hidden = target?.document?.visibilityState === 'hidden';
+  return {
+    ready: !offline && !hidden,
+    reason: offline ? 'offline' : hidden ? 'background' : 'retry'
+  };
+}
+
+function announce(target, message) {
+  const documentObj = target?.document;
+  if (!documentObj?.querySelector) return;
+  const node = documentObj.querySelector('#homeOperatorStatus, #operator-status');
+  if (node) node.textContent = message;
+}
+
+function waitForRetryOpportunity(target, delayMs) {
+  const state = recoveryState(target);
+  if (state.ready) return sleep(delayMs);
+
+  announce(target, state.reason === 'offline'
+    ? 'Waiting for connection…'
+    : 'Paused while the screen is away…');
+
+  return new Promise(resolve => {
+    const documentObj = target?.document;
+    let settled = false;
+    let delayTimer = null;
+    let pollTimer = null;
+
+    const cleanup = () => {
+      target?.removeEventListener?.('online', check);
+      target?.removeEventListener?.('pageshow', check);
+      documentObj?.removeEventListener?.('visibilitychange', check);
+      if (pollTimer) clearInterval(pollTimer);
+    };
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      announce(target, 'Reconnecting to Operator…');
+      delayTimer = setTimeout(resolve, delayMs);
+    };
+
+    function check() {
+      if (recoveryState(target).ready) finish();
+    }
+
+    target?.addEventListener?.('online', check);
+    target?.addEventListener?.('pageshow', check);
+    documentObj?.addEventListener?.('visibilitychange', check);
+    pollTimer = setInterval(check, 2000);
+    check();
+  });
+}
+
 export function installOperatorFetchRetry(target = globalThis) {
   if (!target?.fetch || target[INSTALL_KEY]) return;
 
@@ -35,25 +175,43 @@ export function installOperatorFetchRetry(target = globalThis) {
   target[INSTALL_KEY] = true;
 
   target.fetch = async (input, init) => {
-    try {
-      return await originalFetch(input, init);
-    } catch (error) {
-      const retryable = isOperatorApiRequest(input)
-        && requestMethod(input, init) === 'POST';
-      if (!retryable) throw error;
+    const retryable = isOperatorApiRequest(input)
+      && requestMethod(input, init) === 'POST';
+    if (!retryable) return originalFetch(input, init);
 
-      await sleep(RETRY_DELAY_MS);
+    const pending = persistPendingRequest(target, input, init);
+    let lastError = null;
+
+    for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+      if (attempt > 0) {
+        const delay = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+        await waitForRetryOpportunity(target, delay);
+        updatePendingAttempt(target, pending, attempt);
+      }
+
       try {
-        return await originalFetch(input, init);
-      } catch (retryError) {
-        const message = target.navigator?.onLine === false
-          ? 'You appear to be offline. Reconnect and try Operator again.'
-          : 'Connection to Operator was interrupted. Please try again.';
-        const wrapped = new TypeError(message);
-        wrapped.cause = retryError;
-        throw wrapped;
+        const response = await originalFetch(input, init);
+        clearPendingRequest(target, pending);
+        return response;
+      } catch (error) {
+        lastError = error;
+        if (attempt === 0) {
+          const state = recoveryState(target);
+          announce(target, state.reason === 'offline'
+            ? 'Waiting for connection…'
+            : state.reason === 'background'
+              ? 'Paused while the screen is away…'
+              : 'Connection interrupted. Reconnecting…');
+        }
       }
     }
+
+    const message = target.navigator?.onLine === false
+      ? 'You appear to be offline. Your Operator request is saved on this device; reconnect and try again.'
+      : 'Connection to Operator was interrupted. Your request is saved on this device; please try again.';
+    const wrapped = new TypeError(message);
+    wrapped.cause = lastError;
+    throw wrapped;
   };
 }
 

--- a/tests/operator-network-resilience.test.js
+++ b/tests/operator-network-resilience.test.js
@@ -4,17 +4,33 @@ import { readFile } from 'node:fs/promises';
 
 const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
 
-test('Operator retries browser-level fetch failures once without retrying HTTP responses', async () => {
+test('Operator persists a lightweight pending request and waits for mobile connectivity to recover', async () => {
   const actions = await read('operator/actions.js');
   const network = await read('operator/network-resilience.js');
 
   assert.match(actions, /import '\.\/network-resilience\.js';/);
+  assert.match(network, /3dvr\.operator\.pending-request\.v1/);
+  assert.match(network, /storage\.setItem\(PENDING_KEY/);
+  assert.match(network, /prompt: requestPrompt\(init\)/);
+  assert.doesNotMatch(network, /developerAuth/);
+  assert.match(network, /target\?\.navigator\?\.onLine === false/);
+  assert.match(network, /visibilityState === 'hidden'/);
+  assert.match(network, /addEventListener\?\.\('online', check\)/);
+  assert.match(network, /addEventListener\?\.\('pageshow', check\)/);
+  assert.match(network, /addEventListener\?\.\('visibilitychange', check\)/);
+  assert.match(network, /Paused while the screen is away…/);
+  assert.match(network, /Waiting for connection…/);
+  assert.match(network, /Reconnecting to Operator…/);
+  assert.match(network, /RETRY_DELAYS_MS = \[650, 1500, 3000, 5000, 8000, 12000, 20000, 30000\]/);
+  assert.match(network, /clearPendingRequest\(target, pending\)/);
+});
+
+test('Operator still retries only browser-level POST failures, not HTTP responses', async () => {
+  const network = await read('operator/network-resilience.js');
+
   assert.match(network, /url\.pathname === '\/api\/openai-site'/);
   assert.match(network, /url\.searchParams\.get\('provider'\) === 'operator'/);
   assert.match(network, /requestMethod\(input, init\) === 'POST'/);
-  assert.match(network, /return await originalFetch\(input, init\);/);
-  assert.match(network, /await sleep\(RETRY_DELAY_MS\);/);
-  assert.match(network, /return await originalFetch\(input, init\);/g);
-  assert.match(network, /Connection to Operator was interrupted\. Please try again\./);
+  assert.match(network, /const response = await originalFetch\(input, init\);/);
   assert.doesNotMatch(network, /response\.status/);
 });


### PR DESCRIPTION
Make Operator tolerate low-signal and screen-lock interruptions instead of failing after a single 650ms retry.

- persist a lightweight pending-request marker locally (prompt/path/attempt metadata only; no developer auth or portal snapshot)
- wait for `online`, `pageshow`, or `visibilitychange` before retrying when the phone is offline/backgrounded
- use progressive retry delays for flaky mobile data
- show clearer waiting/reconnecting status text
- clear the pending marker only after a successful HTTP response
- keep HTTP errors non-retryable so application failures are not hidden

This is aimed directly at Android/mobile use where the browser may suspend the page or the radio may briefly drop.