### PR TITLE
Add persistent executive taste and direction to Operator

### DIFF
--- a/docs/3dvr-executive-operator.md
+++ b/docs/3dvr-executive-operator.md
@@ -1,0 +1,41 @@
+# 3DVR Executive Operator
+
+The Money Printer Executive Agent is the model-independent CEO/COO layer for 3DVR. Its job is not to answer every prompt or maximize activity. It keeps a durable direction, applies founder taste, remembers decisions, and chooses the next bounded action.
+
+## Durable state
+
+`npm run money-printer -- init` creates private runtime state under `.money-printer/executive/`:
+
+- `profile.json` — mission, north star, current direction, strategic priorities, taste, anti-patterns, decision rubric, and authority boundaries.
+- `feedback.jsonl` — founder approvals, rejections, preferences, and avoid rules. Recent feedback is injected into future model calls.
+- `decisions.jsonl` — durable executive precedent: decision, rationale, next action, confidence, and what not to do.
+
+The state stays outside Git so the operator can learn without publishing private operating history.
+
+## Steering the executive
+
+```bash
+npm run money-printer -- executive
+npm run money-printer -- executive direction "Run one coherent workflow end to end"
+npm run money-printer -- executive feedback prefer "One obvious action per screen"
+npm run money-printer -- executive feedback avoid "Do not add concept pages without a working loop"
+npm run money-printer -- executive decisions --limit 10
+```
+
+The next Executive Agent, Founder Brief, opportunity, connector-plan, and Codex prompt receives the constitution plus recent feedback and decisions as context.
+
+## Model routing
+
+Routine model work uses `MONEY_PRINTER_MODEL`. High-level executive decisions automatically use `MONEY_PRINTER_REASONING_MODEL` when configured. This keeps the operating layer model-independent while reserving stronger models for direction, portfolio, kill-or-scale, and system-improvement decisions.
+
+## Safety
+
+The executive constitution does not bypass connector guardrails. GREEN work may be bounded and reversible. YELLOW work is prepared for review. RED actions stay blocked unattended, including money movement, user-data deletion, DNS changes, irreversible production changes, legal commitments, and mass outreach.
+
+## Server loop
+
+```bash
+npm run money-printer:supervisor -- --ai
+```
+
+Every Executive Agent daemon cycle records an executive decision before planning connector operations. If no model credentials are present, the deterministic fallback still follows the persistent direction and taste profile rather than reverting to generic startup advice.

--- a/docs/digitalocean-money-printer-supervisor.md
+++ b/docs/digitalocean-money-printer-supervisor.md
@@ -6,6 +6,10 @@ The founder still owns judgment, customer trust, legal/compliance risk, money mo
 
 For the broader runner that combines supervisor, market research, offer generation, owner email reports, and capped warm outreach, see `docs/digitalocean-auto-business.md`.
 
+## Executive memory and taste
+
+The supervisor now loads a persistent executive constitution from `.money-printer/executive/profile.json`, injects recent founder taste feedback and decision precedent into model context, and records each Executive Agent decision in `.money-printer/executive/decisions.jsonl`. High-level executive bots use `MONEY_PRINTER_REASONING_MODEL` when configured; routine work can remain on the cheaper default model. See `docs/3dvr-executive-operator.md`.
+
 ## What It Can Do Today
 
 - Run a scheduled Money Printer daemon cycle.

--- a/scripts/money-printer-cli.mjs
+++ b/scripts/money-printer-cli.mjs
@@ -17,10 +17,13 @@ import {
 } from '../src/money-printer/moneyPrinterCore.js';
 import { runMoneyPrinterDaemonCycle } from '../src/money-printer/moneyPrinterDaemon.js';
 import {
+  appendExecutiveDecision,
+  appendExecutiveFeedback,
   appendMoneyPrinterEvent,
   ensureMoneyPrinterWorkspace,
   loadMoneyPrinterWorkspace,
   saveBusinessConfig,
+  saveExecutiveProfile,
   saveExperiments,
   saveIdeas
 } from '../src/money-printer/moneyPrinterFileStorage.js';
@@ -52,6 +55,7 @@ import {
   extractWeakSignalsFromText,
   loadWeakSignals
 } from '../src/money-printer/moneyPrinterWeakSignals.js';
