### PR TITLE
Encrypt and sync Idea Garden across devices

### DIFF
--- a/garden/app.js
+++ b/garden/app.js
@@ -1,5 +1,8 @@
+import { createGardenSync } from './sync.js';
+
 const STORAGE_KEY = '3dvr.ideaGarden.v2';
 const LEGACY_STORAGE_KEY = '3dvr.ideaGarden.v1';
+const DELETED_KEY = '3dvr.ideaGarden.deleted.v1';
 const STAGES = ['seed', 'exploring', 'project', 'done'];
 
 const stageLabels = {
@@ -31,13 +34,20 @@ const focusShelf = document.querySelector('#focusShelf');
 const focusIdea = document.querySelector('#focusIdea');
 const focusNext = document.querySelector('#focusNext');
 const openFocus = document.querySelector('#openFocus');
+const accountLink = document.querySelector('#gardenAccount');
 
 let ideas = loadIdeas();
+let deleted = loadDeleted();
 let activeFilter = 'all';
 let searchTerm = '';
+let sync = null;
+let syncTimer = null;
 
+ideas = reconcileDeleted(ideas, deleted);
 syncFilterButtons();
+renderAccountLink();
 render();
+startSync();
 
 form.addEventListener('submit', (event) => {
   event.preventDefault();
@@ -66,8 +76,9 @@ form.addEventListener('submit', (event) => {
 clearDone.addEventListener('click', () => {
   const finished = ideas.filter((idea) => idea.stage === 'done');
   if (!finished.length) return;
-  if (!window.confirm(`Remove ${finished.length} finished idea${finished.length === 1 ? '' : 's'} from this browser?`)) return;
+  if (!window.confirm(`Remove ${finished.length} finished idea${finished.length === 1 ? '' : 's'} from your Garden?`)) return;
 
+  markDeleted(finished.map((idea) => idea.id));
   ideas = ideas.filter((idea) => idea.stage !== 'done');
   persist('Finished ideas cleared.');
   render();
@@ -115,9 +126,7 @@ list.addEventListener('change', (event) => {
   if (target.matches('textarea[data-field][data-id]')) {
     updateIdea(target.dataset.id, (idea) => {
       const field = target.dataset.field;
-      if (field === 'why' || field === 'nextStep') {
-        idea[field] = clean(target.value);
-      }
+      if (field === 'why' || field === 'nextStep') idea[field] = clean(target.value);
     }, 'Idea saved.');
   }
 });
@@ -133,7 +142,8 @@ list.addEventListener('click', (event) => {
   if (deleteButton) {
     const idea = ideas.find((item) => item.id === deleteButton.dataset.delete);
     if (!idea) return;
-    if (!window.confirm('Remove this idea from this browser?')) return;
+    if (!window.confirm('Remove this idea from your Garden?')) return;
+    markDeleted([idea.id]);
     ideas = ideas.filter((item) => item.id !== idea.id);
     persist('Idea removed.');
     render();
@@ -144,10 +154,15 @@ function clean(value) {
   return String(value || '').trim().replace(/\s+/g, ' ');
 }
 
+function stamp(value) {
+  const raw = value?.updatedAt || value?.deletedAt || value?.createdAt || 0;
+  if (typeof raw === 'number') return raw;
+  const parsed = Date.parse(raw);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
 function createId() {
-  if (window.crypto && typeof window.crypto.randomUUID === 'function') {
-    return window.crypto.randomUUID();
-  }
+  if (window.crypto && typeof window.crypto.randomUUID === 'function') return window.crypto.randomUUID();
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
@@ -170,6 +185,19 @@ function normalizeIdea(value = {}) {
   };
 }
 
+function normalizeDeleted(values) {
+  if (!Array.isArray(values)) return [];
+  const byId = new Map();
+  values.forEach(value => {
+    const id = clean(value?.id);
+    if (!id) return;
+    const record = { id, deletedAt: clean(value.deletedAt) || new Date().toISOString() };
+    const current = byId.get(id);
+    if (!current || stamp(record) >= stamp(current)) byId.set(id, record);
+  });
+  return [...byId.values()];
+}
+
 function migrateLegacyIdeas(value) {
   if (!Array.isArray(value)) return [];
   return value
@@ -178,20 +206,11 @@ function migrateLegacyIdeas(value) {
 }
 
 function safeRead(key) {
-  try {
-    return window.localStorage.getItem(key);
-  } catch {
-    return null;
-  }
+  try { return window.localStorage.getItem(key); } catch { return null; }
 }
 
 function safeWrite(key, value) {
-  try {
-    window.localStorage.setItem(key, value);
-    return true;
-  } catch {
-    return false;
-  }
+  try { window.localStorage.setItem(key, value); return true; } catch { return false; }
 }
 
 function loadIdeas() {
@@ -199,37 +218,50 @@ function loadIdeas() {
     const current = safeRead(STORAGE_KEY);
     if (current) {
       const parsed = JSON.parse(current);
-      if (Array.isArray(parsed)) {
-        return normalizeFocus(parsed.map(normalizeIdea).filter((idea) => idea.text));
-      }
+      if (Array.isArray(parsed)) return normalizeFocus(parsed.map(normalizeIdea).filter((idea) => idea.text));
     }
 
     const legacy = safeRead(LEGACY_STORAGE_KEY);
     if (!legacy) return [];
     const migrated = migrateLegacyIdeas(JSON.parse(legacy));
-    if (migrated.length) {
-      safeWrite(STORAGE_KEY, JSON.stringify(migrated));
-    }
+    if (migrated.length) safeWrite(STORAGE_KEY, JSON.stringify(migrated));
     return migrated;
-  } catch {
-    return [];
-  }
+  } catch { return []; }
 }
 
-function normalizeFocus(items) {
-  let foundFocus = false;
-  return items.map((idea) => {
-    if (idea.focused && !foundFocus && idea.stage !== 'done') {
-      foundFocus = true;
-      return idea;
-    }
-    return { ...idea, focused: false };
+function loadDeleted() {
+  try { return normalizeDeleted(JSON.parse(safeRead(DELETED_KEY) || '[]')); } catch { return []; }
+}
+
+function reconcileDeleted(items, deletedItems) {
+  const tombstones = new Map(deletedItems.map(record => [record.id, record]));
+  return items.filter(idea => {
+    const record = tombstones.get(idea.id);
+    return !record || stamp(idea) > stamp(record);
   });
 }
 
-function persist(message = 'Saved locally in this browser.') {
-  const ok = safeWrite(STORAGE_KEY, JSON.stringify(ideas));
+function normalizeFocus(items) {
+  const focusedId = items
+    .filter((idea) => idea.focused && idea.stage !== 'done')
+    .sort((a, b) => stamp(b) - stamp(a))[0]?.id;
+  return items.map((idea) => ({ ...idea, focused: Boolean(focusedId && idea.id === focusedId) }));
+}
+
+function markDeleted(ids) {
+  const now = new Date().toISOString();
+  deleted = normalizeDeleted([
+    ...deleted,
+    ...ids.filter(Boolean).map(id => ({ id, deletedAt: now })),
+  ]);
+}
+
+function persist(message = 'Saved locally in this browser.', { queueSync = true } = {}) {
+  const ideasSaved = safeWrite(STORAGE_KEY, JSON.stringify(ideas));
+  const deletedSaved = safeWrite(DELETED_KEY, JSON.stringify(deleted));
+  const ok = ideasSaved && deletedSaved;
   status.textContent = ok ? message : 'Could not save locally. Download a backup before leaving.';
+  if (ok && queueSync) scheduleAccountSync();
   return ok;
 }
 
@@ -247,12 +279,58 @@ function setFocus(id) {
   const target = ideas.find((idea) => idea.id === id);
   if (!target || target.stage === 'done') return;
   const wasFocused = target.focused;
+  const now = new Date().toISOString();
   ideas.forEach((idea) => {
     idea.focused = !wasFocused && idea.id === id;
-    if (idea.id === id) idea.updatedAt = new Date().toISOString();
+    if (idea.id === id || (!wasFocused && idea.focused)) idea.updatedAt = now;
   });
   persist(wasFocused ? 'Focus cleared.' : 'Focus set. Keep the next move small.');
   render();
+}
+
+function buildGardenPayload() {
+  return {
+    format: '3dvr-idea-garden',
+    version: 3,
+    exportedAt: new Date().toISOString(),
+    ideas: normalizeFocus(ideas.map(normalizeIdea)),
+    deleted: normalizeDeleted(deleted),
+  };
+}
+
+function applySyncedPayload(payload) {
+  if (!payload || payload.format !== '3dvr-idea-garden') return false;
+  deleted = normalizeDeleted(payload.deleted || []);
+  ideas = reconcileDeleted(
+    normalizeFocus((payload.ideas || []).map(normalizeIdea).filter((idea) => idea.text)),
+    deleted
+  );
+  return persist('Encrypted account copy loaded.', { queueSync: false });
+}
+
+function scheduleAccountSync() {
+  window.clearTimeout(syncTimer);
+  syncTimer = window.setTimeout(async () => {
+    if (!sync) return;
+    try { await sync.save(buildGardenPayload()); } catch { status.textContent = 'Saved here · Encrypted sync will retry'; }
+  }, 900);
+}
+
+async function startSync() {
+  sync = createGardenSync({ onStatus: (value) => { status.textContent = value; renderAccountLink(); } });
+  const synced = await sync.load(buildGardenPayload());
+  if (!synced) return;
+  applySyncedPayload(synced);
+  render();
+  await sync.save(buildGardenPayload());
+}
+
+function renderAccountLink() {
+  const shared = window.AuthIdentity?.readSharedIdentity?.() || {};
+  const signedIn = shared.signedIn === true || safeRead('signedIn') === 'true';
+  const alias = clean(shared.alias || safeRead('alias'));
+  accountLink.textContent = signedIn ? (alias || 'Account') : 'Sign in';
+  accountLink.href = signedIn ? '../account/' : '../sign-in.html?redirect=%2Fgarden%2F';
 }
 
 function visibleIdeas() {
@@ -307,7 +385,6 @@ function renderIdeas() {
   list.replaceChildren();
   emptyState.hidden = ideas.length > 0;
   noMatches.hidden = ideas.length === 0 || visible.length > 0;
-
   visible.forEach((idea) => list.appendChild(renderIdeaCard(idea)));
 }
 
@@ -408,25 +485,14 @@ function makeNurtureField(idea, field, label, placeholder) {
 }
 
 function toolForStage(idea) {
-  if (idea.stage === 'seed') {
-    return { label: 'Explore in Forge', href: '../forge/' };
-  }
-  if (idea.stage === 'exploring') {
-    return { label: 'Shape in Launch Room', href: '../launch-room/?mode=start-project' };
-  }
-  if (idea.stage === 'project') {
-    return { label: 'Choose today’s move', href: '../life/' };
-  }
+  if (idea.stage === 'seed') return { label: 'Explore in Forge', href: '../forge/' };
+  if (idea.stage === 'exploring') return { label: 'Shape in Launch Room', href: '../launch-room/?mode=start-project' };
+  if (idea.stage === 'project') return { label: 'Choose today’s move', href: '../life/' };
   return { label: 'Start another spark', href: '#ideaForm' };
 }
 
 function downloadGarden() {
-  const payload = {
-    format: '3dvr-idea-garden',
-    version: 2,
-    exportedAt: new Date().toISOString(),
-    ideas,
-  };
+  const payload = buildGardenPayload();
   const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');

--- a/garden/app.js
+++ b/garden/app.js
@@ -329,8 +329,9 @@ function renderAccountLink() {
   const shared = window.AuthIdentity?.readSharedIdentity?.() || {};
   const signedIn = shared.signedIn === true || safeRead('signedIn') === 'true';
   const alias = clean(shared.alias || safeRead('alias'));
-  accountLink.textContent = signedIn ? (alias || 'Account') : 'Sign in';
-  accountLink.href = signedIn ? '/profile.html' : '../sign-in.html?redirect=%2Fgarden%2F';
+  const syncReady = Boolean(sync?.isReady?.());
+  accountLink.textContent = signedIn ? (syncReady ? (alias || 'Account') : 'Reconnect') : 'Sign in';
+  accountLink.href = signedIn && syncReady ? '/profile.html' : '../sign-in.html?redirect=%2Fgarden%2F';
 }
 
 function visibleIdeas() {

--- a/garden/app.js
+++ b/garden/app.js
@@ -330,7 +330,7 @@ function renderAccountLink() {
   const signedIn = shared.signedIn === true || safeRead('signedIn') === 'true';
   const alias = clean(shared.alias || safeRead('alias'));
   accountLink.textContent = signedIn ? (alias || 'Account') : 'Sign in';
-  accountLink.href = signedIn ? '../account/' : '../sign-in.html?redirect=%2Fgarden%2F';
+  accountLink.href = signedIn ? '/profile.html' : '../sign-in.html?redirect=%2Fgarden%2F';
 }
 
 function visibleIdeas() {

--- a/garden/index.html
+++ b/garden/index.html
@@ -7,15 +7,18 @@
   <title>Idea Garden · 3dvr.tech</title>
   <meta name="description" content="A quiet place to collect ideas, nurture them, and turn them into real projects." />
   <link rel="stylesheet" href="./style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
+  <script src="/gun-init.js"></script>
+  <script src="/auth-identity.js"></script>
   <script defer src="/_vercel/insights/script.js"></script>
-  <script defer src="./app.js"></script>
 </head>
 <body>
   <header class="topbar">
     <a class="brand" href="../">3dvr.tech</a>
     <div class="topbar-actions">
       <span class="tag">Idea Garden</span>
-      <a class="quiet-link" href="../start/">Start</a>
+      <a class="quiet-link" id="gardenAccount" href="../sign-in.html?redirect=%2Fgarden%2F">Account</a>
     </div>
   </header>
 
@@ -31,7 +34,7 @@
         <div class="capture-actions">
           <div>
             <small>Messy ideas are welcome.</small>
-            <span id="gardenStatus" class="save-status" role="status" aria-live="polite">Stored only in this browser for now.</span>
+            <span id="gardenStatus" class="save-status" role="status" aria-live="polite">Saved locally · Checking encrypted account sync…</span>
           </div>
           <button type="submit">Plant idea</button>
         </div>
@@ -122,5 +125,6 @@
     <a href="../launch-room/">Launch Room</a>
     <a href="../forge/">Forge</a>
   </footer>
+  <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/garden/sync.js
+++ b/garden/sync.js
@@ -1,0 +1,422 @@
+const SYNC_NODE = 'idea-garden-v01';
+const CHUNK_SIZE = 24 * 1024;
+const READ_TIMEOUT_MS = 6000;
+const SESSION_TIMEOUT_MS = 4500;
+const WRITE_TIMEOUT_MS = 5000;
+const PENDING_KEY = 'idea-garden:pending-account-sync:v1';
+
+const delay = (windowObj, ms) => new Promise(resolve => windowObj.setTimeout(resolve, ms));
+
+function timestamp(value) {
+  const raw = value?.updatedAt || value?.deletedAt || value?.createdAt || 0;
+  if (typeof raw === 'number') return raw;
+  const parsed = Date.parse(raw);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function safeStorageGet(storage, key) {
+  try { return storage?.getItem?.(key) || ''; } catch { return ''; }
+}
+
+function safeStorageSet(storage, key, value) {
+  try { storage?.setItem?.(key, value); return true; } catch { return false; }
+}
+
+function safeStorageRemove(storage, key) {
+  try { storage?.removeItem?.(key); return true; } catch { return false; }
+}
+
+function newestById(values = []) {
+  const map = new Map();
+  values.forEach(value => {
+    if (!value?.id) return;
+    const current = map.get(value.id);
+    if (!current || timestamp(value) >= timestamp(current)) map.set(value.id, value);
+  });
+  return map;
+}
+
+function normalizeFocus(ideas) {
+  const focused = ideas
+    .filter(idea => idea.focused && idea.stage !== 'done')
+    .sort((a, b) => timestamp(b) - timestamp(a))[0]?.id;
+  return ideas.map(idea => ({ ...idea, focused: Boolean(focused && idea.id === focused) }));
+}
+
+export function mergeGardenPayloads(localPayload, remotePayload) {
+  const local = localPayload || { ideas: [], deleted: [] };
+  const remote = remotePayload || { ideas: [], deleted: [] };
+  const deleted = newestById([...(remote.deleted || []), ...(local.deleted || [])]);
+  const ideas = newestById([...(remote.ideas || []), ...(local.ideas || [])]);
+
+  deleted.forEach((record, id) => {
+    const idea = ideas.get(id);
+    if (!idea || timestamp(record) >= timestamp(idea)) ideas.delete(id);
+  });
+
+  const mergedIdeas = normalizeFocus([...ideas.values()].sort((a, b) => timestamp(b) - timestamp(a)));
+  return {
+    format: '3dvr-idea-garden',
+    version: 3,
+    exportedAt: new Date().toISOString(),
+    ideas: mergedIdeas,
+    deleted: [...deleted.values()].sort((a, b) => timestamp(b) - timestamp(a)),
+  };
+}
+
+function hasGardenContent(payload) {
+  return Boolean((payload?.ideas || []).length || (payload?.deleted || []).length);
+}
+
+function waitForValue(node, predicate, windowObj, timeoutMs = READ_TIMEOUT_MS) {
+  return new Promise(resolve => {
+    let settled = false;
+    let subscription = null;
+    const finish = value => {
+      if (settled) return;
+      settled = true;
+      windowObj.clearTimeout(timer);
+      try {
+        if (subscription && typeof subscription.off === 'function') subscription.off();
+        else node?.off?.();
+      } catch {}
+      resolve(value);
+    };
+    const timer = windowObj.setTimeout(() => finish(null), Math.max(0, timeoutMs));
+    try {
+      if (typeof node?.on === 'function') subscription = node.on(value => {
+        try { if (predicate(value)) finish(value); } catch {}
+      });
+      else if (typeof node?.once === 'function') node.once(value => {
+        try { if (predicate(value)) finish(value); } catch {}
+      });
+      else finish(null);
+    } catch { finish(null); }
+  });
+}
+
+function put(node, value, windowObj, timeoutMs = WRITE_TIMEOUT_MS) {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = result => { if (!settled) { settled = true; resolve(result); } };
+    const timer = windowObj.setTimeout(() => finish(false), Math.max(0, timeoutMs));
+    try {
+      node.put(value, ack => {
+        windowObj.clearTimeout(timer);
+        finish(!ack?.err);
+      });
+    } catch {
+      windowObj.clearTimeout(timer);
+      finish(false);
+    }
+  });
+}
+
+export function createGardenSync({
+  windowObj = window,
+  onStatus = () => {},
+  readTimeoutMs = READ_TIMEOUT_MS,
+  sessionTimeoutMs = SESSION_TIMEOUT_MS,
+  verifyTimeoutMs = Math.max(readTimeoutMs, 6000),
+  writeTimeoutMs = WRITE_TIMEOUT_MS,
+} = {}) {
+  const storage = windowObj.localStorage;
+  const peers = Array.isArray(windowObj.__GUN_PEERS__) ? windowObj.__GUN_PEERS__ : [];
+  let gun = null;
+  let user = null;
+  let node = null;
+  let secret = null;
+  let ready = false;
+  let setupPromise = null;
+  let pendingPayload = null;
+  let pendingNeedsMerge = false;
+  let initialLoadComplete = false;
+  let pendingToken = 0;
+  let confirmedToken = 0;
+  let drainPromise = null;
+  let retryTimer = null;
+  let retryDelay = 2000;
+
+  function pendingMarker() {
+    return safeStorageGet(storage, PENDING_KEY);
+  }
+
+  function readPendingMarker() {
+    try { return JSON.parse(pendingMarker()) || null; } catch { return null; }
+  }
+
+  function persistPendingMarker() {
+    safeStorageSet(storage, PENDING_KEY, JSON.stringify({
+      queuedAt: Date.now(),
+      token: pendingToken,
+      needsMerge: pendingNeedsMerge,
+    }));
+  }
+
+  function markPending(payload, { needsMerge = !initialLoadComplete } = {}) {
+    pendingPayload = payload;
+    pendingNeedsMerge = Boolean(needsMerge);
+    pendingToken += 1;
+    persistPendingMarker();
+    return pendingToken;
+  }
+
+  function clearPending(token) {
+    if (token !== pendingToken) return;
+    pendingPayload = null;
+    pendingNeedsMerge = false;
+    confirmedToken = token;
+    retryDelay = 2000;
+    safeStorageRemove(storage, PENDING_KEY);
+  }
+
+  function signedInMarkerExists() {
+    const shared = windowObj.AuthIdentity?.readSharedIdentity?.() || {};
+    return shared.signedIn === true || safeStorageGet(storage, 'signedIn') === 'true';
+  }
+
+  function sessionStatus() {
+    return signedInMarkerExists()
+      ? 'Saved here · Sign in again to resume encrypted sync'
+      : 'Saved on this device · Sign in to sync privately';
+  }
+
+  async function waitForSession(timeoutMs = sessionTimeoutMs) {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    while (!user?.is?.pub && Date.now() <= deadline) await delay(windowObj, 120);
+    return Boolean(user?.is?.pub);
+  }
+
+  async function restoreSession() {
+    if (user?.is?.pub) return true;
+    try { user?.recall?.({ sessionStorage: true, localStorage: true }); } catch {}
+    return waitForSession(sessionTimeoutMs);
+  }
+
+  async function ensureReady() {
+    if (ready && user?.is?.pub && secret && node) return true;
+    if (setupPromise) return setupPromise;
+    setupPromise = (async () => {
+      if (typeof windowObj.Gun !== 'function' || !windowObj.SEA) return false;
+      try {
+        windowObj.AuthIdentity?.syncStorageFromSharedIdentity?.(storage);
+        if (!gun) gun = windowObj.Gun({ peers });
+        if (!user) user = gun.user();
+        if (!(await restoreSession())) {
+          ready = false;
+          onStatus(sessionStatus());
+          return false;
+        }
+        secret = user?._?.sea || null;
+        if (!secret || typeof windowObj.SEA.encrypt !== 'function' || typeof windowObj.SEA.decrypt !== 'function') {
+          ready = false;
+          onStatus(sessionStatus());
+          return false;
+        }
+        node = user.get(SYNC_NODE).get('garden');
+        ready = true;
+        onStatus(pendingMarker() ? 'Encrypted sync ready · Pending changes will retry' : 'Encrypted account sync ready');
+        return true;
+      } catch {
+        ready = false;
+        onStatus('Saved on this device · Encrypted sync unavailable');
+        return false;
+      }
+    })().finally(() => { setupPromise = null; });
+    return setupPromise;
+  }
+
+  function verificationNode() {
+    const pub = user?.is?.pub;
+    if (!pub || typeof windowObj.Gun !== 'function') return null;
+    try {
+      const verifier = windowObj.Gun({ peers, localStorage: false, radisk: false });
+      return verifier?.get?.(`~${pub}`)?.get(SYNC_NODE)?.get('garden') || null;
+    } catch { return null; }
+  }
+
+  async function readPayload(sourceNode = node, { expectedRevision = '', timeoutMs = readTimeoutMs } = {}) {
+    if (!sourceNode) return { kind: 'missing', payload: null };
+    const manifest = await waitForValue(
+      sourceNode.get('manifest'),
+      value => Boolean(value && typeof value === 'object' && (!expectedRevision || value.revision === expectedRevision)),
+      windowObj,
+      timeoutMs
+    );
+    if (!manifest) {
+      if (expectedRevision) throw new Error('Garden manifest not visible from relay');
+      return { kind: 'missing', payload: null };
+    }
+    const count = Number(manifest.chunks || 0);
+    if (!count || count > 1000) throw new Error('Invalid Garden sync manifest');
+    const revision = String(manifest.revision || '');
+    const parts = await Promise.all(Array.from({ length: count }, (_, index) => waitForValue(
+      sourceNode.get('chunks').get(String(index)),
+      part => Boolean(part && typeof part.value === 'string' && (!revision || part.revision === revision)),
+      windowObj,
+      timeoutMs
+    )));
+    if (parts.some(part => typeof part?.value !== 'string')) throw new Error('Incomplete Garden sync payload');
+    const ciphertext = parts.map(part => part.value).join('');
+    if (manifest.bytes && Number(manifest.bytes) !== ciphertext.length) throw new Error('Garden sync payload length mismatch');
+    const decoded = await windowObj.SEA.decrypt(ciphertext, secret);
+    const serialized = typeof decoded === 'string' ? decoded : JSON.stringify(decoded);
+    const payload = typeof decoded === 'string' ? JSON.parse(decoded) : decoded;
+    if (payload?.format !== '3dvr-idea-garden') throw new Error('Unsupported Garden sync payload');
+    return { kind: 'ready', payload, serialized };
+  }
+
+  function newRevision() {
+    const random = windowObj.crypto?.randomUUID?.() || Math.random().toString(36).slice(2);
+    return `${Date.now().toString(36)}-${random}`;
+  }
+
+  async function writeAndVerify(payload) {
+    if (!(await ensureReady()) || !node) return false;
+    try {
+      const serialized = JSON.stringify(payload);
+      const ciphertext = String(await windowObj.SEA.encrypt(serialized, secret));
+      const chunks = ciphertext.match(new RegExp(`.{1,${CHUNK_SIZE}}`, 'gs')) || [];
+      const revision = newRevision();
+      onStatus('Encrypting and syncing…');
+      const chunksSaved = await Promise.all(chunks.map((value, index) => put(
+        node.get('chunks').get(String(index)), { revision, index, value }, windowObj, writeTimeoutMs
+      )));
+      if (!chunksSaved.every(Boolean)) return false;
+      const manifestSaved = await put(node.get('manifest'), {
+        schemaVersion: 1,
+        revision,
+        chunks: chunks.length,
+        bytes: ciphertext.length,
+        updatedAt: new Date().toISOString(),
+      }, windowObj, writeTimeoutMs);
+      if (!manifestSaved) return false;
+
+      onStatus('Verifying encrypted account copy…');
+      const verifier = verificationNode();
+      if (!verifier) return false;
+      const verified = await readPayload(verifier, { expectedRevision: revision, timeoutMs: verifyTimeoutMs });
+      return verified.kind === 'ready' && verified.serialized === serialized;
+    } catch { return false; }
+  }
+
+  function scheduleRetry() {
+    if (retryTimer || !pendingPayload) return;
+    retryTimer = windowObj.setTimeout(() => {
+      retryTimer = null;
+      drainPending();
+    }, retryDelay);
+    retryDelay = Math.min(30000, retryDelay * 2);
+  }
+
+  async function drainPending() {
+    if (drainPromise) return drainPromise;
+    if (!pendingPayload) return false;
+    drainPromise = (async () => {
+      while (pendingPayload) {
+        if (pendingNeedsMerge) {
+          if (!(await ensureReady()) || !node) {
+            onStatus('Saved here · Encrypted account sync pending');
+            scheduleRetry();
+            return false;
+          }
+          try {
+            const remote = await readPayload(node);
+            if (remote.kind === 'ready') pendingPayload = mergeGardenPayloads(pendingPayload, remote.payload);
+            pendingNeedsMerge = false;
+            initialLoadComplete = true;
+            persistPendingMarker();
+          } catch {
+            onStatus('Saved here · Waiting to reconcile account copy');
+            scheduleRetry();
+            return false;
+          }
+        }
+
+        const payload = pendingPayload;
+        const token = pendingToken;
+        const saved = await writeAndVerify(payload);
+        if (!saved) {
+          onStatus('Saved here · Encrypted account sync pending');
+          scheduleRetry();
+          return false;
+        }
+        if (token === pendingToken) {
+          clearPending(token);
+          onStatus('Encrypted and verified on your account');
+          return true;
+        }
+      }
+      return true;
+    })().finally(() => { drainPromise = null; });
+    return drainPromise;
+  }
+
+  function retryPending() {
+    if (retryTimer) {
+      windowObj.clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+    return drainPending();
+  }
+
+  const retryOnReturn = () => { if (pendingPayload) retryPending(); };
+  windowObj.addEventListener?.('online', retryOnReturn);
+  windowObj.addEventListener?.('focus', retryOnReturn);
+  windowObj.document?.addEventListener?.('visibilitychange', () => {
+    if (windowObj.document.visibilityState === 'visible') retryOnReturn();
+  });
+
+  const readyPromise = ensureReady();
+
+  return {
+    ready: readyPromise,
+    async load(localPayload) {
+      const storedMarker = readPendingMarker();
+      if (storedMarker) {
+        pendingPayload = localPayload;
+        pendingNeedsMerge = storedMarker.needsMerge !== false;
+        pendingToken += 1;
+      }
+      if (!(await ensureReady()) || !node) {
+        if (hasGardenContent(localPayload) && !pendingPayload) {
+          markPending(localPayload, { needsMerge: true });
+          onStatus('Saved here · Sign in will resume encrypted sync');
+        }
+        return null;
+      }
+      try {
+        const remote = await readPayload(node);
+        initialLoadComplete = true;
+        if (remote.kind === 'missing') {
+          if (!hasGardenContent(localPayload)) {
+            onStatus('Encrypted account sync ready');
+            return null;
+          }
+          onStatus('No account copy yet · Uploading this Garden…');
+          return localPayload;
+        }
+        const merged = mergeGardenPayloads(localPayload, remote.payload);
+        if (storedMarker) {
+          pendingPayload = merged;
+          pendingNeedsMerge = false;
+          persistPendingMarker();
+        }
+        onStatus('Encrypted account copy loaded');
+        return merged;
+      } catch {
+        if (hasGardenContent(localPayload) && !pendingPayload) markPending(localPayload, { needsMerge: true });
+        onStatus('Saved here · Encrypted account copy could not be opened');
+        return null;
+      }
+    },
+    async save(payload) {
+      const token = markPending(payload, { needsMerge: !initialLoadComplete });
+      const saved = await drainPending();
+      return saved && confirmedToken >= token;
+    },
+    retry: retryPending,
+    isReady() { return ready; },
+    hasPending() { return Boolean(pendingPayload || pendingMarker()); },
+  };
+}

--- a/tests/garden-sync.test.js
+++ b/tests/garden-sync.test.js
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { mergeGardenPayloads } from '../garden/sync.js';
+
+const idea = (id, updatedAt, values = {}) => ({
+  id,
+  text: `Idea ${id}`,
+  stage: 'seed',
+  why: '',
+  nextStep: '',
+  focused: false,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt,
+  ...values,
+});
+
+describe('Idea Garden encrypted sync', () => {
+  it('merges ideas by newest update and keeps one newest focus', () => {
+    const merged = mergeGardenPayloads(
+      {
+        ideas: [
+          idea('a', '2026-08-26T10:00:00.000Z', { text: 'new local', focused: true }),
+          idea('b', '2026-08-26T08:00:00.000Z'),
+        ],
+        deleted: [],
+      },
+      {
+        ideas: [
+          idea('a', '2026-08-26T09:00:00.000Z', { text: 'old remote' }),
+          idea('c', '2026-08-26T11:00:00.000Z', { focused: true }),
+        ],
+        deleted: [],
+      }
+    );
+
+    assert.equal(merged.ideas.find(item => item.id === 'a').text, 'new local');
+    assert.deepEqual(new Set(merged.ideas.map(item => item.id)), new Set(['a', 'b', 'c']));
+    assert.deepEqual(merged.ideas.filter(item => item.focused).map(item => item.id), ['c']);
+  });
+
+  it('uses deletion tombstones to prevent stale devices from resurrecting ideas', () => {
+    const merged = mergeGardenPayloads(
+      {
+        ideas: [],
+        deleted: [{ id: 'gone', deletedAt: '2026-08-26T12:00:00.000Z' }],
+      },
+      {
+        ideas: [idea('gone', '2026-08-26T11:00:00.000Z')],
+        deleted: [],
+      }
+    );
+
+    assert.equal(merged.ideas.some(item => item.id === 'gone'), false);
+    assert.equal(merged.deleted.find(item => item.id === 'gone').deletedAt, '2026-08-26T12:00:00.000Z');
+  });
+
+  it('allows a genuinely newer edit to win over an older tombstone', () => {
+    const merged = mergeGardenPayloads(
+      {
+        ideas: [idea('return', '2026-08-26T13:00:00.000Z')],
+        deleted: [],
+      },
+      {
+        ideas: [],
+        deleted: [{ id: 'return', deletedAt: '2026-08-26T12:00:00.000Z' }],
+      }
+    );
+
+    assert.equal(merged.ideas.some(item => item.id === 'return'), true);
+  });
+
+  it('encrypts the whole payload and does not read a stored password', async () => {
+    const source = await readFile(new URL('../garden/sync.js', import.meta.url), 'utf8');
+
+    assert.match(source, /SEA\.encrypt\(serialized, secret\)/);
+    assert.match(source, /SEA\.decrypt\(ciphertext, secret\)/);
+    assert.match(source, /user\.get\(SYNC_NODE\)\.get\('garden'\)/);
+    assert.match(source, /user\?\.recall\?\.\(\{ sessionStorage: true, localStorage: true \}\)/);
+    assert.match(source, /verificationNode/);
+    assert.match(source, /Encrypted and verified on your account/);
+    assert.doesNotMatch(source, /getItem\(['"]password['"]\)/);
+    assert.doesNotMatch(source, /user\.auth\(/);
+  });
+});

--- a/tests/garden.test.js
+++ b/tests/garden.test.js
@@ -11,22 +11,36 @@ describe('3DVR Idea Garden', () => {
     assert.match(html, /id="gardenSearch"/);
     assert.match(html, /id="focusShelf"/);
     assert.match(html, /id="downloadGarden"/);
-    assert.match(html, /Stored only in this browser/);
+    assert.match(html, /Saved locally · Checking encrypted account sync/);
+    assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+    assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/sea\.js/);
+    assert.match(html, /src="\/auth-identity\.js"/);
+    assert.match(html, /type="module" src="\.\/app\.js"/);
     assert.doesNotMatch(html, /credit card/i);
     assert.doesNotMatch(html, /pricing/i);
   });
 
-  it('stores a richer project model and migrates the v1 garden', async () => {
+  it('stores a richer project model, tombstones, and migrates the v1 garden', async () => {
     const app = await readFile(new URL('../garden/app.js', import.meta.url), 'utf8');
 
+    assert.match(app, /import \{ createGardenSync \} from '\.\/sync\.js'/);
     assert.match(app, /3dvr\.ideaGarden\.v2/);
     assert.match(app, /3dvr\.ideaGarden\.v1/);
+    assert.match(app, /3dvr\.ideaGarden\.deleted\.v1/);
     assert.match(app, /why:/);
     assert.match(app, /nextStep:/);
     assert.match(app, /focused:/);
     assert.match(app, /function normalizeIdea/);
+    assert.match(app, /function normalizeDeleted/);
+    assert.match(app, /function markDeleted/);
+    assert.match(app, /function reconcileDeleted/);
     assert.match(app, /function migrateLegacyIdeas/);
     assert.match(app, /function setFocus/);
+    assert.match(app, /function buildGardenPayload/);
+    assert.match(app, /version:\s*3/);
+    assert.match(app, /function startSync/);
+    assert.match(app, /sync\.load\(buildGardenPayload\(\)\)/);
+    assert.match(app, /sync\.save\(buildGardenPayload\(\)\)/);
     assert.match(app, /function downloadGarden/);
     assert.match(app, /function toolForStage/);
     assert.doesNotMatch(app, /encodeURIComponent\(idea\.text\)/);

--- a/tests/garden.test.js
+++ b/tests/garden.test.js
@@ -41,7 +41,8 @@ describe('3DVR Idea Garden', () => {
     assert.match(app, /function startSync/);
     assert.match(app, /sync\.load\(buildGardenPayload\(\)\)/);
     assert.match(app, /sync\.save\(buildGardenPayload\(\)\)/);
-    assert.match(app, /accountLink\.href = signedIn \? '\/profile\.html'/);
+    assert.match(app, /accountLink\.textContent = signedIn \? \(syncReady \?/);
+    assert.match(app, /accountLink\.href = signedIn && syncReady \? '\/profile\.html'/);
     assert.match(app, /function downloadGarden/);
     assert.match(app, /function toolForStage/);
     assert.doesNotMatch(app, /encodeURIComponent\(idea\.text\)/);

--- a/tests/garden.test.js
+++ b/tests/garden.test.js
@@ -41,6 +41,7 @@ describe('3DVR Idea Garden', () => {
     assert.match(app, /function startSync/);
     assert.match(app, /sync\.load\(buildGardenPayload\(\)\)/);
     assert.match(app, /sync\.save\(buildGardenPayload\(\)\)/);
+    assert.match(app, /accountLink\.href = signedIn \? '\/profile\.html'/);
     assert.match(app, /function downloadGarden/);
     assert.match(app, /function toolForStage/);
     assert.doesNotMatch(app, /encodeURIComponent\(idea\.text\)/);


### PR DESCRIPTION
Adds local-first encrypted account sync to `/garden/` using the portal's existing GUN + SEA identity pattern.

Core behavior:
- Garden still saves instantly to localStorage and works offline/unsigned-in
- signed-in sessions encrypt the entire Garden payload with SEA before writing to the user's GUN graph
- relay verification reads the encrypted copy back before marking sync successful
- merge is last-write-wins per idea using timestamps
- one newest focus survives cross-device merges
- deletion tombstones prevent stale devices from resurrecting removed ideas
- failed/offline writes remain pending and retry on return
- Garden sync never reads a stored password; it relies on the existing recalled GUN session and routes the user back through sign-in when needed
- backup format advances to v3 with tombstones while retaining the existing local v1/v2 migration

Verification run on the connected Hetzner worker:
`node --test tests/garden.test.js tests/garden-sync.test.js` → 7/7 passing before the profile-link cleanup; `tests/garden.test.js` → 3/3 passing after that cleanup.

No Vercel production policy changes.