### PR TITLE
Promote native Termux 3DVR Desktop shell

### DIFF
--- a/3dvr-desktop/README.md
+++ b/3dvr-desktop/README.md
@@ -1,59 +1,48 @@
 # 3DVR Desktop
 
-3DVR Desktop is the native desktop environment for 3DVR personal computing.
-It is intentionally small enough to run on a phone through Termux:X11, in a tiny VM,
-or on a normal Debian/Linux machine.
+3DVR Desktop is the native desktop environment for 3DVR personal computing. It is intended
+to be a reusable environment in the same product category as GNOME or KDE, while staying
+small enough for a phone, a tiny VM, or a normal Linux machine.
 
-Think of it as the 3DVR equivalent of a lightweight GNOME or KDE session:
+## Architecture
 
-- Openbox manages windows.
-- Tint2 provides the panel and task switcher.
-- Rofi is the application launcher.
-- PCManFM provides lightweight file browsing.
-- Xterm is the baseline terminal.
-- 3DVR owns the session, defaults, launchers, install flow, and cross-device behavior.
+The Android/Termux implementation is the primary reference today:
+
+- **3dvr-shell** — our GTK home screen, app launcher, running-app overview, top bar, touch controls, and window actions.
+- **XFWM4** — the underlying X11 window manager.
+- **Termux:X11** — the Android display server and touch/input bridge.
+- **XFCE utilities** — terminal, files, settings, and lightweight supporting services.
+- **3DVR launchers** — phone-aware wrappers for Firefox, Chromium, Terminal, Files, Settings, and the 3DVR cockpit.
+
+The ordinary Linux/VM target currently uses Openbox + Tint2 + Rofi as a lightweight fallback.
+Those are implementation pieces, not the identity of 3DVR Desktop, and can be replaced over time.
 
 ## Targets
 
-- `termux`: Android + Termux:X11 + Debian `proot-distro`
-- `linux`: Debian or Debian-derived Linux using Xorg
-- `vm`: the same Linux target inside `termux-ui-lab`
+- `termux`: native Android + Termux:X11 + XFWM4 + `3dvr-shell`; Debian proot is not required for the desktop.
+- `linux`: Debian-family Linux using Xorg + the lightweight fallback session.
+- `vm`: the Linux target inside `termux-ui-lab` for safe desktop testing.
 
-## Install
+## Install and run
 
 ```sh
 ./3dvr-desktop/install.sh
-```
-
-The installer detects Termux versus normal Linux. Then start the desktop with:
-
-```sh
+3dvr-desktop doctor
 3dvr-desktop start
 ```
 
-Check the environment with:
+On Termux the installer builds `native/shell.c` into `~/3dvr-shell/3dvr-shell`, installs the
+phone launcher scripts, and creates `~/.termux/boot/02-3dvr-desktop` for Termux:Boot.
+The boot entry starts the already-authorized remote control if needed, starts the 3DVR agent
+when present, brings Termux forward, and starts the graphical session automatically.
 
-```sh
-3dvr-desktop doctor
-```
+## Source of truth
+
+The native shell in `native/` and `scripts/phone/` was captured from the working phone setup
+built on August 28, 2026. Device-local edits should be reconciled back here so the monorepo,
+not an individual phone, remains the canonical desktop implementation.
 
 ## Relationship to Daedalos
 
-Daedalos / TommyOS is the browser-native desktop in `3dvr-os/`. 3DVR Desktop is the
-native Linux/X11 desktop. The long-term goal is one 3DVR computing experience with a
-web shell when the browser is the best runtime and a native shell when Linux is available.
-
-## Status
-
-This first checked-in baseline was captured from the working `termux-ui-lab` VM. The
-phone's live Termux configuration should be reconciled into this directory whenever the
-phone endpoint is online, so the repository remains the source of truth rather than any device.
-
-## Android boot automation
-
-The Termux installer creates `~/.termux/boot/00-3dvr-start`. With the Termux:Boot
-companion app installed and opened once, Android runs this script after reboot. It starts
-the existing Desktop Commander remote command, the 3DVR agent when installed, and
-3DVR Desktop / Termux:X11. It also asks Android to foreground Termux and Termux:X11.
-Recent Android versions may block automatic foreground launches, but the background
-startup still works.
+Daedalos / TommyOS in `3dvr-os/` is the browser-native desktop. 3DVR Desktop is the native
+Linux/X11 desktop. They are two runtimes of the same long-term personal-computing system.

--- a/3dvr-desktop/bin/3dvr-desktop
+++ b/3dvr-desktop/bin/3dvr-desktop
@@ -3,26 +3,54 @@ set -eu
 ROOT=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
 command=${1:-start}
 
+is_termux() {
+  [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux/files/usr ]
+}
+
 case "$command" in
   start)
-    if [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux/files/usr ]; then
+    if is_termux; then
       exec "$ROOT/scripts/start-termux.sh"
     fi
     exec "$ROOT/scripts/start-linux.sh"
     ;;
   launcher)
+    if is_termux; then
+      export DISPLAY=${DISPLAY:-:0}
+      if pgrep -f '/3dvr-shell/3dvr-shell$' >/dev/null 2>&1; then
+        exec wmctrl -k on
+      fi
+      exec "$HOME/3dvr-shell/3dvr-shell"
+    fi
     exec rofi -show drun -show-icons
     ;;
   doctor)
     missing=0
-    for name in openbox tint2 rofi xterm; do
-      if command -v "$name" >/dev/null 2>&1; then
-        printf 'ok   %s\n' "$name"
+    if is_termux; then
+      for name in termux-x11 xfwm4 xfsettingsd wmctrl clang pkg-config; do
+        if command -v "$name" >/dev/null 2>&1; then
+          printf 'ok   %s\n' "$name"
+        else
+          printf 'miss %s\n' "$name"
+          missing=1
+        fi
+      done
+      if [ -x "$HOME/3dvr-shell/3dvr-shell" ]; then
+        printf 'ok   3dvr-shell\n'
       else
-        printf 'miss %s\n' "$name"
+        printf 'miss 3dvr-shell\n'
         missing=1
       fi
-    done
+    else
+      for name in openbox tint2 rofi xterm; do
+        if command -v "$name" >/dev/null 2>&1; then
+          printf 'ok   %s\n' "$name"
+        else
+          printf 'miss %s\n' "$name"
+          missing=1
+        fi
+      done
+    fi
     exit "$missing"
     ;;
   *)

--- a/3dvr-desktop/index.html
+++ b/3dvr-desktop/index.html
@@ -72,7 +72,7 @@
   </section>
 
   <section class="grid">
-    <article class="card"><h2>Phone</h2><p>Termux:X11 outside, Debian proot inside, the same 3DVR session on top.</p></article>
+    <article class="card"><h2>Phone</h2><p>Termux:X11 + XFWM4 + our native GTK 3dvr-shell, built directly on Android without requiring proot.</p></article>
     <article class="card"><h2>VM</h2><p>Our tiny Debian lab is the safe reference machine for building and testing the desktop.</p></article>
     <article class="card"><h2>Linux</h2><p>Run it directly on Debian-family machines through normal Xorg and the same config.</p></article>
   </section>
@@ -80,7 +80,7 @@
   <section class="stack">
     <div class="eyebrow">Desktop environment</div>
     <h2>One 3DVR session, replaceable parts.</h2>
-    <p class="note">Openbox manages windows. Tint2 is the panel. Rofi launches apps. PCManFM handles files. Xterm is the baseline terminal. 3DVR owns the session defaults, install flow, launchers, and cross-device behavior—so these components can be swapped later without changing what “3DVR Desktop” means.</p>
+    <p class="note">On Android, XFWM4 manages windows while our GTK 3dvr-shell owns the home screen, app launcher, running-app overview, touch controls, and window actions. Linux/VMs currently keep the smaller Openbox + Tint2 fallback. 3DVR owns the session either way, so implementation pieces can evolve without changing what “3DVR Desktop” means.</p>
     <p class="note"><strong>Daedalos</strong> remains the browser-native desktop. <strong>3DVR Desktop</strong> is the native Linux desktop. The long-term goal is for them to feel like two runtimes of the same personal computer.</p>
   </section>
 </main>

