### PR TITLE
Add rolling seven-day calendar view

### DIFF
--- a/calendar/calendar-v2.css
+++ b/calendar/calendar-v2.css
@@ -1172,3 +1172,173 @@ summary:focus-visible {
     display: none;
   }
 }
+
+/* Rolling 7-day schedule ---------------------------------------------------- */
+.calendar-view__toolbar {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.calendar-view__mode {
+  background: #0d151f;
+  border: 1px solid var(--calendar-border);
+  border-radius: 10px;
+  display: inline-flex;
+  gap: 3px;
+  padding: 3px;
+}
+
+.calendar-view__mode button {
+  border-color: transparent;
+  min-height: 32px;
+  padding: 6px 10px;
+}
+
+.calendar-view__mode button[aria-pressed="true"],
+.calendar-view__mode-button--active {
+  background: #1b2b3a;
+  border-color: var(--calendar-border-strong);
+  color: var(--calendar-text);
+}
+
+.calendar-view__grid[data-calendar-view="week"] {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  padding-bottom: 8px;
+  scroll-behavior: smooth;
+  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
+  touch-action: pan-x pan-y;
+}
+
+.calendar-view__grid[data-calendar-view="week"] .calendar-view__grid-inner {
+  width: 100%;
+}
+
+.calendar-view__grid[data-calendar-view="week"] .calendar-view__day-names {
+  display: none;
+}
+
+.calendar-view__grid[data-calendar-view="week"] .calendar-view__days {
+  display: grid;
+  gap: 7px;
+  grid-auto-columns: calc((100% - 42px) / 7);
+  grid-auto-flow: column;
+  grid-template-columns: none;
+  width: 100%;
+}
+
+.calendar-view__grid[data-calendar-view="week"] .calendar-view__day--rolling {
+  height: 238px;
+  scroll-snap-align: start;
+}
+
+.calendar-view__date--rolling {
+  align-items: baseline;
+  display: flex;
+  gap: 5px;
+  justify-content: space-between;
+}
+
+.calendar-view__rolling-weekday {
+  color: var(--calendar-muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.calendar-view__rolling-date {
+  color: var(--calendar-text);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.calendar-view__grid[data-calendar-view="week"] .calendar-view__events {
+  overflow-y: auto;
+  padding-right: 1px;
+}
+
+.calendar-view__grid[data-calendar-view="week"] .calendar-view__event-title {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+}
+
+@media (max-width: 900px) {
+  .calendar-view__header {
+    align-items: flex-start;
+  }
+
+  .calendar-view__toolbar {
+    align-items: flex-end;
+    flex-direction: column;
+    gap: 5px;
+  }
+}
+
+@media (max-width: 760px) {
+  .calendar-view__header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .calendar-view__toolbar {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .calendar-view__mode button {
+    font-size: 0.72rem;
+    min-height: 34px;
+    padding: 6px 8px;
+  }
+
+  .calendar-view__grid[data-calendar-view="week"] .calendar-view__days {
+    gap: 5px;
+    grid-auto-columns: minmax(150px, calc((100% - 10px) / 3));
+  }
+
+  .calendar-view__grid[data-calendar-view="week"] .calendar-view__day--rolling {
+    height: 190px;
+    padding: 7px 6px;
+  }
+
+  .calendar-view__grid[data-calendar-view="week"] .calendar-view__date--rolling {
+    text-align: left;
+  }
+
+  .calendar-view__grid[data-calendar-view="week"] .calendar-view__event-time {
+    text-align: left;
+  }
+
+  .calendar-view__grid[data-calendar-view="week"] .calendar-view__event-title {
+    display: -webkit-box;
+    font-size: 0.68rem;
+    line-height: 1.15;
+    text-align: left;
+    -webkit-line-clamp: 2;
+  }
+}
+
+@media (max-width: 430px) {
+  .calendar-view__toolbar {
+    gap: 4px;
+  }
+
+  .calendar-view__grid[data-calendar-view="week"] .calendar-view__days {
+    grid-auto-columns: minmax(150px, 68vw);
+  }
+
+  .calendar-view__grid[data-calendar-view="week"] .calendar-view__day--rolling {
+    height: 180px;
+  }
+
+  .calendar-view__grid[data-calendar-view="week"] .calendar-view__event-title {
+    display: -webkit-box;
+  }
+}

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -31,6 +31,9 @@ const DEFAULT_REMINDER_DAY_OFFSET = 0;
 const DEFAULT_REPEAT_WEEKS = null;
 const MAX_REPEAT_WEEKS = 52;
 const DEFAULT_REPEAT_GENERATION_WEEKS = MAX_REPEAT_WEEKS;
+const ROLLING_WEEK_VISIBLE_DAYS = 7;
+const ROLLING_WEEK_BUFFER_DAYS = 14;
+const CALENDAR_VIEW_MODE_KEY = 'calendar.view.mode';
 
 function startOfMonth(date) {
   const result = new Date(date);
@@ -60,11 +63,14 @@ const state = {
 const today = startOfDay(new Date());
 const calendarState = {
   viewDate: startOfMonth(new Date()),
+  rollingAnchorDate: startOfDay(new Date()),
+  viewMode: 'month',
   weekStartsOn: 0,
   selectedDate: today.toISOString().slice(0, 10),
   dayEvents: new Map()
 };
 const reminderTimers = new Map();
+let rollingScrollTimer = null;
 
 const GUN_PEERS = (typeof window !== 'undefined' && window.__GUN_PEERS__) || [
   'wss://relay.3dvr.tech/gun',
@@ -104,6 +110,10 @@ const createEventSubmitButton = createEventForm
   : null;
 const calendarDayNames = document.querySelector('[data-calendar-day-names]');
 const calendarGrid = document.querySelector('[data-calendar-grid]');
+const calendarGridViewport = document.querySelector('.calendar-view__grid');
+const calendarViewTitle = document.querySelector('[data-calendar-view-title]');
+const calendarViewModeButtons = document.querySelectorAll('[data-calendar-view-mode]');
+const calendarControls = document.querySelector('.calendar-view__controls');
 const calendarCurrentLabel = document.querySelector('[data-calendar-current]');
 const calendarTodayButton = document.querySelector('[data-calendar-today]');
 const calendarNavButtons = document.querySelectorAll('[data-calendar-nav]');
@@ -1097,6 +1107,25 @@ function ensureDefaultTodayEvent() {
   writeLocalEvents([...state.localEvents, seededEvent]);
 }
 
+function pruneLegacyAutoSeedEvents() {
+  const before = state.localEvents.length;
+  const cleaned = state.localEvents.filter(event => {
+    const seededOn = event?.metadata?.[AUTO_SEEDED_METADATA_KEY];
+    if (!seededOn) return true;
+    const title = typeof event.title === 'string' ? event.title.trim().toLowerCase() : '';
+    const description = typeof event.description === 'string' ? event.description.trim() : '';
+    const start = Date.parse(event.start || '');
+    const end = Date.parse(event.end || '');
+    const durationMinutes = Number.isNaN(start) || Number.isNaN(end) ? Infinity : Math.round((end - start) / 60000);
+    const untouchedTitle = !title || title === 'new event' || title === 'untitled event';
+    return !(untouchedTitle && !description && durationMinutes > 0 && durationMinutes <= 15);
+  });
+  if (cleaned.length !== before) {
+    writeLocalEvents(cleaned);
+    showLog(`Removed ${before - cleaned.length} old placeholder event${before - cleaned.length === 1 ? '' : 's'}.`, 'success');
+  }
+}
+
 function withTimeZoneLabel(text, timeZone) {
   if (!timeZone || !text || text === '—') {
     return text;
@@ -1183,11 +1212,14 @@ function renderCalendarDayNames() {
   }
 }
 
-function renderCalendar(events = state.localEvents) {
+function renderMonthCalendar(events = state.localEvents) {
   if (calendarCurrentLabel) {
     calendarCurrentLabel.textContent = calendarMonthFormatter.format(calendarState.viewDate);
   }
   if (!calendarGrid) return;
+  if (calendarGridViewport) calendarGridViewport.dataset.calendarView = 'month';
+  if (calendarDayNames) calendarDayNames.hidden = false;
+  calendarGrid.removeAttribute('data-rolling');
   const monthStart = startOfMonth(calendarState.viewDate || new Date());
   const gridStart = new Date(monthStart);
   const offset = getWeekdayIndex(monthStart.getDay());
@@ -1293,6 +1325,214 @@ function renderCalendar(events = state.localEvents) {
     calendarState.selectedDate = null;
   }
   renderSelectedDayDetails();
+}
+
+function formatRollingCalendarRange(anchorDate) {
+  const start = startOfDay(anchorDate instanceof Date ? anchorDate : new Date());
+  const end = new Date(start);
+  end.setDate(end.getDate() + ROLLING_WEEK_VISIBLE_DAYS - 1);
+  const startLabel = calendarShortDateFormatter.format(start);
+  const endLabel = calendarShortDateFormatter.format(end);
+  if (start.getFullYear() === end.getFullYear()) {
+    return `${startLabel} – ${endLabel}, ${end.getFullYear()}`;
+  }
+  return `${startLabel}, ${start.getFullYear()} – ${endLabel}, ${end.getFullYear()}`;
+}
+
+function updateCalendarPeriodLabel() {
+  if (!calendarCurrentLabel) return;
+  if (calendarState.viewMode === 'week') {
+    calendarCurrentLabel.textContent = formatRollingCalendarRange(calendarState.rollingAnchorDate);
+  } else {
+    calendarCurrentLabel.textContent = calendarMonthFormatter.format(calendarState.viewDate);
+  }
+}
+
+function renderRollingWeek(events = state.localEvents) {
+  if (!calendarGrid) return;
+  if (calendarGridViewport) calendarGridViewport.dataset.calendarView = 'week';
+  if (calendarDayNames) calendarDayNames.hidden = true;
+  calendarGrid.dataset.rolling = 'true';
+  calendarGrid.innerHTML = '';
+
+  const anchor = startOfDay(calendarState.rollingAnchorDate || new Date());
+  const rangeStart = new Date(anchor);
+  rangeStart.setDate(rangeStart.getDate() - ROLLING_WEEK_BUFFER_DAYS);
+  const totalDays = (ROLLING_WEEK_BUFFER_DAYS * 2) + ROLLING_WEEK_VISIBLE_DAYS;
+  const normalizedEvents = Array.isArray(events) ? events : [];
+  const todayTime = startOfDay(new Date()).getTime();
+  calendarState.dayEvents = new Map();
+
+  for (let index = 0; index < totalDays; index += 1) {
+    const cellDate = new Date(rangeStart);
+    cellDate.setDate(rangeStart.getDate() + index);
+    const cellDayTime = startOfDay(cellDate).getTime();
+    const dayKey = cellDate.toISOString().slice(0, 10);
+    const cell = document.createElement('div');
+    cell.className = 'calendar-view__day calendar-view__day--rolling';
+    cell.setAttribute('role', 'button');
+    cell.setAttribute('tabindex', '0');
+    cell.dataset.date = dayKey;
+    if (index === ROLLING_WEEK_BUFFER_DAYS) cell.dataset.rollingAnchor = 'true';
+    if (cellDayTime === todayTime) {
+      cell.classList.add('calendar-view__day--today');
+      cell.setAttribute('aria-current', 'date');
+    }
+
+    const dateHeader = document.createElement('p');
+    dateHeader.className = 'calendar-view__date calendar-view__date--rolling';
+    const weekday = document.createElement('span');
+    weekday.className = 'calendar-view__rolling-weekday';
+    weekday.textContent = calendarWeekdayFormatter.format(cellDate);
+    const date = document.createElement('span');
+    date.className = 'calendar-view__rolling-date';
+    date.textContent = calendarShortDateFormatter.format(cellDate);
+    dateHeader.append(weekday, date);
+    cell.appendChild(dateHeader);
+
+    const eventsForDay = normalizedEvents.filter(event => {
+      if (!event || typeof event.start !== 'string' || !event.start) return false;
+      const eventDate = new Date(event.start);
+      if (Number.isNaN(eventDate.getTime())) return false;
+      return startOfDay(eventDate).getTime() === cellDayTime;
+    });
+
+    if (eventsForDay.length) {
+      cell.classList.add('calendar-view__day--has-events');
+      const list = document.createElement('ul');
+      list.className = 'calendar-view__events';
+      eventsForDay.slice(0, 6).forEach(event => {
+        const item = document.createElement('li');
+        item.className = 'calendar-view__event';
+        const timeLabel = formatCalendarRange(event);
+        const compactTimeLabel = formatCompactCalendarRange(event);
+        if (timeLabel) {
+          const time = document.createElement('span');
+          time.className = 'calendar-view__event-time';
+          const full = document.createElement('span');
+          full.className = 'calendar-view__event-time-full';
+          full.textContent = timeLabel;
+          const compact = document.createElement('span');
+          compact.className = 'calendar-view__event-time-compact';
+          compact.textContent = compactTimeLabel || timeLabel;
+          time.append(full, compact);
+          item.appendChild(time);
+        }
+        const titleText = event.title || 'Busy';
+        item.setAttribute('aria-label', `${timeLabel ? `${timeLabel}, ` : ''}${titleText}`);
+        const title = document.createElement('span');
+        title.className = 'calendar-view__event-title';
+        title.textContent = titleText;
+        item.appendChild(title);
+        list.appendChild(item);
+      });
+      if (eventsForDay.length > 6) {
+        const more = document.createElement('li');
+        more.className = 'calendar-view__more';
+        more.textContent = `+${eventsForDay.length - 6} more`;
+        list.appendChild(more);
+      }
+      cell.appendChild(list);
+    }
+
+    const labelParts = [calendarFullDateFormatter.format(cellDate)];
+    if (eventsForDay.length === 1) labelParts.push('1 event');
+    else if (eventsForDay.length > 1) labelParts.push(`${eventsForDay.length} events`);
+    eventsForDay.slice(0, 6).forEach(event => {
+      const range = formatCalendarRange(event);
+      labelParts.push(`${range ? `${range} ` : ''}${event.title || 'Busy'}`);
+    });
+    cell.setAttribute('aria-label', labelParts.join(', '));
+    calendarState.dayEvents.set(dayKey, eventsForDay.slice());
+    if (calendarState.selectedDate === dayKey) {
+      cell.classList.add('calendar-view__day--selected');
+      cell.setAttribute('aria-pressed', 'true');
+    } else {
+      cell.setAttribute('aria-pressed', 'false');
+    }
+    calendarGrid.appendChild(cell);
+  }
+
+  updateCalendarPeriodLabel();
+  requestAnimationFrame(() => {
+    if (!calendarGridViewport || calendarState.viewMode !== 'week') return;
+    const anchorCell = calendarGrid.querySelector('[data-rolling-anchor="true"]');
+    if (anchorCell) calendarGridViewport.scrollLeft = Math.max(0, anchorCell.offsetLeft);
+  });
+  renderSelectedDayDetails();
+}
+
+function renderCalendar(events = state.localEvents) {
+  if (calendarState.viewMode === 'week') {
+    renderRollingWeek(events);
+  } else {
+    renderMonthCalendar(events);
+  }
+}
+
+function syncRollingAnchorFromScroll() {
+  if (calendarState.viewMode !== 'week' || !calendarGridViewport || !calendarGrid) return;
+  const cells = Array.from(calendarGrid.querySelectorAll('.calendar-view__day[data-date]'));
+  if (!cells.length) return;
+  const target = calendarGridViewport.scrollLeft + 4;
+  let anchorCell = cells[0];
+  for (const cell of cells) {
+    if (cell.offsetLeft <= target + 2) anchorCell = cell;
+    else break;
+  }
+  const parsed = new Date(`${anchorCell.dataset.date}T00:00:00`);
+  if (!Number.isNaN(parsed.getTime())) {
+    calendarState.rollingAnchorDate = startOfDay(parsed);
+    updateCalendarPeriodLabel();
+  }
+}
+
+function handleRollingCalendarScroll() {
+  if (calendarState.viewMode !== 'week') return;
+  if (rollingScrollTimer) window.clearTimeout(rollingScrollTimer);
+  rollingScrollTimer = window.setTimeout(syncRollingAnchorFromScroll, 90);
+}
+
+function readStoredCalendarViewMode() {
+  try {
+    return localStorage.getItem(CALENDAR_VIEW_MODE_KEY) === 'week' ? 'week' : 'month';
+  } catch (_err) {
+    return 'month';
+  }
+}
+
+function setCalendarViewMode(mode, options = {}) {
+  const nextMode = mode === 'week' ? 'week' : 'month';
+  calendarState.viewMode = nextMode;
+  if (nextMode === 'week') {
+    const selected = calendarState.selectedDate ? new Date(`${calendarState.selectedDate}T00:00:00`) : null;
+    calendarState.rollingAnchorDate = selected && !Number.isNaN(selected.getTime())
+      ? startOfDay(selected)
+      : startOfDay(new Date());
+  } else {
+    const selected = calendarState.selectedDate ? new Date(`${calendarState.selectedDate}T00:00:00`) : null;
+    if (selected && !Number.isNaN(selected.getTime())) calendarState.viewDate = startOfMonth(selected);
+  }
+
+  if (calendarViewTitle) calendarViewTitle.textContent = nextMode === 'week' ? '7 days' : 'Month';
+  calendarViewModeButtons.forEach(button => {
+    const active = button.dataset.calendarViewMode === nextMode;
+    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+    button.classList.toggle('calendar-view__mode-button--active', active);
+  });
+  if (calendarControls) {
+    calendarControls.setAttribute('aria-label', nextMode === 'week' ? 'Change seven day range' : 'Change month');
+  }
+  calendarNavButtons.forEach(button => {
+    const forward = button.dataset.calendarNav === 'next';
+    button.setAttribute('aria-label', nextMode === 'week'
+      ? `${forward ? 'Next' : 'Previous'} seven days`
+      : `${forward ? 'Next' : 'Previous'} month`);
+  });
+  if (options.persist !== false) {
+    try { localStorage.setItem(CALENDAR_VIEW_MODE_KEY, nextMode); } catch (_err) {}
+  }
+  renderCalendar();
 }
 
 function renderSelectedDayDetails() {
@@ -1925,6 +2165,25 @@ function generateLocalId(prefix = 'local') {
   return `${prefix}:${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+function remoteEventTitle(provider, raw) {
+  if (!raw || typeof raw !== 'object') return 'Busy';
+  const primary = provider === 'google' ? raw.summary : raw.subject;
+  if (typeof primary === 'string' && primary.trim()) return primary.trim();
+
+  const fallbackCandidates = provider === 'google'
+    ? [raw.location, raw.organizer?.displayName, raw.creator?.displayName]
+    : [raw.location?.displayName, raw.organizer?.emailAddress?.name];
+  const fallback = fallbackCandidates.find(value => typeof value === 'string' && value.trim());
+  if (fallback) return fallback.trim();
+
+  if (provider === 'google') {
+    if (raw.eventType === 'workingLocation') return 'Working location';
+    if (raw.eventType === 'outOfOffice') return 'Out of office';
+    if (raw.eventType === 'focusTime') return 'Focus time';
+  }
+  return 'Busy';
+}
+
 function mapRemoteEvent(provider, raw) {
   if (!raw) return null;
   if (provider === 'google') {
@@ -1934,14 +2193,16 @@ function mapRemoteEvent(provider, raw) {
     return {
       id: `remote:${provider}:${raw.id || `${start || ''}:${end || ''}`}`,
       provider,
-      title: raw.summary || 'Untitled event',
+      title: remoteEventTitle(provider, raw),
       description: raw.description || '',
       start: toISOStringIfPossible(start),
       end: toISOStringIfPossible(end),
       timeZone,
       link: raw.htmlLink || '',
       metadata: {
-        remoteId: raw.id || null
+        remoteId: raw.id || null,
+        remoteEventType: raw.eventType || '',
+        remoteTitleMissing: !(typeof raw.summary === 'string' && raw.summary.trim())
       },
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
@@ -1954,14 +2215,15 @@ function mapRemoteEvent(provider, raw) {
     return {
       id: `remote:${provider}:${raw.id || `${start || ''}:${end || ''}`}`,
       provider,
-      title: raw.subject || 'Untitled event',
+      title: remoteEventTitle(provider, raw),
       description: raw.bodyPreview || '',
       start: toISOStringIfPossible(start),
       end: toISOStringIfPossible(end),
       timeZone,
       link: raw.webLink || '',
       metadata: {
-        remoteId: raw.id || null
+        remoteId: raw.id || null,
+        remoteTitleMissing: !(typeof raw.subject === 'string' && raw.subject.trim())
       },
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
@@ -2022,6 +2284,28 @@ async function importCurrentMonthFromProvider(provider) {
   if (provider === 'outlook' && connection.mailbox) payload.mailbox = connection.mailbox;
   const data = await callProvider(provider, payload);
   return importRemoteEvents(provider, data.events || []);
+}
+
+async function refreshUntitledImportedEvents() {
+  if (isSharedCalendar()) return;
+  const providers = Array.from(new Set(
+    state.localEvents
+      .filter(event => (event.provider === 'google' || event.provider === 'outlook') && /^untitled event$/i.test(String(event.title || '').trim()))
+      .map(event => event.provider)
+  ));
+  for (const provider of providers) {
+    if (!state.connections.has(provider)) continue;
+    const before = state.localEvents.filter(event => event.provider === provider && /^untitled event$/i.test(String(event.title || '').trim())).length;
+    try {
+      await importCurrentMonthFromProvider(provider);
+      const after = state.localEvents.filter(event => event.provider === provider && /^untitled event$/i.test(String(event.title || '').trim())).length;
+      if (after < before) {
+        showLog(`Restored ${before - after} event title${before - after === 1 ? '' : 's'} from ${PROVIDERS[provider].label}.`, 'success');
+      }
+    } catch (err) {
+      console.warn(`Unable to refresh untitled ${provider} events`, err);
+    }
+  }
 }
 
 async function handleFetchEvents() {
@@ -2997,24 +3281,32 @@ function initializeCreateEventToggle() {
   updateCreateEventToggleLabel(false);
 }
 
-function changeCalendarMonth(offset) {
-  const next = new Date(calendarState.viewDate);
-  next.setMonth(next.getMonth() + offset);
-  calendarState.viewDate = startOfMonth(next);
-  calendarState.selectedDate = calendarState.viewDate.toISOString().slice(0, 10);
+function changeCalendarPeriod(offset) {
+  if (calendarState.viewMode === 'week') {
+    const next = new Date(calendarState.rollingAnchorDate || new Date());
+    next.setDate(next.getDate() + (offset * ROLLING_WEEK_VISIBLE_DAYS));
+    calendarState.rollingAnchorDate = startOfDay(next);
+    calendarState.selectedDate = calendarState.rollingAnchorDate.toISOString().slice(0, 10);
+  } else {
+    const next = new Date(calendarState.viewDate);
+    next.setMonth(next.getMonth() + offset);
+    calendarState.viewDate = startOfMonth(next);
+    calendarState.selectedDate = calendarState.viewDate.toISOString().slice(0, 10);
+  }
   renderCalendar();
 }
 
 function goToCalendarToday() {
   const now = startOfDay(new Date());
   calendarState.viewDate = startOfMonth(now);
+  calendarState.rollingAnchorDate = now;
   calendarState.selectedDate = now.toISOString().slice(0, 10);
   renderCalendar();
 }
 
 function initializeCalendarView() {
   renderCalendarDayNames();
-  renderCalendar();
+  setCalendarViewMode(readStoredCalendarViewMode(), { persist: false });
 }
 
 function bindEvents() {
@@ -3061,7 +3353,13 @@ function bindEvents() {
   calendarNavButtons.forEach(button => {
     button.addEventListener('click', () => {
       const direction = button.dataset.calendarNav === 'next' ? 1 : -1;
-      changeCalendarMonth(direction);
+      changeCalendarPeriod(direction);
+    });
+  });
+
+  calendarViewModeButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      setCalendarViewMode(button.dataset.calendarViewMode);
     });
   });
 
@@ -3072,6 +3370,10 @@ function bindEvents() {
   if (calendarGrid) {
     calendarGrid.addEventListener('click', handleCalendarGridClick);
     calendarGrid.addEventListener('keydown', handleCalendarGridKeydown);
+  }
+
+  if (calendarGridViewport) {
+    calendarGridViewport.addEventListener('scroll', handleRollingCalendarScroll, { passive: true });
   }
 
   if (addEventForDayButton) {
@@ -3093,8 +3395,9 @@ applyShareModeUi();
 if (initializeSharedCalendar()) {
   showLog('Opening private shared calendar…', 'info');
 } else {
-  ensureDefaultTodayEvent();
+  pruneLegacyAutoSeedEvents();
   setupGunSync();
+  refreshUntitledImportedEvents();
   initializeOwnerShareControls();
   const readyMessage = gunEvents
     ? 'Ready to manage your calendar. Events sync through the 3DVR relay and can connect to Google or Outlook when needed.'

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -53,13 +53,19 @@
           <div class="calendar-view">
             <div class="calendar-view__header">
               <div class="calendar-view__heading">
-                <h2 id="calendar-view-title">Month</h2>
+                <h2 id="calendar-view-title" data-calendar-view-title>Month</h2>
                 <p class="calendar-view__current" data-calendar-current aria-live="polite"></p>
               </div>
-              <div class="calendar-view__controls" role="group" aria-label="Change month">
-                <button type="button" class="button-secondary calendar-nav" data-calendar-nav="prev" aria-label="Previous month">‹</button>
-                <button type="button" class="button-secondary" data-calendar-today>Today</button>
-                <button type="button" class="button-secondary calendar-nav" data-calendar-nav="next" aria-label="Next month">›</button>
+              <div class="calendar-view__toolbar">
+                <div class="calendar-view__mode" role="group" aria-label="Calendar view">
+                  <button type="button" class="button-secondary" data-calendar-view-mode="month" aria-pressed="true">Month</button>
+                  <button type="button" class="button-secondary" data-calendar-view-mode="week" aria-pressed="false">7 days</button>
+                </div>
+                <div class="calendar-view__controls" role="group" aria-label="Change calendar range">
+                  <button type="button" class="button-secondary calendar-nav" data-calendar-nav="prev" aria-label="Previous range">‹</button>
+                  <button type="button" class="button-secondary" data-calendar-today>Today</button>
+                  <button type="button" class="button-secondary calendar-nav" data-calendar-nav="next" aria-label="Next range">›</button>
+                </div>
               </div>
             </div>
 

--- a/calendar/service-worker.js
+++ b/calendar/service-worker.js
@@ -1,6 +1,6 @@
 /* calendar/service-worker.js */
 
-const CACHE_VERSION = 'v3';
+const CACHE_VERSION = 'v4';
 const STATIC_CACHE = `calendar-static-${CACHE_VERSION}`;
 const HTML_CACHE = `calendar-html-${CACHE_VERSION}`;
 const SCOPE_URL = new URL(self.registration.scope);

--- a/tests/calendar-pwa-config.test.js
+++ b/tests/calendar-pwa-config.test.js
@@ -55,11 +55,11 @@ describe('calendar PWA configuration', () => {
   it('ships a calendar-specific service worker', async () => {
     const workerSource = await readProjectFile('calendar/service-worker.js');
 
-    assert.match(workerSource, /const CACHE_VERSION = 'v2';/);
+    assert.match(workerSource, /const CACHE_VERSION = 'v4';/);
     assert.match(workerSource, /calendar-static-/);
     assert.match(workerSource, /calendar-html-/);
     assert.match(workerSource, /scopeAsset\('global\.css'\)/);
-    assert.match(workerSource, /scopeAsset\('calendar\.css'\)/);
+    assert.match(workerSource, /scopeAsset\('calendar-v2\.css'\)/);
     assert.match(workerSource, /scopeAsset\('install-banner\.css'\)/);
     assert.match(workerSource, /scopeAsset\('calendar\.js'\)/);
     assert.match(workerSource, /scopeAsset\('gun-init\.js'\)/);

--- a/tests/calendar-ui.test.js
+++ b/tests/calendar-ui.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
-test('calendar presents a month-first workspace with secondary tools below', async () => {
+test('calendar presents a schedule-first workspace with secondary tools below', async () => {
   const html = await readFile(new URL('../calendar/index.html', import.meta.url), 'utf8');
 
   assert.match(html, /<header class="calendar-header">/);
@@ -12,7 +12,10 @@ test('calendar presents a month-first workspace with secondary tools below', asy
   assert.match(html, />Connections<\/a>/);
   assert.match(html, /<section class="panel panel--primary" aria-labelledby="calendar-view-title">/);
   assert.match(html, /<div class="calendar-workspace">/);
-  assert.match(html, /<h2 id="calendar-view-title">Month<\/h2>/);
+  assert.match(html, /<h2 id="calendar-view-title" data-calendar-view-title>Month<\/h2>/);
+  assert.match(html, /data-calendar-view-mode="month"/);
+  assert.match(html, /data-calendar-view-mode="week"/);
+  assert.match(html, />7 days<\/button>/);
   assert.match(html, /<aside class="calendar-planner" aria-labelledby="calendar-planner-title">/);
   assert.match(html, /<h2 id="calendar-planner-title">Add event<\/h2>/);
   assert.match(html, /data-label-open="\+ Add event"/);
@@ -28,7 +31,7 @@ test('calendar presents a month-first workspace with secondary tools below', asy
 
   assert.ok(
     html.indexOf('calendar-stage') < html.indexOf('calendar-planner'),
-    'expected the month to appear before the event planner'
+    'expected the calendar view to appear before the event planner'
   );
   assert.ok(
     html.indexOf('panel--primary') < html.indexOf('calendar-rail'),
@@ -109,4 +112,30 @@ test('calendar Google OAuth refreshes tokens and imports the current month after
   assert.match(js, /async function importCurrentMonthFromProvider\(provider\)/);
   assert.match(js, /Importing this month/);
   assert.match(js, /await getFreshConnectionOrWarn\(provider/);
+});
+
+
+test('calendar offers a rolling seven-day view that can be scrolled day by day', async () => {
+  const js = await readFile(new URL('../calendar/calendar.js', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../calendar/calendar-v2.css', import.meta.url), 'utf8');
+
+  assert.match(js, /ROLLING_WEEK_VISIBLE_DAYS = 7/);
+  assert.match(js, /function renderRollingWeek\(events = state\.localEvents\)/);
+  assert.match(js, /function handleRollingCalendarScroll\(\)/);
+  assert.match(js, /function syncRollingAnchorFromScroll\(\)/);
+  assert.match(js, /changeCalendarPeriod\(offset\)/);
+  assert.match(css, /\.calendar-view__grid\[data-calendar-view="week"\][\s\S]*?overflow-x:\s*auto;/);
+  assert.match(css, /grid-auto-columns:\s*calc\(\(100% - 42px\) \/ 7\)/);
+  assert.match(css, /scroll-snap-type:\s*x proximity/);
+});
+
+test('calendar repairs stale untitled imports and removes legacy placeholder events', async () => {
+  const js = await readFile(new URL('../calendar/calendar.js', import.meta.url), 'utf8');
+
+  assert.match(js, /function remoteEventTitle\(provider, raw\)/);
+  assert.match(js, /raw\.summary/);
+  assert.match(js, /raw\.subject/);
+  assert.match(js, /async function refreshUntitledImportedEvents\(\)/);
+  assert.match(js, /function pruneLegacyAutoSeedEvents\(\)/);
+  assert.doesNotMatch(js, /\n\s*ensureDefaultTodayEvent\(\);/);
 });


### PR DESCRIPTION
Adds a rolling `7 days` Calendar mode designed for irregular stagehand schedules instead of a rigid Sun–Sat week.

- desktop shows seven days at once
- trackpad/touch horizontal scrolling peeks day-by-day through nearby dates
- mobile deliberately leaves the next day peeking in
- prev/next jumps seven days; Today recenters
- remembers Month vs 7 days
- preserves selected-day details and event creation
- stops generating the old automatic 10-minute placeholder events
- removes untouched legacy auto-seeded placeholders
- refreshes stale imported `Untitled event` entries from connected Google/Outlook calendars
- uses source-aware title fallbacks instead of immediately discarding missing-title context
- bumps the Calendar service-worker cache

Validation: Calendar-focused tests 22/22 pass and `git diff --check` is clean. The repository-wide suite still has unrelated pre-existing failures, including the old Vercel 12-function ceiling test (current repo has 15 functions).