### PR TITLE
Inspect Vercel domain ownership

### DIFF
--- a/.github/workflows/vercel-domain-inspect.yml
+++ b/.github/workflows/vercel-domain-inspect.yml
@@ -1,0 +1,60 @@
+name: Inspect Vercel domain ownership
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/vercel-domain-inspect.yml'
+
+permissions:
+  contents: read
+
+env:
+  DEV_HOST: 167.71.156.94
+  SSH_USER: root
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve server SSH key
+        shell: bash
+        env:
+          SSH_A: ${{ secrets.THREEDVR_SSH_PRIVATE_KEY }}
+          SSH_B: ${{ secrets.DO_SSH_PRIVATE_KEY }}
+          SSH_C: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          key=''
+          for candidate in "$SSH_A" "$SSH_B" "$SSH_C"; do
+            if [ -z "$key" ] && [ -n "$candidate" ]; then key="$candidate"; fi
+          done
+          [ -n "$key" ] || exit 1
+          umask 077
+          printf '%s\n' "$key" > /tmp/key.raw
+          if grep -q 'BEGIN .*PRIVATE KEY' /tmp/key.raw; then
+            cp /tmp/key.raw /tmp/key
+          else
+            base64 -d /tmp/key.raw > /tmp/key
+          fi
+          chmod 600 /tmp/key
+
+      - name: Inspect domain scopes from 3dvr-dev
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -i /tmp/key -o BatchMode=yes -o StrictHostKeyChecking=accept-new root@$DEV_HOST 'bash -s' <<'REMOTE'
+          set +e
+          for scope in tmstephs-projects 3dvr; do
+            echo "===== scope: $scope / os.3dvr.tech ====="
+            npx --yes vercel@latest domains inspect os.3dvr.tech --scope "$scope" 2>&1
+            echo "===== scope: $scope / 3dvr.tech ====="
+            npx --yes vercel@latest domains inspect 3dvr.tech --scope "$scope" 2>&1
+          done
+          REMOTE
+
+      - name: Cleanup
+        if: always()
+        run: rm -f /tmp/key /tmp/key.raw


### PR DESCRIPTION
Adds a one-shot read-only workflow to inspect `os.3dvr.tech` and `3dvr.tech` in both Vercel scopes from the authenticated `3dvr-dev` server. This lets us move only the necessary domain and avoid disturbing Portal DNS.