--- a/3dvr-desktop/native/shell.c
+++ b/3dvr-desktop/native/shell.c
@@ -1,0 +1,578 @@
+#include <gtk/gtk.h>
+#include <gdk/gdkx.h>
+#include <X11/Xatom.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/shape.h>
+#include <time.h>
+#include <stdlib.h>
+#include <string.h>
+
+static GtkWidget *home_window;
+static GtkWidget *clock_label;
+static GtkWidget *input_button;
+static GtkWidget *spinner_label;
+static Window last_client_window = 0;
+static const int BAR_HEIGHT = 120;
+static const int SPIN_SELECT_DISTANCE = 44;
+
+typedef struct {
+  gboolean active;
+  double start_x;
+  double start_y;
+  const char *selection;
+  GdkSeat *seat;
+} SpinnerGesture;
+static SpinnerGesture spin = {0};
+static GtkWidget *search_entry;
+static GtkWidget *running_box;
+static GtkWidget *app_tiles[8];
+
+typedef struct {
+  const char *label;
+  const char *icon;
+  const char *command;
+  const char *match;
+  const char *process;
+  const char *keywords;
+} App;
+
+static const App apps[] = {
+  {"Firefox", "firefox", "/data/data/com.termux/files/home/bin/firefox-touch", "firefox", "firefox", "web browser internet"},
+  {"Chromium", "chromium", "/data/data/com.termux/files/home/bin/chromium-touch", "chromium", "chromium", "web browser chrome internet"},
+  {"Terminal", "utilities-terminal", "/data/data/com.termux/files/home/bin/phone-terminal", "xfce4-terminal", "xfce4-terminal", "shell command line termux"},
+  {"Files", "system-file-manager", "/data/data/com.termux/files/home/bin/phone-files", "thunar", "thunar", "files folders storage"},
+  {"3DVR", "applications-development", "/data/data/com.termux/files/home/bin/phone-3dvr", "3dvr", "/scripts/3dvr", "agent operator cockpit"},
+  {"Settings", "preferences-system", "/data/data/com.termux/files/home/bin/phone-settings", "settings", "xfce4-settings", "preferences display system"},
+};
+
+static void run_async(const char *command) {
+  GError *error = NULL;
+  g_spawn_command_line_async(command, &error);
+  if (error) {
+    g_warning("%s", error->message);
+    g_error_free(error);
+  }
+}
+
+static gboolean window_is_shell(Display *dpy, Window w) {
+  XClassHint hint = {0};
+  if (!XGetClassHint(dpy, w, &hint)) return FALSE;
+  gboolean shell = (hint.res_name && strstr(hint.res_name, "3dvr-shell")) ||
+                   (hint.res_class && strstr(hint.res_class, "3dvr-shell"));
+  if (hint.res_name) XFree(hint.res_name);
+  if (hint.res_class) XFree(hint.res_class);
+  return shell;
+}
+
+static gboolean window_is_client(Display *dpy, Window w) {
+  if (!w || window_is_shell(dpy, w)) return FALSE;
+  Atom type_atom = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False);
+  Atom dock_atom = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DOCK", False);
+  Atom desktop_atom = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DESKTOP", False);
+  Atom actual = None; int format = 0; unsigned long n = 0, extra = 0; unsigned char *data = NULL;
+  if (XGetWindowProperty(dpy, w, type_atom, 0, 8, False, XA_ATOM,
+      &actual, &format, &n, &extra, &data) == Success && data) {
+    Atom *types = (Atom *)data;
+    for (unsigned long i = 0; i < n; i++) {
+      if (types[i] == dock_atom || types[i] == desktop_atom) { XFree(data); return FALSE; }
+    }
+    XFree(data);
+  }
+  return TRUE;
+}
+
+static gboolean track_active_window(gpointer unused) {
+  Display *dpy = GDK_DISPLAY_XDISPLAY(gdk_display_get_default());
+  Window root = DefaultRootWindow(dpy);
+  Atom a = XInternAtom(dpy, "_NET_ACTIVE_WINDOW", False);
+  Atom actual = None; int format = 0; unsigned long n = 0, extra = 0; unsigned char *data = NULL;
+  if (XGetWindowProperty(dpy, root, a, 0, 1, False, XA_WINDOW,
+      &actual, &format, &n, &extra, &data) == Success && data && n) {
+    Window w = *(Window *)data;
+    if (window_is_client(dpy, w)) last_client_window = w;
+    XFree(data);
+  }
+  return G_SOURCE_CONTINUE;
+}
+
+static void activate_window(Window w) {
+  if (!w) return;
+  run_async("wmctrl -k off");
+  char *cmd = g_strdup_printf("wmctrl -ia 0x%lx", w);
+  run_async(cmd); g_free(cmd);
+  last_client_window = w;
+}
+
+static gboolean window_matches(Display *dpy, Window w, const char *needle) {
+  if (!needle || !*needle) return FALSE;
+  char *q = g_ascii_strdown(needle, -1);
+  gboolean match = FALSE;
+  XClassHint hint = {0};
+  if (XGetClassHint(dpy, w, &hint)) {
+    char *a = hint.res_name ? g_ascii_strdown(hint.res_name, -1) : NULL;
+    char *b = hint.res_class ? g_ascii_strdown(hint.res_class, -1) : NULL;
+    match = (a && strstr(a, q)) || (b && strstr(b, q));
+    g_free(a); g_free(b);
+    if (hint.res_name) XFree(hint.res_name);
+    if (hint.res_class) XFree(hint.res_class);
+  }
+  char *title = NULL;
+  if (!match && XFetchName(dpy, w, &title) && title) {
+    char *t = g_ascii_strdown(title, -1);
+    match = strstr(t, q) != NULL;
+    g_free(t); XFree(title);
+  }
+  g_free(q); return match;
+}
+
+static gboolean process_running(const App *app) {
+  Display *dpy = GDK_DISPLAY_XDISPLAY(gdk_display_get_default());
+  Window root = DefaultRootWindow(dpy);
+  Atom list = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
+  Atom actual = None; int format = 0; unsigned long n = 0, extra = 0; unsigned char *data = NULL;
+  if (XGetWindowProperty(dpy, root, list, 0, 256, False, XA_WINDOW,
+      &actual, &format, &n, &extra, &data) != Success || !data) return FALSE;
+  Window *wins = (Window *)data; gboolean found = FALSE;
+  for (unsigned long i = 0; i < n; i++) {
+    if (window_is_client(dpy, wins[i]) && window_matches(dpy, wins[i], app->match)) { found = TRUE; break; }
+  }
+  XFree(data); return found;
+}
+
+static gboolean update_clock(gpointer unused) {
+  time_t now = time(NULL);
+  struct tm *t = localtime(&now);
+  char buf[64];
+  strftime(buf, sizeof(buf), "%a  %-I:%M %p", t);
+  gtk_label_set_text(GTK_LABEL(clock_label), buf);
+  return G_SOURCE_CONTINUE;
+}
+
+static void focus_app(GtkButton *button, gpointer data) {
+  const App *app = data;
+  char *cmd = g_strdup_printf(
+      "/data/data/com.termux/files/home/bin/3dvr-focus-app '%s'", app->match);
+  run_async(cmd);
+  g_free(cmd);
+}
+
+static void launch_app(GtkButton *button, gpointer data) {
+  const App *app = data;
+  if (process_running(app)) {
+    focus_app(NULL, (gpointer)app);
+    return;
+  }
+  run_async("wmctrl -k off");
+  run_async(app->command);
+}
+
+static gboolean get_workarea(int *x, int *y, int *w, int *h) {
+  Display *dpy = GDK_DISPLAY_XDISPLAY(gdk_display_get_default());
+  Window root = DefaultRootWindow(dpy);
+  Atom a = XInternAtom(dpy, "_NET_WORKAREA", False);
+  Atom actual = None; int format = 0; unsigned long n = 0, extra = 0; unsigned char *data = NULL;
+  if (XGetWindowProperty(dpy, root, a, 0, 4, False, XA_CARDINAL,
+      &actual, &format, &n, &extra, &data) == Success && data && n >= 4) {
+    unsigned long *v = (unsigned long *)data;
+    *x = (int)v[0]; *y = (int)v[1]; *w = (int)v[2]; *h = (int)v[3];
+    XFree(data); return TRUE;
+  }
+  if (data) XFree(data);
+  GdkScreen *screen = gdk_screen_get_default();
+  *x = 0; *y = BAR_HEIGHT; *w = gdk_screen_get_width(screen); *h = gdk_screen_get_height(screen) - BAR_HEIGHT;
+  return FALSE;
+}
+
+static GtkWidget *make_icon(const char *name, int size) {
+  GtkWidget *image = gtk_image_new_from_icon_name(name, GTK_ICON_SIZE_DIALOG);
+  gtk_image_set_pixel_size(GTK_IMAGE(image), size);
+  return image;
+}
+static GtkWidget *make_running_card(const App *app) {
+  GtkWidget *button = gtk_button_new();
+  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+  GtkWidget *image = make_icon(app->icon, 82);
+  GtkWidget *label = gtk_label_new(app->label);
+
+  gtk_style_context_add_class(gtk_widget_get_style_context(button), "running-card");
+  gtk_style_context_add_class(gtk_widget_get_style_context(label), "running-label");
+  gtk_widget_set_size_request(button, 230, 160);
+  gtk_box_pack_start(GTK_BOX(box), image, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(box), label, FALSE, FALSE, 0);
+  gtk_container_add(GTK_CONTAINER(button), box);
+  g_signal_connect(button, "clicked", G_CALLBACK(focus_app), (gpointer)app);
+  return button;
+}
+
+static gboolean refresh_running(gpointer unused) {
+  GList *children = gtk_container_get_children(GTK_CONTAINER(running_box));
+  for (GList *l = children; l; l = l->next) gtk_widget_destroy(GTK_WIDGET(l->data));
+  g_list_free(children);
+
+  int count = 0;
+  for (guint i = 0; i < G_N_ELEMENTS(apps); i++) {
+    if (!process_running(&apps[i])) continue;
+    GtkWidget *card = make_running_card(&apps[i]);
+    gtk_box_pack_start(GTK_BOX(running_box), card, FALSE, FALSE, 0);
+    count++;
+  }
+  if (!count) {
+    GtkWidget *empty = gtk_label_new("Nothing open yet");
+    gtk_style_context_add_class(gtk_widget_get_style_context(empty), "empty-running");
+    gtk_box_pack_start(GTK_BOX(running_box), empty, FALSE, FALSE, 0);
+  }
+  gtk_widget_show_all(running_box);
+  return G_SOURCE_CONTINUE;
+}
+
+static void tile_last_client(const char *where) {
+  if (!last_client_window) track_active_window(NULL);
+  if (!last_client_window) return;
+  int x, y, w, h; get_workarea(&x, &y, &w, &h);
+  char *cmd = NULL;
+  if (!strcmp(where, "full")) {
+    cmd = g_strdup_printf("sh -lc 'wmctrl -k off; wmctrl -ir 0x%lx -b add,maximized_vert,maximized_horz; wmctrl -ia 0x%lx'",
+                          last_client_window, last_client_window);
+  } else {
+    int half = h / 2;
+    int ty = !strcmp(where, "bottom") ? y + half : y;
+    int th = !strcmp(where, "bottom") ? h - half : half;
+    cmd = g_strdup_printf("sh -lc 'wmctrl -k off; wmctrl -ir 0x%lx -b remove,maximized_vert,maximized_horz; wmctrl -ir 0x%lx -e 0,%d,%d,%d,%d; wmctrl -ia 0x%lx'",
+                          last_client_window, last_client_window, x, ty, w, th, last_client_window);
+  }
+  run_async(cmd); g_free(cmd);
+}
+
+static void focus_relative(int step) {
+  Display *dpy = GDK_DISPLAY_XDISPLAY(gdk_display_get_default());
+  Window root = DefaultRootWindow(dpy);
+  Atom a = XInternAtom(dpy, "_NET_CLIENT_LIST_STACKING", False);
+  Atom actual = None; int format = 0; unsigned long n = 0, extra = 0; unsigned char *data = NULL;
+  if (XGetWindowProperty(dpy, root, a, 0, 256, False, XA_WINDOW,
+      &actual, &format, &n, &extra, &data) != Success || !data || !n) return;
+  Window *wins = (Window *)data;
+  long start = step > 0 ? -1 : 0;
+  for (unsigned long i = 0; i < n; i++) if (wins[i] == last_client_window) { start = (long)i; break; }
+  for (unsigned long off = 1; off <= n; off++) {
+    long idx = (start + step * (long)off) % (long)n;
+    if (idx < 0) idx += n;
+    if (window_is_client(dpy, wins[idx])) { Window target = wins[idx]; XFree(data); activate_window(target); return; }
+  }
+  XFree(data);
+}
+
+static gboolean input_is_direct(void) {
+  gchar *text = NULL; gsize len = 0;
+  gboolean direct = TRUE;
+  if (g_file_get_contents("/data/data/com.termux/files/home/.config/termux-x11/input-mode", &text, &len, NULL)) {
+    direct = g_str_has_prefix(text, "direct"); g_free(text);
+  }
+  return direct;
+}
+
+static void sync_input_label(void) {
+  if (input_button) gtk_button_set_label(GTK_BUTTON(input_button), input_is_direct() ? "Touch" : "Trackpad");
+}
+
+static void toggle_input(GtkButton *button, gpointer unused) {
+  if (input_is_direct()) {
+    run_async("termux-x11-preference touchMode:Trackpad tapToMove:true");
+    g_file_set_contents("/data/data/com.termux/files/home/.config/termux-x11/input-mode", "trackpad", -1, NULL);
+  } else {
+    run_async("termux-x11-preference \"touchMode:Direct touch\"");
+    g_file_set_contents("/data/data/com.termux/files/home/.config/termux-x11/input-mode", "direct", -1, NULL);
+  }
+  sync_input_label();
+}
+
+static const char *spinner_selection(double dx, double dy) {
+  double d2 = dx * dx + dy * dy;
+  if (d2 < (double)(SPIN_SELECT_DISTANCE * SPIN_SELECT_DISTANCE)) return "";
+  double ax = dx < 0 ? -dx : dx;
+  double ay = dy < 0 ? -dy : dy;
+  if (ax > ay) return dx > 0 ? "next" : "prev";
+  return dy > 0 ? "bottom" : "top";
+}
+
+static void spinner_set_label(const char *selection) {
+  if (!spinner_label) return;
+  const char *text = "◎";
+  if (selection && !strcmp(selection, "top")) text = "↑ Top";
+  else if (selection && !strcmp(selection, "bottom")) text = "↓ Bottom";
+  else if (selection && !strcmp(selection, "prev")) text = "← Prev";
+  else if (selection && !strcmp(selection, "next")) text = "Next →";
+  gtk_label_set_text(GTK_LABEL(spinner_label), text);
+}
+
+static gboolean spinner_press(GtkWidget *widget, GdkEventButton *event, gpointer unused) {
+  if (event->button != 1) return FALSE;
+  track_active_window(NULL);
+  spin.active = TRUE; spin.start_x = event->x_root; spin.start_y = event->y_root; spin.selection = "";
+  spinner_set_label("");
+  spin.seat = gdk_display_get_default_seat(gdk_display_get_default());
+  if (spin.seat) gdk_seat_grab(spin.seat, gtk_widget_get_window(widget),
+      GDK_SEAT_CAPABILITY_POINTER, FALSE, NULL, (GdkEvent *)event, NULL, NULL);
+  return TRUE;
+}
+
+static gboolean spinner_motion(GtkWidget *widget, GdkEventMotion *event, gpointer unused) {
+  if (!spin.active) return FALSE;
+  spin.selection = spinner_selection(event->x_root - spin.start_x, event->y_root - spin.start_y);
+  spinner_set_label(spin.selection);
+  return TRUE;
+}
+
+static gboolean spinner_release(GtkWidget *widget, GdkEventButton *event, gpointer unused) {
+  if (!spin.active || event->button != 1) return FALSE;
+  const char *selection = spinner_selection(event->x_root - spin.start_x, event->y_root - spin.start_y);
+  if (spin.seat) gdk_seat_ungrab(spin.seat);
+  spin.active = FALSE; spin.seat = NULL; spinner_set_label("");
+  if (!selection || !*selection) tile_last_client("full");
+  else if (!strcmp(selection, "top")) tile_last_client("top");
+  else if (!strcmp(selection, "bottom")) tile_last_client("bottom");
+  else if (!strcmp(selection, "prev")) focus_relative(-1);
+  else if (!strcmp(selection, "next")) focus_relative(1);
+  return TRUE;
+}
+
+static void show_overview(GtkButton *button, gpointer unused) {
+  gtk_entry_set_text(GTK_ENTRY(search_entry), "");
+  refresh_running(NULL);
+  run_async("wmctrl -k on");
+  gtk_window_present(GTK_WINDOW(home_window));
+  gtk_widget_grab_focus(search_entry);
+}
+
+static gboolean matches_search(const App *app, const char *needle) {
+  if (!needle || !*needle) return TRUE;
+  char *label = g_ascii_strdown(app->label, -1);
+  char *keys = g_ascii_strdown(app->keywords, -1);
+  char *q = g_ascii_strdown(needle, -1);
+  gboolean match = strstr(label, q) || strstr(keys, q);
+  g_free(label); g_free(keys); g_free(q);
+  return match;
+}
+
+static void search_changed(GtkEditable *editable, gpointer unused) {
+  const char *text = gtk_entry_get_text(GTK_ENTRY(editable));
+  for (guint i = 0; i < G_N_ELEMENTS(apps); i++)
+    gtk_widget_set_visible(app_tiles[i], matches_search(&apps[i], text));
+}
+
+static void search_activate(GtkEntry *entry, gpointer unused) {
+  const char *text = gtk_entry_get_text(entry);
+  for (guint i = 0; i < G_N_ELEMENTS(apps); i++) {
+    if (matches_search(&apps[i], text)) {
+      launch_app(NULL, (gpointer)&apps[i]);
+      return;
+    }
+  }
+}
+
+static GtkWidget *make_tile(const App *app) {
+  GtkWidget *button = gtk_button_new();
+  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 16);
+  GtkWidget *image = make_icon(app->icon, 156);
+  GtkWidget *label = gtk_label_new(app->label);
+
+  gtk_style_context_add_class(gtk_widget_get_style_context(button), "app-tile");
+  gtk_style_context_add_class(gtk_widget_get_style_context(label), "app-label");
+  gtk_widget_set_hexpand(button, TRUE);
+  gtk_widget_set_vexpand(button, FALSE);
+  gtk_widget_set_size_request(button, -1, 300);
+  gtk_box_pack_start(GTK_BOX(box), image, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(box), label, FALSE, FALSE, 0);
+  gtk_container_add(GTK_CONTAINER(button), box);
+  g_signal_connect(button, "clicked", G_CALLBACK(launch_app), (gpointer)app);
+  return button;
+}
+
+static void load_css(void) {
+  GtkCssProvider *provider = gtk_css_provider_new();
+  gtk_css_provider_load_from_path(provider,
+      "/data/data/com.termux/files/home/3dvr-shell/style.css", NULL);
+  gtk_style_context_add_provider_for_screen(gdk_screen_get_default(),
+      GTK_STYLE_PROVIDER(provider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  g_object_unref(provider);
+}
+
+static GtkWidget *section_label(const char *text) {
+  GtkWidget *label = gtk_label_new(text);
+  gtk_style_context_add_class(gtk_widget_get_style_context(label), "section-label");
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  return label;
+}
+
+static GtkWidget *build_home(void) {
+  GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
+  GtkWidget *outer = gtk_box_new(GTK_ORIENTATION_VERTICAL, 30);
+  GtkWidget *title = gtk_label_new("Overview");
+  GtkWidget *subtitle = gtk_label_new("Search, switch, or launch.");
+  GtkWidget *grid = gtk_grid_new();
+
+  gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+  gtk_window_set_type_hint(GTK_WINDOW(window), GDK_WINDOW_TYPE_HINT_DESKTOP);
+  gtk_window_set_keep_below(GTK_WINDOW(window), TRUE);
+  gtk_window_set_accept_focus(GTK_WINDOW(window), TRUE);
+  GdkScreen *screen = gdk_screen_get_default();
+  gtk_window_set_default_size(GTK_WINDOW(window), gdk_screen_get_width(screen), gdk_screen_get_height(screen));
+  gtk_window_move(GTK_WINDOW(window), 0, 0);
+  gtk_style_context_add_class(gtk_widget_get_style_context(window), "home");
+  gtk_style_context_add_class(gtk_widget_get_style_context(title), "title");
+  gtk_style_context_add_class(gtk_widget_get_style_context(subtitle), "subtitle");
+  gtk_widget_set_halign(title, GTK_ALIGN_START);
+  gtk_widget_set_halign(subtitle, GTK_ALIGN_START);
+  gtk_box_pack_start(GTK_BOX(outer), title, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(outer), subtitle, FALSE, FALSE, 0);
+
+  search_entry = gtk_search_entry_new();
+  gtk_entry_set_placeholder_text(GTK_ENTRY(search_entry), "Search apps");
+  gtk_widget_set_size_request(search_entry, -1, 104);
+  gtk_style_context_add_class(gtk_widget_get_style_context(search_entry), "search");
+  g_signal_connect(search_entry, "changed", G_CALLBACK(search_changed), NULL);
+  g_signal_connect(search_entry, "activate", G_CALLBACK(search_activate), NULL);
+  gtk_box_pack_start(GTK_BOX(outer), search_entry, FALSE, FALSE, 0);
+
+  gtk_box_pack_start(GTK_BOX(outer), section_label("Running"), FALSE, FALSE, 0);
+  running_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 22);
+  gtk_box_pack_start(GTK_BOX(outer), running_box, FALSE, FALSE, 0);
+
+  gtk_box_pack_start(GTK_BOX(outer), section_label("Apps"), FALSE, FALSE, 0);
+  gtk_grid_set_row_spacing(GTK_GRID(grid), 18);
+  gtk_grid_set_column_spacing(GTK_GRID(grid), 18);
+  for (guint i = 0; i < G_N_ELEMENTS(apps); i++) {
+    app_tiles[i] = make_tile(&apps[i]);
+    gtk_grid_attach(GTK_GRID(grid), app_tiles[i], i % 3, i / 3, 1, 1);
+  }
+  gtk_box_pack_start(GTK_BOX(outer), grid, FALSE, FALSE, 0);
+  gtk_container_set_border_width(GTK_CONTAINER(outer), 64);
+  gtk_widget_set_margin_top(outer, 120);
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+  gtk_container_add(GTK_CONTAINER(scroll), outer);
+  gtk_container_add(GTK_CONTAINER(window), scroll);
+  g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+  return window;
+}
+
+static void reserve_top(GtkWidget *window) {
+  GdkWindow *gw = gtk_widget_get_window(window);
+  if (!gw) return;
+  Display *dpy = GDK_DISPLAY_XDISPLAY(gdk_window_get_display(gw));
+  Window xid = GDK_WINDOW_XID(gw);
+  int sw = gdk_screen_get_width(gdk_window_get_screen(gw));
+  unsigned long strut[4] = {0, 0, BAR_HEIGHT, 0};
+  unsigned long partial[12] = {0,0,BAR_HEIGHT,0, 0,0,0,0, 0,(unsigned long)(sw-1),0,0};
+  Atom a = XInternAtom(dpy, "_NET_WM_STRUT", False);
+  Atom ap = XInternAtom(dpy, "_NET_WM_STRUT_PARTIAL", False);
+  XChangeProperty(dpy, xid, a, XA_CARDINAL, 32, PropModeReplace, (unsigned char*)strut, 4);
+  XChangeProperty(dpy, xid, ap, XA_CARDINAL, 32, PropModeReplace, (unsigned char*)partial, 12);
+  XFlush(dpy);
+}
+
+static void shape_spinner_window(GtkWidget *window) {
+  GdkWindow *gw = gtk_widget_get_window(window);
+  if (!gw) return;
+  Display *dpy = GDK_DISPLAY_XDISPLAY(gdk_window_get_display(gw));
+  Window xid = GDK_WINDOW_XID(gw);
+  int w = gtk_widget_get_allocated_width(window);
+  int h = gtk_widget_get_allocated_height(window);
+  Pixmap mask = XCreatePixmap(dpy, xid, w, h, 1);
+  GC gc = XCreateGC(dpy, mask, 0, NULL);
+  XSetForeground(dpy, gc, 0); XFillRectangle(dpy, mask, gc, 0, 0, w, h);
+  XSetForeground(dpy, gc, 1); XFillArc(dpy, mask, gc, 0, 0, w, h, 0, 360 * 64);
+  XShapeCombineMask(dpy, xid, ShapeBounding, 0, 0, mask, ShapeSet);
+  XFreeGC(dpy, gc); XFreePixmap(dpy, mask); XFlush(dpy);
+}
+
+static GtkWidget *build_spinner_window(void) {
+  const int size = 220;
+  GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GtkWidget *event = gtk_event_box_new();
+  spinner_label = gtk_label_new("◎");
+  gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+  gtk_window_set_resizable(GTK_WINDOW(window), FALSE);
+  gtk_window_set_keep_above(GTK_WINDOW(window), TRUE);
+  gtk_window_set_accept_focus(GTK_WINDOW(window), FALSE);
+  gtk_window_set_focus_on_map(GTK_WINDOW(window), FALSE);
+  gtk_window_set_skip_taskbar_hint(GTK_WINDOW(window), TRUE);
+  gtk_window_set_skip_pager_hint(GTK_WINDOW(window), TRUE);
+  gtk_window_set_type_hint(GTK_WINDOW(window), GDK_WINDOW_TYPE_HINT_UTILITY);
+  gtk_window_set_default_size(GTK_WINDOW(window), size, size);
+  GdkScreen *screen = gdk_screen_get_default();
+  int sw = gdk_screen_get_width(screen), sh = gdk_screen_get_height(screen);
+  gtk_window_move(GTK_WINDOW(window), sw - size - 28, (sh - size) / 2);
+  gtk_style_context_add_class(gtk_widget_get_style_context(window), "spinner-float");
+  gtk_style_context_add_class(gtk_widget_get_style_context(event), "spinner-knob");
+  gtk_style_context_add_class(gtk_widget_get_style_context(spinner_label), "spinner-label");
+  gtk_container_add(GTK_CONTAINER(event), spinner_label);
+  gtk_container_add(GTK_CONTAINER(window), event);
+  gtk_widget_add_events(event, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_POINTER_MOTION_MASK);
+  g_signal_connect(event, "button-press-event", G_CALLBACK(spinner_press), NULL);
+  g_signal_connect(event, "motion-notify-event", G_CALLBACK(spinner_motion), NULL);
+  g_signal_connect(event, "button-release-event", G_CALLBACK(spinner_release), NULL);
+  return window;
+}
+
+static GtkWidget *build_bar(void) {
+  GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GtkWidget *grid = gtk_grid_new();
+  GtkWidget *brand = gtk_button_new_with_label("3DVR");
+  input_button = gtk_button_new_with_label("Touch");
+  GtkWidget *overview = gtk_button_new_with_label("Overview");
+
+  gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+  gtk_window_set_keep_above(GTK_WINDOW(window), TRUE);
+  gtk_window_set_accept_focus(GTK_WINDOW(window), FALSE);
+  gtk_window_set_focus_on_map(GTK_WINDOW(window), FALSE);
+  gtk_window_set_type_hint(GTK_WINDOW(window), GDK_WINDOW_TYPE_HINT_DOCK);
+  GdkScreen *screen = gdk_screen_get_default();
+  gtk_window_set_default_size(GTK_WINDOW(window), gdk_screen_get_width(screen), BAR_HEIGHT);
+  gtk_window_move(GTK_WINDOW(window), 0, 0);
+  gtk_style_context_add_class(gtk_widget_get_style_context(window), "topbar");
+  gtk_widget_set_hexpand(grid, TRUE);
+  gtk_widget_set_vexpand(grid, TRUE);
+  gtk_widget_set_hexpand(clock_label, TRUE);
+  gtk_widget_set_halign(clock_label, GTK_ALIGN_CENTER);
+  gtk_widget_set_halign(brand, GTK_ALIGN_START);
+  gtk_widget_set_halign(overview, GTK_ALIGN_END);
+  gtk_style_context_add_class(gtk_widget_get_style_context(brand), "bar-button");
+  gtk_style_context_add_class(gtk_widget_get_style_context(input_button), "bar-button");
+  gtk_style_context_add_class(gtk_widget_get_style_context(overview), "bar-button");
+  gtk_style_context_add_class(gtk_widget_get_style_context(clock_label), "clock");
+
+  gtk_grid_attach(GTK_GRID(grid), brand, 0, 0, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), clock_label, 1, 0, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), input_button, 2, 0, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid), overview, 3, 0, 1, 1);
+  gtk_grid_set_column_homogeneous(GTK_GRID(grid), TRUE);
+  gtk_container_set_border_width(GTK_CONTAINER(grid), 18);
+  gtk_container_add(GTK_CONTAINER(window), grid);
+  g_signal_connect(brand, "clicked", G_CALLBACK(show_overview), NULL);
+  g_signal_connect(input_button, "clicked", G_CALLBACK(toggle_input), NULL);
+  g_signal_connect(overview, "clicked", G_CALLBACK(show_overview), NULL);
+  sync_input_label();
+  return window;
+}
+
+int main(int argc, char **argv) {
+  gtk_init(&argc, &argv);
+  load_css();
+  clock_label = gtk_label_new("");
+  home_window = build_home();
+  GtkWidget *bar = build_bar();
+  GtkWidget *spinner = build_spinner_window();
+
+  update_clock(NULL);
+  refresh_running(NULL);
+  track_active_window(NULL);
+  g_timeout_add_seconds(20, update_clock, NULL);
+  g_timeout_add(350, track_active_window, NULL);
+  gtk_widget_show_all(home_window);
+  gtk_widget_show_all(bar);
+  gtk_widget_show_all(spinner);
+  reserve_top(bar);
+  shape_spinner_window(spinner);
+  gtk_main();
+  return 0;
+}

