### PR TITLE
Add Idea Garden as the project-centered 3DVR hub

### DIFF
--- a/garden/app.js
+++ b/garden/app.js
@@ -1,0 +1,116 @@
+const STORAGE_KEY = "3dvr.ideaGarden.v1";
+
+const form = document.querySelector("#ideaForm");
+const input = document.querySelector("#ideaInput");
+const list = document.querySelector("#ideaList");
+const emptyState = document.querySelector("#emptyState");
+const clearDone = document.querySelector("#clearDone");
+
+let ideas = loadIdeas();
+render();
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+
+  ideas.unshift({
+    id: crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`,
+    text,
+    stage: "seed",
+    createdAt: new Date().toISOString(),
+  });
+
+  persist();
+  input.value = "";
+  input.focus();
+  render();
+});
+
+clearDone.addEventListener("click", () => {
+  ideas = ideas.filter((idea) => idea.stage !== "done");
+  persist();
+  render();
+});
+
+list.addEventListener("change", (event) => {
+  if (!event.target.matches("select[data-id]")) return;
+  const idea = ideas.find((item) => item.id === event.target.dataset.id);
+  if (!idea) return;
+  idea.stage = event.target.value;
+  persist();
+  render();
+});
+
+list.addEventListener("click", (event) => {
+  const button = event.target.closest("button[data-delete]");
+  if (!button) return;
+  ideas = ideas.filter((idea) => idea.id !== button.dataset.delete);
+  persist();
+  render();
+});
+
+function loadIdeas() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function persist() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(ideas));
+}
+
+function render() {
+  list.innerHTML = "";
+  emptyState.hidden = ideas.length > 0;
+  clearDone.hidden = !ideas.some((idea) => idea.stage === "done");
+
+  for (const idea of ideas) {
+    const card = document.createElement("article");
+    card.className = "idea-card";
+    card.dataset.stage = idea.stage;
+
+    const copy = document.createElement("div");
+    copy.className = "idea-copy";
+    copy.textContent = idea.text;
+
+    const meta = document.createElement("div");
+    meta.className = "idea-meta";
+
+    const date = document.createElement("small");
+    date.textContent = `Planted ${formatDate(idea.createdAt)}`;
+
+    const controls = document.createElement("div");
+    controls.className = "idea-controls";
+
+    const select = document.createElement("select");
+    select.dataset.id = idea.id;
+    select.setAttribute("aria-label", `Stage for ${idea.text}`);
+    select.innerHTML = `
+      <option value="seed">🌱 Seed</option>
+      <option value="exploring">✨ Exploring</option>
+      <option value="project">🛠 Project</option>
+      <option value="done">✓ Finished</option>
+    `;
+    select.value = idea.stage;
+
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.className = "delete-button";
+    remove.dataset.delete = idea.id;
+    remove.textContent = "Remove";
+
+    controls.append(select, remove);
+    meta.append(date, controls);
+    card.append(copy, meta);
+    list.append(card);
+  }
+}
+
+function formatDate(value) {
+  const date = new Date(value);
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
+}

--- a/garden/index.html
+++ b/garden/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="theme-color" content="#f6f7f3" />
+  <title>Idea Garden · 3dvr.tech</title>
+  <meta name="description" content="A quiet place to collect ideas, nurture them, and turn them into real projects." />
+  <link rel="stylesheet" href="./style.css" />
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script defer src="./app.js"></script>
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="../">3dvr.tech</a>
+    <span class="tag">Idea Garden</span>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="eyebrow">Your ideas deserve somewhere to live.</p>
+      <h1>Plant the idea.<br />We’ll help it grow.</h1>
+      <p class="lede">You do not need a business plan, a website, or even a good explanation. Start with the spark.</p>
+
+      <form id="ideaForm" class="capture-card">
+        <label for="ideaInput">What’s on your mind?</label>
+        <textarea id="ideaInput" maxlength="280" placeholder="I want to…" required></textarea>
+        <div class="capture-actions">
+          <small>Messy ideas are welcome.</small>
+          <button type="submit">Plant idea</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="garden-section" aria-labelledby="gardenTitle">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Your garden</p>
+          <h2 id="gardenTitle">Keep the sparks alive</h2>
+        </div>
+        <button id="clearDone" class="text-button" type="button">Clear finished</button>
+      </div>
+
+      <div id="emptyState" class="empty-state">
+        <strong>Nothing planted yet.</strong>
+        <span>Your first idea can be tiny.</span>
+      </div>
+      <div id="ideaList" class="idea-list" aria-live="polite"></div>
+    </section>
+
+    <section class="path-section" aria-labelledby="pathTitle">
+      <p class="eyebrow">When an idea wants more</p>
+      <h2 id="pathTitle">Tools appear when you need them</h2>
+      <div class="tool-grid">
+        <a class="tool-card" href="../forge/">
+          <span>Explore</span>
+          <strong>Shape the idea in Forge</strong>
+          <p>Turn a fuzzy thought into something clearer without committing to a project.</p>
+        </a>
+        <a class="tool-card" href="../launch-room/?mode=start-project">
+          <span>Build</span>
+          <strong>Move it into Launch Room</strong>
+          <p>Give a growing idea a purpose, next step, and real-world experiment.</p>
+        </a>
+        <a class="tool-card" href="../life/">
+          <span>Today</span>
+          <strong>Pick one next move</strong>
+          <p>Use Daily Direction when life is noisy and you only need the next useful step.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="philosophy">
+      <p>3DVR is not a website factory.</p>
+      <h2>It is a place where people remember what they wanted to make—and get help making it real.</h2>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../start/">Start</a>
+    <a href="../launch-room/">Launch Room</a>
+    <a href="../forge/">Forge</a>
+  </footer>
+</body>
+</html>

--- a/garden/style.css
+++ b/garden/style.css
@@ -1,0 +1,75 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7f3;
+  --paper: #ffffff;
+  --ink: #172019;
+  --muted: #637066;
+  --line: #dfe5df;
+  --soft: #edf2ec;
+  --accent: #376449;
+  --accent-ink: #ffffff;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--ink); }
+a { color: inherit; }
+button, textarea, select { font: inherit; }
+
+.topbar, main, footer { width: min(920px, calc(100% - 32px)); margin-inline: auto; }
+.topbar { display: flex; align-items: center; justify-content: space-between; padding: 24px 0 8px; }
+.brand { font-weight: 800; text-decoration: none; letter-spacing: -.03em; }
+.tag { border: 1px solid var(--line); border-radius: 999px; padding: 6px 10px; color: var(--muted); font-size: .82rem; }
+
+.hero { padding: 64px 0 48px; }
+.eyebrow { margin: 0 0 10px; text-transform: uppercase; letter-spacing: .12em; color: var(--accent); font-size: .75rem; font-weight: 800; }
+h1, h2, p { margin-top: 0; }
+h1 { max-width: 760px; margin-bottom: 18px; font-size: clamp(2.6rem, 9vw, 5.7rem); line-height: .92; letter-spacing: -.065em; }
+h2 { letter-spacing: -.035em; line-height: 1.05; }
+.lede { max-width: 640px; color: var(--muted); font-size: 1.15rem; line-height: 1.55; }
+
+.capture-card { margin-top: 34px; background: var(--paper); border: 1px solid var(--line); border-radius: 24px; padding: 18px; box-shadow: 0 12px 34px rgba(31,44,34,.06); }
+.capture-card label { display: block; margin-bottom: 10px; font-weight: 750; }
+textarea { width: 100%; min-height: 110px; border: 0; outline: 0; resize: vertical; background: transparent; color: var(--ink); font-size: 1.25rem; line-height: 1.4; }
+textarea::placeholder { color: #a5aea7; }
+.capture-actions { display: flex; align-items: center; justify-content: space-between; gap: 14px; border-top: 1px solid var(--line); padding-top: 14px; }
+.capture-actions small { color: var(--muted); }
+button { border: 0; border-radius: 999px; padding: 11px 16px; background: var(--accent); color: var(--accent-ink); font-weight: 750; cursor: pointer; }
+button:hover { filter: brightness(.97); }
+
+.garden-section, .path-section { padding: 46px 0; border-top: 1px solid var(--line); }
+.section-heading { display: flex; justify-content: space-between; gap: 20px; align-items: end; }
+.section-heading h2 { margin-bottom: 0; font-size: clamp(1.9rem, 4vw, 2.8rem); }
+.text-button { padding: 0; border-radius: 0; background: transparent; color: var(--muted); font-size: .9rem; }
+.empty-state { margin-top: 22px; padding: 28px; border: 1px dashed #c9d0ca; border-radius: 18px; color: var(--muted); display: grid; gap: 5px; }
+.idea-list { display: grid; gap: 14px; margin-top: 22px; }
+.idea-card { background: var(--paper); border: 1px solid var(--line); border-radius: 18px; padding: 18px; display: grid; gap: 14px; }
+.idea-card[data-stage="project"] { border-color: #a9c2b0; box-shadow: inset 4px 0 0 var(--accent); }
+.idea-card[data-stage="done"] { opacity: .58; }
+.idea-copy { font-size: 1.05rem; line-height: 1.45; overflow-wrap: anywhere; }
+.idea-meta { display: flex; gap: 10px; align-items: center; justify-content: space-between; flex-wrap: wrap; }
+.idea-meta small { color: var(--muted); }
+.idea-controls { display: flex; gap: 8px; align-items: center; }
+select { border: 1px solid var(--line); border-radius: 999px; padding: 8px 12px; color: var(--ink); background: var(--soft); }
+.delete-button { background: transparent; color: var(--muted); padding: 8px 10px; }
+
+.path-section > h2 { max-width: 640px; font-size: clamp(2rem, 5vw, 3.4rem); }
+.tool-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.tool-card { min-height: 210px; display: flex; flex-direction: column; border: 1px solid var(--line); border-radius: 20px; padding: 20px; background: var(--paper); text-decoration: none; transition: transform .16s ease, border-color .16s ease; }
+.tool-card:hover { transform: translateY(-2px); border-color: #b9c6bc; }
+.tool-card span { color: var(--accent); font-size: .75rem; text-transform: uppercase; letter-spacing: .1em; font-weight: 800; }
+.tool-card strong { margin: auto 0 10px; font-size: 1.2rem; }
+.tool-card p { margin-bottom: 0; color: var(--muted); line-height: 1.45; }
+
+.philosophy { margin: 42px 0 80px; padding: clamp(28px, 6vw, 54px); border-radius: 28px; background: #1d2a20; color: white; }
+.philosophy p { color: #aebcaf; }
+.philosophy h2 { margin-bottom: 0; max-width: 760px; font-size: clamp(2rem, 5vw, 3.7rem); }
+footer { display: flex; gap: 20px; padding: 0 0 34px; color: var(--muted); font-size: .9rem; }
+
+@media (max-width: 720px) {
+  .hero { padding-top: 44px; }
+  .tool-grid { grid-template-columns: 1fr; }
+  .tool-card { min-height: 160px; }
+  .section-heading { align-items: start; }
+  .capture-actions { align-items: end; }
+}


### PR DESCRIPTION
Adds a mobile-first `/garden/` MVP centered on persistent ideas rather than websites.

Core loop:
- capture a messy idea immediately
- keep it locally in the browser
- move it through Seed → Exploring → Project → Finished
- reveal Forge, Launch Room, and Daily Direction as helpers around the idea

This intentionally starts browser-local so the interaction can be tested before wiring identity/sync/GUN. No Vercel preview requested; preserve the repo's main-only production deployment policy.