### PR TITLE
Harden 3DVR Desktop boot and recovery

### DIFF
--- a/3dvr-desktop/ARCHITECTURE.md
+++ b/3dvr-desktop/ARCHITECTURE.md
@@ -1,0 +1,47 @@
+# 3DVR Desktop architecture
+
+3DVR Desktop is a portable desktop environment with one product identity and multiple runtimes.
+The goal is not to fork every component. 3DVR owns the session, shell, defaults, launch behavior,
+recovery, and cross-device experience while reusing strong open-source building blocks.
+
+## Native phone runtime
+
+```text
+Android
+  ├─ 3DVR Companion        Android-native, permissioned control bridge
+  ├─ Termux:Boot           post-boot entry point
+  ├─ Termux:X11            X server + Android touch/input viewer
+  └─ Termux
+       ├─ XFWM4            window manager
+       ├─ 3dvr-shell       3DVR home/launcher/window UI
+       ├─ XFCE utilities   terminal, files, settings
+       └─ 3DVR agent       optional automation/control services
+```
+
+The desktop itself is native Termux. A Debian proot may still be useful for Linux software,
+but it is not required to render or manage the 3DVR Desktop session.
+
+## Boot lifecycle
+
+Termux:Boot starts non-graphical services first. The graphical supervisor waits for Android's
+first normal unlock, asks the already-paired 3DVR Companion to foreground Termux, and then starts
+Termux:X11 and the 3DVR session. This keeps reboot recovery compatible with Android's lock-screen
+and background-activity restrictions instead of trying to bypass them.
+## Linux and VM runtime
+
+Normal Linux and `termux-ui-lab` currently use Xorg + Openbox + Tint2 + Rofi. That fallback is
+intentionally boring and reproducible: it gives us a safe lab for shell/session work while the
+phone runtime evolves. Components can converge later without changing the 3DVR Desktop identity.
+
+## Control plane
+
+The 3DVR Companion exposes named capabilities such as UI snapshots, taps, navigation, and opening
+known apps. It does not expose arbitrary Android package execution. Termux supplies the Linux shell,
+source tree, compilers, and processes. Together they let an agent reason about both Android UI state
+and the Linux environment without turning the phone into an unrestricted remote shell.
+
+## Source-of-truth rule
+
+Device-local experimentation is temporary. Once a behavior works, move the source/config/script into
+`3dvr-desktop/`, add a test or doctor check, and reinstall from the monorepo. A phone or VM should be
+replaceable; the repository should be sufficient to reconstruct the environment.

--- a/3dvr-desktop/README.md
+++ b/3dvr-desktop/README.md
@@ -28,13 +28,17 @@ Those are implementation pieces, not the identity of 3DVR Desktop, and can be re
 ```sh
 ./3dvr-desktop/install.sh
 3dvr-desktop doctor
+3dvr-desktop probe-x11   # optional isolated X11 check on Termux
 3dvr-desktop start
 ```
 
 On Termux the installer builds `native/shell.c` into `~/3dvr-shell/3dvr-shell`, installs the
 phone launcher scripts, and creates `~/.termux/boot/02-3dvr-desktop` for Termux:Boot.
-The boot entry starts the already-authorized remote control if needed, starts the 3DVR agent
-when present, brings Termux forward, and starts the graphical session automatically.
+The boot entry starts non-graphical services first, waits for Android to be normally unlocked, then
+uses the paired 3DVR Companion for the foreground handoff before starting the graphical session.
+
+For implementation details see [`ARCHITECTURE.md`](./ARCHITECTURE.md). For recovery and known
+Termux:X11 issues see [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md).
 
 ## Source of truth
 

