### PR TITLE
Complete noninteractive Calendar domain handoff

### DIFF
--- a/.github/workflows/calendar-production.yml
+++ b/.github/workflows/calendar-production.yml
@@ -83,7 +83,7 @@ jobs:
           legacy_endpoint="/v9/projects/$LEGACY_VERCEL_PROJECT/domains/$CALENDAR_DOMAIN"
           if "${cli[@]}" api "$legacy_endpoint" --scope "$LEGACY_VERCEL_SCOPE" >/dev/null 2>&1; then
             echo "Detaching $CALENDAR_DOMAIN from the legacy Portal project..."
-            "${cli[@]}" api "$legacy_endpoint" -X DELETE --scope "$LEGACY_VERCEL_SCOPE" >/dev/null
+            "${cli[@]}" api "$legacy_endpoint" -X DELETE --scope "$LEGACY_VERCEL_SCOPE" --dangerously-skip-permissions >/dev/null
           fi
 
           if ! "${cli[@]}" project inspect "$VERCEL_PROJECT" --scope "$VERCEL_SCOPE" >/dev/null 2>&1; then


### PR DESCRIPTION
## What changed
- explicitly allow the authenticated Vercel API DELETE to run non-interactively

## Why
Vercel correctly found the legacy project-domain assignment, but its CLI requires an explicit non-interactive permission flag before a DELETE request. This only removes the project-level `calendar.3dvr.tech` assignment; it does not delete `3dvr.tech` from the account.

## Validation
- `git diff --check`
- Calendar PWA config tests 9/9 passing