### PR TITLE
Add reusable 3DVR Desktop environment

### DIFF
--- a/3dvr-desktop/README.md
+++ b/3dvr-desktop/README.md
@@ -1,0 +1,50 @@
+# 3DVR Desktop
+
+3DVR Desktop is the native desktop environment for 3DVR personal computing.
+It is intentionally small enough to run on a phone through Termux:X11, in a tiny VM,
+or on a normal Debian/Linux machine.
+
+Think of it as the 3DVR equivalent of a lightweight GNOME or KDE session:
+
+- Openbox manages windows.
+- Tint2 provides the panel and task switcher.
+- Rofi is the application launcher.
+- PCManFM provides lightweight file browsing.
+- Xterm is the baseline terminal.
+- 3DVR owns the session, defaults, launchers, install flow, and cross-device behavior.
+
+## Targets
+
+- `termux`: Android + Termux:X11 + Debian `proot-distro`
+- `linux`: Debian or Debian-derived Linux using Xorg
+- `vm`: the same Linux target inside `termux-ui-lab`
+
+## Install
+
+```sh
+./3dvr-desktop/install.sh
+```
+
+The installer detects Termux versus normal Linux. Then start the desktop with:
+
+```sh
+3dvr-desktop start
+```
+
+Check the environment with:
+
+```sh
+3dvr-desktop doctor
+```
+
+## Relationship to Daedalos
+
+Daedalos / TommyOS is the browser-native desktop in `3dvr-os/`. 3DVR Desktop is the
+native Linux/X11 desktop. The long-term goal is one 3DVR computing experience with a
+web shell when the browser is the best runtime and a native shell when Linux is available.
+
+## Status
+
+This first checked-in baseline was captured from the working `termux-ui-lab` VM. The
+phone's live Termux configuration should be reconciled into this directory whenever the
+phone endpoint is online, so the repository remains the source of truth rather than any device.

--- a/3dvr-desktop/bin/3dvr-desktop
+++ b/3dvr-desktop/bin/3dvr-desktop
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+ROOT=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
+command=${1:-start}
+
+case "$command" in
+  start)
+    if [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux/files/usr ]; then
+      exec "$ROOT/scripts/start-termux.sh"
+    fi
+    exec "$ROOT/scripts/start-linux.sh"
+    ;;
+  launcher)
+    exec rofi -show drun -show-icons
+    ;;
+  doctor)
+    missing=0
+    for name in openbox tint2 rofi xterm; do
+      if command -v "$name" >/dev/null 2>&1; then
+        printf 'ok   %s\n' "$name"
+      else
+        printf 'miss %s\n' "$name"
+        missing=1
+      fi
+    done
+    exit "$missing"
+    ;;
+  *)
+    echo 'usage: 3dvr-desktop [start|launcher|doctor]' >&2
+    exit 2
+    ;;
+esac

--- a/3dvr-desktop/config/applications/3dvr-files.desktop
+++ b/3dvr-desktop/config/applications/3dvr-files.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Files
+Exec=pcmanfm
+Icon=system-file-manager
+Terminal=false
+Categories=System;FileManager;

--- a/3dvr-desktop/config/applications/3dvr-launcher.desktop
+++ b/3dvr-desktop/config/applications/3dvr-launcher.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=3DVR Apps
+Comment=Open the 3DVR Desktop application launcher
+Exec=rofi -show drun -show-icons
+Icon=system-run
+Terminal=false
+Categories=System;

--- a/3dvr-desktop/config/applications/3dvr-terminal.desktop
+++ b/3dvr-desktop/config/applications/3dvr-terminal.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Terminal
+Exec=xterm
+Icon=utilities-terminal
+Terminal=false
+Categories=System;TerminalEmulator;

--- a/3dvr-desktop/config/openbox/autostart
+++ b/3dvr-desktop/config/openbox/autostart
@@ -1,0 +1,4 @@
+# 3DVR Desktop session
+xsetroot -solid '#101418' &
+tint2 &
+xterm &

