### PR TITLE
Polish Calendar Week navigation

### DIFF
--- a/calendar/calendar-v2.css
+++ b/calendar/calendar-v2.css
@@ -1205,13 +1205,25 @@ summary:focus-visible {
 }
 
 .calendar-view__grid[data-calendar-view="week"] {
+  cursor: grab;
   overflow-x: auto;
   overscroll-behavior-x: contain;
-  padding-bottom: 8px;
-  scroll-behavior: smooth;
+  padding-bottom: 0;
+  scroll-behavior: auto;
   scroll-snap-type: x proximity;
-  scrollbar-width: thin;
+  scrollbar-width: none;
   touch-action: pan-x pan-y;
+}
+
+.calendar-view__grid[data-calendar-view="week"]::-webkit-scrollbar {
+  display: none;
+}
+
+.calendar-view__grid[data-calendar-view="week"].is-dragging {
+  cursor: grabbing;
+  scroll-behavior: auto;
+  scroll-snap-type: none;
+  user-select: none;
 }
 
 .calendar-view__grid[data-calendar-view="week"] .calendar-view__grid-inner {

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -71,6 +71,8 @@ const calendarState = {
 };
 const reminderTimers = new Map();
 let rollingScrollTimer = null;
+let rollingDragState = null;
+let suppressCalendarClickAfterDrag = false;
 
 const GUN_PEERS = (typeof window !== 'undefined' && window.__GUN_PEERS__) || [
   'wss://relay.3dvr.tech/gun',
@@ -1457,9 +1459,16 @@ function renderRollingWeek(events = state.localEvents) {
   requestAnimationFrame(() => {
     if (!calendarGridViewport || calendarState.viewMode !== 'week') return;
     const anchorCell = calendarGrid.querySelector('[data-rolling-anchor="true"]');
-    if (anchorCell) calendarGridViewport.scrollLeft = Math.max(0, anchorCell.offsetLeft);
+    if (anchorCell) calendarGridViewport.scrollLeft = Math.max(0, rollingCellScrollLeft(anchorCell));
   });
   renderSelectedDayDetails();
+}
+
+function rollingCellScrollLeft(cell) {
+  if (!cell || !calendarGridViewport) return 0;
+  const viewportRect = calendarGridViewport.getBoundingClientRect();
+  const cellRect = cell.getBoundingClientRect();
+  return calendarGridViewport.scrollLeft + (cellRect.left - viewportRect.left);
 }
 
 function renderCalendar(events = state.localEvents) {
@@ -1477,7 +1486,7 @@ function syncRollingAnchorFromScroll() {
   const target = calendarGridViewport.scrollLeft + 4;
   let anchorCell = cells[0];
   for (const cell of cells) {
-    if (cell.offsetLeft <= target + 2) anchorCell = cell;
+    if (rollingCellScrollLeft(cell) <= target + 2) anchorCell = cell;
     else break;
   }
   const parsed = new Date(`${anchorCell.dataset.date}T00:00:00`);
@@ -1491,6 +1500,45 @@ function handleRollingCalendarScroll() {
   if (calendarState.viewMode !== 'week') return;
   if (rollingScrollTimer) window.clearTimeout(rollingScrollTimer);
   rollingScrollTimer = window.setTimeout(syncRollingAnchorFromScroll, 90);
+}
+
+function startRollingCalendarDrag(event) {
+  if (calendarState.viewMode !== 'week' || !calendarGridViewport) return;
+  if (event.pointerType === 'touch' || event.button !== 0) return;
+  rollingDragState = {
+    pointerId: event.pointerId,
+    startX: event.clientX,
+    startScrollLeft: calendarGridViewport.scrollLeft,
+    moved: false
+  };
+  if (typeof calendarGridViewport.setPointerCapture === 'function') {
+    calendarGridViewport.setPointerCapture(event.pointerId);
+  }
+}
+
+function moveRollingCalendarDrag(event) {
+  if (!rollingDragState || rollingDragState.pointerId !== event.pointerId || !calendarGridViewport) return;
+  const delta = event.clientX - rollingDragState.startX;
+  if (!rollingDragState.moved && Math.abs(delta) < 5) return;
+  rollingDragState.moved = true;
+  calendarGridViewport.classList.add('is-dragging');
+  calendarGridViewport.scrollLeft = rollingDragState.startScrollLeft - delta;
+  event.preventDefault();
+}
+
+function endRollingCalendarDrag(event) {
+  if (!rollingDragState || rollingDragState.pointerId !== event.pointerId || !calendarGridViewport) return;
+  const moved = rollingDragState.moved;
+  if (typeof calendarGridViewport.releasePointerCapture === 'function'
+      && calendarGridViewport.hasPointerCapture?.(event.pointerId)) {
+    calendarGridViewport.releasePointerCapture(event.pointerId);
+  }
+  rollingDragState = null;
+  calendarGridViewport.classList.remove('is-dragging');
+  if (moved) {
+    suppressCalendarClickAfterDrag = true;
+    window.setTimeout(() => { suppressCalendarClickAfterDrag = false; }, 0);
+  }
 }
 
 function readStoredCalendarViewMode() {
@@ -1514,19 +1562,19 @@ function setCalendarViewMode(mode, options = {}) {
     if (selected && !Number.isNaN(selected.getTime())) calendarState.viewDate = startOfMonth(selected);
   }
 
-  if (calendarViewTitle) calendarViewTitle.textContent = nextMode === 'week' ? '7 days' : 'Month';
+  if (calendarViewTitle) calendarViewTitle.textContent = nextMode === 'week' ? 'Week' : 'Month';
   calendarViewModeButtons.forEach(button => {
     const active = button.dataset.calendarViewMode === nextMode;
     button.setAttribute('aria-pressed', active ? 'true' : 'false');
     button.classList.toggle('calendar-view__mode-button--active', active);
   });
   if (calendarControls) {
-    calendarControls.setAttribute('aria-label', nextMode === 'week' ? 'Change seven day range' : 'Change month');
+    calendarControls.setAttribute('aria-label', nextMode === 'week' ? 'Move week view by day' : 'Change month');
   }
   calendarNavButtons.forEach(button => {
     const forward = button.dataset.calendarNav === 'next';
     button.setAttribute('aria-label', nextMode === 'week'
-      ? `${forward ? 'Next' : 'Previous'} seven days`
+      ? `${forward ? 'Next' : 'Previous'} day`
       : `${forward ? 'Next' : 'Previous'} month`);
   });
   if (options.persist !== false) {
@@ -1667,6 +1715,10 @@ function selectCalendarDate(dateString) {
 }
 
 function handleCalendarGridClick(event) {
+  if (suppressCalendarClickAfterDrag) {
+    suppressCalendarClickAfterDrag = false;
+    return;
+  }
   const cell = event.target.closest('.calendar-view__day');
   if (!cell) return;
   const { date } = cell.dataset;
@@ -3284,14 +3336,12 @@ function initializeCreateEventToggle() {
 function changeCalendarPeriod(offset) {
   if (calendarState.viewMode === 'week') {
     const next = new Date(calendarState.rollingAnchorDate || new Date());
-    next.setDate(next.getDate() + (offset * ROLLING_WEEK_VISIBLE_DAYS));
+    next.setDate(next.getDate() + offset);
     calendarState.rollingAnchorDate = startOfDay(next);
-    calendarState.selectedDate = calendarState.rollingAnchorDate.toISOString().slice(0, 10);
   } else {
     const next = new Date(calendarState.viewDate);
     next.setMonth(next.getMonth() + offset);
     calendarState.viewDate = startOfMonth(next);
-    calendarState.selectedDate = calendarState.viewDate.toISOString().slice(0, 10);
   }
   renderCalendar();
 }
@@ -3374,6 +3424,10 @@ function bindEvents() {
 
   if (calendarGridViewport) {
     calendarGridViewport.addEventListener('scroll', handleRollingCalendarScroll, { passive: true });
+    calendarGridViewport.addEventListener('pointerdown', startRollingCalendarDrag);
+    calendarGridViewport.addEventListener('pointermove', moveRollingCalendarDrag);
+    calendarGridViewport.addEventListener('pointerup', endRollingCalendarDrag);
+    calendarGridViewport.addEventListener('pointercancel', endRollingCalendarDrag);
   }
 
   if (addEventForDayButton) {

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -59,7 +59,7 @@
               <div class="calendar-view__toolbar">
                 <div class="calendar-view__mode" role="group" aria-label="Calendar view">
                   <button type="button" class="button-secondary" data-calendar-view-mode="month" aria-pressed="true">Month</button>
-                  <button type="button" class="button-secondary" data-calendar-view-mode="week" aria-pressed="false">7 days</button>
+                  <button type="button" class="button-secondary" data-calendar-view-mode="week" aria-pressed="false">Week</button>
                 </div>
                 <div class="calendar-view__controls" role="group" aria-label="Change calendar range">
                   <button type="button" class="button-secondary calendar-nav" data-calendar-nav="prev" aria-label="Previous range">‹</button>

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -30,14 +30,6 @@
     <h1 class="calendar-header__title">Calendar</h1>
   </header>
 
-  <div class="install-banner" data-install-banner hidden>
-    <div class="install-banner__text">
-      <p class="install-banner__title">Install Calendar</p>
-      <p class="install-banner__meta">Keep your schedule one tap away.</p>
-    </div>
-    <button type="button" class="install-banner__action" data-install-button>Install</button>
-  </div>
-
   <div class="share-access-banner" data-share-access hidden>
     <div>
       <strong data-share-access-title>Opening shared calendar…</strong>
@@ -364,6 +356,15 @@
       </section>
     </aside>
   </main>
+
+
+  <div class="install-banner" data-install-banner hidden>
+    <div class="install-banner__text">
+      <p class="install-banner__title">Install Calendar</p>
+      <p class="install-banner__meta">Keep it one tap away.</p>
+    </div>
+    <button type="button" class="install-banner__action" data-install-button>Install</button>
+  </div>
 
   <template id="event-template">
     <li class="event-card">

--- a/calendar/install-banner.css
+++ b/calendar/install-banner.css
@@ -1,14 +1,12 @@
 .install-banner {
-  display: flex;
   align-items: center;
-  gap: 12px;
-  margin: 0 auto 16px;
-  padding: 12px 16px;
-  border-radius: 12px;
-  background: var(--bg-panel, rgba(255, 255, 255, 0.92));
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.08);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text-muted, #9aa7b5);
+  display: flex;
+  gap: 10px;
+  margin: 24px auto 8px;
   max-width: 1100px;
+  padding: 10px 4px 2px;
 }
 
 .install-banner[hidden],
@@ -17,45 +15,59 @@
 }
 
 .install-banner__text {
-  display: grid;
-  gap: 4px;
-  line-height: 1.4;
-  color: var(--text-primary, #0f172a);
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  line-height: 1.3;
+}
+
+.install-banner__title,
+.install-banner__meta {
+  margin: 0;
 }
 
 .install-banner__title {
-  margin: 0;
-  font-size: 1rem;
+  color: var(--text-primary, #d7e0e8);
+  font-size: 0.8rem;
   font-weight: 600;
 }
 
 .install-banner__meta {
-  margin: 0;
-  color: var(--text-muted, #4b5563);
-  font-size: 0.93rem;
+  color: var(--text-muted, #7f8b98);
+  font-size: 0.75rem;
 }
 
 .install-banner__action {
-  margin-left: auto;
-  padding: 10px 16px;
-  border-radius: 999px;
-  border: 1px solid var(--accent, #2563eb);
-  background: var(--accent, #2563eb);
-  color: #fff;
-  font-weight: 600;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  color: var(--text-primary, #d7e0e8);
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-left: auto;
+  padding: 5px 9px;
 }
 
 .install-banner__action:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.24);
 }
 
 .install-banner__action:disabled {
-  opacity: 0.6;
   cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
+  opacity: 0.5;
+}
+
+@media (max-width: 760px) {
+  .install-banner {
+    margin: 18px 12px 8px;
+    padding-top: 8px;
+  }
+
+  .install-banner__meta {
+    display: none;
+  }
 }

--- a/calendar/service-worker.js
+++ b/calendar/service-worker.js
@@ -1,6 +1,6 @@
 /* calendar/service-worker.js */
 
-const CACHE_VERSION = 'v5';
+const CACHE_VERSION = 'v6';
 const STATIC_CACHE = `calendar-static-${CACHE_VERSION}`;
 const HTML_CACHE = `calendar-html-${CACHE_VERSION}`;
 const SCOPE_URL = new URL(self.registration.scope);

--- a/calendar/service-worker.js
+++ b/calendar/service-worker.js
@@ -1,6 +1,6 @@
 /* calendar/service-worker.js */
 
-const CACHE_VERSION = 'v4';
+const CACHE_VERSION = 'v5';
 const STATIC_CACHE = `calendar-static-${CACHE_VERSION}`;
 const HTML_CACHE = `calendar-html-${CACHE_VERSION}`;
 const SCOPE_URL = new URL(self.registration.scope);

--- a/tests/calendar-pwa-config.test.js
+++ b/tests/calendar-pwa-config.test.js
@@ -55,7 +55,7 @@ describe('calendar PWA configuration', () => {
   it('ships a calendar-specific service worker', async () => {
     const workerSource = await readProjectFile('calendar/service-worker.js');
 
-    assert.match(workerSource, /const CACHE_VERSION = 'v4';/);
+    assert.match(workerSource, /const CACHE_VERSION = 'v5';/);
     assert.match(workerSource, /calendar-static-/);
     assert.match(workerSource, /calendar-html-/);
     assert.match(workerSource, /scopeAsset\('global\.css'\)/);

--- a/tests/calendar-pwa-config.test.js
+++ b/tests/calendar-pwa-config.test.js
@@ -55,7 +55,7 @@ describe('calendar PWA configuration', () => {
   it('ships a calendar-specific service worker', async () => {
     const workerSource = await readProjectFile('calendar/service-worker.js');
 
-    assert.match(workerSource, /const CACHE_VERSION = 'v5';/);
+    assert.match(workerSource, /const CACHE_VERSION = 'v6';/);
     assert.match(workerSource, /calendar-static-/);
     assert.match(workerSource, /calendar-html-/);
     assert.match(workerSource, /scopeAsset\('global\.css'\)/);

--- a/tests/calendar-ui.test.js
+++ b/tests/calendar-ui.test.js
@@ -15,7 +15,7 @@ test('calendar presents a schedule-first workspace with secondary tools below', 
   assert.match(html, /<h2 id="calendar-view-title" data-calendar-view-title>Month<\/h2>/);
   assert.match(html, /data-calendar-view-mode="month"/);
   assert.match(html, /data-calendar-view-mode="week"/);
-  assert.match(html, />7 days<\/button>/);
+  assert.match(html, />Week<\/button>/);
   assert.match(html, /<aside class="calendar-planner" aria-labelledby="calendar-planner-title">/);
   assert.match(html, /<h2 id="calendar-planner-title">Add event<\/h2>/);
   assert.match(html, /data-label-open="\+ Add event"/);
@@ -115,7 +115,7 @@ test('calendar Google OAuth refreshes tokens and imports the current month after
 });
 
 
-test('calendar offers a rolling seven-day view that can be scrolled day by day', async () => {
+test('calendar Week view pans naturally and arrows move one day at a time', async () => {
   const js = await readFile(new URL('../calendar/calendar.js', import.meta.url), 'utf8');
   const css = await readFile(new URL('../calendar/calendar-v2.css', import.meta.url), 'utf8');
 
@@ -123,10 +123,19 @@ test('calendar offers a rolling seven-day view that can be scrolled day by day',
   assert.match(js, /function renderRollingWeek\(events = state\.localEvents\)/);
   assert.match(js, /function handleRollingCalendarScroll\(\)/);
   assert.match(js, /function syncRollingAnchorFromScroll\(\)/);
-  assert.match(js, /changeCalendarPeriod\(offset\)/);
+  assert.match(js, /function rollingCellScrollLeft\(cell\)/);
+  assert.doesNotMatch(js, /anchorCell\.offsetLeft/);
+  assert.match(js, /next\.setDate\(next\.getDate\(\) \+ offset\)/);
+  assert.doesNotMatch(js, /offset \* ROLLING_WEEK_VISIBLE_DAYS/);
+  assert.match(js, /function startRollingCalendarDrag\(event\)/);
+  assert.match(js, /function moveRollingCalendarDrag\(event\)/);
+  assert.match(js, /suppressCalendarClickAfterDrag/);
   assert.match(css, /\.calendar-view__grid\[data-calendar-view="week"\][\s\S]*?overflow-x:\s*auto;/);
   assert.match(css, /grid-auto-columns:\s*calc\(\(100% - 42px\) \/ 7\)/);
-  assert.match(css, /scroll-snap-type:\s*x proximity/);
+  assert.match(css, /scrollbar-width:\s*none/);
+  assert.match(css, /::-webkit-scrollbar/);
+  assert.match(css, /cursor:\s*grab/);
+  assert.match(css, /scroll-behavior:\s*auto/);
 });
 
 test('calendar repairs stale untitled imports and removes legacy placeholder events', async () => {


### PR DESCRIPTION
Refines the rolling Week calendar interaction after a focused desktop/mobile UX pass.

- rename “7 days” to “Week”
- Week arrows move one day at a time; Month arrows still move by month
- navigation no longer changes the selected day
- hide the horizontal scrollbar while preserving wheel/trackpad/touch scrolling
- add mouse click-drag panning with grab/grabbing affordance
- suppress accidental day selection after a drag
- fix rolling-week coordinate math so the visible dates match the displayed range
- remove the smooth buffer animation that could sweep through hidden dates when entering Week
- bump the Calendar PWA cache

Validation:
- focused calendar tests: 22/22 pass
- Chromium interaction pass at 1440x900 and 390x844
- no page-level horizontal overflow
- Week opens directly on the correct range
- arrows advance exactly one day
- drag advances the rolling range without changing the selected day