### PR TITLE
Align website outreach with free draft → $99 upgrade funnel

### DIFF
--- a/apps/agent/thomas-agent/scripts/ask-sales
+++ b/apps/agent/thomas-agent/scripts/ask-sales
@@ -33,11 +33,11 @@ case "$MODE" in
     ;;
   website)
     printf '%s\n' \
-    "Hey, I help small businesses get websites cleaned up and launched for \$20/month." \
+    "Hey, I make simple one-page websites for small businesses." \
     "Need help fixing or improving your website this week?" \
-    "I help with simple website updates and launch support for \$20/month." \
+    "I can make a free draft first so you can see it before deciding." \
     "Want me to take a quick look at your site and suggest fixes?" \
-    "I help business owners get unstuck with websites for \$20/month." \
+    "If you like the draft, the Website Upgrade is \$99 one time." \
     "Just following up in case you still want help with your website." \
     "Still happy to help if you want to get your site moving this week." \
     "Want me to take a look?" \
@@ -77,7 +77,7 @@ case "$MODE" in
     "Checking back in to see if you still want help with your tech setup." \
     "Wanted to follow up and see if your app idea still needs support." \
     "Still interested in getting this launched or cleaned up?" \
-    "I can keep it simple and affordable at \$20/month." \
+    "I can start with a free draft so you can see it first." \
     "Happy to take a quick look whenever you're ready." \
     "Want me to send details?" \
     "Want me to take a look?" \
@@ -92,7 +92,7 @@ case "$MODE" in
     "Want help mapping it out?" \
     "Should I send a simple plan?" \
     "Want me to help you launch it?" \
-    "Want to keep it simple at \$20/month?" \
+    "Want me to make the free draft?" \
     "Want me to show you what I’d fix?" \
     "Should we start this week?"
     ;;
@@ -113,11 +113,11 @@ case "$MODE" in
     ;;
   *)
     printf '%s\n' \
-    "Hey, I help small businesses with websites and tech for \$20/month." \
+    "Hey, I help small businesses with simple websites and tech." \
     "Need help getting your website cleaned up or launched this week?" \
-    "I help with simple websites, app ideas, and tech support for \$20/month." \
+    "I help with simple websites, app ideas, and tech support." \
     "Want me to take a quick look at your website or tech setup?" \
-    "I help business owners get unstuck with websites and tech for \$20/month." \
+    "I help business owners get unstuck with websites and tech." \
     "Just following up in case you still want help with your website." \
     "Still happy to help if you want to get your site moving this week." \
     "Want me to take a look?" \

--- a/docs/business-sites-outreach-campaign.md
+++ b/docs/business-sites-outreach-campaign.md
@@ -8,7 +8,7 @@ Front door: https://portal.3dvr.tech/business-sites/
 
 Trust step: free first draft through https://portal.3dvr.tech/free-page/
 
-Paid path: $5/month to keep a basic page live; $20–$50/month for ongoing launch, updates, and follow-up help.
+Paid path: $99 one-time Website Upgrade to keep a basic page live; $20–$50/month for ongoing launch, updates, and follow-up help.
 
 ## Target order
 


### PR DESCRIPTION
Removes stale $20/month website-sales helper copy and aligns the website campaign docs/helper with the current free-draft-first funnel. Paid Website Upgrade remains an optional $99 one-time step after value is delivered. bash -n passes.