### PR TITLE
Make calendar month mobile-friendly

### DIFF
--- a/calendar/calendar.css
+++ b/calendar/calendar.css
@@ -127,11 +127,13 @@ body {
 }
 
 .panel--primary {
+  min-width: 0;
   padding: 30px;
 }
 
 .calendar-rail {
   display: grid;
+  min-width: 0;
   gap: 18px;
   position: sticky;
   top: 24px;
@@ -139,6 +141,7 @@ body {
 
 .panel {
   background: var(--calendar-surface);
+  min-width: 0;
   border: 1px solid rgba(132, 156, 188, 0.18);
   border-radius: var(--calendar-radius);
   box-shadow: var(--calendar-shadow);
@@ -201,6 +204,7 @@ body {
 
 .calendar-workspace {
   display: grid;
+  min-width: 0;
   gap: 22px;
   grid-template-columns: minmax(0, 1.45fr) minmax(300px, 360px);
   align-items: start;
@@ -262,6 +266,7 @@ body {
 }
 
 .connection-card {
+  min-width: 0;
   background: var(--calendar-surface-soft);
   border: 1px solid rgba(132, 156, 188, 0.18);
   border-radius: calc(var(--calendar-radius) - 6px);
@@ -483,6 +488,7 @@ button:focus-visible {
   flex-direction: column;
   gap: 16px;
   min-height: 100%;
+  min-width: 0;
   padding: 26px;
   scroll-margin-top: 20px;
 }
@@ -520,6 +526,8 @@ button:focus-visible {
 
 
 .calendar-view__grid {
+  max-width: 100%;
+  min-width: 0;
   overflow-x: auto;
   padding-bottom: 8px;
   -webkit-overflow-scrolling: touch;
@@ -588,6 +596,13 @@ button:focus-visible {
   box-shadow: 0 0 0 2px rgba(67, 109, 147, 0.28);
 }
 
+.calendar-view__day--today .calendar-view__date {
+  align-self: flex-start;
+  background: rgba(156, 192, 224, 0.24);
+  border-radius: 999px;
+  padding: 2px 7px;
+}
+
 .calendar-view__day--selected {
   border-color: var(--calendar-primary-dark);
   box-shadow: 0 0 0 2px rgba(67, 109, 147, 0.36);
@@ -611,7 +626,7 @@ button:focus-visible {
   list-style: none;
   margin: 0;
   min-height: 0;
-  overflow-y: auto;
+  overflow: hidden;
   padding: 0;
 }
 
@@ -636,6 +651,10 @@ button:focus-visible {
   font-size: 0.72rem;
   font-weight: 700;
   white-space: nowrap;
+}
+
+.calendar-view__event-time-compact {
+  display: none;
 }
 
 .calendar-view__event-title {
@@ -985,7 +1004,7 @@ button:focus-visible {
   }
 
   .calendar-shell {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .calendar-rail {
@@ -1011,7 +1030,7 @@ button:focus-visible {
   }
 
   .calendar-workspace {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .calendar-view {
@@ -1034,18 +1053,48 @@ button:focus-visible {
   }
 
   .calendar-view__grid-inner {
-    min-width: 760px;
+    min-width: 0;
     width: 100%;
   }
 
   .calendar-view__day-names,
   .calendar-view__days {
-    gap: 8px;
-    grid-template-columns: repeat(7, 1fr);
+    gap: 3px;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .calendar-view__day-name {
+    font-size: 0.68rem;
   }
 
   .calendar-view__day {
-    min-height: 100px;
+    border-radius: 9px;
+    min-height: 136px;
+    padding: 8px 5px;
+  }
+
+  .calendar-view__event {
+    border-radius: 6px;
+    gap: 1px;
+    padding: 5px 4px;
+  }
+
+  .calendar-view__event-time {
+    font-size: 0.64rem;
+    letter-spacing: -0.035em;
+  }
+
+  .calendar-view__event-time-full {
+    display: none;
+  }
+
+  .calendar-view__event-time-compact {
+    display: inline;
+  }
+
+  .calendar-view__event-title {
+    font-size: 0.68rem;
+    -webkit-line-clamp: 1;
   }
 
   .calendar-view__details {
@@ -1053,7 +1102,7 @@ button:focus-visible {
   }
 
   .calendar-activity__grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -1156,30 +1205,54 @@ button:focus-visible {
     width: 100%;
   }
 
+  .calendar-view__grid {
+    margin-left: -8px;
+    margin-right: -8px;
+  }
+
   .calendar-view__grid-inner {
-    gap: 8px;
-    min-width: 760px;
+    gap: 5px;
+    min-width: 0;
     width: 100%;
   }
 
   .calendar-view__day-names,
   .calendar-view__days {
-    gap: 6px;
-    grid-template-columns: repeat(7, 1fr);
+    gap: 2px;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .calendar-view__day-name {
+    font-size: 0.6rem;
   }
 
   .calendar-view__day {
-    height: 116px;
-    padding: 10px 8px;
+    border-radius: 7px;
+    height: 132px;
+    padding: 6px 3px;
   }
 
   .calendar-view__date {
-    font-size: 1rem;
+    font-size: 0.88rem;
+    text-align: center;
   }
 
   .calendar-view__event {
-    font-size: 0.8rem;
-    padding: 5px 6px;
+    font-size: 0.68rem;
+    padding: 4px 3px;
+  }
+
+  .calendar-view__event-time {
+    font-size: 0.58rem;
+    text-align: center;
+    width: 100%;
+  }
+
+  .calendar-view__event-title {
+    font-size: 0.62rem;
+    line-height: 1.05;
+    text-align: center;
+    width: 100%;
   }
 
   .calendar-view__details {
@@ -1227,3 +1300,31 @@ button:focus-visible {
     width: 100%;
   }
 }
+
+@media (max-width: 420px) {
+  body {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  .panel--primary,
+  .panel {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
+  .calendar-view {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
+  .calendar-view__day {
+    height: 122px;
+  }
+
+  .calendar-view__event-title {
+    font-size: 0.56rem;
+  }
+}
+
+.calendar-rail code { overflow-wrap: anywhere; word-break: break-word; }

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -824,6 +824,36 @@ function formatCalendarRange(event) {
   return start || '';
 }
 
+function formatCompactCalendarTime(value, timeZone) {
+  if (!value) return '';
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    const options = { hour: 'numeric', minute: '2-digit', hour12: true };
+    if (timeZone) options.timeZone = timeZone;
+    const parts = new Intl.DateTimeFormat(undefined, options).formatToParts(date);
+    const hour = parts.find(part => part.type === 'hour')?.value || '';
+    const minute = parts.find(part => part.type === 'minute')?.value || '';
+    const period = (parts.find(part => part.type === 'dayPeriod')?.value || '').slice(0, 1).toLowerCase();
+    return `${hour}${minute && minute !== '00' ? `:${minute}` : ''}${period}`;
+  } catch (err) {
+    console.warn('Unable to format compact calendar time', value, err);
+    return '';
+  }
+}
+
+function formatCompactCalendarRange(event) {
+  if (!event) return '';
+  const start = formatCompactCalendarTime(event.start, event.timeZone);
+  const end = formatCompactCalendarTime(event.end, event.timeZone);
+  const overnight =
+    typeof event.start === 'string' &&
+    typeof event.end === 'string' &&
+    event.start.slice(0, 10) !== event.end.slice(0, 10);
+  if (start && end) return `${start}–${end}${overnight ? '+1' : ''}`;
+  return start || '';
+}
+
 function renderCalendarDayNames() {
   if (!calendarDayNames) return;
   calendarDayNames.innerHTML = '';
@@ -894,12 +924,20 @@ function renderCalendar(events = state.localEvents) {
         const item = document.createElement('li');
         item.className = 'calendar-view__event';
         const timeLabel = formatCalendarRange(event);
+        const compactTimeLabel = formatCompactCalendarRange(event);
         if (timeLabel) {
           const time = document.createElement('span');
           time.className = 'calendar-view__event-time';
-          time.textContent = timeLabel;
+          const full = document.createElement('span');
+          full.className = 'calendar-view__event-time-full';
+          full.textContent = timeLabel;
+          const compact = document.createElement('span');
+          compact.className = 'calendar-view__event-time-compact';
+          compact.textContent = compactTimeLabel || timeLabel;
+          time.append(full, compact);
           item.appendChild(time);
         }
+        item.setAttribute('aria-label', `${timeLabel ? `${timeLabel}, ` : ''}${event.title || 'Untitled event'}`);
         const title = document.createElement('span');
         title.className = 'calendar-view__event-title';
         title.textContent = event.title || 'Untitled event';
@@ -921,6 +959,10 @@ function renderCalendar(events = state.localEvents) {
     } else if (eventsForDay.length > 1) {
       labelParts.push(`${eventsForDay.length} events`);
     }
+    eventsForDay.slice(0, 3).forEach(event => {
+      const range = formatCalendarRange(event);
+      labelParts.push(`${range ? `${range} ` : ''}${event.title || 'Untitled event'}`);
+    });
     const dayKey = cellDate.toISOString().slice(0, 10);
     cell.setAttribute('aria-label', labelParts.join(', '));
     cell.dataset.date = dayKey;

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -93,7 +93,7 @@
             <div class="calendar-view__header">
               <div>
                 <h3 id="calendar-view-title">Monthly overview</h3>
-                <p class="calendar-view__subtitle">See start and end times at a glance, then click a day to focus it.</p>
+                <p class="calendar-view__subtitle">See start and end times at a glance. Tap a day for the full details.</p>
               </div>
               <div class="calendar-view__controls" role="group" aria-label="Change month">
                 <button type="button" class="button-secondary" data-calendar-nav="prev" aria-label="Previous month">‹</button>

--- a/tests/calendar-ui.test.js
+++ b/tests/calendar-ui.test.js
@@ -47,9 +47,12 @@ test('calendar month cells show full time ranges without hiding the event title'
 
   assert.match(html, /See start and end times at a glance/);
   assert.match(js, /const timeLabel = formatCalendarRange\(event\);/);
+  assert.match(js, /function formatCompactCalendarRange\(event\)/);
+  assert.match(js, /calendar-view__event-time-compact/);
   assert.match(js, /title\.className = 'calendar-view__event-title';/);
   assert.match(css, /\.calendar-view__event-title \{/);
-  assert.match(css, /min-width: 760px;/);
+  assert.match(css, /@media \(max-width: 720px\) \{[\s\S]*?min-width: 0;/);
+  assert.match(css, /\.calendar-view__event-time-compact \{[\s\S]*?display: inline;/);
 });
 
 test('calendar runtime updates the quick summary strip from event and connection state', async () => {
@@ -71,4 +74,12 @@ test('calendar stylesheet keeps the month view reachable on smaller screens', as
   assert.match(css, /@media \(max-width: 720px\) \{[\s\S]*?\.calendar-header__highlights \{[\s\S]*?overflow-x: auto;/);
   assert.match(css, /@media \(max-width: 720px\) \{[\s\S]*?\.calendar-quickstats \{[\s\S]*?overflow-x: auto;/);
   assert.match(css, /@media \(max-width: 540px\) \{[\s\S]*?\.calendar-header__action \{[\s\S]*?width: 100%;/);
+});
+
+test('calendar month cells expose useful event details to assistive tech', async () => {
+  const js = await readFile(new URL('../calendar/calendar.js', import.meta.url), 'utf8');
+
+  assert.match(js, /item\.setAttribute\('aria-label'/);
+  assert.match(js, /eventsForDay\.slice\(0, 3\)\.forEach\(event =>/);
+  assert.match(js, /labelParts\.push/);
 });


### PR DESCRIPTION
Removes horizontal month panning on phones, adds compact start/end ranges while retaining full accessible labels, removes nested day scrolling, fixes narrow-layout overflow, and keeps tapped-day details unchanged. Calendar tests pass (5/5) plus 390px browser verification.