### PR TITLE
Deploy portal from 3DVR servers

### DIFF
--- a/.github/workflows/self-host-production.yml
+++ b/.github/workflows/self-host-production.yml
@@ -1,0 +1,214 @@
+name: 3DVR Self-Hosted Production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: 3dvr-self-host-production
+  cancel-in-progress: true
+
+env:
+  DEFAULT_HOST: 167.172.193.194
+
+jobs:
+  deploy:
+    name: Deploy portal to 3DVR server
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.0
+          cache: npm
+
+      - name: Verify self-host server
+        run: |
+          set -euo pipefail
+          npm ci
+          node --check scripts/self-host-server.mjs
+          bash -n scripts/ops/deploy-self-host-portal.sh
+          node --test tests/operator-developer-access.test.js
+
+      - name: Resolve server credentials and host
+        id: resolve
+        shell: bash
+        env:
+          SSH_A: ${{ secrets.THREEDVR_SSH_PRIVATE_KEY }}
+          SSH_B: ${{ secrets.DO_SSH_PRIVATE_KEY }}
+          SSH_C: ${{ secrets.SSH_PRIVATE_KEY }}
+          DO_A: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          DO_B: ${{ secrets.DIGITALOCEAN_TOKEN }}
+          DO_C: ${{ secrets.DO_TOKEN }}
+        run: |
+          set -euo pipefail
+          ssh_key=''; do_token=''
+          for value in "$SSH_A" "$SSH_B" "$SSH_C"; do
+            if [ -z "$ssh_key" ] && [ -n "$value" ]; then ssh_key="$value"; fi
+          done
+          for value in "$DO_A" "$DO_B" "$DO_C"; do
+            if [ -z "$do_token" ] && [ -n "$value" ]; then do_token="$value"; fi
+          done
+          [ -n "$ssh_key" ] || { echo 'No 3DVR server SSH private key is configured.' >&2; exit 1; }
+
+          target="$DEFAULT_HOST"
+          power_action=not_checked
+          if [ -n "$do_token" ]; then
+            http="$(curl -sS -o /tmp/droplets.json -w '%{http_code}' -H "Authorization: Bearer $do_token" 'https://api.digitalocean.com/v2/droplets?per_page=200' || true)"
+            if [ "$http" = 200 ]; then
+              read -r id state ip < <(python3 - "$DEFAULT_HOST" <<'PY'
+import json,sys
+known=sys.argv[1]
+data=json.load(open('/tmp/droplets.json'))
+for d in data.get('droplets',[]):
+    ips=[n.get('ip_address','') for n in d.get('networks',{}).get('v4',[]) if n.get('type')=='public']
+    if known in ips or d.get('name')=='3dvr-agent':
+        print(d.get('id',''),d.get('status',''),ips[0] if ips else '')
+        break
+else:
+    print('','','')
+PY
+              )
+              if [ -n "${id:-}" ]; then
+                [ -n "${ip:-}" ] && target="$ip"
+                if [ "${state:-}" = off ]; then
+                  action_http="$(curl -sS -o /tmp/power.json -w '%{http_code}' -X POST -H "Authorization: Bearer $do_token" -H 'Content-Type: application/json' -d '{"type":"power_on"}' "https://api.digitalocean.com/v2/droplets/$id/actions" || true)"
+                  [ "$action_http" = 201 ] || { echo 'DigitalOcean power-on request failed.' >&2; exit 1; }
+                  power_action=powered_on
+                  sleep 15
+                else
+                  power_action=already_active
+                fi
+              fi
+            fi
+          fi
+
+          umask 077
+          printf '%s\n' "$ssh_key" > /tmp/3dvr-key.raw
+          if grep -q 'BEGIN .*PRIVATE KEY' /tmp/3dvr-key.raw; then
+            cp /tmp/3dvr-key.raw /tmp/3dvr-key
+          elif base64 -d /tmp/3dvr-key.raw > /tmp/3dvr-key 2>/dev/null && grep -q 'BEGIN .*PRIVATE KEY' /tmp/3dvr-key; then
+            :
+          else
+            echo 'Configured 3DVR SSH key is invalid.' >&2
+            exit 1
+          fi
+          chmod 600 /tmp/3dvr-key
+          rm -f /tmp/3dvr-key.raw /tmp/droplets.json /tmp/power.json
+
+          echo "host=$target" >> "$GITHUB_OUTPUT"
+          echo "power_action=$power_action" >> "$GITHUB_OUTPUT"
+
+      - name: Provision portal runtime secrets
+        shell: bash
+        env:
+          TARGET: ${{ steps.resolve.outputs.host }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          TUNNEL_TOKEN: ${{ secrets.THREEDVR_CLOUDFLARE_TUNNEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          opts=(-i /tmp/3dvr-key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
+          [ -n "$OPENAI_API_KEY" ] || [ -n "$AI_GATEWAY_API_KEY" ] || { echo 'No OpenAI or AI Gateway API key is configured for Operator.' >&2; exit 1; }
+          ssh "${opts[@]}" "root@$TARGET" 'mkdir -p "$HOME/.3dvr/config"; chmod 700 "$HOME/.3dvr/config"; umask 077; cat > "$HOME/.3dvr/config/portal-secrets.env"'
+          {
+            [ -n "$OPENAI_API_KEY" ] && printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY"
+            [ -n "$AI_GATEWAY_API_KEY" ] && printf 'AI_GATEWAY_API_KEY=%s\n' "$AI_GATEWAY_API_KEY"
+            [ -n "$TUNNEL_TOKEN" ] && printf 'THREEDVR_CLOUDFLARE_TUNNEL_TOKEN=%s\n' "$TUNNEL_TOKEN"
+          } | ssh "${opts[@]}" "root@$TARGET" 'umask 077; cat > "$HOME/.3dvr/config/portal-secrets.env"'
+
+      - name: Deploy production release
+        id: deploy
+        shell: bash
+        env:
+          TARGET: ${{ steps.resolve.outputs.host }}
+          DEPLOY_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          opts=(-i /tmp/3dvr-key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
+          output="$(ssh "${opts[@]}" "root@$TARGET" "GITHUB_REPOSITORY='$GITHUB_REPOSITORY' DEPLOY_SHA='$DEPLOY_SHA' bash -s" <<'REMOTE'
+          set -euo pipefail
+          source_repo="$HOME/.3dvr/self-host-portal-source"
+          if [ ! -d "$source_repo/.git" ]; then
+            rm -rf "$source_repo"
+            git clone "https://github.com/$GITHUB_REPOSITORY.git" "$source_repo"
+          fi
+          git -C "$source_repo" fetch --prune origin main
+          git -C "$source_repo" cat-file -e "$DEPLOY_SHA^{commit}"
+          git -C "$source_repo" checkout --detach "$DEPLOY_SHA"
+
+          config_dir="$HOME/.3dvr/config"
+          portal_env="$config_dir/portal.env"
+          secrets_env="$config_dir/portal-secrets.env"
+          mkdir -p "$config_dir"
+          if [ -f "$secrets_env" ]; then
+            set -a
+            . "$secrets_env"
+            set +a
+          fi
+          bash "$source_repo/scripts/ops/deploy-self-host-portal.sh" "$source_repo" main "$DEPLOY_SHA" 4320
+          REMOTE
+          )"
+          printf '%s\n' "$output"
+          url="$(printf '%s\n' "$output" | sed -n 's/^PORTAL_SELF_HOST_URL=//p' | tail -n1)"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Verify self-host from outside server
+        id: verify
+        shell: bash
+        env:
+          URL: ${{ steps.deploy.outputs.url }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$URL" == https://*.trycloudflare.com ]]; then
+            curl -fsS --retry 10 --retry-delay 2 --retry-all-errors "$URL/__3dvr-health" > /tmp/health.json
+            node - "$SHA" <<'NODE'
+          const fs = require('node:fs');
+          const expected = process.argv[2];
+          const health = JSON.parse(fs.readFileSync('/tmp/health.json','utf8'));
+          if (!health.ok || health.sha !== expected || health.operatorApi !== 'native') {
+            throw new Error(`self-host health mismatch: ${JSON.stringify(health)}`);
+          }
+          NODE
+            curl -fsS --retry 5 --retry-delay 1 "$URL/operator/" | grep -Fq 'Message your operator'
+            options="$(curl -sS -o /dev/null -w '%{http_code}' -X OPTIONS "$URL/api/openai-site?provider=operator")"
+            [ "$options" = 200 ]
+          elif [ "$URL" = named-cloudflare-tunnel ]; then
+            echo 'Named Cloudflare tunnel started; domain verification is handled after DNS/tunnel binding.'
+          else
+            echo 'No public HTTPS URL was returned by the server.' >&2
+            exit 1
+          fi
+
+      - name: Publish self-host status
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          set -euo pipefail
+          state=failure
+          description='3DVR self-host production deploy failed'
+          target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          if [ "$DEPLOY_OUTCOME" = success ] && [ "$VERIFY_OUTCOME" = success ]; then
+            state=success
+            description='3DVR portal deployed from our server'
+            if [[ "$URL" == https://* ]]; then target_url="$URL"; fi
+          fi
+          payload="$(STATE="$state" DESCRIPTION="$description" TARGET_URL="$target_url" node -e 'process.stdout.write(JSON.stringify({state:process.env.STATE,context:"3DVR Self Host Production",description:process.env.DESCRIPTION,target_url:process.env.TARGET_URL}))')"
+          curl -fsS -X POST -H "Authorization: Bearer $GH_TOKEN" -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" -d "$payload"
+          rm -f /tmp/3dvr-key /tmp/health.json
+          [ "$state" = success ]

--- a/.github/workflows/self-host-production.yml
+++ b/.github/workflows/self-host-production.yml
@@ -119,12 +119,11 @@ PY
           set -euo pipefail
           opts=(-i /tmp/3dvr-key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
           [ -n "$OPENAI_API_KEY" ] || [ -n "$AI_GATEWAY_API_KEY" ] || { echo 'No OpenAI or AI Gateway API key is configured for Operator.' >&2; exit 1; }
-          ssh "${opts[@]}" "root@$TARGET" 'mkdir -p "$HOME/.3dvr/config"; chmod 700 "$HOME/.3dvr/config"; umask 077; cat > "$HOME/.3dvr/config/portal-secrets.env"'
           {
             [ -n "$OPENAI_API_KEY" ] && printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY"
             [ -n "$AI_GATEWAY_API_KEY" ] && printf 'AI_GATEWAY_API_KEY=%s\n' "$AI_GATEWAY_API_KEY"
             [ -n "$TUNNEL_TOKEN" ] && printf 'THREEDVR_CLOUDFLARE_TUNNEL_TOKEN=%s\n' "$TUNNEL_TOKEN"
-          } | ssh "${opts[@]}" "root@$TARGET" 'umask 077; cat > "$HOME/.3dvr/config/portal-secrets.env"'
+          } | ssh "${opts[@]}" "root@$TARGET" 'mkdir -p "$HOME/.3dvr/config"; chmod 700 "$HOME/.3dvr/config"; umask 077; cat > "$HOME/.3dvr/config/portal-secrets.env"'
 
       - name: Deploy production release
         id: deploy
@@ -147,7 +146,6 @@ PY
           git -C "$source_repo" checkout --detach "$DEPLOY_SHA"
 
           config_dir="$HOME/.3dvr/config"
-          portal_env="$config_dir/portal.env"
           secrets_env="$config_dir/portal-secrets.env"
           mkdir -p "$config_dir"
           if [ -f "$secrets_env" ]; then
@@ -183,6 +181,8 @@ PY
             curl -fsS --retry 5 --retry-delay 1 "$URL/operator/" | grep -Fq 'Message your operator'
             options="$(curl -sS -o /dev/null -w '%{http_code}' -X OPTIONS "$URL/api/openai-site?provider=operator")"
             [ "$options" = 200 ]
+            private_status="$(curl -sS -o /dev/null -w '%{http_code}' "$URL/package.json")"
+            [ "$private_status" = 404 ]
           elif [ "$URL" = named-cloudflare-tunnel ]; then
             echo 'Named Cloudflare tunnel started; domain verification is handled after DNS/tunnel binding.'
           else

--- a/scripts/ops/deploy-self-host-portal.sh
+++ b/scripts/ops/deploy-self-host-portal.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:-}"
+ref="${2:-main}"
+sha="${3:-}"
+port="${4:-4320}"
+
+if [ -z "$repo" ] || [ ! -d "$repo/.git" ]; then
+  echo 'Usage: deploy-self-host-portal.sh <repo-root> [ref] [sha] [port]' >&2
+  exit 2
+fi
+
+if [ -z "$sha" ]; then
+  sha="$(git -C "$repo" rev-parse "$ref")"
+fi
+
+git -C "$repo" fetch --force origin "$ref"
+git -C "$repo" cat-file -e "$sha^{commit}"
+
+if [ "$(id -u)" = 0 ]; then
+  base="${THREEDVR_PORTAL_PRODUCTION_DIR:-/opt/3dvr-portal-production}"
+else
+  base="${THREEDVR_PORTAL_PRODUCTION_DIR:-$HOME/.3dvr/portal-production}"
+fi
+releases="$base/releases"
+release="$releases/$sha"
+current="$base/current"
+state="$base/state"
+config_dir="${THREEDVR_CONFIG_DIR:-$HOME/.3dvr/config}"
+common_env="$config_dir/env"
+portal_env="$config_dir/portal.env"
+
+mkdir -p "$releases" "$state" "$config_dir"
+chmod 700 "$config_dir" 2>/dev/null || true
+
+if [ ! -d "$release" ]; then
+  tmp="$releases/.tmp-$sha-$$"
+  rm -rf "$tmp"
+  mkdir -p "$tmp"
+  git -C "$repo" archive "$sha" | tar -x -C "$tmp"
+  npm --prefix "$tmp" ci --omit=dev
+  mv "$tmp" "$release"
+fi
+
+ln -sfn "$release" "$current"
+
+cat > "$portal_env.tmp" <<EOF
+PORT=4320
+HOST=127.0.0.1
+PORTAL_ROOT=$current
+PORTAL_RELEASE_REF=$ref
+PORTAL_RELEASE_SHA=$sha
+LEGACY_API_ORIGIN=https://3dvr-portal.vercel.app
+EOF
+
+# Preserve private runtime values that may already have been provisioned by an
+# operator or deployment workflow. Never overwrite them with empty values.
+for key in OPENAI_API_KEY AI_GATEWAY_API_KEY THREEDVR_CLOUDFLARE_TUNNEL_TOKEN; do
+  value="${!key:-}"
+  if [ -z "$value" ] && [ -f "$portal_env" ]; then
+    value="$(sed -n "s/^${key}=//p" "$portal_env" | tail -n1)"
+  fi
+  if [ -z "$value" ] && [ -f "$common_env" ]; then
+    value="$(sed -n "s/^${key}=//p" "$common_env" | tail -n1)"
+  fi
+  if [ -n "$value" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$portal_env.tmp"
+  fi
+done
+mv "$portal_env.tmp" "$portal_env"
+chmod 600 "$portal_env"
+
+start_with_systemd() {
+  [ "$(id -u)" = 0 ] || return 1
+  command -v systemctl >/dev/null 2>&1 || return 1
+  cat > /etc/systemd/system/3dvr-portal.service <<EOF
+[Unit]
+Description=3DVR self-hosted portal
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$current
+EnvironmentFile=-$common_env
+EnvironmentFile=$portal_env
+ExecStart=/usr/bin/env node $current/scripts/self-host-server.mjs
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable --now 3dvr-portal.service
+  systemctl restart 3dvr-portal.service
+}
+
+start_with_tmux() {
+  local session=3dvr-portal-production
+  local log="$state/server.log"
+  command -v tmux >/dev/null 2>&1 || {
+    echo 'Neither systemd nor tmux is available for the portal service.' >&2
+    exit 3
+  }
+  tmux kill-session -t "$session" 2>/dev/null || true
+  printf -v current_q '%q' "$current"
+  printf -v common_env_q '%q' "$common_env"
+  printf -v portal_env_q '%q' "$portal_env"
+  printf -v log_q '%q' "$log"
+  command="set -a; [ -f $common_env_q ] && . $common_env_q; . $portal_env_q; set +a; cd $current_q; exec node scripts/self-host-server.mjs >>$log_q 2>&1"
+  tmux new-session -d -s "$session" "$command"
+}
+
+if ! start_with_systemd; then
+  start_with_tmux
+fi
+
+ready=false
+for _ in $(seq 1 30); do
+  health="$(curl -fsS "http://127.0.0.1:$port/__3dvr-health" 2>/dev/null || true)"
+  if printf '%s' "$health" | grep -Fq "\"sha\":\"$sha\""; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+if [ "$ready" != true ]; then
+  echo '3DVR portal service did not become healthy.' >&2
+  systemctl status 3dvr-portal.service --no-pager 2>/dev/null || true
+  [ -f "$state/server.log" ] && tail -n 100 "$state/server.log" >&2 || true
+  exit 4
+fi
+
+cloudflared="$(command -v cloudflared || true)"
+if [ -z "$cloudflared" ]; then
+  if [ "$(id -u)" = 0 ]; then cloudflared=/usr/local/bin/cloudflared; else cloudflared="$base/bin/cloudflared"; fi
+  mkdir -p "$(dirname "$cloudflared")"
+  case "$(uname -m)" in
+    x86_64|amd64) cf_arch=amd64 ;;
+    aarch64|arm64) cf_arch=arm64 ;;
+    *) echo "Unsupported cloudflared architecture: $(uname -m)" >&2; exit 5 ;;
+  esac
+  curl -fsSL --retry 3 --connect-timeout 10 "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$cf_arch" -o "$cloudflared.tmp"
+  chmod +x "$cloudflared.tmp"
+  mv "$cloudflared.tmp" "$cloudflared"
+fi
+
+set -a
+[ -f "$common_env" ] && . "$common_env"
+. "$portal_env"
+set +a
+
+portal_url=''
+if [ -n "${THREEDVR_CLOUDFLARE_TUNNEL_TOKEN:-}" ] && [ "$(id -u)" = 0 ] && command -v systemctl >/dev/null 2>&1; then
+  cat > /etc/systemd/system/3dvr-portal-tunnel.service <<EOF
+[Unit]
+Description=3DVR portal Cloudflare tunnel
+After=3dvr-portal.service
+Requires=3dvr-portal.service
+
+[Service]
+Type=simple
+EnvironmentFile=$portal_env
+ExecStart=/bin/sh -lc 'exec $cloudflared tunnel --no-autoupdate run --token "$THREEDVR_CLOUDFLARE_TUNNEL_TOKEN"'
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable --now 3dvr-portal-tunnel.service
+  systemctl restart 3dvr-portal-tunnel.service
+  portal_url='named-cloudflare-tunnel'
+else
+  tunnel_session=3dvr-portal-quick-tunnel
+  tunnel_log="$state/tunnel.log"
+  : > "$tunnel_log"
+  if command -v tmux >/dev/null 2>&1; then
+    tmux kill-session -t "$tunnel_session" 2>/dev/null || true
+    tmux new-session -d -s "$tunnel_session" "$cloudflared tunnel --no-autoupdate --url http://127.0.0.1:$port >>'$tunnel_log' 2>&1"
+  else
+    nohup "$cloudflared" tunnel --no-autoupdate --url "http://127.0.0.1:$port" >>"$tunnel_log" 2>&1 </dev/null &
+    echo $! > "$state/tunnel.pid"
+  fi
+  for _ in $(seq 1 40); do
+    portal_url="$(grep -Eo 'https://[-a-z0-9]+\.trycloudflare\.com' "$tunnel_log" | tail -n1 || true)"
+    [ -n "$portal_url" ] && break
+    sleep 0.5
+  done
+fi
+
+printf 'PORTAL_SELF_HOST_SHA=%s\n' "$sha"
+printf 'PORTAL_SELF_HOST_PORT=%s\n' "$port"
+printf 'PORTAL_SELF_HOST_URL=%s\n' "$portal_url"
+printf 'PORTAL_SELF_HOST_HEALTH=%s\n' "$(curl -fsS "http://127.0.0.1:$port/__3dvr-health")"

--- a/scripts/ops/deploy-self-host-portal.sh
+++ b/scripts/ops/deploy-self-host-portal.sh
@@ -46,7 +46,7 @@ fi
 ln -sfn "$release" "$current"
 
 cat > "$portal_env.tmp" <<EOF
-PORT=4320
+PORT=$port
 HOST=127.0.0.1
 PORTAL_ROOT=$current
 PORTAL_RELEASE_REF=$ref
@@ -54,8 +54,8 @@ PORTAL_RELEASE_SHA=$sha
 LEGACY_API_ORIGIN=https://3dvr-portal.vercel.app
 EOF
 
-# Preserve private runtime values that may already have been provisioned by an
-# operator or deployment workflow. Never overwrite them with empty values.
+# Preserve private runtime values already provisioned by an operator or workflow.
+# Never overwrite them with empty values and never print them.
 for key in OPENAI_API_KEY AI_GATEWAY_API_KEY THREEDVR_CLOUDFLARE_TUNNEL_TOKEN; do
   value="${!key:-}"
   if [ -z "$value" ] && [ -f "$portal_env" ]; then
@@ -163,7 +163,7 @@ Requires=3dvr-portal.service
 [Service]
 Type=simple
 EnvironmentFile=$portal_env
-ExecStart=/bin/sh -lc 'exec $cloudflared tunnel --no-autoupdate run --token "$THREEDVR_CLOUDFLARE_TUNNEL_TOKEN"'
+ExecStart=/bin/sh -lc 'exec $cloudflared tunnel --no-autoupdate run --token "\$THREEDVR_CLOUDFLARE_TUNNEL_TOKEN"'
 Restart=always
 RestartSec=5
 

--- a/scripts/self-host-server.mjs
+++ b/scripts/self-host-server.mjs
@@ -1,0 +1,210 @@
+import { createServer } from 'node:http';
+import { access, readFile, stat } from 'node:fs/promises';
+import { extname, join, normalize, resolve } from 'node:path';
+import openAiSiteHandler from '../api/openai-site.js';
+
+const PORT = Number(process.env.PORT || 4320);
+const HOST = process.env.HOST || '127.0.0.1';
+const ROOT = resolve(process.env.PORTAL_ROOT || process.cwd());
+const RELEASE_SHA = String(process.env.PORTAL_RELEASE_SHA || '').trim();
+const RELEASE_REF = String(process.env.PORTAL_RELEASE_REF || 'main').trim();
+const LEGACY_API_ORIGIN = String(process.env.LEGACY_API_ORIGIN || '').replace(/\/+$/, '');
+
+const MIME_TYPES = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.htm', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.webmanifest', 'application/manifest+json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.gif', 'image/gif'],
+  ['.webp', 'image/webp'],
+  ['.ico', 'image/x-icon'],
+  ['.woff', 'font/woff'],
+  ['.woff2', 'font/woff2'],
+  ['.txt', 'text/plain; charset=utf-8']
+]);
+
+function applyBaseHeaders(res, pathname = '') {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  if (pathname.endsWith('service-worker.js') || pathname.endsWith('pwa-install.js')) {
+    res.setHeader('Cache-Control', 'no-cache');
+  } else if (/\.(png|jpg|jpeg|gif|svg|webp|woff2?)$/i.test(pathname)) {
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+  } else {
+    res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+  }
+}
+
+function json(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(payload));
+}
+
+function safePath(pathname) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(pathname || '/');
+  } catch {
+    return null;
+  }
+  const clean = decoded.replace(/^\/+/, '').replace(/\.\.(\/|\\|$)/g, '');
+  const candidate = normalize(join(ROOT, clean || 'index.html'));
+  return candidate.startsWith(ROOT) ? candidate : null;
+}
+
+async function findFile(pathname) {
+  const candidate = safePath(pathname === '/' ? '/index.html' : pathname);
+  if (!candidate) return null;
+  try {
+    const fileStat = await stat(candidate);
+    if (fileStat.isDirectory()) {
+      const indexPath = join(candidate, 'index.html');
+      await access(indexPath);
+      return { path: indexPath, redirect: pathname.endsWith('/') ? null : `${pathname}/` };
+    }
+    return { path: candidate, redirect: null };
+  } catch {
+    const indexPath = join(candidate, 'index.html');
+    try {
+      await access(indexPath);
+      return { path: indexPath, redirect: pathname.endsWith('/') ? null : `${pathname}/` };
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function readRequestBody(req, maxBytes = 1024 * 1024) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > maxBytes) throw Object.assign(new Error('Request body too large'), { statusCode: 413 });
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function prepareApiRequest(req, url) {
+  const raw = await readRequestBody(req);
+  if (!raw.length) req.body = {};
+  else {
+    try { req.body = JSON.parse(raw.toString('utf8')); }
+    catch { throw Object.assign(new Error('Invalid JSON request body'), { statusCode: 400 }); }
+  }
+  req.query = Object.fromEntries(url.searchParams.entries());
+}
+
+function adaptResponse(res) {
+  res.status = code => { res.statusCode = code; return res; };
+  res.json = payload => {
+    if (!res.headersSent) res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify(payload));
+    return res;
+  };
+  return res;
+}
+
+async function runOpenAiSite(req, res, url) {
+  try {
+    if (req.method !== 'OPTIONS') await prepareApiRequest(req, url);
+    else { req.body = {}; req.query = Object.fromEntries(url.searchParams.entries()); }
+    await openAiSiteHandler(req, adaptResponse(res));
+  } catch (error) {
+    if (!res.headersSent) json(res, error?.statusCode || 500, { error: error?.message || 'API request failed' });
+    else res.destroy(error);
+  }
+}
+
+async function proxyLegacyApi(req, res, url) {
+  if (!LEGACY_API_ORIGIN) return json(res, 404, { error: 'API route is not enabled on this self-host yet.' });
+  const target = new URL(url.pathname + url.search, `${LEGACY_API_ORIGIN}/`);
+  const body = ['GET', 'HEAD'].includes(req.method || '') ? undefined : await readRequestBody(req);
+  let upstream;
+  try {
+    upstream = await fetch(target, {
+      method: req.method,
+      headers: {
+        'content-type': req.headers['content-type'] || 'application/json',
+        'accept': req.headers.accept || '*/*'
+      },
+      body
+    });
+  } catch (error) {
+    return json(res, 502, { error: 'Legacy API fallback unavailable', detail: error?.message || String(error) });
+  }
+  res.statusCode = upstream.status;
+  for (const name of ['content-type', 'cache-control', 'location']) {
+    const value = upstream.headers.get(name);
+    if (value) res.setHeader(name, value);
+  }
+  const buffer = Buffer.from(await upstream.arrayBuffer());
+  res.end(buffer);
+}
+
+function rewriteForHost(url, host) {
+  const hostname = String(host || '').split(':')[0].toLowerCase();
+  if (url.pathname === '/api/cache-reset') return '/cache-reset.html';
+  if (url.pathname === '/' && hostname === 'crm.3dvr.tech') return '/crm/index.html';
+  if (url.pathname === '/' && hostname === 'purpose.3dvr.tech') return '/purpose/index.html';
+  if (url.pathname === '/' && hostname === 'growth.3dvr.tech') return '/growth-desk/index.html';
+  if (url.pathname === '/' && hostname === 'danny.3dvr.tech') return '/danny/index.html';
+  for (const [subdomain, prefix] of [['thomas-av.3dvr.tech','/thomas-av'], ['thomas-cs.3dvr.tech','/thomas-cs'], ['wenzo.3dvr.tech','/wenzo']]) {
+    if (hostname === subdomain) return `${prefix}${url.pathname === '/' ? '/index.html' : url.pathname}`;
+  }
+  return url.pathname;
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url || '/', `http://${req.headers.host || `${HOST}:${PORT}`}`);
+  applyBaseHeaders(res, url.pathname);
+
+  if (url.pathname === '/__3dvr-health') {
+    return json(res, 200, { ok: true, host: 'self', sha: RELEASE_SHA, ref: RELEASE_REF, operatorApi: 'native' });
+  }
+
+  if (url.pathname === '/api/openai-site') {
+    return runOpenAiSite(req, res, url);
+  }
+
+  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/webhooks/')) {
+    return proxyLegacyApi(req, res, url);
+  }
+
+  if (!['GET', 'HEAD'].includes(req.method || '')) return json(res, 405, { error: 'Method Not Allowed' });
+
+  const pathname = rewriteForHost(url, req.headers.host);
+  const found = await findFile(pathname);
+  if (!found) {
+    res.statusCode = 404;
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    return res.end('Not found');
+  }
+
+  if (found.redirect) {
+    res.statusCode = 308;
+    res.setHeader('Location', `${found.redirect}${url.search}`);
+    return res.end();
+  }
+
+  try {
+    const body = await readFile(found.path);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', MIME_TYPES.get(extname(found.path).toLowerCase()) || 'application/octet-stream');
+    if (pathname.endsWith('service-worker.js')) res.setHeader('Service-Worker-Allowed', '/');
+    res.end(req.method === 'HEAD' ? undefined : body);
+  } catch (error) {
+    json(res, 500, { error: error?.message || 'Failed to read file' });
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`3DVR self-host ${RELEASE_SHA || 'unknown'} listening on http://${HOST}:${PORT}`);
+});

