### PR TITLE
Add OAuth privacy and terms pages

### DIFF
--- a/.github/workflows/self-host-production.yml
+++ b/.github/workflows/self-host-production.yml
@@ -103,6 +103,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
           TUNNEL_TOKEN: ${{ secrets.THREEDVR_CLOUDFLARE_TUNNEL_TOKEN }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
         run: |
           set -euo pipefail
           opts=(-i /tmp/3dvr-key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10)
@@ -112,6 +114,8 @@ jobs:
             [ -n "$OPENAI_API_KEY" ] && printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY"
             [ -n "$AI_GATEWAY_API_KEY" ] && printf 'AI_GATEWAY_API_KEY=%s\n' "$AI_GATEWAY_API_KEY"
             [ -n "$TUNNEL_TOKEN" ] && printf 'THREEDVR_CLOUDFLARE_TUNNEL_TOKEN=%s\n' "$TUNNEL_TOKEN"
+            [ -n "$GOOGLE_OAUTH_CLIENT_ID" ] && printf 'GOOGLE_OAUTH_CLIENT_ID=%s\n' "$GOOGLE_OAUTH_CLIENT_ID"
+            [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ] && printf 'GOOGLE_OAUTH_CLIENT_SECRET=%s\n' "$GOOGLE_OAUTH_CLIENT_SECRET"
           } > "$updates"
 
           if [ ! -s "$updates" ]; then

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Privacy · 3DVR</title><link rel="stylesheet" href="/global.css"><style>body{max-width:760px;margin:auto;padding:32px 20px;line-height:1.65}h1,h2{line-height:1.2}a{color:inherit}</style></head><body>
+<p><a href="/">← 3DVR Portal</a></p><h1>Privacy</h1><p>Last updated August 27, 2026.</p>
+<p>3DVR is built to help people manage their own projects, contacts, and schedules. We collect only the information needed to provide the features you choose to use.</p>
+<h2>Google account and Calendar data</h2><p>If you connect Google, 3DVR uses the permissions you approve to read or create calendar events for calendar import and sync. Google data is not sold, used for advertising, or shared with unrelated third parties.</p>
+<p>Use of information received from Google APIs follows the Google API Services User Data Policy, including its Limited Use requirements.</p>
+<h2>3DVR calendar and sharing</h2><p>Calendar events may be stored in your browser and synchronized through the 3DVR relay when that feature is enabled. Secret calendar share links grant the permission shown when the link is created. Anyone with a live share link can use that permission until the owner revokes it.</p>
+<h2>Control</h2><p>You can disconnect Google, revoke Google access from your Google Account, remove calendar events, and revoke 3DVR share links. We do not sell personal information.</p>
+<h2>Contact</h2><p>Questions about privacy can be sent to <a href="mailto:tmsteph1290@gmail.com">tmsteph1290@gmail.com</a>.</p>
+</body></html>

--- a/scripts/ops/deploy-self-host-portal.sh
+++ b/scripts/ops/deploy-self-host-portal.sh
@@ -56,7 +56,7 @@ EOF
 
 # Preserve private runtime values already provisioned by an operator or workflow.
 # Never overwrite them with empty values and never print them.
-for key in OPENAI_API_KEY AI_GATEWAY_API_KEY THREEDVR_CLOUDFLARE_TUNNEL_TOKEN; do
+for key in OPENAI_API_KEY AI_GATEWAY_API_KEY THREEDVR_CLOUDFLARE_TUNNEL_TOKEN GOOGLE_OAUTH_CLIENT_ID GOOGLE_OAUTH_CLIENT_SECRET; do
   value="${!key:-}"
   if [ -z "$value" ] && [ -f "$portal_env" ]; then
     value="$(sed -n "s/^${key}=//p" "$portal_env" | tail -n1)"

--- a/scripts/self-host-server.mjs
+++ b/scripts/self-host-server.mjs
@@ -2,6 +2,7 @@ import { createServer } from 'node:http';
 import { access, readFile, stat } from 'node:fs/promises';
 import { extname, join, normalize, resolve } from 'node:path';
 import openAiSiteHandler from '../api/openai-site.js';
+import { createOAuthProviderHandler } from '../src/oauth/provider-api.js';
 
 const PORT = Number(process.env.PORT || 4320);
 const HOST = process.env.HOST || '127.0.0.1';
@@ -9,6 +10,7 @@ const ROOT = resolve(process.env.PORTAL_ROOT || process.cwd());
 const RELEASE_SHA = String(process.env.PORTAL_RELEASE_SHA || '').trim();
 const RELEASE_REF = String(process.env.PORTAL_RELEASE_REF || 'main').trim();
 const LEGACY_API_ORIGIN = String(process.env.LEGACY_API_ORIGIN || '').replace(/\/+$/, '');
