### PR TITLE
Fix research-only task risk classification

### DIFF
--- a/apps/agent/test/task-orchestrator.test.js
+++ b/apps/agent/test/task-orchestrator.test.js
@@ -31,6 +31,21 @@ test('classifyTask separates code and high-risk side effects', () => {
   assert.equal(risky.highRisk, true);
 });
 
+test('classifyTask does not treat explicit no-side-effect research constraints as requested actions', () => {
+  const research = classifyTask(
+    'Research up to 10 public prospects. Do NOT send email, submit forms, DM, publish, buy anything, or contact anyone. Return the top 3 candidates with public evidence and a draft message for later review.'
+  );
+
+  assert.equal(research.kind, 'sales');
+  assert.equal(research.highRisk, false);
+});
+
+test('classifyTask keeps mixed or conditional side-effect instructions high risk', () => {
+  const mixed = classifyTask('Do not send anything yet, but publish the message after review.');
+
+  assert.equal(mixed.highRisk, true);
+});
+
 test('pickBackend prefers codex for code and openclaw for tool-heavy general work', () => {
   assert.equal(pickBackend(
     { backend: 'auto' },

--- a/apps/agent/thomas-agent/node/task-orchestrator.js
+++ b/apps/agent/thomas-agent/node/task-orchestrator.js
@@ -10,7 +10,7 @@ const DEFAULT_CLAUDE_MODEL = process.env.THREEDVR_AGENT_TASK_CLAUDE_MODEL || pro
 const DEFAULT_THINKING = process.env.THREEDVR_AGENT_TASK_THINKING || 'high';
 const HIGH_RISK_PATTERN = /\b(send|email|dm|sms|post|publish|deploy|merge|push|delete|remove|rm\s+-rf|reset\s+--hard|payment|charge|refund|purchase|buy|invoice|stripe|bank|payroll|credential|secret|token|password)\b/i;
 const CODE_PATTERN = /\b(code|repo|github|pull request|pr\b|commit|test|bug|fix|refactor|file|function|typescript|javascript|node|python|css|html)\b/i;
-const SALES_PATTERN = /\b(lead|sales|outreach|reply|inbox|customer|client|prospect|invoice|proposal|close)\b/i;
+const SALES_PATTERN = /\b(leads?|sales|outreach|repl(?:y|ies)|inbox|customers?|clients?|prospects?|invoices?|proposals?|close)\b/i;
 
 function parseInteger(value, fallback) {
   const parsed = Number.parseInt(String(value || ''), 10);
@@ -92,11 +92,27 @@ function parseArgs(argv) {
   return options;
 }
 
+function riskScanText(task) {
+  const text = normalizeText(task);
+  if (!text) return '';
+
+  return text
+    .split(/(?<=[.!?])\s+|\n+/)
+    .filter((sentence) => {
+      const trimmed = sentence.trim();
+      const prohibition = /^(?:do\s+not|don't|never|must\s+not)\b/i.test(trimmed);
+      const mixedIntent = /\b(?:then|after(?:wards)?|once|unless|but|however)\b/i.test(trimmed);
+      return !prohibition || mixedIntent;
+    })
+    .join(' ');
+}
+
 function classifyTask(task) {
   const text = normalizeText(task);
+  const requestedActions = riskScanText(text);
   return {
     kind: CODE_PATTERN.test(text) ? 'code' : SALES_PATTERN.test(text) ? 'sales' : 'general',
-    highRisk: HIGH_RISK_PATTERN.test(text),
+    highRisk: HIGH_RISK_PATTERN.test(requestedActions),
     needsTools: /\b(browser|website|gmail|calendar|file|terminal|shell|server|digital ocean|vps|deploy|repo|github)\b/i.test(text),
   };
 }


### PR DESCRIPTION
Fixes the Agent task classifier so explicit prohibition sentences such as “Do NOT send email… or contact anyone” are not mistaken for requested side effects. Mixed/conditional instructions remain high risk. Also recognizes plural sales terms such as prospects/customers.

Verification:
- `node --test test/task-orchestrator.test.js` — 12/12 passing
- `git diff --check` — clean
- Full `npm test` reached unrelated existing environment/data failures (missing `nodemailer` in this fresh worktree and CLI tests reading live lead state); the focused classifier suite passes.