### PR TITLE
Cache Workboard GitHub feed server-side

### DIFF
--- a/api/workboard/github.js
+++ b/api/workboard/github.js
@@ -1,6 +1,11 @@
 const REPOSITORY = 'tmsteph/3dvr-portal';
 const API_VERSION = '2022-11-28';
 const ITEM_LIMIT = 40;
+const CACHE_TTL_MS = 60_000;
+const STALE_TTL_MS = 5 * 60_000;
+
+let cachedFeed = null;
+let cachedAt = 0;
 
 function githubHeaders(config = process.env) {
   const headers = {
@@ -34,17 +39,39 @@ function normalizeItem(item = {}) {
   };
 }
 
+function cachedPayload(maxAgeMs, now = Date.now()) {
+  if (!cachedFeed || !cachedAt) return null;
+  if (now - cachedAt > maxAgeMs) return null;
+  return cachedFeed;
+}
+
+function sendFeed(res, payload, { stale = false } = {}) {
+  res.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300');
+  if (stale) res.setHeader('Warning', '110 - Response is stale');
+  return res.status(200).json(payload);
+}
+
+export function __resetWorkboardGithubCacheForTests() {
+  cachedFeed = null;
+  cachedAt = 0;
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
     return res.status(405).json({ error: 'Method Not Allowed' });
   }
 
+  const fresh = cachedPayload(CACHE_TTL_MS);
+  if (fresh) return sendFeed(res, fresh);
+
   const url = `https://api.github.com/repos/${REPOSITORY}/issues?state=all&per_page=${ITEM_LIMIT}&sort=updated&direction=desc`;
 
   try {
     const response = await fetch(url, { headers: githubHeaders() });
     if (!response.ok) {
+      const stale = cachedPayload(STALE_TTL_MS);
+      if (stale) return sendFeed(res, stale, { stale: true });
       return res.status(502).json({
         error: 'GitHub work feed is temporarily unavailable.',
         status: response.status
@@ -53,10 +80,12 @@ export default async function handler(req, res) {
 
     const payload = await response.json();
     const items = Array.isArray(payload) ? payload.map(normalizeItem).filter(item => item.id) : [];
-
-    res.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300');
-    return res.status(200).json({ ok: true, repository: REPOSITORY, items });
+    cachedFeed = { ok: true, repository: REPOSITORY, items };
+    cachedAt = Date.now();
+    return sendFeed(res, cachedFeed);
   } catch (error) {
+    const stale = cachedPayload(STALE_TTL_MS);
+    if (stale) return sendFeed(res, stale, { stale: true });
     return res.status(502).json({
       error: error?.message || 'GitHub work feed is temporarily unavailable.'
     });

--- a/tests/workboard-github-api.test.js
+++ b/tests/workboard-github-api.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
 
-import workboardGithubHandler from '../api/workboard/github.js';
+import workboardGithubHandler, { __resetWorkboardGithubCacheForTests } from '../api/workboard/github.js';
 
 const originalFetch = globalThis.fetch;
 
@@ -27,6 +27,7 @@ function createResponse() {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  __resetWorkboardGithubCacheForTests();
 });
 
 test('Workboard GitHub feed rejects non-GET requests', async () => {
@@ -98,7 +99,30 @@ test('Workboard GitHub feed normalizes issues and pull requests', async () => {
   assert.match(String(res.headers.get('cache-control')), /s-maxage=60/);
 });
 
-test('Workboard GitHub feed returns a controlled error when GitHub fails', async () => {
+test('Workboard GitHub feed reuses its server-side cache', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return [{ id: 101, number: 42, title: 'Cached item', state: 'open' }];
+      }
+    };
+  };
+
+  const req = { method: 'GET' };
+  const first = createResponse();
+  const second = createResponse();
+  await workboardGithubHandler(req, first);
+  await workboardGithubHandler(req, second);
+
+  assert.equal(calls, 1);
+  assert.deepEqual(second.body, first.body);
+});
+
+test('Workboard GitHub feed returns a controlled error when GitHub fails without cache', async () => {
   globalThis.fetch = async () => ({ ok: false, status: 403 });
 
   const req = { method: 'GET' };


### PR DESCRIPTION
Follow-up to #1885. Adds a real in-process cache to `/api/workboard/github` so self-hosted Workboard page loads do not consume one anonymous GitHub API request each. Keeps stale data available briefly during transient upstream failures and adds regression coverage for cache reuse.

This addresses the quota-exhaustion review finding from #1885. The separate pre-switch deployment validation finding will be tracked independently so this reliability fix can land immediately.