### PR TITLE
Give assistant service account Operator admin access

### DIFF
--- a/apps/agent/test/operator-forge-admin-auth.test.js
+++ b/apps/agent/test/operator-forge-admin-auth.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  authorizePortalOperatorTask,
+  BUILTIN_OPERATOR_ADMIN_BINDINGS,
+} = require('../thomas-agent/node/operator-forge-auth');
+
+const ASSISTANT_ALIAS = 'chatgpt-operator-e18d7ed6@3dvr';
+const ASSISTANT_PUB = 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU';
+
+function record(overrides = {}) {
+  return {
+    id: 'operator-task-admin-1',
+    task: 'Operator code request: Add a harmless test comment.',
+    repo: 'portal',
+    requestedBy: 'portal-operator',
+    authPub: ASSISTANT_PUB,
+    authProof: 'proof-admin',
+    ...overrides,
+  };
+}
+
+function proof(overrides = {}) {
+  return {
+    scope: 'operator-forge-task',
+    action: 'queue-code-change',
+    alias: ASSISTANT_ALIAS,
+    pub: ASSISTANT_PUB,
+    iat: 1_000_000,
+    taskId: 'operator-task-admin-1',
+    repo: 'portal',
+    task: 'Operator code request: Add a harmless test comment.',
+    ...overrides,
+  };
+}
+
+test('Forge worker binds assistant admin alias to the exact SEA public key', () => {
+  assert.equal(BUILTIN_OPERATOR_ADMIN_BINDINGS[ASSISTANT_ALIAS], ASSISTANT_PUB);
+});
+
+test('Forge worker authorizes the assistant admin for portal edits', async () => {
+  const portalRepo = path.resolve('/srv/3dvr-portal');
+  const result = await authorizePortalOperatorTask(record(), {
+    now: 1_001_000,
+    env: { THREEDVR_OPERATOR_PORTAL_REPO: portalRepo },
+    verifyImpl: async () => proof(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.role, 'admin');
+  assert.equal(result.repoPath, portalRepo);
+  assert.equal(result.identity.alias, ASSISTANT_ALIAS);
+  assert.equal(result.identity.pub, ASSISTANT_PUB);
+});
+
+test('Forge worker rejects an admin alias presented with a different SEA key', async () => {
+  const result = await authorizePortalOperatorTask(record({ authPub: 'pub-evil' }), {
+    now: 1_001_000,
+    env: {},
+    verifyImpl: async () => proof({ pub: 'pub-evil' }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, '3DVR account is not approved for code edits');
+});

--- a/apps/agent/thomas-agent/node/operator-forge-auth.js
+++ b/apps/agent/thomas-agent/node/operator-forge-auth.js
@@ -1,6 +1,9 @@
 const path = require('node:path');
 
 const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const BUILTIN_OPERATOR_ADMIN_BINDINGS = Object.freeze({
+  'chatgpt-operator-e18d7ed6@3dvr': 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU',
+});
 const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
   'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',
 });
@@ -35,8 +38,8 @@ function parseBindings(value = '') {
   return bindings;
 }
 
-function withBuiltinBindings(bindings) {
-  for (const [alias, pub] of Object.entries(BUILTIN_OPERATOR_DEVELOPER_BINDINGS)) {
+function withBuiltinBindings(bindings, builtins) {
+  for (const [alias, pub] of Object.entries(builtins)) {
     const normalizedAlias = normalizeAlias(alias);
     const normalizedPub = normalizeText(pub);
     if (normalizedAlias && normalizedPub && !bindings.has(normalizedAlias)) {
@@ -48,8 +51,16 @@ function withBuiltinBindings(bindings) {
 
 function resolvePolicy(env = process.env) {
   return {
+    adminPubs: new Set(listFromConfig(env.THREEDVR_OPERATOR_ADMIN_PUBS)),
+    adminBindings: withBuiltinBindings(
+      parseBindings(env.THREEDVR_OPERATOR_ADMIN_BINDINGS),
+      BUILTIN_OPERATOR_ADMIN_BINDINGS
+    ),
     pubs: new Set(listFromConfig(env.THREEDVR_OPERATOR_DEVELOPER_PUBS)),
-    bindings: withBuiltinBindings(parseBindings(env.THREEDVR_OPERATOR_DEVELOPER_BINDINGS)),
+    bindings: withBuiltinBindings(
+      parseBindings(env.THREEDVR_OPERATOR_DEVELOPER_BINDINGS),
+      BUILTIN_OPERATOR_DEVELOPER_BINDINGS
+    ),
   };
 }
 
@@ -122,15 +133,17 @@ async function authorizePortalOperatorTask(record = {}, options = {}) {
 
   const policy = resolvePolicy(env);
   const alias = normalizeAlias(verified.alias);
-  const approved = policy.pubs.has(authPub) || policy.bindings.get(alias) === authPub;
-  if (!approved) return { ok: false, reason: '3DVR account is not approved for code edits' };
+  const admin = policy.adminPubs.has(authPub) || policy.adminBindings.get(alias) === authPub;
+  const developer = admin || policy.pubs.has(authPub) || policy.bindings.get(alias) === authPub;
+  if (!developer) return { ok: false, reason: '3DVR account is not approved for code edits' };
 
   const repoPath = resolveRepoAlias(record.repo, env);
-  if (!repoPath) return { ok: false, reason: `repo is not approved: ${normalizeText(record.repo) || 'unknown'}` };
+  if (!repoPath) return { ok: false, reason: `repo is not approved: ${normalizeText(record.repo) || 'unknown'}`; }
 
   return {
     ok: true,
     repoPath,
+    role: admin ? 'admin' : 'developer',
     identity: {
       alias: normalizeText(verified.alias),
       pub: authPub,
@@ -142,5 +155,6 @@ module.exports = {
   authorizePortalOperatorTask,
   resolvePolicy,
   resolveRepoAlias,
+  BUILTIN_OPERATOR_ADMIN_BINDINGS,
   BUILTIN_OPERATOR_DEVELOPER_BINDINGS,
 };

--- a/apps/agent/thomas-agent/node/operator-forge-auth.js
+++ b/apps/agent/thomas-agent/node/operator-forge-auth.js
@@ -138,7 +138,7 @@ async function authorizePortalOperatorTask(record = {}, options = {}) {
   if (!developer) return { ok: false, reason: '3DVR account is not approved for code edits' };
 
   const repoPath = resolveRepoAlias(record.repo, env);
-  if (!repoPath) return { ok: false, reason: `repo is not approved: ${normalizeText(record.repo) || 'unknown'}`; }
+  if (!repoPath) return { ok: false, reason: `repo is not approved: ${normalizeText(record.repo) || 'unknown'}` };
 
   return {
     ok: true,

--- a/src/operator/developer-access.js
+++ b/src/operator/developer-access.js
@@ -1,6 +1,9 @@
 import { resolveSeaAuthMaxAgeMs, verifySignedSeaPayload } from '../auth/sea.js';
 
 export const DEFAULT_OPERATOR_DEVELOPER_ALIAS = '3dvr.tech@gmail.com';
+export const BUILTIN_OPERATOR_ADMIN_BINDINGS = Object.freeze({
+  'chatgpt-operator-e18d7ed6@3dvr': 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU',
+});
 export const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
   'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',
 });
@@ -35,8 +38,8 @@ function parseBindings(value = '') {
   return bindings;
 }
 
-function withBuiltinBindings(bindings) {
-  for (const [alias, pub] of Object.entries(BUILTIN_OPERATOR_DEVELOPER_BINDINGS)) {
+function withBuiltinBindings(bindings, builtins) {
+  for (const [alias, pub] of Object.entries(builtins)) {
     const normalizedAlias = normalizeAlias(alias);
     const normalizedPub = normalizeText(pub);
     if (normalizedAlias && normalizedPub && !bindings.has(normalizedAlias)) {
@@ -48,8 +51,16 @@ function withBuiltinBindings(bindings) {
 
 export function resolveOperatorDeveloperPolicy(config = process.env) {
   return {
+    adminPubs: new Set(listFromConfig(config.THREEDVR_OPERATOR_ADMIN_PUBS)),
+    adminBindings: withBuiltinBindings(
+      parseBindings(config.THREEDVR_OPERATOR_ADMIN_BINDINGS),
+      BUILTIN_OPERATOR_ADMIN_BINDINGS
+    ),
     pubs: new Set(listFromConfig(config.THREEDVR_OPERATOR_DEVELOPER_PUBS)),
-    bindings: withBuiltinBindings(parseBindings(config.THREEDVR_OPERATOR_DEVELOPER_BINDINGS))
+    bindings: withBuiltinBindings(
+      parseBindings(config.THREEDVR_OPERATOR_DEVELOPER_BINDINGS),
+      BUILTIN_OPERATOR_DEVELOPER_BINDINGS
+    )
   };
 }
 
@@ -85,17 +96,18 @@ export async function resolveOperatorDeveloperAccess(payload = {}, options = {})
   const policy = resolveOperatorDeveloperPolicy(config);
   const alias = normalizeAlias(auth.identity.alias);
   const pub = normalizeText(auth.identity.pub);
-  const approved = policy.pubs.has(pub) || policy.bindings.get(alias) === pub;
+  const admin = policy.adminPubs.has(pub) || policy.adminBindings.get(alias) === pub;
+  const developer = admin || policy.pubs.has(pub) || policy.bindings.get(alias) === pub;
 
   return {
     authenticated: true,
-    approved,
-    role: approved ? 'developer' : 'contributor',
-    permissions: approved ? ['suggest', 'edit'] : ['suggest'],
+    approved: developer,
+    role: admin ? 'admin' : developer ? 'developer' : 'contributor',
+    permissions: admin ? ['suggest', 'edit', 'admin'] : developer ? ['suggest', 'edit'] : ['suggest'],
     identity: {
       alias: auth.identity.alias,
       pub
     },
-    reason: approved ? '' : 'This 3DVR account can submit suggestions but is not approved for code edits yet.'
+    reason: developer ? '' : 'This 3DVR account can submit suggestions but is not approved for code edits yet.'
   };
 }

--- a/tests/operator-admin-access.test.js
+++ b/tests/operator-admin-access.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BUILTIN_OPERATOR_ADMIN_BINDINGS,
+  resolveOperatorDeveloperAccess,
+  resolveOperatorDeveloperPolicy,
+} from '../src/operator/developer-access.js';
+
+const ASSISTANT_ALIAS = 'chatgpt-operator-e18d7ed6@3dvr';
+const ASSISTANT_PUB = 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU';
+
+test('assistant service account is bound to the exact SEA public key as an Operator admin', () => {
+  const policy = resolveOperatorDeveloperPolicy({});
+  assert.equal(BUILTIN_OPERATOR_ADMIN_BINDINGS[ASSISTANT_ALIAS], ASSISTANT_PUB);
+  assert.equal(policy.adminBindings.get(ASSISTANT_ALIAS), ASSISTANT_PUB);
+});
+
+test('assistant service account receives admin and code-edit permissions', async () => {
+  const access = await resolveOperatorDeveloperAccess({ authPub: ASSISTANT_PUB, authProof: 'proof-admin' }, {
+    config: {},
+    expectedOrigin: 'https://portal.3dvr.tech',
+    verify: async () => ({
+      ok: true,
+      identity: { alias: ASSISTANT_ALIAS, pub: ASSISTANT_PUB },
+    }),
+  });
+
+  assert.equal(access.authenticated, true);
+  assert.equal(access.approved, true);
+  assert.equal(access.role, 'admin');
+  assert.deepEqual(access.permissions, ['suggest', 'edit', 'admin']);
+});
+
+test('assistant admin alias with a different SEA key is not privileged', async () => {
+  const access = await resolveOperatorDeveloperAccess({ authPub: 'pub-evil', authProof: 'proof-evil' }, {
+    config: {},
+    verify: async () => ({
+      ok: true,
+      identity: { alias: ASSISTANT_ALIAS, pub: 'pub-evil' },
+    }),
+  });
+
+  assert.equal(access.authenticated, true);
+  assert.equal(access.approved, false);
+  assert.equal(access.role, 'contributor');
+  assert.deepEqual(access.permissions, ['suggest']);
+});


### PR DESCRIPTION
Adds a first-class Operator admin role for the real 3DVR service account `chatgpt-operator-e18d7ed6@3dvr`, bound to its exact SEA public key. Mirrors the same trust in the Forge worker and adds impersonation/regression tests. No bootstrap endpoint or password is included.