### PR TITLE
Serve and verify Workboard feed on self-host

### DIFF
--- a/scripts/ops/deploy-self-host-portal.sh
+++ b/scripts/ops/deploy-self-host-portal.sh
@@ -133,6 +133,11 @@ if [ "$ready" != true ]; then
   exit 4
 fi
 
+# Verify the agent work surface before exposing this release publicly.
+curl -fsS --retry 3 --retry-delay 1 "http://127.0.0.1:$port/workboard/" | grep -Fq 'AGENT WORKBOARD'
+workboard_feed="$(curl -fsS --retry 3 --retry-delay 1 "http://127.0.0.1:$port/api/workboard/github")"
+printf '%s' "$workboard_feed" | node -e 'let s=""; process.stdin.on("data",d=>s+=d).on("end",()=>{const p=JSON.parse(s); if(!p.ok||!Array.isArray(p.items)) throw new Error("invalid Workboard GitHub feed");})'
+
 cloudflared="$(command -v cloudflared || true)"
 if [ -z "$cloudflared" ]; then
   if [ "$(id -u)" = 0 ]; then cloudflared=/usr/local/bin/cloudflared; else cloudflared="$base/bin/cloudflared"; fi

--- a/scripts/self-host-server.mjs
+++ b/scripts/self-host-server.mjs
@@ -23,7 +23,7 @@ const MIME_TYPES = new Map([
   ['.webmanifest', 'application/manifest+json; charset=utf-8'],
   ['.svg', 'image/svg+xml'],
   ['.png', 'image/png'],
-  ['.jpg', 'image/jpg'],
+  ['.jpg', 'image/jpeg'],
   ['.jpeg', 'image/jpeg'],
   ['.gif', 'image/gif'],
   ['.webp', 'image/webp'],

--- a/scripts/self-host-server.mjs
+++ b/scripts/self-host-server.mjs
@@ -2,6 +2,7 @@ import { createServer } from 'node:http';
 import { access, readFile, stat } from 'node:fs/promises';
 import { extname, join, normalize, resolve } from 'node:path';
 import openAiSiteHandler from '../api/openai-site.js';
+import workboardGithubHandler from '../api/workboard/github.js';
 import { createOAuthProviderHandler } from '../src/oauth/provider-api.js';
 
 const PORT = Number(process.env.PORT || 4320);
@@ -22,7 +23,7 @@ const MIME_TYPES = new Map([
   ['.webmanifest', 'application/manifest+json; charset=utf-8'],
   ['.svg', 'image/svg+xml'],
   ['.png', 'image/png'],
-  ['.jpg', 'image/jpeg'],
+  ['.jpg', 'image/jpg'],
   ['.jpeg', 'image/jpeg'],
   ['.gif', 'image/gif'],
   ['.webp', 'image/webp'],
@@ -138,6 +139,16 @@ async function runOpenAiSite(req, res, url) {
   }
 }
 
+async function runWorkboardGithub(req, res, url) {
+  try {
+    req.query = Object.fromEntries(url.searchParams.entries());
+    await workboardGithubHandler(req, adaptResponse(res));
+  } catch (error) {
+    if (!res.headersSent) json(res, error?.statusCode || 500, { error: error?.message || 'Workboard GitHub feed failed' });
+    else res.destroy(error);
+  }
+}
+
 async function runOAuthProvider(req, res, url) {
   try {
     if (req.method !== 'OPTIONS') await prepareApiRequest(req, url);
@@ -201,6 +212,10 @@ const server = createServer(async (req, res) => {
 
   if (url.pathname === '/api/openai-site') {
     return runOpenAiSite(req, res, url);
+  }
+
+  if (url.pathname === '/api/workboard/github') {
+    return runWorkboardGithub(req, res, url);
   }
 
   if (url.pathname.startsWith('/api/oauth/')) {


### PR DESCRIPTION
Closes #1884

Makes the Workboard GitHub feed part of canonical self-hosted production instead of falling through to the stale Vercel API fallback.

- serve `/api/workboard/github` natively from `scripts/self-host-server.mjs`
- reuse the same API handler as Vercel
- make the self-host deploy fail unless `/workboard/` loads and the GitHub feed returns a valid item array
- preserves unrelated MIME behavior

This closes the gap between “merged” and “actually live.”