### PR TITLE
Fix opt-in Vercel previews without a token

### DIFF
--- a/.github/workflows/vercel-dev-preview.yml
+++ b/.github/workflows/vercel-dev-preview.yml
@@ -1,82 +1,84 @@
 name: Vercel Dev Preview
 
 on:
-  workflow_dispatch:
-    inputs:
-      set_alias:
-        description: 'Alias this deployment to the stable dev URL (uses VERCEL_DEV_ALIAS)'
-        required: false
-        default: 'false'
   pull_request:
     types:
       - labeled
+      - unlabeled
+      - synchronize
+      - reopened
+      - closed
 
-# Preview deployments are opt-in so routine agent/docs/backend PR churn does not
-# consume the Vercel Hobby deployment quota. Add the `vercel-preview` label when
-# a live browser preview is actually useful, or run this workflow manually.
+# Preview deployments stay opt-in so routine agent/docs/backend PR churn does not
+# consume the Vercel Hobby deployment quota. Add the `vercel-preview` label and
+# this workflow mirrors the PR head to preview-pr-<number>. Vercel's normal Git
+# integration deploys only those bridge branches, so no VERCEL_TOKEN is needed.
 permissions:
-  contents: read
+  contents: write
+  issues: write
+  pull-requests: read
 
-env:
-  VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
-  VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch
-  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-  VERCEL_DEV_ALIAS: ${{ secrets.VERCEL_DEV_ALIAS }}
+concurrency:
+  group: vercel-preview-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  deploy-preview:
-    name: Deploy preview alias
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'vercel-preview' }}
+  sync-preview-branch:
+    name: Update preview branch
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'vercel-preview') ||
+        (
+          github.event.action != 'labeled' &&
+          github.event.action != 'unlabeled' &&
+          contains(github.event.pull_request.labels.*.name, 'vercel-preview')
+        )
+      )
     runs-on: ubuntu-latest
-    env:
-      SHOULD_ALIAS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.set_alias == 'true' }}
     steps:
-      - name: Check Vercel preview configuration
-        id: config
-        shell: bash
-        run: |
-          if [ -n "$VERCEL_TOKEN" ]; then
-            echo "can_deploy=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping Vercel Dev Preview because VERCEL_TOKEN is not configured for this event."
-          fi
-
-      - name: Checkout repository
-        if: ${{ steps.config.outputs.can_deploy == 'true' }}
+      - name: Checkout PR head
         uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        if: ${{ steps.config.outputs.can_deploy == 'true' }}
-        uses: actions/setup-node@v4
         with:
-          node-version: 22
-          cache: npm
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
-      - name: Install dependencies
-        if: ${{ steps.config.outputs.can_deploy == 'true' }}
-        run: npm ci
+      - name: Push stable preview bridge branch
+        env:
+          PREVIEW_BRANCH: preview-pr-${{ github.event.pull_request.number }}
+        run: git push --force origin "HEAD:refs/heads/${PREVIEW_BRANCH}"
 
-      - name: Install Vercel CLI
-        if: ${{ steps.config.outputs.can_deploy == 'true' }}
-        run: npm install --global vercel
+      - name: Post preview URL
+        if: ${{ github.event.action == 'labeled' || github.event.action == 'reopened' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.payload.pull_request.number;
+            const url = `https://3dvr-portal-git-preview-pr-${number}-tmstephs-projects.vercel.app`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: `Vercel preview: ${url}\n\nThis URL updates automatically while the \`vercel-preview\` label is present.`
+            });
 
-      - name: Pull preview environment from Vercel
-        if: ${{ steps.config.outputs.can_deploy == 'true' }}
-        run: vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
+  cleanup-preview-branch:
+    name: Remove preview branch
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        github.event.action == 'closed' ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'vercel-preview')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Build preview artifact
-        if: ${{ steps.config.outputs.can_deploy == 'true' }}
-        run: vercel build --token=$VERCEL_TOKEN
-
-      - name: Deploy preview artifact
-        if: ${{ steps.config.outputs.can_deploy == 'true' }}
-        id: deploy
-        run: |
-          DEPLOY_URL=$(vercel deploy --prebuilt --target=preview --token=$VERCEL_TOKEN --yes)
-          echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
-          echo "Preview URL: $DEPLOY_URL"
-
-      - name: Alias deployment to stable dev URL
-        if: ${{ steps.config.outputs.can_deploy == 'true' && env.VERCEL_DEV_ALIAS != '' && env.SHOULD_ALIAS == 'true' }}
-        run: vercel alias set ${{ steps.deploy.outputs.url }} $VERCEL_DEV_ALIAS --token=$VERCEL_TOKEN
+      - name: Delete preview bridge branch
+        env:
+          PREVIEW_BRANCH: preview-pr-${{ github.event.pull_request.number }}
+        run: git push origin --delete "$PREVIEW_BRANCH" || true