--- a/3dvr-desktop/config/tint2/tint2rc
+++ b/3dvr-desktop/config/tint2/tint2rc
@@ -1,0 +1,59 @@
+# 3DVR Desktop panel
+rounded = 0
+border_width = 0
+background_color = #101418 92
+border_color = #30383f 100
+
+rounded = 7
+border_width = 1
+background_color = #1d2429 100
+border_color = #344048 100
+
+panel_items = LTSC
+panel_size = 100% 36
+panel_position = bottom center horizontal
+panel_background_id = 1
+panel_padding = 6 4 6
+panel_layer = top
+panel_monitor = all
+panel_shrink = 0
+
+launcher_padding = 2 5 2
+launcher_background_id = 0
+launcher_icon_background_id = 0
+launcher_icon_size = 25
+launcher_tooltip = 1
+launcher_item_app = 3dvr-launcher.desktop
+launcher_item_app = 3dvr-files.desktop
+launcher_item_app = 3dvr-terminal.desktop
+
+taskbar_mode = single_desktop
+taskbar_padding = 4 0 4
+taskbar_background_id = 0
+taskbar_active_background_id = 0
+task_align = left
+
+task_text = 1
+task_icon = 1
+task_centered = 1
+task_maximum_size = 180 32
+task_padding = 6 3 6
+task_background_id = 2
+task_active_background_id = 2
+task_font_color = #eef3f5 100
+mouse_left = toggle_iconify
+mouse_right = close
+
+systray_padding = 4 2 4
+systray_background_id = 0
+systray_icon_size = 22
+
+clock_background_id = 0
+clock_padding = 8 0
+time1_format = %H:%M
+time1_font = Sans 10
+clock_font_color = #eef3f5 100
+
+tooltip_padding = 6 4
+tooltip_background_id = 2
+tooltip_font_color = #eef3f5 100

