### PR TITLE
Repair machine access and worker recovery

### DIFF
--- a/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon
+++ b/apps/agent/thomas-agent/scripts/ask-agent-worker-daemon
@@ -19,7 +19,6 @@ TMUX_SESSION="${THREEDVR_AGENT_WORKER_TMUX_SESSION:-3dvr-worker}"
 INTERVAL_SECONDS="${THREEDVR_AGENT_WORKER_INTERVAL_SECONDS:-20}"
 ROUTER_DAEMON="$SCRIPT_DIR/ask-context-task-router-daemon"
 SUPERVISOR_DAEMON="$SCRIPT_DIR/ask-agent-supervisor-daemon"
-OPERATOR_FORGE_WORKER="$ROOT/node/operator-forge-worker.js"
 
 mkdir -p "$STATE_DIR"
 
@@ -45,8 +44,10 @@ case "${1:-}" in
     # tmux can retain an older environment than the invoking shell. Load the
     # selected 3DVR config inside the session so the managed worker always uses
     # the current owner alias, queue settings, and backend configuration.
+    # ask-agent-queue owns Forge dispatch for run-once, so invoke the wrapper
+    # exactly once per poll to avoid duplicate Forge scans/reprocessing.
     printf -v config_file_q '%q' "$CONFIG_FILE"
-    worker_loop="unset THREEDVR_ENV_LOADED; export THREEDVR_CONFIG_FILE=$config_file_q; if [ -f \"\$THREEDVR_CONFIG_FILE\" ]; then set -a; . \"\$THREEDVR_CONFIG_FILE\"; set +a; fi; cd \"$ROOT\" && while true; do \"$SCRIPT_DIR/ask-agent-queue\" run-once >>\"$LOG_FILE\" 2>&1; node \"$OPERATOR_FORGE_WORKER\" run-once >>\"$LOG_FILE\" 2>&1; sleep \"$INTERVAL_SECONDS\"; done"
+    worker_loop="unset THREEDVR_ENV_LOADED; export THREEDVR_CONFIG_FILE=$config_file_q; if [ -f \"\$THREEDVR_CONFIG_FILE\" ]; then set -a; . \"\$THREEDVR_CONFIG_FILE\"; set +a; fi; cd \"$ROOT\" && while true; do \"$SCRIPT_DIR/ask-agent-queue\" run-once >>\"$LOG_FILE\" 2>&1; sleep \"$INTERVAL_SECONDS\"; done"
     if command -v tmux >/dev/null 2>&1; then
       tmux new-session -d -s "$TMUX_SESSION" "$worker_loop"
       echo "Started agent worker in tmux session $TMUX_SESSION. Log: $LOG_FILE"
@@ -99,7 +100,6 @@ case "${1:-}" in
     ;;
   run-once)
     "$SCRIPT_DIR/ask-agent-queue" run-once "${@:2}"
-    node "$OPERATOR_FORGE_WORKER" run-once
     ;;
   logs)
     tail -n 40 "$LOG_FILE"

--- a/ops/do-host-recovery-trigger.txt
+++ b/ops/do-host-recovery-trigger.txt
@@ -1,2 +1,2 @@
-2026-08-24T18:53:00Z
-Reason: live out-of-band recovery probe for 3DVR server access after last night's Operator/Forge worker outage; verify DigitalOcean power state, public ports, SSH credential availability, and preview worker recovery without relying on Vercel.
+2026-08-24T18:58:00Z
+Reason: run one coordinated DigitalOcean host recovery probe with the German worker recovery; verify control-plane state, public reachability, SSH availability, and preview worker status without relying on Vercel.

--- a/ops/german-worker-recovery-trigger.txt
+++ b/ops/german-worker-recovery-trigger.txt
@@ -1,2 +1,2 @@
-2026-08-24T01:50:00Z
-Reason: run the repaired worker recovery workflow and expose its exact Actions run for Operator Forge diagnosis.
+2026-08-24T18:58:00Z
+Reason: recover the German 3DVR worker through the managed/legacy outbound task queue after the Operator Forge access failures; verify worker, router, inbox, autopilot, heartbeat, and OpenClaw health.


### PR DESCRIPTION
Removes the duplicate Operator Forge dispatch from the managed worker loop, then triggers one coordinated recovery probe for the German worker queue and the DigitalOcean preview host. This is intended to diagnose/recover last night's machine-access failure without adding more worker paths.