--- a/3dvr-desktop/native/style.css
+++ b/3dvr-desktop/native/style.css
@@ -1,0 +1,106 @@
+* {
+  font-family: Sans;
+  color: #f4f5f7;
+}
+.home {
+  background: #0b0e12;
+}
+.title {
+  font-size: 62px;
+  font-weight: 800;
+}
+.subtitle {
+  font-size: 32px;
+  color: #8e98a4;
+  margin-bottom: 4px;
+}
+.section-label {
+  font-size: 30px;
+  font-weight: 700;
+  color: #cbd1d8;
+  margin-top: 10px;
+}
+.search {
+  min-height: 78px;
+  font-size: 34px;
+  border-radius: 28px;
+  padding: 0 28px;
+  background: #151a20;
+  border: 1px solid #252c34;
+}
+.search:focus {
+  border-color: #687481;
+  background: #171d23;
+}
+.running-card {
+  background: #151b21;
+  border: 1px solid #252d35;
+  border-radius: 26px;
+  padding: 18px;
+}
+.running-card:hover,
+.running-card:active {
+  background: #1b232b;
+}
+.running-label {
+  font-size: 28px;
+  font-weight: 700;
+}
+.empty-running {
+  font-size: 26px;
+  color: #77818c;
+  padding: 20px;
+}
+.app-tile {
+  background: transparent;
+  border: none;
+  border-radius: 34px;
+  padding: 24px;
+}
+.app-tile:hover,
+.app-tile:active {
+  background: #141a20;
+}
+.app-label {
+  font-size: 30px;
+  font-weight: 650;
+}
+.topbar {
+  background: rgba(8, 11, 15, 0.98);
+  border-bottom: 1px solid #1b2128;
+}
+.bar-button {
+  background: transparent;
+  border: none;
+  border-radius: 24px;
+  font-size: 30px;
+  font-weight: 700;
+  padding: 16px 26px;
+}
+.bar-button:hover,
+.bar-button:active {
+  background: #151b21;
+}
+.clock {
+  font-size: 30px;
+  font-weight: 650;
+  color: #d8dde3;
+}
+.spinner-knob {
+  background: rgba(17, 23, 29, 0.94);
+  border: 1px solid #38434d;
+  border-radius: 999px;
+}
+.spinner-knob:hover,
+.spinner-knob:active {
+  background: #1a232b;
+  border-color: #6f7d89;
+}
+.spinner-label {
+  font-size: 46px;
+  font-weight: 700;
+  color: #d9dee4;
+}
+.spinner-float {
+  background: transparent;
+}

