### PR TITLE
Companion: bounded remote SMS/WhatsApp read and reply

### DIFF
--- a/apps/companion/native-spec/android/CompanionNotificationListener.kt
+++ b/apps/companion/native-spec/android/CompanionNotificationListener.kt
@@ -64,10 +64,12 @@ object MessageNotificationStore {
     private val lock = Any()
     private val entries = LinkedHashMap<String, MessageNotificationEntry>()
     private var loaded = false
-    private val knownSmsPackages = setOf(
+    private val knownMessagePackages = setOf(
         "com.google.android.apps.messaging",
         "com.samsung.android.messaging",
         "com.android.mms",
+        "com.whatsapp",
+        "com.whatsapp.w4b",
     )
 
     fun initialize(context: Context) {
@@ -83,9 +85,9 @@ object MessageNotificationStore {
     fun upsert(context: Context, notification: StatusBarNotification) {
         initialize(context)
         val defaultSmsPackage = runCatching { Telephony.Sms.getDefaultSmsPackage(context) }.getOrNull()
-        val isSmsApp = notification.packageName == defaultSmsPackage ||
-            notification.packageName in knownSmsPackages
-        if (!isSmsApp) return
+        val isMessageApp = notification.packageName == defaultSmsPackage ||
+            notification.packageName in knownMessagePackages
+        if (!isMessageApp) return
 
         val source = notification.notification
         val extras = source.extras
@@ -261,7 +263,7 @@ object MessageNotificationStore {
 
 /**
  * Keeps low-sensitivity notification metadata in one store and a separate,
- * encrypted-at-rest history for notifications from the current/default SMS app.
+ * encrypted-at-rest history for notifications from approved messaging apps.
  *
  * Message bodies are never written to plaintext disk or to the metadata store.
  * Dismissed notifications are retained for at most seven days / fifty entries,

--- a/apps/companion/native-spec/android/CompanionRemoteRelayClient.kt
+++ b/apps/companion/native-spec/android/CompanionRemoteRelayClient.kt
@@ -38,10 +38,10 @@ object CompanionRemoteRelayState {
  * Owns Companion's direct relay from the always-on foreground service.
  *
  * Remote execution is deliberately capability-based rather than a shell. The
- * user-facing admitted set is health, device.status, app.open_known, and
- * url.open. `voice.authorize` is an internal one-time proof-of-possession
+ * user-facing admitted set is health, device.status, app.open_known, url.open,
+ * and bounded notification-backed message read/reply. `voice.authorize` is an internal one-time proof-of-possession
  * challenge used only to bootstrap a locally initiated Realtime voice session.
- * Accessibility, messages, arbitrary packages, Shizuku actions, and shell
+ * Accessibility, arbitrary packages, Shizuku actions, raw SMS permissions, and shell
  * execution remain outside this direct-relay surface.
  */
 class CompanionRemoteRelayClient(context: Context) {
@@ -160,6 +160,8 @@ class CompanionRemoteRelayClient(context: Context) {
             "device.status" -> CommandResult(ok = true, data = deviceStatus())
             "app.open_known" -> openKnownApp(arguments)
             "url.open" -> openHttpsUrl(arguments)
+            "messages.notification.read" -> readMessageNotifications(arguments)
+            "messages.notification.reply" -> replyMessageNotification(arguments)
             "voice.authorize" -> authorizeVoice(arguments)
             else -> CommandResult(ok = false, code = "unsupported_capability")
         }
@@ -181,6 +183,36 @@ class CompanionRemoteRelayClient(context: Context) {
             return
         }
         require(response.statusCode in 200..299) { "result HTTP ${response.statusCode}" }
+    }
+
+    private fun readMessageNotifications(arguments: JSONObject): CommandResult {
+        val limit = if (arguments.has("limit")) arguments.optInt("limit", -1) else 10
+        if (limit !in 1..20) return CommandResult(false, "invalid_message_limit")
+        MessageNotificationStore.initialize(appContext)
+        val messages = MessageNotificationStore.snapshot().take(limit)
+        return CommandResult(
+            ok = true,
+            data = mapOf(
+                "messages" to messages,
+                "storage" to "encrypted-on-device-history",
+                "maxReturned" to 20,
+            ),
+        )
+    }
+
+    private fun replyMessageNotification(arguments: JSONObject): CommandResult {
+        val key = arguments.optString("key").trim()
+        val text = arguments.optString("text").trim()
+        if (key.isEmpty() || key.length > 512 || text.isEmpty() || text.length > 4000) {
+            return CommandResult(false, "invalid_message_reply")
+        }
+        MessageNotificationStore.initialize(appContext)
+        val replied = MessageNotificationStore.reply(appContext, key, text)
+        return if (replied) {
+            CommandResult(true, data = mapOf("key" to key, "replied" to true))
+        } else {
+            CommandResult(false, "message_reply_unavailable", mapOf("key" to key))
+        }
     }
 
     private fun authorizeVoice(arguments: JSONObject): CommandResult {
@@ -233,7 +265,10 @@ class CompanionRemoteRelayClient(context: Context) {
             "model" to Build.MODEL,
             "batteryPercent" to battery?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY),
             "bridgeActive" to true,
-            "capabilities" to listOf("health", "device.status", "app.open_known", "url.open"),
+            "capabilities" to listOf(
+                "health", "device.status", "app.open_known", "url.open",
+                "messages.notification.read", "messages.notification.reply",
+            ),
         )
     }
 

--- a/src/device/companion-command-proxy.js
+++ b/src/device/companion-command-proxy.js
@@ -7,6 +7,8 @@ export const REMOTE_COMPANION_CAPABILITIES = new Set([
   'device.status',
   'app.open_known',
   'url.open',
+  'messages.notification.read',
+  'messages.notification.reply',
 ]);
 const ALLOWED_APP_ALIASES = new Set([
   'settings',
@@ -51,6 +53,21 @@ function normalizeArguments(capabilityId, value) {
       throw new Error('valid https url required');
     }
     return { url: parsed.toString() };
+  }
+  if (capabilityId === 'messages.notification.read') {
+    const keys = Object.keys(args);
+    if (keys.some((key) => key !== 'limit')) throw new Error('unsupported message read argument');
+    if (!keys.length) return {};
+    const limit = Number(args.limit);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 20) throw new Error('message read limit must be 1-20');
+    return { limit };
+  }
+  if (capabilityId === 'messages.notification.reply') {
+    const key = text(args.key);
+    const replyText = text(args.text);
+    if (!key || key.length > 512) throw new Error('valid message key required');
+    if (!replyText || replyText.length > 4000) throw new Error('reply text must be 1-4000 characters');
+    return { key, text: replyText };
   }
   throw new Error('capability is not enabled for remote invocation');
 }

--- a/tests/companion-command-api.test.js
+++ b/tests/companion-command-api.test.js
@@ -88,7 +88,10 @@ test('lists active Companion devices and admitted capabilities', async () => {
   const res = createResponse();
   await handler(request({ mode: 'devices' }), res);
   assert.equal(res.statusCode, 200); assert.equal(res.body.devices.length, 1);
-  assert.deepEqual(res.body.capabilities, ['health', 'device.status', 'app.open_known', 'url.open']);
+  assert.deepEqual(res.body.capabilities, [
+    'health', 'device.status', 'app.open_known', 'url.open',
+    'messages.notification.read', 'messages.notification.reply',
+  ]);
   assert.equal(calls[0].options.headers.authorization, 'Bearer vercel-oidc-secret'); assert.equal(JSON.stringify(res.body).includes('vercel-oidc-secret'), false);
 });
 
@@ -108,6 +111,41 @@ test('invokes device.status on the sole connected phone and returns the result',
   await handler(request({ mode: 'invoke', capabilityId: 'device.status' }), res);
   assert.equal(res.statusCode, 200); assert.equal(res.body.ok, true); assert.equal(res.body.deviceId, 'device_abcdefghijklmnopqrstuv');
   assert.deepEqual(res.body.data, { model: 'SM-F936U1', batteryPercent: 67 }); assert.equal(calls.length, 3);
+});
+
+test('forwards bounded message reads and exact notification replies', async () => {
+  for (const [capabilityId, args] of [
+    ['messages.notification.read', { limit: 5 }],
+    ['messages.notification.reply', { key: 'sms|thread|42', text: 'On my way' }],
+  ]) {
+    const handler = createCompanionCommandHandler({
+      config: { VERCEL_OIDC_TOKEN: 'vercel-oidc-secret' }, verifyAuth: acceptedAuth(signed(capabilityId, args)),
+      fetchImpl: async (url, options) => {
+        if (url.endsWith('/relay/v1/devices')) return mockJsonResponse(200, { ok: true, devices: [{ deviceId: 'device_abcdefghijklmnopqrstuv', expiresAt: 999999 }] });
+        if (url.endsWith('/relay/v1/commands')) { const body = JSON.parse(options.body); assert.equal(body.capabilityId, capabilityId); assert.deepEqual(body.arguments, args); return mockJsonResponse(201, { ok: true, requestId: body.requestId }); }
+        if (url.includes('/relay/v1/results/')) return mockJsonResponse(200, { ok: true, commandOk: true, data: {}, completedAt: 123456 });
+        throw new Error(`unexpected URL ${url}`);
+      },
+    });
+    const res = createResponse();
+    await handler(request({ mode: 'invoke', capabilityId, arguments: args }), res);
+    assert.equal(res.statusCode, 200); assert.equal(res.body.ok, true);
+  }
+});
+
+test('rejects overbroad message reads and malformed replies before relay access', async () => {
+  for (const body of [
+    { mode: 'invoke', capabilityId: 'messages.notification.read', arguments: { limit: 50 } },
+    { mode: 'invoke', capabilityId: 'messages.notification.read', arguments: { packageName: 'com.whatsapp' } },
+    { mode: 'invoke', capabilityId: 'messages.notification.reply', arguments: { key: '', text: 'hi' } },
+    { mode: 'invoke', capabilityId: 'messages.notification.reply', arguments: { key: 'message-key', text: '' } },
+  ]) {
+    let networkCalls = 0;
+    const handler = createCompanionCommandHandler({ config: { VERCEL_OIDC_TOKEN: 'oidc-token' }, fetchImpl: async () => { networkCalls += 1; throw new Error('should not call network'); }, verifyAuth: acceptedAuth('unused') });
+    const res = createResponse();
+    await handler(request(body), res);
+    assert.equal(res.statusCode, 400); assert.equal(networkCalls, 0);
+  }
 });
 
 test('forwards a normalized known-app action to the relay', async () => {


### PR DESCRIPTION
Closed intentionally as an unsafe prototype; the branch/commit remains preserved for reference.

Two P1 architecture requirements prevent merging:
1. Relay device enrollment/discovery is not bound to the authenticated portal owner, so message access cannot yet be safely scoped to one user's phone.
2. Yellow/red message read/reply requires a short-lived **device-local** approval bound to request + capability + scope. That approval primitive is documented in `apps/companion/docs/TRANSPORT.md` but is not implemented on this remote path.

The safer pieces from this work—WhatsApp/WhatsApp Business recognition and truthful Android notification-permission diagnostics—have since landed through #1830.

Re-open/rebuild remote message access only after owner-scoped device enrollment and the local approval envelope are implemented and freshly security-tested.