### PR TITLE
Document ecosystem consolidation and restore Vercel headroom

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,4 +1,3 @@
 apps/agent/
 apps/companion/
 apps/computing/
-api/workboard/github.js

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The customer-facing portal remains at the repository root. Separately deployed/r
 
 Run `npm test` for the portal, `npm run test:agent` for the agent, or `npm run test:all` for both.
 
+## Current consolidation plan
+
+The ecosystem-wide simplification and shipping plan is tracked in [`docs/ecosystem-consolidation.md`](docs/ecosystem-consolidation.md). Its operating rule is simple: keep the public story clear, route users through a few strong intents, and move experiments behind stable core products.
+
 ## What is here now?
 
 - Portal Home and installable web apps

--- a/api/workboard/github.js
+++ b/api/workboard/github.js
@@ -1,6 +1,0 @@
-export {
-  __resetWorkboardGithubCacheForTests,
-  createWorkboardGithubHandler
-} from '../../src/workboard/github-feed.js';
-
-export { default } from '../../src/workboard/github-feed.js';

--- a/docs/ecosystem-consolidation.md
+++ b/docs/ecosystem-consolidation.md
@@ -1,0 +1,153 @@
+# 3DVR ecosystem consolidation
+
+Status: active
+
+Started: 2026-08-29
+
+## North star
+
+3DVR helps people build real things today, and uses that work to create open computing infrastructure everyone can own.
+
+The ecosystem is already broad enough. The current phase is consolidation: ship what exists, make the strongest paths obvious, reduce duplicate surfaces, and turn working experiments into dependable products.
+
+Operating rule: **Sell first. Build second. Keep it simple.**
+
+## Product map
+
+### Core
+
+These are the surfaces we should make dependable, easy to explain, and easy to find.
+
+- **3dvr.tech** — public commercial front door. Explain what 3DVR does, show proof, and convert visitors into customers or collaborators.
+- **Portal** — product shell and operating environment. Lead with user intent rather than an app catalog.
+- **3DVR OS** — open personal-computing product. Absorb proven ideas from experiments such as TommyOS.
+- **3DVR Calendar** — independently deployable calendar experience connected back into Portal identity and workflows.
+- **tmsteph.com** — public founder/builder identity, portfolio, field-work credibility, and open-source contribution proof.
+
+### Labs
+
+Labs can stay weird, experimental, and fast-moving. They should not compete with Core for first-time-user attention.
+
+Examples include TommyOS, AI Systems Lab, browser-computing experiments, character/universe work, hardware concepts, meditation/Three.js experiments, and research prototypes.
+
+A Lab graduates into Core when it has a clear user, a stable purpose, a maintained path, and evidence that people benefit from it.
+
+### Legacy
+
+Superseded repositories and old product directions should remain available as history but be clearly labeled and archived where appropriate.
+
+Known cleanup candidates include:
+
+- `3DVR-Website` → superseded by `3dvr-web`
+- `3dvr-website-build`
+- `3dvr-app`
+- `3dvr-react-app`
+- older browser/product forks that no longer represent the active path
+
+Legacy README files should point directly to the current project so visitors never have to guess which repository is alive.
+
+## Public experience
+
+### 3dvr.tech
+
+Keep the simple commercial promise: help people and small businesses actually launch.
+
+Next improvements:
+
+1. Add three strong case studies with screenshot, problem, what shipped, turnaround, and customer result.
+2. Reconcile pricing language across homepage and supporting pages.
+3. Upgrade thin supporting pages rather than adding more navigation destinations.
+4. Make the funding loop explicit: client work helps fund open tools for everyone.
+5. Surface a small amount of credible open-source proof without turning the customer homepage into a developer portfolio.
+
+### Portal
+
+The four user intents remain the front door:
+
+- Find my path
+- Make money
+- Build something
+- Open my stuff
+
+Individual apps are implementation details. Prefer routing through Operator and intent-driven flows over introducing additional top-level apps.
+
+Desired flow:
+
+**intent → guided action → saved project/data → useful outcome**
+
+A flagship example is Launch Room:
+
+**frustration → vision → movement → tiny project → actions → launch page**
+
+The next useful connection is:
+
+**Movement Brief → Project → Page → People → First Customer**
+
+## tmsteph.com
+
+The public root should increasingly behave as a clear founder/builder portfolio rather than exposing the entire personal command center at once.
+
+Suggested first-level story:
+
+- **Building** — 3DVR, open computing, software and hardware
+- **Open Source** — upstream contributions and contribution ledger
+- **Field Work** — AV, Broadway/touring, live production, and systems experience
+
+Keep personal tools and command-center experiments available one layer deeper.
+
+The open-source contribution ledger is high-value proof and should be easy to reach from the first screen.
+
+## Repository rules
+
+1. **New capability does not automatically mean new app.** Extend an existing user flow when that is simpler.
+2. **Core / Labs / Legacy must be obvious.** Names and README files should tell contributors where active work belongs.
+3. **Independent deployment is earned by a real boundary.** Calendar and OS are good candidates because they have distinct product surfaces. Tiny features should not become separate services by default.
+4. **Portal stays under its hosting budget.** On Vercel Hobby, keep root serverless endpoints at or below 12 until the hosting strategy changes.
+5. **Proof beats breadth.** Prefer finishing, screenshots, users, case studies, upstream merges, and reliability over another unfinished surface.
+
+## Immediate consolidation sprint
+
+### P0 — ship reliably
+
+- [x] Identify Portal production blocker: Vercel Hobby serverless-function ceiling.
+- [x] Confirm Portal root currently contains 13 deployable API entry files.
+- [x] Identify redundant Workboard endpoint already routed through shared `/api/session?route=workboard-github`.
+- [x] Remove that redundant serverless entry while preserving self-host/test imports.
+- [x] Add an automated serverless-function budget guard.
+- [ ] Verify a production deployment from current `main` reaches READY.
+
+### P1 — make the ecosystem legible
+
+- [ ] Add Core / Labs / Legacy guidance to relevant public/project indexes.
+- [ ] Label or archive superseded 3DVR repositories and point them to active replacements.
+- [ ] Canonize TommyOS as a research prototype and 3DVR OS as the product path.
+- [ ] Reduce Portal first-screen emphasis on individual tools; keep the four intents dominant.
+
+### P2 — increase proof and conversion
+
+- [ ] Publish three 3DVR client case studies.
+- [ ] Tighten supporting 3dvr.tech pages and pricing consistency.
+- [ ] Elevate tmsteph open-source contribution proof.
+- [ ] Make the commercial-to-open-source funding loop understandable in one sentence.
+
+## Definition of done for this phase
+
+This consolidation phase is successful when:
+
+- `main` can deploy repeatedly without manual rescue.
+- A new visitor can explain the relationship between 3dvr.tech, Portal, 3DVR OS, and tmsteph.com after one short visit.
+- Portal users can start from intent without understanding the internal app catalog.
+- Active repositories are clearly distinguishable from experiments and history.
+- The public sites show concrete proof: customers served, things shipped, and upstream contributions accepted.
+- New work is more often finishing or connecting an existing path than creating another disconnected surface.
+
+## Work log
+
+### 2026-08-29
+
+- Completed ecosystem audit across the main site, Portal, tmsteph, active repositories, and Vercel projects.
+- Confirmed the latest failed Portal production deployment exceeded the Hobby limit of 12 serverless functions.
+- Found 13 root API entry files in current source.
+- Found `/api/workboard/github` already rewritten to the shared session handler, making its standalone API file redundant for Vercel deployment.
+- Reduced Portal API entry files from 13 to 12 by removing the redundant Workboard deployment wrapper while keeping the shared implementation intact.
+- Added a deployment-budget regression test so future API growth fails locally/CI before it breaks production.