--- a/3dvr-desktop/scripts/build-termux-shell.sh
+++ b/3dvr-desktop/scripts/build-termux-shell.sh
@@ -1,0 +1,13 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SHELL_DIR="${THREEDVR_SHELL_DIR:-$HOME/3dvr-shell}"
+
+mkdir -p "$SHELL_DIR"
+cp "$ROOT/native/shell.c" "$SHELL_DIR/shell.c"
+cp "$ROOT/native/style.css" "$SHELL_DIR/style.css"
+
+clang -O2 "$SHELL_DIR/shell.c" -o "$SHELL_DIR/3dvr-shell" \
+  $(pkg-config --cflags --libs gtk+-3.0 x11 xext)
+chmod +x "$SHELL_DIR/3dvr-shell"
+echo "Built $SHELL_DIR/3dvr-shell"

--- a/3dvr-desktop/scripts/install-termux.sh
+++ b/3dvr-desktop/scripts/install-termux.sh
@@ -1,27 +1,38 @@
-#!/data/data/com.termux/files/usr/bin/sh
-set -eu
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 DEST="$HOME/.3dvr/desktop"
+TERMUX_PREFIX=${PREFIX:-/data/data/com.termux/files/usr}
+BACKUP="$HOME/.local/state/3dvr-desktop-backups/$(date +%Y%m%d-%H%M%S)"
 
