### PR TITLE
Add Balthazar north-star supply-chain path

### DIFF
--- a/supply-chain/index.html
+++ b/supply-chain/index.html
@@ -18,6 +18,7 @@
     <a href="/open-source/">Open Source</a>
     <a href="/everyday-life/">Everyday Life</a>
     <a href="#registry">Registry</a>
+    <a href="#balthazar">Balthazar</a>
     <a href="#contribute">Contribute</a>
   </nav>
 
@@ -30,7 +31,7 @@
     </p>
     <div class="hero-actions">
       <a class="button primary" href="#registry">Start with the registry</a>
-      <a class="button" href="#contribute">Help map one component</a>
+      <a class="button" href="#balthazar">See the north-star device</a>
     </div>
   </header>
 
@@ -96,6 +97,52 @@
         <li><strong>Can we substitute it?</strong><span>More available, repairable, open, or lower-impact alternatives.</span></li>
         <li><strong>Can we make it?</strong><span>Open designs, tools, skills, and organizations moving toward local production.</span></li>
       </ol>
+    </section>
+
+    <section id="balthazar" aria-labelledby="balthazar-title">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">North-Star Device</p>
+          <h2 id="balthazar-title">Build toward a Balthazar.</h2>
+        </div>
+        <p>A real open laptop gives the registry a concrete target instead of leaving it as an abstract catalog.</p>
+      </div>
+
+      <div class="project-grid">
+        <article class="project-card live">
+          <span class="status">Start here</span>
+          <h3>Lichee Pi 4A / LM4A</h3>
+          <p>Trace a RISC-V computer we can physically inspect: TH1520, memory, storage, power, radios, connectors, PCB, and enclosure.</p>
+          <p class="project-seed">Sipeed publishes schematics, a BOM, dimensional drawings, and a 3D model, giving us a strong first source set.</p>
+        </article>
+
+        <article class="project-card">
+          <span class="status">Prototype</span>
+          <h3>Balthazar-style laptop</h3>
+          <p>Use an existing swappable RISC-V compute module inside a repairable laptop before attempting to design a processor ourselves.</p>
+          <p class="project-seed">Open case, keyboard, power, I/O, storage, privacy controls, and Linux integration first.</p>
+        </article>
+
+        <article class="project-card">
+          <span class="status">Then</span>
+          <h3>Replace closed layers</h3>
+          <p>Identify proprietary firmware, undocumented chips, closed GPU/NPU paths, and fragile supplier dependencies.</p>
+          <p class="project-seed">Replace one dependency at a time with open, documented, repairable alternatives.</p>
+        </article>
+
+        <article class="project-card">
+          <span class="status">Long term</span>
+          <h3>Community manufacturing</h3>
+          <p>Move from assembly toward regional production of cases, keyboards, boards, power systems, and eventually compute hardware.</p>
+          <p class="project-seed">Open source all the way down without pretending every layer can be localized on day one.</p>
+        </article>
+      </div>
+
+      <div class="hero-actions">
+        <a class="button primary" href="https://balthazar.space/">Explore Balthazar</a>
+        <a class="button" href="https://github.com/balthazar-space">Balthazar hardware repositories</a>
+        <a class="button" href="./balthazar.md">Read our roadmap</a>
+      </div>
     </section>
 
     <section id="contribute" class="makers" aria-labelledby="contribute-title">


### PR DESCRIPTION
Adds Balthazar as the north-star device for Open Supply Chain and connects it to a concrete first trace: the Lichee Pi 4A / LM4A.

The page now frames a progression from documenting existing RISC-V hardware to a Balthazar-style repairable laptop, replacing closed layers one at a time, and eventually enabling community manufacturing.

Also links to the Balthazar project, its hardware repositories, and the local roadmap document.

No billing, account, API, or data-layer impact.