--- a/3dvr-desktop/TROUBLESHOOTING.md
+++ b/3dvr-desktop/TROUBLESHOOTING.md
@@ -1,0 +1,52 @@
+# 3DVR Desktop troubleshooting
+
+Start with read-only diagnostics:
+
+```sh
+3dvr-desktop doctor
+```
+
+For an isolated Termux:X11 startup test that does not launch XFWM4 or 3dvr-shell:
+
+```sh
+3dvr-desktop probe-x11
+```
+
+Runtime logs live under `~/.local/state/3dvr-desktop/`. The main X11 log is `x11.log` and the
+isolated probe writes `x11-probe.log`.
+
+## After an Android reboot
+
+Termux:Boot may start background services before Android allows graphical activities. 3DVR Desktop
+therefore waits for the first normal unlock. The paired 3DVR Companion then foregrounds Termux;
+newer Companion builds can foreground Termux:X11 as an explicit allow-listed app as well.
+
+Do not add a busy loop that repeatedly forces activities over the Android lock screen. Recovery
+should respect the platform lifecycle and remain quiet when the phone is locked.
+
+## X11 says “Not connected”
+
+Check both halves: the Android `com.termux.x11` app and the Termux `termux-x11-nightly` package.
+Then run `3dvr-desktop probe-x11`. A healthy probe creates an X socket and answers an `xprop` root
+query. If the command exits without a socket, the failure is below XFWM4 and `3dvr-shell`.
+## Current Samsung / Android 16 investigation
+
+On 2026-08-29 a Samsung Android 16 test device reproduced a Termux:X11 loader failure after reboot:
+the viewer remained “Not connected” and the shell command exited without creating an X socket.
+The same device had a working 3DVR/X11 session the previous evening with `termux-x11-nightly`
+1.03.01-5. Updating both Android and shell-side X11 components did not by itself restore the server.
+
+This is tracked as a dependency-layer issue, not silently attributed to 3DVR Desktop. Keep the VM and
+Linux targets usable, keep boot/remote services recoverable, and attach the probe output when reporting
+or debugging the upstream problem.
+
+## Safe update pattern
+
+Use the installer again to reconcile repository files. It creates a timestamped device backup first.
+For a source/config-only reconciliation on an already-provisioned phone:
+
+```sh
+THREEDVR_SKIP_PACKAGES=1 ./3dvr-desktop/install.sh
+```
+
+This updates the canonical shell/scripts and boot entry without doing a broad Termux package upgrade.

--- a/3dvr-desktop/bin/3dvr-desktop
+++ b/3dvr-desktop/bin/3dvr-desktop
@@ -25,36 +25,29 @@ case "$command" in
     exec rofi -show drun -show-icons
     ;;
   doctor)
-    missing=0
     if is_termux; then
-      for name in termux-x11 xfwm4 xfsettingsd wmctrl clang pkg-config; do
-        if command -v "$name" >/dev/null 2>&1; then
-          printf 'ok   %s\n' "$name"
-        else
-          printf 'miss %s\n' "$name"
-          missing=1
-        fi
-      done
-      if [ -x "$HOME/3dvr-shell/3dvr-shell" ]; then
-        printf 'ok   3dvr-shell\n'
+      exec "$ROOT/scripts/doctor-termux.sh"
+    fi
+    missing=0
+    for name in openbox tint2 rofi xterm; do
+      if command -v "$name" >/dev/null 2>&1; then
+        printf 'ok   %s\n' "$name"
       else
-        printf 'miss 3dvr-shell\n'
+        printf 'miss %s\n' "$name"
         missing=1
       fi
-    else
-      for name in openbox tint2 rofi xterm; do
-        if command -v "$name" >/dev/null 2>&1; then
-          printf 'ok   %s\n' "$name"
-        else
-          printf 'miss %s\n' "$name"
-          missing=1
-        fi
-      done
-    fi
+    done
     exit "$missing"
     ;;
+  probe-x11)
+    if ! is_termux; then
+      echo 'probe-x11 is only available on the Termux target.' >&2
+      exit 2
+    fi
+    exec "$ROOT/scripts/probe-termux-x11.sh"
+    ;;
   *)
-    echo 'usage: 3dvr-desktop [start|launcher|doctor]' >&2
+    echo 'usage: 3dvr-desktop [start|launcher|doctor|probe-x11]' >&2
     exit 2
     ;;
 esac

--- a/3dvr-desktop/index.html
+++ b/3dvr-desktop/index.html
@@ -58,6 +58,8 @@
   <p class="lede">A tiny, reusable graphical desktop environment for phones, VMs, and Linux machines.</p>
   <div class="actions">
     <a class="button primary" href="./README.md">Install / source</a>
+    <a class="button" href="./ARCHITECTURE.md">Architecture</a>
+    <a class="button" href="./TROUBLESHOOTING.md">Recovery</a>
     <a class="button" href="../3dvr-os/">Open Daedalos web desktop</a>
   </div>
 
@@ -65,14 +67,14 @@
     <div class="screen">
       <div class="window">
         <div class="titlebar">Terminal — 3DVR Desktop</div>
