### PR TITLE
Link linen repair guide

### DIFF
--- a/linen/index.html
+++ b/linen/index.html
@@ -21,6 +21,7 @@
     <nav aria-label="Page navigation">
       <a href="#pattern-001">Pattern 001</a>
       <a href="./robe/">Work robe</a>
+      <a href="./repair/">Repair guide</a>
       <a href="./3dvr-linen-pattern-001-drawstring-pants.pdf">Download PDF</a>
       <a href="#materials">Buy materials</a>
       <a href="#principles">Principles</a>
@@ -40,6 +41,7 @@
         <a class="button primary" href="./3dvr-linen-pattern-001-drawstring-pants.pdf">Download Pattern 001 PDF</a>
         <a class="button" href="#pattern-001">Make the first pair</a>
         <a class="button" href="./robe/">See the men's work robe</a>
+        <a class="button" href="./repair/">Repair linen stronger</a>
         <a class="button" href="#materials">Buy the materials</a>
         <a class="button" href="#principles">Why linen?</a>
       </div>


### PR DESCRIPTION
Makes the live `/linen/repair/` guide discoverable from the existing 3DVR Linen page by adding it to the page navigation and hero actions.

No billing, Stripe, account, or backend changes.