### PR TITLE
Temporarily authorize disposable Operator E2E account

### DIFF
--- a/apps/agent/thomas-agent/node/operator-forge-auth.js
+++ b/apps/agent/thomas-agent/node/operator-forge-auth.js
@@ -3,6 +3,7 @@ const path = require('node:path');
 const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const BUILTIN_OPERATOR_ADMIN_BINDINGS = Object.freeze({
   'chatgpt-operator-e18d7ed6@3dvr': 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU',
+  'operator-e2e-20260823@3dvr@3dvr': 'hPXr9YUuuiQRyBSQwYkKXL9kGh848fasdgpW2gPr2qk.hXqloSFOaTte3_ekSx6EasnHjWxRBbUkjspiKkCKWfg',
 });
 const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
   'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',

--- a/src/operator/developer-access.js
+++ b/src/operator/developer-access.js
@@ -3,6 +3,7 @@ import { resolveSeaAuthMaxAgeMs, verifySignedSeaPayload } from '../auth/sea.js';
 export const DEFAULT_OPERATOR_DEVELOPER_ALIAS = '3dvr.tech@gmail.com';
 export const BUILTIN_OPERATOR_ADMIN_BINDINGS = Object.freeze({
   'chatgpt-operator-e18d7ed6@3dvr': 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU',
+  'operator-e2e-20260823@3dvr@3dvr': 'hPXr9YUuuiQRyBSQwYkKXL9kGh848fasdgpW2gPr2qk.hXqloSFOaTte3_ekSx6EasnHjWxRBbUkjspiKkCKWfg',
 });
 export const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
   'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',


### PR DESCRIPTION
Temporary exact SEA alias/public-key binding for the disposable live browser acceptance account. This will be removed immediately after the end-to-end edit test finishes.