### PR TITLE
Deploy 3DVR OS from the 3dvr Vercel team

### DIFF
--- a/.github/workflows/3dvr-os-deploy.yml
+++ b/.github/workflows/3dvr-os-deploy.yml
@@ -17,7 +17,8 @@ env:
   DEV_HOST: 167.71.156.94
   FALLBACK_HOST: 167.172.193.194
   SSH_USER: root
-  VERCEL_TEAM_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
+  VERCEL_TEAM_ID: team_KXuVUd00RMnDsjoqwdREcZ7J
+  VERCEL_SCOPE_SLUG: 3dvr
   PROJECT_NAME: 3dvr-os
   PROJECT_DOMAIN: os.3dvr.tech
 
@@ -64,7 +65,7 @@ jobs:
           for host in "$DEV_HOST" "$FALLBACK_HOST"; do
             echo "Trying 3DVR deployment host: $host"
             if ssh "${opts[@]}" "$SSH_USER@$host" \
-              "GITHUB_REPOSITORY='$GITHUB_REPOSITORY' VERCEL_TEAM_ID='$VERCEL_TEAM_ID' PROJECT_NAME='$PROJECT_NAME' PROJECT_DOMAIN='$PROJECT_DOMAIN' bash -s" <<'REMOTE'
+              "GITHUB_REPOSITORY='$GITHUB_REPOSITORY' VERCEL_TEAM_ID='$VERCEL_TEAM_ID' VERCEL_SCOPE_SLUG='$VERCEL_SCOPE_SLUG' PROJECT_NAME='$PROJECT_NAME' PROJECT_DOMAIN='$PROJECT_DOMAIN' bash -s" <<'REMOTE'
           set -euo pipefail
           repo="$HOME/.3dvr/portal"
           mkdir -p "$HOME/.3dvr"

--- a/.github/workflows/vercel-dev-login.yml
+++ b/.github/workflows/vercel-dev-login.yml
@@ -106,12 +106,14 @@ jobs:
               if [ ! -d "$repo/.git" ]; then
                 git clone https://github.com/tmsteph/3dvr-portal.git "$repo" || exit 1
               fi
+              git -C "$repo" reset --hard || exit 1
+              git -C "$repo" clean -fd || exit 1
               git -C "$repo" fetch --prune origin main || exit 1
-              git -C "$repo" checkout main || exit 1
+              git -C "$repo" checkout -B main origin/main || exit 1
               git -C "$repo" reset --hard origin/main || exit 1
               GITHUB_REPOSITORY=tmsteph/3dvr-portal \
-              VERCEL_TEAM_ID=team_xxJGO7S7h1ZP4BHidYV0CX9Z \
-              VERCEL_SCOPE_SLUG=tmstephs-projects \
+              VERCEL_TEAM_ID=team_KXuVUd00RMnDsjoqwdREcZ7J \
+              VERCEL_SCOPE_SLUG=3dvr \
               PROJECT_NAME=3dvr-os \
               PROJECT_DOMAIN=os.3dvr.tech \
               bash "$repo/scripts/vercel/deploy-3dvr-os-worker.sh" "$repo"

--- a/scripts/vercel/deploy-3dvr-os-worker.sh
+++ b/scripts/vercel/deploy-3dvr-os-worker.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 repo="${1:-$HOME/.3dvr/portal}"
-team_id="${VERCEL_TEAM_ID:-team_xxJGO7S7h1ZP4BHidYV0CX9Z}"
-scope_slug="${VERCEL_SCOPE_SLUG:-tmstephs-projects}"
+team_id="${VERCEL_TEAM_ID:-team_KXuVUd00RMnDsjoqwdREcZ7J}"
+scope_slug="${VERCEL_SCOPE_SLUG:-3dvr}"
 project_name="${PROJECT_NAME:-3dvr-os}"
 project_domain="${PROJECT_DOMAIN:-os.3dvr.tech}"
 env_file="${MONEY_PRINTER_ENV_FILE:-$HOME/.config/3dvr/money-printer.env}"
@@ -46,13 +46,13 @@ if [ -z "$auth_mode" ]; then
 fi
 
 echo "Vercel authentication mode: $auth_mode"
+echo "Vercel scope: $scope_slug ($team_id)"
 
 mkdir -p "$(dirname "$repo")"
 if [ ! -d "$repo/.git" ]; then
   git clone "https://github.com/${GITHUB_REPOSITORY:-tmsteph/3dvr-portal}.git" "$repo"
 fi
 
-# Dedicated managed clone: discard leftovers from previous automated runs before switching refs.
 git -C "$repo" reset --hard
 git -C "$repo" clean -fd
 git -C "$repo" fetch --prune origin main


### PR DESCRIPTION
Moves the dedicated 3DVR OS Vercel project from the full `tmstephs-projects` Hobby scope to the separate `3dvr` team. Updates the server deploy worker, deploy workflow, and post-login watcher consistently so `3dvr-os` can be created and `os.3dvr.tech` can stay on Vercel without deleting existing projects.