### PR TITLE
Lock Vercel to main-only production deploys

### DIFF
--- a/tests/vercel-main-only.test.js
+++ b/tests/vercel-main-only.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const vercel = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'));
+
+test('Vercel deploys production from main and never auto-builds feature branches', () => {
+  assert.deepEqual(vercel.git?.deploymentEnabled, {
+    '*': false,
+    main: true,
+  });
+  assert.equal(
+    vercel.ignoreCommand,
+    '[ "$VERCEL_GIT_COMMIT_REF" != "main" ]'
+  );
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
   },
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [


### PR DESCRIPTION
The deployment quota guard has twice been changed to `git.deploymentEnabled: false`, which disables **all** automatic Git deployments including `main` and leaves production stale.

Restore the intended policy:
- `main`: automatic production deploys enabled
- every other branch: automatic deploys disabled
- keep the existing `ignoreCommand` as a second non-main guard
- add a regression test so future quota-guard changes cannot silently disable production again

This is also required to ship the Operator mobile-resume fix already merged in #1736.