### PR TITLE
Remove unnecessary legacy OS redirect

### DIFF
--- a/os/index.html
+++ b/os/index.html
@@ -1,8 +1,0 @@
-<!doctype html>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta http-equiv="refresh" content="0; url=/3dvr-os/">
-<title>Moving to 3DVR OS</title>
-<link rel="canonical" href="/3dvr-os/">
-<p>3DVR OS moved to <a href="/3dvr-os/">/3dvr-os/</a>.</p>
-<script>location.replace('/3dvr-os/' + location.search + location.hash)</script>


### PR DESCRIPTION
Removes the temporary `/os/` redirect. The browser OS remains in `3dvr-os/` as its monorepo project root and will be served directly from `os.3dvr.tech` once deployed.