### PR TITLE
Queue agent work directly from Workboard

### DIFF
--- a/workboard/app.js
+++ b/workboard/app.js
@@ -1,3 +1,5 @@
+import { queueCodeChange } from '../operator/forge.js';
+
 const ROOT = '3dvr-portal';
 const DEFAULT_PEERS = [
   'wss://gun-relay-3dvr.fly.dev/gun',
@@ -10,6 +12,10 @@ const laneEls = Object.fromEntries(lanes.map(name => [name, document.querySelect
 const template = document.getElementById('card-template');
 const connectionStatus = document.getElementById('connection-status');
 const liveDot = document.getElementById('live-dot');
+const dispatchForm = document.getElementById('dispatch-form');
+const dispatchStatus = document.getElementById('dispatch-status');
+const dispatchSubmit = document.getElementById('dispatch-submit');
+const dispatchResult = document.getElementById('dispatch-result');
 
 function clean(value = '', max = 500) {
   return String(value ?? '').trim().slice(0, max);
@@ -104,7 +110,36 @@ function watchCollection(node, kind) {
   });
 }
 
+async function submitDispatch(event) {
+  event.preventDefault();
+  const formData = new FormData(dispatchForm);
+  const title = clean(formData.get('title'), 160);
+  const repo = clean(formData.get('repo'), 80) || 'portal';
+  const text = clean(formData.get('task'), 4000);
+  if (!text) return;
+
+  dispatchSubmit.disabled = true;
+  dispatchResult.hidden = true;
+  dispatchStatus.textContent = 'Signing and queuing…';
+
+  try {
+    const result = await queueCodeChange({ title, repo, text });
+    dispatchStatus.textContent = result.message || 'Queued.';
+    dispatchResult.href = result.url;
+    dispatchResult.textContent = `${result.label || 'Open queued task'} →`;
+    dispatchResult.hidden = false;
+    document.getElementById('dispatch-title-input').value = '';
+    document.getElementById('dispatch-task').value = '';
+  } catch (error) {
+    dispatchStatus.textContent = clean(error?.message || 'Could not queue this task.', 240);
+  } finally {
+    dispatchSubmit.disabled = false;
+  }
+}
+
 function start() {
+  dispatchForm?.addEventListener('submit', submitDispatch);
+
   if (typeof globalThis.Gun !== 'function') {
     connectionStatus.textContent = 'Forge unavailable';
     return;

--- a/workboard/index.html
+++ b/workboard/index.html
@@ -9,6 +9,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gun/sea.js"></script>
   <script src="/gun-init.js"></script>
+  <script src="/auth-identity.js"></script>
   <script type="module" src="app.js"></script>
   <script defer src="/_vercel/insights/script.js"></script>
 </head>
@@ -29,6 +30,26 @@
         <p class="lede">Operator is the command line. This board is the persistent work graph.</p>
       </div>
       <div class="status-pill"><span id="live-dot" aria-hidden="true"></span><span id="connection-status">Connecting…</span></div>
+    </section>
+
+    <section class="dispatch" aria-labelledby="dispatch-title">
+      <div class="dispatch-copy">
+        <p class="eyebrow">DISPATCH</p>
+        <h2 id="dispatch-title">Give an agent work</h2>
+        <p>Queue a signed Forge task without starting a chat.</p>
+      </div>
+      <form id="dispatch-form">
+        <div class="dispatch-grid">
+          <label>Title <input id="dispatch-title-input" name="title" maxlength="160" placeholder="Improve the calendar"></label>
+          <label>Repo <input id="dispatch-repo" name="repo" maxlength="80" value="portal" autocapitalize="none" spellcheck="false"></label>
+        </div>
+        <label>Task <textarea id="dispatch-task" name="task" rows="3" maxlength="4000" placeholder="Describe the outcome you want…" required></textarea></label>
+        <div class="dispatch-actions">
+          <span id="dispatch-status" role="status">Ready to queue</span>
+          <button id="dispatch-submit" type="submit">Queue work →</button>
+        </div>
+        <a id="dispatch-result" class="dispatch-result" hidden>Open queued task →</a>
+      </form>
     </section>
 
     <section class="summary" aria-label="Work summary">

--- a/workboard/styles.css
+++ b/workboard/styles.css
@@ -25,6 +25,7 @@ body {
 }
 a { color: inherit; text-decoration: none; }
 button, a { -webkit-tap-highlight-color: transparent; }
+button, input, textarea { font: inherit; }
 
 main { width: min(1500px, 100%); margin: 0 auto; padding: 0 18px 48px; }
 .topbar {
@@ -58,6 +59,51 @@ h1 { max-width: 780px; margin: 0; font-size: clamp(2rem, 5vw, 4.7rem); line-heig
 .status-pill { flex: none; display: inline-flex; align-items: center; gap: 8px; padding: 9px 12px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); font-size: .82rem; background: rgba(255,255,255,.025); }
 #live-dot { width: 8px; height: 8px; border-radius: 999px; background: var(--warn); box-shadow: 0 0 0 4px rgba(253,230,138,.08); }
 #live-dot.live { background: var(--good); box-shadow: 0 0 0 4px rgba(134,239,172,.08); }
+
+.dispatch {
+  display: grid;
+  grid-template-columns: minmax(220px,.7fr) minmax(0,1.8fr);
+  gap: 22px;
+  margin: 0 0 18px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(125,211,252,.06), rgba(255,255,255,.02));
+}
+.dispatch-copy h2 { margin: 0; font-size: 1.25rem; }
+.dispatch-copy > p:last-child { margin: 8px 0 0; color: var(--muted); font-size: .84rem; line-height: 1.5; }
+.dispatch form { display: grid; gap: 10px; }
+.dispatch-grid { display: grid; grid-template-columns: minmax(0,1fr) minmax(120px,.35fr); gap: 10px; }
+.dispatch label { display: grid; gap: 6px; color: var(--muted); font-size: .72rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; }
+.dispatch input, .dispatch textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  outline: none;
+  background: rgba(3,10,18,.62);
+  color: var(--text);
+  padding: 10px 11px;
+  font-size: .9rem;
+  text-transform: none;
+  letter-spacing: normal;
+  resize: vertical;
+}
+.dispatch input:focus, .dispatch textarea:focus { border-color: rgba(125,211,252,.55); box-shadow: 0 0 0 3px rgba(125,211,252,.08); }
+.dispatch-actions { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+#dispatch-status { color: var(--muted); font-size: .78rem; }
+#dispatch-submit {
+  flex: none;
+  border: 0;
+  border-radius: 10px;
+  background: var(--accent);
+  color: #06131d;
+  padding: 10px 14px;
+  font-weight: 800;
+  cursor: pointer;
+}
+#dispatch-submit:disabled { opacity: .55; cursor: wait; }
+.dispatch-result { width: max-content; max-width: 100%; color: var(--accent); font-size: .8rem; font-weight: 800; }
+.dispatch-result[hidden] { display: none; }
 
 .summary {
   display: grid;
@@ -111,12 +157,20 @@ h1 { max-width: 780px; margin: 0; font-size: clamp(2rem, 5vw, 4.7rem); line-heig
   .board { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
+@media (max-width: 760px) {
+  .dispatch { grid-template-columns: 1fr; }
+}
+
 @media (max-width: 640px) {
   main { padding-inline: 12px; }
   .topbar { min-height: 56px; }
   .topbar nav a { padding: 8px 9px; font-size: .8rem; }
   .hero { align-items: flex-start; flex-direction: column; padding: 34px 2px 22px; }
   h1 { font-size: clamp(2.25rem, 12vw, 3.55rem); }
+  .dispatch { padding: 14px; gap: 14px; }
+  .dispatch-grid { grid-template-columns: 1fr; }
+  .dispatch-actions { align-items: stretch; flex-direction: column; }
+  #dispatch-submit { width: 100%; }
   .summary { grid-template-columns: repeat(2, 1fr); }
   .summary div:nth-child(2) { border-right: 0; }
   .summary div:nth-child(-n+2) { border-bottom: 1px solid var(--line); }


### PR DESCRIPTION
Closes #1880

Adds a compact dispatch composer to `/workboard/` that reuses the existing signed Forge `queueCodeChange()` path.

- title, repo, and task inputs
- signed developer dispatch using the same safety/auth path as Operator
- visible queue/error status
- direct link to the queued Forge record
- mobile-first layout

This makes Workboard both the persistent work graph and a lightweight command surface.