### PR TITLE
Fix recovery workflows so self-healing can run

### DIFF
--- a/.github/workflows/do-host-recovery.yml
+++ b/.github/workflows/do-host-recovery.yml
@@ -49,16 +49,16 @@ jobs:
             code="$(curl -sS -o /tmp/droplets.json -w '%{http_code}' -H "Authorization: Bearer $do_token" 'https://api.digitalocean.com/v2/droplets?per_page=200' || true)"
             if [ "$code" = 200 ]; then
               read -r id state ip < <(python3 - "$KNOWN_HOST" <<'PY'
-import json,sys
-known=sys.argv[1]
-data=json.load(open('/tmp/droplets.json'))
-for d in data.get('droplets',[]):
-    ips=[v.get('ip_address','') for v in d.get('networks',{}).get('v4',[]) if v.get('type')=='public']
-    if known in ips or d.get('name')=='3dvr-agent':
-        print(d.get('id',''),d.get('status',''),ips[0] if ips else '')
-        break
-else: print('','','')
-PY
+          import json,sys
+          known=sys.argv[1]
+          data=json.load(open('/tmp/droplets.json'))
+          for d in data.get('droplets',[]):
+              ips=[v.get('ip_address','') for v in d.get('networks',{}).get('v4',[]) if v.get('type')=='public']
+              if known in ips or d.get('name')=='3dvr-agent':
+                  print(d.get('id',''),d.get('status',''),ips[0] if ips else '')
+                  break
+          else: print('','','')
+          PY
               )
               if [ -n "${id:-}" ]; then
                 api_matched=true; [ -n "${ip:-}" ] && target="$ip"
@@ -156,10 +156,10 @@ PY
           set -euo pipefail
           curl -fsS --retry 8 --retry-delay 2 --retry-all-errors "$URL/__3dvr-preview" >/tmp/health.json
           python3 - "$PREVIEW_SHA" <<'PY'
-import json,sys
-h=json.load(open('/tmp/health.json'))
-assert h.get('ok') is True and h.get('sha')==sys.argv[1]
-PY
+          import json,sys
+          h=json.load(open('/tmp/health.json'))
+          assert h.get('ok') is True and h.get('sha')==sys.argv[1]
+          PY
           curl -fsS --retry 5 --retry-delay 1 --retry-all-errors "$URL/" | grep -Fq 'home-operator.js'
           curl -fsS --retry 5 --retry-delay 1 --retry-all-errors "$URL/home-operator.js" | grep -Fq 'persistHistory'
 
@@ -183,26 +183,34 @@ PY
         run: |
           set -euo pipefail
           python3 - <<'PY' >/tmp/result.json
-import datetime,json,os
-b=lambda k: os.environ.get(k,'').lower()=='true'
-u=os.environ.get('URL','')
-if u and not u.startswith('https://'): u=''
-print(json.dumps({
- 'checkedAt':datetime.datetime.now(datetime.timezone.utc).isoformat(),
- 'sshKeyPresent':b('SSH_PRESENT'),'doTokenPresent':b('TOKEN_PRESENT'),
- 'apiMatchedKnownHost':b('API_MATCHED'),'powerAction':os.environ.get('POWER_ACTION') or 'unavailable',
- 'port22':b('P22'),'port80':b('P80'),'port443':b('P443'),'port4310':b('P4310'),
- 'sshAuthenticated':b('AUTH'),'previewWorkerRecovered':b('WORKER'),
- 'previewUrl':u,'previewVerified':os.environ.get('VERIFIED')=='success'
-},indent=2))
-PY
+          import datetime,json,os
+          b=lambda k: os.environ.get(k,'').lower()=='true'
+          u=os.environ.get('URL','')
+          if u and not u.startswith('https://'): u=''
+          print(json.dumps({
+           'checkedAt':datetime.datetime.now(datetime.timezone.utc).isoformat(),
+           'sshKeyPresent':b('SSH_PRESENT'),'doTokenPresent':b('TOKEN_PRESENT'),
+           'apiMatchedKnownHost':b('API_MATCHED'),'powerAction':os.environ.get('POWER_ACTION') or 'unavailable',
+           'port22':b('P22'),'port80':b('P80'),'port443':b('P443'),'port4310':b('P4310'),
+           'sshAuthenticated':b('AUTH'),'previewWorkerRecovered':b('WORKER'),
+           'previewUrl':u,'previewVerified':os.environ.get('VERIFIED')=='success'
+          },indent=2))
+          PY
           content="$(base64 -w0 /tmp/result.json)"
