### PR TITLE
Add bounded website upgrade order reader

### DIFF
--- a/apps/agent/test/website-upgrade-order-reader.test.js
+++ b/apps/agent/test/website-upgrade-order-reader.test.js
@@ -1,0 +1,94 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  listCompletedUpgradeOrders,
+  normalizeHostedSiteUrl,
+  sessionToUpgradeOrder,
+} = require('../thomas-agent/node/website-upgrade-order-reader');
+
+function paidSession(overrides = {}) {
+  return {
+    id: 'cs_live_upgrade_123',
+    status: 'complete',
+    payment_status: 'paid',
+    amount_total: 9900,
+    currency: 'usd',
+    created: 123,
+    customer_details: { email: 'buyer@example.com' },
+    custom_fields: [
+      { key: 'business_name', type: 'text', text: { value: 'Example Studio' } },
+      { key: 'site_url', type: 'text', text: { value: 'https://www.3dvr.tech/free-sites/example-studio/' } },
+      { key: 'main_action', type: 'text', text: { value: 'Book a consultation' } },
+    ],
+    ...overrides,
+  };
+}
+
+test('normalizes a 3DVR-hosted free-site URL', () => {
+  assert.deepEqual(normalizeHostedSiteUrl('https://www.3dvr.tech/free-sites/Example-Studio/'), {
+    slug: 'example-studio',
+    siteUrl: 'https://3dvr.tech/free-sites/example-studio/',
+  });
+});
+
+test('rejects external sites from automatic fulfillment', () => {
+  assert.throws(
+    () => normalizeHostedSiteUrl('https://example.com/'),
+    /only supports 3DVR-hosted free drafts/,
+  );
+});
+
+test('turns a paid completed checkout into a bounded upgrade order', () => {
+  assert.deepEqual(sessionToUpgradeOrder(paidSession()), {
+    sessionId: 'cs_live_upgrade_123',
+    businessName: 'Example Studio',
+    mainAction: 'Book a consultation',
+    siteUrl: 'https://3dvr.tech/free-sites/example-studio/',
+    slug: 'example-studio',
+    customerEmail: 'buyer@example.com',
+    amountTotal: 9900,
+    currency: 'usd',
+    created: 123,
+  });
+});
+
+test('ignores unpaid or incomplete sessions', () => {
+  assert.equal(sessionToUpgradeOrder(paidSession({ payment_status: 'unpaid' })), null);
+  assert.equal(sessionToUpgradeOrder(paidSession({ status: 'open' })), null);
+});
+
+test('lists eligible orders and separately reports blocked paid orders', async () => {
+  const seen = {};
+  const result = await listCompletedUpgradeOrders({
+    env: { STRIPE_SECRET_KEY: 'sk_test_fake' },
+    fetchImpl: async (url, init) => {
+      seen.url = url;
+      seen.authorization = init.headers.Authorization;
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            data: [
+              paidSession(),
+              paidSession({
+                id: 'cs_live_external_456',
+                custom_fields: [
+                  { key: 'business_name', type: 'text', text: { value: 'External Business' } },
+                  { key: 'site_url', type: 'text', text: { value: 'https://example.com/' } },
+                  { key: 'main_action', type: 'text', text: { value: 'Call now' } },
+                ],
+              }),
+            ],
+          };
+        },
+      };
+    },
+  });
+
+  assert.match(seen.url, /payment_link=plink_1U9JF6GiUl5dM378HHz6Ss5z/);
+  assert.equal(seen.authorization, 'Bearer sk_test_fake');
+  assert.equal(result.orders.length, 1);
+  assert.equal(result.blocked.length, 1);
+  assert.equal(result.blocked[0].sessionId, 'cs_live_external_456');
+});

