### PR TITLE
Let Money Autopilot exit after its one-shot brief

### DIFF
--- a/scripts/money/operator-brief.mjs
+++ b/scripts/money/operator-brief.mjs
@@ -107,7 +107,12 @@ async function main() {
   });
 }
 
-main().catch(error => {
+main().then(() => {
+  // Gun keeps background timers/sockets alive after the CLI has completed its
+  // awaited work. This is a one-shot workflow command, so terminate cleanly
+  // once outputs and delivery have finished instead of waiting for handles.
+  process.exit(0);
+}).catch(error => {
   console.error(error?.message || error);
   process.exit(1);
 });


### PR DESCRIPTION
Fixes the Aug 28 Money Autopilot failure from workflow run 33225078707.

The operator brief completed its business logic and wrote all five artifacts, but Gun background handles kept Node alive until the workflow's 4-minute timeout killed it with exit 124. This makes the one-shot CLI exit successfully after all awaited output and delivery work finishes.

Observed failing run:
- `Money operator brief: Day Money Brief` printed successfully
- all artifact paths printed successfully
- process then idled until `Process completed with exit code 124`

No money selection, outreach, pricing, or send policy changes.