-          python3 - "$content" <<'PY' >/tmp/payload.json
-import json,sys
-print(json.dumps({'message':'Record DigitalOcean recovery result','content':sys.argv[1],'branch':'main'}))
-PY
+          result_url="https://api.github.com/repos/$GITHUB_REPOSITORY/contents/ops/do-host-recovery-result.json"
+          existing_sha="$(curl -fsS \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$result_url" 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin).get("sha", ""))' 2>/dev/null || true)"
+          python3 - "$content" "$existing_sha" <<'PY' >/tmp/payload.json
+          import json,sys
+          payload={'message':'Record DigitalOcean recovery result','content':sys.argv[1],'branch':'main'}
+          if sys.argv[2]: payload['sha']=sys.argv[2]
+          print(json.dumps(payload))
+          PY
           curl -fsS -X PUT -H "Authorization: Bearer $GH_TOKEN" -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/ops/do-host-recovery-result.json" --data-binary @/tmp/payload.json >/dev/null
+            "$result_url" --data-binary @/tmp/payload.json >/dev/null
           rm -f /tmp/key /tmp/result.json /tmp/payload.json /tmp/preview.out /tmp/health.json
 
 # Triggered for Operator Forge worker recovery diagnosis on 2026-08-24T01:35:00Z.

--- a/.github/workflows/operator-worker-host-recovery.yml
+++ b/.github/workflows/operator-worker-host-recovery.yml
@@ -56,17 +56,17 @@ jobs:
             code="$(curl -sS -o /tmp/droplets.json -w '%{http_code}' -H "Authorization: Bearer $do_token" 'https://api.digitalocean.com/v2/droplets?per_page=200' || true)"
             if [ "$code" = 200 ]; then
               read -r id state ip < <(python3 - "$KNOWN_HOST" <<'PY'
-import json,sys
-known=sys.argv[1]
-data=json.load(open('/tmp/droplets.json'))
-for d in data.get('droplets',[]):
-    ips=[v.get('ip_address','') for v in d.get('networks',{}).get('v4',[]) if v.get('type')=='public']
-    if known in ips or d.get('name')=='3dvr-agent':
-        print(d.get('id',''), d.get('status',''), ips[0] if ips else '')
-        break
-else:
-    print('','','')
-PY
+          import json,sys
+          known=sys.argv[1]
+          data=json.load(open('/tmp/droplets.json'))
+          for d in data.get('droplets',[]):
+              ips=[v.get('ip_address','') for v in d.get('networks',{}).get('v4',[]) if v.get('type')=='public']
+              if known in ips or d.get('name')=='3dvr-agent':
+                  print(d.get('id',''), d.get('status',''), ips[0] if ips else '')
+                  break
+          else:
+              print('','','')
+          PY
               )
               if [ -n "${id:-}" ]; then
                 [ -n "${ip:-}" ] && target="$ip"
@@ -201,9 +201,9 @@ PY
           fi
           target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           payload="$(python3 - "$state" "$description" "$target_url" <<'PY'
-import json,sys
-print(json.dumps({'state':sys.argv[1],'context':'3DVR Operator Worker Recovery','description':sys.argv[2][:140],'target_url':sys.argv[3]}))
-PY
+          import json,sys
+          print(json.dumps({'state':sys.argv[1],'context':'3DVR Operator Worker Recovery','description':sys.argv[2][:140],'target_url':sys.argv[3]}))
+          PY
           )"
           curl -fsS -X POST \
             -H "Authorization: Bearer $GH_TOKEN" \


### PR DESCRIPTION
Fixes the two recovery workflows that were failing at workflow-definition time with zero jobs.

- indent embedded Python heredocs so the YAML is valid
- preserve the existing recovery behavior
- make the DigitalOcean result write update-safe by including the existing content SHA when present

This should stop the spurious failed workflow runs on unrelated pushes and allow the recovery jobs to actually execute.