### PR TITLE
Limit Google Calendar OAuth to event access

### DIFF
--- a/src/oauth/provider-api.js
+++ b/src/oauth/provider-api.js
@@ -323,7 +323,7 @@ function createGoogleProvider(config = process.env) {
         scopes.add('https://www.googleapis.com/auth/contacts.readonly');
       }
       if (scopeKey === 'calendar' || scopeKey === 'contacts-calendar') {
-        scopes.add('https://www.googleapis.com/auth/calendar');
+        scopes.add('https://www.googleapis.com/auth/calendar.events');
       }
       if (scopeKey === 'mail' || scopeKey === 'gmail') {
         scopes.add('https://mail.google.com/');

--- a/tests/oauth-provider-api.test.js
+++ b/tests/oauth-provider-api.test.js
@@ -109,6 +109,25 @@ describe('oauth provider api', () => {
     assert.match(String(res.body), /not configured on this deployment yet/i);
   });
 
+  it('requests event-level Google Calendar access instead of full calendar administration', async () => {
+    const handler = createOAuthProviderHandler({
+      config: { GOOGLE_OAUTH_CLIENT_ID: 'client.apps.googleusercontent.com', GOOGLE_OAUTH_CLIENT_SECRET: 'secret' },
+    });
+    const res = createMockRes();
+
+    await handler({
+      method: 'GET',
+      headers: { host: 'portal.3dvr.tech', 'x-forwarded-proto': 'https' },
+      query: { provider: 'google', action: 'start', scopeKey: 'calendar', returnTo: '/calendar/' },
+    }, res);
+
+    assert.equal(res.statusCode, 302);
+    const location = new URL(res.headers.Location);
+    const scopes = location.searchParams.get('scope') || '';
+    assert.match(scopes, /https:\/\/www\.googleapis\.com\/auth\/calendar\.events/);
+    assert.doesNotMatch(scopes, /https:\/\/www\.googleapis\.com\/auth\/calendar(?:\s|$)/);
+  });
+
   it('renders copyable CLI OAuth result instead of redirecting immediately', async () => {
     const handler = createOAuthProviderHandler({
       config: {},


### PR DESCRIPTION
Narrows Google Calendar OAuth from full calendar administration to calendar.events, which is sufficient for the portal event read/write endpoints. Adds regression coverage. Calendar UI tests pass; the focused OAuth scope test passes.