### PR TITLE
Verify Operator SEA keypair before Forge signing

### DIFF
--- a/operator/forge.js
+++ b/operator/forge.js
@@ -135,6 +135,27 @@ export function developerIdentityMatches({
   return true;
 }
 
+export async function seaPairCanSign(sea, expectedPub = '') {
+  const pub = normalizeText(expectedPub || sea?.pub, 500);
+  const SEA = globalThis.Gun?.SEA;
+  if (!sea || !pub || !SEA?.sign || !SEA?.verify) return false;
+  const challenge = {
+    scope: 'operator-session-self-check',
+    nonce: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(16).slice(2)}`
+  };
+  try {
+    const signed = await SEA.sign(challenge, sea);
+    const verified = await SEA.verify(signed, pub);
+    return Boolean(
+      verified
+      && verified.scope === challenge.scope
+      && verified.nonce === challenge.nonce
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function restoreStoredPortalSea(user) {
   const stored = readStoredPortalAuth();
   if (!stored || typeof user?.auth !== 'function') return null;
@@ -163,7 +184,9 @@ async function restoreStoredPortalSea(user) {
   });
 
   if (!authenticated) return null;
-  return waitForSea(user, AUTH_WAIT_MS);
+  const sea = await waitForSea(user, AUTH_WAIT_MS);
+  const actualPub = normalizeText(user?.is?.pub || sea?.pub, 500);
+  return await seaPairCanSign(sea, actualPub) ? sea : null;
 }
 
 async function ensurePortalSea(user) {
@@ -177,7 +200,7 @@ async function ensurePortalSea(user) {
       expectedPub: stored?.expectedPub,
       actualAlias,
       actualPub
-    })) {
+    }) && await seaPairCanSign(recalled, actualPub)) {
       return recalled;
     }
     try {
@@ -226,6 +249,16 @@ async function signedPortalProof(scope, action, extra = {}, options = {}) {
     ...extra
   };
   const authProof = await globalThis.Gun.SEA.sign(payload, sea);
+  let verified = null;
+  try {
+    verified = await globalThis.Gun.SEA.verify(authProof, pub);
+  } catch {}
+  if (!verified || verified.scope !== scope || verified.action !== action || verified.pub !== pub) {
+    try {
+      context.user?.leave?.();
+    } catch {}
+    throw new Error('3DVR developer signing session is invalid. Sign in again.');
+  }
   return {
     authPub: pub,
     authProof,

--- a/tests/operator-developer-key-ui.test.js
+++ b/tests/operator-developer-key-ui.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 import { getStoredDeveloperKey } from '../operator/developer-key-ui.js';
-import { developerIdentityMatches } from '../operator/forge.js';
+import { developerIdentityMatches, seaPairCanSign } from '../operator/forge.js';
 
 function storage(values = {}) {
   return {
@@ -22,11 +22,31 @@ test('Operator developer proof can restore the existing Portal password session 
   const forge = await readFile(new URL('../operator/forge.js', import.meta.url), 'utf8');
 
   assert.match(forge, /storage\.getItem\('alias'\)/);
-  assert.match(forge, /storage\.getItem\('password'\)/);
+  assert.match(forge, /globalThis\.localStorage\?\.getItem\?\.\('password'\)/);
   assert.match(forge, /storage\.getItem\('userPubKey'\)/);
   assert.match(forge, /user\.auth\(stored\.alias, stored\.password/);
   assert.match(forge, /stored\.expectedPub && stored\.expectedPub !== actualPub/);
   assert.match(forge, /const sea = await ensurePortalSea\(context\.user\)/);
+});
+
+test('Operator cryptographically verifies a recalled SEA keypair before signing', async () => {
+  const originalGun = globalThis.Gun;
+  globalThis.Gun = {
+    SEA: {
+      async sign(challenge, sea) {
+        return { challenge, marker: sea.marker };
+      },
+      async verify(signed, pub) {
+        return signed.marker === 'good' && pub === 'current-pub' ? signed.challenge : null;
+      }
+    }
+  };
+  try {
+    assert.equal(await seaPairCanSign({ pub: 'current-pub', marker: 'good' }, 'current-pub'), true);
+    assert.equal(await seaPairCanSign({ pub: 'current-pub', marker: 'stale-private-key' }, 'current-pub'), false);
+  } finally {
+    globalThis.Gun = originalGun;
+  }
 });
 
 test('Operator refuses a stale recalled SEA identity before signing a developer proof', async () => {
@@ -47,6 +67,7 @@ test('Operator refuses a stale recalled SEA identity before signing a developer 
   const forge = await readFile(new URL('../operator/forge.js', import.meta.url), 'utf8');
   assert.match(forge, /const stored = readStoredPortalIdentity\(\)/);
   assert.match(forge, /developerIdentityMatches\(\{/);
+  assert.match(forge, /seaPairCanSign\(recalled, actualPub\)/);
   assert.match(forge, /user\?\.leave\?\.\(\)/);
 });
 


### PR DESCRIPTION
Hardens the Portal side of Operator Forge signing after the live worker recovered yesterday's queued requests and found that their stored SEA proofs did not verify.

This change:
- cryptographically self-checks the recalled SEA keypair against the expected public key
- refuses a stale/mismatched private key even when the public-key metadata looks correct
- re-validates restored password sessions before using them
- verifies every freshly created Operator proof before it can be queued
- updates the stale session-recovery regression test

Validation:
- focused Operator auth/routing/network suite passes 19/19
- real GUN SEA test: valid pair verifies; deliberately mismatched public/private pair is rejected