### PR TITLE
Stop deployment policy automation loop

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -1,16 +1,13 @@
-name: Vercel Production Prebuilt
+name: Vercel Production Fallback
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: vercel-production-prebuilt
+  group: vercel-production-fallback
   cancel-in-progress: true
 
 env:
@@ -20,7 +17,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy canonical production
+    name: Deploy canonical production fallback
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/tests/vercel-main-only.test.js
+++ b/tests/vercel-main-only.test.js
@@ -4,8 +4,11 @@ import { readFile } from 'node:fs/promises';
 
 const vercel = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'));
 
-test('Vercel automatic Git deployments stay disabled', () => {
-  assert.equal(vercel.git?.deploymentEnabled, false);
+test('Vercel deploys production from main and never auto-builds feature branches', () => {
+  assert.deepEqual(vercel.git?.deploymentEnabled, {
+    '*': false,
+    main: true,
+  });
   assert.equal(
     vercel.ignoreCommand,
     '[ "$VERCEL_GIT_COMMIT_REF" != "main" ]'

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
   },
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [


### PR DESCRIPTION
Align the portal on one deployment policy and remove the contradictory automation state.

- native Vercel Git deploys enabled for `main` only
- all non-main branches disabled
- keep the existing non-main `ignoreCommand` guard
- restore the regression test protecting main-only deployment
- return the token-dependent GitHub Actions production deploy to manual fallback only

This prevents the free-site/founder loops from repeatedly flipping production deployment behavior and avoids double production builds.