### PR TITLE
Fix Calendar subdomain deployment auth

### DIFF
--- a/.github/workflows/calendar-production.yml
+++ b/.github/workflows/calendar-production.yml
@@ -17,9 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
-  VERCEL_PROJECT_ID: prj_pESdbRo2Hhfz4mfXXcdJy1A8swEk
-  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  DEV_HOST: 167.71.156.94
+  SSH_USER: root
   VERCEL_SCOPE: tmstephs-projects
   VERCEL_PROJECT: 3dvr-portal-calendar
   CALENDAR_DOMAIN: calendar.3dvr.tech
@@ -30,64 +29,83 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Require Vercel credentials
+      - name: Resolve server SSH key
         shell: bash
+        env:
+          SSH_A: ${{ secrets.THREEDVR_SSH_PRIVATE_KEY }}
+          SSH_B: ${{ secrets.DO_SSH_PRIVATE_KEY }}
+          SSH_C: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "::error::VERCEL_TOKEN is not configured."
-            exit 1
+          set -euo pipefail
+          key=''
+          for candidate in "$SSH_A" "$SSH_B" "$SSH_C"; do
+            if [ -z "$key" ] && [ -n "$candidate" ]; then key="$candidate"; fi
+          done
+          [ -n "$key" ] || { echo '::error::No 3DVR SSH key configured.'; exit 1; }
+          umask 077
+          printf '%s\n' "$key" > /tmp/key.raw
+          if grep -q 'BEGIN .*PRIVATE KEY' /tmp/key.raw; then
+            cp /tmp/key.raw /tmp/key
+          else
+            base64 -d /tmp/key.raw > /tmp/key
           fi
+          chmod 600 /tmp/key
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.22.0
-
-      - name: Install Vercel CLI
-        run: npm install --global vercel
-
-      - name: Link standalone Calendar project
-        working-directory: calendar
-        shell: bash
-        run: |
-          rm -rf .vercel
-          vercel link --yes \
-            --project "$VERCEL_PROJECT" \
-            --scope "$VERCEL_SCOPE" \
-            --token "$VERCEL_TOKEN"
-      - name: Attach calendar.3dvr.tech
-        working-directory: calendar
-        shell: bash
-        run: |
-          vercel domains add "$CALENDAR_DOMAIN" "$VERCEL_PROJECT" \
-            --scope "$VERCEL_SCOPE" \
-            --token "$VERCEL_TOKEN" \
-            --force
-
-      - name: Deploy Calendar production
-        id: deploy
-        working-directory: calendar
-        shell: bash
-        run: |
-          DEPLOY_URL="$(vercel deploy --prod --yes --force \
-            --scope "$VERCEL_SCOPE" \
-            --token "$VERCEL_TOKEN")"
-          echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
-          echo "Calendar deployment: $DEPLOY_URL"
-          vercel alias set "$DEPLOY_URL" "$CALENDAR_DOMAIN" \
-            --scope "$VERCEL_SCOPE" \
-            --token "$VERCEL_TOKEN"
-
-      - name: Verify calendar domain
+      - name: Deploy Calendar from 3DVR dev host
         shell: bash
         run: |
           set -euo pipefail
+          ssh -i /tmp/key \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=accept-new \
+            "$SSH_USER@$DEV_HOST" \
+            "VERCEL_SCOPE='$VERCEL_SCOPE' VERCEL_PROJECT='$VERCEL_PROJECT' CALENDAR_DOMAIN='$CALENDAR_DOMAIN' bash -s" <<'REMOTE'
+          set -euo pipefail
+          cli=(npx --yes vercel@latest)
+          "${cli[@]}" whoami
+
+          repo="$HOME/.3dvr/calendar-deploy"
+          mkdir -p "$HOME/.3dvr"
+          if [ ! -d "$repo/.git" ]; then
+            git clone https://github.com/tmsteph/3dvr-portal.git "$repo"
+          fi
+          git -C "$repo" reset --hard
+          git -C "$repo" clean -fd
+          git -C "$repo" fetch --prune origin main
+          git -C "$repo" checkout -B main origin/main
+          git -C "$repo" reset --hard origin/main
+          git -C "$repo" clean -fd
+
+          cd "$repo/calendar"
+          rm -rf .vercel
+          "${cli[@]}" link --yes \
+            --project "$VERCEL_PROJECT" \
+            --scope "$VERCEL_SCOPE"
+          "${cli[@]}" domains add "$CALENDAR_DOMAIN" "$VERCEL_PROJECT" \
+            --scope "$VERCEL_SCOPE" \
+            --force
+
+          deploy_url="$("${cli[@]}" deploy --prod --yes --force \
+            --scope "$VERCEL_SCOPE")"
+          echo "Calendar deployment: $deploy_url"
+          "${cli[@]}" alias set "$deploy_url" "$CALENDAR_DOMAIN" \
+            --scope "$VERCEL_SCOPE"
+
+          curl --fail --silent --show-error --location \
+            --retry 12 --retry-delay 5 --retry-all-errors \
+            "$deploy_url" -o /tmp/calendar-deploy.html
+          grep -q 'data-calendar-view-title' /tmp/calendar-deploy.html
+          grep -q '3DVR Portal – Calendar' /tmp/calendar-deploy.html
+
           curl --fail --silent --show-error --location \
             --retry 18 --retry-delay 5 --retry-all-errors \
             "https://$CALENDAR_DOMAIN/" -o /tmp/calendar-live.html
           grep -q 'data-calendar-view-title' /tmp/calendar-live.html
           grep -q '3DVR Portal – Calendar' /tmp/calendar-live.html
           ! grep -q '<title>3DVR Portal</title>' /tmp/calendar-live.html
+          echo "Calendar is live at https://$CALENDAR_DOMAIN/"
+          REMOTE
+
+      - name: Cleanup
+        if: always()
+        run: rm -f /tmp/key /tmp/key.raw

--- a/scripts/playwright/smoke.mjs
+++ b/scripts/playwright/smoke.mjs
@@ -97,7 +97,7 @@ try {
   assert.equal(pageTitle, '3DVR Portal');
   assert.equal(heading, 'What do you want to do?');
   assert.equal(await operatorLink.count(), 1);
-  assert.equal(await coreActions.count(), 4);
+  assert.equal(await coreActions.count(), 5);
 
   console.log(`Playwright smoke check passed in ${browserTarget.displayName} at ${baseUrl}`);
 } finally {


### PR DESCRIPTION
## What changed
- stop depending on the missing repo-level `VERCEL_TOKEN` secret
- deploy the standalone Calendar project through the already-authenticated 3DVR dev host
- reuse the same SSH credential pattern already present in the repo
- keep the domain reassignment and live verification in the deployment lane

## Validation
- `git diff --check`
- `node --test tests/calendar-pwa-config.test.js` (9/9 passing)

Follow-up to #1938 after its first production run showed `VERCEL_TOKEN` is not configured.