### PR TITLE
Teach Money Autopilot from Stripe revenue

### DIFF
--- a/api/money/autopilot-cron.js
+++ b/api/money/autopilot-cron.js
@@ -1,4 +1,5 @@
 import { runAutopilotCycle } from '../../src/money/autopilot.js';
+import { makeStripeClient } from '../../src/billing/stripe.js';
 
 function parseBoolean(value, fallback) {
   if (typeof value === 'boolean') {
@@ -54,6 +55,7 @@ function setHeaders(res) {
 export function createMoneyAutopilotCronHandler(options = {}) {
   const runAutopilotImpl = options.runAutopilotImpl || runAutopilotCycle;
   const config = options.config || process.env;
+  const stripeClient = options.stripeClient || makeStripeClient(config);
 
   return async function handler(req, res) {
     setHeaders(res);
@@ -93,7 +95,8 @@ export function createMoneyAutopilotCronHandler(options = {}) {
         autoDiscover,
         publishEnabled,
         vercelDeploy,
-        promotionEnabled
+        promotionEnabled,
+        stripeClient
       });
 
       return res.status(200).json({

--- a/api/money/loop.js
+++ b/api/money/loop.js
@@ -317,7 +317,8 @@ export function createMoneyLoopHandler(options = {}) {
           market: req?.query?.market ? String(req.query.market) : undefined,
           keywords: req?.query?.keywords ? parseCsvQuery(req.query.keywords) : undefined,
           channels: req?.query?.channels ? parseCsvQuery(req.query.channels) : undefined,
-          budget: req?.query?.budget
+          budget: req?.query?.budget,
+          stripeClient
         });
 
         return res.status(200).json({

--- a/api/webhooks/stripe.js
+++ b/api/webhooks/stripe.js
@@ -259,6 +259,62 @@ async function notifyTeamOfSubscriptionUpdate(email, details = {}, { transporter
   }
 }
 
+function readPaymentFailureDetails(invoice = {}, config = process.env) {
+  const amount = formatCurrencyAmount(invoice?.amount_due, invoice?.currency) || 'your invoice amount';
+  const portalOrigin = String(config?.PORTAL_ORIGIN || 'https://portal.3dvr.tech').trim().replace(/\/+$/, '');
+  const recoveryUrl = String(invoice?.hosted_invoice_url || '').trim() || `${portalOrigin}/billing/`;
+  const attemptCount = Number(invoice?.attempt_count || 0);
+  const nextPaymentAttempt = Number(invoice?.next_payment_attempt || 0);
+  const nextAttemptAt = nextPaymentAttempt
+    ? new Date(nextPaymentAttempt * 1000).toISOString()
+    : '';
+
+  return {
+    amount,
+    recoveryUrl,
+    attemptCount: Number.isFinite(attemptCount) ? attemptCount : 0,
+    nextAttemptAt
+  };
+}
+
+function shouldSendPaymentFailureRecovery(invoice = {}) {
+  const attemptCount = Number(invoice?.attempt_count || 0);
+  return !Number.isFinite(attemptCount) || attemptCount <= 1;
+}
+
+async function sendPaymentFailureRecoveryEmail(email, details = {}, { transporter, config } = {}) {
+  const gmailUser = String(config?.GMAIL_USER || '').trim();
+  const recoveryUrl = String(details.recoveryUrl || '').trim();
+  if (!email || !gmailUser || !recoveryUrl || !transporter?.sendMail) return false;
+
+  const amount = String(details.amount || 'your invoice amount').trim();
+  const retryText = details.nextAttemptAt
+    ? ` Stripe currently has another retry scheduled after ${details.nextAttemptAt}.`
+    : '';
+
+  try {
+    await sendMailSafely(transporter, {
+      from: `"Thomas @ 3DVR.Tech" <${gmailUser}>`,
+      to: email,
+      subject: 'Payment issue with your 3DVR plan',
+      text: `Hey there — Stripe could not process ${amount} for your 3DVR plan.${retryText}\n\nYou can fix the payment here:\n${recoveryUrl}\n\nThanks,\nThomas`,
+      html: `
+        <div style="font-family: sans-serif; font-size: 16px; line-height: 1.5;">
+          <h2>Quick billing fix</h2>
+          <p>Stripe could not process <strong>${escapeHtml(amount)}</strong> for your 3DVR plan.</p>
+          <p><a href="${escapeHtml(recoveryUrl)}">Update or complete the payment</a></p>
+          ${details.nextAttemptAt ? `<p>Stripe currently has another retry scheduled.</p>` : ''}
+          <p>Thanks,<br>Thomas<br>3DVR.Tech</p>
+        </div>
+      `
+    });
+    return true;
+  } catch (error) {
+    console.error(`Failed to send payment recovery email to ${email}:`, error?.message || error);
+    return false;
+  }
+}
+
 function formatCurrencyAmount(amountCents, currency = 'usd') {
   const normalizedCurrency = String(currency || 'usd').trim().toUpperCase() || 'USD';
   const normalizedAmountCents = Number(amountCents);
@@ -557,10 +613,18 @@ export function createStripeWebhookHandler(options = {}) {
       });
     }
 
+    const eventObject = event.data?.object || {};
+    const eventPaymentLink = typeof eventObject.payment_link === 'string'
+      ? eventObject.payment_link
+      : String(eventObject.payment_link?.id || '').trim();
     await logStripeEvent(event, {
       receivedAt: new Date().toISOString(),
       canceledCount: cleanupResult.canceledCount || 0,
-      cancelledSubscriptionIds: cleanupResult.cancelledSubscriptionIds || []
+      cancelledSubscriptionIds: cleanupResult.cancelledSubscriptionIds || [],
+      clientReferenceId: String(eventObject.client_reference_id || '').trim(),
+      paymentLinkId: eventPaymentLink,
+      amountCents: Number(eventObject.amount_total ?? eventObject.amount_paid ?? eventObject.amount_due ?? 0),
+      currency: String(eventObject.currency || '').trim().toLowerCase()
     }, {
       transporter,
       config: runtimeConfig
@@ -601,6 +665,19 @@ export function createStripeWebhookHandler(options = {}) {
         const updateDetails = readSubscriptionUpdateDetails(invoice, runtimeConfig);
         await sendSubscriptionUpdateEmail(email, updateDetails, { transporter, config: runtimeConfig });
         await notifyTeamOfSubscriptionUpdate(email, updateDetails, { transporter, config: runtimeConfig });
+      }
+    }
+
+    if (event.type === 'invoice.payment_failed') {
+      const invoice = event.data?.object || {};
+      const email = String(invoice.customer_email || '').trim();
+      if (email && shouldSendPaymentFailureRecovery(invoice)) {
+        const recoveryDetails = readPaymentFailureDetails(invoice, runtimeConfig);
+        const sent = await sendPaymentFailureRecoveryEmail(email, recoveryDetails, {
+          transporter,
+          config: runtimeConfig
+        });
+        console.log('Stripe payment recovery:', invoice.id || '', email, sent ? 'sent' : 'not-sent');
       }
     }
 

--- a/src/money/autopilot.js
+++ b/src/money/autopilot.js
@@ -1,6 +1,7 @@
 import { runMoneyLoop } from './engine.js';
 import { collectDemandSignals } from './sources.js';
 import { fetchFirstPartyAnalyticsHints } from '../analytics/freePageReader.js';
+import { collectStripeRevenueHints } from './stripe-revenue.js';
 
 const DEFAULT_AUTOPILOT_PROFILE = {
   market: 'people who need a simple first website for a project, service, or small business',
@@ -14,7 +15,7 @@ const DEFAULT_AUTOPILOT_PROFILE = {
   publishPathPrefix: 'money-ai/offers',
   checkoutCtaLabel: 'Keep It Live',
   defaultDestinationUrl: 'https://portal.3dvr.tech/free-page/',
-  offerProfile: 'free-page-starter'
+  offerProfile: 'auto'
 };
 
 const FIRST_PARTY_OFFER_PROFILES = {
@@ -62,6 +63,46 @@ const FIRST_PARTY_OFFER_PROFILES = {
         headline: 'A free first website page',
         body: 'Not everyone needs a full site first. I am helping people get one simple page live: what you do, who it is for, proof, and a contact path.',
         cta: 'Get a free page'
+      }
+    ]
+  },
+  'website-upgrade': {
+    id: '3dvr-website-upgrade',
+    title: '3DVR Website Upgrade',
+    audience: 'small service businesses with an existing site that is dated, unclear, or weak at turning visitors into calls and inquiries',
+    problem: 'A business can have a website and still lose customers when the offer, proof, mobile layout, or next action is hard to understand.',
+    solution: 'A focused one-page website upgrade with a clearer offer, stronger call to action, mobile cleanup, and a simple customer contact path.',
+    mvp: 'One business-ready page with offer, proof, services, primary CTA, contact path, and mobile-first layout.',
+    suggestedPrice: '$99 one time',
+    painScore: 84,
+    willingnessToPay: 78,
+    speedToBuild: 92,
+    competitionGap: 63,
+    evidence: [
+      '3DVR already has a live Website Upgrade checkout and free-site outreach pipeline.',
+      'The existing workflow can use a free concept as proof before asking for the paid upgrade.'
+    ],
+    executionChecklist: [
+      'Target owner-led service businesses whose current site has an unclear offer or customer path.',
+      'Create a small personalized homepage concept before asking for payment.',
+      'Send the concept with one question and one $99 Website Upgrade checkout.',
+      'After payment, move the business into the build queue automatically.',
+      'Use completed upgrades and customer replies to refine the next concept and offer.'
+    ],
+    adDrafts: [
+      {
+        id: 'website-upgrade-email-1',
+        channel: 'email',
+        headline: 'I made a cleaner homepage direction for your business',
+        body: 'I put together a simple homepage direction that makes the offer and next step easier to understand. If you like the direction, I can turn it into a business-ready one-page upgrade for $99.',
+        cta: 'See the concept'
+      },
+      {
+        id: 'website-upgrade-local-1',
+        channel: 'local outreach',
+        headline: 'A small website upgrade instead of a rebuild',
+        body: 'You may not need a whole new website. I can clean up the main page so customers understand what you do and what to do next.',
+        cta: 'See a free concept'
       }
     ]
   },
@@ -675,6 +716,68 @@ export function resolveAutopilotConfig(options = {}) {
   };
 }
 
+const REVENUE_OFFER_ALIASES = Object.freeze({
+  'free-page-starter': 'free-page-starter',
+  'website-upgrade': 'website-upgrade',
+  'microbusiness-launch-sprint': 'microbusiness-launch-sprint'
+});
+
+function trackingValue(value, maxLength = 150) {
+  return String(value || '')
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, maxLength);
+}
+
+export function buildAutopilotReferenceId(runId = '', offerProfile = '') {
+  const run = trackingValue(runId, 150);
+  const offer = trackingValue(offerProfile, 40);
+  return [run, offer].filter(Boolean).join('__').slice(0, 200);
+}
+
+export function addCheckoutAttribution(checkoutUrl = '', { runId = '', offerProfile = '' } = {}) {
+  const raw = String(checkoutUrl || '').trim();
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    const referenceId = buildAutopilotReferenceId(runId, offerProfile);
+    if (referenceId) url.searchParams.set('client_reference_id', referenceId);
+    if (!url.searchParams.has('utm_source')) url.searchParams.set('utm_source', '3dvr');
+    if (!url.searchParams.has('utm_medium')) url.searchParams.set('utm_medium', 'money-autopilot');
+    if (offerProfile && !url.searchParams.has('utm_campaign')) {
+      url.searchParams.set('utm_campaign', trackingValue(offerProfile, 150));
+    }
+    return url.toString();
+  } catch {
+    return raw;
+  }
+}
+
+export function selectRevenueBackedOffer(configuredProfile = 'auto', revenue = {}) {
+  const requested = String(configuredProfile || '').trim() || 'auto';
+  if (requested !== 'auto') {
+    return { profile: requested, source: 'configured', checkoutUrl: '', evidence: null };
+  }
+
+  const candidates = (Array.isArray(revenue?.byOffer) ? revenue.byOffer : [])
+    .map(item => ({ ...item, profile: REVENUE_OFFER_ALIASES[item?.offer] || '' }))
+    .filter(item => item.profile && (Number(item.paidCheckouts) >= 2 || Number(item.grossRevenueCents) >= 20000))
+    .sort((a, b) => Number(b.grossRevenueCents || 0) - Number(a.grossRevenueCents || 0));
+
+  if (candidates.length) {
+    const winner = candidates[0];
+    return {
+      profile: winner.profile,
+      source: 'stripe-revenue',
+      checkoutUrl: String(winner.checkoutUrl || '').trim(),
+      evidence: winner
+    };
+  }
+
+  return { profile: 'free-page-starter', source: 'fallback', checkoutUrl: '', evidence: null };
+}
+
 function applyFirstPartyOfferProfile(report = {}, profileName = '') {
   const profile = FIRST_PARTY_OFFER_PROFILES[profileName];
   if (!profile) {
@@ -1025,6 +1128,19 @@ export async function runAutopilotCycle(options = {}) {
   const config = resolveAutopilotConfig(options);
   const warnings = [];
 
+  let revenue = options.revenue || null;
+  if (!revenue) {
+    try {
+      revenue = await (options.collectRevenueImpl || collectStripeRevenueHints)({
+        stripeClient: options.stripeClient,
+        limit: options.revenueSampleLimit || 100
+      });
+    } catch (error) {
+      revenue = { enabled: false, byOffer: [] };
+      warnings.push(`Stripe revenue signals unavailable: ${error?.message || error}`);
+    }
+  }
+
   const useFirstPartyAnalytics = config.analytics.source === 'gun';
   const analytics = useFirstPartyAnalytics
     ? await (options.firstPartyAnalyticsImpl || fetchFirstPartyAnalyticsHints)(config.analytics, {
@@ -1091,20 +1207,26 @@ export async function runAutopilotCycle(options = {}) {
     openAiModel: config.openAiModel
   });
 
-  const profiledReport = applyFirstPartyOfferProfile(report, config.offerProfile);
+  const offerSelection = selectRevenueBackedOffer(config.offerProfile, revenue);
+  const profiledReport = applyFirstPartyOfferProfile(report, offerSelection.profile);
+  const baseCheckoutUrl = offerSelection.checkoutUrl || config.monetization.checkoutUrl;
+  const attributedCheckoutUrl = addCheckoutAttribution(baseCheckoutUrl, {
+    runId: profiledReport.runId,
+    offerProfile: offerSelection.profile
+  });
 
   const reportWithMonetization = {
     ...profiledReport,
     monetization: {
       ...(profiledReport.monetization || {}),
-      checkoutUrl: config.monetization.checkoutUrl || config.promotion.defaultDestinationUrl,
-      checkoutCtaLabel: config.monetization.checkoutUrl
+      checkoutUrl: attributedCheckoutUrl || config.promotion.defaultDestinationUrl,
+      checkoutCtaLabel: baseCheckoutUrl
         ? config.monetization.checkoutCtaLabel
         : 'Start Free'
     }
   };
 
-  if (!config.monetization.checkoutUrl) {
+  if (!baseCheckoutUrl) {
     warnings.push(`Checkout URL not configured. Campaign traffic will use ${config.promotion.defaultDestinationUrl}.`);
   }
 
@@ -1193,7 +1315,7 @@ export async function runAutopilotCycle(options = {}) {
 
   publish.destinationUrl = publish.vercel.url
     || publish.github.htmlUrl
-    || config.monetization.checkoutUrl
+    || attributedCheckoutUrl
     || config.promotion.defaultDestinationUrl
     || '';
 
@@ -1253,6 +1375,8 @@ export async function runAutopilotCycle(options = {}) {
     budget: reportWithMonetization.input?.budget || config.budget,
     marketSelection,
     analytics,
+    revenue,
+    offerSelection,
     signalsAnalyzed: reportWithMonetization.signals.length,
     warnings: uniqueStrings([...warnings, ...(reportWithMonetization.warnings || [])]),
     topOpportunity: reportWithMonetization.topOpportunity,
@@ -1262,9 +1386,11 @@ export async function runAutopilotCycle(options = {}) {
     publish,
     promotion,
     monetization: {
-      checkoutConfigured: Boolean(config.monetization.checkoutUrl),
-      checkoutUrl: config.monetization.checkoutUrl,
-      checkoutCtaLabel: config.monetization.checkoutCtaLabel
+      checkoutConfigured: Boolean(baseCheckoutUrl),
+      baseCheckoutUrl,
+      checkoutUrl: attributedCheckoutUrl,
+      checkoutCtaLabel: baseCheckoutUrl ? config.monetization.checkoutCtaLabel : 'Start Free',
+      clientReferenceId: buildAutopilotReferenceId(reportWithMonetization.runId, offerSelection.profile)
     },
     artifacts: {
       offerHtml

--- a/src/money/stripe-revenue.js
+++ b/src/money/stripe-revenue.js
@@ -1,0 +1,150 @@
+const ACTIVE_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing', 'past_due']);
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+export function normalizeOfferKey(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+export function parseAutopilotReferenceId(value = '') {
+  const normalized = normalizeText(value);
+  const [runId = '', offerProfile = ''] = normalized.split('__', 2);
+  return {
+    runId: normalizeText(runId),
+    offerProfile: normalizeOfferKey(offerProfile)
+  };
+}
+
+function paymentLinkId(session = {}) {
+  return typeof session.payment_link === 'string'
+    ? session.payment_link
+    : normalizeText(session.payment_link?.id);
+}
+
+function offerKeyFromPaymentLink(link = {}) {
+  const metadata = link.metadata && typeof link.metadata === 'object' ? link.metadata : {};
+  return normalizeOfferKey(
+    metadata.offer
+    || metadata['3dvr_offer']
+    || metadata.offer_id
+    || metadata.plan
+    || ''
+  );
+}
+function monthlyCentsForItem(item = {}) {
+  const price = item.price || {};
+  const recurring = price.recurring || {};
+  const amount = Number(price.unit_amount ?? price.unit_amount_decimal ?? 0);
+  const quantity = Math.max(1, Number(item.quantity || 1));
+  const intervalCount = Math.max(1, Number(recurring.interval_count || 1));
+  if (!Number.isFinite(amount) || amount <= 0 || !recurring.interval) return 0;
+
+  const gross = amount * quantity;
+  if (recurring.interval === 'month') return Math.round(gross / intervalCount);
+  if (recurring.interval === 'year') return Math.round(gross / (12 * intervalCount));
+  if (recurring.interval === 'week') return Math.round((gross * 52) / (12 * intervalCount));
+  if (recurring.interval === 'day') return Math.round((gross * 30) / intervalCount);
+  return 0;
+}
+
+function addOfferRevenue(groups, offer, session, link) {
+  if (!offer) return;
+  const current = groups.get(offer) || {
+    offer,
+    paidCheckouts: 0,
+    grossRevenueCents: 0,
+    checkoutUrl: normalizeText(link?.url),
+    lastPaidAt: null
+  };
+  current.paidCheckouts += 1;
+  current.grossRevenueCents += Number(session.amount_total || 0);
+  const created = Number(session.created || 0);
+  if (created && (!current.lastPaidAt || created > current.lastPaidAt)) current.lastPaidAt = created;
+  if (!current.checkoutUrl && link?.url) current.checkoutUrl = normalizeText(link.url);
+  groups.set(offer, current);
+}
+export function summarizeStripeRevenue({ sessions = [], paymentLinks = [], subscriptions = [] } = {}) {
+  const links = new Map(paymentLinks.map(link => [normalizeText(link?.id), link]));
+  const groups = new Map();
+  let paidCheckouts = 0;
+  let grossRevenueCents = 0;
+  let attributedPaidCheckouts = 0;
+
+  for (const session of sessions) {
+    if (normalizeText(session?.payment_status).toLowerCase() !== 'paid') continue;
+    paidCheckouts += 1;
+    grossRevenueCents += Number(session?.amount_total || 0);
+
+    const reference = parseAutopilotReferenceId(session?.client_reference_id);
+    const link = links.get(paymentLinkId(session));
+    const offer = reference.offerProfile || offerKeyFromPaymentLink(link);
+    if (reference.runId || offer) attributedPaidCheckouts += 1;
+    addOfferRevenue(groups, offer, session, link);
+  }
+
+  let monthlyRecurringRevenueCents = 0;
+  let activeSubscribers = 0;
+  for (const subscription of subscriptions) {
+    if (!ACTIVE_SUBSCRIPTION_STATUSES.has(normalizeText(subscription?.status).toLowerCase())) continue;
+    activeSubscribers += 1;
+    for (const item of subscription?.items?.data || []) {
+      monthlyRecurringRevenueCents += monthlyCentsForItem(item);
+    }
+  }
+
+  return {
+    enabled: true,
+    paidCheckouts,
+    attributedPaidCheckouts,
+    unattributedPaidCheckouts: Math.max(0, paidCheckouts - attributedPaidCheckouts),
+    grossRevenueCents,
+    activeSubscribers,
+    monthlyRecurringRevenueCents,
+    byOffer: [...groups.values()].sort((a, b) => (
+      b.grossRevenueCents - a.grossRevenueCents || b.paidCheckouts - a.paidCheckouts
+    ))
+  };
+}
+export async function collectStripeRevenueHints({ stripeClient, limit = 100 } = {}) {
+  if (!stripeClient?.checkout?.sessions?.list) {
+    return {
+      enabled: false,
+      reason: 'Stripe Checkout session access is unavailable.',
+      paidCheckouts: 0,
+      attributedPaidCheckouts: 0,
+      unattributedPaidCheckouts: 0,
+      grossRevenueCents: 0,
+      activeSubscribers: 0,
+      monthlyRecurringRevenueCents: 0,
+      byOffer: []
+    };
+  }
+
+  const boundedLimit = Math.max(10, Math.min(Number(limit) || 100, 100));
+  const [sessionsResult, linksResult, subscriptionsResult] = await Promise.all([
+    stripeClient.checkout.sessions.list({ limit: boundedLimit }),
+    stripeClient.paymentLinks?.list
+      ? stripeClient.paymentLinks.list({ limit: boundedLimit })
+      : Promise.resolve({ data: [] }),
+    stripeClient.subscriptions?.list
+      ? stripeClient.subscriptions.list({ status: 'all', limit: boundedLimit })
+      : Promise.resolve({ data: [] })
+  ]);
+
+  return {
+    ...summarizeStripeRevenue({
+      sessions: sessionsResult?.data || [],
+      paymentLinks: linksResult?.data || [],
+      subscriptions: subscriptionsResult?.data || []
+    }),
+    generatedAt: new Date().toISOString(),
+    sampleLimit: boundedLimit
+  };
+}

--- a/tests/money-autopilot.test.js
+++ b/tests/money-autopilot.test.js
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  addCheckoutAttribution,
+  buildAutopilotReferenceId,
   buildOfferHtml,
   deployOfferToVercel,
   publishOfferToGitHub,
   resolveAutopilotConfig,
-  runAutopilotCycle
+  runAutopilotCycle,
+  selectRevenueBackedOffer
 } from '../src/money/autopilot.js';
 
 function createGithubFetchMock() {
@@ -107,7 +110,7 @@ test('resolveAutopilotConfig defaults to the free page starter profile', () => {
 
   assert.equal(config.market, 'people who need a simple first website for a project, service, or small business');
   assert.equal(config.autoDiscover, false);
-  assert.equal(config.offerProfile, 'free-page-starter');
+  assert.equal(config.offerProfile, 'auto');
   assert.equal(config.analytics.source, 'auto');
 });
 
@@ -406,7 +409,9 @@ test('runAutopilotCycle uses checkout URL as destination fallback', async () => 
     })
   });
 
-  assert.equal(result.publish.destinationUrl, 'https://buy.stripe.com/example123');
+  const checkoutDestination = new URL(result.publish.destinationUrl);
+  assert.equal(`${checkoutDestination.origin}${checkoutDestination.pathname}`, 'https://buy.stripe.com/example123');
+  assert.equal(checkoutDestination.searchParams.get('client_reference_id'), 'money-checkout__free-page-starter');
   assert.equal(result.monetization.checkoutConfigured, true);
   assert.equal(result.monetization.checkoutCtaLabel, 'Keep It Live');
   assert.equal(result.topOpportunity.title, '3DVR Free Page');
@@ -452,4 +457,62 @@ test('runAutopilotCycle uses public free page campaign page when checkout is mis
   assert.equal(result.promotion.destinationUrl, 'https://portal.3dvr.tech/free-page/');
   assert.equal(result.monetization.checkoutConfigured, false);
   assert.match(result.warnings.join('\n'), /free-page/);
+});
+
+test('checkout attribution adds Stripe reconciliation and campaign parameters', () => {
+  const url = addCheckoutAttribution('https://buy.stripe.com/example123', {
+    runId: 'money-20260828-abc',
+    offerProfile: 'website-upgrade'
+  });
+  const parsed = new URL(url);
+
+  assert.equal(buildAutopilotReferenceId('money-20260828-abc', 'website-upgrade'), 'money-20260828-abc__website-upgrade');
+  assert.equal(parsed.searchParams.get('client_reference_id'), 'money-20260828-abc__website-upgrade');
+  assert.equal(parsed.searchParams.get('utm_source'), '3dvr');
+  assert.equal(parsed.searchParams.get('utm_medium'), 'money-autopilot');
+  assert.equal(parsed.searchParams.get('utm_campaign'), 'website-upgrade');
+});
+
+test('revenue-backed offer selection requires meaningful evidence', () => {
+  const oneSmallSale = selectRevenueBackedOffer('auto', {
+    byOffer: [{ offer: 'website-upgrade', paidCheckouts: 1, grossRevenueCents: 9900, checkoutUrl: 'https://buy.stripe.com/upgrade' }]
+  });
+  assert.equal(oneSmallSale.profile, 'free-page-starter');
+
+  const winner = selectRevenueBackedOffer('auto', {
+    byOffer: [{ offer: 'website-upgrade', paidCheckouts: 2, grossRevenueCents: 19800, checkoutUrl: 'https://buy.stripe.com/upgrade' }]
+  });
+  assert.equal(winner.profile, 'website-upgrade');
+  assert.equal(winner.source, 'stripe-revenue');
+  assert.equal(winner.checkoutUrl, 'https://buy.stripe.com/upgrade');
+});
+test('runAutopilotCycle follows a proven Stripe offer and tracks the next checkout', async () => {
+  const result = await runAutopilotCycle({
+    env: {
+      MONEY_AUTOPILOT_PUBLISH: 'false',
+      MONEY_AUTOPILOT_PROMOTION: 'false',
+      MONEY_AUTOPILOT_OFFER_PROFILE: 'auto'
+    },
+    revenue: {
+      enabled: true,
+      byOffer: [{ offer: 'website-upgrade', paidCheckouts: 2, grossRevenueCents: 19800, checkoutUrl: 'https://buy.stripe.com/upgrade' }]
+    },
+    runLoopImpl: async payload => ({
+      runId: 'money-proven-offer',
+      generatedAt: '2026-08-28T00:00:00.000Z',
+      input: payload,
+      warnings: [],
+      signals: [],
+      opportunities: [],
+      adDrafts: [],
+      executionChecklist: []
+    })
+  });
+
+  assert.equal(result.offerSelection.profile, 'website-upgrade');
+  assert.equal(result.offerSelection.source, 'stripe-revenue');
+  assert.equal(result.topOpportunity.title, '3DVR Website Upgrade');
+  assert.equal(result.monetization.checkoutConfigured, true);
+  assert.match(result.monetization.checkoutUrl, /client_reference_id=money-proven-offer__website-upgrade/);
+  assert.match(result.artifacts.offerHtml, /3DVR Website Upgrade/);
 });

--- a/tests/money-stripe-revenue.test.js
+++ b/tests/money-stripe-revenue.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  collectStripeRevenueHints,
+  parseAutopilotReferenceId,
+  summarizeStripeRevenue,
+} from '../src/money/stripe-revenue.js';
+
+test('parseAutopilotReferenceId separates run and offer profile', () => {
+  assert.deepEqual(
+    parseAutopilotReferenceId('money-20260828-abc__free-page-starter'),
+    { runId: 'money-20260828-abc', offerProfile: 'free-page-starter' }
+  );
+});
+
+test('summarizeStripeRevenue attributes paid checkouts and calculates MRR', () => {
+  const result = summarizeStripeRevenue({
+    paymentLinks: [
+      { id: 'plink_upgrade', url: 'https://buy.stripe.com/upgrade', metadata: { offer: 'website-upgrade' } },
+    ],
+    sessions: [
+      { payment_status: 'paid', amount_total: 500, client_reference_id: 'money-run-1__free-page-starter', payment_link: 'plink_upgrade', created: 10 },
+      { payment_status: 'paid', amount_total: 9900, payment_link: 'plink_upgrade', created: 20 },
+      { payment_status: 'unpaid', amount_total: 9900, payment_link: 'plink_upgrade', created: 30 },
+    ],
+    subscriptions: [
+      {
+        status: 'active',
+        items: { data: [{ quantity: 1, price: { unit_amount: 2000, recurring: { interval: 'month', interval_count: 1 } } }] },
+      },
+    ],
+  });
+
+  assert.equal(result.paidCheckouts, 2);
+  assert.equal(result.grossRevenueCents, 10400);
+  assert.equal(result.monthlyRecurringRevenueCents, 2000);
+  assert.equal(result.byOffer.find(item => item.offer === 'website-upgrade').grossRevenueCents, 9900);
+  assert.equal(result.byOffer.find(item => item.offer === 'free-page-starter').grossRevenueCents, 500);
+});
+test('collectStripeRevenueHints reads recent Stripe sessions, links, and subscriptions', async () => {
+  const stripeClient = {
+    checkout: {
+      sessions: {
+        async list() {
+          return { data: [{ payment_status: 'paid', amount_total: 9900, payment_link: 'plink_upgrade', created: 20 }] };
+        },
+      },
+    },
+    paymentLinks: {
+      async list() {
+        return { data: [{ id: 'plink_upgrade', url: 'https://buy.stripe.com/upgrade', metadata: { offer: 'website-upgrade' } }] };
+      },
+    },
+    subscriptions: {
+      async list() {
+        return { data: [] };
+      },
+    },
+  };
+
+  const result = await collectStripeRevenueHints({ stripeClient, limit: 50 });
+  assert.equal(result.enabled, true);
+  assert.equal(result.sampleLimit, 50);
+  assert.equal(result.paidCheckouts, 1);
+  assert.equal(result.byOffer[0].offer, 'website-upgrade');
+  assert.equal(result.byOffer[0].checkoutUrl, 'https://buy.stripe.com/upgrade');
+});

--- a/tests/stripe-webhook-cleanup.test.js
+++ b/tests/stripe-webhook-cleanup.test.js
@@ -639,3 +639,71 @@ test('stripe webhook sends subscription update emails for prorated plan changes'
   assert.match(transporter.sendMail.mock.calls[1].arguments[0].html, /Amount charged today:<\/strong> \$68\.55/);
   assert.doesNotMatch(transporter.sendMail.mock.calls[0].arguments[0].subject, /Welcome to 3DVR\.Tech/);
 });
+
+test('stripe webhook sends one recovery email on the first failed invoice attempt', async () => {
+  const transporter = { sendMail: mock.fn(async payload => payload) };
+  const handler = createStripeWebhookHandler({
+    stripeClient: createStripeState().stripe,
+    config: { ...baseConfig, GMAIL_USER: 'billing@3dvr.tech', STRIPE_LOG_EMAIL: '' },
+    transporter,
+    readRawBody: async () => Buffer.from('{}'),
+    constructEvent: () => ({
+      id: 'evt_invoice_failed',
+      type: 'invoice.payment_failed',
+      created: 1700000000,
+      data: {
+        object: {
+          id: 'in_failed',
+          amount_due: 2000,
+          currency: 'usd',
+          customer_email: 'client@example.com',
+          hosted_invoice_url: 'https://invoice.stripe.com/recover-me',
+          attempt_count: 1,
+          next_payment_attempt: 1700086400
+        }
+      }
+    })
+  });
+
+  const req = { method: 'POST', headers: { 'stripe-signature': 'sig_test' } };
+  const res = createMockRes();
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(transporter.sendMail.mock.calls.length, 1);
+  const message = transporter.sendMail.mock.calls[0].arguments[0];
+  assert.equal(message.subject, 'Payment issue with your 3DVR plan');
+  assert.match(message.text, /\$20\.00/);
+  assert.match(message.text, /https:\/\/invoice\.stripe\.com\/recover-me/);
+});
+test('stripe webhook does not email on later automatic retry failures', async () => {
+  const transporter = { sendMail: mock.fn(async payload => payload) };
+  const handler = createStripeWebhookHandler({
+    stripeClient: createStripeState().stripe,
+    config: { ...baseConfig, GMAIL_USER: 'billing@3dvr.tech', STRIPE_LOG_EMAIL: '' },
+    transporter,
+    readRawBody: async () => Buffer.from('{}'),
+    constructEvent: () => ({
+      id: 'evt_invoice_failed_retry',
+      type: 'invoice.payment_failed',
+      created: 1700000000,
+      data: {
+        object: {
+          id: 'in_failed',
+          amount_due: 2000,
+          currency: 'usd',
+          customer_email: 'client@example.com',
+          hosted_invoice_url: 'https://invoice.stripe.com/recover-me',
+          attempt_count: 2
+        }
+      }
+    })
+  });
+
+  const req = { method: 'POST', headers: { 'stripe-signature': 'sig_test' } };
+  const res = createMockRes();
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(transporter.sendMail.mock.calls.length, 0);
+});


### PR DESCRIPTION
$## What changed\n- feed recent Stripe checkout + subscription revenue into Money Autopilot\n- keep the free-page wedge until a known offer has >=2 paid checkouts or >=$200 observed revenue\n- attribute generated Stripe Payment Link checkouts to the exact money run/offer\n- send one recovery email on the first failed subscription invoice attempt\n- pass Stripe into scheduled/manual Money Autopilot runs\n\n## Safety\n- no send-volume increase\n- no automatic spend increase\n- no offer switch on a single small sale\n- no repeated failed-payment email on later Stripe retries\n\n## Verification\n39 focused money/Stripe tests pass.