--- a/.github/workflows/vercel-dev-preview.yml
+++ b/.github/workflows/vercel-dev-preview.yml
@@ -15,7 +15,6 @@ on:
 # integration deploys only those bridge branches, so no VERCEL_TOKEN is needed.
 permissions:
   contents: write
-  issues: write
   pull-requests: read
 
 concurrency:
@@ -49,19 +48,14 @@ jobs:
           PREVIEW_BRANCH: preview-pr-${{ github.event.pull_request.number }}
         run: git push --force origin "HEAD:refs/heads/${PREVIEW_BRANCH}"
 
-      - name: Post preview URL
-        if: ${{ github.event.action == 'labeled' || github.event.action == 'reopened' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const number = context.payload.pull_request.number;
-            const url = `https://3dvr-portal-git-preview-pr-${number}-tmstephs-projects.vercel.app`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: number,
-              body: `Vercel preview: ${url}\n\nThis URL updates automatically while the \`vercel-preview\` label is present.`
-            });
+      - name: Publish preview URL
+        env:
+          PREVIEW_URL: https://3dvr-portal-git-preview-pr-${{ github.event.pull_request.number }}-tmstephs-projects.vercel.app
+        run: |
+          echo "### Vercel preview" >> "$GITHUB_STEP_SUMMARY"
+          echo "$PREVIEW_URL" >> "$GITHUB_STEP_SUMMARY"
+          echo "This URL updates automatically while the \`vercel-preview\` label is present." >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=Vercel preview::$PREVIEW_URL"
 
   cleanup-preview-branch:
     name: Remove preview branch

--- a/tests/vercel-main-only.test.js
+++ b/tests/vercel-main-only.test.js
@@ -4,13 +4,11 @@ import { readFile } from 'node:fs/promises';
 
 const vercel = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'));
 
