### PR TITLE
Restore free-site Vercel quota guard

### DIFF
--- a/tests/vercel-main-only.test.js
+++ b/tests/vercel-main-only.test.js
@@ -4,11 +4,8 @@ import { readFile } from 'node:fs/promises';
 
 const vercel = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'));
 
-test('Vercel deploys production from main and never auto-builds feature branches', () => {
-  assert.deepEqual(vercel.git?.deploymentEnabled, {
-    '*': false,
-    main: true,
-  });
+test('Vercel automatic Git deployments stay disabled', () => {
+  assert.equal(vercel.git?.deploymentEnabled, false);
   assert.equal(
     vercel.ignoreCommand,
     '[ "$VERCEL_GIT_COMMIT_REF" != "main" ]'

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "*": false,
-      "main": true
-    }
+    "deploymentEnabled": false
   },
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [


### PR DESCRIPTION
Restores the required `git.deploymentEnabled: false` guard after #1738 re-enabled automatic Git deployments from `main`. Also updates the regression test so future changes preserve the campaign's no-auto-Git-deploy requirement. No worker recovery triggers or deployment probes are touched.