### PR TITLE
Add guided money paths to Growth Operator

### DIFF
--- a/growth-operator/campaigns.js
+++ b/growth-operator/campaigns.js
@@ -1,0 +1,303 @@
+const CAMPAIGN_STORAGE_KEY = '3dvr.growthOperator.activeCampaign.v1';
+const LAUNCH_ROOM_STORAGE_KEY = '3dvr.launch-room.movement-brief.v1';
+const AGENT_OWNER_ALIAS = '3dvr-managed';
+const DEFAULT_CAMPAIGN = 'my-skill';
+const DEFAULT_PEERS = [
+  'wss://relay.3dvr.tech/gun',
+  'wss://gun-relay-3dvr.fly.dev/gun'
+];
+
+const CAMPAIGN_PRESETS = Object.freeze({
+  'av-freelance': {
+    label: 'AV freelance',
+    title: 'Get booked for live events',
+    description: 'Find production companies, venues, hotels, event agencies, labor providers, and AV teams that regularly need freelance technicians.',
+    offer: 'Freelance audio visual support',
+    audience: 'Production companies, AV vendors, venues, hotels, event agencies, and labor providers that book freelance AV technicians.',
+    research: 'Find up to 10 relevant organizations in the chosen market that publicly produce live events or staff AV crews. Prefer public staffing, production, operations, or general business contact routes. Look for real signals such as upcoming events, production services, freelancer rosters, or hiring pages. Never guess an email address.',
+    messageAngle: 'A short availability introduction: what kind of AV work the freelancer can do, where they work, and a tiny ask for the right staffing or production contact.'
+  },
+  'web-design': {
+    label: 'Web design',
+    title: 'Fix visible website problems',
+    description: 'Find small businesses with a real public website problem, then offer one small useful improvement instead of a vague redesign pitch.',
+    offer: 'Small website or landing-page improvement',
+    audience: 'Owner-led businesses with a visible website, mobile, conversion, intake, or follow-up problem.',
+    research: 'Find up to 10 small businesses with a verifiable public web problem such as no site, a broken or unavailable site, weak mobile usability, no clear call to action, no quote or booking path, or obviously stale information. Record the exact public evidence and URL. Do not invent problems.',
+    messageAngle: 'Mention one verified problem, describe the smallest useful fix, and offer to show a lightweight concept or next step.'
+  },
+  'lead-generation': {
+    label: 'Lead generation',
+    title: 'Sell useful prospect research',
+    description: 'Help a business by researching a small, verified list of likely prospects with public contact paths and reasons they fit.',
+    offer: 'Small prospect research and lead-list sprint',
+    audience: 'Small B2B businesses and independent service providers that need a clearer prospect list but do not need a giant sales stack.',
+    research: 'Find up to 10 businesses that sell a clear B2B service and appear to have a reachable niche. Research only public information. The pitch is a small sample of relevant prospects with public contact routes and fit notes, not a promise of guaranteed sales.',
+    messageAngle: 'Offer a tiny sample research sprint and ask whether a short verified prospect list for their niche would be useful.'
+  },
+  'market-research': {
+    label: 'Market research',
+    title: 'Turn research into a decision brief',
+    description: 'Sell focused research that helps someone make one decision about a market, competitor set, offer, location, or customer segment.',
+    offer: 'Focused market research brief',
+    audience: 'Founders, local businesses, creators, and independent operators making a concrete market, pricing, positioning, or expansion decision.',
+    research: 'Find up to 10 reachable businesses or founders with a current public decision signal: launching an offer, entering a market, opening a location, changing pricing, expanding services, or competing in a visibly active niche. Use public sources and describe the decision signal precisely.',
+    messageAngle: 'Offer a short research brief around one decision: competitors, pricing, demand signals, customer language, or opportunity gaps.'
+  },
+  'my-skill': {
+    label: 'My own skill',
+    title: 'Turn my idea into a first paid test',
+    description: 'Use the project or service from Launch Room, find a narrow group that may need it, and aim for one real conversation before scaling anything.',
+    offer: 'Small service test based on my skill',
+    audience: 'The first reachable people named in the Launch Room brief.',
+    research: 'Use the saved Launch Room brief as the source of truth. Find up to 10 people or organizations that match its first audience and could realistically benefit from the tiny project. Prefer warm or clearly relevant public contact paths.',
+    messageAngle: 'Describe the useful skill or tiny project in plain language, connect it to the recipient only with verified context, and ask for a small conversation or pilot.'
+  }
+});
+
+function clean(value) {
+  return String(value == null ? '' : value).trim();
+}
+
+function readJson(key, fallback = {}) {
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+function readText(key) {
+  try {
+    return clean(window.localStorage.getItem(key));
+  } catch (_error) {
+    return '';
+  }
+}
+
+function writeText(key, value) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (_error) {
+    // The campaign still works for this page load if storage is unavailable.
+  }
+}
+
+function normalizeCampaign(value) {
+  const key = clean(value).toLowerCase();
+  return CAMPAIGN_PRESETS[key] ? key : DEFAULT_CAMPAIGN;
+}
+
+function getCampaign(key) {
+  return CAMPAIGN_PRESETS[normalizeCampaign(key)];
+}
+
+function loadLaunchRoomBrief() {
+  const brief = readJson(LAUNCH_ROOM_STORAGE_KEY, {});
+  return brief && typeof brief === 'object' ? brief : {};
+}
+
+function launchRoomContext() {
+  const brief = loadLaunchRoomBrief();
+  const lines = [
+    clean(brief.movementName) ? `Project: ${clean(brief.movementName)}` : '',
+    clean(brief.firstAudience) ? `First audience: ${clean(brief.firstAudience)}` : '',
+    clean(brief.worldPain) ? `Problem: ${clean(brief.worldPain)}` : '',
+    clean(brief.worldWish) ? `Desired result: ${clean(brief.worldWish)}` : '',
+    clean(brief.tinyProject) ? `Tiny first project: ${clean(brief.tinyProject)}` : ''
+  ].filter(Boolean);
+  return lines.join('\n');
+}
+
+function campaignContext(key) {
+  const campaign = getCampaign(key);
+  if (normalizeCampaign(key) === 'my-skill') {
+    return launchRoomContext() || 'Use the smallest useful version of my skill or service. Ask one reachable person whether it would help.';
+  }
+  return `Campaign: ${campaign.label}\nIdeal customer: ${campaign.audience}\nMessage angle: ${campaign.messageAngle}`;
+}
+
+function taskId(key) {
+  return `growth-campaign-${key}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildCampaignTask(key) {
+  const campaignKey = normalizeCampaign(key);
+  const campaign = getCampaign(campaignKey);
+  const launchContext = campaignKey === 'my-skill' ? launchRoomContext() : '';
+  const now = new Date().toISOString();
+  const id = taskId(campaignKey);
+  const task = [
+    `Run a focused 3DVR Growth Operator campaign research pass: ${campaign.title}.`,
+    '',
+    `Campaign key: ${campaignKey}`,
+    `Offer: ${campaign.offer}`,
+    `Ideal customer: ${campaign.audience}`,
+    launchContext ? `Launch Room context:\n${launchContext}` : '',
+    '',
+    'Research job:',
+    campaign.research,
+    '',
+    'Outreach angle:',
+    campaign.messageAngle,
+    '',
+    'Use the existing system instead of creating parallel data:',
+    '- Save qualified people/businesses in the unified 3dvr-crm records.',
+    '- Put message history and follow-ups through the existing Growth Operator / outreach pipeline.',
+    '- If the current autopilot policy allows routine direct email, hand qualified records to that existing outbound pipeline. Otherwise leave an honest draft ready for review.',
+    '',
+    'Rules:',
+    '- Keep this to a small relevant batch, maximum 10 prospects.',
+    '- Research public information only.',
+    '- Never guess or synthesize email addresses, phone numbers, names, or business facts.',
+    '- Do not mass email or blast generic lists.',
+    '- Respect existing campaign caps, do-not-contact state, unsubscribe handling, delivery checks, and compliance gates.',
+    '- Personalize only with verified public facts.',
+    '- Do not promise guaranteed leads, revenue, bookings, rankings, or business outcomes.',
+    '',
+    'Return: qualified CRM records, the evidence for fit, proposed short drafts, and one recommended next action.'
+  ].filter(Boolean).join('\n');
+
+  return {
+    id,
+    task,
+    tenantId: 'portal:growth-operator',
+    tenantAlias: readText('alias') || readText('username') || 'growth-operator',
+    tenantPlan: 'builder',
+    backend: 'codex',
+    repo: 'tmsteph/3dvr-portal',
+    model: '',
+    thinking: 'high',
+    unsafe: false,
+    riskClass: 'workspace_write',
+    approvalStatus: 'not_required',
+    requiredCapabilities: 'codex,crm,email,gun',
+    maxRuntimeMs: 0,
+    status: 'queued',
+    requestedBy: `growth-campaign:${campaignKey}`,
+    campaign: campaignKey,
+    createdAt: now,
+    updatedAt: now,
+    resultSummary: '',
+    error: '',
+    workerDeviceId: ''
+  };
+}
+
+function putGun(node, payload) {
+  return new Promise((resolve, reject) => {
+    if (!node || typeof node.put !== 'function') {
+      reject(new Error('Growth relay is unavailable.'));
+      return;
+    }
+    const timer = window.setTimeout(() => resolve({ timedOut: true }), 6000);
+    node.put(payload, ack => {
+      window.clearTimeout(timer);
+      if (ack?.err) reject(new Error(String(ack.err)));
+      else resolve(ack || {});
+    });
+  });
+}
+
+function updatePageStatus(message) {
+  const target = document.getElementById('syncStatus');
+  if (target) target.textContent = message;
+}
+
+function setCampaignSeed(input, value) {
+  if (!input) return;
+  const canReplace = !clean(input.value) || input.dataset.campaignSeed === 'true';
+  if (!canReplace) return;
+  input.value = value;
+  input.dataset.campaignSeed = 'true';
+}
+
+function seedQuickAdd(key) {
+  const campaignKey = normalizeCampaign(key);
+  const campaign = getCampaign(campaignKey);
+  const offer = document.getElementById('itemOffer');
+  const context = document.getElementById('itemContext');
+  const launch = campaignKey === 'my-skill' ? loadLaunchRoomBrief() : {};
+
+  setCampaignSeed(offer, clean(launch.tinyProject) || campaign.offer);
+  setCampaignSeed(context, campaignContext(campaignKey));
+}
+
+function renderCampaign(key) {
+  const campaignKey = normalizeCampaign(key);
+  const campaign = getCampaign(campaignKey);
+  document.querySelectorAll('[data-campaign]').forEach(button => {
+    button.setAttribute('aria-pressed', String(button.dataset.campaign === campaignKey));
+  });
+
+  const title = document.getElementById('activeCampaignTitle');
+  const description = document.getElementById('activeCampaignDescription');
+  const finderLink = document.getElementById('campaignLeadFinderLink');
+  if (title) title.textContent = campaign.title;
+  if (description) description.textContent = campaign.description;
+  if (finderLink) finderLink.href = `../lead-finder/?campaign=${encodeURIComponent(campaignKey)}`;
+  seedQuickAdd(campaignKey);
+}
+
+function selectCampaign(key, { announce = true } = {}) {
+  const campaignKey = normalizeCampaign(key);
+  writeText(CAMPAIGN_STORAGE_KEY, campaignKey);
+  renderCampaign(campaignKey);
+  if (announce) {
+    updatePageStatus(`${getCampaign(campaignKey).label} selected. Ready to research a small first batch.`);
+  }
+  return campaignKey;
+}
+
+async function queueCampaignResearch(key) {
+  const campaignKey = normalizeCampaign(key);
+  const task = buildCampaignTask(campaignKey);
+  const gun = typeof window.Gun === 'function' ? window.Gun(window.__GUN_PEERS__ || DEFAULT_PEERS) : null;
+  const queueRoot = gun
+    ? gun.get('3dvr-portal').get('agentOps').get(AGENT_OWNER_ALIAS).get('taskQueue')
+    : null;
+
+  updatePageStatus(`Queuing ${getCampaign(campaignKey).label} research…`);
+  try {
+    await putGun(queueRoot?.get(task.id), task);
+    await putGun(queueRoot?.get('latest'), {
+      id: task.id,
+      kind: 'campaign-find-leads',
+      campaign: campaignKey,
+      updatedAt: task.updatedAt
+    });
+    updatePageStatus(`${getCampaign(campaignKey).label} research queued. The first pass is capped at 10 relevant prospects.`);
+  } catch (error) {
+    updatePageStatus(`Campaign research was not queued. ${error.message || 'Check the relay.'}`);
+  }
+}
+
+function initCampaigns() {
+  const params = new URLSearchParams(window.location.search);
+  const requested = params.get('campaign');
+  const stored = readText(CAMPAIGN_STORAGE_KEY);
+  let active = selectCampaign(requested || stored || DEFAULT_CAMPAIGN, { announce: false });
+
+  document.querySelectorAll('[data-campaign]').forEach(button => {
+    button.addEventListener('click', () => {
+      active = selectCampaign(button.dataset.campaign);
+    });
+  });
+
+  [document.getElementById('itemOffer'), document.getElementById('itemContext')].forEach(input => {
+    input?.addEventListener('input', () => {
+      input.dataset.campaignSeed = 'false';
+    });
+  });
+
+  document.getElementById('campaignFindButton')?.addEventListener('click', () => {
+    queueCampaignResearch(active);
+  });
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initCampaigns);
+}
+
+export { CAMPAIGN_PRESETS, buildCampaignTask, loadLaunchRoomBrief, normalizeCampaign, selectCampaign };

--- a/growth-operator/index.html
+++ b/growth-operator/index.html
@@ -11,6 +11,73 @@
   <link rel="manifest" href="/manifest.webmanifest" />
   <meta name="theme-color" content="#0d1117" />
   <link rel="stylesheet" href="style.css" />
+  <style>
+    .campaign-grid {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: .75rem;
+    }
+    .campaign-card {
+      display: grid;
+      gap: .35rem;
+      min-height: 150px;
+      align-content: start;
+      text-align: left;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--surface-soft);
+      color: var(--text);
+      padding: .9rem;
+    }
+    .campaign-card span,
+    .campaign-active > div > span {
+      color: var(--teal);
+      font-size: .72rem;
+      font-weight: 900;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    .campaign-card strong {
+      font-size: 1rem;
+      line-height: 1.25;
+    }
+    .campaign-card small {
+      color: var(--muted);
+      line-height: 1.45;
+    }
+    .campaign-card[aria-pressed="true"] {
+      border-color: var(--teal);
+      background: rgba(94, 234, 212, .09);
+      box-shadow: 0 0 0 1px rgba(94, 234, 212, .18);
+    }
+    .campaign-active {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-top: .9rem;
+      padding-top: .9rem;
+      border-top: 1px solid var(--line);
+    }
+    .campaign-active strong {
+      display: block;
+      margin-top: .2rem;
+      font-size: 1.2rem;
+    }
+    .campaign-active p {
+      max-width: 720px;
+      margin: .35rem 0 0;
+      color: var(--muted);
+    }
+    @media (max-width: 900px) {
+      .campaign-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .campaign-active { align-items: stretch; flex-direction: column; }
+    }
+    @media (max-width: 640px) {
+      .campaign-grid { grid-template-columns: 1fr; }
+      .campaign-card { min-height: 0; }
+    }
+  </style>
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="../gun-init.js"></script>
 </head>
@@ -69,6 +136,54 @@
           <span>Delivery</span>
           <strong id="deliveryQueueCount">0</strong>
         </article>
+      </section>
+
+      <section class="panel campaign-panel" aria-labelledby="campaign-title">
+        <div class="section-head">
+          <p class="eyebrow">Pick a money path</p>
+          <h2 id="campaign-title">What do you want to get paid for?</h2>
+          <p>Choose one simple lane. The Operator will focus lead research, drafts, and follow-ups around it. You can change paths anytime.</p>
+        </div>
+
+        <div class="campaign-grid" role="list" aria-label="Outreach campaign presets">
+          <button class="campaign-card" type="button" data-campaign="av-freelance" aria-pressed="false">
+            <span>AV freelance</span>
+            <strong>Get booked for shows</strong>
+            <small>Production companies, venues, hotels, labor teams.</small>
+          </button>
+          <button class="campaign-card" type="button" data-campaign="web-design" aria-pressed="false">
+            <span>Web design</span>
+            <strong>Fix visible website problems</strong>
+            <small>Find a real issue, show a small useful improvement.</small>
+          </button>
+          <button class="campaign-card" type="button" data-campaign="lead-generation" aria-pressed="false">
+            <span>Lead generation</span>
+            <strong>Sell useful prospect research</strong>
+            <small>Small verified lists with public contact paths and fit notes.</small>
+          </button>
+          <button class="campaign-card" type="button" data-campaign="market-research" aria-pressed="false">
+            <span>Market research</span>
+            <strong>Turn research into a decision brief</strong>
+            <small>Competitors, pricing, demand signals, and opportunities.</small>
+          </button>
+          <button class="campaign-card" type="button" data-campaign="my-skill" aria-pressed="false">
+            <span>My own skill</span>
+            <strong>Use my Launch Room idea</strong>
+            <small>Turn the project or service you care about into a first outreach test.</small>
+          </button>
+        </div>
+
+        <div class="campaign-active" aria-live="polite">
+          <div>
+            <span>Active money path</span>
+            <strong id="activeCampaignTitle">Choose a path</strong>
+            <p id="activeCampaignDescription">Pick the closest match. The first goal is one real conversation, not a giant campaign.</p>
+          </div>
+          <div class="hero-actions">
+            <button id="campaignFindButton" class="button primary" type="button">Find 10 leads for this path</button>
+            <a id="campaignLeadFinderLink" class="button" href="../lead-finder/">Research manually</a>
+          </div>
+        </div>
       </section>
 
       <section class="operator-grid">
@@ -174,6 +289,7 @@
   </nav>
 
   <script type="module" src="app.js"></script>
+  <script type="module" src="campaigns.js"></script>
   <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -488,13 +488,13 @@
         </section>
 
         <div class="actions" aria-label="Core portal actions">
-          <a class="action-card" href="/life/">
-            <strong>Plan my day</strong>
-            <span>Get direction and choose the next useful step.</span>
+          <a class="action-card" href="/launch-room/">
+            <strong>Find my path</strong>
+            <span>Start with what you care about and turn it into one small real project.</span>
           </a>
-          <a class="action-card" href="/growth-desk/">
-            <strong>Find work or customers</strong>
-            <span>Open leads, follow-ups, CRM, and revenue work.</span>
+          <a class="action-card" href="/growth-operator/?campaign=my-skill">
+            <strong>Make money</strong>
+            <span>Pick a skill, find people who need it, and start a guided outreach loop.</span>
           </a>
           <a class="action-card" href="/forge/">
             <strong>Build something</strong>
@@ -527,6 +527,7 @@
       <a class="app-link" href="/lead-finder/" data-app="lead finder prospects customers sales"><strong>Lead Finder</strong><span>Find potential customers.</span></a>
       <a class="app-link" href="/growth-desk/" data-app="growth desk revenue sales work customers"><strong>Growth Desk</strong><span>Revenue and outreach work.</span></a>
       <a class="app-link" href="/revenue-desk/" data-app="revenue desk money proposals billing"><strong>Revenue Desk</strong><span>Follow-ups, proposals, and billing.</span></a>
+      <a class="app-link" href="/growth-operator/" data-app="growth operator outreach campaigns leads email freelance"><strong>Growth Operator</strong><span>Pick a money path, find leads, and run outreach.</span></a>
       <a class="app-link" href="/forge/" data-app="forge build idea project"><strong>Forge</strong><span>Turn ideas into useful action.</span></a>
       <a class="app-link" href="/launch-room/" data-app="launch room project website offer"><strong>Launch Room</strong><span>Launch a project or offer.</span></a>
       <a class="app-link" href="/web-builder-app/" data-app="website web builder sites"><strong>Web Builder</strong><span>Build and launch websites.</span></a>

--- a/launch-room/modes.js
+++ b/launch-room/modes.js
@@ -17,7 +17,7 @@ export const LAUNCH_ROOM_MODES = Object.freeze({
     },
     tools: [
       ['Open Projects', '../projects/index.html'],
-      ['Open Growth Operator', '../growth-operator/'],
+      ['Make this earn money', '../growth-operator/?campaign=my-skill'],
       ['Track people in CRM', '../crm/index.html']
     ]
   },
@@ -97,7 +97,7 @@ export const LAUNCH_ROOM_MODES = Object.freeze({
     },
     tools: [
       ['Turn this into an offer', '../offer-garden/'],
-      ['Open Growth Operator', '../growth-operator/'],
+      ['Make this earn money', '../growth-operator/?campaign=my-skill'],
       ['Track conversations in CRM', '../crm/index.html']
     ]
   },
@@ -117,7 +117,7 @@ export const LAUNCH_ROOM_MODES = Object.freeze({
     },
     tools: [
       ['Save it as a Project', '../projects/index.html'],
-      ['Open Growth Operator', '../growth-operator/'],
+      ['Make this earn money', '../growth-operator/?campaign=my-skill'],
       ['Turn this into an offer', '../offer-garden/']
     ]
   }

--- a/tests/growth-campaign-presets.test.js
+++ b/tests/growth-campaign-presets.test.js
@@ -1,0 +1,53 @@
+import { readFile } from 'node:fs/promises';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const operatorDir = new URL('../growth-operator/', import.meta.url);
+
+test('growth operator exposes simple campaign presets for common money paths', async () => {
+  const html = await readFile(new URL('index.html', operatorDir), 'utf8');
+  const js = await readFile(new URL('campaigns.js', operatorDir), 'utf8');
+
+  assert.match(html, /What do you want to get paid for\?/);
+  assert.match(html, /data-campaign="av-freelance"/);
+  assert.match(html, /data-campaign="web-design"/);
+  assert.match(html, /data-campaign="lead-generation"/);
+  assert.match(html, /data-campaign="market-research"/);
+  assert.match(html, /data-campaign="my-skill"/);
+  assert.match(html, /id="campaignFindButton"/);
+  assert.match(html, /type="module" src="campaigns\.js"/);
+
+  assert.match(js, /CAMPAIGN_PRESETS = Object\.freeze/);
+  assert.match(js, /'av-freelance'/);
+  assert.match(js, /'web-design'/);
+  assert.match(js, /'lead-generation'/);
+  assert.match(js, /'market-research'/);
+  assert.match(js, /'my-skill'/);
+});
+
+test('campaign research reuses the existing CRM and outbound pipeline with conservative outreach rules', async () => {
+  const js = await readFile(new URL('campaigns.js', operatorDir), 'utf8');
+
+  assert.match(js, /maximum 10 prospects/);
+  assert.match(js, /Research public information only/);
+  assert.match(js, /Never guess or synthesize email addresses/);
+  assert.match(js, /Do not mass email or blast generic lists/);
+  assert.match(js, /existing campaign caps/);
+  assert.match(js, /unified 3dvr-crm records/);
+  assert.match(js, /existing Growth Operator \/ outreach pipeline/);
+  assert.match(js, /agentOps'\)\.get\(AGENT_OWNER_ALIAS\)\.get\('taskQueue'/);
+});
+
+test('my skill campaign carries Launch Room context into the money path', async () => {
+  const js = await readFile(new URL('campaigns.js', operatorDir), 'utf8');
+  const modes = await readFile(new URL('../launch-room/modes.js', import.meta.url), 'utf8');
+
+  assert.match(js, /3dvr\.launch-room\.movement-brief\.v1/);
+  assert.match(js, /function loadLaunchRoomBrief/);
+  assert.match(js, /First audience:/);
+  assert.match(js, /Tiny first project:/);
+  assert.match(js, /setCampaignSeed/);
+  assert.match(js, /campaignSeed = 'false'/);
+  assert.match(modes, /Make this earn money/);
+  assert.match(modes, /growth-operator\/\?campaign=my-skill/);
+});

--- a/tests/growth-desk.test.js
+++ b/tests/growth-desk.test.js
@@ -23,8 +23,8 @@ test('Growth Desk ships as a CRM-backed operator surface', async () => {
   assert.match(script, /gun\.get\('3dvr-crm'\)/);
   assert.match(script, /crm-outreach-drafts/);
   assert.match(script, /Inspect outreach/);
-  assert.match(portal, /href="growth-desk\/"/);
-  assert.match(portal, /<span class="app-card__title">Growth Desk<\/span>/);
+  assert.match(portal, /href="\/growth-desk\/"/);
+  assert.match(portal, /<strong>Growth Desk<\/strong>/);
   assert.match(vercel, /growth\.3dvr\.tech/);
   assert.match(vercel, /\/growth-desk\/index\.html/);
 });

--- a/tests/growth-operator.test.js
+++ b/tests/growth-operator.test.js
@@ -72,22 +72,23 @@ test('growth operator app queues agent work and can send approved outreach throu
   assert.match(js, /itemsRoot\.map\(\)\.on/);
 });
 
-test('growth operator is discoverable from the portal and email operator', async () => {
+test('growth operator is discoverable from the simplified portal and email operator', async () => {
   const portalHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
   const emailOperatorHtml = await readFile(new URL('../email-operator/index.html', import.meta.url), 'utf8');
 
-  assert.match(portalHtml, /href="growth-operator\/"/);
-  assert.match(portalHtml, /<span class="app-card__title">Growth Operator<\/span>/);
-  assert.match(portalHtml, /Find leads, prepare approved email, triage support, and keep delivery moving\./);
+  assert.match(portalHtml, /href="\/growth-operator\/\?campaign=my-skill"/);
+  assert.match(portalHtml, /<strong>Make money<\/strong>/);
+  assert.match(portalHtml, /href="\/growth-operator\/"[^>]*><strong>Growth Operator<\/strong>/);
+  assert.match(portalHtml, /Pick a money path, find leads, and run outreach\./);
   assert.match(emailOperatorHtml, /href="..\/growth-operator\/"/);
 
-  const revenueIndex = portalHtml.indexOf('>Revenue Desk<');
-  const growthIndex = portalHtml.indexOf('>Growth Operator<');
-  const agentIndex = portalHtml.indexOf('>Agent Ops<');
+  const revenueIndex = portalHtml.indexOf('<strong>Revenue Desk</strong>');
+  const growthIndex = portalHtml.indexOf('<strong>Growth Operator</strong>');
+  const forgeIndex = portalHtml.indexOf('<strong>Forge</strong>');
 
-  assert.ok(revenueIndex !== -1, 'Revenue Desk app card should be listed');
-  assert.ok(growthIndex !== -1, 'Growth Operator app card should be listed');
-  assert.ok(agentIndex !== -1, 'Agent Ops app card should be listed');
+  assert.ok(revenueIndex !== -1, 'Revenue Desk app should be listed');
+  assert.ok(growthIndex !== -1, 'Growth Operator app should be listed');
+  assert.ok(forgeIndex !== -1, 'Forge app should be listed');
   assert.ok(revenueIndex < growthIndex, 'Growth Operator should render after Revenue Desk');
-  assert.ok(growthIndex < agentIndex, 'Growth Operator should render before Agent Ops');
+  assert.ok(growthIndex < forgeIndex, 'Growth Operator should render before Forge');
 });


### PR DESCRIPTION
## Summary
- add simple Growth Operator presets for AV freelance, web design, lead generation, market research, and a user's own skill
- bridge saved Launch Room context into the `my-skill` money path
- preserve manual offer/context edits when switching campaign presets
- queue a small capped public-research pass through the existing Agent Ops / CRM / outreach pipeline instead of creating a parallel system
- make the simplified Portal surface the money path directly
- refresh the stale Growth Desk homepage regression to match the current simplified Portal markup

## Safety / operating rules
- maximum 10 prospects per research pass
- public information only
- never synthesize contact details or business facts
- no mass blasting
- reuse existing campaign caps, do-not-contact, unsubscribe, delivery, and compliance gates
- no promises of guaranteed leads, revenue, bookings, rankings, or outcomes

## Verification
- focused Growth / Launch Room suite: 8/8 passed
- `git diff --check` clean
- full Portal suite still encounters pre-existing main-branch failures/hangs (including the Vercel function ceiling and stale discoverability tests); the Growth Desk failure observed during this pass was reproduced on untouched `main` and repaired here