### PR TITLE
Start 3DVR Desktop automatically on Termux boot

### DIFF
--- a/3dvr-desktop/README.md
+++ b/3dvr-desktop/README.md
@@ -48,3 +48,12 @@ web shell when the browser is the best runtime and a native shell when Linux is 
 This first checked-in baseline was captured from the working `termux-ui-lab` VM. The
 phone's live Termux configuration should be reconciled into this directory whenever the
 phone endpoint is online, so the repository remains the source of truth rather than any device.
+
+## Android boot automation
+
+The Termux installer creates `~/.termux/boot/00-3dvr-start`. With the Termux:Boot
+companion app installed and opened once, Android runs this script after reboot. It starts
+the existing Desktop Commander remote command, the 3DVR agent when installed, and
+3DVR Desktop / Termux:X11. It also asks Android to foreground Termux and Termux:X11.
+Recent Android versions may block automatic foreground launches, but the background
+startup still works.

--- a/3dvr-desktop/scripts/install-termux.sh
+++ b/3dvr-desktop/scripts/install-termux.sh
@@ -11,13 +11,17 @@ if ! proot-distro list | grep -qE '^ *debian '; then
   proot-distro install debian
 fi
 
-mkdir -p "$DEST" "$HOME/.local/bin"
+mkdir -p "$DEST" "$HOME/.local/bin" "$HOME/.termux/boot"
 cp -R "$ROOT/." "$DEST/"
 ln -sf "$DEST/bin/3dvr-desktop" "$PREFIX/bin/3dvr-desktop"
+cp "$DEST/scripts/termux-boot.sh" "$HOME/.termux/boot/00-3dvr-start"
+chmod +x "$HOME/.termux/boot/00-3dvr-start"
 
 proot-distro login debian \
   --bind "$DEST:/opt/3dvr-desktop" \
   -- /bin/sh -lc '/opt/3dvr-desktop/scripts/install-debian.sh'
 
 echo '3DVR Desktop installed for Termux.'
+echo 'Boot script installed at ~/.termux/boot/00-3dvr-start.'
+echo 'Install and open Termux:Boot once so Android runs it after reboot.'
 echo 'Make sure the Termux:X11 Android app is installed, then run: 3dvr-desktop start'

--- a/3dvr-desktop/scripts/termux-boot.sh
+++ b/3dvr-desktop/scripts/termux-boot.sh
@@ -1,0 +1,30 @@
+#!/data/data/com.termux/files/usr/bin/sh
+set -u
+DEST=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
+LOG_DIR="$HOME/.3dvr/logs"
+mkdir -p "$LOG_DIR"
+
+# Wait for Android to finish bringing networking and storage online.
+sleep 20
+
+if command -v desktop-commander >/dev/null 2>&1; then
+  nohup desktop-commander remote >>"$LOG_DIR/desktop-commander-boot.log" 2>&1 &
+elif command -v npx >/dev/null 2>&1; then
+  nohup npx --yes @wonderwhy-er/desktop-commander@latest remote >>"$LOG_DIR/desktop-commander-boot.log" 2>&1 &
+fi
+
+if command -v 3dvr >/dev/null 2>&1; then
+  nohup 3dvr agent start >>"$LOG_DIR/agent-boot.log" 2>&1 &
+fi
+
+if command -v 3dvr-desktop >/dev/null 2>&1; then
+  nohup 3dvr-desktop start >>"$LOG_DIR/desktop-boot.log" 2>&1 &
+fi
+
+# Ask Android to bring the Termux UI forward after boot. Some Android versions
+# may refuse background activity launches; the services above still start.
+if command -v monkey >/dev/null 2>&1; then
+  monkey -p com.termux -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1 || true
+  sleep 2
+  monkey -p com.termux.x11 -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1 || true
+fi

--- a/tests/3dvr-desktop.test.js
+++ b/tests/3dvr-desktop.test.js
@@ -28,3 +28,15 @@ test('3DVR Desktop session has a panel, launcher, and terminal', () => {
   assert.match(panel, /3dvr-launcher\.desktop/);
   assert.match(launcher, /rofi -show drun/);
 });
+
+test('Termux install creates Android boot startup', () => {
+  const install = read('3dvr-desktop/scripts/install-termux.sh');
+  const boot = read('3dvr-desktop/scripts/termux-boot.sh');
+
+  assert.match(install, /\.termux\/boot\/00-3dvr-start/);
+  assert.match(install, /Termux:Boot/);
+  assert.match(boot, /desktop-commander remote/);
+  assert.match(boot, /3dvr agent start/);
+  assert.match(boot, /3dvr-desktop start/);
+  assert.match(boot, /com\.termux\.x11/);
+});


### PR DESCRIPTION
Adds Termux:Boot integration for 3DVR Desktop.

- installs ~/.termux/boot/00-3dvr-start
- starts existing Desktop Commander remote command
- starts 3DVR agent when installed
- starts 3DVR Desktop / Termux:X11
- attempts to foreground Termux and Termux:X11
- adds focused tests and docs