### PR TITLE
Fix clean-clone Vercel deployment

### DIFF
--- a/.github/workflows/3dvr-os-deploy.yml
+++ b/.github/workflows/3dvr-os-deploy.yml
@@ -79,12 +79,10 @@ jobs:
           if [ ! -d "$repo/.git" ]; then
             git clone "https://github.com/$GITHUB_REPOSITORY.git" "$repo"
           fi
-          git -C "$repo" diff --quiet
-          git -C "$repo" diff --cached --quiet
           git -C "$repo" fetch --prune origin main
-          git -C "$repo" checkout main
-          git -C "$repo" pull --ff-only origin main
-          chmod +x "$repo/scripts/vercel/deploy-3dvr-os-worker.sh"
+          git -C "$repo" checkout -B main origin/main
+          git -C "$repo" reset --hard origin/main
+          git -C "$repo" clean -fd
           bash "$repo/scripts/vercel/deploy-3dvr-os-worker.sh" "$repo"
           REMOTE
             then

--- a/scripts/vercel/deploy-3dvr-os-worker.sh
+++ b/scripts/vercel/deploy-3dvr-os-worker.sh
@@ -55,11 +55,12 @@ if [ ! -d "$repo/.git" ]; then
   git clone "https://github.com/${GITHUB_REPOSITORY:-tmsteph/3dvr-portal}.git" "$repo"
 fi
 
-git -C "$repo" diff --quiet
-git -C "$repo" diff --cached --quiet
+# This is a dedicated managed deployment clone. Always converge it to origin/main
+# instead of treating local file-mode or generated-file changes as user work.
 git -C "$repo" fetch --prune origin main
-git -C "$repo" checkout main
-git -C "$repo" pull --ff-only origin main
+git -C "$repo" checkout -B main origin/main
+git -C "$repo" reset --hard origin/main
+git -C "$repo" clean -fd
 
 cd "$repo/3dvr-os"
 rm -rf .vercel


### PR DESCRIPTION
Fixes the 3DVR OS server-side Vercel deployment so the dedicated managed clone converges to `origin/main` instead of aborting on its own file-mode/generated changes. Removes the redundant chmod that dirtied the clone before the deploy wrapper ran.