### PR TITLE
Add idempotent Website Upgrade fulfillment state

### DIFF
--- a/apps/agent/test/website-upgrade-fulfillment-state.test.js
+++ b/apps/agent/test/website-upgrade-fulfillment-state.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
+  readNode,
   receiveOrder,
   reserveDelivery,
   shouldDeliver,
@@ -42,6 +43,19 @@ test('receives each Stripe Checkout Session only once', async () => {
   assert.equal(replay.created, false);
   assert.equal(node.records.size, 1);
   assert.equal(replay.record.businessName, 'Example Studio');
+});
+
+test('fails closed on malformed shared fulfillment state', async () => {
+  const malformedNode = {
+    once(callback) {
+      callback('corrupt-existing-record');
+    },
+  };
+
+  await assert.rejects(
+    readNode(malformedNode),
+    /Malformed Website Upgrade fulfillment state/
+  );
 });
 
 test('tracks processing attempts and safe retry state', async () => {

--- a/apps/agent/test/website-upgrade-fulfillment-state.test.js
+++ b/apps/agent/test/website-upgrade-fulfillment-state.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
   receiveOrder,
+  reserveDelivery,
   shouldDeliver,
   transitionOrder,
 } = require('../thomas-agent/node/website-upgrade-fulfillment-state');
@@ -17,50 +18,76 @@ function order() {
   };
 }
 
