### PR TITLE
Shorten AV freelance landing page

### DIFF
--- a/av-freelance/index.html
+++ b/av-freelance/index.html
@@ -17,9 +17,8 @@
     <header class="freelance-nav">
       <a class="brand-link" href="../index.html">3DVR</a>
       <nav aria-label="AV Freelance Launchpad navigation">
-        <a href="#path">The path</a>
-        <a href="#tools">Tools</a>
-        <a href="../career-launch/">Start</a>
+        <a href="../career-launch/">Career Plan</a>
+        <a href="../job-tracker/index.html">Job Tracker</a>
       </nav>
     </header>
 
@@ -33,110 +32,24 @@
         </p>
         <div class="hero-actions">
           <a class="button button--primary" href="../career-launch/">Build my freelance plan</a>
-          <a class="button" href="#path">See the transition path</a>
+          <a class="button" href="../job-tracker/index.html">Track opportunities</a>
         </div>
         <p class="hero-note">
           Especially relevant to people working at Encore and other large event-production companies who are curious about independent work. 3DVR is not affiliated with Encore.
         </p>
       </section>
 
-      <section class="proof" aria-labelledby="proofTitle">
+      <section class="path" aria-labelledby="pathTitle">
         <div class="section-heading">
-          <p class="eyebrow">Your experience already has value</p>
-          <h2 id="proofTitle">The hard part is not starting over. It is packaging what you already know.</h2>
-          <p>
-            Corporate AV teaches skills clients already pay freelancers for: calm troubleshooting, show awareness,
-            communication, setup speed, technical judgment, and the ability to make an event happen under pressure.
-          </p>
-        </div>
-        <div class="role-grid" aria-label="Common freelance AV roles">
-          <span>A1</span>
-          <span>A2</span>
-          <span>V1</span>
-          <span>V2</span>
-          <span>Graphics</span>
-          <span>Camera</span>
-          <span>LED</span>
-          <span>Playback</span>
-          <span>RF</span>
-          <span>Show Crew</span>
-        </div>
-      </section>
-
-      <section id="path" class="path" aria-labelledby="pathTitle">
-        <div class="section-heading">
-          <p class="eyebrow">A safer way out</p>
-          <h2 id="pathTitle">Do not leap. Build a runway.</h2>
-          <p>Freelancing gets less scary when it becomes a sequence of small proofs instead of one giant decision.</p>
+          <p class="eyebrow">Build a runway, not a leap</p>
+          <h2 id="pathTitle">Make independence boringly real.</h2>
         </div>
         <ol class="path-list">
-          <li>
-            <span class="step">01</span>
-            <div><h3>Name your strongest lane</h3><p>Pick the work you want to be called for first. You can expand later.</p></div>
-          </li>
-          <li>
-            <span class="step">02</span>
-            <div><h3>Set a real day rate</h3><p>Know your target, minimum, overtime terms, travel expectations, and what makes a job worth accepting.</p></div>
-          </li>
-          <li>
-            <span class="step">03</span>
-            <div><h3>Build three direct relationships</h3><p>Start with production companies, PMs, crew leads, and technicians who already understand your work.</p></div>
-          </li>
-          <li>
-            <span class="step">04</span>
-            <div><h3>Prove consistency before leaving</h3><p>Track calls, income, repeat clients, and your calendar until independent work feels boringly real.</p></div>
-          </li>
+          <li><span class="step">01</span><div><h3>Pick your lane</h3><p>Start with the AV role you want people to call you for.</p></div></li>
+          <li><span class="step">02</span><div><h3>Set your rate</h3><p>Know your target day rate, minimum, and boundaries.</p></div></li>
+          <li><span class="step">03</span><div><h3>Build relationships</h3><p>Find production companies and people who can call you directly.</p></div></li>
+          <li><span class="step">04</span><div><h3>Leave when ready</h3><p>Track repeat work until freelancing can support the life you want.</p></div></li>
         </ol>
-      </section>
-
-      <section class="offer" aria-labelledby="offerTitle">
-        <p class="eyebrow">What 3DVR can help with</p>
-        <h2 id="offerTitle">Your freelance business, without the business-school nonsense.</h2>
-        <div class="offer-grid">
-          <article><h3>Positioning</h3><p>Turn years of mixed AV experience into a clear one-sentence offer people remember.</p></article>
-          <article><h3>Rates</h3><p>Create a simple rate card and boundaries so every new call does not become a negotiation crisis.</p></article>
-          <article><h3>Opportunities</h3><p>Track companies, contacts, applications, callbacks, and who you should follow up with next.</p></article>
-          <article><h3>Availability</h3><p>Build a calendar that makes it easy to see when you can accept work and when your life needs space.</p></article>
-          <article><h3>Proof</h3><p>Collect credits, roles, photos, references, and repeat-client wins into a portfolio that earns trust.</p></article>
-          <article><h3>Independence</h3><p>Know when freelancing is actually strong enough to replace a job instead of gambling your stability.</p></article>
-        </div>
-      </section>
-
-      <section id="tools" class="tools" aria-labelledby="toolsTitle">
-        <div class="section-heading">
-          <p class="eyebrow">Use what already exists</p>
-          <h2 id="toolsTitle">Start building the runway today.</h2>
-        </div>
-        <div class="tool-grid">
-          <a class="tool-card" href="../career-launch/">
-            <span>Start here</span>
-            <h3>Career Launch</h3>
-            <p>Turn your current experience into a practical next-step plan.</p>
-          </a>
-          <a class="tool-card" href="../job-tracker/index.html">
-            <span>Build pipeline</span>
-            <h3>Job Tracker</h3>
-            <p>Keep companies, opportunities, status, and follow-ups in one place.</p>
-          </a>
-          <a class="tool-card" href="../launch-room/">
-            <span>Shape the bigger move</span>
-            <h3>Launch Room</h3>
-            <p>Clarify the kind of work and life you are actually trying to build.</p>
-          </a>
-        </div>
-      </section>
-
-      <section class="closing" aria-labelledby="closingTitle">
-        <p class="eyebrow">The goal</p>
-        <h2 id="closingTitle">More freedom. Better work. Stronger relationships.</h2>
-        <p>
-          Freelancing is not automatically better than employment. The point is choice: enough skill, reputation,
-          relationships, and tools that you can decide where your time goes instead of feeling trapped.
-        </p>
-        <div class="hero-actions">
-          <a class="button button--primary" href="../career-launch/">Start my transition</a>
-          <a class="button" href="../human-value-network/">Explore the bigger vision</a>
-        </div>
       </section>
     </main>
 


### PR DESCRIPTION
Keeps the strong first screen, removes in-page jump links and long explanatory sections, and reduces the page to a concise runway flow with direct links to Career Plan and Job Tracker.