### PR TITLE
Launch 3DVR Compute website

### DIFF
--- a/compute/index.html
+++ b/compute/index.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3DVR Compute | Open Personal Computing Hardware</title>
+  <meta name="description" content="3DVR Compute is a community-driven open hardware project for modular, repairable, Linux-first personal computers.">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-mark.svg">
+  <link rel="stylesheet" href="./styles.css?v=20260828">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <nav class="site-nav" aria-label="3DVR Compute navigation">
+    <a class="brand" href="/compute/">
+      <img src="/brand/portal-mark.svg" alt="">
+      <span>3DVR Compute</span>
+    </a>
+    <div class="nav-links">
+      <a href="#vision">Vision</a>
+      <a href="/compute/laptop/">Laptop</a>
+      <a href="/supply-chain/">Supply Chain</a>
+      <a href="#roadmap">Roadmap</a>
+    </div>
+    <a class="button" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Compute">Join the project</a>
+  </nav>
+
+  <main>
+    <header class="hero" id="vision">
+      <div>
+        <p class="eyebrow">Open by design. Made for people.</p>
+        <h1>Open personal computing hardware.</h1>
+        <p class="lede">
+          3DVR Compute is a community-driven effort to build computers that are modular, repairable,
+          Linux-first, and increasingly open all the way down.
+        </p>
+        <div class="hero-actions">
+          <a class="button primary" href="/compute/laptop/">Explore the laptop</a>
+          <a class="button" href="#roadmap">See the roadmap</a>
+          <a class="button" href="/supply-chain/">Open supply chain</a>
+        </div>
+      </div>
+
+      <div class="device-stage" role="img" aria-label="Concept illustration of a modular 3DVR laptop with removable compute modules">
+        <div class="laptop" aria-hidden="true">
+          <div class="screen"><span class="screen-mark">3DVR</span></div>
+          <div class="keyboard"></div>
+        </div>
+        <div class="module one" aria-hidden="true"></div>
+        <div class="module two" aria-hidden="true"></div>
+        <div class="module three" aria-hidden="true"></div>
+        <p class="device-note">One laptop shell. Many replaceable compute paths.</p>
+      </div>
+    </header>
+
+    <section class="value-strip" aria-label="Project values">
+      <div class="value"><strong>Modular</strong><span>Upgrade parts instead of replacing the machine.</span></div>
+      <div class="value"><strong>Repairable</strong><span>Standard tools, replaceable parts, clear documentation.</span></div>
+      <div class="value"><strong>Privacy-first</strong><span>Physical controls and ownership of your data.</span></div>
+      <div class="value"><strong>Linux-first</strong><span>Freedom to use, inspect, and improve the software.</span></div>
+      <div class="value"><strong>Community-built</strong><span>Design, test, document, manufacture, and improve together.</span></div>
+    </section>
+
+    <section class="section" aria-labelledby="device-title">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">First device</p>
+          <h2 id="device-title">3DVR Laptop</h2>
+        </div>
+        <p>
+          A continuation of the best ideas behind Balthazar: a useful laptop shell that can survive multiple
+          generations of compute hardware instead of becoming disposable when one board is obsolete.
+        </p>
+      </div>
+
+      <div class="cards">
+        <article class="card">
+          <span class="tag">Compute module</span>
+          <h3>Swap the brain.</h3>
+          <p>Prototype around modules such as Lichee Pi 4A, StarFive-based boards, Beagle boards, and other documented compute platforms.</p>
+          <a href="/compute/laptop/">Laptop concept →</a>
+        </article>
+        <article class="card">
+          <span class="tag">Open hardware</span>
+          <h3>Design the shell to last.</h3>
+          <p>Keep the keyboard, display, storage, ports, battery, enclosure, and privacy controls understandable and replaceable.</p>
+          <a href="/supply-chain/balthazar.md">Balthazar roadmap →</a>
+        </article>
+        <article class="card">
+          <span class="tag">Open supply chain</span>
+          <h3>Know what is inside.</h3>
+          <p>Trace components and materials, document substitutes, prioritize reuse, and gradually replace closed dependencies.</p>
+          <a href="/supply-chain/">Explore the registry →</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="roadmap" aria-labelledby="roadmap-title">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Roadmap</p>
+          <h2 id="roadmap-title">Build the open layers one at a time.</h2>
+        </div>
+        <p>We are not waiting for a perfectly open computer. We start with hardware that exists, learn from it, and replace closed layers as the community gains capability.</p>
+      </div>
+
+      <div class="path">
+        <div class="step"><strong>1. Prototype</strong><span>Fit real modular boards into a practical laptop architecture and validate power, display, input, storage, thermals, and Linux.</span></div>
+        <div class="step"><strong>2. Open modules</strong><span>Publish mechanical, electrical, firmware, and service documentation with clear interfaces between modules.</span></div>
+        <div class="step"><strong>3. Open supply chain</strong><span>Trace components, find repairable substitutes, and work with community and regional manufacturers.</span></div>
+        <div class="step"><strong>4. Open ecosystem</strong><span>Support new RISC-V boards, accelerators, accessories, and future community-designed compute hardware.</span></div>
+      </div>
+    </section>
+
+    <section class="callout" aria-labelledby="community-title">
+      <div>
+        <p class="eyebrow">Community hardware</p>
+        <h2 id="community-title">Help finish the computer we wish existed.</h2>
+        <p>Hardware designers, Linux developers, CAD people, repair technicians, manufacturers, makers, and curious users are all useful here.</p>
+      </div>
+      <a class="button" href="mailto:3dvr.tech@gmail.com?subject=Join%203DVR%20Compute">Join 3DVR Compute</a>
+    </section>
+  </main>
+
+  <footer>
+    <strong>3DVR Compute</strong>
+    <a href="/">Portal</a>
+    <a href="/supply-chain/">Open Supply Chain</a>
+    <a href="https://balthazar.space/">Balthazar</a>
+    <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>
+  </footer>
+
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/compute/laptop/index.html
+++ b/compute/laptop/index.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3DVR Laptop | 3DVR Compute</title>
+  <meta name="description" content="A modular, repairable, Linux-first laptop concept from 3DVR Compute, continuing the open hardware ideas behind Balthazar.">
+  <link rel="icon" type="image/svg+xml" href="/brand/portal-mark.svg">
+  <link rel="stylesheet" href="../styles.css?v=20260828">
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <nav class="site-nav" aria-label="3DVR Laptop navigation">
+    <a class="brand" href="/compute/">
+      <img src="/brand/portal-mark.svg" alt="">
+      <span>3DVR Compute</span>
+    </a>
+    <div class="nav-links">
+      <a href="/compute/">Vision</a>
+      <a href="#architecture">Architecture</a>
+      <a href="/supply-chain/">Supply Chain</a>
+      <a href="#prototype">Prototype</a>
+    </div>
+    <a class="button" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Laptop">Join the project</a>
+  </nav>
+
+  <main>
+    <header class="hero">
+      <div>
+        <p class="eyebrow">3DVR Compute / first device</p>
+        <h1>3DVR Laptop</h1>
+        <p class="lede">
+          A laptop designed around the idea that the computer should outlive the compute board inside it.
+          Modular. Repairable. Linux-first. Built in the open.
+        </p>
+        <div class="hero-actions">
+          <a class="button primary" href="mailto:3dvr.tech@gmail.com?subject=Help%20build%203DVR%20Laptop">Help build it</a>
+          <a class="button" href="/supply-chain/balthazar.md">Read the Balthazar roadmap</a>
+          <a class="button" href="#prototype">Prototype plan</a>
+        </div>
+      </div>
+
+      <div class="device-stage" role="img" aria-label="Concept illustration showing the 3DVR Laptop and removable modules">
+        <div class="laptop" aria-hidden="true">
+          <div class="screen"><span class="screen-mark">3DVR</span></div>
+          <div class="keyboard"></div>
+        </div>
+        <div class="module one" aria-hidden="true"></div>
+        <div class="module two" aria-hidden="true"></div>
+        <div class="module three" aria-hidden="true"></div>
+        <p class="device-note">Keep the useful machine. Replace only what actually needs to change.</p>
+      </div>
+    </header>
+
+    <section class="value-strip" aria-label="3DVR Laptop principles">
+      <div class="value"><strong>Modular compute</strong><span>Support more than one processor family over time.</span></div>
+      <div class="value"><strong>Replaceable essentials</strong><span>Battery, storage, keyboard, display, and ports should be serviceable.</span></div>
+      <div class="value"><strong>Hardware privacy</strong><span>Prefer physical controls for camera, mic, radios, and sensitive devices.</span></div>
+      <div class="value"><strong>Open documentation</strong><span>Publish what people need to repair, modify, and manufacture.</span></div>
+      <div class="value"><strong>Linux native</strong><span>Make upstream-friendly Linux support a first-class requirement.</span></div>
+    </section>
+
+    <section class="section" id="architecture" aria-labelledby="architecture-title">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Architecture</p>
+          <h2 id="architecture-title">Separate the laptop from the compute generation.</h2>
+        </div>
+        <p>
+          Balthazar's strongest idea was the separation between the useful physical laptop and the replaceable compute module.
+          We want to preserve that philosophy while adapting it to hardware we can obtain and test today.
+        </p>
+      </div>
+
+      <div class="cards">
+        <article class="card">
+          <span class="tag">01 / Compute</span>
+          <h3>Replaceable compute module</h3>
+          <p>CPU, RAM, and board-level compute live in a replaceable module with a documented interface to the rest of the laptop.</p>
+        </article>
+        <article class="card">
+          <span class="tag">02 / I/O</span>
+          <h3>Stable laptop interfaces</h3>
+          <p>Display, keyboard, trackpad, storage, USB, networking, audio, and power should remain useful across several compute generations.</p>
+        </article>
+        <article class="card">
+          <span class="tag">03 / Service</span>
+          <h3>Designed to come apart</h3>
+          <p>Favor screws, documented fasteners, standard tools, replaceable cells and modules, and parts that can be made or sourced independently.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="prototype" aria-labelledby="prototype-title">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Prototype targets</p>
+          <h2 id="prototype-title">Use existing boards before inventing new silicon.</h2>
+        </div>
+        <p>Our first job is to prove the laptop architecture. The compute module can improve as RISC-V and open hardware improve.</p>
+      </div>
+
+      <div class="cards">
+        <article class="card">
+          <span class="tag">RISC-V</span>
+          <h3>Lichee Pi 4A / LM4A</h3>
+          <p>TH1520-based modular compute with published documentation. A practical starting point for a RISC-V prototype and supply-chain trace.</p>
+          <a href="/supply-chain/">Trace the hardware →</a>
+        </article>
+        <article class="card">
+          <span class="tag">RISC-V</span>
+          <h3>StarFive / Beagle ecosystem</h3>
+          <p>Boards around open-friendly RISC-V ecosystems give us alternative compute paths and prevent the chassis from becoming tied to one vendor.</p>
+        </article>
+        <article class="card">
+          <span class="tag">Bridge platform</span>
+          <h3>x86 compute modules</h3>
+          <p>Documented x86 modules can help validate power, display, keyboard, battery, thermals, and enclosure design while RISC-V catches up.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="glance-title">
+      <div class="spec-grid">
+        <div>
+          <p class="eyebrow">Design target</p>
+          <h2 id="glance-title">A computer you can keep.</h2>
+          <p class="lede">These are goals, not final specifications. The project stays intentionally flexible until real prototypes teach us what works.</p>
+        </div>
+        <ul class="specs">
+          <li><strong>Compute</strong><span>Replaceable module; RISC-V first where practical, other open/documented options welcome.</span></li>
+          <li><strong>Storage</strong><span>Standard replaceable NVMe or similarly serviceable storage.</span></li>
+          <li><strong>Memory</strong><span>Replaceable where the module architecture allows it.</span></li>
+          <li><strong>Display</strong><span>Common, documented interface with a replaceable panel assembly.</span></li>
+          <li><strong>Input</strong><span>Replaceable keyboard and trackpad modules.</span></li>
+          <li><strong>Battery</strong><span>Serviceable pack with published electrical and mechanical information.</span></li>
+          <li><strong>Firmware</strong><span>Minimize opaque firmware and document every unavoidable closed dependency.</span></li>
+          <li><strong>OS</strong><span>Linux-first with upstream support preferred over vendor-only software stacks.</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="callout" aria-labelledby="build-title">
+      <div>
+        <p class="eyebrow">Build in public</p>
+        <h2 id="build-title">The design starts before the hardware is perfect.</h2>
+        <p>We can document interfaces, preserve Balthazar's work, trace candidate boards, and develop the enclosure and module standard while testing real hardware.</p>
+      </div>
+      <a class="button" href="mailto:3dvr.tech@gmail.com?subject=Contribute%20to%203DVR%20Laptop">Contribute</a>
+    </section>
+  </main>
+
+  <footer>
+    <strong>3DVR Laptop</strong>
+    <a href="/compute/">3DVR Compute</a>
+    <a href="/supply-chain/">Open Supply Chain</a>
+    <a href="https://balthazar.space/">Original Balthazar</a>
+    <a href="mailto:3dvr.tech@gmail.com">3dvr.tech@gmail.com</a>
+  </footer>
+
+  <script defer src="/issue-launcher.js"></script>
+</body>
+</html>