+const oauthProviderHandler = createOAuthProviderHandler();
 
 const MIME_TYPES = new Map([
   ['.html', 'text/html; charset=utf-8'],
@@ -136,6 +138,20 @@ async function runOpenAiSite(req, res, url) {
   }
 }
 
+async function runOAuthProvider(req, res, url) {
+  try {
+    if (req.method !== 'OPTIONS') await prepareApiRequest(req, url);
+    else { req.body = {}; req.query = Object.fromEntries(url.searchParams.entries()); }
+    const parts = url.pathname.split('/').filter(Boolean);
+    const provider = decodeURIComponent(parts[parts.length - 1] || '');
+    req.query = { ...(req.query || {}), provider };
+    await oauthProviderHandler(req, adaptResponse(res));
+  } catch (error) {
+    if (!res.headersSent) json(res, error?.statusCode || 500, { error: error?.message || 'OAuth request failed' });
+    else res.destroy(error);
+  }
+}
+
 async function proxyLegacyApi(req, res, url) {
   if (!LEGACY_API_ORIGIN) return json(res, 404, { error: 'API route is not enabled on this self-host yet.' });
   const target = new URL(url.pathname + url.search, `${LEGACY_API_ORIGIN}/`);
@@ -185,6 +201,10 @@ const server = createServer(async (req, res) => {
 
   if (url.pathname === '/api/openai-site') {
     return runOpenAiSite(req, res, url);
+  }
+
+  if (url.pathname.startsWith('/api/oauth/')) {
+    return runOAuthProvider(req, res, url);
   }
 
   if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/webhooks/')) {

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Terms · 3DVR</title><link rel="stylesheet" href="/global.css"><style>body{max-width:760px;margin:auto;padding:32px 20px;line-height:1.65}h1,h2{line-height:1.2}a{color:inherit}</style></head><body>
+<p><a href="/">← 3DVR Portal</a></p><h1>Terms of use</h1><p>Last updated August 27, 2026.</p>
+<p>3DVR provides experimental and evolving tools for personal organization, projects, contacts, calendars, and related workflows. By using the portal, you agree to use it lawfully and responsibly.</p>
+<h2>Your accounts and links</h2><p>You are responsible for the accounts you connect and for secret sharing links you create. Treat editable calendar links like passwords and revoke them when access is no longer needed.</p>
+<h2>Connected services</h2><p>Google, Microsoft, and other connected services remain subject to their own terms. You can disconnect a service at any time.</p>
+<h2>Availability</h2><p>3DVR is under active development. Features may change, and the service is provided without a guarantee of uninterrupted availability. Keep appropriate backups of information that is important to you.</p>
+<h2>Contact</h2><p>Questions can be sent to <a href="mailto:tmsteph1290@gmail.com">tmsteph1290@gmail.com</a>.</p>
+</body></html>

--- a/tests/self-host-oauth-route.test.js
+++ b/tests/self-host-oauth-route.test.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('self-host serves OAuth provider routes natively before legacy proxy', async () => {
+  const server = await readFile(new URL('../scripts/self-host-server.mjs', import.meta.url), 'utf8');
+  assert.match(server, /createOAuthProviderHandler/);
+  assert.match(server, /url\.pathname\.startsWith\('\/api\/oauth\/'\)/);
+  assert.match(server, /runOAuthProvider/);
+  assert.ok(server.indexOf("url.pathname.startsWith('/api/oauth/')") < server.indexOf("url.pathname.startsWith('/api/')"));
+});

--- a/tests/self-host-secret-provisioning.test.js
+++ b/tests/self-host-secret-provisioning.test.js
@@ -11,4 +11,10 @@ test('self-host deploy preserves server secrets when Actions has no secret updat
   assert.match(workflow, /touch "\$secrets_env"/);
   assert.match(workflow, /grep -v "\^\$\{key\}=" "\$next"/);
   assert.match(workflow, /printf '%s\\n' "\$line" >> "\$next"/);
+  assert.match(workflow, /GOOGLE_OAUTH_CLIENT_ID/);
+  assert.match(workflow, /GOOGLE_OAUTH_CLIENT_SECRET/);
+
+  const deploy = await readFile(new URL('../scripts/ops/deploy-self-host-portal.sh', import.meta.url), 'utf8');
+  assert.match(deploy, /GOOGLE_OAUTH_CLIENT_ID/);
+  assert.match(deploy, /GOOGLE_OAUTH_CLIENT_SECRET/);
 });


### PR DESCRIPTION
Adds public Privacy and Terms pages required for Google OAuth branding. Privacy explicitly documents Google Calendar use, Limited Use, calendar relay storage, and revocable secret sharing links.