### PR TITLE
Fix homepage account state and simplify first-screen UX

### DIFF
--- a/home-operator.js
+++ b/home-operator.js
@@ -2,201 +2,53 @@ import { runOperatorAction } from './operator/actions.js';
 import { collectPortalContext } from './operator/portal-context.js';
 import { createOperatorDeveloperProof } from './operator/forge.js';
 
-const ACCOUNT_SCORE_PREFIX = '3dvr:score:';
-
 function aliasToDisplay(alias) {
   const normalized = typeof alias === 'string' ? alias.trim() : '';
   if (!normalized) return '';
   return normalized.includes('@') ? normalized.split('@')[0] : normalized;
 }
 
-function readSharedIdentity() {
-  const entry = document.cookie
-    .split(';')
-    .map(part => part.trim())
-    .find(part => part.startsWith('portalIdentity='));
-  if (!entry) return null;
+function syncHomepageIdentity() {
   try {
-    return JSON.parse(decodeURIComponent(entry.slice('portalIdentity='.length)));
-  } catch {
-    return null;
+    window.AuthIdentity?.syncStorageFromSharedIdentity?.(localStorage);
+  } catch (error) {
+    console.warn('Homepage identity sync unavailable.', error);
   }
 }
 
 function readAccountState() {
-  const shared = readSharedIdentity() || {};
+  syncHomepageIdentity();
+  const shared = window.AuthIdentity?.readSharedIdentity?.() || {};
   const signedIn = localStorage.getItem('signedIn') === 'true';
-  const guest = !signedIn && localStorage.getItem('guest') === 'true';
   const alias = (localStorage.getItem('alias') || shared.alias || '').trim();
   const username = (localStorage.getItem('username') || shared.username || '').trim();
-  const guestName = (localStorage.getItem('guestDisplayName') || '').trim();
-  const displayName = signedIn
-    ? username || aliasToDisplay(alias) || 'User'
-    : guest
-      ? guestName || 'Guest'
-      : '';
-
-  return { signedIn, guest, alias, displayName };
-}
-
-function readCachedPoints(state) {
-  try {
-    let key = `${ACCOUNT_SCORE_PREFIX}anon`;
-    if (state.signedIn) {
-      key = `${ACCOUNT_SCORE_PREFIX}user:${state.alias.toLowerCase()}`;
-    } else if (state.guest) {
-      key = `${ACCOUNT_SCORE_PREFIX}${localStorage.getItem('guestId') || 'guest'}`;
-    }
-    return [key, `${key}:pending`, `${key}:portalPending`]
-      .map(cacheKey => Number(localStorage.getItem(cacheKey) || 0))
-      .filter(Number.isFinite)
-      .reduce((best, value) => Math.max(best, Math.max(0, Math.round(value))), 0);
-  } catch {
-    return 0;
-  }
-}
-
-function loadClassicScript(src) {
-  const existing = Array.from(document.scripts).find(script => script.src === new URL(src, window.location.href).href);
-  if (existing) {
-    return existing.dataset.loaded === 'true'
-      ? Promise.resolve()
-      : new Promise((resolve, reject) => {
-          existing.addEventListener('load', resolve, { once: true });
-          existing.addEventListener('error', reject, { once: true });
-        });
-  }
-
-  return new Promise((resolve, reject) => {
-    const script = document.createElement('script');
-    script.src = src;
-    script.async = true;
-    script.addEventListener('load', () => {
-      script.dataset.loaded = 'true';
-      resolve();
-    }, { once: true });
-    script.addEventListener('error', reject, { once: true });
-    document.head.appendChild(script);
-  });
+  return {
+    signedIn,
+    displayName: signedIn ? username || aliasToDisplay(alias) || 'User' : ''
+  };
 }
 
 function installAccountStatus() {
-  const menu = document.querySelector('.menu');
-  const summary = menu?.querySelector('summary');
-  const panel = menu?.querySelector('.menu-panel');
-  const signInLink = document.querySelector('.top-action--signin');
-  if (!menu || !summary || !panel || !signInLink) return;
-
-  const style = document.createElement('style');
-  style.textContent = `
-    .menu summary[data-account-state="user"],
-    .menu summary[data-account-state="guest"] {
-      max-width: min(250px, 42vw);
-      gap: 5px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .menu-panel [data-account-profile] {
-      color: #79c0ff;
-      font-weight: 800;
-    }
-
-    @media (max-width: 580px) {
-      .top-action--signin.account-signin-visible { display: inline-flex; }
-      .menu summary[data-account-state="user"],
-      .menu summary[data-account-state="guest"] {
-        max-width: 145px;
-        padding-inline: 10px;
-        font-size: 0.84rem;
-      }
-    }
-  `;
-  document.head.appendChild(style);
-
-  let latestNetworkPoints = null;
-
-  const ensureProfileLink = () => {
-    let profile = panel.querySelector('[data-account-profile]');
-    if (!profile) {
-      profile = document.createElement('a');
-      profile.href = '/profile.html#profile';
-      profile.dataset.accountProfile = 'true';
-      panel.prepend(profile);
-    }
-    return profile;
-  };
+  const authEntry = document.querySelector('[data-auth-entry]');
+  if (!authEntry) return;
 
   const render = () => {
     const state = readAccountState();
-    const cachedPoints = readCachedPoints(state);
-    const points = latestNetworkPoints == null
-      ? cachedPoints
-      : Math.max(cachedPoints, latestNetworkPoints);
-    const profile = ensureProfileLink();
-
     if (state.signedIn) {
-      signInLink.hidden = true;
-      signInLink.classList.remove('account-signin-visible');
-      summary.dataset.accountState = 'user';
-      summary.textContent = `${state.displayName} · ⭐ ${points}`;
-      summary.setAttribute('aria-label', `Signed in as ${state.displayName}. ${points} points. Open account menu.`);
-      profile.hidden = false;
-      profile.textContent = `Profile · ⭐ ${points}`;
+      authEntry.href = '/profile.html#profile';
+      authEntry.textContent = 'Profile';
+      authEntry.setAttribute('aria-label', `Open profile for ${state.displayName}`);
       return;
     }
 
-    if (state.guest) {
-      signInLink.hidden = false;
-      signInLink.classList.add('account-signin-visible');
-      summary.dataset.accountState = 'guest';
-      summary.textContent = `${state.displayName} · ⭐ ${points}`;
-      summary.setAttribute('aria-label', `Guest profile. ${points} points. Open account menu.`);
-      profile.hidden = false;
-      profile.textContent = `Guest profile · ⭐ ${points}`;
-      return;
-    }
-
-    signInLink.hidden = false;
-    signInLink.classList.add('account-signin-visible');
-    summary.dataset.accountState = 'anon';
-    summary.textContent = 'Menu';
-    summary.setAttribute('aria-label', 'Open portal menu');
-    profile.hidden = true;
+    authEntry.href = '/sign-in.html?redirect=%2F';
+    authEntry.textContent = 'Sign in';
+    authEntry.setAttribute('aria-label', 'Sign in or create an account');
   };
 
   render();
   window.addEventListener('storage', render);
   window.addEventListener('portal-auth:changed', render);
-
-  const state = readAccountState();
-  if (!state.signedIn && !state.guest) return;
-
-  (async () => {
-    try {
-      await loadClassicScript('https://cdn.jsdelivr.net/npm/gun/gun.js');
-      await loadClassicScript('/gun-init.js');
-      await loadClassicScript('https://cdn.jsdelivr.net/npm/gun/sea.js');
-      await loadClassicScript('/score.js');
-      if (!window.Gun || !window.ScoreSystem) return;
-
-      const gun = window.Gun({ peers: window.__GUN_PEERS__ || ['wss://gun-relay-3dvr.fly.dev/gun'] });
-      const user = gun.user();
-      window.ScoreSystem.recallUserSession(user);
-      const scoreManager = window.ScoreSystem.getManager({
-        gun,
-        user,
-        portalRoot: gun.get('3dvr-portal')
-      });
-      scoreManager.subscribe(points => {
-        latestNetworkPoints = window.ScoreSystem.sanitizeScore(points);
-        render();
-      });
-    } catch (error) {
-      console.warn('Homepage account score sync unavailable; using cached points.', error);
-    }
-  })();
 }
 
 installAccountStatus();

--- a/index.html
+++ b/index.html
@@ -233,7 +233,6 @@
     .spinner-stage[data-open="true"] .spinner-nav__item--apps { transform: translate(0, -50%) scale(1); }
 
     .spinner-hint { margin: -2px 0 20px; color: #6e7681; font-size: 0.78rem; text-align: center; }
-    .eyebrow { margin: 0 0 8px; color: #8b949e; font-size: 0.85rem; font-weight: 800; letter-spacing: 0.09em; text-transform: uppercase; }
 
     h1 {
       margin: 0;
@@ -301,6 +300,7 @@
     .operator-bar button:disabled { opacity: 0.55; cursor: progress; }
 
     .operator-status { margin: 8px 4px 0; color: #6e7681; font-size: 0.78rem; }
+    .operator-status:empty { display: none; }
 
     .operator-result {
       margin-top: 10px;
@@ -392,9 +392,9 @@
 
     @media (max-width: 580px) {
       .topbar { gap: 7px; }
+      .brand span { display: none; }
       .top-action,
       .menu summary { padding-inline: 11px; }
-      .top-action--signin { display: none; }
       main { align-items: flex-start; padding-top: 30px; }
       .spinner-stage { width: min(248px, 78vw); height: min(248px, 78vw); }
       .spinner-nav__item { min-width: 58px; min-height: 40px; padding-inline: 11px; font-size: 0.88rem; }
@@ -410,6 +410,7 @@
       .spinner-nav__item { transition: none; }
     }
   </style>
+  <script src="/auth-identity.js" defer></script>
   <script src="/portal-swirl-logo.js" defer></script>
   <script type="module" src="/home-operator.js"></script>
   <script defer src="/_vercel/insights/script.js"></script>
@@ -435,7 +436,7 @@
           <a href="/releases/">Releases</a>
         </nav>
       </details>
-      <a class="top-action top-action--signin" href="/sign-in.html?redirect=%2F">Sign in</a>
+      <a class="top-action top-action--signin" href="/sign-in.html?redirect=%2F" data-auth-entry>Sign in</a>
     </header>
 
     <main>
@@ -464,18 +465,17 @@
             </span>
           </div>
         </div>
-        <p class="spinner-hint">Tap to navigate · drag to spin</p>
+        <p class="spinner-hint">Tap for shortcuts</p>
 
-        <p class="eyebrow">3DVR Portal</p>
         <h1 id="home-title">What do you want to do?</h1>
-        <p class="subhead">Tell your Operator what you need. It can use this page and your Portal context to help act on it.</p>
+        <p class="subhead">Ask Operator, or choose a starting point.</p>
 
         <form class="operator-link operator-bar" id="homeOperatorForm" aria-label="Ask Operator">
           <span class="operator-bar__label" aria-hidden="true">Operator</span>
           <input id="homeOperatorInput" name="prompt" type="text" autocomplete="off" placeholder="Ask Operator…" aria-label="Ask Operator anything">
           <button id="homeOperatorSubmit" type="submit" aria-label="Send to Operator">→</button>
         </form>
-        <p class="operator-status" id="homeOperatorStatus" aria-live="polite">Operator sees this page plus available Life Space, lead, CRM, and calendar context.</p>
+        <p class="operator-status" id="homeOperatorStatus" aria-live="polite"></p>
 
         <section class="operator-result" id="homeOperatorResult" aria-live="polite" hidden>
           <div class="operator-result__head">
@@ -490,19 +490,19 @@
         <div class="actions" aria-label="Core portal actions">
           <a class="action-card" href="/launch-room/">
             <strong>Find my path</strong>
-            <span>Start with what you care about and turn it into one small real project.</span>
+            <span>Turn what matters into one clear next step.</span>
           </a>
           <a class="action-card" href="/growth-operator/?campaign=my-skill">
             <strong>Make money</strong>
-            <span>Pick a skill, find people who need it, and start a guided outreach loop.</span>
+            <span>Use a skill to find work and reach out.</span>
           </a>
           <a class="action-card" href="/forge/">
             <strong>Build something</strong>
-            <span>Turn an idea into a project, offer, page, or experiment.</span>
+            <span>Turn an idea into something real.</span>
           </a>
           <button class="action-card" type="button" data-open-apps>
             <strong>Open my stuff</strong>
-            <span>Search apps and jump into your workspace.</span>
+            <span>Apps, calendar, CRM, projects, and more.</span>
           </button>
         </div>
       </section>

--- a/tests/homepage-account-ux.test.js
+++ b/tests/homepage-account-ux.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('homepage account entry follows portal auth state', async () => {
+  const [html, app] = await Promise.all([
+    read('index.html'),
+    read('home-operator.js')
+  ]);
+
+  assert.match(html, /<script src="\/auth-identity\.js" defer><\/script>/);
+  assert.match(html, /data-auth-entry>Sign in<\/a>/);
+  assert.match(app, /syncStorageFromSharedIdentity\?\.\(localStorage\)/);
+  assert.match(app, /authEntry\.href = '\/profile\.html#profile'/);
+  assert.match(app, /authEntry\.textContent = 'Profile'/);
+  assert.match(app, /authEntry\.href = '\/sign-in\.html\?redirect=%2F'/);
+  assert.match(app, /authEntry\.textContent = 'Sign in'/);
+  assert.doesNotMatch(app, /signInLink\.hidden/);
+});
+
+test('homepage keeps the first screen concise and action-oriented', async () => {
+  const html = await read('index.html');
+
+  assert.match(html, /Tap for shortcuts/);
+  assert.match(html, /What do you want to do\?/);
+  assert.match(html, /Ask Operator, or choose a starting point\./);
+  assert.match(html, /Turn what matters into one clear next step\./);
+  assert.match(html, /Use a skill to find work and reach out\./);
+  assert.match(html, /Turn an idea into something real\./);
+  assert.match(html, /Apps, calendar, CRM, projects, and more\./);
+  assert.doesNotMatch(html, /Operator sees this page plus available/);
+  assert.doesNotMatch(html, /<p class="eyebrow">3DVR Portal<\/p>/);
+});


### PR DESCRIPTION
Fixes the awkward signed-in homepage state and simplifies the first screen.

- Sync shared portal identity before rendering the account entry.
- Show Profile when authenticated and Sign in when signed out.
- Keep Menu predictable instead of turning it into account/score status.
- Remove homepage-only Gun/score loading from the header.
- Shorten technical/redundant copy and keep the main choices action-oriented.
- Keep the account control visible on 360px mobile without horizontal overflow.
- Add focused homepage auth/UX regression tests.

Verification:
- 13 focused Node tests passing (auth identity + homepage Operator + new homepage UX tests).
- Browser-tested signed in/out on desktop and 360x740 mobile.
- Search dialog and spinner shortcuts verified.
- No horizontal overflow after the mobile header fix.
- Local-only Vercel Insights 404 is expected on the plain development server.