### PR TITLE
Route approved Operator code requests to Forge edits

### DIFF
--- a/src/operator/api.js
+++ b/src/operator/api.js
@@ -145,6 +145,18 @@ export function normalizeOperatorResult(value = {}) {
   };
 }
 
+export function reconcileOperatorCodeAction(result = {}, developerAccess = {}) {
+  if (!result?.action) return result;
+  const approved = developerAccess?.approved === true;
+  if (approved && result.action.type === 'suggest_code_change') {
+    result.action.type = 'request_code_change';
+    result.reply = `I’ll queue that approved ${result.action.repo || 'portal'} code edit through Forge.`;
+  } else if (!approved && result.action.type === 'request_code_change') {
+    result.action.type = 'suggest_code_change';
+  }
+  return result;
+}
+
 export function createOperatorHandler(options = {}) {
   const apiKey = options.apiKey ?? process.env.OPENAI_API_KEY;
   const gatewayToken = options.gatewayToken ?? process.env.AI_GATEWAY_API_KEY ?? process.env.VERCEL_OIDC_TOKEN;
@@ -205,10 +217,7 @@ export function createOperatorHandler(options = {}) {
       });
       if (!response.ok) return res.status(response.status).json({ error: await readUpstreamError(response) });
       const raw = outputText(await response.json());
-      const result = normalizeOperatorResult(JSON.parse(raw));
-      if (result.action.type === 'request_code_change' && !developerAccess.approved) {
-        result.action.type = 'suggest_code_change';
-      }
+      const result = reconcileOperatorCodeAction(normalizeOperatorResult(JSON.parse(raw)), developerAccess);
       return res.status(200).json({
         ...result,
         developerAccess: {

--- a/tests/operator-code-action-routing.test.js
+++ b/tests/operator-code-action-routing.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { reconcileOperatorCodeAction } from '../src/operator/api.js';
+
+test('approved developers get a Forge edit even if the model chose suggestion', () => {
+  const result = reconcileOperatorCodeAction({
+    reply: 'I can only save a suggestion.',
+    action: {
+      type: 'suggest_code_change',
+      repo: 'portal',
+      title: 'Edit operator template',
+      text: 'Add a marker comment.'
+    }
+  }, { approved: true, role: 'admin' });
+
+  assert.equal(result.action.type, 'request_code_change');
+  assert.match(result.reply, /queue that approved portal code edit through Forge/i);
+});
+
+test('unapproved accounts cannot escalate a model-selected edit request', () => {
+  const result = reconcileOperatorCodeAction({
+    reply: 'I will edit it.',
+    action: {
+      type: 'request_code_change',
+      repo: 'portal',
+      title: 'Edit operator template',
+      text: 'Add a marker comment.'
+    }
+  }, { approved: false, role: 'contributor' });
+
+  assert.equal(result.action.type, 'suggest_code_change');
+});


### PR DESCRIPTION
Fixes the live acceptance-test failure where an authenticated approved admin was still saved as a Forge suggestion because the model chose `suggest_code_change`. The server now deterministically promotes recognized code-change actions to `request_code_change` for approved identities, while retaining the downgrade for unapproved users. Adds regression tests.