-        <div class="terminal"><b>tmsteph@3dvr</b>:~$ 3dvr-desktop doctor<br>ok&nbsp;&nbsp;&nbsp;openbox<br>ok&nbsp;&nbsp;&nbsp;tint2<br>ok&nbsp;&nbsp;&nbsp;rofi<br>ok&nbsp;&nbsp;&nbsp;xterm</div>
+        <div class="terminal"><b>you@3dvr</b>:~$ 3dvr-desktop doctor<br>ok&nbsp;&nbsp;&nbsp;3dvr-shell<br>ok&nbsp;&nbsp;&nbsp;Termux:Boot<br>ok&nbsp;&nbsp;&nbsp;3DVR Companion bridge<br><br>$ 3dvr-desktop probe-x11</div>
       </div>
       <div class="panel"><span class="app">3D</span><span class="app">▤</span><span class="app">›_</span><span class="clock">10:32</span></div>
     </div>
   </section>
 
   <section class="grid">
-    <article class="card"><h2>Phone</h2><p>Termux:X11 + XFWM4 + our native GTK 3dvr-shell, built directly on Android without requiring proot.</p></article>
+    <article class="card"><h2>Phone</h2><p>Termux:X11 + XFWM4 + native GTK 3dvr-shell, with unlock-aware boot recovery and a permissioned Android bridge.</p></article>
     <article class="card"><h2>VM</h2><p>Our tiny Debian lab is the safe reference machine for building and testing the desktop.</p></article>
     <article class="card"><h2>Linux</h2><p>Run it directly on Debian-family machines through normal Xorg and the same config.</p></article>
   </section>

