### PR TITLE
Connect instant audit to paid conversion path

### DIFF
--- a/ideas/business-audit-generator.html
+++ b/ideas/business-audit-generator.html
@@ -15,6 +15,7 @@
       h2 { margin-top: 0; }
       .muted { color: #b7c8bb; }
       a { color: #9cc8ff; }
+      .paid { display: inline-block; margin-top: 10px; padding: 12px 16px; background: #f4f7f2; color: #07110f; font-weight: 800; text-decoration: none; border-radius: 6px; }
     </style>
   </head>
   <body>
@@ -32,7 +33,11 @@
       <h2>Your focused audit</h2>
       <div id="copy"></div>
       <p><button id="download" type="button">Download report</button></p>
-      <p class="muted">Want a human implementation pass? <a href="/ideas/offer-audit.html">See the 48-hour 3DVR audit.</a></p>
+      <hr>
+      <h3>Want us to turn this into a sellable offer?</h3>
+      <p>Get the fixed-price 48-hour 3DVR Offer Audit: offer rewrite, landing-page copy, first outreach sequence, and a decision rule.</p>
+      <a class="paid" href="https://buy.stripe.com/aFabJ1eua5pV24DdQEc7u0a" target="_blank" rel="noopener noreferrer">Buy the $300 audit →</a>
+      <p class="muted">Prefer a fit check first? <a href="/ideas/offer-audit.html#fit-check">Send the messy version free.</a></p>
     </section>
     <script>
       const esc = s => s.replace(/[&<>"']/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));


### PR DESCRIPTION
Revenue-first follow-up to #1789. After generating and downloading the free instant audit, visitors now get a direct, existing $300 Stripe checkout CTA plus the free fit-check fallback. No Vercel policy changes; routine PR uses GitHub CI only.