-pkg update -y
-pkg install -y x11-repo proot-distro
-pkg install -y termux-x11-nightly || true
-
-if ! proot-distro list | grep -qE '^ *debian '; then
-  proot-distro install debian
+if [ "${THREEDVR_SKIP_PACKAGES:-0}" != "1" ]; then
+  pkg update -y
+  pkg install -y x11-repo
+  pkg install -y termux-x11-nightly xfce4 clang pkg-config gtk3 wmctrl xorg-xprop pulseaudio
 fi
 
-mkdir -p "$DEST" "$HOME/.local/bin" "$HOME/.termux/boot"
-cp -R "$ROOT/." "$DEST/"
-ln -sf "$DEST/bin/3dvr-desktop" "$PREFIX/bin/3dvr-desktop"
-cp "$DEST/scripts/termux-boot.sh" "$HOME/.termux/boot/00-3dvr-start"
-chmod +x "$HOME/.termux/boot/00-3dvr-start"
+mkdir -p "$BACKUP" "$DEST" "$HOME/bin" "$HOME/.termux/boot"
+[ -d "$HOME/3dvr-shell" ] && cp -a "$HOME/3dvr-shell" "$BACKUP/" || true
+for f in "$ROOT/scripts/phone/"*; do
+  name=$(basename "$f")
+  [ -f "$HOME/bin/$name" ] && cp -a "$HOME/bin/$name" "$BACKUP/$name" || true
+done
 
