### PR TITLE
Deploy Calendar under the 3dvr Vercel team

### DIFF
--- a/.github/workflows/calendar-production.yml
+++ b/.github/workflows/calendar-production.yml
@@ -19,8 +19,8 @@ concurrency:
 env:
   DEV_HOST: 167.71.156.94
   SSH_USER: root
-  VERCEL_SCOPE: tmstephs-projects
-  VERCEL_PROJECT: 3dvr-portal-calendar
+  VERCEL_SCOPE: 3dvr
+  VERCEL_PROJECT: 3dvr-calendar
   CALENDAR_DOMAIN: calendar.3dvr.tech
 
 jobs:
@@ -75,6 +75,11 @@ jobs:
           git -C "$repo" checkout -B main origin/main
           git -C "$repo" reset --hard origin/main
           git -C "$repo" clean -fd
+
+          "${cli[@]}" domains inspect 3dvr.tech --scope "$VERCEL_SCOPE" >/dev/null
+          if ! "${cli[@]}" project inspect "$VERCEL_PROJECT" --scope "$VERCEL_SCOPE" >/dev/null 2>&1; then
+            "${cli[@]}" project add "$VERCEL_PROJECT" --scope "$VERCEL_SCOPE"
+          fi
 
           cd "$repo/calendar"
           rm -rf .vercel

--- a/calendar/DEPLOYMENT.md
+++ b/calendar/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Calendar deployment
 
-`calendar/` is deployed as the standalone Vercel project `3dvr-portal-calendar`.
+`calendar/` is deployed as the standalone Vercel project `3dvr-calendar` in the `3dvr` team.
 
 Production URL: `https://calendar.3dvr.tech/`
 


### PR DESCRIPTION
## What changed
- deploy standalone Calendar under the Vercel team that owns `3dvr.tech`
- create/link `3dvr-calendar` there when needed
- attach `calendar.3dvr.tech` from the correct scope
- keep the existing standalone Calendar verification

## Why
The previous deployment reached the authenticated Vercel host successfully, but Vercel returned 403 because `calendar.3dvr.tech` belongs to the `3dvr` team while the old Calendar project lived under the personal scope.

## Validation
- `git diff --check`
- `node --test tests/calendar-pwa-config.test.js` (9/9 passing)