### PR TITLE
Use Termux activity launcher for desktop startup

### DIFF
--- a/3dvr-desktop/scripts/start-termux.sh
+++ b/3dvr-desktop/scripts/start-termux.sh
@@ -25,7 +25,7 @@ if ! pgrep -x termux-x11 >/dev/null 2>&1; then
   termux-x11 $TERMUX_X11_ARGS "$DISPLAY_NUM" >>"$STATE/x11.log" 2>&1 &
   sleep 1
 fi
-/system/bin/am start --user 0 -n com.termux.x11/com.termux.x11.MainActivity >/dev/null 2>&1 || true
+am start --user 0 -n com.termux.x11/com.termux.x11.MainActivity >/dev/null 2>&1 || true
 sleep 1
 
 exec "$DEST/scripts/phone/start-3dvr-shell-session"

--- a/3dvr-desktop/scripts/termux-boot.sh
+++ b/3dvr-desktop/scripts/termux-boot.sh
@@ -5,7 +5,7 @@ mkdir -p "$LOG_DIR"
 sleep 15
 
 termux-wake-lock >/dev/null 2>&1 || true
-/system/bin/am start --user 0 -n com.termux/.app.TermuxActivity >/dev/null 2>&1 || true
+am start --user 0 -n com.termux/.app.TermuxActivity >/dev/null 2>&1 || true
 
 if ! pgrep -f 'desktop-commander.* remote' >/dev/null 2>&1; then
   if [ -x "$HOME/bin/start-desktop-commander-remote" ]; then

--- a/tests/3dvr-desktop.test.js
+++ b/tests/3dvr-desktop.test.js
@@ -54,3 +54,13 @@ test('Termux install creates Android boot startup', () => {
   assert.match(boot, /3dvr agent start/);
   assert.match(boot, /3dvr-desktop start/);
 });
+
+test('Termux activity launches use the Termux am compatibility wrapper', () => {
+  const start = read('3dvr-desktop/scripts/start-termux.sh');
+  const boot = read('3dvr-desktop/scripts/termux-boot.sh');
+
+  assert.match(start, /\nam start .*com\.termux\.x11/);
+  assert.match(boot, /\nam start .*com\.termux\//);
+  assert.doesNotMatch(start, /\/system\/bin\/am start/);
+  assert.doesNotMatch(boot, /\/system\/bin\/am start/);
+});


### PR DESCRIPTION
Fix Android foreground launches to use Termux's packaged am compatibility wrapper instead of /system/bin/am.

This matters on newer Samsung/Android builds where /system/bin/am runs as the wrong package/uid. Adds a focused regression test.