### PR TITLE
Coalesce concurrent Workboard GitHub refreshes

### DIFF
--- a/api/workboard/github.js
+++ b/api/workboard/github.js
@@ -6,6 +6,7 @@ const STALE_TTL_MS = 5 * 60_000;
 
 let cachedFeed = null;
 let cachedAt = 0;
+let refreshPromise = null;
 
 function githubHeaders(config = process.env) {
   const headers = {
@@ -51,9 +52,34 @@ function sendFeed(res, payload, { stale = false } = {}) {
   return res.status(200).json(payload);
 }
 
+async function refreshFeed() {
+  if (!refreshPromise) {
+    const url = `https://api.github.com/repos/${REPOSITORY}/issues?state=all&per_page=${ITEM_LIMIT}&sort=updated&direction=desc`;
+    refreshPromise = (async () => {
+      const response = await fetch(url, { headers: githubHeaders() });
+      if (!response.ok) {
+        const error = new Error('GitHub work feed is temporarily unavailable.');
+        error.status = response.status;
+        throw error;
+      }
+
+      const payload = await response.json();
+      const items = Array.isArray(payload) ? payload.map(normalizeItem).filter(item => item.id) : [];
+      cachedFeed = { ok: true, repository: REPOSITORY, items };
+      cachedAt = Date.now();
+      return cachedFeed;
+    })().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+}
+
 export function __resetWorkboardGithubCacheForTests() {
   cachedFeed = null;
   cachedAt = 0;
+  refreshPromise = null;
 }
 
 export default async function handler(req, res) {
@@ -65,29 +91,15 @@ export default async function handler(req, res) {
   const fresh = cachedPayload(CACHE_TTL_MS);
   if (fresh) return sendFeed(res, fresh);
 
-  const url = `https://api.github.com/repos/${REPOSITORY}/issues?state=all&per_page=${ITEM_LIMIT}&sort=updated&direction=desc`;
-
   try {
-    const response = await fetch(url, { headers: githubHeaders() });
-    if (!response.ok) {
-      const stale = cachedPayload(STALE_TTL_MS);
-      if (stale) return sendFeed(res, stale, { stale: true });
-      return res.status(502).json({
-        error: 'GitHub work feed is temporarily unavailable.',
-        status: response.status
-      });
-    }
-
-    const payload = await response.json();
-    const items = Array.isArray(payload) ? payload.map(normalizeItem).filter(item => item.id) : [];
-    cachedFeed = { ok: true, repository: REPOSITORY, items };
-    cachedAt = Date.now();
-    return sendFeed(res, cachedFeed);
+    const payload = await refreshFeed();
+    return sendFeed(res, payload);
   } catch (error) {
     const stale = cachedPayload(STALE_TTL_MS);
     if (stale) return sendFeed(res, stale, { stale: true });
     return res.status(502).json({
-      error: error?.message || 'GitHub work feed is temporarily unavailable.'
+      error: error?.message || 'GitHub work feed is temporarily unavailable.',
+      ...(Number.isFinite(error?.status) ? { status: error.status } : {})
     });
   }
 }

--- a/tests/workboard-github-api.test.js
+++ b/tests/workboard-github-api.test.js
@@ -122,6 +122,37 @@ test('Workboard GitHub feed reuses its server-side cache', async () => {
   assert.deepEqual(second.body, first.body);
 });
 
+test('Workboard GitHub feed coalesces concurrent cache misses', async () => {
+  let calls = 0;
+  let releaseFetch;
+  const gate = new Promise(resolve => { releaseFetch = resolve; });
+  globalThis.fetch = async () => {
+    calls += 1;
+    await gate;
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return [{ id: 101, number: 42, title: 'Single flight', state: 'open' }];
+      }
+    };
+  };
+
+  const req = { method: 'GET' };
+  const first = createResponse();
+  const second = createResponse();
+  const firstRun = workboardGithubHandler(req, first);
+  const secondRun = workboardGithubHandler(req, second);
+
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(calls, 1);
+  releaseFetch();
+  await Promise.all([firstRun, secondRun]);
+
+  assert.equal(first.statusCode, 200);
+  assert.deepEqual(second.body, first.body);
+});
+
 test('Workboard GitHub feed returns a controlled error when GitHub fails without cache', async () => {
   globalThis.fetch = async () => ({ ok: false, status: 403 });
 


### PR DESCRIPTION
Follow-up to Codex review on #1906.

The 60-second Workboard cache still allowed a burst of simultaneous cold/expired requests to each call GitHub before the first response populated the cache. This adds a shared in-flight refresh promise so concurrent misses coalesce into one upstream request.

Also resets the in-flight state in tests and adds regression coverage for two concurrent requests.

Focused validation: concurrent-miss, cache-reuse, and upstream-error tests all pass locally.