--- a/3dvr-desktop/scripts/doctor-termux.sh
+++ b/3dvr-desktop/scripts/doctor-termux.sh
@@ -1,0 +1,82 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+TERMUX_PREFIX=${PREFIX:-/data/data/com.termux/files/usr}
+export PREFIX="$TERMUX_PREFIX"
+export HOME=${HOME:-/data/data/com.termux/files/home}
+export TMPDIR=${TMPDIR:-$TERMUX_PREFIX/tmp}
+export PATH="$HOME/bin:$TERMUX_PREFIX/bin:/system/bin:${PATH:-}"
+
+fail=0
+ok() { printf 'ok   %s\n' "$1"; }
+warn() { printf 'warn %s\n' "$1"; }
+miss() { printf 'miss %s\n' "$1"; fail=1; }
+
+for name in termux-x11 xfwm4 xfsettingsd wmctrl xprop clang pkg-config python3; do
+  command -v "$name" >/dev/null 2>&1 && ok "$name" || miss "$name"
+done
+
+if [ -x "$HOME/3dvr-shell/3dvr-shell" ]; then
+  ok '3dvr-shell'
+else
+  miss '3dvr-shell'
+fi
+
+if /system/bin/pm path com.termux.x11 >/dev/null 2>&1; then
+  ok 'Termux:X11 Android app'
+else
+  miss 'Termux:X11 Android app'
+fi
+if /system/bin/pm path com.termux.boot >/dev/null 2>&1; then
+  ok 'Termux:Boot Android app'
+else
+  warn 'Termux:Boot Android app not detected; reboot autostart will not run'
+fi
+
+shell_version=$(dpkg-query -W -f='${Version}' termux-x11-nightly 2>/dev/null || true)
+[ -n "$shell_version" ] && ok "termux-x11 package $shell_version" || miss 'termux-x11 package'
+
+boot="$HOME/.termux/boot/02-3dvr-desktop"
+if [ -x "$boot" ]; then
+  ok '3DVR boot entry'
+else
+  miss '3DVR boot entry'
+fi
+
+pairing="$HOME/.config/3dvr-terminal-bridge/companion.json"
+if [ -s "$pairing" ]; then
+  ok '3DVR Companion pairing'
+  if python3 - "$pairing" <<'PY' >/dev/null 2>&1
+import json, sys, urllib.request
+spec=json.load(open(sys.argv[1], encoding='utf-8'))
+req=urllib.request.Request(spec['url'].rstrip('/')+'/v1/health', headers={'Authorization':'Bearer '+spec['token']})
+with urllib.request.urlopen(req, timeout=3) as response:
+    assert json.load(response).get('ok') is True
+PY
+  then ok '3DVR Companion bridge'; else warn '3DVR Companion bridge unavailable'; fi
+else
+  warn '3DVR Companion is not paired; unlock handoff cannot foreground Termux'
+fi
+display=${THREEDVR_DISPLAY:-:0}
+number=${display#:}
+socket="$TMPDIR/.X11-unix/X$number"
+
+if pgrep -x termux-x11 >/dev/null 2>&1; then
+  ok 'Termux:X11 server process'
+  if [ -S "$socket" ] && DISPLAY="$display" xprop -root >/dev/null 2>&1; then
+    ok "X11 display $display"
+  else
+    warn "Termux:X11 process exists but $display is not responding"
+  fi
+else
+  warn 'Termux:X11 server is not running'
+  [ -e "$socket" ] && warn "stale X11 socket: $socket"
+fi
+
+if pgrep -x xfwm4 >/dev/null 2>&1; then
+  ok 'XFWM4 session'
+else
+  warn 'XFWM4 session is not running'
+fi
+
+printf '\nUse `3dvr-desktop probe-x11` for an isolated X-server startup test.\n'
+exit "$fail"

--- a/3dvr-desktop/scripts/phone/await-android-ready.py
+++ b/3dvr-desktop/scripts/phone/await-android-ready.py
@@ -1,0 +1,61 @@
+#!/data/data/com.termux/files/usr/bin/python3
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+PAIRING = os.path.expanduser('~/.config/3dvr-terminal-bridge/companion.json')
+TIMEOUT = int(os.environ.get('THREEDVR_UNLOCK_TIMEOUT_SECONDS', '900'))
+POLL = 2
+
+
+def request(base, token, path, method='GET', body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {'Authorization': 'Bearer ' + token, 'Accept': 'application/json'}
+    if data is not None:
+        headers['Content-Type'] = 'application/json'
+    req = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=4) as response:
+        return json.load(response)
+
+
+def is_locked(payload):
+    snap = payload.get('snapshot') or {}
+    if not snap.get('available'):
+        return None
+    for node in snap.get('nodes') or []:
+        values = (node.get('text'), node.get('contentDescription'))
+        if any(str(value or '').strip().lower() == 'device locked' for value in values):
+            return True
+    return False
+
+
+def main():
+    deadline = time.monotonic() + TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            spec = json.load(open(PAIRING, encoding='utf-8'))
+            base = str(spec['url']).rstrip('/')
+            token = str(spec['token'])
+            locked = is_locked(request(base, token, '/v1/ui/snapshot'))
+            if locked is False:
+                result = request(base, token, '/v1/open-app', 'POST', {'alias': 'termux'})
+                if result.get('ok'):
+                    # Newer Companion builds also expose Termux:X11 as a separate,
+                    # allow-listed target. Older builds simply return ok=false here.
+                    try:
+                        request(base, token, '/v1/open-app', 'POST', {'alias': 'termux_x11'})
+                    except urllib.error.URLError:
+                        pass
+                    print('Android unlocked; Termux handoff completed through 3DVR Companion.')
+                    return 0
+        except (OSError, KeyError, ValueError, urllib.error.URLError):
+            pass
+        time.sleep(POLL)
+    print('Timed out waiting for Android unlock; continuing without foreground handoff.')
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/3dvr-desktop/scripts/phone/start-after-unlock.sh
+++ b/3dvr-desktop/scripts/phone/start-after-unlock.sh
@@ -1,0 +1,12 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+DEST=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
+LOG_DIR="$HOME/.local/state/3dvr-desktop"
+mkdir -p "$LOG_DIR"
+
+"$DEST/scripts/phone/await-android-ready.py" >>"$LOG_DIR/android-ready.log" 2>&1 || true
+sleep 1
+
+if command -v 3dvr-desktop >/dev/null 2>&1 && ! pgrep -x xfwm4 >/dev/null 2>&1; then
+  exec 3dvr-desktop start
+fi

--- a/3dvr-desktop/scripts/probe-termux-x11.sh
+++ b/3dvr-desktop/scripts/probe-termux-x11.sh
@@ -1,0 +1,44 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -u
+TERMUX_PREFIX=${PREFIX:-/data/data/com.termux/files/usr}
+export PREFIX="$TERMUX_PREFIX"
+export HOME=${HOME:-/data/data/com.termux/files/home}
+export TMPDIR=${TMPDIR:-$TERMUX_PREFIX/tmp}
+export PATH="$HOME/bin:$TERMUX_PREFIX/bin:/system/bin:${PATH:-}"
+
+DISPLAY_NUM=${THREEDVR_PROBE_DISPLAY:-:99}
+number=${DISPLAY_NUM#:}
+socket="$TMPDIR/.X11-unix/X$number"
+lock="$TMPDIR/.X${number}-lock"
+state="$HOME/.local/state/3dvr-desktop"
+log="$state/x11-probe.log"
+mkdir -p "$state" "$TMPDIR/.X11-unix"
+rm -f "$socket" "$lock"
+: >"$log"
+
+TERMUX_X11_DEBUG=1 termux-x11 "$DISPLAY_NUM" >>"$log" 2>&1 &
+pid=$!
+ready=0
+for _ in $(seq 1 32); do
+  if [ -S "$socket" ] && DISPLAY="$DISPLAY_NUM" xprop -root >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  kill -0 "$pid" >/dev/null 2>&1 || break
+  sleep 0.25
+done
+if [ "$ready" -eq 1 ]; then
+  echo "ok   Termux:X11 created a working display on $DISPLAY_NUM"
+  kill "$pid" >/dev/null 2>&1 || true
+  wait "$pid" 2>/dev/null || true
+  rm -f "$socket" "$lock"
+  exit 0
+fi
+
+wait "$pid" 2>/dev/null
+status=$?
+echo "fail Termux:X11 did not create a display (exit $status)" >&2
+echo "log  $log" >&2
+[ -s "$log" ] && tail -80 "$log" >&2
+rm -f "$socket" "$lock"
+exit 1

--- a/3dvr-desktop/scripts/start-termux.sh
+++ b/3dvr-desktop/scripts/start-termux.sh
@@ -1,31 +1,64 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+
+TERMUX_PREFIX=${PREFIX:-/data/data/com.termux/files/usr}
+export PREFIX="$TERMUX_PREFIX"
+export HOME=${HOME:-/data/data/com.termux/files/home}
+export TMPDIR=${TMPDIR:-$TERMUX_PREFIX/tmp}
+export PATH="$HOME/bin:$TERMUX_PREFIX/bin:/system/bin:${PATH:-}"
+
 DEST=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
 DISPLAY_NUM=${THREEDVR_DISPLAY:-:0}
 TERMUX_X11_ARGS=${TERMUX_X11_ARGS:--legacy-drawing}
+X11_WAIT_SECONDS=${THREEDVR_X11_WAIT_SECONDS:-8}
 STATE="$HOME/.local/state/3dvr-desktop"
-mkdir -p "$STATE"
+mkdir -p "$STATE" "$TMPDIR/.X11-unix"
 
 export DISPLAY="$DISPLAY_NUM"
-export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/data/data/com.termux/files/usr/tmp}"
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-$TMPDIR}
 export PULSE_SERVER=127.0.0.1
 
 termux-x11-preference \
   clipboardEnable:true keepScreenOn:true showAdditionalKbd:true \
   additionalKbdVisible:true fullscreen:false displayResolutionMode:native \
   displayScale:100 showIMEWhileExternalConnected:true >/dev/null 2>&1 || true
