### PR TITLE
Define 3DVR Compute module interface v0

### DIFF
--- a/compute/STATUS.md
+++ b/compute/STATUS.md
@@ -1,10 +1,17 @@
 # Status
 
-3DVR Compute is in early design and prototype planning.
+3DVR Compute is in early engineering design and prototype planning.
 
 Current focus:
-- define the modular laptop architecture
-- test available compute modules before designing custom silicon
+- **Compute Module Interface v0 drafted** — keep the laptop-side boundary vendor-neutral and use per-board adapters
+- **Prototype 01 planned around LM4A / Lichee Pi 4A**
+- validate power, video, USB, storage, service access, thermals, and Linux on real hardware
 - preserve useful Balthazar work and attribution
 - connect component choices to the Open Supply Chain registry
 - build one functional physical prototype before optimizing industrial design
+
+Engineering notes:
+- [Compute Module Interface v0](./hardware/compute-module-v0.md)
+- [Prototype 01 — LM4A laptop mule](./hardware/prototype-01-lm4a.md)
+
+The next gate requires hands-on measurements from the real LM4A hardware. Until then, avoid freezing final module dimensions or power limits from assumptions.

--- a/compute/hardware/compute-module-v0.md
+++ b/compute/hardware/compute-module-v0.md
@@ -1,0 +1,150 @@
+# 3DVR Compute Module Interface v0
+
+Status: **draft for first physical prototype**
+
+The purpose of this interface is not to invent another high-density board connector. It is to define a small, stable boundary between a long-lived laptop shell and replaceable compute hardware.
+
+## Core decision
+
+**The laptop-side interface is functional, not tied to one SoM connector.**
+
+Each supported compute board gets a thin adapter/carrier that maps its native connector into the 3DVR laptop interface. An LM4A adapter may use Sipeed's native 260-pin SODIMM-style connector internally; a future StarFive, Beagle, x86, or community board can use a completely different native connector without forcing a redesign of the laptop shell.
+
+This follows the strongest part of the original Balthazar architecture: support multiple System-on-Module boards and keep the minimum common interface small. Balthazar identified power, USB, and HDMI as the minimum compatibility set and used a unifying board to connect modular subsystems.
+
+## v0 required functions
+
+A compute adapter MUST provide:
+
+1. **Power input**
+   - Laptop power subsystem feeds the adapter.
+   - Exact rail(s), voltage, and current envelope remain prototype decisions.
+   - Adapter owns board-specific regulation when practical.
+
+2. **Primary display output**
+   - v0 transport: HDMI-compatible digital video from compute adapter to the laptop display controller.
+   - The panel itself should not be electrically coupled to one compute board generation.
+
+3. **Primary peripheral link**
+   - At least one USB 3.x host link from compute adapter to the laptop I/O subsystem.
+   - Keyboard, pointing device, camera, audio, and general peripheral expansion should preferably sit behind the laptop-side I/O subsystem rather than on a compute-specific carrier.
+
+4. **Boot/storage path**
+   - Compute board may contain local boot storage (for example eMMC).
+   - Laptop should also expose replaceable storage through a standard interface where feasible.
+
+5. **Service/debug access**
+   - UART or equivalent serial console exposed through a service connector or internal header.
+   - Reset/recovery controls should be reachable without destructive disassembly.
+
+## v0 optional functions
+
+Adapters MAY expose:
+
+- second USB link
+- Ethernet
+- PCIe or another high-speed expansion link
+- direct MIPI display/camera links
+- I2C management bus
+- fan PWM / tachometer
+- power-state signals
+- GPIO
+- audio I2S/PDM
+- hardware accelerator-specific links
+
+Optional signals must not become required for basic laptop operation.
+
+## Mechanical boundary
+
+For prototype 0, do **not** freeze the final module dimensions.
+
+Instead:
+
+- reserve a rectangular service bay behind or below the keyboard
+- mount the compute adapter on removable standoffs or rails
+- use short replaceable cables between adapter and laptop subsystems
+- make the adapter the sacrificial compatibility layer
+- leave room for a heat spreader and active cooling if needed
+
+After two substantially different compute boards have been adapted successfully, we can freeze a mechanical envelope based on evidence rather than guessing.
+
+## Laptop-side subsystem split
+
+```text
+                +----------------------+
+                |  Replaceable compute |
+                |  board + adapter     |
+                +----------+-----------+
+                           |
+          power + video + USB + service
+                           |
+       +-------------------+------------------+
+       |        3DVR laptop-side bus          |
+       +---------+--------------+-------------+
+                 |              |             |
+             Display          I/O hub       Power
+                 |              |             |
+              Panel      keyboard/cam/     Battery
+                          audio/USB/etc.     charger
+```
+
+The shell, display, keyboard, battery system, storage bay, and most peripheral I/O should remain useful when the compute module changes.
+
+## Why not standardize LM4A's connector?
+
+The LM4A is a strong first prototype board, but its connector exposes many TH1520-specific functions including MIPI CSI/DSI, HDMI, USB, Ethernet PHY signals, SDIO, UART, I2C, I2S, GPIO, boot/recovery signals, and more. Making that exact pinout the 3DVR standard would unnecessarily couple future modules to one vendor's SoM architecture.
+
+Instead, the LM4A native connector terminates on an **LM4A adapter**, and only the smaller common function set crosses into the laptop architecture.
+
+## Compatibility levels
+
+### Level A — boots as a laptop
+Required:
+- power
+- display
+- USB peripherals
+- boot/storage
+- service console
+
+### Level B — daily-driver capable
+Adds:
+- replaceable high-speed storage
+- Wi-Fi/Bluetooth or replaceable radio module
+- audio
+- camera
+- suspend/resume and battery-state integration
+- thermal control
+
+### Level C — advanced/open compute
+Adds as hardware permits:
+- PCIe/high-speed accelerator expansion
+- direct open accelerator support
+- hardware privacy controls
+- increasingly open firmware/boot chain
+- open or community-designed compute hardware
+
+## Non-goals for v0
+
+- custom silicon
+- a universal 260-pin electrical standard
+- final industrial design
+- fanless operation at all costs
+- perfect openness on day one
+- requiring RISC-V for every prototype
+
+The architecture should make it possible to replace closed pieces over time without throwing away the rest of the computer.
+
+## Upstream / reference work
+
+- Balthazar Specifications: https://balthazar.space/wiki/Specifications
+- Balthazar Documentation / Unifying Board: https://balthazar.space/wiki/Documentation
+- Sipeed LM4A documentation: https://wiki.sipeed.com/hardware/en/lichee/th1520/lm4a.html
+- Sipeed LM4A Datasheet v1.1: https://dl.sipeed.com/fileList/LICHEE/licheepi4a/01_Specification/SIPEED_LM4A_DataSheet_EN_V1.1.pdf
+
+## Gate before v1
+
+Do not call this interface v1 until:
+
+1. one LM4A-based prototype boots and operates as a laptop through the boundary above;
+2. one meaningfully different compute board is mapped to the same laptop-side functions;
+3. we have measured power, thermals, cable routing, and serviceability on real hardware.