-test('Vercel deploys production from main and never auto-builds feature branches', () => {
+test('Vercel builds main and opt-in preview bridges while skipping ordinary branches', () => {
   assert.deepEqual(vercel.git?.deploymentEnabled, {
-    '*': false,
+    '**': false,
     main: true,
+    'preview-pr-*': true,
   });
-  assert.equal(
-    vercel.ignoreCommand,
-    '[ "$VERCEL_GIT_COMMIT_REF" != "main" ]'
-  );
+  assert.equal(vercel.ignoreCommand, undefined);
 });

--- a/tests/vercel-production-policy.test.js
+++ b/tests/vercel-production-policy.test.js
@@ -4,11 +4,14 @@ import { readFile } from 'node:fs/promises';
 
 const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
 
-test('native Vercel Git deploys main and skips non-main builds', async () => {
+test('native Vercel Git deploys production plus explicit preview bridge branches', async () => {
   const config = JSON.parse(await read('vercel.json'));
-  assert.equal(config.git?.deploymentEnabled?.main, true);
-  assert.equal(config.git?.deploymentEnabled?.['*'], false);
-  assert.equal(config.ignoreCommand, '[ "$VERCEL_GIT_COMMIT_REF" != "main" ]');
+  assert.deepEqual(config.git?.deploymentEnabled, {
+    '**': false,
+    main: true,
+    'preview-pr-*': true,
+  });
+  assert.equal(config.ignoreCommand, undefined);
 });
 
 test('GitHub Actions production workflow is manual fallback only', async () => {

--- a/tests/workspace-sync.test.js
+++ b/tests/workspace-sync.test.js
@@ -69,7 +69,7 @@ test('preview workflow is opt-in, token-free, and cleans up its bridge branch', 
   assert.match(workflow, /3dvr-portal-git-preview-pr-/);
   assert.match(workflow, /contents: write/);
   assert.doesNotMatch(workflow, /^\s*push:/m);
-  assert.doesNotMatch(workflow, /VERCEL_TOKEN/);
+  assert.doesNotMatch(workflow, /secrets\.VERCEL_TOKEN/);
   assert.doesNotMatch(workflow, /VERCEL_PROJECT_ID/);
   assert.doesNotMatch(workflow, /VERCEL_ORG_ID/);
   assert.doesNotMatch(workflow, /workflow_dispatch:/);
@@ -77,7 +77,7 @@ test('preview workflow is opt-in, token-free, and cleans up its bridge branch', 
 
 test('workspace and Codex Cloud link to each other', async () => {
   const workspace = await read('workspace/index.html');
-  const codexCloud = await read('codex-cloud/index.html');
+  const codexCloud = await read('codex-cloud/index.html', 'utf8');
 
   assert.match(workspace, /href="\.\.\/codex-cloud\/"/);
   assert.match(codexCloud, /href="\/workspace\/"/);

--- a/tests/workspace-sync.test.js
+++ b/tests/workspace-sync.test.js
@@ -34,13 +34,14 @@ test('relay timeout never auto-saves empty startup state', async () => {
   assert.doesNotMatch(timeoutBlock, /\bsave\s*\(/, 'timeout must not overwrite unknown remote state');
 });
 
-test('production uses main-only native Vercel Git with a non-main safety net', async () => {
+test('production uses main plus opt-in Vercel preview bridges with a default deny rule', async () => {
   const workflow = await read('.github/workflows/vercel-production-prebuilt.yml');
   const vercelConfig = JSON.parse(await read('vercel.json'));
 
   assert.equal(vercelConfig.git?.deploymentEnabled?.main, true);
-  assert.equal(vercelConfig.git?.deploymentEnabled?.['*'], false);
-  assert.equal(vercelConfig.ignoreCommand, '[ "$VERCEL_GIT_COMMIT_REF" != "main" ]');
+  assert.equal(vercelConfig.git?.deploymentEnabled?.['preview-pr-*'], true);
+  assert.equal(vercelConfig.git?.deploymentEnabled?.['**'], false);
+  assert.equal(vercelConfig.ignoreCommand, undefined);
   assert.match(workflow, /workflow_dispatch:/);
   assert.doesNotMatch(workflow, /^\s*push:/m);
   assert.doesNotMatch(workflow, /^\s*pull_request:/m);
@@ -51,16 +52,27 @@ test('production uses main-only native Vercel Git with a non-main safety net', a
   assert.doesNotMatch(workflow, /German worker/i);
 });
 
-test('preview workflow is opt-in and targets the portal Vercel project', async () => {
+test('preview workflow is opt-in, token-free, and cleans up its bridge branch', async () => {
   const workflow = await read('.github/workflows/vercel-dev-preview.yml');
 
-  assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /pull_request:/);
   assert.match(workflow, /- labeled/);
+  assert.match(workflow, /- unlabeled/);
+  assert.match(workflow, /- synchronize/);
+  assert.match(workflow, /- reopened/);
+  assert.match(workflow, /- closed/);
   assert.match(workflow, /vercel-preview/);
+  assert.match(workflow, /preview-pr-\$\{\{ github\.event\.pull_request\.number \}\}/);
+  assert.match(workflow, /git push --force origin/);
+  assert.match(workflow, /git push origin --delete/);
+  assert.match(workflow, /head\.repo\.full_name == github\.repository/);
+  assert.match(workflow, /3dvr-portal-git-preview-pr-/);
+  assert.match(workflow, /contents: write/);
   assert.doesNotMatch(workflow, /^\s*push:/m);
-  assert.match(workflow, /VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z/);
-  assert.match(workflow, /VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch/);
+  assert.doesNotMatch(workflow, /VERCEL_TOKEN/);
+  assert.doesNotMatch(workflow, /VERCEL_PROJECT_ID/);
+  assert.doesNotMatch(workflow, /VERCEL_ORG_ID/);
+  assert.doesNotMatch(workflow, /workflow_dispatch:/);
 });
 
 test('workspace and Codex Cloud link to each other', async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,10 @@
   "git": {
     "deploymentEnabled": {
       "*": false,
-      "main": true
+      "main": true,
+      "preview-pr-*": true
     }
   },
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "crons": [
     { "path": "/api/growth/homepage-hero-cron", "schedule": "43 2 * * *" },
     { "path": "/api/money/autopilot-cron", "schedule": "17 16 * * 1-5" }

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
-      "*": false,
+      "**": false,
       "main": true,
       "preview-pr-*": true
     }


### PR DESCRIPTION
Replaces the broken token-based preview workflow with opt-in Git bridge branches.

How it works:
- label a same-repo PR `vercel-preview`
- GitHub mirrors the PR head to `preview-pr-<number>`
- Vercel Git integration is enabled only for `main` and `preview-pr-*`; all other branches are denied by default
- the stable Vercel branch URL is published in the workflow summary/notice
- pushes keep the preview updated while the label is present
- removing the label or closing the PR deletes the bridge branch
- fork PRs are intentionally excluded from this automatic preview path

This keeps Hobby deployment usage opt-in and avoids requiring `VERCEL_TOKEN` in GitHub Actions.