-test('receives each Stripe Checkout Session only once', () => {
-  const state = { version: 1, orders: {} };
-  const first = receiveOrder(state, order());
-  const replay = receiveOrder(state, { ...order(), businessName: 'Changed on replay' });
+function memoryNodeFactory() {
+  const records = new Map();
+  const node = sessionId => ({
+    once(callback) {
+      callback(records.get(sessionId) || null);
+    },
+    put(value, callback) {
+      records.set(sessionId, structuredClone(value));
+      callback({ ok: 1 });
+    },
+  });
+  node.records = records;
+  return node;
+}
+
+test('receives each Stripe Checkout Session only once', async () => {
+  const node = memoryNodeFactory();
+  const first = await receiveOrder(order(), { node });
+  const replay = await receiveOrder({ ...order(), businessName: 'Changed on replay' }, { node });
 
   assert.equal(first.created, true);
   assert.equal(replay.created, false);
-  assert.equal(Object.keys(state.orders).length, 1);
+  assert.equal(node.records.size, 1);
   assert.equal(replay.record.businessName, 'Example Studio');
 });
 
-test('tracks processing attempts and safe retry state', () => {
-  const state = { version: 1, orders: {} };
-  receiveOrder(state, order());
-  transitionOrder(state, order().sessionId, 'processing');
-  transitionOrder(state, order().sessionId, 'failed', { reason: 'verification timeout' });
-  const retry = transitionOrder(state, order().sessionId, 'processing');
+test('tracks processing attempts and safe retry state', async () => {
+  const node = memoryNodeFactory();
+  await receiveOrder(order(), { node });
+  await transitionOrder(order().sessionId, 'processing', {}, { node });
+  await transitionOrder(order().sessionId, 'failed', { reason: 'verification timeout' }, { node });
+  const retry = await transitionOrder(order().sessionId, 'processing', {}, { node });
 
   assert.equal(retry.attempts, 2);
   assert.equal(retry.status, 'processing');
 });
 
-test('delivery is exactly-once guarded by durable delivery state', () => {
-  const state = { version: 1, orders: {} };
-  const { record } = receiveOrder(state, order());
+test('delivery reservation survives restart and prevents duplicate send', async () => {
+  const node = memoryNodeFactory();
+  const { record } = await receiveOrder(order(), { node });
   assert.equal(shouldDeliver(record), true);
 
-  const delivered = transitionOrder(state, order().sessionId, 'delivered', {
-    finalUrl: order().siteUrl,
-  });
-  assert.equal(shouldDeliver(delivered), false);
-  assert.ok(delivered.deliverySentAt);
+  const first = await reserveDelivery(order().sessionId, 'delivery-attempt-1', { node });
+  assert.equal(first.reserved, true);
+  assert.equal(first.record.deliveryState, 'reserved');
+  assert.ok(first.record.deliveryReservedAt);
+  assert.equal(shouldDeliver(first.record), false);
 
-  const replay = transitionOrder(state, order().sessionId, 'processing');
-  assert.equal(replay.status, 'delivered');
-  assert.equal(replay.attempts, delivered.attempts);
+  const restartedWorker = await reserveDelivery(order().sessionId, 'delivery-attempt-2', { node });
+  assert.equal(restartedWorker.reserved, false);
+  assert.equal(restartedWorker.record.deliveryReservationId, 'delivery-attempt-1');
+  assert.equal(shouldDeliver(restartedWorker.record), false);
+
+  const delivered = await transitionOrder(order().sessionId, 'delivered', {
+    finalUrl: order().siteUrl,
+  }, { node });
+  assert.equal(delivered.deliveryState, 'sent');
+  assert.ok(delivered.deliverySentAt);
+  assert.equal(shouldDeliver(delivered), false);
 });
 
-test('blocked orders remain terminal on replay', () => {
-  const state = { version: 1, orders: {} };
-  receiveOrder(state, order());
-  const blocked = transitionOrder(state, order().sessionId, 'blocked', { reason: 'target rejected' });
-  const replay = transitionOrder(state, order().sessionId, 'processing');
+test('blocked orders remain terminal and cannot pass the delivery guard', async () => {
+  const node = memoryNodeFactory();
+  await receiveOrder(order(), { node });
+  const blocked = await transitionOrder(order().sessionId, 'blocked', { reason: 'target rejected' }, { node });
+  const replay = await transitionOrder(order().sessionId, 'processing', {}, { node });
 
   assert.equal(blocked.status, 'blocked');
   assert.equal(replay.status, 'blocked');
+  assert.equal(shouldDeliver(blocked), false);
+  const reservation = await reserveDelivery(order().sessionId, 'should-not-reserve', { node });
+  assert.equal(reservation.reserved, false);
 });

--- a/apps/agent/test/website-upgrade-fulfillment-state.test.js
+++ b/apps/agent/test/website-upgrade-fulfillment-state.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  receiveOrder,
+  shouldDeliver,
+  transitionOrder,
+} = require('../thomas-agent/node/website-upgrade-fulfillment-state');
+
+function order() {
+  return {
+    sessionId: 'cs_live_upgrade_123',
+    businessName: 'Example Studio',
+    mainAction: 'Book a consultation',
+    siteUrl: 'https://3dvr.tech/free-sites/example-studio/',
+    slug: 'example-studio',
+    customerEmail: 'buyer@example.com',
+  };
+}
+
+test('receives each Stripe Checkout Session only once', () => {
+  const state = { version: 1, orders: {} };
+  const first = receiveOrder(state, order());
+  const replay = receiveOrder(state, { ...order(), businessName: 'Changed on replay' });
+
+  assert.equal(first.created, true);
+  assert.equal(replay.created, false);
+  assert.equal(Object.keys(state.orders).length, 1);
+  assert.equal(replay.record.businessName, 'Example Studio');
+});
+
+test('tracks processing attempts and safe retry state', () => {
+  const state = { version: 1, orders: {} };
+  receiveOrder(state, order());
+  transitionOrder(state, order().sessionId, 'processing');
+  transitionOrder(state, order().sessionId, 'failed', { reason: 'verification timeout' });
+  const retry = transitionOrder(state, order().sessionId, 'processing');
+
+  assert.equal(retry.attempts, 2);
+  assert.equal(retry.status, 'processing');
+});
+
+test('delivery is exactly-once guarded by durable delivery state', () => {
+  const state = { version: 1, orders: {} };
+  const { record } = receiveOrder(state, order());
+  assert.equal(shouldDeliver(record), true);
+
+  const delivered = transitionOrder(state, order().sessionId, 'delivered', {
+    finalUrl: order().siteUrl,
+  });
+  assert.equal(shouldDeliver(delivered), false);
+  assert.ok(delivered.deliverySentAt);
+
+  const replay = transitionOrder(state, order().sessionId, 'processing');
+  assert.equal(replay.status, 'delivered');
+  assert.equal(replay.attempts, delivered.attempts);
+});
+
+test('blocked orders remain terminal on replay', () => {
+  const state = { version: 1, orders: {} };
+  receiveOrder(state, order());
+  const blocked = transitionOrder(state, order().sessionId, 'blocked', { reason: 'target rejected' });
+  const replay = transitionOrder(state, order().sessionId, 'processing');
+
+  assert.equal(blocked.status, 'blocked');
+  assert.equal(replay.status, 'blocked');
+});

--- a/apps/agent/test/website-upgrade-fulfillment-state.test.js
+++ b/apps/agent/test/website-upgrade-fulfillment-state.test.js
@@ -1,12 +1,18 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+
+const gunDbPath = require.resolve('../thomas-agent/node/gun-db');
+const fulfillmentPath = require.resolve('../thomas-agent/node/website-upgrade-fulfillment-state');
+delete require.cache[gunDbPath];
+delete require.cache[fulfillmentPath];
+
 const {
   readNode,
   receiveOrder,
   reserveDelivery,
   shouldDeliver,
   transitionOrder,
-} = require('../thomas-agent/node/website-upgrade-fulfillment-state');
+} = require(fulfillmentPath);
 
 function order() {
   return {
@@ -33,6 +39,10 @@ function memoryNodeFactory() {
   node.records = records;
   return node;
 }
+
+test('importing fulfillment state does not open the real Gun client', () => {
+  assert.equal(require.cache[gunDbPath], undefined);
+});
 
 test('receives each Stripe Checkout Session only once', async () => {
   const node = memoryNodeFactory();

--- a/apps/agent/thomas-agent/node/gun-db.js
+++ b/apps/agent/thomas-agent/node/gun-db.js
@@ -38,6 +38,12 @@ function autopilotStateNode() {
   return gun.get(APP_ROOT).get(OPS_ROOT).get(AUTOPILOT_ROOT).get('state');
 }
 
+// Canonical paid Website Upgrade fulfillment records. Each child is keyed by
+// the immutable Stripe Checkout Session ID so every worker sees the same state.
+function websiteUpgradeFulfillmentNode() {
+  return gun.get(APP_ROOT).get(OPS_ROOT).get(AUTOPILOT_ROOT).get('website-upgrade-fulfillment');
+}
+
 function portalAgentOpsNode() {
   return gun.get(PORTAL_ROOT).get('agentOps');
 }
@@ -64,6 +70,7 @@ module.exports = {
   outreachArtifactsNode,
   autopilotRunsNode,
   autopilotStateNode,
+  websiteUpgradeFulfillmentNode,
   portalAgentOpsNode,
   portalCrmNode,
   portalCrmTouchLogNode,

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
@@ -1,5 +1,3 @@
-const { websiteUpgradeFulfillmentNode } = require('./gun-db');
-
 const TERMINAL_STATUSES = new Set(['delivered', 'blocked']);
 const VALID_STATUSES = new Set(['received', 'processing', 'delivered', 'blocked', 'failed']);
 
@@ -14,6 +12,9 @@ function requireSessionId(order) {
 }
 
 function sessionNode(sessionId) {
+  // Keep the real Gun client lazy. Unit tests inject a node factory and should
+  // not open a persistent relay connection merely by importing this module.
+  const { websiteUpgradeFulfillmentNode } = require('./gun-db');
   return websiteUpgradeFulfillmentNode().get(sessionId);
 }
 

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
@@ -20,15 +20,15 @@ function ensureStateFile(stateFile = DEFAULT_STATE_FILE) {
     fs.writeFileSync(stateFile, `${JSON.stringify(initial, null, 2)}\n`);
     return initial;
   }
-  try {
-    const parsed = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
-    return {
-      version: 1,
-      orders: parsed.orders && typeof parsed.orders === 'object' ? parsed.orders : {},
-    };
-  } catch {
-    return { version: 1, orders: {} };
+
+  // Fulfillment history is safety-critical: never treat unreadable/corrupt
+  // persisted state as an empty history, because that could redeliver a paid
+  // Stripe Checkout Session. Surface the error and require recovery instead.
+  const parsed = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  if (!parsed.orders || typeof parsed.orders !== 'object' || Array.isArray(parsed.orders)) {
+    throw new Error(`Invalid Website Upgrade fulfillment state: ${stateFile}`);
   }
+  return { version: 1, orders: parsed.orders };
 }
 
 function saveState(state, stateFile = DEFAULT_STATE_FILE) {

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
@@ -1,10 +1,4 @@
-const fs = require('node:fs');
-const path = require('node:path');
-
-const ROOT = path.join(__dirname, '..');
-const DEFAULT_STATE_DIR = process.env.THREEDVR_AUTOPILOT_STATE_DIR || path.join(ROOT, 'state');
-const DEFAULT_STATE_FILE = process.env.THREEDVR_WEBSITE_UPGRADE_STATE_FILE
-  || path.join(DEFAULT_STATE_DIR, 'website-upgrade-fulfillment-state.json');
+const { websiteUpgradeFulfillmentNode } = require('./gun-db');
 
 const TERMINAL_STATUSES = new Set(['delivered', 'blocked']);
 const VALID_STATUSES = new Set(['received', 'processing', 'delivered', 'blocked', 'failed']);
@@ -13,40 +7,41 @@ function nowIso(now = () => new Date()) {
   return now().toISOString();
 }
 
-function ensureStateFile(stateFile = DEFAULT_STATE_FILE) {
-  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
-  if (!fs.existsSync(stateFile)) {
-    const initial = { version: 1, orders: {} };
-    fs.writeFileSync(stateFile, `${JSON.stringify(initial, null, 2)}\n`);
-    return initial;
-  }
-
-  // Fulfillment history is safety-critical: never treat unreadable/corrupt
-  // persisted state as an empty history, because that could redeliver a paid
-  // Stripe Checkout Session. Surface the error and require recovery instead.
-  const parsed = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
-  if (!parsed.orders || typeof parsed.orders !== 'object' || Array.isArray(parsed.orders)) {
-    throw new Error(`Invalid Website Upgrade fulfillment state: ${stateFile}`);
-  }
-  return { version: 1, orders: parsed.orders };
-}
-
-function saveState(state, stateFile = DEFAULT_STATE_FILE) {
-  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
-  const tmp = `${stateFile}.tmp`;
-  fs.writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
-  fs.renameSync(tmp, stateFile);
-}
-
 function requireSessionId(order) {
   const sessionId = String(order?.sessionId || '').trim();
   if (!sessionId) throw new Error('Website Upgrade fulfillment requires a Stripe Checkout Session ID.');
   return sessionId;
 }
 
-function receiveOrder(state, order, options = {}) {
+function sessionNode(sessionId) {
+  return websiteUpgradeFulfillmentNode().get(sessionId);
+}
+
+function readNode(node, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out reading Website Upgrade fulfillment state from GunJS.')), timeoutMs);
+    node.once((data) => {
+      clearTimeout(timer);
+      resolve(data && typeof data === 'object' ? data : null);
+    });
+  });
+}
+
+function writeNode(node, value, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out writing Website Upgrade fulfillment state to GunJS.')), timeoutMs);
+    node.put(value, (ack) => {
+      clearTimeout(timer);
+      if (ack && ack.err) reject(new Error(`GunJS fulfillment write failed: ${ack.err}`));
+      else resolve(value);
+    });
+  });
+}
+
+async function receiveOrder(order, options = {}) {
   const sessionId = requireSessionId(order);
-  const existing = state.orders[sessionId];
+  const node = (options.node || sessionNode)(sessionId);
+  const existing = await readNode(node, options.timeoutMs);
   if (existing) return { record: existing, created: false, terminal: TERMINAL_STATUSES.has(existing.status) };
 
   const at = nowIso(options.now);
@@ -63,13 +58,14 @@ function receiveOrder(state, order, options = {}) {
     attempts: 0,
     deliverySentAt: null,
   };
-  state.orders[sessionId] = record;
+  await writeNode(node, record, options.timeoutMs);
   return { record, created: true, terminal: false };
 }
 
-function transitionOrder(state, sessionId, status, details = {}, options = {}) {
+async function transitionOrder(sessionId, status, details = {}, options = {}) {
   if (!VALID_STATUSES.has(status)) throw new Error(`Invalid Website Upgrade fulfillment status: ${status}`);
-  const record = state.orders[sessionId];
+  const node = (options.node || sessionNode)(sessionId);
+  const record = await readNode(node, options.timeoutMs);
   if (!record) throw new Error(`Unknown Website Upgrade fulfillment session: ${sessionId}`);
   if (TERMINAL_STATUSES.has(record.status) && record.status !== status) return record;
 
@@ -77,7 +73,7 @@ function transitionOrder(state, sessionId, status, details = {}, options = {}) {
   const next = { ...record, ...details, status, updatedAt: at };
   if (status === 'processing') next.attempts = Number(record.attempts || 0) + 1;
   if (status === 'delivered' && !next.deliverySentAt) next.deliverySentAt = at;
-  state.orders[sessionId] = next;
+  await writeNode(node, next, options.timeoutMs);
   return next;
 }
 
@@ -86,11 +82,10 @@ function shouldDeliver(record) {
 }
 
 module.exports = {
-  DEFAULT_STATE_FILE,
   TERMINAL_STATUSES,
-  ensureStateFile,
+  readNode,
   receiveOrder,
-  saveState,
   shouldDeliver,
   transitionOrder,
+  writeNode,
 };

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
@@ -56,10 +56,41 @@ async function receiveOrder(order, options = {}) {
     receivedAt: at,
     updatedAt: at,
     attempts: 0,
+    deliveryState: 'pending',
+    deliveryReservedAt: null,
+    deliveryReservationId: null,
     deliverySentAt: null,
   };
   await writeNode(node, record, options.timeoutMs);
   return { record, created: true, terminal: false };
+}
+
+async function reserveDelivery(sessionId, reservationId, options = {}) {
+  const id = String(reservationId || '').trim();
+  if (!id) throw new Error('Website Upgrade delivery reservation requires an ID.');
+
+  const node = (options.node || sessionNode)(sessionId);
+  const record = await readNode(node, options.timeoutMs);
+  if (!record) throw new Error(`Unknown Website Upgrade fulfillment session: ${sessionId}`);
+
+  if (
+    TERMINAL_STATUSES.has(record.status)
+    || record.deliverySentAt
+    || record.deliveryReservedAt
+  ) {
+    return { record, reserved: false };
+  }
+
+  const at = nowIso(options.now);
+  const next = {
+    ...record,
+    deliveryState: 'reserved',
+    deliveryReservedAt: at,
+    deliveryReservationId: id,
+    updatedAt: at,
+  };
+  await writeNode(node, next, options.timeoutMs);
+  return { record: next, reserved: true };
 }
 
 async function transitionOrder(sessionId, status, details = {}, options = {}) {
@@ -72,19 +103,28 @@ async function transitionOrder(sessionId, status, details = {}, options = {}) {
   const at = nowIso(options.now);
   const next = { ...record, ...details, status, updatedAt: at };
   if (status === 'processing') next.attempts = Number(record.attempts || 0) + 1;
-  if (status === 'delivered' && !next.deliverySentAt) next.deliverySentAt = at;
+  if (status === 'delivered') {
+    if (!next.deliverySentAt) next.deliverySentAt = at;
+    next.deliveryState = 'sent';
+  }
   await writeNode(node, next, options.timeoutMs);
   return next;
 }
 
 function shouldDeliver(record) {
-  return Boolean(record && record.status !== 'delivered' && !record.deliverySentAt);
+  return Boolean(
+    record
+    && !TERMINAL_STATUSES.has(record.status)
+    && !record.deliveryReservedAt
+    && !record.deliverySentAt
+  );
 }
 
 module.exports = {
   TERMINAL_STATUSES,
   readNode,
   receiveOrder,
+  reserveDelivery,
   shouldDeliver,
   transitionOrder,
   writeNode,

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
@@ -1,0 +1,96 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_STATE_DIR = process.env.THREEDVR_AUTOPILOT_STATE_DIR || path.join(ROOT, 'state');
+const DEFAULT_STATE_FILE = process.env.THREEDVR_WEBSITE_UPGRADE_STATE_FILE
+  || path.join(DEFAULT_STATE_DIR, 'website-upgrade-fulfillment-state.json');
+
+const TERMINAL_STATUSES = new Set(['delivered', 'blocked']);
+const VALID_STATUSES = new Set(['received', 'processing', 'delivered', 'blocked', 'failed']);
+
+function nowIso(now = () => new Date()) {
+  return now().toISOString();
+}
+
+function ensureStateFile(stateFile = DEFAULT_STATE_FILE) {
+  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+  if (!fs.existsSync(stateFile)) {
+    const initial = { version: 1, orders: {} };
+    fs.writeFileSync(stateFile, `${JSON.stringify(initial, null, 2)}\n`);
+    return initial;
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    return {
+      version: 1,
+      orders: parsed.orders && typeof parsed.orders === 'object' ? parsed.orders : {},
+    };
+  } catch {
+    return { version: 1, orders: {} };
+  }
+}
+
+function saveState(state, stateFile = DEFAULT_STATE_FILE) {
+  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+  const tmp = `${stateFile}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  fs.renameSync(tmp, stateFile);
+}
+
+function requireSessionId(order) {
+  const sessionId = String(order?.sessionId || '').trim();
+  if (!sessionId) throw new Error('Website Upgrade fulfillment requires a Stripe Checkout Session ID.');
+  return sessionId;
+}
+
+function receiveOrder(state, order, options = {}) {
+  const sessionId = requireSessionId(order);
+  const existing = state.orders[sessionId];
+  if (existing) return { record: existing, created: false, terminal: TERMINAL_STATUSES.has(existing.status) };
+
+  const at = nowIso(options.now);
+  const record = {
+    sessionId,
+    status: 'received',
+    slug: String(order.slug || '').trim(),
+    siteUrl: String(order.siteUrl || '').trim(),
+    customerEmail: String(order.customerEmail || '').trim(),
+    businessName: String(order.businessName || '').trim(),
+    mainAction: String(order.mainAction || '').trim(),
+    receivedAt: at,
+    updatedAt: at,
+    attempts: 0,
+    deliverySentAt: null,
+  };
+  state.orders[sessionId] = record;
+  return { record, created: true, terminal: false };
+}
+
+function transitionOrder(state, sessionId, status, details = {}, options = {}) {
+  if (!VALID_STATUSES.has(status)) throw new Error(`Invalid Website Upgrade fulfillment status: ${status}`);
+  const record = state.orders[sessionId];
+  if (!record) throw new Error(`Unknown Website Upgrade fulfillment session: ${sessionId}`);
+  if (TERMINAL_STATUSES.has(record.status) && record.status !== status) return record;
+
+  const at = nowIso(options.now);
+  const next = { ...record, ...details, status, updatedAt: at };
+  if (status === 'processing') next.attempts = Number(record.attempts || 0) + 1;
+  if (status === 'delivered' && !next.deliverySentAt) next.deliverySentAt = at;
+  state.orders[sessionId] = next;
+  return next;
+}
+
+function shouldDeliver(record) {
+  return Boolean(record && record.status !== 'delivered' && !record.deliverySentAt);
+}
+
+module.exports = {
+  DEFAULT_STATE_FILE,
+  TERMINAL_STATUSES,
+  ensureStateFile,
+  receiveOrder,
+  saveState,
+  shouldDeliver,
+  transitionOrder,
+};

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
@@ -22,7 +22,15 @@ function readNode(node, timeoutMs = 5000) {
     const timer = setTimeout(() => reject(new Error('Timed out reading Website Upgrade fulfillment state from GunJS.')), timeoutMs);
     node.once((data) => {
       clearTimeout(timer);
-      resolve(data && typeof data === 'object' ? data : null);
+      if (data === null || data === undefined) {
+        resolve(null);
+        return;
+      }
+      if (typeof data !== 'object' || Array.isArray(data)) {
+        reject(new Error('Malformed Website Upgrade fulfillment state in GunJS.'));
+        return;
+      }
+      resolve(data);
     });
   });
 }


### PR DESCRIPTION
Superseded by exact-current-main #1975.

This branch was fully hardened, all four review findings were resolved, and after lazy-loading the Gun client it passed both full Agent Checks and Playwright. Because `main` had moved substantially and this branch became conflicted, the exact tested three-file change was reconstructed on current `main` as #1975 instead of force-merging stale history.

The branch remains preserved as review/audit history.