### PR TITLE
Give server analytics a WebSocket transport

### DIFF
--- a/scripts/playwright/smoke.mjs
+++ b/scripts/playwright/smoke.mjs
@@ -87,6 +87,8 @@ try {
   assert(response && response.ok(), `Expected ${baseUrl} to return 2xx/3xx`);
 
   await page.waitForSelector('#home-title', { timeout: 10000 });
+  await page.waitForLoadState('networkidle');
+  await page.waitForFunction(() => document.title === '3DVR Portal', null, { timeout: 10000 });
   const pageTitle = await page.title();
   const heading = (await page.locator('#home-title').innerText()).trim();
   const operatorLink = page.locator('.operator-link');

--- a/src/analytics/freePageReader.js
+++ b/src/analytics/freePageReader.js
@@ -43,6 +43,18 @@ async function resolveGunImpl(explicitImpl) {
   return GunImpl;
 }
 
+async function resolveWebSocketImpl(explicitImpl) {
+  if (explicitImpl) return explicitImpl;
+  if (typeof globalThis.WebSocket === 'function') return globalThis.WebSocket;
+  try {
+    const moduleResult = await import('ws');
+    const WebSocketImpl = moduleResult.WebSocket || moduleResult.default || moduleResult;
+    return typeof WebSocketImpl === 'function' ? WebSocketImpl : null;
+  } catch {
+    return null;
+  }
+}
+
 function waitForPeer(gun, timeoutMs, triggerNode) {
   return new Promise(resolve => {
     let settled = false;
@@ -63,6 +75,7 @@ export async function createFreePageAnalyticsReader(options = {}) {
   if (options.client) return options.client;
 
   const GunImpl = await resolveGunImpl(options.GunImpl);
+  const WebSocketImpl = await resolveWebSocketImpl(options.WebSocketImpl);
   const peers = parsePeers(options.peers);
   const gun = options.gun || GunImpl({
     peers,
@@ -70,7 +83,8 @@ export async function createFreePageAnalyticsReader(options = {}) {
     multicast: false,
     localStorage: false,
     radisk: false,
-    file: false
+    file: false,
+    ...(WebSocketImpl ? { WebSocket: WebSocketImpl } : {})
   });
   const eventsNode = getGunNode(gun, FREE_PAGE_ANALYTICS_PATH);
   const connectedPeer = await waitForPeer(gun, options.connectTimeoutMs || 3500, eventsNode);
@@ -99,6 +113,7 @@ export async function fetchFirstPartyAnalyticsHints(config = {}, options = {}) {
     const reader = await createFreePageAnalyticsReader({
       client: options.client,
       GunImpl: options.GunImpl,
+      WebSocketImpl: options.WebSocketImpl,
       gun: options.gun,
       peers: config.gunPeers,
       connectTimeoutMs: options.connectTimeoutMs

--- a/tests/free-page-analytics.test.js
+++ b/tests/free-page-analytics.test.js
@@ -7,7 +7,7 @@ import {
   summarizeFreePageAnalytics,
   writeFreePageAnalyticsEvent
 } from '../src/analytics/freePage.js';
-import { fetchFirstPartyAnalyticsHints } from '../src/analytics/freePageReader.js';
+import { createFreePageAnalyticsReader, fetchFirstPartyAnalyticsHints } from '../src/analytics/freePageReader.js';
 
 function trackingGun() {
   const writes = [];
@@ -133,4 +133,39 @@ test('server analytics reader uses the filesystem-free Gun core build', async ()
   const source = await readFile(new URL('../src/analytics/freePageReader.js', import.meta.url), 'utf8');
   assert.match(source, /import\('gun\/gun\.js'\)/);
   assert.doesNotMatch(source, /import\('gun'\)/);
+});
+
+
+test('server analytics reader passes an explicit WebSocket transport to Gun', async () => {
+  let receivedOptions = null;
+  class FakeWebSocket {}
+  const chain = {
+    get() { return this; },
+    once(callback) { callback?.(); return this; }
+  };
+  const gun = {
+    ...chain,
+    _: {
+      root: {
+        on(event, callback) {
+          if (event === 'hi') queueMicrotask(() => callback({ url: 'wss://example.test/gun' }));
+        }
+      }
+    }
+  };
+  const GunImpl = options => {
+    receivedOptions = options;
+    return gun;
+  };
+
+  await createFreePageAnalyticsReader({
+    GunImpl,
+    WebSocketImpl: FakeWebSocket,
+    peers: ['wss://example.test/gun'],
+    connectTimeoutMs: 50
+  });
+
+  assert.equal(receivedOptions.WebSocket, FakeWebSocket);
+  assert.equal(receivedOptions.radisk, false);
+  assert.equal(receivedOptions.file, false);
 });


### PR DESCRIPTION
Completes the first-party analytics server fix. The filesystem-free Gun core now receives an explicit WebSocket implementation, preferring the Node global transport and falling back to the bundled ws dependency. Verified against the real relay from the server: connection succeeded. Analytics unit tests: 6/6 passed.