### PR TITLE
Preserve server secrets during portal deploy

### DIFF
--- a/.github/workflows/self-host-production.yml
+++ b/.github/workflows/self-host-production.yml
@@ -106,12 +106,43 @@ jobs:
         run: |
           set -euo pipefail
           opts=(-i /tmp/3dvr-key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
-          [ -n "$OPENAI_API_KEY" ] || [ -n "$AI_GATEWAY_API_KEY" ] || { echo 'No OpenAI or AI Gateway API key is configured for Operator.' >&2; exit 1; }
+          updates="$(mktemp)"
+          trap 'rm -f "$updates"' EXIT
           {
             [ -n "$OPENAI_API_KEY" ] && printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY"
             [ -n "$AI_GATEWAY_API_KEY" ] && printf 'AI_GATEWAY_API_KEY=%s\n' "$AI_GATEWAY_API_KEY"
             [ -n "$TUNNEL_TOKEN" ] && printf 'THREEDVR_CLOUDFLARE_TUNNEL_TOKEN=%s\n' "$TUNNEL_TOKEN"
-          } | ssh "${opts[@]}" "root@$TARGET" 'mkdir -p "$HOME/.3dvr/config"; chmod 700 "$HOME/.3dvr/config"; umask 077; cat > "$HOME/.3dvr/config/portal-secrets.env"'
+          } > "$updates"
+
+          if [ ! -s "$updates" ]; then
+            echo 'No runtime secret updates supplied; preserving the server configuration.'
+            exit 0
+          fi
+
+          ssh "${opts[@]}" "root@$TARGET" \
+            'mkdir -p "$HOME/.3dvr/config"; chmod 700 "$HOME/.3dvr/config"; umask 077; cat > "$HOME/.3dvr/config/portal-secrets.update"' \
+            < "$updates"
+
+          ssh "${opts[@]}" "root@$TARGET" 'bash -s' <<'REMOTE'
+          set -euo pipefail
+          config_dir="$HOME/.3dvr/config"
+          secrets_env="$config_dir/portal-secrets.env"
+          incoming="$config_dir/portal-secrets.update"
+          next="$(mktemp)"
+          trap 'rm -f "$incoming" "$next" "${next}.filtered"' EXIT
+          umask 077
+          touch "$secrets_env"
+          cp "$secrets_env" "$next"
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            key="${line%%=*}"
+            grep -v "^${key}=" "$next" > "${next}.filtered" || true
+            mv "${next}.filtered" "$next"
+            printf '%s\n' "$line" >> "$next"
+          done < "$incoming"
+          mv "$next" "$secrets_env"
+          chmod 600 "$secrets_env"
+          REMOTE
 
       - name: Deploy portal and Forge worker
         id: deploy

--- a/tests/self-host-secret-provisioning.test.js
+++ b/tests/self-host-secret-provisioning.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('self-host deploy preserves server secrets when Actions has no secret updates', async () => {
+  const workflow = await readFile(new URL('../.github/workflows/self-host-production.yml', import.meta.url), 'utf8');
+
+  assert.match(workflow, /No runtime secret updates supplied; preserving the server configuration\./);
+  assert.doesNotMatch(workflow, /No OpenAI or AI Gateway API key is configured for Operator/);
+  assert.match(workflow, /portal-secrets\.update/);
+  assert.match(workflow, /touch "\$secrets_env"/);
+  assert.match(workflow, /grep -v "\^\$\{key\}=" "\$next"/);
+  assert.match(workflow, /printf '%s\\n' "\$line" >> "\$next"/);
+});


### PR DESCRIPTION
Fixes production deploys that were blocked when GitHub had no Operator runtime secret updates. The workflow now preserves the server-side secret file when no updates are supplied, and merges only supplied keys when updates exist. Adds regression coverage. This is needed so static portal changes such as the calendar UI can deploy without unrelated AI secrets in Actions.