--- a/3dvr-desktop/index.html
+++ b/3dvr-desktop/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#101418">
+  <title>3DVR Desktop — a portable Linux desktop environment</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0d1114;
+      --panel: #151b1f;
+      --line: #283238;
+      --text: #f1f5f7;
+      --muted: #9eabb2;
+      --accent: #82d7a3;
+      font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--bg); color: var(--text); }
+    a { color: inherit; }
+    main { width: min(980px, calc(100% - 32px)); margin: 0 auto; padding: 64px 0 80px; }
+    .eyebrow { color: var(--accent); text-transform: uppercase; letter-spacing: .14em; font-size: 12px; }
+    h1 { margin: 10px 0 14px; font-size: clamp(42px, 8vw, 84px); line-height: .94; letter-spacing: -.06em; }
+    .lede { max-width: 680px; color: var(--muted); font-size: clamp(18px, 3vw, 24px); line-height: 1.45; }
+    .actions { display: flex; gap: 10px; flex-wrap: wrap; margin: 28px 0 46px; }
+    .button { text-decoration: none; border: 1px solid var(--line); border-radius: 10px; padding: 10px 14px; background: var(--panel); }
+    .button.primary { color: #07110b; background: var(--accent); border-color: var(--accent); font-weight: 700; }
+    .desktop { border: 1px solid var(--line); border-radius: 16px; overflow: hidden; background: #101418; box-shadow: 0 24px 80px rgba(0,0,0,.35); }
+    .screen { height: 330px; position: relative; background: linear-gradient(145deg, #131a1e, #0b0f11); }
+    .window { position: absolute; left: 9%; top: 12%; width: min(560px, 72%); height: 230px; border: 1px solid #3b474e; background: #0d1113; border-radius: 9px; overflow: hidden; }
+    .titlebar { height: 34px; padding: 8px 12px; background: #1b2227; color: var(--muted); font-size: 12px; }
+    .terminal { padding: 16px; font: 13px/1.55 ui-monospace, monospace; color: #d8e2e7; }
+    .terminal b { color: var(--accent); }
+    .panel { position: absolute; inset: auto 0 0; height: 38px; display: flex; align-items: center; gap: 8px; padding: 0 8px; background: rgba(16,20,24,.96); border-top: 1px solid #29343a; }
+    .app { width: 27px; height: 27px; border-radius: 7px; display: grid; place-items: center; background: #20292e; font-size: 11px; }
+    .clock { margin-left: auto; color: var(--muted); font-size: 12px; }
+    .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 42px; }
+    .card { border: 1px solid var(--line); background: var(--panel); border-radius: 13px; padding: 18px; }
+    .card h2 { margin: 0 0 7px; font-size: 17px; }
+    .card p { margin: 0; color: var(--muted); line-height: 1.5; }
+    .stack { margin-top: 42px; padding: 22px; border: 1px solid var(--line); border-radius: 14px; }
+    .stack h2 { margin-top: 0; }
+    code { color: #cfe7d8; }
+    .note { color: var(--muted); line-height: 1.55; }
+    @media (max-width: 700px) {
+      main { padding-top: 42px; }
+      .grid { grid-template-columns: 1fr; }
+      .screen { height: 260px; }
+      .window { width: 82%; height: 180px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <div class="eyebrow">Open personal computing · native layer</div>
+  <h1>3DVR Desktop</h1>
+  <p class="lede">A tiny, reusable graphical desktop environment for phones, VMs, and Linux machines.</p>
+  <div class="actions">
+    <a class="button primary" href="./README.md">Install / source</a>
+    <a class="button" href="../3dvr-os/">Open Daedalos web desktop</a>
+  </div>
+
+  <section class="desktop" aria-label="3DVR Desktop preview">
+    <div class="screen">
+      <div class="window">
+        <div class="titlebar">Terminal — 3DVR Desktop</div>
+        <div class="terminal"><b>tmsteph@3dvr</b>:~$ 3dvr-desktop doctor<br>ok&nbsp;&nbsp;&nbsp;openbox<br>ok&nbsp;&nbsp;&nbsp;tint2<br>ok&nbsp;&nbsp;&nbsp;rofi<br>ok&nbsp;&nbsp;&nbsp;xterm</div>
+      </div>
+      <div class="panel"><span class="app">3D</span><span class="app">▤</span><span class="app">›_</span><span class="clock">10:32</span></div>
+    </div>
+  </section>
+
+  <section class="grid">
+    <article class="card"><h2>Phone</h2><p>Termux:X11 outside, Debian proot inside, the same 3DVR session on top.</p></article>
+    <article class="card"><h2>VM</h2><p>Our tiny Debian lab is the safe reference machine for building and testing the desktop.</p></article>
+    <article class="card"><h2>Linux</h2><p>Run it directly on Debian-family machines through normal Xorg and the same config.</p></article>
+  </section>
+
+  <section class="stack">
+    <div class="eyebrow">Desktop environment</div>
+    <h2>One 3DVR session, replaceable parts.</h2>
+    <p class="note">Openbox manages windows. Tint2 is the panel. Rofi launches apps. PCManFM handles files. Xterm is the baseline terminal. 3DVR owns the session defaults, install flow, launchers, and cross-device behavior—so these components can be swapped later without changing what “3DVR Desktop” means.</p>
+    <p class="note"><strong>Daedalos</strong> remains the browser-native desktop. <strong>3DVR Desktop</strong> is the native Linux desktop. The long-term goal is for them to feel like two runtimes of the same personal computer.</p>
+  </section>
+</main>
+</body>
+</html>

--- a/3dvr-desktop/install.sh
+++ b/3dvr-desktop/install.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+if [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux/files/usr ]; then
+  exec "$ROOT/scripts/install-termux.sh"
+fi
+
+exec "$ROOT/scripts/install-debian.sh"

--- a/3dvr-desktop/scripts/install-debian.sh
+++ b/3dvr-desktop/scripts/install-debian.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+DEST=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
+
+if command -v sudo >/dev/null 2>&1; then
+  SUDO=sudo
+elif [ "$(id -u)" -eq 0 ]; then
+  SUDO=
+else
+  echo '3DVR Desktop needs sudo or root to install Debian packages.' >&2
+  exit 1
+fi
+
+$SUDO apt-get update
+$SUDO apt-get install -y xorg openbox tint2 rofi xterm pcmanfm dbus-x11
+
+mkdir -p "$DEST" "$HOME/.config/openbox" "$HOME/.config/tint2" \
+  "$HOME/.local/share/applications" "$HOME/.local/bin"
+cp -R "$ROOT/." "$DEST/"
+cp "$DEST/config/openbox/autostart" "$HOME/.config/openbox/autostart"
+cp "$DEST/config/tint2/tint2rc" "$HOME/.config/tint2/tint2rc"
+cp "$DEST/config/applications/"*.desktop "$HOME/.local/share/applications/"
+ln -sf "$DEST/bin/3dvr-desktop" "$HOME/.local/bin/3dvr-desktop"
+
+cat > "$HOME/.xinitrc" <<'XINIT'
+#!/bin/sh
+exec dbus-run-session openbox-session
+XINIT
+chmod +x "$HOME/.xinitrc"
+
+echo '3DVR Desktop installed. Run: 3dvr-desktop start'

--- a/3dvr-desktop/scripts/install-termux.sh
+++ b/3dvr-desktop/scripts/install-termux.sh
@@ -1,0 +1,23 @@
+#!/data/data/com.termux/files/usr/bin/sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+DEST="$HOME/.3dvr/desktop"
+
+pkg update -y
+pkg install -y x11-repo proot-distro
+pkg install -y termux-x11-nightly || true
+
+if ! proot-distro list | grep -qE '^ *debian '; then
+  proot-distro install debian
+fi
+
+mkdir -p "$DEST" "$HOME/.local/bin"
+cp -R "$ROOT/." "$DEST/"
+ln -sf "$DEST/bin/3dvr-desktop" "$PREFIX/bin/3dvr-desktop"
+
+proot-distro login debian \
+  --bind "$DEST:/opt/3dvr-desktop" \
+  -- /bin/sh -lc '/opt/3dvr-desktop/scripts/install-debian.sh'
+
+echo '3DVR Desktop installed for Termux.'
+echo 'Make sure the Termux:X11 Android app is installed, then run: 3dvr-desktop start'

--- a/3dvr-desktop/scripts/start-linux.sh
+++ b/3dvr-desktop/scripts/start-linux.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+if [ -n "${DISPLAY:-}" ]; then
+  exec dbus-run-session openbox-session
+fi
+exec startx

--- a/3dvr-desktop/scripts/start-termux.sh
+++ b/3dvr-desktop/scripts/start-termux.sh
@@ -1,0 +1,18 @@
+#!/data/data/com.termux/files/usr/bin/sh
+set -eu
+DEST=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
+DISPLAY_NUM=${THREEDVR_DISPLAY:-:0}
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-$TMPDIR}
+
+if ! command -v termux-x11 >/dev/null 2>&1; then
+  echo 'termux-x11 command not found. Run 3DVR Desktop install first.' >&2
+  exit 1
+fi
+
+termux-x11 "$DISPLAY_NUM" -ac >/dev/null 2>&1 &
+sleep 1
+
+exec proot-distro login debian \
+  --shared-tmp \
+  --bind "$DEST:/opt/3dvr-desktop" \
+  -- /bin/sh -lc "export DISPLAY='$DISPLAY_NUM'; exec dbus-run-session openbox-session"

--- a/tests/3dvr-desktop.test.js
+++ b/tests/3dvr-desktop.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('3DVR Desktop exposes a portal route and reusable targets', () => {
+  const page = read('3dvr-desktop/index.html');
+  const readme = read('3dvr-desktop/README.md');
+  const termux = read('3dvr-desktop/scripts/start-termux.sh');
+  const linux = read('3dvr-desktop/scripts/start-linux.sh');
+
+  assert.match(page, /3DVR Desktop/);
+  assert.match(readme, /desktop environment/i);
+  assert.match(readme, /Termux:X11/);
+  assert.match(termux, /termux-x11/);
+  assert.match(termux, /proot-distro login debian/);
+  assert.match(linux, /startx/);
+});
+
+test('3DVR Desktop session has a panel, launcher, and terminal', () => {
+  const autostart = read('3dvr-desktop/config/openbox/autostart');
+  const panel = read('3dvr-desktop/config/tint2/tint2rc');
+  const launcher = read('3dvr-desktop/config/applications/3dvr-launcher.desktop');
+
+  assert.match(autostart, /tint2/);
+  assert.match(autostart, /xterm/);
+  assert.match(panel, /3dvr-launcher\.desktop/);
+  assert.match(launcher, /rofi -show drun/);
+});


### PR DESCRIPTION
Adds the first reusable native 3DVR desktop environment baseline.

- Termux:X11 + Debian proot target
- normal Debian/Linux + VM target
- Openbox + Tint2 + Rofi + PCManFM + Xterm session
- /3dvr-desktop/ portal page
- focused tests and shell syntax validation

Daedalos remains the browser-native desktop; 3DVR Desktop is the native Linux layer.