### PR TITLE
Restore username and points on portal home

### DIFF
--- a/home-operator.js
+++ b/home-operator.js
@@ -24,8 +24,22 @@ function readAccountState() {
   const username = (localStorage.getItem('username') || shared.username || '').trim();
   return {
     signedIn,
+    alias,
     displayName: signedIn ? username || aliasToDisplay(alias) || 'User' : ''
   };
+}
+
+function readCachedPoints(state) {
+  if (!state.signedIn || !state.alias) return 0;
+  try {
+    const key = `3dvr:score:user:${state.alias.toLowerCase()}`;
+    return [key, `${key}:pending`, `${key}:portalPending`]
+      .map(cacheKey => Number(localStorage.getItem(cacheKey) || 0))
+      .filter(Number.isFinite)
+      .reduce((best, value) => Math.max(best, Math.max(0, Math.round(value))), 0);
+  } catch {
+    return 0;
+  }
 }
 
 function installAccountStatus() {
@@ -35,9 +49,10 @@ function installAccountStatus() {
   const render = () => {
     const state = readAccountState();
     if (state.signedIn) {
+      const points = readCachedPoints(state);
       authEntry.href = '/profile.html#profile';
-      authEntry.textContent = 'Profile';
-      authEntry.setAttribute('aria-label', `Open profile for ${state.displayName}`);
+      authEntry.textContent = `${state.displayName} · ⭐ ${points}`;
+      authEntry.setAttribute('aria-label', `Open profile for ${state.displayName}. ${points} points.`);
       return;
     }
 

--- a/tests/homepage-account-ux.test.js
+++ b/tests/homepage-account-ux.test.js
@@ -14,7 +14,10 @@ test('homepage account entry follows portal auth state', async () => {
   assert.match(html, /data-auth-entry>Sign in<\/a>/);
   assert.match(app, /syncStorageFromSharedIdentity\?\.\(localStorage\)/);
   assert.match(app, /authEntry\.href = '\/profile\.html#profile'/);
-  assert.match(app, /authEntry\.textContent = 'Profile'/);
+  assert.match(app, /3dvr:score:user:/);
+  assert.match(app, /:pending/);
+  assert.match(app, /:portalPending/);
+  assert.match(app, /authEntry\.textContent = `\$\{state\.displayName\} · ⭐ \$\{points\}`/);
   assert.match(app, /authEntry\.href = '\/sign-in\.html\?redirect=%2F'/);
   assert.match(app, /authEntry\.textContent = 'Sign in'/);
   assert.doesNotMatch(app, /signInLink\.hidden/);


### PR DESCRIPTION
Superseded by #1972, which rebuilt this change on the current homepage while preserving the newer 3DVR OS launcher. #1972 passed fresh Playwright checks and was merged to `main`.