--- a/scripts/self-host-server.mjs
+++ b/scripts/self-host-server.mjs
@@ -2,7 +2,7 @@ import { createServer } from 'node:http';
 import { access, readFile, stat } from 'node:fs/promises';
 import { extname, join, normalize, resolve } from 'node:path';
 import openAiSiteHandler from '../api/openai-site.js';
-import workboardGithubHandler from '../api/workboard/github.js';
+import workboardGithubHandler from '../src/workboard/github-feed.js';
 import { createOAuthProviderHandler } from '../src/oauth/provider-api.js';
 
 const PORT = Number(process.env.PORT || 4320);

--- a/tests/vercel-function-budget.test.js
+++ b/tests/vercel-function-budget.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { relative } from 'node:path';
+import { test } from 'node:test';
+
+const API_ROOT = new URL('../api/', import.meta.url);
+const HOBBY_FUNCTION_LIMIT = 12;
+
+async function listApiEntries(dir = API_ROOT) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.name === '_lib') continue;
+    const child = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, dir);
+    if (entry.isDirectory()) files.push(...await listApiEntries(child));
+    else if (entry.isFile() && entry.name.endsWith('.js')) files.push(child);
+  }
+
+  return files;
+}
+
+test('Portal stays within the Vercel Hobby serverless function budget', async () => {
+  const entries = await listApiEntries();
+  const names = entries.map(url => relative(new URL('..', API_ROOT).pathname, url.pathname)).sort();
+
+  assert.ok(
+    entries.length <= HOBBY_FUNCTION_LIMIT,
+    `Portal has ${entries.length} API entry files; Vercel Hobby allows ${HOBBY_FUNCTION_LIMIT}.\n${names.join('\n')}`
+  );
+});
+
+test('Workboard GitHub feed uses the shared session function', async () => {
+  const vercelConfig = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'));
+  const rewrite = vercelConfig.rewrites.find(item => item.source === '/api/workboard/github');
+
+  assert.deepEqual(rewrite, {
+    source: '/api/workboard/github',
+    destination: '/api/session?route=workboard-github'
+  });
+});

--- a/tests/workboard-github-api.test.js
+++ b/tests/workboard-github-api.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
 
-import workboardGithubHandler, { __resetWorkboardGithubCacheForTests } from '../api/workboard/github.js';
+import workboardGithubHandler, { __resetWorkboardGithubCacheForTests } from '../src/workboard/github-feed.js';
 
 const originalFetch = globalThis.fetch;
 


### PR DESCRIPTION
## What changed
- add a living ecosystem consolidation plan covering Core / Labs / Legacy and the immediate shipping priorities
- link the plan from the Portal README
- remove the redundant `api/workboard/github.js` Vercel entrypoint while keeping the shared Workboard implementation in `src/workboard/github-feed.js`
- update self-host and tests to import that shared implementation directly
- add a regression test that keeps Portal at or below the Vercel Hobby 12-function ceiling and verifies the Workboard rewrite still routes through `/api/session`

## Why
The latest Portal production deployment was blocked because the project exposed 13 serverless API entry files while Vercel Hobby allows 12. Workboard was already rewritten through the shared session function, so its standalone wrapper was redundant.

This is the first implementation slice of the ecosystem audit: stabilize shipping first, then simplify the public/product hierarchy.

## Verification
- API entry count: 13 -> 12
- `node --test tests/vercel-function-budget.test.js tests/workboard-github-api.test.js tests/vercel-production-policy.test.js tests/vercel-main-only.test.js`
- 10 tests passed
- `node --check scripts/self-host-server.mjs`
- `node --check tests/vercel-function-budget.test.js`
- `git diff --check`

Stripe / billing behavior is unchanged.