### PR TITLE
Reassign calendar.3dvr.tech to Calendar

### DIFF
--- a/.github/workflows/calendar-production.yml
+++ b/.github/workflows/calendar-production.yml
@@ -21,6 +21,8 @@ env:
   SSH_USER: root
   VERCEL_SCOPE: 3dvr
   VERCEL_PROJECT: 3dvr-calendar
+  LEGACY_VERCEL_SCOPE: tmstephs-projects
+  LEGACY_VERCEL_PROJECT: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch
   CALENDAR_DOMAIN: calendar.3dvr.tech
 
 jobs:
@@ -59,7 +61,7 @@ jobs:
             -o BatchMode=yes \
             -o StrictHostKeyChecking=accept-new \
             "$SSH_USER@$DEV_HOST" \
-            "VERCEL_SCOPE='$VERCEL_SCOPE' VERCEL_PROJECT='$VERCEL_PROJECT' CALENDAR_DOMAIN='$CALENDAR_DOMAIN' bash -s" <<'REMOTE'
+            "VERCEL_SCOPE='$VERCEL_SCOPE' VERCEL_PROJECT='$VERCEL_PROJECT' LEGACY_VERCEL_SCOPE='$LEGACY_VERCEL_SCOPE' LEGACY_VERCEL_PROJECT='$LEGACY_VERCEL_PROJECT' CALENDAR_DOMAIN='$CALENDAR_DOMAIN' bash -s" <<'REMOTE'
           set -euo pipefail
           cli=(npx --yes vercel@latest)
           "${cli[@]}" whoami
@@ -77,6 +79,13 @@ jobs:
           git -C "$repo" clean -fd
 
           "${cli[@]}" domains inspect 3dvr.tech --scope "$VERCEL_SCOPE" >/dev/null
+
+          legacy_endpoint="/v9/projects/$LEGACY_VERCEL_PROJECT/domains/$CALENDAR_DOMAIN"
+          if "${cli[@]}" api "$legacy_endpoint" --scope "$LEGACY_VERCEL_SCOPE" >/dev/null 2>&1; then
+            echo "Detaching $CALENDAR_DOMAIN from the legacy Portal project..."
+            "${cli[@]}" api "$legacy_endpoint" -X DELETE --scope "$LEGACY_VERCEL_SCOPE" >/dev/null
+          fi
+
           if ! "${cli[@]}" project inspect "$VERCEL_PROJECT" --scope "$VERCEL_SCOPE" >/dev/null 2>&1; then
             "${cli[@]}" project add "$VERCEL_PROJECT" --scope "$VERCEL_SCOPE"
           fi


### PR DESCRIPTION
## What changed
- detach `calendar.3dvr.tech` from the legacy personal-scope Portal project through Vercel’s project-domain API
- then attach it to the standalone `3dvr/3dvr-calendar` project
- make the detach idempotent so future Calendar deploys skip it once the move is complete

## Why
The correct 3dvr-team Calendar project is now created, but Vercel refuses to attach the hostname until its old project assignment is removed.

## Validation
- `git diff --check`
- `node --test tests/calendar-pwa-config.test.js` (9/9 passing)