### PR TITLE
Harden Operator live E2E credentials

### DIFF
--- a/.github/workflows/operator-portal-e2e.yml
+++ b/.github/workflows/operator-portal-e2e.yml
@@ -1,6 +1,16 @@
 name: Operator portal E2E
 
 on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Acceptance mode
+        required: true
+        default: bootstrap
+        type: choice
+        options:
+          - bootstrap
+          - edit
   pull_request:
     paths:
       - '.github/e2e/operator-e2e-mode.txt'
@@ -20,8 +30,9 @@ jobs:
     timeout-minutes: 10
     env:
       PORTAL_E2E_URL: https://portal.3dvr.tech
-      PORTAL_E2E_ALIAS: operator-e2e-20260823@3dvr
-      PORTAL_E2E_PASSWORD: PublicE2E-20260823-Disposable-Account!
+      PORTAL_E2E_MODE: ${{ inputs.mode || 'bootstrap' }}
+      PORTAL_E2E_ALIAS: ${{ secrets.PORTAL_E2E_ALIAS }}
+      PORTAL_E2E_PASSWORD: ${{ secrets.PORTAL_E2E_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/scripts/operator-portal-e2e.mjs
+++ b/scripts/operator-portal-e2e.mjs
@@ -2,10 +2,13 @@ import { chromium } from 'playwright';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 
 const baseUrl = process.env.PORTAL_E2E_URL || 'https://portal.3dvr.tech';
-const alias = process.env.PORTAL_E2E_ALIAS || 'operator-e2e-20260823@3dvr';
-const password = process.env.PORTAL_E2E_PASSWORD || 'PublicE2E-20260823-Disposable-Account!';
+const publicAlias = 'operator-e2e-20260823@3dvr';
+const publicPassword = 'PublicE2E-20260823-Disposable-Account!';
+const alias = process.env.PORTAL_E2E_ALIAS || publicAlias;
+const password = process.env.PORTAL_E2E_PASSWORD || publicPassword;
 const modeRaw = await readFile('.github/e2e/operator-e2e-mode.txt', 'utf8').catch(() => 'bootstrap');
-const mode = String(modeRaw || '').trim().toLowerCase();
+const mode = String(process.env.PORTAL_E2E_MODE || modeRaw || '').trim().toLowerCase();
+const usingPublicCredentials = alias === publicAlias && password === publicPassword;
 const artifactDir = 'e2e-artifacts';
 await mkdir(artifactDir, { recursive: true });
 
@@ -116,6 +119,9 @@ async function runEditAcceptance() {
 
 try {
   log('E2E_MODE', mode || 'bootstrap');
+  if (mode.startsWith('edit') && usingPublicCredentials) {
+    throw new Error('Edit mode requires private PORTAL_E2E_ALIAS and PORTAL_E2E_PASSWORD credentials.');
+  }
   await signInOrCreate();
   await saveArtifacts('signed-in-operator');
   if (mode.startsWith('edit')) {

--- a/src/operator/developer-access.js
+++ b/src/operator/developer-access.js
@@ -3,7 +3,6 @@ import { resolveSeaAuthMaxAgeMs, verifySignedSeaPayload } from '../auth/sea.js';
 export const DEFAULT_OPERATOR_DEVELOPER_ALIAS = '3dvr.tech@gmail.com';
 export const BUILTIN_OPERATOR_ADMIN_BINDINGS = Object.freeze({
   'chatgpt-operator-e18d7ed6@3dvr': 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU',
-  'operator-e2e-20260823@3dvr@3dvr': 'hPXr9YUuuiQRyBSQwYkKXL9kGh848fasdgpW2gPr2qk.hXqloSFOaTte3_ekSx6EasnHjWxRBbUkjspiKkCKWfg',
 });
 export const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
   'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',

--- a/tests/operator-admin-access.test.js
+++ b/tests/operator-admin-access.test.js
@@ -46,3 +46,10 @@ test('assistant admin alias with a different SEA key is not privileged', async (
   assert.equal(access.role, 'contributor');
   assert.deepEqual(access.permissions, ['suggest']);
 });
+
+test('public Operator E2E account is never a built-in admin', () => {
+  assert.equal(
+    BUILTIN_OPERATOR_ADMIN_BINDINGS['operator-e2e-20260823@3dvr@3dvr'],
+    undefined
+  );
+});


### PR DESCRIPTION
## What changed
- remove the public-password disposable E2E account from built-in Operator admin bindings
- refuse edit-mode acceptance runs when they are using the public fallback credentials
- add an explicit manual `edit` acceptance mode backed by GitHub secrets
- keep normal PR bootstrap/sign-in coverage available
- add regression coverage ensuring the public E2E account is never a built-in admin

## Why
The live Operator acceptance run authenticated successfully but its current SEA public key no longer matched the stale built-in admin binding, so Operator correctly downgraded the account to suggestion-only before Forge. Rebinding a publicly credentialed account as admin would create an unnecessary production privilege path.

## Verification
- `node --check scripts/operator-portal-e2e.mjs`
- `node --test tests/operator-admin-access.test.js tests/operator-code-action-routing.test.js tests/operator-developer-key-ui.test.js` — 12/12 passed
- `git diff --check`

A true live edit acceptance run now requires private `PORTAL_E2E_ALIAS` / `PORTAL_E2E_PASSWORD` secrets for an approved identity.