--- a/scripts/self-host-server.mjs
+++ b/scripts/self-host-server.mjs
@@ -30,6 +30,19 @@ const MIME_TYPES = new Map([
   ['.txt', 'text/plain; charset=utf-8']
 ]);
 
+const PRIVATE_PREFIXES = [
+  '/.github/', '/api/', '/src/', '/scripts/', '/tests/', '/ops/', '/node_modules/', '/apps/agent/'
+];
+const PRIVATE_ROOT_FILES = new Set([
+  '/package.json', '/package-lock.json', '/vercel.json', '/AGENTS.md', '/.gitignore'
+]);
+
+function isPrivateStaticPath(pathname) {
+  const clean = String(pathname || '/');
+  return PRIVATE_ROOT_FILES.has(clean)
+    || PRIVATE_PREFIXES.some(prefix => clean === prefix.slice(0, -1) || clean.startsWith(prefix));
+}
+
 function applyBaseHeaders(res, pathname = '') {
   res.setHeader('X-Content-Type-Options', 'nosniff');
   if (pathname.endsWith('service-worker.js') || pathname.endsWith('pwa-install.js')) {
@@ -181,6 +194,8 @@ const server = createServer(async (req, res) => {
   if (!['GET', 'HEAD'].includes(req.method || '')) return json(res, 405, { error: 'Method Not Allowed' });
 
   const pathname = rewriteForHost(url, req.headers.host);
+  if (isPrivateStaticPath(pathname)) return json(res, 404, { error: 'Not found' });
+
   const found = await findFile(pathname);
   if (!found) {
     res.statusCode = 404;

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "*": false,
-      "main": true
-    }
+    "deploymentEnabled": false
   },
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [


### PR DESCRIPTION
Cut over the Portal deployment path away from Vercel Git builds. Adds a native Node production server that serves the tracked portal and runs `/api/openai-site` locally, a durable versioned deploy/restart script, and a GitHub workflow that deploys `main` directly to the 3DVR DigitalOcean host with external health verification. Blocks internal source/config paths from static serving. Disables automatic Vercel Git deployments so self-host deploy commits no longer burn the Vercel build quota. Non-Operator API routes temporarily fall back to the last Vercel production alias for continuity while we migrate them.