-proot-distro login debian \
-  --bind "$DEST:/opt/3dvr-desktop" \
-  -- /bin/sh -lc '/opt/3dvr-desktop/scripts/install-debian.sh'
+rm -rf "$DEST.new"
+mkdir -p "$DEST.new"
+cp -R "$ROOT/." "$DEST.new/"
+rm -rf "$DEST"
+mv "$DEST.new" "$DEST"
 
-echo '3DVR Desktop installed for Termux.'
-echo 'Boot script installed at ~/.termux/boot/00-3dvr-start.'
-echo 'Install and open Termux:Boot once so Android runs it after reboot.'
-echo 'Make sure the Termux:X11 Android app is installed, then run: 3dvr-desktop start'
+for f in "$DEST/scripts/phone/"*; do
+  cp "$f" "$HOME/bin/$(basename "$f")"
+  chmod +x "$HOME/bin/$(basename "$f")"
+done
+"$DEST/scripts/build-termux-shell.sh"
+ln -sf "$DEST/bin/3dvr-desktop" "$TERMUX_PREFIX/bin/3dvr-desktop"
+cp "$DEST/scripts/termux-boot.sh" "$HOME/.termux/boot/02-3dvr-desktop"
+chmod +x "$HOME/.termux/boot/02-3dvr-desktop"
+
+echo '3DVR Desktop installed for native Termux:X11.'
+echo "Backup: $BACKUP"
+echo 'Termux:Boot will start it automatically after Android boots.'

--- a/3dvr-desktop/scripts/phone/3dvr-focus-app
+++ b/3dvr-desktop/scripts/phone/3dvr-focus-app
@@ -1,0 +1,15 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+needle="${1:-}"
+[ -n "$needle" ] || exit 2
+export DISPLAY="${DISPLAY:-:0}"
+wmctrl -k off >/dev/null 2>&1 || true
+clients="$(xprop -root _NET_CLIENT_LIST 2>/dev/null | grep -o '0x[0-9a-fA-F]*' || true)"
+for id in $clients; do
+  props="$(xprop -id "$id" WM_CLASS _NET_WM_NAME WM_NAME 2>/dev/null || true)"
+  if printf '%s' "$props" | grep -qi -- "$needle"; then
+    wmctrl -ia "$id" >/dev/null 2>&1 || true
+    exit 0
+  fi
+done
+exit 1

--- a/3dvr-desktop/scripts/phone/3dvr-place-class
+++ b/3dvr-desktop/scripts/phone/3dvr-place-class
@@ -1,0 +1,41 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+export DISPLAY=:0
+match="${1:?window class match required}"
+slot="${2:-auto}"
+
+for _ in $(seq 1 100); do
+  ids=$(xprop -root _NET_CLIENT_LIST 2>/dev/null | grep -o '0x[0-9a-fA-F]*')
+  for id in $ids; do
+    xprop -id "$id" WM_CLASS 2>/dev/null | grep -qi -- "$match" || continue
+
+    read -r x y w h <<EOF
+$(xprop -root _NET_WORKAREA 2>/dev/null | grep -o '[0-9][0-9]*' | head -4 | tr '\n' ' ')
+EOF
+    : "${x:=0}" "${y:=120}" "${w:=1808}" "${h:=4338}"
+    half=$((h / 2))
+
+    if [ "$slot" = auto ]; then
+      count=0
+      for wid in $ids; do
+        cls=$(xprop -id "$wid" WM_CLASS 2>/dev/null || true)
+        echo "$cls" | grep -qi '3dvr-shell' && continue
+        [ -n "$cls" ] && count=$((count + 1))
+      done
+      [ $((count % 2)) -eq 0 ] && slot=bottom || slot=top
+    fi
+    "$HOME/bin/3dvr-undecorate" "$id" >/dev/null 2>&1 || true
+    sleep .12
+    wmctrl -ir "$id" -b remove,maximized_vert,maximized_horz >/dev/null 2>&1 || true
+    case "$slot" in
+      bottom) yy=$((y + half)); hh=$half ;;
+      full)   yy=$y; hh=$h ;;
+      *)      yy=$y; hh=$half ;;
+    esac
+    wmctrl -ir "$id" -e "0,$x,$yy,$w,$hh" >/dev/null 2>&1 || true
+    wmctrl -ia "$id" >/dev/null 2>&1 || true
+    exit 0
+  done
+  sleep .15
+done
+exit 1