--- a/apps/agent/thomas-agent/node/website-upgrade-order-reader.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-order-reader.js
@@ -1,0 +1,150 @@
+const DEFAULT_PAYMENT_LINK_ID = process.env.THREEDVR_WEBSITE_UPGRADE_PAYMENT_LINK_ID || 'plink_1U9JF6GiUl5dM378HHz6Ss5z';
+const STRIPE_API_BASE = 'https://api.stripe.com/v1';
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function customFieldValue(field = {}) {
+  const type = normalizeText(field.type);
+  if (type && field[type] && typeof field[type] === 'object') {
+    return normalizeText(field[type].value);
+  }
+  for (const key of ['text', 'dropdown', 'numeric']) {
+    if (field[key] && typeof field[key] === 'object' && field[key].value != null) {
+      return normalizeText(field[key].value);
+    }
+  }
+  return '';
+}
+
+function customFieldsObject(session = {}) {
+  const output = {};
+  for (const field of Array.isArray(session.custom_fields) ? session.custom_fields : []) {
+    const key = normalizeText(field.key);
+    if (!key) continue;
+    output[key] = customFieldValue(field);
+  }
+  return output;
+}
+
+function normalizeHostedSiteUrl(value) {
+  const input = normalizeText(value);
+  if (!input) throw new Error('Website Upgrade checkout is missing site_url.');
+
+  let parsed;
+  try {
+    parsed = new URL(input);
+  } catch {
+    throw new Error('Website Upgrade site_url is not a valid URL.');
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (!['3dvr.tech', 'www.3dvr.tech'].includes(host)) {
+    throw new Error('Website Upgrade auto-fulfillment only supports 3DVR-hosted free drafts.');
+  }
+
+  const match = parsed.pathname.match(/^\/free-sites\/([a-z0-9][a-z0-9-]{0,79})\/?$/i);
+  if (!match) {
+    throw new Error('Website Upgrade site_url must point to a 3DVR free-site draft.');
+  }
+
+  const slug = match[1].toLowerCase();
+  return {
+    slug,
+    siteUrl: `https://3dvr.tech/free-sites/${slug}/`,
+  };
+}
+
+function sessionToUpgradeOrder(session = {}) {
+  if (normalizeText(session.payment_status).toLowerCase() !== 'paid') return null;
+  if (normalizeText(session.status).toLowerCase() !== 'complete') return null;
+
+  const sessionId = normalizeText(session.id);
+  if (!sessionId) throw new Error('Website Upgrade checkout is missing a session id.');
+
+  const fields = customFieldsObject(session);
+  const businessName = normalizeText(fields.business_name);
+  const mainAction = normalizeText(fields.main_action);
+  if (!businessName) throw new Error(`Website Upgrade ${sessionId} is missing business_name.`);
+  if (!mainAction) throw new Error(`Website Upgrade ${sessionId} is missing main_action.`);
+
+  const hosted = normalizeHostedSiteUrl(fields.site_url);
+  return {
+    sessionId,
+    businessName,
+    mainAction,
+    siteUrl: hosted.siteUrl,
+    slug: hosted.slug,
+    customerEmail: normalizeText(session.customer_details?.email || session.customer_email),
+    amountTotal: Number.isFinite(Number(session.amount_total)) ? Number(session.amount_total) : null,
+    currency: normalizeText(session.currency).toLowerCase(),
+    created: Number.isFinite(Number(session.created)) ? Number(session.created) : null,
+  };
+}
+
+async function listCompletedUpgradeOrders(options = {}) {
+  const env = options.env || process.env;
+  const fetchImpl = options.fetchImpl || fetch;
+  const secretKey = normalizeText(env.STRIPE_SECRET_KEY);
+  if (!secretKey) throw new Error('STRIPE_SECRET_KEY is required.');
+
+  const paymentLinkId = normalizeText(
+    options.paymentLinkId
+    || env.THREEDVR_WEBSITE_UPGRADE_PAYMENT_LINK_ID
+    || DEFAULT_PAYMENT_LINK_ID,
+  );
+  if (!paymentLinkId) throw new Error('Website Upgrade payment link id is required.');
+
+  const params = new URLSearchParams({
+    payment_link: paymentLinkId,
+    status: 'complete',
+    limit: String(Math.max(1, Math.min(Number(options.limit || 20), 100))),
+  });
+  const response = await fetchImpl(`${STRIPE_API_BASE}/checkout/sessions?${params}`, {
+    headers: { Authorization: `Bearer ${secretKey}` },
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const message = payload?.error?.message || `Stripe returned ${response.status}`;
+    throw new Error(message);
+  }
+
+  const orders = [];
+  const blocked = [];
+  for (const session of Array.isArray(payload.data) ? payload.data : []) {
+    try {
+      const order = sessionToUpgradeOrder(session);
+      if (order) orders.push(order);
+    } catch (error) {
+      blocked.push({
+        sessionId: normalizeText(session?.id),
+        reason: String(error?.message || error),
+      });
+    }
+  }
+
+  orders.sort((a, b) => Number(a.created || 0) - Number(b.created || 0));
+  return { orders, blocked, paymentLinkId };
+}
+
+async function cli() {
+  const result = await listCompletedUpgradeOrders();
+  console.log(JSON.stringify(result, null, 2));
+}
+
+module.exports = {
+  DEFAULT_PAYMENT_LINK_ID,
+  customFieldValue,
+  customFieldsObject,
+  listCompletedUpgradeOrders,
+  normalizeHostedSiteUrl,
+  sessionToUpgradeOrder,
+};
+
+if (require.main === module) {
+  cli().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Starts closing the free-site → paid Website Upgrade loop without touching production behavior yet.

What this adds:
- reads completed Stripe Checkout Sessions for the $99 Website Upgrade payment link
- converts checkout custom fields into a deterministic fulfillment brief
- only accepts 3DVR-hosted `/free-sites/<slug>/` drafts for automatic fulfillment
- rejects external sites into a blocked queue instead of touching them
- keeps secrets server-side and never prints the Stripe key
- adds unit coverage for hosted URL normalization, paid-session parsing, unpaid-session rejection, and blocked external URLs

Validation: 5/5 new Node tests passed locally before opening this PR.

Next slice after this lands: connect these normalized orders to the existing free-site publisher so paid upgrades can publish + verify + email automatically and idempotently.