-
 if ! pulseaudio --check >/dev/null 2>&1; then
   pulseaudio --start \
     --load="module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1" \
     --exit-idle-time=-1 >/dev/null 2>&1 || true
 fi
 
+number=${DISPLAY_NUM#:}
+socket="$TMPDIR/.X11-unix/X$number"
+lock="$TMPDIR/.X${number}-lock"
+
 if ! pgrep -x termux-x11 >/dev/null 2>&1; then
-  termux-x11 $TERMUX_X11_ARGS "$DISPLAY_NUM" >>"$STATE/x11.log" 2>&1 &
-  sleep 1
+  rm -f "$socket" "$lock"
+  : >"$STATE/x11.log"
+  TERMUX_X11_DEBUG=${TERMUX_X11_DEBUG:-1} \
+    termux-x11 $TERMUX_X11_ARGS "$DISPLAY_NUM" >>"$STATE/x11.log" 2>&1 &
 fi
+
+# Use Termux's Android compatibility launcher. Samsung may still defer the
+# activity while the phone is locked; the boot supervisor waits for unlock.
 am start --user 0 -n com.termux.x11/com.termux.x11.MainActivity >/dev/null 2>&1 || true
-sleep 1
+
+ready=0
+for ((i=0; i<X11_WAIT_SECONDS*4; i++)); do
+  if [ -S "$socket" ] && DISPLAY="$DISPLAY_NUM" xprop -root >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [ "$ready" -ne 1 ]; then
+  {
+    echo "3DVR Desktop: Termux:X11 did not become ready on $DISPLAY_NUM."
+    echo "The remote bridge and agent can keep running; the graphical session was not started."
+    echo "Run: 3dvr-desktop doctor"
+    echo "Log: $STATE/x11.log"
+  } >&2
+  exit 1
+fi
 
 exec "$DEST/scripts/phone/start-3dvr-shell-session"

--- a/3dvr-desktop/scripts/termux-boot.sh
+++ b/3dvr-desktop/scripts/termux-boot.sh
@@ -1,12 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -u
+DEST=${THREEDVR_DESKTOP_ROOT:-"$HOME/.3dvr/desktop"}
 LOG_DIR="$HOME/.local/state/3dvr-desktop"
 mkdir -p "$LOG_DIR"
-sleep 15
+sleep 12
 
 termux-wake-lock >/dev/null 2>&1 || true
-am start --user 0 -n com.termux/.app.TermuxActivity >/dev/null 2>&1 || true
 
+# Remote access and the agent can start while the phone is still locked.
 if ! pgrep -f 'desktop-commander.* remote' >/dev/null 2>&1; then
   if [ -x "$HOME/bin/start-desktop-commander-remote" ]; then
     "$HOME/bin/start-desktop-commander-remote" >/dev/null 2>&1 || true
@@ -19,6 +20,8 @@ if command -v 3dvr >/dev/null 2>&1; then
   nohup 3dvr agent start >>"$LOG_DIR/agent.log" 2>&1 &
 fi
 
-if command -v 3dvr-desktop >/dev/null 2>&1 && ! pgrep -x xfwm4 >/dev/null 2>&1; then
-  nohup 3dvr-desktop start >>"$LOG_DIR/session.log" 2>&1 &
+# Android does not surface X11 over the lock screen. Wait for the first normal
+# unlock, then let Companion foreground Termux and start the graphical session.
+if ! pgrep -f 'start-after-unlock\.sh' >/dev/null 2>&1; then
+  nohup "$DEST/scripts/phone/start-after-unlock.sh" >>"$LOG_DIR/session.log" 2>&1 &
 fi

--- a/apps/companion/native-spec/android/CompanionNativeBridgeServer.kt
+++ b/apps/companion/native-spec/android/CompanionNativeBridgeServer.kt
@@ -220,6 +220,7 @@ object CompanionNativeBridgeServer {
             "gmail" to listOf("com.google.android.gm"),
             "chrome" to listOf("com.android.chrome"),
             "termux" to listOf("com.termux"),
+            "termux_x11" to listOf("com.termux.x11"),
             "calendar" to listOf("com.google.android.calendar", "com.samsung.android.calendar"),
             "camera" to listOf("com.sec.android.app.camera", "com.google.android.GoogleCamera"),
             "messages" to listOf("com.google.android.apps.messaging", "com.samsung.android.messaging", "com.android.mms"),

--- a/apps/companion/native-spec/android/MainActivity.kt
+++ b/apps/companion/native-spec/android/MainActivity.kt
@@ -30,6 +30,7 @@ class MainActivity : FlutterActivity() {
         "gmail" to listOf("com.google.android.gm"),
         "chrome" to listOf("com.android.chrome"),
         "termux" to listOf("com.termux"),
+        "termux_x11" to listOf("com.termux.x11"),
         "calendar" to listOf("com.google.android.calendar", "com.samsung.android.calendar"),
         "camera" to listOf("com.sec.android.app.camera", "com.google.android.GoogleCamera"),
     )

--- a/tests/3dvr-desktop.test.js
+++ b/tests/3dvr-desktop.test.js
@@ -44,23 +44,61 @@ test('Linux fallback keeps panel, launcher, and terminal', () => {
   assert.match(launcher, /rofi -show drun/);
 });
 
-test('Termux install creates Android boot startup', () => {
+test('Termux install creates unlock-aware Android boot startup', () => {
   const install = read('3dvr-desktop/scripts/install-termux.sh');
   const boot = read('3dvr-desktop/scripts/termux-boot.sh');
+  const afterUnlock = read('3dvr-desktop/scripts/phone/start-after-unlock.sh');
 
   assert.match(install, /\.termux\/boot\/02-3dvr-desktop/);
   assert.match(install, /build-termux-shell\.sh/);
-  assert.match(boot, /TermuxActivity/);
   assert.match(boot, /3dvr agent start/);
-  assert.match(boot, /3dvr-desktop start/);
+  assert.match(boot, /start-after-unlock\.sh/);
+  assert.match(afterUnlock, /3dvr-desktop start/);
 });
 
-test('Termux activity launches use the Termux am compatibility wrapper', () => {
+test('Termux startup verifies a real X11 display before starting the shell', () => {
   const start = read('3dvr-desktop/scripts/start-termux.sh');
-  const boot = read('3dvr-desktop/scripts/termux-boot.sh');
-
+  assert.match(start, /\.X11-unix/);
+  assert.match(start, /xprop -root/);
+  assert.match(start, /Termux:X11 did not become ready/);
+  assert.match(start, /start-3dvr-shell-session/);
   assert.match(start, /\nam start .*com\.termux\.x11/);
-  assert.match(boot, /\nam start .*com\.termux\//);
   assert.doesNotMatch(start, /\/system\/bin\/am start/);
-  assert.doesNotMatch(boot, /\/system\/bin\/am start/);
+});
+
+test('Android boot waits for unlock and uses the Companion foreground handoff', () => {
+  const wait = read('3dvr-desktop/scripts/phone/await-android-ready.py');
+  assert.match(wait, /\/v1\/ui\/snapshot/);
+  assert.match(wait, /device locked/);
+  assert.match(wait, /\/v1\/open-app/);
+  assert.match(wait, /'alias': 'termux'/);
+  assert.match(wait, /'alias': 'termux_x11'/);
+});
+
+test('Termux doctor and probe make dependency failures observable', () => {
+  const cli = read('3dvr-desktop/bin/3dvr-desktop');
+  const doctor = read('3dvr-desktop/scripts/doctor-termux.sh');
+  const probe = read('3dvr-desktop/scripts/probe-termux-x11.sh');
+
+  assert.match(cli, /probe-x11/);
+  assert.match(doctor, /com\.termux\.x11/);
+  assert.match(doctor, /com\.termux\.boot/);
+  assert.match(doctor, /3DVR Companion bridge/);
+  assert.match(probe, /x11-probe\.log/);
+  assert.match(probe, /xprop -root/);
+});
+
+test('Companion keeps Termux:X11 as an explicit allow-listed Android target', () => {
+  const activity = read('apps/companion/native-spec/android/MainActivity.kt');
+  const bridge = read('apps/companion/native-spec/android/CompanionNativeBridgeServer.kt');
+  assert.match(activity, /"termux_x11" to listOf\("com\.termux\.x11"\)/);
+  assert.match(bridge, /"termux_x11" to listOf\("com\.termux\.x11"\)/);
+});
+
+test('desktop architecture and troubleshooting are checked in', () => {
+  const architecture = read('3dvr-desktop/ARCHITECTURE.md');
+  const troubleshooting = read('3dvr-desktop/TROUBLESHOOTING.md');
+  assert.match(architecture, /Source-of-truth rule/);
+  assert.match(troubleshooting, /probe-x11/);
+  assert.match(troubleshooting, /Android 16/);
 });


### PR DESCRIPTION
Makes the native 3DVR Desktop reproducible and recoverable after Android reboot.

- waits for first Android unlock through the paired 3DVR Companion
- keeps remote/agent services independent of graphical startup
- verifies a real X11 socket/root window before launching XFWM4 + 3dvr-shell
- adds `3dvr-desktop doctor` and isolated `probe-x11` diagnostics
- adds an allow-listed `termux_x11` Companion target
- documents architecture, source-of-truth rules, recovery, and the current Android 16 Termux:X11 investigation
- updates the public /3dvr-desktop/ page

Validation: 25 focused desktop/Companion tests pass; native `3dvr-shell` rebuild succeeds on ARM64 Termux. The live Android 16 phone currently isolates one dependency-layer failure: Termux:X11 exits 0 without creating an X display, while 3DVR/Companion/Boot checks pass.