--- a/3dvr-desktop/scripts/phone/3dvr-undecorate
+++ b/3dvr-desktop/scripts/phone/3dvr-undecorate
@@ -1,0 +1,27 @@
+#!/data/data/com.termux/files/usr/bin/python3
+import ctypes, sys, time
+
+wid = int(sys.argv[1], 0)
+X = ctypes.CDLL('/data/data/com.termux/files/usr/lib/libX11.so')
+P = ctypes.c_void_p
+X.XOpenDisplay.argtypes = [ctypes.c_char_p]
+X.XOpenDisplay.restype = P
+X.XInternAtom.argtypes = [P, ctypes.c_char_p, ctypes.c_int]
+X.XInternAtom.restype = ctypes.c_ulong
+X.XChangeProperty.argtypes = [P, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong,
+                              ctypes.c_int, ctypes.c_int, ctypes.c_void_p, ctypes.c_int]
+X.XUnmapWindow.argtypes = [P, ctypes.c_ulong]
+X.XMapRaised.argtypes = [P, ctypes.c_ulong]
+X.XSync.argtypes = [P, ctypes.c_int]
+
+d = X.XOpenDisplay(b':0')
+if not d:
+    raise SystemExit(1)
+a = X.XInternAtom(d, b'_MOTIF_WM_HINTS', 0)
+vals = (ctypes.c_ulong * 5)(2, 0, 0, 0, 0)
+X.XChangeProperty(d, wid, a, a, 32, 0, ctypes.cast(vals, ctypes.c_void_p), 5)
+X.XUnmapWindow(d, wid)
+X.XSync(d, 0)
+time.sleep(.08)
+X.XMapRaised(d, wid)
+X.XSync(d, 0)

--- a/3dvr-desktop/scripts/phone/chromium-touch
+++ b/3dvr-desktop/scripts/phone/chromium-touch
@@ -1,0 +1,15 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+export DISPLAY=:0
+mkdir -p "$HOME/.config/termux-x11"
+timeout 4 termux-x11-preference touchMode:"Direct touch" >/dev/null 2>&1 || true
+printf direct > "$HOME/.config/termux-x11/input-mode"
+chromium-browser \
+  --force-device-scale-factor=1.65 \
+  --touch-events=enabled \
+  --no-default-browser-check \
+  --disable-session-crashed-bubble \
+  "$@" &
+pid=$!
+"$HOME/bin/3dvr-place-class" chromium auto >/dev/null 2>&1 &
+wait "$pid"

--- a/3dvr-desktop/scripts/phone/firefox-touch
+++ b/3dvr-desktop/scripts/phone/firefox-touch
@@ -1,0 +1,11 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+export DISPLAY=:0
+mkdir -p "$HOME/.config/termux-x11"
+timeout 4 termux-x11-preference touchMode:"Direct touch" >/dev/null 2>&1 || true
+printf direct > "$HOME/.config/termux-x11/input-mode"
+export MOZ_USE_XINPUT2=1
+firefox "$@" &
+pid=$!
+"$HOME/bin/3dvr-place-class" firefox auto >/dev/null 2>&1 &
+wait "$pid"

--- a/3dvr-desktop/scripts/phone/phone-3dvr
+++ b/3dvr-desktop/scripts/phone/phone-3dvr
@@ -1,0 +1,9 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+export DISPLAY=:0
+export GDK_SCALE=1
+export GDK_DPI_SCALE=1.00
+xfce4-terminal --hide-menubar --hide-borders --hide-toolbar --hide-scrollbar --font="Cascadia Mono PL 24" --command="bash -lc 3dvr" &
+pid=$!
+"$HOME/bin/3dvr-place-class" 'xfce4-terminal' auto >/dev/null 2>&1 &
+wait "$pid"

--- a/3dvr-desktop/scripts/phone/phone-files
+++ b/3dvr-desktop/scripts/phone/phone-files
@@ -1,0 +1,9 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+export DISPLAY=:0
+export GDK_SCALE=1
+export GDK_DPI_SCALE=1.00
+thunar "$@" &
+pid=$!
+"$HOME/bin/3dvr-place-class" 'Thunar' auto >/dev/null 2>&1 &
+wait "$pid"

--- a/3dvr-desktop/scripts/phone/phone-settings
+++ b/3dvr-desktop/scripts/phone/phone-settings
@@ -1,0 +1,9 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+export DISPLAY=:0
+export GDK_SCALE=1
+export GDK_DPI_SCALE=1.00
+xfce4-settings-manager &
+pid=$!
+"$HOME/bin/3dvr-place-class" 'settings' auto >/dev/null 2>&1 &
+wait "$pid"

--- a/3dvr-desktop/scripts/phone/phone-terminal
+++ b/3dvr-desktop/scripts/phone/phone-terminal
@@ -1,0 +1,9 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+export DISPLAY=:0
+export GDK_SCALE=1
+export GDK_DPI_SCALE=1.00
+xfce4-terminal --hide-menubar --hide-borders --hide-toolbar --hide-scrollbar --font="Cascadia Mono PL 24" "$@" &
+pid=$!
+"$HOME/bin/3dvr-place-class" 'xfce4-terminal' auto >/dev/null 2>&1 &
+wait "$pid"

--- a/3dvr-desktop/scripts/phone/start-3dvr-shell-session
+++ b/3dvr-desktop/scripts/phone/start-3dvr-shell-session
@@ -1,0 +1,30 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+export DISPLAY="${DISPLAY:-:0}"
+state="$HOME/.local/state/termux-gui-v2"
+mkdir -p "$state"
+
+# Minimal X11 session: XFWM handles windows; 3DVR owns the shell.
+xfsettingsd >"$state/xfsettingsd.log" 2>&1 &
+settings_pid=$!
+xfwm4 --replace >"$state/xfwm4.log" 2>&1 &
+wm_pid=$!
+
+for _ in $(seq 1 60); do
+  kill -0 "$wm_pid" 2>/dev/null || exit 1
+  DISPLAY=:0 xprop -root _NET_SUPPORTING_WM_CHECK >/dev/null 2>&1 && break
+  sleep .2
+done
+
+# Phone performance: dragging draws a lightweight outline; snapping is instant.
+xfconf-query -c xfwm4 -p /general/box_move -s true 2>/dev/null || true
+xfconf-query -c xfwm4 -p /general/box_resize -s true 2>/dev/null || true
+xfconf-query -c xfwm4 -p /general/use_compositing -s false 2>/dev/null || true
+xfconf-query -c xfwm4 -p /general/show_frame_shadow -s false 2>/dev/null || true
+
+while kill -0 "$wm_pid" 2>/dev/null; do
+  if ! pgrep -f '^/data/data/com.termux/files/home/3dvr-shell/3dvr-shell$' >/dev/null 2>&1; then
+    "$HOME/3dvr-shell/3dvr-shell" >>"$state/3dvr-shell-session.log" 2>&1 &
+  fi
+  sleep 2
+done

--- a/3dvr-desktop/scripts/phone/x11-touch-toggle
+++ b/3dvr-desktop/scripts/phone/x11-touch-toggle
@@ -1,0 +1,15 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+state_dir="$HOME/.config/termux-x11"
+state_file="$state_dir/input-mode"
+mkdir -p "$state_dir"
+mode="$(cat "$state_file" 2>/dev/null || printf touch)"
+if [ "$mode" = touch ]; then
+  timeout 4 termux-x11-preference touchMode:Trackpad >/dev/null 2>&1 || true
+  printf trackpad > "$state_file"
+  command -v notify-send >/dev/null && notify-send "Input: Trackpad" "Precise pointer + multi-touch gestures"
+else
+  timeout 4 termux-x11-preference 'touchMode:Simulated touchscreen' >/dev/null 2>&1 || true
+  printf touch > "$state_file"
+  command -v notify-send >/dev/null && notify-send "Input: Touch" "Tap apps directly; two fingers scroll"
+fi

--- a/3dvr-desktop/scripts/start-termux.sh
+++ b/3dvr-desktop/scripts/start-termux.sh
@@ -1,18 +1,31 @@
-#!/data/data/com.termux/files/usr/bin/sh
-set -eu
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
 DEST=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
 DISPLAY_NUM=${THREEDVR_DISPLAY:-:0}
