### PR TITLE
Include checkout intake in Stripe job notifications

### DIFF
--- a/api/webhooks/stripe.js
+++ b/api/webhooks/stripe.js
@@ -292,7 +292,22 @@ function readOneTimePaymentDetails(session = {}) {
   const amountCents = Number(session?.amount_total || metadata.custom_amount_cents || 0);
   const currency = String(session?.currency || 'usd').trim() || 'usd';
   const reason = String(metadata.custom_label || '').trim() || 'Custom one-time payment';
-  const description = String(metadata.custom_description || '').trim();
+  const checkoutFields = (Array.isArray(session?.custom_fields) ? session.custom_fields : [])
+    .map(field => {
+      const label = String(field?.label?.custom || field?.key || '').trim();
+      const value = String(
+        field?.text?.value
+        ?? field?.numeric?.value
+        ?? field?.dropdown?.value
+        ?? ''
+      ).trim();
+      return label && value ? `${label}: ${value}` : '';
+    })
+    .filter(Boolean);
+  const description = [
+    String(metadata.custom_description || '').trim(),
+    ...checkoutFields
+  ].filter(Boolean).join('\n');
   const amount = formatCurrencyAmount(amountCents, currency);
 
   return {

--- a/tests/stripe-webhook-cleanup.test.js
+++ b/tests/stripe-webhook-cleanup.test.js
@@ -508,7 +508,21 @@ test('stripe webhook sends one-time payment emails for payment-mode checkout ses
             custom_label: 'Custom project deposit',
             custom_description: 'Scoped sprint deposit',
             custom_amount_cents: '25000'
-          }
+          },
+          custom_fields: [
+            {
+              key: 'business_name',
+              label: { type: 'custom', custom: 'Business name' },
+              type: 'text',
+              text: { value: 'Acme Plumbing' }
+            },
+            {
+              key: 'site_url',
+              label: { type: 'custom', custom: 'Current site or free draft URL' },
+              type: 'text',
+              text: { value: 'https://example.com/draft' }
+            }
+          ]
         }
       }
     })
@@ -540,6 +554,8 @@ test('stripe webhook sends one-time payment emails for payment-mode checkout ses
   assert.match(transporter.sendMail.mock.calls[0].arguments[0].text, /\$250\.00/);
   assert.match(transporter.sendMail.mock.calls[0].arguments[0].text, /Custom project deposit/);
   assert.match(transporter.sendMail.mock.calls[0].arguments[0].text, /Scoped sprint deposit/);
+  assert.match(transporter.sendMail.mock.calls[0].arguments[0].text, /Business name: Acme Plumbing/);
+  assert.match(transporter.sendMail.mock.calls[1].arguments[0].html, /Current site or free draft URL: https:\/\/example\.com\/draft/);
   assert.match(transporter.sendMail.mock.calls[1].arguments[0].html, /Amount:<\/strong> \$250\.00/);
   assert.match(transporter.sendMail.mock.calls[1].arguments[0].html, /Reason:<\/strong> Custom project deposit/);
   assert.doesNotMatch(transporter.sendMail.mock.calls[0].arguments[0].subject, /Welcome to 3DVR\.Tech/);


### PR DESCRIPTION
Adds Checkout custom-field answers to one-time payment notification details. This makes the Website Upgrade payment arrive with business name, draft/site URL, and desired CTA instead of requiring a second intake chase. Includes webhook regression coverage. Syntax checks pass; repository CI will run dependencies/tests.