### PR TITLE
Rollback self-host portal through the active backend

### DIFF
--- a/scripts/ops/deploy-self-host-portal.sh
+++ b/scripts/ops/deploy-self-host-portal.sh
@@ -191,14 +191,28 @@ start_with_tmux() {
   tmux new-session -d -s "$session" "$command"
 }
 
+live_backend=''
+
 restart_live_service() {
-  if [ "$(id -u)" = 0 ] && command -v systemctl >/dev/null 2>&1; then
-    systemctl restart 3dvr-portal.service
-  elif command -v tmux >/dev/null 2>&1; then
-    start_with_tmux
-  else
-    return 1
-  fi
+  case "$live_backend" in
+    systemd)
+      if systemctl restart 3dvr-portal.service; then
+        return 0
+      fi
+      if command -v tmux >/dev/null 2>&1; then
+        start_with_tmux
+        live_backend=tmux
+        return 0
+      fi
+      return 1
+      ;;
+    tmux)
+      start_with_tmux
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 rollback_live() {
@@ -224,8 +238,11 @@ rollback_live() {
   set -e
 }
 
-if ! start_with_systemd; then
+if start_with_systemd; then
+  live_backend=systemd
+else
   start_with_tmux
+  live_backend=tmux
 fi
 
 live_url="http://127.0.0.1:$port"

--- a/tests/self-host-deploy-safety.test.js
+++ b/tests/self-host-deploy-safety.test.js
@@ -24,6 +24,13 @@ test('self-host deploy rolls back live health or Workboard failures', () => {
   assert.match(source, /if ! validate_workboard "\$live_url"; then[\s\S]*?rollback_live/);
 });
 
+test('rollback restarts the backend that actually started', () => {
+  assert.match(source, /live_backend=''/);
+  assert.match(source, /if start_with_systemd; then\s+live_backend=systemd\s+else\s+start_with_tmux\s+live_backend=tmux/s);
+  assert.match(source, /restart_live_service\(\) \{\s+case "\$live_backend" in/s);
+  assert.match(source, /tmux\)\s+start_with_tmux/s);
+});
+
 test('Cloudflare tunnel changes happen only after live validation', () => {
   const liveWorkboard = source.indexOf('validate_workboard "$live_url"');
   const cloudflared = source.indexOf('cloudflared="$(command -v cloudflared || true)"');


### PR DESCRIPTION
Follow-up to the Codex review on #1910.

When systemctl exists but cannot actually manage the service, deployment falls back to tmux. Rollback previously checked only whether systemctl existed, so it could attempt the wrong backend and fail to restart the previous release.

This tracks the backend that successfully started (`systemd` or `tmux`) and uses that backend for rollback. If a previously-working systemd restart itself fails and tmux is available, rollback can fall back to tmux.

Validation:
- `bash -n scripts/ops/deploy-self-host-portal.sh`
- focused deploy safety suite: 4/4 passing