--- a/compute/styles.css
+++ b/compute/styles.css
@@ -1,0 +1,310 @@
+:root {
+  color-scheme: light;
+  --ink: #172224;
+  --muted: #5e6b6c;
+  --teal: #226c70;
+  --teal-dark: #174e52;
+  --teal-soft: #dceceb;
+  --sand: #f1ece2;
+  --linen: #faf7f0;
+  --line: #d9d8d1;
+  --card: rgba(255, 255, 255, 0.78);
+  --shadow: 0 18px 48px rgba(31, 48, 49, 0.09);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--linen);
+  color: var(--ink);
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 80% 8%, rgba(34, 108, 112, 0.1), transparent 28rem),
+    linear-gradient(180deg, #fbf8f2 0%, #f5f1e8 100%);
+  color: var(--ink);
+}
+
+a { color: inherit; }
+img { max-width: 100%; }
+
+.site-nav {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+}
+
+.brand {
+  margin-right: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 850;
+  font-size: 1.05rem;
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+.brand img { width: 30px; height: 30px; }
+.nav-links { display: flex; align-items: center; gap: 22px; }
+.nav-links a { color: var(--muted); text-decoration: none; font-weight: 650; font-size: 0.92rem; }
+.nav-links a:hover,
+.nav-links a:focus-visible { color: var(--teal); outline: none; }
+
+.button {
+  min-height: 44px;
+  padding: 11px 16px;
+  border: 1px solid #b9c8c8;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.58);
+  color: var(--teal-dark);
+  font-weight: 760;
+  text-decoration: none;
+}
+
+.button.primary {
+  border-color: var(--teal);
+  background: var(--teal);
+  color: white;
+}
+
+.button:hover,
+.button:focus-visible { transform: translateY(-1px); box-shadow: 0 8px 24px rgba(34, 108, 112, 0.12); outline: none; }
+
+main { width: min(1180px, calc(100% - 32px)); margin: 0 auto; }
+.hero {
+  min-height: 610px;
+  padding: 78px 0 60px;
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(420px, 1.05fr);
+  gap: 70px;
+  align-items: center;
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  color: var(--teal);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1, h2, h3 { margin-top: 0; }
+h1,
+h2 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 500;
+  letter-spacing: -0.035em;
+}
+
+h1 { margin-bottom: 22px; font-size: clamp(3.2rem, 7vw, 6.2rem); line-height: 0.93; }
+h2 { margin-bottom: 14px; font-size: clamp(2rem, 4vw, 3.5rem); line-height: 1; }
+h3 { margin-bottom: 8px; font-size: 1.08rem; }
+.lede { max-width: 650px; margin: 0; color: #425051; font-size: 1.08rem; line-height: 1.65; }
+.hero-actions { margin-top: 28px; display: flex; flex-wrap: wrap; gap: 10px; }
+
+.device-stage {
+  position: relative;
+  min-height: 460px;
+  border: 1px solid rgba(34, 108, 112, 0.15);
+  border-radius: 36px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 48% 25%, rgba(255, 255, 255, 0.9), transparent 13rem),
+    linear-gradient(145deg, #e9e4da, #f8f5ee 58%, #dfeae8);
+  box-shadow: var(--shadow);
+}
+
+.laptop {
+  position: absolute;
+  width: 62%;
+  left: 20%;
+  top: 13%;
+}
+.screen {
+  aspect-ratio: 16 / 10;
+  border: 9px solid #252a2a;
+  border-bottom-width: 13px;
+  border-radius: 12px 12px 5px 5px;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle at 62% 28%, rgba(120, 186, 188, 0.35), transparent 30%),
+    linear-gradient(155deg, #152427, #273c41 52%, #122124);
+  color: #d9eeee;
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.22);
+}
+.screen-mark { font-size: clamp(1rem, 4vw, 2.2rem); font-weight: 900; letter-spacing: 0.08em; }
+.keyboard {
+  width: 108%;
+  height: 54px;
+  margin-left: -4%;
+  background: linear-gradient(#4a5050, #252929);
+  clip-path: polygon(5% 0, 95% 0, 100% 100%, 0 100%);
+  border-radius: 0 0 14px 14px;
+  box-shadow: 0 16px 20px rgba(0, 0, 0, 0.18);
+}
+.module {
+  position: absolute;
+  width: 120px;
+  height: 80px;
+  border-radius: 14px;
+  border: 1px solid #596161;
+  background: linear-gradient(145deg, #414848, #252929);
+  box-shadow: 0 14px 24px rgba(0, 0, 0, 0.15);
+}
+.module::before {
+  content: "3DVR";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #b9c7c6;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+}
+.module.one { left: 8%; bottom: 13%; transform: rotate(-5deg); }
+.module.two { right: 8%; bottom: 11%; width: 150px; transform: rotate(4deg); }
+.module.three { left: 35%; bottom: 4%; width: 138px; height: 88px; transform: rotate(1deg); }
+.device-note {
+  position: absolute;
+  right: 7%;
+  top: 10%;
+  max-width: 150px;
+  color: var(--teal-dark);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  font-weight: 700;
+}
+
+.value-strip {
+  margin: 0 0 72px;
+  padding: 22px 0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+.value { padding: 4px 20px; border-left: 1px solid var(--line); }
+.value:first-child { border-left: 0; padding-left: 0; }
+.value:last-child { padding-right: 0; }
+.value strong { display: block; margin-bottom: 4px; }
+.value span { color: var(--muted); font-size: 0.84rem; line-height: 1.4; }
+
+.section { padding: 58px 0; border-top: 1px solid var(--line); }
+.section-head {
+  margin-bottom: 28px;
+  display: flex;
+  justify-content: space-between;
+  gap: 32px;
+  align-items: end;
+}
+.section-head p:last-child { max-width: 520px; margin: 0; color: var(--muted); line-height: 1.6; }
+.cards { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
+.card {
+  min-height: 260px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--card);
+  box-shadow: 0 10px 28px rgba(31, 48, 49, 0.04);
+}
+.card .tag {
+  display: inline-flex;
+  margin-bottom: 34px;
+  padding: 6px 9px;
+  border-radius: 999px;
+  background: var(--teal-soft);
+  color: var(--teal-dark);
+  font-size: 0.72rem;
+  font-weight: 820;
+}
+.card p { color: var(--muted); line-height: 1.55; }
+.card a { color: var(--teal); font-weight: 760; text-decoration: none; }
+
+.path {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+.step { padding: 22px; border-top: 3px solid #bfd0cf; background: rgba(255, 255, 255, 0.35); }
+.step strong { display: block; margin-bottom: 7px; }
+.step span { color: var(--muted); font-size: 0.9rem; line-height: 1.5; }
+
+.callout {
+  margin: 62px 0;
+  padding: 42px;
+  border-radius: 24px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 32px;
+  align-items: center;
+  background: var(--teal-dark);
+  color: white;
+}
+.callout h2 { margin-bottom: 8px; }
+.callout p { margin: 0; color: #d8eeee; line-height: 1.6; }
+.callout .button { border-color: white; background: white; color: var(--teal-dark); }
+
+.spec-grid { display: grid; grid-template-columns: 0.85fr 1.15fr; gap: 42px; }
+.specs { margin: 0; padding: 0; list-style: none; }
+.specs li { padding: 12px 0; display: grid; grid-template-columns: 130px 1fr; gap: 16px; border-bottom: 1px solid var(--line); }
+.specs strong { color: var(--teal-dark); }
+.specs span { color: var(--muted); }
+
+footer {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 28px 0 40px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 26px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+footer strong { color: var(--ink); margin-right: auto; }
+footer a { text-decoration: none; }
+
+@media (max-width: 860px) {
+  .nav-links { display: none; }
+  .hero { min-height: auto; padding-top: 42px; grid-template-columns: 1fr; gap: 36px; }
+  .device-stage { min-height: 390px; }
+  .value-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .value { padding: 14px; border-left: 0; border-top: 1px solid var(--line); }
+  .value:first-child { padding-left: 14px; }
+  .cards { grid-template-columns: 1fr; }
+  .path { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .section-head { display: block; }
+  .callout { grid-template-columns: 1fr; }
+  .spec-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 560px) {
+  .site-nav { min-height: 62px; }
+  .site-nav > .button { display: none; }
+  main { width: min(100% - 24px, 1180px); }
+  h1 { font-size: clamp(3.3rem, 17vw, 5rem); }
+  .hero { padding-top: 36px; }
+  .device-stage { min-height: 310px; border-radius: 24px; }
+  .laptop { width: 72%; left: 14%; top: 14%; }
+  .module { transform: scale(0.78) !important; transform-origin: center; }
+  .module.one { left: 1%; bottom: 5%; }
+  .module.two { right: -4%; bottom: 7%; }
+  .module.three { left: 30%; bottom: -1%; }
+  .device-note { display: none; }
+  .value-strip { grid-template-columns: 1fr; }
+  .path { grid-template-columns: 1fr; }
+  .callout { padding: 28px; }
+  .specs li { grid-template-columns: 1fr; gap: 4px; }
+  footer { width: min(100% - 24px, 1180px); }
+}


### PR DESCRIPTION
## What
- add `/compute/` as the 3DVR Compute landing page
- add `/compute/laptop/` for the first device concept
- add responsive shared styles
- connect the project to the existing Open Supply Chain and Balthazar continuation work

## Why
Turn the 3DVR Compute concept into a public, usable project home with the smallest useful scope.

## Verification
- static HTML/CSS only; no billing, account, or Stripe changes
- mobile-first responsive layout
- uses the existing 3DVR mark, canonical contact email, Vercel Insights, and issue launcher

Portal/account impact: none.