### PR TITLE
Add AV Freelance Launchpad

### DIFF
--- a/av-freelance/index.html
+++ b/av-freelance/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="A practical 3DVR path for AV technicians who want to build a more independent freelance career without making a reckless jump.">
+  <meta name="theme-color" content="#07111f">
+  <title>AV Freelance Launchpad | 3DVR</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body class="theme-dark freelance-page">
+  <a class="skip-link" href="#mainContent">Skip to main content</a>
+
+  <div class="freelance-shell">
+    <header class="freelance-nav">
+      <a class="brand-link" href="../index.html">3DVR</a>
+      <nav aria-label="AV Freelance Launchpad navigation">
+        <a href="#path">The path</a>
+        <a href="#tools">Tools</a>
+        <a href="../career-launch/">Start</a>
+      </nav>
+    </header>
+
+    <main id="mainContent">
+      <section class="hero" aria-labelledby="heroTitle">
+        <p class="eyebrow">AV Freelance Launchpad</p>
+        <h1 id="heroTitle">You already know how to run the show. Build work that belongs to you.</h1>
+        <p class="hero-copy">
+          For event technicians who are good at the work but want more control over their time, clients,
+          rates, and direction. Keep your income stable while you build a freelance runway one relationship at a time.
+        </p>
+        <div class="hero-actions">
+          <a class="button button--primary" href="../career-launch/">Build my freelance plan</a>
+          <a class="button" href="#path">See the transition path</a>
+        </div>
+        <p class="hero-note">
+          Especially relevant to people working at Encore and other large event-production companies who are curious about independent work. 3DVR is not affiliated with Encore.
+        </p>
+      </section>
+
+      <section class="proof" aria-labelledby="proofTitle">
+        <div class="section-heading">
+          <p class="eyebrow">Your experience already has value</p>
+          <h2 id="proofTitle">The hard part is not starting over. It is packaging what you already know.</h2>
+          <p>
+            Corporate AV teaches skills clients already pay freelancers for: calm troubleshooting, show awareness,
+            communication, setup speed, technical judgment, and the ability to make an event happen under pressure.
+          </p>
+        </div>
+        <div class="role-grid" aria-label="Common freelance AV roles">
+          <span>A1</span>
+          <span>A2</span>
+          <span>V1</span>
+          <span>V2</span>
+          <span>Graphics</span>
+          <span>Camera</span>
+          <span>LED</span>
+          <span>Playback</span>
+          <span>RF</span>
+          <span>Show Crew</span>
+        </div>
+      </section>
+
+      <section id="path" class="path" aria-labelledby="pathTitle">
+        <div class="section-heading">
+          <p class="eyebrow">A safer way out</p>
+          <h2 id="pathTitle">Do not leap. Build a runway.</h2>
+          <p>Freelancing gets less scary when it becomes a sequence of small proofs instead of one giant decision.</p>
+        </div>
+        <ol class="path-list">
+          <li>
+            <span class="step">01</span>
+            <div><h3>Name your strongest lane</h3><p>Pick the work you want to be called for first. You can expand later.</p></div>
+          </li>
+          <li>
+            <span class="step">02</span>
+            <div><h3>Set a real day rate</h3><p>Know your target, minimum, overtime terms, travel expectations, and what makes a job worth accepting.</p></div>
+          </li>
+          <li>
+            <span class="step">03</span>
+            <div><h3>Build three direct relationships</h3><p>Start with production companies, PMs, crew leads, and technicians who already understand your work.</p></div>
+          </li>
+          <li>
+            <span class="step">04</span>
+            <div><h3>Prove consistency before leaving</h3><p>Track calls, income, repeat clients, and your calendar until independent work feels boringly real.</p></div>
+          </li>
+        </ol>
+      </section>
+
+      <section class="offer" aria-labelledby="offerTitle">
+        <p class="eyebrow">What 3DVR can help with</p>
+        <h2 id="offerTitle">Your freelance business, without the business-school nonsense.</h2>
+        <div class="offer-grid">
+          <article><h3>Positioning</h3><p>Turn years of mixed AV experience into a clear one-sentence offer people remember.</p></article>
+          <article><h3>Rates</h3><p>Create a simple rate card and boundaries so every new call does not become a negotiation crisis.</p></article>
+          <article><h3>Opportunities</h3><p>Track companies, contacts, applications, callbacks, and who you should follow up with next.</p></article>
+          <article><h3>Availability</h3><p>Build a calendar that makes it easy to see when you can accept work and when your life needs space.</p></article>
+          <article><h3>Proof</h3><p>Collect credits, roles, photos, references, and repeat-client wins into a portfolio that earns trust.</p></article>
+          <article><h3>Independence</h3><p>Know when freelancing is actually strong enough to replace a job instead of gambling your stability.</p></article>
+        </div>
+      </section>
+
+      <section id="tools" class="tools" aria-labelledby="toolsTitle">
+        <div class="section-heading">
+          <p class="eyebrow">Use what already exists</p>
+          <h2 id="toolsTitle">Start building the runway today.</h2>
+        </div>
+        <div class="tool-grid">
+          <a class="tool-card" href="../career-launch/">
+            <span>Start here</span>
+            <h3>Career Launch</h3>
+            <p>Turn your current experience into a practical next-step plan.</p>
+          </a>
+          <a class="tool-card" href="../job-tracker/index.html">
+            <span>Build pipeline</span>
+            <h3>Job Tracker</h3>
+            <p>Keep companies, opportunities, status, and follow-ups in one place.</p>
+          </a>
+          <a class="tool-card" href="../launch-room/">
+            <span>Shape the bigger move</span>
+            <h3>Launch Room</h3>
+            <p>Clarify the kind of work and life you are actually trying to build.</p>
+          </a>
+        </div>
+      </section>
+
+      <section class="closing" aria-labelledby="closingTitle">
+        <p class="eyebrow">The goal</p>
+        <h2 id="closingTitle">More freedom. Better work. Stronger relationships.</h2>
+        <p>
+          Freelancing is not automatically better than employment. The point is choice: enough skill, reputation,
+          relationships, and tools that you can decide where your time goes instead of feeling trapped.
+        </p>
+        <div class="hero-actions">
+          <a class="button button--primary" href="../career-launch/">Start my transition</a>
+          <a class="button" href="../human-value-network/">Explore the bigger vision</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <span>3DVR.Tech — Build the future together.</span>
+      <a href="../index.html">Back to Portal</a>
+    </footer>
+  </div>
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/av-freelance/styles.css
+++ b/av-freelance/styles.css
@@ -1,0 +1,347 @@
+body.freelance-page {
+  --page-background: radial-gradient(120% 100% at 10% 0%, #142a48 0%, #07111f 48%, #03070d 100%);
+  --surface: rgba(10, 24, 42, 0.78);
+  --surface-border: rgba(125, 211, 252, 0.18);
+  --text-main: #eff6ff;
+  --text-muted: #b7c9dc;
+  --accent: #7dd3fc;
+  --accent-strong: #bae6fd;
+  --accent-contrast: #062033;
+  background: var(--page-background);
+  color: var(--text-main);
+}
+
+.freelance-page::before {
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.2), transparent 62%);
+}
+
+.freelance-page::after {
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.14), transparent 62%);
+}
+
+.freelance-shell {
+  position: relative;
+  z-index: 1;
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1rem 0 4rem;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  z-index: 1000;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #07111f;
+}
+
+.freelance-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 0;
+}
+
+.freelance-nav nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.55rem;
+}
+
+.freelance-nav a {
+  color: #dbeafe;
+}
+
+.freelance-nav nav a {
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--surface-border);
+  border-radius: 999px;
+  background: rgba(4, 15, 28, 0.42);
+}
+
+.brand-link {
+  font-weight: 850;
+  letter-spacing: 0.08em;
+}
+
+main {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.hero,
+.proof,
+.path,
+.offer,
+.tools,
+.closing {
+  border: 1px solid var(--surface-border);
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(14, 35, 59, 0.88), rgba(4, 12, 22, 0.9));
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.28);
+}
+
+.hero {
+  min-height: 72vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(2rem, 6vw, 5.5rem);
+}
+
+.hero h1,
+section h2 {
+  margin: 0;
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+}
+
+.hero h1 {
+  max-width: 13ch;
+  font-size: clamp(3rem, 8.5vw, 7rem);
+}
+
+section h2 {
+  max-width: 17ch;
+  font-size: clamp(2rem, 5vw, 4.4rem);
+}
+
+.hero-copy,
+.section-heading > p:last-child,
+.closing > p:not(.eyebrow) {
+  max-width: 760px;
+  color: var(--text-muted);
+  font-size: clamp(1.03rem, 2vw, 1.25rem);
+}
+
+.hero-copy {
+  margin: 1.5rem 0 0;
+}
+
+.hero-note {
+  max-width: 720px;
+  margin-top: 1.8rem;
+  color: #93a9bf;
+  font-size: 0.92rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.8rem;
+  color: var(--accent);
+  font-size: 0.77rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0.75rem 1.1rem;
+  border: 1px solid rgba(186, 230, 253, 0.22);
+  border-radius: 999px;
+  background: rgba(25, 62, 96, 0.64);
+  color: #eff6ff;
+  font-weight: 750;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(186, 230, 253, 0.56);
+  color: #fff;
+}
+
+.button--primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: var(--accent-contrast);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  background: var(--accent-strong);
+  color: #061522;
+}
+
+.proof,
+.path,
+.offer,
+.tools,
+.closing {
+  padding: clamp(1.5rem, 5vw, 4.25rem);
+}
+
+.role-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 2rem;
+}
+
+.role-grid span {
+  padding: 0.7rem 0.9rem;
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.08);
+  color: #dff5ff;
+  font-weight: 750;
+}
+
+.path-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.path-list li {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 1rem;
+  padding: 1.2rem;
+  border: 1px solid rgba(125, 211, 252, 0.14);
+  border-radius: 18px;
+  background: rgba(2, 9, 17, 0.3);
+}
+
+.step {
+  color: var(--accent);
+  font-weight: 850;
+  font-size: 1.25rem;
+}
+
+.path-list h3,
+.offer-grid h3,
+.tool-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.path-list p,
+.offer-grid p,
+.tool-card p {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+}
+
+.offer-grid,
+.tool-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.offer-grid article,
+.tool-card {
+  padding: 1.35rem;
+  border: 1px solid rgba(125, 211, 252, 0.14);
+  border-radius: 18px;
+  background: rgba(2, 9, 17, 0.3);
+}
+
+.tool-card {
+  display: block;
+  color: #eff6ff;
+  text-decoration: none;
+}
+
+.tool-card:hover,
+.tool-card:focus-visible {
+  border-color: rgba(125, 211, 252, 0.45);
+  transform: translateY(-2px);
+}
+
+.tool-card > span {
+  display: block;
+  margin-bottom: 0.7rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 2rem 0 0;
+  color: #93a9bf;
+  font-size: 0.9rem;
+}
+
+footer a {
+  color: var(--accent);
+}
+
+@media (max-width: 780px) {
+  .freelance-shell {
+    width: min(100% - 1rem, 1120px);
+    padding-top: 0.4rem;
+  }
+
+  .freelance-nav {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .freelance-nav nav {
+    width: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 0.25rem;
+  }
+
+  .freelance-nav nav a {
+    white-space: nowrap;
+  }
+
+  .hero,
+  .proof,
+  .path,
+  .offer,
+  .tools,
+  .closing {
+    border-radius: 20px;
+  }
+
+  .hero {
+    min-height: 64vh;
+  }
+
+  .path-list li {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+
+  .offer-grid,
+  .tool-grid {
+    grid-template-columns: 1fr;
+  }
+
+  footer {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
Creates a focused landing page for AV technicians who want to build an independent freelance career. The page emphasizes a gradual runway instead of a reckless jump, names common AV freelance roles, and routes people into existing Career Launch, Job Tracker, Launch Room, and Human Value Network tools.

Path: `/av-freelance/`

Includes a clear non-affiliation note for Encore.