### PR TITLE
Authorize private Operator E2E developer

### DIFF
--- a/apps/agent/test/operator-forge-admin-auth.test.js
+++ b/apps/agent/test/operator-forge-admin-auth.test.js
@@ -40,6 +40,10 @@ test('Forge worker binds assistant admin alias to the exact SEA public key', () 
   assert.equal(BUILTIN_OPERATOR_ADMIN_BINDINGS[ASSISTANT_ALIAS], ASSISTANT_PUB);
 });
 
+test('Forge worker never grants built-in admin to the public Operator E2E account', () => {
+  assert.equal(BUILTIN_OPERATOR_ADMIN_BINDINGS['operator-e2e-20260823@3dvr@3dvr'], undefined);
+});
+
 test('Forge worker authorizes the assistant admin for portal edits', async () => {
   const portalRepo = path.resolve('/srv/3dvr-portal');
   const result = await authorizePortalOperatorTask(record(), {

--- a/apps/agent/thomas-agent/node/operator-forge-auth.js
+++ b/apps/agent/thomas-agent/node/operator-forge-auth.js
@@ -3,9 +3,9 @@ const path = require('node:path');
 const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const BUILTIN_OPERATOR_ADMIN_BINDINGS = Object.freeze({
   'chatgpt-operator-e18d7ed6@3dvr': 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU',
-  'operator-e2e-20260823@3dvr@3dvr': 'hPXr9YUuuiQRyBSQwYkKXL9kGh848fasdgpW2gPr2qk.hXqloSFOaTte3_ekSx6EasnHjWxRBbUkjspiKkCKWfg',
 });
 const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
+  'operator-secure-e2e-1787643003@3dvr': 'ANISeXozjNF0rrLuDI9HTIh6Mk3UuHIwUa_WpURZhGc.vnOeQy3vExpG07dGXPOAB1PAQ9iskI2SKnYOLbEhYSY',
   'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',
 });
 

--- a/src/operator/developer-access.js
+++ b/src/operator/developer-access.js
@@ -5,6 +5,7 @@ export const BUILTIN_OPERATOR_ADMIN_BINDINGS = Object.freeze({
   'chatgpt-operator-e18d7ed6@3dvr': 'jcsaMMOmGSjWVJOtiPHI3hZWsudATRhOglXRdDatfSA.pzn7gtgVsDxfbV_md8B4a_W4eNTOavwnZwFU0qOtYcU',
 });
 export const BUILTIN_OPERATOR_DEVELOPER_BINDINGS = Object.freeze({
+  'operator-secure-e2e-1787643003@3dvr': 'ANISeXozjNF0rrLuDI9HTIh6Mk3UuHIwUa_WpURZhGc.vnOeQy3vExpG07dGXPOAB1PAQ9iskI2SKnYOLbEhYSY',
   'tmsteph@3dvr': 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg',
 });
 


### PR DESCRIPTION
Temporary live-acceptance authorization for a private, non-admin 3DVR test identity. Also removes the stale public E2E admin binding from the Forge worker and adds regression coverage so that public disposable account cannot regain built-in worker admin access.

Verification on debian-web:
- Portal auth/routing/developer suite: 12/12 passed
- Forge worker admin auth suite: 4/4 passed
- git diff --check clean

This private developer binding will be removed immediately after the real Operator → Forge edit acceptance succeeds.