### PR TITLE
Make calendar month view more glanceable

### DIFF
--- a/calendar/calendar.css
+++ b/calendar/calendar.css
@@ -562,7 +562,7 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  height: 124px;
+  height: 148px;
   padding: 12px;
   position: relative;
   transition: box-shadow 0.2s ease, transform 0.2s ease;
@@ -616,27 +616,33 @@ button:focus-visible {
 }
 
 .calendar-view__event {
+  align-items: flex-start;
   background: rgba(67, 109, 147, 0.2);
   border-radius: 10px;
   color: #d9e7f4;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   font-size: 0.85rem;
   font-weight: 600;
   line-height: 1.2;
   margin: 0;
   overflow: hidden;
   padding: 6px 8px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .calendar-view__event-time {
-  display: inline-block;
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.calendar-view__event-title {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .calendar-view__more {
@@ -1028,7 +1034,7 @@ button:focus-visible {
   }
 
   .calendar-view__grid-inner {
-    min-width: 100%;
+    min-width: 760px;
     width: 100%;
   }
 
@@ -1152,7 +1158,7 @@ button:focus-visible {
 
   .calendar-view__grid-inner {
     gap: 8px;
-    min-width: 100%;
+    min-width: 760px;
     width: 100%;
   }
 
@@ -1163,7 +1169,7 @@ button:focus-visible {
   }
 
   .calendar-view__day {
-    height: 92px;
+    height: 116px;
     padding: 10px 8px;
   }
 

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -893,14 +893,17 @@ function renderCalendar(events = state.localEvents) {
       eventsForDay.slice(0, 3).forEach(event => {
         const item = document.createElement('li');
         item.className = 'calendar-view__event';
-        const timeLabel = formatCalendarTime(event.start, event.timeZone);
+        const timeLabel = formatCalendarRange(event);
         if (timeLabel) {
           const time = document.createElement('span');
           time.className = 'calendar-view__event-time';
           time.textContent = timeLabel;
           item.appendChild(time);
         }
-        item.appendChild(document.createTextNode(event.title || 'Untitled event'));
+        const title = document.createElement('span');
+        title.className = 'calendar-view__event-title';
+        title.textContent = event.title || 'Untitled event';
+        item.appendChild(title);
         list.appendChild(item);
       });
       if (eventsForDay.length > 3) {

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -93,7 +93,7 @@
             <div class="calendar-view__header">
               <div>
                 <h3 id="calendar-view-title">Monthly overview</h3>
-                <p class="calendar-view__subtitle">See your saved events at a glance and click a day to focus it.</p>
+                <p class="calendar-view__subtitle">See start and end times at a glance, then click a day to focus it.</p>
               </div>
               <div class="calendar-view__controls" role="group" aria-label="Change month">
                 <button type="button" class="button-secondary" data-calendar-nav="prev" aria-label="Previous month">‹</button>

--- a/tests/calendar-ui.test.js
+++ b/tests/calendar-ui.test.js
@@ -40,6 +40,18 @@ test('calendar hub presents a clear hero, month-first workspace, and side rail',
   );
 });
 
+test('calendar month cells show full time ranges without hiding the event title', async () => {
+  const html = await readFile(new URL('../calendar/index.html', import.meta.url), 'utf8');
+  const js = await readFile(new URL('../calendar/calendar.js', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../calendar/calendar.css', import.meta.url), 'utf8');
+
+  assert.match(html, /See start and end times at a glance/);
+  assert.match(js, /const timeLabel = formatCalendarRange\(event\);/);
+  assert.match(js, /title\.className = 'calendar-view__event-title';/);
+  assert.match(css, /\.calendar-view__event-title \{/);
+  assert.match(css, /min-width: 760px;/);
+});
+
 test('calendar runtime updates the quick summary strip from event and connection state', async () => {
   const js = await readFile(new URL('../calendar/calendar.js', import.meta.url), 'utf8');
 


### PR DESCRIPTION
Updates the existing Portal Calendar month grid to show full start–end ranges, keeps event titles readable, and preserves the existing local/GUN/OAuth behavior.\n\nVerification: calendar-focused tests 4/4 passing and git diff --check. The broader repo suite currently has unrelated stale homepage-card assertions on main.