-export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-$TMPDIR}
+TERMUX_X11_ARGS=${TERMUX_X11_ARGS:--legacy-drawing}
+STATE="$HOME/.local/state/3dvr-desktop"
+mkdir -p "$STATE"
 
-if ! command -v termux-x11 >/dev/null 2>&1; then
-  echo 'termux-x11 command not found. Run 3DVR Desktop install first.' >&2
-  exit 1
+export DISPLAY="$DISPLAY_NUM"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/data/data/com.termux/files/usr/tmp}"
+export PULSE_SERVER=127.0.0.1
+
+termux-x11-preference \
+  clipboardEnable:true keepScreenOn:true showAdditionalKbd:true \
+  additionalKbdVisible:true fullscreen:false displayResolutionMode:native \
+  displayScale:100 showIMEWhileExternalConnected:true >/dev/null 2>&1 || true
+
+if ! pulseaudio --check >/dev/null 2>&1; then
+  pulseaudio --start \
+    --load="module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1" \
+    --exit-idle-time=-1 >/dev/null 2>&1 || true
 fi
 
-termux-x11 "$DISPLAY_NUM" -ac >/dev/null 2>&1 &
+if ! pgrep -x termux-x11 >/dev/null 2>&1; then
+  termux-x11 $TERMUX_X11_ARGS "$DISPLAY_NUM" >>"$STATE/x11.log" 2>&1 &
+  sleep 1
+fi
+/system/bin/am start --user 0 -n com.termux.x11/com.termux.x11.MainActivity >/dev/null 2>&1 || true
 sleep 1
 
-exec proot-distro login debian \
-  --shared-tmp \
-  --bind "$DEST:/opt/3dvr-desktop" \
-  -- /bin/sh -lc "export DISPLAY='$DISPLAY_NUM'; exec dbus-run-session openbox-session"
+exec "$DEST/scripts/phone/start-3dvr-shell-session"

--- a/3dvr-desktop/scripts/termux-boot.sh
+++ b/3dvr-desktop/scripts/termux-boot.sh
@@ -1,30 +1,24 @@
-#!/data/data/com.termux/files/usr/bin/sh
+#!/data/data/com.termux/files/usr/bin/bash
 set -u
-DEST=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
-LOG_DIR="$HOME/.3dvr/logs"
+LOG_DIR="$HOME/.local/state/3dvr-desktop"
 mkdir -p "$LOG_DIR"
+sleep 15
 
-# Wait for Android to finish bringing networking and storage online.
-sleep 20
+termux-wake-lock >/dev/null 2>&1 || true
+/system/bin/am start --user 0 -n com.termux/.app.TermuxActivity >/dev/null 2>&1 || true
 
-if command -v desktop-commander >/dev/null 2>&1; then
-  nohup desktop-commander remote >>"$LOG_DIR/desktop-commander-boot.log" 2>&1 &
-elif command -v npx >/dev/null 2>&1; then
-  nohup npx --yes @wonderwhy-er/desktop-commander@latest remote >>"$LOG_DIR/desktop-commander-boot.log" 2>&1 &
+if ! pgrep -f 'desktop-commander.* remote' >/dev/null 2>&1; then
+  if [ -x "$HOME/bin/start-desktop-commander-remote" ]; then
+    "$HOME/bin/start-desktop-commander-remote" >/dev/null 2>&1 || true
+  elif command -v desktop-commander >/dev/null 2>&1; then
+    nohup desktop-commander remote >>"$LOG_DIR/desktop-commander.log" 2>&1 &
+  fi
 fi
 
 if command -v 3dvr >/dev/null 2>&1; then
-  nohup 3dvr agent start >>"$LOG_DIR/agent-boot.log" 2>&1 &
+  nohup 3dvr agent start >>"$LOG_DIR/agent.log" 2>&1 &
 fi
 
-if command -v 3dvr-desktop >/dev/null 2>&1; then
-  nohup 3dvr-desktop start >>"$LOG_DIR/desktop-boot.log" 2>&1 &
-fi
-
-# Ask Android to bring the Termux UI forward after boot. Some Android versions
-# may refuse background activity launches; the services above still start.
-if command -v monkey >/dev/null 2>&1; then
-  monkey -p com.termux -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1 || true
-  sleep 2
-  monkey -p com.termux.x11 -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1 || true
+if command -v 3dvr-desktop >/dev/null 2>&1 && ! pgrep -x xfwm4 >/dev/null 2>&1; then
+  nohup 3dvr-desktop start >>"$LOG_DIR/session.log" 2>&1 &
 fi

--- a/tests/3dvr-desktop.test.js
+++ b/tests/3dvr-desktop.test.js
@@ -4,7 +4,7 @@ import test from 'node:test';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 
-test('3DVR Desktop exposes a portal route and reusable targets', () => {
+test('3DVR Desktop exposes native Termux and Linux targets', () => {
   const page = read('3dvr-desktop/index.html');
   const readme = read('3dvr-desktop/README.md');
   const termux = read('3dvr-desktop/scripts/start-termux.sh');
@@ -12,13 +12,28 @@ test('3DVR Desktop exposes a portal route and reusable targets', () => {
 
   assert.match(page, /3DVR Desktop/);
   assert.match(readme, /desktop environment/i);
-  assert.match(readme, /Termux:X11/);
+  assert.match(readme, /3dvr-shell/);
+  assert.match(readme, /XFWM4/);
   assert.match(termux, /termux-x11/);
-  assert.match(termux, /proot-distro login debian/);
+  assert.match(termux, /start-3dvr-shell-session/);
+  assert.doesNotMatch(termux, /proot-distro/);
   assert.match(linux, /startx/);
 });
 
-test('3DVR Desktop session has a panel, launcher, and terminal', () => {
+test('native Termux shell is buildable source with phone launchers', () => {
+  const shell = read('3dvr-desktop/native/shell.c');
+  const build = read('3dvr-desktop/scripts/build-termux-shell.sh');
+  const session = read('3dvr-desktop/scripts/phone/start-3dvr-shell-session');
+
+  assert.match(shell, /#include <gtk\/gtk\.h>/);
+  assert.match(shell, /3DVR/);
+  assert.match(build, /clang -O2/);
+  assert.match(build, /gtk\+-3\.0 x11 xext/);
+  assert.match(session, /xfwm4 --replace/);
+  assert.match(session, /3dvr-shell/);
+});
+
+test('Linux fallback keeps panel, launcher, and terminal', () => {
   const autostart = read('3dvr-desktop/config/openbox/autostart');
   const panel = read('3dvr-desktop/config/tint2/tint2rc');
   const launcher = read('3dvr-desktop/config/applications/3dvr-launcher.desktop');
@@ -33,10 +48,9 @@ test('Termux install creates Android boot startup', () => {
   const install = read('3dvr-desktop/scripts/install-termux.sh');
   const boot = read('3dvr-desktop/scripts/termux-boot.sh');
 
-  assert.match(install, /\.termux\/boot\/00-3dvr-start/);
-  assert.match(install, /Termux:Boot/);
-  assert.match(boot, /desktop-commander remote/);
+  assert.match(install, /\.termux\/boot\/02-3dvr-desktop/);
+  assert.match(install, /build-termux-shell\.sh/);
+  assert.match(boot, /TermuxActivity/);
   assert.match(boot, /3dvr agent start/);
   assert.match(boot, /3dvr-desktop start/);
-  assert.match(boot, /com\.termux\.x11/);
 });


### PR DESCRIPTION
Captures the working phone desktop from Termux and makes it the canonical Android target.

- checks in the GTK 3dvr-shell C source and CSS
- checks in the phone launch/window-control scripts
- builds the shell from source on Termux
- uses Termux:X11 + XFWM4 natively instead of Debian proot/Openbox on Android
- keeps Openbox/Tint2 as the Linux/VM fallback
- adds Termux:Boot startup for Termux, remote access, agent, and graphical session
- supports package-skipping updates on already-configured phones
- verifies the checked-in shell rebuilds successfully on ARM64 Termux