### PR TITLE
Expose Agent Workboard as a PWA shortcut

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -13,5 +13,16 @@
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
     { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ],
+  "shortcuts": [
+    {
+      "name": "Agent Workboard",
+      "short_name": "Workboard",
+      "description": "See, dispatch, and review persistent agent work.",
+      "url": "/workboard/?source=pwa-shortcut",
+      "icons": [
+        { "src": "/brand/portal-mark.svg", "sizes": "any", "type": "image/svg+xml" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Closes #1889

Adds Agent Workboard to the Portal web app manifest shortcuts so installed Portal users can jump directly into persistent agent work.

This is intentionally small and does not alter the homepage layout.