### PR TITLE
Prevent duplicate outbound email retries

### DIFF
--- a/api/calendar/reminder-email.js
+++ b/api/calendar/reminder-email.js
@@ -4,11 +4,16 @@ import nodemailer from 'nodemailer';
 function setCorsHeaders(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Operator-Token');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Operator-Token, Idempotency-Key');
 }
 
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeIdempotencyKey(value) {
+  const key = normalizeText(value);
+  return /^[A-Za-z0-9._:-]{16,160}$/.test(key) ? key : '';
 }
 
 function normalizeEmail(value) {
@@ -834,6 +839,9 @@ export function createLeadOutreachEmailHandler(options = {}) {
     const senderEmail = normalizeEmail(req.body?.senderEmail || resolveMailCredentials(config).user);
     const inReplyTo = normalizeText(req.body?.inReplyTo);
     const references = normalizeText(req.body?.references);
+    const idempotencyKey = normalizeIdempotencyKey(
+      req.body?.idempotencyKey || req.headers?.['idempotency-key']
+    );
 
     if (!to.length) {
       return res.status(400).json({ error: 'At least one outreach recipient is required.' });
@@ -869,6 +877,7 @@ export function createLeadOutreachEmailHandler(options = {}) {
         references: references || undefined,
         subject,
         text,
+        messageId: idempotencyKey ? `<3dvr-${idempotencyKey}@3dvr.tech>` : undefined,
         html: buildLeadOutreachHtml({
           headline,
           message: text,
@@ -877,7 +886,7 @@ export function createLeadOutreachEmailHandler(options = {}) {
         })
       });
 
-      return res.status(200).json({ success: true, mode: 'lead-outreach' });
+      return res.status(200).json({ success: true, mode: 'lead-outreach', idempotencyKey: idempotencyKey || undefined });
     } catch (error) {
       return res.status(500).json({
         error: error.message || 'Unable to send lead outreach email.'

--- a/apps/agent/test/email-idempotency.test.js
+++ b/apps/agent/test/email-idempotency.test.js
@@ -1,0 +1,91 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  acquireEmailSend,
+  fingerprintEmail,
+  markEmailSent,
+  markEmailUncertain,
+} = require('../thomas-agent/node/email-idempotency');
+
+function tempConfig() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-email-idempotency-'));
+  return {
+    dir,
+    config: {
+      THREEDVR_EMAIL_IDEMPOTENCY_DIR: dir,
+      THREEDVR_EMAIL_IDEMPOTENCY_SENT_TTL_MS: String(7 * 24 * 60 * 60 * 1000),
+      THREEDVR_EMAIL_IDEMPOTENCY_UNCERTAIN_TTL_MS: String(30 * 60 * 1000),
+    },
+  };
+}
+
+const message = {
+  from: '3dvr.tech@gmail.com',
+  to: 'hello@example.com',
+  subject: 'Hello',
+  text: 'A useful note.\nThanks!',
+};
+
+test('fingerprint is stable across email casing and CRLF line endings', () => {
+  assert.equal(
+    fingerprintEmail(message),
+    fingerprintEmail({ ...message, from: '3DVR.TECH@GMAIL.COM', to: 'HELLO@EXAMPLE.COM', text: 'A useful note.\r\nThanks!' })
+  );
+});
+
+test('blocks a concurrent identical send while the first is inflight', () => {
+  const { dir, config } = tempConfig();
+  try {
+    const first = acquireEmailSend(message, { config });
+    const second = acquireEmailSend(message, { config });
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, false);
+    assert.match(second.reason, /in progress|uncertain/i);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('blocks an identical email after a confirmed send', () => {
+  const { dir, config } = tempConfig();
+  try {
+    const first = acquireEmailSend(message, { config });
+    markEmailSent(first, { transport: 'portal' });
+    const second = acquireEmailSend(message, { config });
+    assert.equal(second.ok, false);
+    assert.match(second.reason, /already sent/i);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('an ambiguous send failure blocks automatic retry', () => {
+  const { dir, config } = tempConfig();
+  try {
+    const first = acquireEmailSend(message, { config });
+    markEmailUncertain(first, new Error('connection reset after DATA'));
+    const second = acquireEmailSend(message, { config });
+    assert.equal(second.ok, false);
+    assert.equal(second.record.status, 'uncertain');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a stale inflight lock can be recovered after the safety window', () => {
+  const { dir, config } = tempConfig();
+  config.THREEDVR_EMAIL_IDEMPOTENCY_UNCERTAIN_TTL_MS = '1';
+  const now = Date.now();
+  try {
+    const first = acquireEmailSend(message, { config, now });
+    const second = acquireEmailSend(message, { config, now: now + 5 });
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/apps/agent/thomas-agent/node/autopilot.js
+++ b/apps/agent/thomas-agent/node/autopilot.js
@@ -6,6 +6,7 @@ const { execFile } = require('child_process');
 const { promisify } = require('util');
 const nodemailer = require('nodemailer');
 const { buildGmailTransportOptions } = require('./gmail-transport');
+const { acquireEmailSend, markEmailSent, markEmailUncertain } = require('./email-idempotency');
 const {
   getCampaignAllowance,
   getFollowupEligibility,
@@ -589,7 +590,7 @@ function createMailTransport() {
   return nodemailer.createTransport(buildGmailTransportOptions(process.env, { user, pass }));
 }
 
-async function sendViaPortalEmail(email, summary, actions) {
+async function sendViaPortalEmail(email, summary, actions, idempotencyKey = '') {
   if (!DEFAULT_PORTAL_EMAIL_ENDPOINT) {
     return { ok: false, reason: 'portal email endpoint not configured' };
   }
@@ -602,9 +603,11 @@ async function sendViaPortalEmail(email, summary, actions) {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${DEFAULT_PORTAL_EMAIL_TOKEN}`,
+      ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
     },
     body: JSON.stringify({
       mode: 'operator-alert',
+      ...(idempotencyKey ? { idempotencyKey } : {}),
       to: [DEFAULT_NOTIFY_EMAIL],
       subject: email.subject,
       text: email.text,
@@ -652,7 +655,7 @@ async function sendViaPortalEmail(email, summary, actions) {
   };
 }
 
-async function sendViaLocalGmail(email) {
+async function sendViaLocalGmail(email, idempotencyKey = '') {
   const transport = createMailTransport();
   if (!transport) {
     return { ok: false, reason: 'gmail transport not configured' };
@@ -663,6 +666,7 @@ async function sendViaLocalGmail(email) {
     to: DEFAULT_NOTIFY_EMAIL,
     subject: email.subject,
     text: email.text,
+    ...(idempotencyKey ? { messageId: `<3dvr-${idempotencyKey}@3dvr.tech>` } : {}),
   });
 
   return {
@@ -831,37 +835,52 @@ async function sendEmail(summary, actions, state) {
   }
 
   const email = buildEmail(summary, actions);
+  const reservation = acquireEmailSend({
+    from: DEFAULT_GMAIL_USER,
+    to: DEFAULT_NOTIFY_EMAIL,
+    subject: email.subject,
+    text: email.text,
+  });
+  if (!reservation.ok) {
+    return {
+      ok: false,
+      skipped: true,
+      reason: `duplicate notification blocked: ${reservation.reason}`,
+      idempotencyKey: reservation.key,
+    };
+  }
+
   const transportMode = ['portal', 'auto', 'gmail'].includes(DEFAULT_EMAIL_TRANSPORT)
     ? DEFAULT_EMAIL_TRANSPORT
     : 'portal';
 
   let result = null;
-  if (transportMode === 'portal' || transportMode === 'auto') {
-    result = await sendViaPortalEmail(email, summary, actions);
-    if (result.ok) {
-      state.email = {
-        lastHash: decision.fingerprint,
-        lastSentAt: new Date().toISOString(),
-      };
-      return { ok: true, skipped: false, ...result };
+  try {
+    const usePortal = transportMode === 'portal'
+      || (transportMode === 'auto' && DEFAULT_PORTAL_EMAIL_ENDPOINT && DEFAULT_PORTAL_EMAIL_TOKEN);
+    if (usePortal) {
+      result = await sendViaPortalEmail(email, summary, actions, reservation.key);
+    } else {
+      result = await sendViaLocalGmail(email, reservation.key);
     }
-
-    if (transportMode === 'portal') {
-      return { ok: false, skipped: true, reason: result.reason || 'portal email failed', via: 'portal' };
-    }
+  } catch (error) {
+    markEmailUncertain(reservation, error);
+    return { ok: false, skipped: true, reason: error.message || String(error), via: transportMode };
   }
 
-  result = await sendViaLocalGmail(email);
-  if (!result.ok) {
-    return { ok: false, skipped: true, reason: result.reason || 'email transport not configured', via: 'gmail' };
+  if (!result?.ok) {
+    markEmailUncertain(reservation, new Error(result?.reason || 'email send outcome was not confirmed'));
+    return { ok: false, skipped: true, reason: result?.reason || 'email send failed', via: result?.via || transportMode };
   }
 
+  markEmailSent(reservation, { via: result.via || transportMode, runId: summary.runId });
   state.email = {
     lastHash: decision.fingerprint,
     lastSentAt: new Date().toISOString(),
+    idempotencyKey: reservation.key,
   };
 
-  return { ok: true, skipped: false, ...result };
+  return { ok: true, skipped: false, ...result, idempotencyKey: reservation.key };
 }
 
 function serializeAck(ack) {

--- a/apps/agent/thomas-agent/node/email-idempotency.js
+++ b/apps/agent/thomas-agent/node/email-idempotency.js
@@ -1,0 +1,137 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const DEFAULT_SENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_UNCERTAIN_TTL_MS = 30 * 60 * 1000;
+
+function normalizeText(value) {
+  return String(value || '').replace(/\r\n/g, '\n').trim();
+}
+
+function parseDuration(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function stateDir(config = process.env) {
+  return normalizeText(config.THREEDVR_EMAIL_IDEMPOTENCY_DIR)
+    || path.join(os.homedir(), '.3dvr', 'state', 'outbound-email-idempotency');
+}
+
+function fingerprintEmail(message = {}) {
+  const canonical = JSON.stringify({
+    from: normalizeText(message.from).toLowerCase(),
+    to: normalizeText(message.to).toLowerCase(),
+    subject: normalizeText(message.subject),
+    text: normalizeText(message.text),
+  });
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+function readRecord(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeRecord(filePath, record) {
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(tmp, filePath);
+}
+
+function blockWindowMs(record, config = process.env) {
+  if (record?.status === 'sent') {
+    return parseDuration(config.THREEDVR_EMAIL_IDEMPOTENCY_SENT_TTL_MS, DEFAULT_SENT_TTL_MS);
+  }
+  return parseDuration(config.THREEDVR_EMAIL_IDEMPOTENCY_UNCERTAIN_TTL_MS, DEFAULT_UNCERTAIN_TTL_MS);
+}
+
+function isFresh(record, now, config = process.env) {
+  const timestamp = Date.parse(record?.updatedAt || record?.createdAt || '');
+  if (!Number.isFinite(timestamp)) return true;
+  return now - timestamp < blockWindowMs(record, config);
+}
+
+function acquireEmailSend(message, { config = process.env, now = Date.now() } = {}) {
+  const key = fingerprintEmail(message);
+  const dir = stateDir(config);
+  const filePath = path.join(dir, `${key}.json`);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const record = {
+      key,
+      status: 'inflight',
+      createdAt: new Date(now).toISOString(),
+      updatedAt: new Date(now).toISOString(),
+      to: normalizeText(message.to).toLowerCase(),
+      subject: normalizeText(message.subject),
+    };
+    try {
+      const fd = fs.openSync(filePath, 'wx', 0o600);
+      try {
+        fs.writeFileSync(fd, `${JSON.stringify(record, null, 2)}\n`);
+      } finally {
+        fs.closeSync(fd);
+      }
+      return { ok: true, key, filePath, record };
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+      const existing = readRecord(filePath);
+      if (!existing || isFresh(existing, now, config)) {
+        return {
+          ok: false,
+          key,
+          filePath,
+          record: existing,
+          reason: existing?.status === 'sent'
+            ? 'Identical email was already sent recently.'
+            : 'Identical email send is already in progress or has an uncertain outcome.',
+        };
+      }
+      try {
+        fs.renameSync(filePath, `${filePath}.stale-${process.pid}-${now}`);
+      } catch (renameError) {
+        if (renameError?.code !== 'ENOENT') throw renameError;
+      }
+    }
+  }
+
+  return { ok: false, key, filePath, reason: 'Unable to acquire outbound email idempotency lock.' };
+}
+
+function updateReservation(reservation, status, extra = {}) {
+  if (!reservation?.filePath) return;
+  const current = readRecord(reservation.filePath) || reservation.record || {};
+  writeRecord(reservation.filePath, {
+    ...current,
+    ...extra,
+    key: reservation.key || current.key,
+    status,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+function markEmailSent(reservation, extra = {}) {
+  updateReservation(reservation, 'sent', extra);
+}
+
+function markEmailUncertain(reservation, error) {
+  updateReservation(reservation, 'uncertain', {
+    error: normalizeText(error?.message || error).slice(0, 500),
+  });
+}
+
+module.exports = {
+  DEFAULT_SENT_TTL_MS,
+  DEFAULT_UNCERTAIN_TTL_MS,
+  acquireEmailSend,
+  fingerprintEmail,
+  markEmailSent,
+  markEmailUncertain,
+};

--- a/apps/agent/thomas-agent/node/inbox-monitor.js
+++ b/apps/agent/thomas-agent/node/inbox-monitor.js
@@ -8,6 +8,7 @@ const { getOAuthAccessToken } = require('./oauth-connection');
 const { appendContactFooter, buildContactFooter } = require('./contact-footer');
 const { appendOutreachLog, readOutreachLog } = require('./outreach-log');
 const { buildPersonalizedPreviewUrl } = require('./outreach-draft-queue');
+const { acquireEmailSend, markEmailSent, markEmailUncertain } = require('./email-idempotency');
 const {
   claimLease,
   isHandled,
@@ -1448,7 +1449,7 @@ async function sendPortalAlert(alert) {
   };
 }
 
-async function sendLeadReply(message, lead, state) {
+async function sendLeadReply(message, lead, state, idempotencyKey = '') {
   if (!DEFAULT_PORTAL_EMAIL_ENDPOINT) {
     return { ok: false, reason: 'portal email endpoint not configured' };
   }
@@ -1464,9 +1465,11 @@ async function sendLeadReply(message, lead, state) {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${DEFAULT_PORTAL_EMAIL_TOKEN}`,
+        ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
       },
       body: JSON.stringify({
         mode: 'lead-outreach',
+        ...(idempotencyKey ? { idempotencyKey } : {}),
         to: [message.replyToEmail || message.fromEmail],
         subject: buildReplySubject(message.subject),
         headline: draft.headline,
@@ -1503,7 +1506,7 @@ async function sendLeadReply(message, lead, state) {
   };
 }
 
-async function sendPublicAgentReply(message, state) {
+async function sendPublicAgentReply(message, state, idempotencyKey = '') {
   if (!DEFAULT_PORTAL_EMAIL_ENDPOINT) {
     return { ok: false, reason: 'portal email endpoint not configured' };
   }
@@ -1519,9 +1522,11 @@ async function sendPublicAgentReply(message, state) {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${DEFAULT_PORTAL_EMAIL_TOKEN}`,
+        ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
       },
       body: JSON.stringify({
         mode: 'lead-outreach',
+        ...(idempotencyKey ? { idempotencyKey } : {}),
         to: [message.replyToEmail || message.fromEmail],
         subject: buildReplySubject(message.subject),
         headline: draft.headline,
@@ -1559,7 +1564,7 @@ async function sendPublicAgentReply(message, state) {
   };
 }
 
-async function sendFreeDesignReply(message, state) {
+async function sendFreeDesignReply(message, state, idempotencyKey = '') {
   if (!DEFAULT_PORTAL_EMAIL_ENDPOINT) return { ok: false, reason: 'portal email endpoint not configured' };
   if (!DEFAULT_PORTAL_EMAIL_TOKEN) return { ok: false, reason: 'portal email token not configured' };
   const draft = buildFreeDesignReplyDraft(message, state);
@@ -1571,9 +1576,11 @@ async function sendFreeDesignReply(message, state) {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${DEFAULT_PORTAL_EMAIL_TOKEN}`,
+        ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
       },
       body: JSON.stringify({
         mode: 'lead-outreach',
+        ...(idempotencyKey ? { idempotencyKey } : {}),
         to: [message.replyToEmail || message.fromEmail],
         subject: buildReplySubject(message.subject),
         headline: draft.headline,
@@ -1661,16 +1668,46 @@ async function sendCoordinatedReply(kind, message, sendImpl) {
     };
   }
 
+  const recipient = normalizeEmail(message.replyToEmail || message.fromEmail);
+  const subject = buildReplySubject(message.subject);
+  const reservation = acquireEmailSend({
+    from: DEFAULT_REPLY_SENDER_EMAIL,
+    to: recipient,
+    subject,
+    text: `coordinated-reply:${actionId}`,
+  });
+
+  if (!reservation.ok) {
+    await releaseLease(`reply:${actionId}`, lease.lease?.token).catch(() => {});
+    return {
+      ok: false,
+      skipped: true,
+      reason: `duplicate reply blocked: ${reservation.reason}`,
+      idempotencyKey: reservation.key,
+    };
+  }
+
   try {
-    const result = await sendImpl();
+    let result;
+    try {
+      result = await sendImpl(reservation.key);
+    } catch (error) {
+      markEmailUncertain(reservation, error);
+      throw error;
+    }
+
     if (result?.ok) {
+      markEmailSent(reservation, { kind, actionId });
       await markHandled(kind, actionId, {
         to: result.to || '',
-        subject: result.subject || buildReplySubject(message.subject),
+        subject: result.subject || subject,
         replySource: result.replySource || '',
+        idempotencyKey: reservation.key,
       }).catch((error) => {
         console.warn(`Unable to mark coordinated reply handled: ${error.message || error}`);
       });
+    } else {
+      markEmailUncertain(reservation, new Error(result?.reason || 'reply send outcome was not confirmed'));
     }
     return result;
   } finally {
@@ -2017,7 +2054,7 @@ async function main() {
     } else {
       for (const { message, lead, meta } of autoReplyCandidates) {
         if (!canSendAutoReply(state)) break;
-        const result = await sendCoordinatedReply('inbox-lead-reply', message, () => sendLeadReply(message, lead, state));
+        const result = await sendCoordinatedReply('inbox-lead-reply', message, (idempotencyKey) => sendLeadReply(message, lead, state, idempotencyKey));
         if (result.skipped) {
           console.log(`Skipped auto-reply to ${lead.name || message.from}: ${result.reason}`);
           continue;
@@ -2051,7 +2088,7 @@ async function main() {
     } else {
       for (const { message, meta } of publicAgentAutoReplyCandidates) {
         if (!canSendAutoReply(state)) break;
-        const result = await sendCoordinatedReply('inbox-public-agent-reply', message, () => sendPublicAgentReply(message, state));
+        const result = await sendCoordinatedReply('inbox-public-agent-reply', message, (idempotencyKey) => sendPublicAgentReply(message, state, idempotencyKey));
         if (result.skipped) {
           console.log(`Skipped public 3dvr-agent auto-reply from ${message.fromEmail}: ${result.reason}`);
           continue;
@@ -2084,7 +2121,7 @@ async function main() {
     } else {
       for (const { message, meta } of freeDesignAutoReplyCandidates) {
         if (!canSendAutoReply(state)) break;
-        const result = await sendCoordinatedReply('inbox-free-design-reply', message, () => sendFreeDesignReply(message, state));
+        const result = await sendCoordinatedReply('inbox-free-design-reply', message, (idempotencyKey) => sendFreeDesignReply(message, state, idempotencyKey));
         if (result.skipped) {
           console.log(`Skipped free-design auto-reply from ${message.fromEmail}: ${result.reason}`);
           continue;

--- a/apps/agent/thomas-agent/node/send-outreach-email.js
+++ b/apps/agent/thomas-agent/node/send-outreach-email.js
@@ -6,6 +6,7 @@ const { getOAuthAccessToken } = require('./oauth-connection');
 const { createGmailTransport } = require('./gmail-transport');
 const { validateCommercialOutreach } = require('./outreach-compliance');
 const { businessHoursStatus } = require('./send-window');
+const { acquireEmailSend, markEmailSent, markEmailUncertain } = require('./email-idempotency');
 
 const DEFAULT_TRANSPORT = normalizeText(
   process.env.THREEDVR_OUTREACH_EMAIL_TRANSPORT
@@ -136,6 +137,7 @@ async function sendViaPortal(options) {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${DEFAULT_PORTAL_EMAIL_TOKEN}`,
+      ...(options.idempotencyKey ? { 'Idempotency-Key': options.idempotencyKey } : {}),
     },
     body: JSON.stringify({
       mode: 'lead-outreach',
@@ -145,6 +147,7 @@ async function sendViaPortal(options) {
       text: options.text,
       senderName: 'Thomas',
       senderEmail,
+      ...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
     }),
   });
 
@@ -185,6 +188,7 @@ async function sendViaGmail(options) {
       to: options.to,
       subject: options.subject,
       text: options.text,
+      ...(options.idempotencyKey ? { messageId: `<3dvr-${options.idempotencyKey}@3dvr.tech>` } : {}),
     });
     return;
   }
@@ -201,6 +205,7 @@ async function sendViaGmail(options) {
     to: options.to,
     subject: options.subject,
     text: options.text,
+    ...(options.idempotencyKey ? { messageId: `<3dvr-${options.idempotencyKey}@3dvr.tech>` } : {}),
   });
 }
 
@@ -250,20 +255,38 @@ async function main() {
     return;
   }
 
-  if (DEFAULT_TRANSPORT === 'gmail') {
-    await sendViaGmail(options);
-  } else if (DEFAULT_TRANSPORT === 'auto') {
-    try {
-      await sendViaPortal(options);
-    } catch (error) {
+  const reservation = acquireEmailSend({
+    from: DEFAULT_GMAIL_USER,
+    to: options.to,
+    subject: options.subject,
+    text: options.text,
+  });
+  if (!reservation.ok) {
+    throw new Error(`Duplicate email blocked: ${reservation.reason} Key=${reservation.key}`);
+  }
+  options.idempotencyKey = reservation.key;
+
+  try {
+    // Never fail over to a second transport after a send attempt. A network error can
+    // mean the first provider accepted the message but the acknowledgement was lost.
+    if (DEFAULT_TRANSPORT === 'gmail') {
       await sendViaGmail(options);
-      console.warn(error.message || error);
+    } else if (DEFAULT_TRANSPORT === 'auto') {
+      if (DEFAULT_PORTAL_EMAIL_ENDPOINT && DEFAULT_PORTAL_EMAIL_TOKEN) {
+        await sendViaPortal(options);
+      } else {
+        await sendViaGmail(options);
+      }
+    } else {
+      await sendViaPortal(options);
     }
-  } else {
-    await sendViaPortal(options);
+    markEmailSent(reservation, { transport: DEFAULT_TRANSPORT });
+  } catch (error) {
+    markEmailUncertain(reservation, error);
+    throw error;
   }
 
-  console.log(`Sent outreach email to ${options.to}`);
+  console.log(`Sent outreach email to ${options.to} [idempotency=${reservation.key.slice(0, 12)}]`);
 }
 
 module.exports = {

--- a/apps/agent/thomas-agent/node/weekly-newsletter.js
+++ b/apps/agent/thomas-agent/node/weekly-newsletter.js
@@ -1,5 +1,6 @@
 const { ImapFlow } = require('imapflow');
 const { createGmailTransport } = require('./gmail-transport');
+const { acquireEmailSend, markEmailSent, markEmailUncertain } = require('./email-idempotency');
 const DRY_RUN = /^(1|true|yes|on)$/i.test(String(process.env.NEWSLETTER_DRY_RUN || '').trim());
 const FROM = process.env.NEWSLETTER_FROM || process.env.GMAIL_USER || '3dvr.tech@gmail.com';
 const REPLY_TO = process.env.NEWSLETTER_REPLY_TO || '3dvr.tech@gmail.com';
@@ -85,17 +86,29 @@ async function main() {
     const path = `/v1/sends/${encodeURIComponent(week)}/${encodeURIComponent(subscriber.email)}`;
     const prior = await store(path);
     if (prior.send?.status === 'sent') { result.skipped += 1; continue; }
-    await store(path, { method: 'PUT', body: JSON.stringify({ status: DRY_RUN ? 'dry-run' : 'sending' }) });
+    let reservation = null;
+    if (!DRY_RUN) {
+      reservation = acquireEmailSend({ from: FROM, to: subscriber.email, subject: mail.subject, text: mail.text });
+      if (!reservation.ok) {
+        result.skipped += 1;
+        await store(path, { method: 'PUT', body: JSON.stringify({ status: 'duplicate-blocked', idempotencyKey: reservation.key }) });
+        continue;
+      }
+    }
+    await store(path, { method: 'PUT', body: JSON.stringify({ status: DRY_RUN ? 'dry-run' : 'sending', idempotencyKey: reservation?.key || '' }) });
     try {
       if (!DRY_RUN) await transport.sendMail({
         from: FROM, to: subscriber.email, replyTo: REPLY_TO, subject: mail.subject,
         text: mail.text, html: mail.html,
+        ...(reservation?.key ? { messageId: `<3dvr-${reservation.key}@3dvr.tech>` } : {}),
         headers: { 'List-Unsubscribe': `<mailto:${REPLY_TO}?subject=unsubscribe>`, 'Precedence': 'bulk' },
       });
-      await store(path, { method: 'PUT', body: JSON.stringify({ status: DRY_RUN ? 'dry-run' : 'sent', subject: mail.subject }) });
+      if (reservation) markEmailSent(reservation, { week, subscriber: subscriber.email });
+      await store(path, { method: 'PUT', body: JSON.stringify({ status: DRY_RUN ? 'dry-run' : 'sent', subject: mail.subject, idempotencyKey: reservation?.key || '' }) });
       result.sent += 1;
     } catch (error) {
-      await store(path, { method: 'PUT', body: JSON.stringify({ status: 'failed', error: text(error.message).slice(0, 300) }) });
+      if (reservation) markEmailUncertain(reservation, error);
+      await store(path, { method: 'PUT', body: JSON.stringify({ status: 'uncertain', error: text(error.message).slice(0, 300), idempotencyKey: reservation?.key || '' }) });
       result.failed.push({ email: subscriber.email, error: text(error.message).slice(0, 300) });
     }
   }

--- a/tests/account-recovery-email.test.js
+++ b/tests/account-recovery-email.test.js
@@ -437,7 +437,8 @@ describe('account recovery email api', () => {
         senderName: 'Thomas at 3dvr.tech',
         senderEmail: '3dvr.tech@gmail.com',
         inReplyTo: '<reply-message@example.com>',
-        references: '<thread-root@example.com> <reply-message@example.com>'
+        references: '<thread-root@example.com> <reply-message@example.com>',
+        idempotencyKey: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
       }
     };
     const res = createMockRes();
@@ -453,6 +454,8 @@ describe('account recovery email api', () => {
     assert.equal(sent.replyTo, '3dvr.tech@gmail.com');
     assert.equal(sent.inReplyTo, '<reply-message@example.com>');
     assert.equal(sent.references, '<thread-root@example.com> <reply-message@example.com>');
+    assert.equal(sent.messageId, '<3dvr-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef@3dvr.tech>');
+    assert.equal(res.body.idempotencyKey, '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
     assert.match(sent.html, /Quick note from 3dvr\.tech/i);
     assert.match(sent.html, /font-size: 11px[^>]*>Postal address:/i);
     assert.equal((sent.html.match(/Thomas at 3dvr\.tech/gi) || []).length, 0);


### PR DESCRIPTION
## What\n- add durable outbound email idempotency fingerprints\n- block identical concurrent/recent sends\n- fail closed after ambiguous transport errors\n- remove unsafe cross-transport retry behavior\n- protect inbox auto-replies, outreach, newsletters, and autopilot notifications\n- propagate deterministic Message-ID through the portal mail endpoint\n\n## Why\nA retry loop sent multiple duplicate emails after an attachment/send ambiguity. Email delivery is not safe to retry blindly because the provider may accept a message before the client sees the acknowledgement.\n\n## Validation\n- idempotency unit tests\n- inbox monitor tests\n- autopilot routing tests\n- calendar/email API tests\n- 32 relevant tests passed on the clean branch\n