--- a/compute/hardware/prototype-01-lm4a.md
+++ b/compute/hardware/prototype-01-lm4a.md
@@ -1,0 +1,168 @@
+# Prototype 01 — LM4A laptop mule
+
+Status: **planned**
+
+Goal: build the fastest useful physical test of the 3DVR Compute architecture using a Sipeed LM4A / Lichee Pi 4A compute path.
+
+This prototype is deliberately allowed to be ugly. It exists to answer architectural questions before we spend time on industrial design.
+
+## Why LM4A first
+
+The LM4A is a useful first compute module because:
+
+- it is a RISC-V SoM built around the TH1520;
+- Sipeed exposes the module through a SODIMM-style carrier architecture;
+- public documentation includes a module datasheet and pin definition;
+- Sipeed has already demonstrated the same SoM in multiple products, including desktop/baseboard, console, cluster, and laptop-style systems;
+- Debian is a supported operating-system path in Sipeed's laptop implementation.
+
+The project should still treat LM4A as a **prototype implementation**, not the permanent 3DVR connector standard.
+
+## Prototype architecture
+
+```text
+LM4A
+  |
+LM4A adapter / existing carrier for early bring-up
+  |
+  +-- HDMI/video ----------> display controller/panel
+  +-- USB 3.x -------------> laptop I/O hub
+  +-- storage -------------> eMMC first; replaceable SSD second
+  +-- UART/service --------> accessible debug header
+  +-- power ---------------> prototype power subsystem
+
+Laptop I/O hub
+  +-- keyboard
+  +-- pointing device
+  +-- audio
+  +-- camera
+  +-- external USB
+```
+
+## Phase 0 — bench validation
+
+When the hardware is physically available:
+
+1. Inventory the exact LM4A and carrier/baseboard revision.
+2. Record:
+   - RAM and eMMC size
+   - connector revision
+   - input voltage
+   - idle and loaded power draw
+   - CPU temperature and cooling arrangement
+   - working display outputs
+   - working USB ports
+   - kernel and Debian version
+3. Confirm boot from the existing setup before changing anything.
+4. Run a small stability workload and tinygrad CPU smoke test.
+5. Photograph connector placement and measure the real board stack with calipers.
+
+No destructive modifications in this phase.
+
+## Phase 1 — laptop mule
+
+Use off-the-shelf parts wherever possible:
+
+- LM4A plus known-good carrier/baseboard or a minimal LM4A adapter
+- 13–14 inch display with a replaceable HDMI/eDP controller path
+- USB keyboard/trackpad assembly
+- replaceable USB audio if integrated audio slows the prototype down
+- external or protected battery/power solution initially
+- simple aluminum/acrylic/3D-printed mounting plate
+- accessible fan and heat spreader
+
+Success criterion: the device can boot Debian, use its built-in display and keyboard/pointing device, connect to Wi-Fi or Ethernet, run from its intended power path, and survive normal interactive use without thermal instability.
+
+## Phase 2 — separate long-lived laptop functions
+
+Move functions away from the compute-specific carrier:
+
+- keyboard + pointing device -> laptop I/O board
+- camera -> laptop I/O board
+- audio -> laptop I/O board
+- storage -> replaceable laptop storage bay where practical
+- power switching / battery management -> laptop power board
+- physical privacy switches -> laptop-side hardware
+
+The compute module should increasingly need only the small function set defined in `compute-module-v0.md`.
+
+## First measurements that matter
+
+Do not optimize dimensions from internet specifications alone. Measure the actual unit.
+
+Capture:
+
+- module + socket stack height
+- carrier footprint
+- heatsink/fan envelope
+- connector keep-out zones
+- cable bend radius
+- peak wall power during CPU load
+- peak wall power during GPU/NPU tests if usable
+- surface and core temperatures
+- display power draw
+- battery/runtime estimate
+
+These measurements become the input to the first CAD envelope.
+
+## Software bring-up
+
+Minimum:
+
+```text
+Debian boots
+network works
+USB input works
+display works
+audio works or has a documented temporary substitute
+suspend/resume tested and documented
+tinygrad CPU smoke test runs
+```
+
+Nice to have:
+
+- upstream-friendly kernel
+- working GPU acceleration
+- NPU experimentation
+- tinygrad RISC-V fixes upstreamed where concrete issues are found
+
+## Hardware privacy targets
+
+Borrow a particularly good Balthazar idea: physical controls for sensitive hardware.
+
+Prototype candidates:
+
+- camera power cut
+- microphone power/mute cut
+- radio/Wi-Fi disable
+- speaker mute
+
+The exact electrical implementation comes after we map the laptop-side I/O board.
+
+## What we are reusing from Balthazar
+
+Preserve, study, and credit:
+
+- replaceable SoM philosophy
+- unifying/carrier-board concept
+- modular power and I/O separation
+- repair-oriented enclosure thinking
+- hardware privacy switches
+- serviceable keyboard direction
+
+Do not copy obsolete constraints merely for compatibility. Keep interfaces when they help; adapt when modern available hardware provides a better route.
+
+## Exit criteria
+
+Prototype 01 is successful when we can say, with measurements:
+
+> This laptop shell can run an LM4A compute module without making the display, keyboard, power, and I/O architecture LM4A-specific.
+
+At that point, Prototype 02 should use a different compute family to test whether the interface is genuinely modular.
+
+## References
+
+- Sipeed LM4A: https://wiki.sipeed.com/hardware/en/lichee/th1520/lm4a.html
+- Sipeed Lichee Book 4A: https://wiki.sipeed.com/hardware/en/lichee/th1520/lbook4a/lbook4a.html
+- Balthazar Specifications: https://balthazar.space/wiki/Specifications
+- Balthazar Features: https://balthazar.space/wiki/Features


### PR DESCRIPTION
## What
- define a vendor-neutral laptop-side compute boundary
- treat each SoM/board connector as an adapter concern rather than the 3DVR standard
- plan Prototype 01 around LM4A / Lichee Pi 4A
- add a bench-validation checklist for power, thermals, dimensions, Linux, and tinygrad
- update project status to engineering-design phase

## Key decision
Keep the required common boundary small: power, display, USB/peripherals, boot/storage, and service/debug. Optional high-speed and board-specific signals stay optional.

This preserves Balthazar's replaceable-SoM philosophy while avoiding accidental lock-in to LM4A's native 260-pin connector.

No application code, auth, billing, or production behavior changes.