### PR TITLE
Bootstrap GitHub automation key on 3dvr-dev

### DIFF
--- a/.github/workflows/vercel-dev-login.yml
+++ b/.github/workflows/vercel-dev-login.yml
@@ -47,6 +47,9 @@ jobs:
             exit 1
           fi
           chmod 600 /tmp/3dvr-server-key
+          ssh-keygen -y -f /tmp/3dvr-server-key > /tmp/3dvr-server-key.pub
+          echo "AUTOMATION_PUBLIC_KEY=$(cat /tmp/3dvr-server-key.pub)"
+          echo "AUTOMATION_KEY_FINGERPRINT=$(ssh-keygen -lf /tmp/3dvr-server-key.pub | awk '{print $2}')"
 
       - name: Start persistent Vercel device login on 3dvr-dev
         shell: bash
@@ -128,4 +131,4 @@ jobs:
 
       - name: Remove SSH key
         if: always()
-        run: rm -f /tmp/3dvr-server-key /tmp/3dvr-server-key.raw
+        run: rm -f /tmp/3dvr-server-key /tmp/3dvr-server-key.raw /tmp/3dvr-server-key.pub


### PR DESCRIPTION
Temporarily surfaces only the public key/fingerprint derived from the existing GitHub Actions SSH private key so the rebuilt `3dvr-dev` droplet can be provisioned with the correct automation key. No private key material is printed.