### PR TITLE
Fix Operator Forge proof transport

### DIFF
--- a/apps/agent/test/operator-forge-auth.test.js
+++ b/apps/agent/test/operator-forge-auth.test.js
@@ -6,6 +6,7 @@ const {
   authorizePortalOperatorTask,
   resolveRepoAlias,
   BUILTIN_OPERATOR_DEVELOPER_BINDINGS,
+  decodeForgeProof,
 } = require('../thomas-agent/node/operator-forge-auth');
 
 const TMSTEPH_PUB = 'Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8.1fppECqamDOHh2tKt1G5t8Yd21NjBCZ3C6qunST3lvg';
@@ -35,6 +36,26 @@ function validProof(overrides = {}) {
     ...overrides,
   };
 }
+
+test('base64 wrapped Forge proof survives transport unchanged', async () => {
+  const rawProof = 'SEA{\"m\":{\"scope\":\"operator-forge-task\",\"label\":\"test ✓\"},\"s\":\"signature\"}';
+  const wrappedProof = `b64:${Buffer.from(rawProof, 'utf8').toString('base64')}`;
+  assert.equal(decodeForgeProof(wrappedProof), rawProof);
+  assert.equal(decodeForgeProof(rawProof), rawProof);
+
+  let verifiedProof = '';
+  const result = await authorizePortalOperatorTask(validRecord({ authProof: wrappedProof }), {
+    now: 1_001_000,
+    env: { THREEDVR_OPERATOR_DEVELOPER_PUBS: 'pub-1' },
+    verifyImpl: async proof => {
+      verifiedProof = proof;
+      return validProof();
+    },
+  });
+
+  assert.equal(verifiedProof, rawProof);
+  assert.equal(result.ok, true);
+});
 
 test('built-in worker policy binds tmsteph alias to the exact SEA public key', () => {
   assert.equal(BUILTIN_OPERATOR_DEVELOPER_BINDINGS['tmsteph@3dvr'], TMSTEPH_PUB);

--- a/apps/agent/thomas-agent/node/gun-db.js
+++ b/apps/agent/thomas-agent/node/gun-db.js
@@ -1,6 +1,6 @@
 const Gun = require('gun');
 
-const RELAY = process.env.THREEDVR_GUN_RELAY || 'wss://gun-relay-3dvr.fly.dev/gun';
+const RELAY = process.env.THREEDVR_GUN_RELAY || 'https://gun-relay-3dvr.fly.dev/gun';
 const APP_ROOT = process.env.THREEDVR_GUN_ROOT || '3dvr';
 const CRM_ROOT = process.env.THREEDVR_GUN_CRM || 'crm';
 const LEADS_ROOT = process.env.THREEDVR_GUN_LEADS || 'leads';

--- a/apps/agent/thomas-agent/node/operator-forge-auth.js
+++ b/apps/agent/thomas-agent/node/operator-forge-auth.js
@@ -17,6 +17,16 @@ function normalizeAlias(value = '') {
   return normalizeText(value).toLowerCase();
 }
 
+function decodeForgeProof(value = '') {
+  const proof = normalizeText(value);
+  if (!proof.startsWith('b64:')) return proof;
+  try {
+    return Buffer.from(proof.slice(4), 'base64').toString('utf8');
+  } catch {
+    return '';
+  }
+}
+
 function listFromConfig(value = '') {
   return String(value || '')
     .split(',')
@@ -101,7 +111,7 @@ async function authorizePortalOperatorTask(record = {}, options = {}) {
     return { ok: false, reason: 'untrusted forge request producer' };
   }
 
-  const authProof = normalizeText(record.authProof);
+  const authProof = decodeForgeProof(record.authProof);
   const authPub = normalizeText(record.authPub);
   if (!authProof || !authPub) return { ok: false, reason: 'missing 3DVR developer proof' };
 
@@ -158,4 +168,5 @@ module.exports = {
   resolveRepoAlias,
   BUILTIN_OPERATOR_ADMIN_BINDINGS,
   BUILTIN_OPERATOR_DEVELOPER_BINDINGS,
+  decodeForgeProof,
 };

--- a/operator/forge.js
+++ b/operator/forge.js
@@ -24,6 +24,17 @@ function makeId(prefix) {
   return `${prefix}-${globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(16).slice(2)}`}`;
 }
 
+function encodeForgeProof(value = '') {
+  const text = String(value || '');
+  if (!text) return '';
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + 0x8000));
+  }
+  return `b64:${globalThis.btoa(binary)}`;
+}
+
 function forgeRecordUrl(kind, id) {
   const params = new URLSearchParams({ kind, id });
   return `/forge/record.html?${params.toString()}`;
@@ -334,7 +345,7 @@ export async function queueCodeChange(action = {}) {
     requestedByAlias: proof.portalAlias || proof.authPub,
     resultSummary: '',
     error: '',
-    authProof: proof.authProof,
+    authProof: encodeForgeProof(proof.authProof),
     authPub: proof.authPub
   };
   const writeResult = await writeGun(context.gun.get(FORGE_ROOT).get('forge').get('editRequests').get(id), record);

--- a/src/operator/api.js
+++ b/src/operator/api.js
@@ -86,6 +86,7 @@ async function readUpstreamError(response) {
     const payload = await response.json();
     const code = clean(payload?.error?.code || payload?.code, 80);
     if (code === 'insufficient_quota') return 'The configured AI account has no available credits.';
+    if (response.status === 429) return fallback;
     return clean(payload?.error?.message || payload?.message, 300) || fallback;
   } catch {
     return fallback;

--- a/tests/operator.test.js
+++ b/tests/operator.test.js
@@ -8,3 +8,26 @@ test('operator page is a single conversation front door with real local actions'
 test('operator keeps a browsable, account-scoped conversation archive',async()=>{const[html,app,sync]=await Promise.all([readFile(new URL('../operator/index.html',import.meta.url),'utf8'),readFile(new URL('../operator/app.js',import.meta.url),'utf8'),readFile(new URL('../operator/sync.js',import.meta.url),'utf8')]);assert.match(html,/Past conversations/);assert.match(html,/gun\/sea\.js/);assert.match(html,/auth-identity\.js/);assert.match(app,/3dvr\.operator\.conversations\.v2/);assert.match(app,/\.account\.\$\{encodeURIComponent\(accountKey\)\}/);assert.match(app,/LEGACY_KEY/);assert.match(app,/data-conversation-id/);assert.match(sync,/SEA\.encrypt/);assert.match(sync,/user\.get\(SYNC_NODE\)/)});
 test('operator can safely save checklists and web links',async()=>{const checklist=normalizeOperatorResult({reply:'Saved.',action:{type:'create_checklist',title:'Today',text:'Call Sam\nSend quote',url:''}});assert.equal(checklist.action.type,'create_checklist');const link=normalizeOperatorResult({reply:'Saved.',action:{type:'save_link',title:'Guide',text:'Read later',url:'https://example.com/guide'}});assert.equal(link.action.url,'https://example.com/guide');const unsafe=normalizeOperatorResult({reply:'No.',action:{type:'save_link',title:'Bad',text:'',url:'javascript:alert(1)'}});assert.equal(unsafe.action.url,'');const actions=await readFile(new URL('../operator/actions.js',import.meta.url),'utf8');assert.match(actions,/Saved as a checklist/);assert.match(actions,/Only web links can be saved/)});
 test('operator returns a bounded set of clean next-step suggestions',()=>{const result=normalizeOperatorResult({reply:'Ready.',suggestions:['  Make the checklist  ','Save this plan','Find a customer','Extra choice'],action:{type:'none'}});assert.deepEqual(result.suggestions,['Make the checklist','Save this plan','Find a customer'])});
+
+
+test('operator hides provider upsell details on ordinary rate limits', async () => {
+  let body;
+  const handler = createOperatorHandler({
+    apiKey: '',
+    gatewayToken: 'gateway-test',
+    fetchImpl: async () => ({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: { message: 'Free tier requests are rate-limited. Upgrade at https://example.invalid/top-up' } }),
+    }),
+  });
+  const req = { method: 'POST', body: { prompt: 'Help me' }, headers: {} };
+  const res = {
+    setHeader() {},
+    status(code) { this.statusCode = code; return this; },
+    json(value) { body = value; return this; },
+  };
+  await handler(req, res);
+  assert.equal(res.statusCode, 429);
+  assert.equal(body.error, 'The operator is busy right now. Please try again in a moment.');
+});


### PR DESCRIPTION
Fixes the live Operator self-edit path uncovered by the home-page comment test.

- base64-wrap SEA Forge proofs before writing them through GUN and decode server-side
- default the agent GUN relay to the stable HTTPS transport
- hide provider credit/upsell details on ordinary 429s
- add regression coverage for proof transport and rate-limit messaging

Focused tests: 17 Forge worker/auth tests pass; 2 rate-limit tests pass.