### PR TITLE
Clean money evidence in server runtime

### DIFF
--- a/src/analytics/freePageReader.js
+++ b/src/analytics/freePageReader.js
@@ -35,7 +35,7 @@ function dateRange(now, days) {
 
 async function resolveGunImpl(explicitImpl) {
   if (explicitImpl) return explicitImpl;
-  const moduleResult = await import('gun');
+  const moduleResult = await import('gun/gun.js');
   const GunImpl = moduleResult.default || moduleResult;
   if (typeof GunImpl !== 'function') {
     throw new Error('Unable to load Gun for first-party analytics.');

--- a/src/money/stripe-revenue.js
+++ b/src/money/stripe-revenue.js
@@ -15,10 +15,18 @@ export function normalizeOfferKey(value) {
 
 export function parseAutopilotReferenceId(value = '') {
   const normalized = normalizeText(value);
+  if (!normalized.includes('__')) {
+    return { runId: '', offerProfile: '' };
+  }
   const [runId = '', offerProfile = ''] = normalized.split('__', 2);
+  const normalizedRunId = normalizeText(runId);
+  const normalizedOffer = normalizeOfferKey(offerProfile);
+  if (!/^money-[a-z0-9_-]+$/i.test(normalizedRunId) || !normalizedOffer) {
+    return { runId: '', offerProfile: '' };
+  }
   return {
-    runId: normalizeText(runId),
-    offerProfile: normalizeOfferKey(offerProfile)
+    runId: normalizedRunId,
+    offerProfile: normalizedOffer
   };
 }
 

--- a/tests/free-page-analytics.test.js
+++ b/tests/free-page-analytics.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { readFile } from 'node:fs/promises';
 import {
   FREE_PAGE_ANALYTICS_PATH,
   createFreePageAnalyticsEvent,
@@ -125,4 +126,11 @@ test('returns Money Printer compatible analytics from a Gun reader', async () =>
   assert.equal(result.pageViews, 1);
   assert.equal(result.leads, 1);
   assert.deepEqual(result.topPaths, ['/free-page/']);
+});
+
+
+test('server analytics reader uses the filesystem-free Gun core build', async () => {
+  const source = await readFile(new URL('../src/analytics/freePageReader.js', import.meta.url), 'utf8');
+  assert.match(source, /import\('gun\/gun\.js'\)/);
+  assert.doesNotMatch(source, /import\('gun'\)/);
 });

--- a/tests/money-stripe-revenue.test.js
+++ b/tests/money-stripe-revenue.test.js
@@ -14,6 +14,18 @@ test('parseAutopilotReferenceId separates run and offer profile', () => {
   );
 });
 
+
+test('parseAutopilotReferenceId rejects unrelated legacy client references', () => {
+  assert.deepEqual(parseAutopilotReferenceId('Cg-NVNIbxWPDBqX7OmllJQqjxy2t3KA_U2DqQBjcPQ8'), {
+    runId: '',
+    offerProfile: ''
+  });
+  assert.deepEqual(parseAutopilotReferenceId('portal-user__'), {
+    runId: '',
+    offerProfile: ''
+  });
+});
+
 test('summarizeStripeRevenue attributes paid checkouts and calculates MRR', () => {
   const result = summarizeStripeRevenue({
     paymentLinks: [
@@ -38,6 +50,22 @@ test('summarizeStripeRevenue attributes paid checkouts and calculates MRR', () =
   assert.equal(result.byOffer.find(item => item.offer === 'website-upgrade').grossRevenueCents, 9900);
   assert.equal(result.byOffer.find(item => item.offer === 'free-page-starter').grossRevenueCents, 500);
 });
+
+test('summarizeStripeRevenue does not count arbitrary Stripe client references as autopilot attribution', () => {
+  const result = summarizeStripeRevenue({
+    sessions: [
+      { payment_status: 'paid', amount_total: 10000, client_reference_id: 'portal-user-public-key', created: 10 },
+      { payment_status: 'paid', amount_total: 500, client_reference_id: 'money-run-2__free-page-starter', created: 20 }
+    ]
+  });
+
+  assert.equal(result.paidCheckouts, 2);
+  assert.equal(result.attributedPaidCheckouts, 1);
+  assert.equal(result.unattributedPaidCheckouts, 1);
+  assert.equal(result.byOffer.length, 1);
+  assert.equal(result.byOffer[0].offer, 'free-page-starter');
+});
+
 test('collectStripeRevenueHints reads recent Stripe sessions, links, and subscriptions', async () => {
   const stripeClient = {
     checkout: {


### PR DESCRIPTION
Tightens Money Autopilot evidence quality after live verification.\n\n- only treat `money-*__offer-profile` client references as Autopilot attribution\n- keep legacy/portal Stripe references out of attribution counts\n- load the filesystem-free Gun core build for first-party analytics in Vercel\n\nFocused evidence/analytics/autopilot tests: 29/29 passed.