+import { formatExecutiveProfile, formatRecentExecutiveFeedback } from '../src/money-printer/moneyPrinterExecutiveMemory.js';
 
 const BOT_ALIASES = {
   executive: 'executive-agent',
@@ -137,6 +141,9 @@ Usage:
   npm run money-printer -- promote <idea-id>
   npm run money-printer -- brief
   npm run money-printer -- run executive
+  npm run money-printer -- executive
+  npm run money-printer -- executive direction "Make the CRM earn its place"
+  npm run money-printer -- executive feedback prefer "One obvious action per screen"
   npm run money-printer -- status
   npm run money-printer -- ai-status
   npm run money-printer -- daemon --once
@@ -152,6 +159,7 @@ Commands:
   brief                 Generate Founder Command Brief (--ai, --mock, --json)
   run <bot-name>        Run a bot loop (--ai, --mock, --model, --save, --json)
   status                Show operator status
+  executive             Show/set direction and record founder taste feedback
   ai-status             Show provider, connector, and Codex runtime status
   daemon --once         Run one safe daemon cycle and write report/log (--ai, --execute, --json)
   operations            List/approve/execute operation plans
@@ -215,6 +223,7 @@ async function commandInit(rootDir) {
   console.log(`Config: ${path.relative(rootDir, paths.businessPath)}`);
   console.log(`Ideas: ${path.relative(rootDir, paths.ideasPath)}`);
   console.log(`Experiments: ${path.relative(rootDir, paths.experimentsPath)}`);
+  console.log(`Executive constitution: ${path.relative(rootDir, paths.executivePath)}`);
 }
 
 async function commandMission(rootDir, args) {
@@ -353,6 +362,18 @@ async function commandRun(rootDir, args, flags = {}) {
     aiMode: output.aiMode || 'mock',
     model: output.model || ''
   });
+  if (botId === 'executive-agent') {
+    await appendExecutiveDecision(rootDir, {
+      decision: output.executiveDecision?.decision || output.summary || output.title,
+      why: output.executiveDecision?.why || output.summary || '',
+      nextAction: output.nextBestMoneyAction || getNextBestMoneyAction(loaded.state),
+      whatNotToDo: output.executiveDecision?.whatNotToDo || [],
+      confidence: output.executiveDecision?.confidence,
+      bot: botId,
+      model: output.model || '',
+      source: 'cli-run'
+    });
+  }
   if (flags.json) {
     printJson(output);
     return;
@@ -367,6 +388,91 @@ async function commandRun(rootDir, args, flags = {}) {
   printBotOutput(output);
 }
 
+async function commandExecutive(rootDir, args = [], flags = {}) {
+  const subcommand = args[0] || 'show';
+  const loaded = await loadMoneyPrinterWorkspace(rootDir);
+
+  if (subcommand === 'direction') {
+    const direction = args.slice(1).join(' ').trim();
+    if (!direction) throw new Error('Missing direction. Example: executive direction "Make the CRM earn its place"');
+    const saved = await saveExecutiveProfile(rootDir, {
+      ...loaded.executiveProfile,
+      currentDirection: direction
+    });
+    await appendMoneyPrinterEvent(rootDir, {
+      command: 'executive direction',
+      inputSummary: direction,
+      outputSummary: 'Updated persistent executive direction.',
+      nextAction: 'Run executive agent with --ai or let the next supervisor cycle use the new direction.'
+    });
+    if (flags.json) {
+      printJson(saved.profile);
+      return;
+    }
+    console.log(`Executive direction updated: ${saved.profile.currentDirection}`);
+    return;
+  }
+
+  if (subcommand === 'feedback') {
+    const kind = String(args[1] || 'note').toLowerCase();
+    const text = args.slice(2).join(' ').trim();
+    if (!text) throw new Error('Missing feedback. Example: executive feedback prefer "One obvious action per screen"');
+    const result = await appendExecutiveFeedback(rootDir, {
+      kind,
+      text,
+      reason: typeof flags.reason === 'string' ? flags.reason : ''
+    });
+    await appendMoneyPrinterEvent(rootDir, {
+      command: 'executive feedback',
+      inputSummary: `${result.entry.kind}: ${result.entry.text}`,
+      outputSummary: 'Recorded founder taste feedback for future model calls.',
+      nextAction: 'The next executive/model cycle will receive this feedback as context.'
+    });
+    if (flags.json) {
+      printJson(result.entry);
+      return;
+    }
+    console.log(`Taste learned: [${result.entry.kind.toUpperCase()}] ${result.entry.text}`);
+    return;
+  }
+
+  if (subcommand === 'decisions') {
+    const limit = Math.max(1, Number.parseInt(flags.limit || '10', 10) || 10);
+    const decisions = loaded.executiveDecisions.slice(-limit).reverse();
+    if (flags.json) {
+      printJson(decisions);
+      return;
+    }
+    console.log('Recent executive decisions');
+    if (!decisions.length) {
+      console.log('No executive decisions recorded yet.');
+      return;
+    }
+    decisions.forEach(item => {
+      console.log(`- ${item.decision}`);
+      if (item.why) console.log(`  Why: ${item.why}`);
+      if (item.nextAction) console.log(`  Next: ${item.nextAction}`);
+    });
+    return;
+  }
+
+  if (subcommand !== 'show') throw new Error(`Unknown executive command: ${subcommand}`);
+  if (flags.json) {
+    printJson({
+      profile: loaded.executiveProfile,
+      recentFeedback: loaded.executiveFeedback,
+      recentDecisions: loaded.executiveDecisions
+    });
+    return;
+  }
+  console.log(formatExecutiveProfile(loaded.executiveProfile));
+  console.log();
+  console.log('Recent founder feedback:');
+  console.log(formatRecentExecutiveFeedback(loaded.executiveFeedback));
+  console.log();
+  console.log(`Decisions recorded: ${loaded.executiveDecisions.length}`);
+}
+
 async function commandStatus(rootDir) {
   const loaded = await loadMoneyPrinterWorkspace(rootDir);
   const metrics = buildMetrics(loaded.state);
@@ -374,6 +480,7 @@ async function commandStatus(rootDir) {
 
   console.log('Money Printer Status');
   console.log(`Mission: ${loaded.businessConfig.mission}`);
+  console.log(`Direction: ${loaded.executiveProfile.currentDirection}`);
   console.log(`Ideas Generated: ${metrics.ideasGenerated}`);
   console.log(`Experiments Active: ${metrics.experimentsActive}`);
   console.log(`Offers Launched: ${metrics.offersLaunched}`);
@@ -384,6 +491,8 @@ async function commandStatus(rootDir) {
   console.log(`Weak Signals Found: ${metrics.weakSignalsFound || 0}`);
   console.log(`Portfolio Focus: ${portfolio.primaryFocus}`);
   console.log(`Next Best Money Action: ${metrics.nextBestMoneyAction}`);
+  console.log(`Taste Feedback Recorded: ${loaded.executiveFeedback.length}`);
+  console.log(`Executive Decisions Recorded: ${loaded.executiveDecisions.length}`);
 }
 
 function printWeakSignals(signals = []) {
@@ -699,6 +808,9 @@ async function main() {
       break;
     case 'status':
       await commandStatus(rootDir);
+      break;
+    case 'executive':
+      await commandExecutive(rootDir, positional, flags);
       break;
     case 'ai-status':
       await commandAiStatus(rootDir, flags);

--- a/src/money-printer/moneyPrinterBots.js
+++ b/src/money-printer/moneyPrinterBots.js
@@ -287,6 +287,8 @@ export function runBotLoop(botId, context = {}) {
   const brief = context.brief || {};
   const config = context.businessConfig || state.businessConfig || {};
   const experiments = context.experiments || state.experiments || [];
+  const executiveProfile = context.executiveProfile || state.executiveProfile || {};
+  const executiveFeedback = context.executiveFeedback || state.executiveFeedback || [];
   const decision = context.decision || killOrScaleExperiment(state);
   const portfolio = summarizePortfolio(experiments);
   const nextBestMoneyAction = context.nextBestMoneyAction
@@ -306,18 +308,35 @@ export function runBotLoop(botId, context = {}) {
   };
 
   switch (botId) {
-    case 'executive-agent':
+    case 'executive-agent': {
+      const direction = executiveProfile.currentDirection || nextBestMoneyAction;
+      const latestTaste = executiveFeedback.at(-1)?.text || executiveProfile.taste?.[0] || '';
+      const whatNotToDo = executiveProfile.antiPatterns?.[0]
+        || 'Do not add disconnected work that does not advance the current direction.';
+      const executiveNextAction = executiveProfile.currentDirection
+        ? `Pick the highest-leverage reversible action that advances this direction: ${direction}`
+        : nextBestMoneyAction;
       return {
         title: 'Executive Agent decision',
         generatedAt,
-        summary: 'Run Validation Bot next. The fastest money loop is buyer outreach before product build.',
+        summary: `Stay on direction: ${direction}`,
         lines: [
-          `Priority 1: ${nextBestMoneyAction}`,
-          `Priority 2: create a single validation page for ${topIdea?.business_name || 'the top offer'}.`,
-          'Priority 3: update the Founder Command Brief after replies or silence.',
-          'Do not add features until the first buyer confirms pain, urgency, and price.'
-        ]
+          `Direction: ${direction}`,
+          `Next operational move: ${executiveNextAction}`,
+          latestTaste ? `Taste check: ${latestTaste}` : 'Taste check: keep the path simple, useful, and reversible.',
+          `Do not: ${whatNotToDo}`
+        ],
+        nextBestMoneyAction: executiveNextAction,
+        executiveDecision: {
+          decision: direction,
+          why: 'Persistent company direction and founder taste should outrank generic task generation.',
+          confidence: 0.72,
+          tasteCheck: latestTaste || 'Prefer the simplest coherent path that creates real user value.',
+          tradeoffs: ['Defers work that does not compound the current direction.'],
+          whatNotToDo: [whatNotToDo]
+        }
       };
+    }
     case 'opportunity-scanner-bot':
       return {
         title: 'Opportunity scan',

--- a/src/money-printer/moneyPrinterDaemon.js
+++ b/src/money-printer/moneyPrinterDaemon.js
@@ -5,6 +5,7 @@ import {
   runBotLoop
 } from './moneyPrinterCore.js';
 import {
+  appendExecutiveDecision,
   appendMoneyPrinterEvent,
   loadMoneyPrinterWorkspace,
   writeMoneyPrinterReport
@@ -42,7 +43,20 @@ export async function runMoneyPrinterDaemonCycle(options = {}) {
     : { brief: generateFounderCommandBrief(loaded.state), aiMode: 'mock' };
   const founderBrief = founderBriefResult.brief;
   const metrics = buildMetrics(loaded.state);
-  const nextBestMoneyAction = getNextBestMoneyAction(loaded.state);
+  const baselineNextBestMoneyAction = getNextBestMoneyAction(loaded.state);
+  const nextBestMoneyAction = botOutput.nextBestMoneyAction || baselineNextBestMoneyAction;
+  const executiveDecisionWrite = botId === 'executive-agent'
+    ? await appendExecutiveDecision(rootDir, {
+      decision: botOutput.executiveDecision?.decision || botOutput.summary || nextBestMoneyAction,
+      why: botOutput.executiveDecision?.why || botOutput.summary || '',
+      nextAction: botOutput.nextBestMoneyAction || nextBestMoneyAction,
+      whatNotToDo: botOutput.executiveDecision?.whatNotToDo || [],
+      confidence: botOutput.executiveDecision?.confidence,
+      bot: botId,
+      model: botOutput.model || providerStatus.model,
+      source: command
+    })
+    : null;
   const connectorPlan = await generateConnectorPlanWithModel({
     ...loaded.state,
     ideas: ideaResult.ideas || loaded.state.ideas
@@ -66,7 +80,7 @@ export async function runMoneyPrinterDaemonCycle(options = {}) {
     generatedAt: new Date().toISOString(),
     mode: providerStatus.mode === 'openai' ? 'openai' : 'dry-run',
     aiMode: providerStatus.mode,
-    model: providerStatus.model,
+    model: botOutput.model || providerStatus.model,
     command,
     botId,
     mission: loaded.state.businessConfig.mission,
@@ -74,6 +88,8 @@ export async function runMoneyPrinterDaemonCycle(options = {}) {
     nextBestMoneyAction,
     founderBrief,
     botOutput,
+    executiveDecision: executiveDecisionWrite?.entry || null,
+    executiveDecisionPath: executiveDecisionWrite?.path || '',
     ideas: ideaResult.ideas || [],
     connectorOperationsPlanned: operationsWrite.added,
     connectorOperationsExecuted: executedOperations,
@@ -94,9 +110,10 @@ export async function runMoneyPrinterDaemonCycle(options = {}) {
     outputSummary: botOutput.summary,
     nextAction: nextBestMoneyAction,
     aiMode: providerStatus.mode,
-    model: providerStatus.model,
+    model: botOutput.model || providerStatus.model,
     operationsPlanned: operationsWrite.added.length,
-    operationsExecuted: executedOperations.length
+    operationsExecuted: executedOperations.length,
+    executiveDecisionId: executiveDecisionWrite?.entry?.id || ''
   });
 
   return {

--- a/src/money-printer/moneyPrinterExecutiveMemory.js
+++ b/src/money-printer/moneyPrinterExecutiveMemory.js
@@ -1,0 +1,129 @@
+export const EXECUTIVE_PROFILE_VERSION = 1;
+
+export const DEFAULT_EXECUTIVE_PROFILE = Object.freeze({
+  version: EXECUTIVE_PROFILE_VERSION,
+  name: '3DVR Executive Constitution',
+  role: 'Model-independent CEO/COO operating layer for 3DVR.',
+  mission: 'Build open, human-scale computing and business systems that increase ordinary people\'s agency.',
+  northStar: 'Turn purpose into useful open systems, sustainable revenue, and community-owned capability.',
+  currentDirection: 'Make 3DVR useful enough to run real work and earn trust before expanding the platform.',
+  strategicPriorities: [
+    'Create useful, revenue-connected outcomes for real people and small businesses.',
+    'Unify Operator, CRM, calendar, communications, projects, and knowledge into one coherent system.',
+    'Build open personal computing that can swap models and providers without losing the user\'s memory, tools, or control.'
+  ],
+  taste: [
+    'Prefer obvious, glanceable interfaces over clever or dense ones.',
+    'Prefer working systems and real user outcomes over extra copy, demos, or speculative features.',
+    'Prefer open standards, interoperability, self-hosting, and user ownership over lock-in.',
+    'Prefer one strong path through a product over many competing choices.',
+    'Prefer warm, human language and concrete actions over corporate jargon.',
+    'Prefer service-first validation and manual learning before expensive automation.',
+    'Prefer systems that become simpler as capability increases.'
+  ],
+  antiPatterns: [
+    'Do not build a broad platform before proving the next concrete user outcome.',
+    'Do not add dashboards, settings, or explanatory copy when the action can be made obvious instead.',
+    'Do not confuse activity, code volume, or generated ideas with progress.',
+    'Do not chase a new model or framework when the surrounding system is the bottleneck.',
+    'Do not trade customer trust, reversibility, or user control for short-term automation.',
+    'Do not let many weak experiments crowd out one strong revenue or learning loop.'
+  ],
+  decisionRubric: [
+    { id: 'user-value', weight: 25, question: 'Does this solve a real, current user problem?' },
+    { id: 'mission-fit', weight: 20, question: 'Does this move 3DVR toward open, human-scale agency?' },
+    { id: 'learning-or-revenue', weight: 20, question: 'Does this create measurable learning, trust, or revenue soon?' },
+    { id: 'simplicity', weight: 15, question: 'Is this the smallest coherent move with a clear path for the user?' },
+    { id: 'leverage', weight: 10, question: 'Will this make future useful work easier or more reusable?' },
+    { id: 'reversibility', weight: 5, question: 'Can we undo or correct this safely?' },
+    { id: 'openness', weight: 5, question: 'Does this preserve portability, interoperability, and user ownership?' }
+  ],
+  authority: {
+    green: 'May execute bounded, reversible internal work and prepare drafts without asking.',
+    yellow: 'May investigate and prepare, but requires review before external commitments, sends, or consequential writes.',
+    red: 'Never execute unattended: moving money, deleting user data, DNS changes, irreversible production changes, legal commitments, or mass outreach.'
+  }
+});
+
+function stringList(value, fallback = []) {
+  return Array.isArray(value) ? value.map(item => String(item || '').trim()).filter(Boolean) : [...fallback];
+}
+
+export function createDefaultExecutiveProfile() {
+  return JSON.parse(JSON.stringify(DEFAULT_EXECUTIVE_PROFILE));
+}
+
+export function normalizeExecutiveProfile(value = {}) {
+  const fallback = createDefaultExecutiveProfile();
+  return {
+    ...fallback,
+    ...(value && typeof value === 'object' ? value : {}),
+    version: EXECUTIVE_PROFILE_VERSION,
+    name: String(value?.name || fallback.name).trim(),
+    role: String(value?.role || fallback.role).trim(),
+    mission: String(value?.mission || fallback.mission).trim(),
+    northStar: String(value?.northStar || fallback.northStar).trim(),
+    currentDirection: String(value?.currentDirection || fallback.currentDirection).trim(),
+    strategicPriorities: stringList(value?.strategicPriorities, fallback.strategicPriorities),
+    taste: stringList(value?.taste, fallback.taste),
+    antiPatterns: stringList(value?.antiPatterns, fallback.antiPatterns),
+    decisionRubric: Array.isArray(value?.decisionRubric) && value.decisionRubric.length
+      ? value.decisionRubric.map(item => ({
+        id: String(item?.id || '').trim(),
+        weight: Number(item?.weight || 0),
+        question: String(item?.question || '').trim()
+      })).filter(item => item.id && item.question)
+      : fallback.decisionRubric,
+    authority: {
+      ...fallback.authority,
+      ...(value?.authority && typeof value.authority === 'object' ? value.authority : {})
+    }
+  };
+}
+
+export function formatExecutiveProfile(profile = DEFAULT_EXECUTIVE_PROFILE) {
+  const value = normalizeExecutiveProfile(profile);
+  return [
+    `${value.name}`,
+    `Role: ${value.role}`,
+    `Mission: ${value.mission}`,
+    `North star: ${value.northStar}`,
+    `Current direction: ${value.currentDirection}`,
+    'Strategic priorities:',
+    ...value.strategicPriorities.map((item, index) => `${index + 1}. ${item}`),
+    'Taste:',
+    ...value.taste.map(item => `- ${item}`),
+    'Avoid:',
+    ...value.antiPatterns.map(item => `- ${item}`),
+    'Decision rubric:',
+    ...value.decisionRubric.map(item => `- ${item.weight}% ${item.question}`),
+    'Authority:',
+    `- GREEN: ${value.authority.green}`,
+    `- YELLOW: ${value.authority.yellow}`,
+    `- RED: ${value.authority.red}`
+  ].join('\n');
+}
+
+export function createExecutiveFeedback({ kind = 'note', text = '', reason = '', source = 'founder' } = {}, now = new Date()) {
+  const normalizedKind = ['approve', 'reject', 'prefer', 'avoid', 'note'].includes(String(kind).toLowerCase())
+    ? String(kind).toLowerCase()
+    : 'note';
+  const normalizedText = String(text || '').trim();
+  if (!normalizedText) throw new Error('Executive feedback text is required.');
+  return {
+    id: `feedback-${now.toISOString().replace(/[:.]/g, '-')}`,
+    timestamp: now.toISOString(),
+    kind: normalizedKind,
+    text: normalizedText,
+    reason: String(reason || '').trim(),
+    source: String(source || 'founder').trim() || 'founder'
+  };
+}
+
+export function formatRecentExecutiveFeedback(feedback = []) {
+  if (!feedback.length) return 'No founder taste feedback recorded yet.';
+  return feedback
+    .slice(-12)
+    .map(item => `- [${String(item.kind || 'note').toUpperCase()}] ${item.text}${item.reason ? ` — ${item.reason}` : ''}`)
+    .join('\n');
+}

--- a/src/money-printer/moneyPrinterFileStorage.js
+++ b/src/money-printer/moneyPrinterFileStorage.js
@@ -5,6 +5,11 @@ import {
   createDefaultBusinessConfig,
   refreshMoneyPrinterState
 } from './moneyPrinterCore.js';
+import {
+  createDefaultExecutiveProfile,
+  createExecutiveFeedback,
+  normalizeExecutiveProfile
+} from './moneyPrinterExecutiveMemory.js';
 
 // File storage for money-printer-cli and the future server daemon.
 // Keep browser localStorage in moneyPrinterStorage.js; this module is Node-only by design.
@@ -13,6 +18,7 @@ export const DEFAULT_MONEY_PRINTER_WORKSPACE = '.money-printer';
 
 export function getMoneyPrinterWorkspacePaths(rootDir = process.cwd()) {
   const workspaceDir = path.resolve(rootDir, DEFAULT_MONEY_PRINTER_WORKSPACE);
+  const executiveDir = path.join(workspaceDir, 'executive');
   return {
     rootDir: path.resolve(rootDir),
     workspaceDir,
@@ -20,6 +26,10 @@ export function getMoneyPrinterWorkspacePaths(rootDir = process.cwd()) {
     ideasPath: path.join(workspaceDir, 'ideas.json'),
     experimentsPath: path.join(workspaceDir, 'experiments.json'),
     weakSignalsPath: path.join(workspaceDir, 'weak-signals.json'),
+    executiveDir,
+    executivePath: path.join(executiveDir, 'profile.json'),
+    executiveFeedbackPath: path.join(executiveDir, 'feedback.jsonl'),
+    executiveDecisionsPath: path.join(executiveDir, 'decisions.jsonl'),
     reportsDir: path.join(workspaceDir, 'reports'),
     logsDir: path.join(workspaceDir, 'logs'),
     eventsPath: path.join(workspaceDir, 'logs', 'events.jsonl')
@@ -51,6 +61,21 @@ export async function readJsonFile(filePath, fallbackValue = null) {
   return JSON.parse(raw);
 }
 
+export async function readJsonLines(filePath, limit = 50) {
+  if (!(await exists(filePath))) return [];
+  const raw = await readFile(filePath, 'utf8');
+  const rows = raw.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  const parsed = [];
+  for (const row of rows) {
+    try {
+      parsed.push(JSON.parse(row));
+    } catch {
+      // Ignore malformed historical lines instead of breaking the operator.
+    }
+  }
+  return Number.isFinite(Number(limit)) && Number(limit) > 0 ? parsed.slice(-Number(limit)) : parsed;
+}
+
 export async function writeJsonFile(filePath, value) {
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
@@ -62,13 +87,15 @@ export async function ensureMoneyPrinterWorkspace(rootDir = process.cwd()) {
   await mkdir(paths.workspaceDir, { recursive: true });
   await mkdir(paths.reportsDir, { recursive: true });
   await mkdir(paths.logsDir, { recursive: true });
+  await mkdir(paths.executiveDir, { recursive: true });
 
   const created = [];
   const defaults = [
     [paths.businessPath, createDefaultBusinessConfig()],
     [paths.ideasPath, []],
     [paths.experimentsPath, []],
-    [paths.weakSignalsPath, []]
+    [paths.weakSignalsPath, []],
+    [paths.executivePath, createDefaultExecutiveProfile()]
   ];
 
   for (const [filePath, value] of defaults) {
@@ -90,7 +117,12 @@ export async function loadMoneyPrinterWorkspace(rootDir = process.cwd()) {
   const ideas = await readJsonFile(paths.ideasPath, []);
   const experiments = await readJsonFile(paths.experimentsPath, []);
   const weakSignals = await readJsonFile(paths.weakSignalsPath, []);
-  const state = refreshMoneyPrinterState({
+  const executiveProfile = normalizeExecutiveProfile(
+    await readJsonFile(paths.executivePath, createDefaultExecutiveProfile())
+  );
+  const executiveFeedback = await readJsonLines(paths.executiveFeedbackPath, 24);
+  const executiveDecisions = await readJsonLines(paths.executiveDecisionsPath, 24);
+  const refreshedState = refreshMoneyPrinterState({
     mission: businessConfig.mission,
     businessConfig,
     ideas: Array.isArray(ideas) ? ideas : [],
@@ -98,6 +130,12 @@ export async function loadMoneyPrinterWorkspace(rootDir = process.cwd()) {
     weakSignals: Array.isArray(weakSignals) ? weakSignals : [],
     botOutputs: {}
   });
+  const state = {
+    ...refreshedState,
+    executiveProfile,
+    executiveFeedback,
+    executiveDecisions
+  };
 
   return {
     paths,
@@ -106,8 +144,46 @@ export async function loadMoneyPrinterWorkspace(rootDir = process.cwd()) {
     ideas: state.ideas,
     experiments: state.experiments,
     weakSignals: state.weakSignals || [],
+    executiveProfile,
+    executiveFeedback,
+    executiveDecisions,
     metrics: buildMetrics(state)
   };
+}
+
+
+export async function saveExecutiveProfile(rootDir = process.cwd(), profile = {}) {
+  const { paths } = await ensureMoneyPrinterWorkspace(rootDir);
+  const normalized = normalizeExecutiveProfile(profile);
+  await writeJsonFile(paths.executivePath, normalized);
+  return { profile: normalized, path: paths.executivePath };
+}
+
+export async function appendExecutiveFeedback(rootDir = process.cwd(), feedback = {}) {
+  const { paths } = await ensureMoneyPrinterWorkspace(rootDir);
+  const entry = createExecutiveFeedback(feedback);
+  await appendFile(paths.executiveFeedbackPath, `${JSON.stringify(entry)}\n`, 'utf8');
+  return { entry, path: paths.executiveFeedbackPath };
+}
+
+export async function appendExecutiveDecision(rootDir = process.cwd(), decision = {}) {
+  const { paths } = await ensureMoneyPrinterWorkspace(rootDir);
+  const timestamp = String(decision.timestamp || new Date().toISOString());
+  const entry = {
+    id: String(decision.id || `decision-${timestamp.replace(/[:.]/g, '-')}`),
+    timestamp,
+    decision: String(decision.decision || decision.summary || '').trim(),
+    why: String(decision.why || '').trim(),
+    nextAction: String(decision.nextAction || '').trim(),
+    whatNotToDo: Array.isArray(decision.whatNotToDo) ? decision.whatNotToDo.map(String).filter(Boolean) : [],
+    confidence: Number.isFinite(Number(decision.confidence)) ? Number(decision.confidence) : null,
+    bot: String(decision.bot || 'executive-agent'),
+    model: String(decision.model || ''),
+    source: String(decision.source || 'operator-cycle')
+  };
+  if (!entry.decision) throw new Error('Executive decision text is required.');
+  await appendFile(paths.executiveDecisionsPath, `${JSON.stringify(entry)}\n`, 'utf8');
+  return { entry, path: paths.executiveDecisionsPath };
 }
 
 export async function saveBusinessConfig(rootDir = process.cwd(), businessConfig) {

--- a/src/money-printer/moneyPrinterModelProvider.js
+++ b/src/money-printer/moneyPrinterModelProvider.js
@@ -11,6 +11,7 @@ import {
 import { generateValidationTest } from './moneyPrinterExperiments.js';
 import { getMoneyPrinterWorkspacePaths } from './moneyPrinterFileStorage.js';
 import { formatMoneyPrinterFounderDoctrine } from './moneyPrinterFounderDoctrine.js';
+import { formatExecutiveProfile, formatRecentExecutiveFeedback } from './moneyPrinterExecutiveMemory.js';
 import { createConnectorOperationPlan } from './moneyPrinterOperations.js';
 
 export const DEFAULT_MONEY_PRINTER_MODEL = 'gpt-4.1-mini';
@@ -18,6 +19,12 @@ export const DEFAULT_MONEY_PRINTER_FAST_MODEL = 'gpt-4.1-mini';
 export const DEFAULT_MONEY_PRINTER_REASONING_MODEL = 'gpt-5.4-mini';
 
 const GPT_5_RE = /^gpt-5([.-]|$)/;
+const EXECUTIVE_REASONING_BOTS = new Set([
+  'executive-agent',
+  'portfolio-manager-bot',
+  'kill-or-scale-bot',
+  'system-improvement-bot'
+]);
 const CONNECTOR_ACTION_ENUM = [
   'createIssue',
   'createIssueFromOperation',
@@ -62,7 +69,20 @@ const BOT_OUTPUT_SCHEMA = {
           }
         }
       },
-      codexPrompt: { type: 'string' }
+      codexPrompt: { type: 'string' },
+      executiveDecision: {
+        type: 'object',
+        required: ['decision', 'why', 'confidence', 'tasteCheck', 'tradeoffs', 'whatNotToDo'],
+        additionalProperties: false,
+        properties: {
+          decision: { type: 'string' },
+          why: { type: 'string' },
+          confidence: { type: 'number' },
+          tasteCheck: { type: 'string' },
+          tradeoffs: { type: 'array', items: { type: 'string' } },
+          whatNotToDo: { type: 'array', items: { type: 'string' } }
+        }
+      }
     }
   }
 };
@@ -327,6 +347,21 @@ export function validateFounderBrief(value = {}, fallback = {}) {
   };
 }
 
+export function validateExecutiveDecision(value = {}, fallback = {}) {
+  if (!value || typeof value !== 'object') return fallback;
+  const decision = String(value.decision || fallback.decision || '').trim();
+  if (!decision) return fallback;
+  const confidence = Number(value.confidence);
+  return {
+    decision,
+    why: String(value.why || fallback.why || '').trim(),
+    confidence: Number.isFinite(confidence) ? Math.max(0, Math.min(1, confidence)) : Number(fallback.confidence || 0.5),
+    tasteCheck: String(value.tasteCheck || fallback.tasteCheck || '').trim(),
+    tradeoffs: Array.isArray(value.tradeoffs) ? value.tradeoffs.map(String).filter(Boolean).slice(0, 6) : fallback.tradeoffs || [],
+    whatNotToDo: Array.isArray(value.whatNotToDo) ? value.whatNotToDo.map(String).filter(Boolean).slice(0, 6) : fallback.whatNotToDo || []
+  };
+}
+
 export function validateConnectorOperations(value = []) {
   const raw = Array.isArray(value) ? value : value?.operations;
   return (Array.isArray(raw) ? raw : [])
@@ -367,7 +402,11 @@ export async function fallbackToMockOnModelFailure({
 function buildInstructions() {
   return [
     'You are Money Printer, a model-powered 3DVR venture operator.',
-    'Your job is to find painful markets, make useful offers, validate demand, and create safe execution plans.',
+    'Your job is to run the business toward its durable mission, not merely generate ideas or complete prompts.',
+    'Treat executiveProfile as the operating constitution. Treat executiveFeedback as founder taste training data. Treat executiveDecisions as precedent, not immutable law.',
+    'When choices conflict, prefer the option that best fits the current direction, user value, simplicity, learning/revenue, reversibility, and openness.',
+    'Do not flatter the founder. Disagree when evidence or the executive constitution points elsewhere, and explain the tradeoff briefly.',
+    'Find painful markets, make useful offers, validate demand, and create safe execution plans.',
     'Sell first. Build second. Keep it simple.',
     'Prefer service-first, software-later businesses with reachable buyers and clear first-dollar paths.',
     'Never propose red-zone execution as allowed. Money movement, DNS, deletion, mass email, and production merges stay blocked.',
@@ -382,7 +421,7 @@ function buildInstructions() {
   ].join('\n');
 }
 
-function buildStatePayload(context = {}) {
+export function buildStatePayload(context = {}) {
   const state = context.state || context;
   return {
     businessConfig: state.businessConfig || context.businessConfig || {},
@@ -393,7 +432,10 @@ function buildStatePayload(context = {}) {
     metrics: context.metrics || {},
     recentReports: context.recentReports || [],
     availableConnectors: context.availableConnectors || ['github', 'vercel', 'codex'],
-    autonomy: state.businessConfig?.autonomy || {}
+    autonomy: state.businessConfig?.autonomy || {},
+    executiveProfile: state.executiveProfile || context.executiveProfile || null,
+    executiveFeedback: (state.executiveFeedback || context.executiveFeedback || []).slice(-12),
+    executiveDecisions: (state.executiveDecisions || context.executiveDecisions || []).slice(-12)
   };
 }
 
@@ -514,10 +556,22 @@ export async function runStructuredModelPrompt(prompt, options = {}) {
 
 function botPrompt(botId, state = {}) {
   const bot = BOT_DEFINITIONS.find(item => item.id === botId);
+  const executiveContext = state.executiveProfile
+    ? [
+      'Executive constitution:',
+      formatExecutiveProfile(state.executiveProfile),
+      'Recent founder taste feedback:',
+      formatRecentExecutiveFeedback(state.executiveFeedback || [])
+    ].join('\n')
+    : '';
   return [
     `Bot: ${bot?.name || botId}`,
     `Purpose: ${bot?.purpose || 'Operate the money machine.'}`,
     `Prompt template: ${findPromptForBot(botId)}`,
+    executiveContext,
+    botId === 'executive-agent'
+      ? 'Make one clear executiveDecision. Include why, confidence from 0 to 1, a tasteCheck against the constitution, tradeoffs, and whatNotToDo.'
+      : 'Follow the executive constitution and recent founder feedback when choosing what good looks like.',
     'Context JSON:',
     JSON.stringify(buildStatePayload(state), null, 2),
     'Return a practical bot output with safe connector operations and a Codex prompt when useful.'
@@ -541,6 +595,7 @@ export async function runBotWithModel(botId, state = {}, options = {}) {
   try {
     const result = await runStructuredModelPrompt(botPrompt(botId, state), {
       ...options,
+      model: options.model || (EXECUTIVE_REASONING_BOTS.has(botId) ? status.reasoningModel : status.model),
       schema: BOT_OUTPUT_SCHEMA
     });
     const data = result.data || {};
@@ -552,6 +607,14 @@ export async function runBotWithModel(botId, state = {}, options = {}) {
       nextBestMoneyAction: String(data.nextBestMoneyAction || getNextBestMoneyAction(state)),
       connectorOperations: validateConnectorOperations(data.connectorOperations),
       codexPrompt: String(data.codexPrompt || ''),
+      executiveDecision: validateExecutiveDecision(data.executiveDecision, {
+        decision: String(data.summary || ''),
+        why: String(data.nextBestMoneyAction || ''),
+        confidence: 0.5,
+        tasteCheck: '',
+        tradeoffs: [],
+        whatNotToDo: []
+      }),
       aiMode: 'openai',
       model: result.model
     };

--- a/src/money-printer/moneyPrinterPrompts.js
+++ b/src/money-printer/moneyPrinterPrompts.js
@@ -3,7 +3,7 @@
 
 export const PROMPT_TEMPLATES = {
   executiveAgent:
-    'Given the business config, current experiments, traction, and available tools, decide which bot should run next and create a prioritized action plan. Prefer one painful niche, one high-value manual offer, one validation channel, and one paid pilot ask.',
+    'Act as the persistent 3DVR executive. Use the executive constitution, current direction, recent founder taste feedback, decision history, business state, traction, and available tools to choose one clear direction. Decide what matters now, what not to do, and which bot or tool should act next. Prefer concrete user value, simplicity, evidence, sustainable revenue, openness, and reversible execution over activity for its own sake.',
   opportunityScanner:
     'Scan the available business context, founder notes, market assumptions, and connected tools. Identify underserved customer pains and rank possible opportunities by urgency, reachability, purchasing power, monetization potential, and speed to validation.',
   businessIdeaGenerator:

--- a/src/operator/api.js
+++ b/src/operator/api.js
@@ -1,4 +1,5 @@
 import { buildOperatorOwnerContext } from './context.js';
+import { DEFAULT_EXECUTIVE_PROFILE, formatExecutiveProfile } from '../money-printer/moneyPrinterExecutiveMemory.js';
 import { resolveOperatorDeveloperAccess } from './developer-access.js';
 import {
   buildOperatorDraftRequest,
@@ -102,6 +103,8 @@ export function buildOperatorRequest({ prompt, history = [], portalContext = nul
     instructions: [
       'You are the 3DVR Operator, a calm personal operator inside a life and business portal.',
       buildOperatorOwnerContext(),
+      'For 3DVR business strategy, prioritization, product direction, or operating decisions, act as the founder-aligned executive layer rather than a generic assistant. Apply this constitution and be willing to reject distracting work:',
+      formatExecutiveProfile(DEFAULT_EXECUTIVE_PROFILE),
       buildPortalSnapshotInstruction(portalContext),
       `3DVR developer access for this turn is ${developerApproved ? 'approved for local code edits' : 'not approved for code edits; suggestions are allowed'}.`,
       'Talk like a capable partner. Lead with the useful answer. Use short, plain sentences.',

--- a/tests/money-printer-cli.test.js
+++ b/tests/money-printer-cli.test.js
@@ -49,6 +49,7 @@ describe('money-printer CLI', () => {
       const businessPath = path.join(workspaceDir, 'business.json');
       const ideasPath = path.join(workspaceDir, 'ideas.json');
       const experimentsPath = path.join(workspaceDir, 'experiments.json');
+      const executivePath = path.join(workspaceDir, 'executive', 'profile.json');
       const reportsDir = path.join(workspaceDir, 'reports');
       const eventsPath = path.join(workspaceDir, 'logs', 'events.jsonl');
 
@@ -57,7 +58,19 @@ describe('money-printer CLI', () => {
       assert.equal(await exists(businessPath), true);
       assert.equal(await exists(ideasPath), true);
       assert.equal(await exists(experimentsPath), true);
+      assert.equal(await exists(executivePath), true);
       assert.equal(await exists(reportsDir), true);
+
+      const executive = await runCli(cwd, ['executive']);
+      assert.match(executive.stdout, /3DVR Executive Constitution/);
+      assert.match(executive.stdout, /Recent founder feedback/);
+
+      const direction = await runCli(cwd, ['executive', 'direction', 'Make the first useful workflow unmistakable.']);
+      assert.match(direction.stdout, /Executive direction updated/);
+      assert.match((await readJson(executivePath)).currentDirection, /first useful workflow/);
+
+      const feedback = await runCli(cwd, ['executive', 'feedback', 'prefer', 'One obvious action per screen.']);
+      assert.match(feedback.stdout, /Taste learned: \[PREFER\]/);
 
       const mission = await runCli(cwd, [
         'mission',
@@ -84,12 +97,15 @@ describe('money-printer CLI', () => {
 
       const run = await runCli(cwd, ['run', 'executive']);
       assert.match(run.stdout, /Executive Agent decision/);
-      assert.match(run.stdout, /buyer outreach/);
+      assert.match(run.stdout, /Stay on direction/);
+      assert.match(run.stdout, /Make the first useful workflow unmistakable/);
 
       const status = await runCli(cwd, ['status']);
       assert.match(status.stdout, /Money Printer Status/);
       assert.match(status.stdout, /Ideas Generated: 5/);
       assert.match(status.stdout, /Experiments Active: 1/);
+      assert.match(status.stdout, /Direction: Make the first useful workflow unmistakable/);
+      assert.match(status.stdout, /Taste Feedback Recorded: 1/);
 
       const daemon = await runCli(cwd, ['daemon', '--once']);
       assert.match(daemon.stdout, /Daemon dry-run cycle completed once/);

--- a/tests/money-printer-executive-memory.test.js
+++ b/tests/money-printer-executive-memory.test.js
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  appendExecutiveDecision,
+  appendExecutiveFeedback,
+  ensureMoneyPrinterWorkspace,
+  loadMoneyPrinterWorkspace,
+  saveExecutiveProfile
+} from '../src/money-printer/moneyPrinterFileStorage.js';
+import {
+  createDefaultExecutiveProfile,
+  formatExecutiveProfile
+} from '../src/money-printer/moneyPrinterExecutiveMemory.js';
+import { buildStatePayload } from '../src/money-printer/moneyPrinterModelProvider.js';
+
+test('initializes a persistent 3DVR executive constitution', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), '3dvr-executive-'));
+  try {
+    const { paths } = await ensureMoneyPrinterWorkspace(root);
+    const profile = JSON.parse(await readFile(paths.executivePath, 'utf8'));
+
+    assert.equal(profile.name, '3DVR Executive Constitution');
+    assert.match(profile.currentDirection, /useful enough to run real work/i);
+    assert.equal(profile.taste.some(item => /glanceable/i.test(item)), true);
+    assert.equal(profile.antiPatterns.some(item => /activity.*progress/i.test(item)), true);
+    assert.equal(profile.authority.red.includes('Never execute unattended'), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('founder feedback and executive decisions persist and enter model context', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), '3dvr-executive-'));
+  try {
+    await ensureMoneyPrinterWorkspace(root);
+    const profile = createDefaultExecutiveProfile();
+    profile.currentDirection = 'Make the CRM obvious enough to use without instructions.';
+    await saveExecutiveProfile(root, profile);
+    await appendExecutiveFeedback(root, {
+      kind: 'prefer',
+      text: 'One obvious action per screen.',
+      reason: 'The interface should be understandable at a glance.'
+    });
+    await appendExecutiveFeedback(root, {
+      kind: 'avoid',
+      text: 'Do not add explanatory copy when layout can carry the meaning.'
+    });
+    await appendExecutiveDecision(root, {
+      decision: 'Polish the existing CRM flow before adding another app.',
+      why: 'It compounds an existing business workflow and reduces fragmentation.',
+      nextAction: 'User-test the CRM primary flow.',
+      confidence: 0.86,
+      whatNotToDo: ['Do not start a replacement CRM.']
+    });
+
+    const loaded = await loadMoneyPrinterWorkspace(root);
+    const payload = buildStatePayload(loaded.state);
+
+    assert.equal(loaded.executiveFeedback.length, 2);
+    assert.equal(loaded.executiveDecisions.length, 1);
+    assert.equal(payload.executiveProfile.currentDirection, profile.currentDirection);
+    assert.match(payload.executiveFeedback[0].text, /one obvious action/i);
+    assert.match(payload.executiveDecisions[0].decision, /Polish the existing CRM/i);
+    assert.match(formatExecutiveProfile(loaded.executiveProfile), /Current direction: Make the CRM obvious/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tests/money-printer-runtime.test.js
+++ b/tests/money-printer-runtime.test.js
@@ -121,6 +121,67 @@ describe('money-printer model runtime', () => {
     assert.equal(result.ideas.length, 2);
   });
 
+  it('routes executive decisions through the configured reasoning model and constitution', async () => {
+    const requests = [];
+    const result = await runBotWithModel('executive-agent', {
+      businessConfig: { mission: 'Build useful open systems.' },
+      ideas: [],
+      experiments: [],
+      executiveProfile: {
+        currentDirection: 'Make one real workflow work end to end.',
+        taste: ['Prefer one obvious action.']
+      },
+      executiveFeedback: [{ kind: 'prefer', text: 'Keep it glanceable.' }],
+      executiveDecisions: []
+    }, {
+      ai: true,
+      fetchImpl: async (url, options) => {
+        requests.push(JSON.parse(options.body));
+        return {
+          ok: true,
+          json: async () => ({
+            output: [{
+              type: 'message',
+              content: [{
+                type: 'output_text',
+                text: JSON.stringify({
+                  title: 'Executive direction',
+                  summary: 'Finish one workflow before expanding.',
+                  lines: ['Polish the current path.'],
+                  nextBestMoneyAction: 'Test the current path with one user.',
+                  connectorOperations: [],
+                  codexPrompt: '',
+                  executiveDecision: {
+                    decision: 'Finish one workflow before expanding.',
+                    why: 'It fits the current direction and simplicity rubric.',
+                    confidence: 0.88,
+                    tasteCheck: 'One obvious path, less fragmentation.',
+                    tradeoffs: ['Defers new features.'],
+                    whatNotToDo: ['Do not start another app.']
+                  }
+                })
+              }]
+            }]
+          })
+        };
+      },
+      env: {
+        MONEY_PRINTER_AI_MODE: 'openai',
+        OPENAI_API_KEY: 'sk-test-not-real',
+        MONEY_PRINTER_MODEL: 'gpt-fast-test',
+        MONEY_PRINTER_REASONING_MODEL: 'gpt-reasoning-test'
+      }
+    });
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].model, 'gpt-reasoning-test');
+    assert.match(requests[0].instructions, /operating constitution/i);
+    assert.match(requests[0].input, /Make one real workflow work end to end/);
+    assert.match(requests[0].input, /Keep it glanceable/);
+    assert.equal(result.executiveDecision.confidence, 0.88);
+    assert.match(result.executiveDecision.whatNotToDo[0], /another app/);
+  });
+
   it('logs invalid model JSON and falls back to mock bot output', async () => {
     const cwd = await createTempWorkspace();
     try {

--- a/tests/operator-context.test.js
+++ b/tests/operator-context.test.js
@@ -19,3 +19,10 @@ test('founder context stays focused on professional product context', () => {
   assert.doesNotMatch(text, /medical|diagnosis|partner|child|address|password|secret/i);
   assert.match(text, /Do not expose, guess, or invent private or sensitive personal details/);
 });
+
+test('operator carries the 3DVR executive constitution', () => {
+  const request = buildOperatorRequest({ prompt: 'What should 3DVR do next?' });
+  assert.match(request.instructions, /3DVR Executive Constitution/i);
+  assert.match(request.instructions, /glanceable interfaces/i);
+  assert.match(request.instructions, /reject distracting work/i);
+});


### PR DESCRIPTION
## What this changes

Turns the existing Money Printer Executive Agent into a persistent, model-independent CEO/COO layer for 3DVR.

- adds a 3DVR Executive Constitution with mission, north star, current direction, taste, anti-patterns, weighted decision rubric, and authority boundaries
- persists founder feedback and executive decisions under `.money-printer/executive/`
- injects the constitution, recent founder feedback, and decision precedent into model calls
- routes executive/portfolio/kill-or-scale/system-improvement decisions through the configured reasoning model
- records every Executive Agent decision before connector planning
- adds CLI steering: `executive`, `executive direction`, `executive feedback`, and `executive decisions`
- makes deterministic/mock mode follow persistent direction instead of generic startup advice
- gives the main Portal Operator the same executive constitution for 3DVR business strategy and prioritization
- preserves existing GREEN/YELLOW/RED connector guardrails

## Verification

Focused executive/operator-runtime suite: 25/25 passing.

A safe server dry-run records the persistent direction, executes zero connector operations, and now chooses a next action derived from that direction.

The repository-wide suite currently exposes unrelated baseline issues in this clean worktree (old homepage-card assertions plus missing `gun`/`nodemailer` dependencies), so those are not represented as regressions from this branch.