### PR TITLE
Add delete action to calendar event details

### DIFF
--- a/calendar/calendar-v2.css
+++ b/calendar/calendar-v2.css
@@ -389,9 +389,19 @@ body {
 }
 
 .calendar-view__details-actions button,
-.calendar-view__details-edit {
+.calendar-view__details-edit,
+.calendar-view__details-delete {
   font-size: 0.82rem;
   padding: 7px 10px;
+}
+
+.calendar-view__details-delete {
+  border-color: rgba(239, 176, 176, 0.3);
+  color: var(--calendar-danger);
+}
+
+.calendar-view__details-delete:hover {
+  background: rgba(239, 176, 176, 0.12);
 }
 
 .calendar-view__details-list {

--- a/calendar/calendar.js
+++ b/calendar/calendar.js
@@ -1668,6 +1668,7 @@ function renderSelectedDayDetails() {
       if (item.normalized.provider === 'local' && canEditCalendar()) {
         const actions = document.createElement('div');
         actions.className = 'calendar-view__details-item-actions';
+
         const editButton = document.createElement('button');
         editButton.type = 'button';
         editButton.className = 'button-secondary calendar-view__details-edit';
@@ -1675,6 +1676,16 @@ function renderSelectedDayDetails() {
         editButton.dataset.eventId = item.raw.id;
         editButton.textContent = 'Edit';
         actions.appendChild(editButton);
+
+        const deleteButton = document.createElement('button');
+        deleteButton.type = 'button';
+        deleteButton.className = 'button-secondary calendar-view__details-delete';
+        deleteButton.dataset.action = 'delete-event';
+        deleteButton.dataset.eventId = item.raw.id;
+        deleteButton.setAttribute('aria-label', `Delete ${item.normalized.title}`);
+        deleteButton.textContent = 'Delete';
+        actions.appendChild(deleteButton);
+
         listItem.appendChild(actions);
       }
 
@@ -2542,6 +2553,15 @@ function updateLocalEvent(eventId, patch, options = {}) {
   writeLocalEvents(list, options);
 }
 
+function confirmAndDeleteEvent(id) {
+  if (!id || !canEditCalendar()) return;
+  const target = state.localEvents.find(event => event.id === id);
+  if (!target) return;
+  const title = typeof target.title === 'string' && target.title.trim() ? target.title.trim() : 'this event';
+  if (!window.confirm(`Delete “${title}”? This can’t be undone.`)) return;
+  deleteLocalEvent(id);
+}
+
 function deleteLocalEvent(id, options = {}) {
   if (!id) return;
   if (!canEditCalendar() && !options.skipGunSync) {
@@ -2697,17 +2717,22 @@ function handleEventListClick(event) {
   if (!deleteButton) return;
   const { eventId } = deleteButton.dataset;
   if (eventId) {
-    deleteLocalEvent(eventId);
+    confirmAndDeleteEvent(eventId);
   }
 }
 
 function handleCalendarDetailsClick(event) {
   const editButton = event.target.closest('button[data-action="edit-event"]');
-  if (!editButton) return;
-  const { eventId } = editButton.dataset;
-  if (eventId) {
-    openEventEditor(eventId);
+  if (editButton) {
+    const { eventId } = editButton.dataset;
+    if (eventId) openEventEditor(eventId);
+    return;
   }
+
+  const deleteButton = event.target.closest('button[data-action="delete-event"]');
+  if (!deleteButton) return;
+  const { eventId } = deleteButton.dataset;
+  if (eventId) confirmAndDeleteEvent(eventId);
 }
 
 async function handleCreateEvent(event) {

--- a/tests/calendar-ui.test.js
+++ b/tests/calendar-ui.test.js
@@ -52,6 +52,18 @@ test('calendar month cells show time ranges and useful event titles', async () =
   assert.match(css, /@media \(max-width: 760px\)[\s\S]*?\.calendar-view__event-time-compact\s*\{\s*display:\s*inline;/);
 });
 
+test('calendar selected-day details expose a confirmed delete action for local events', async () => {
+  const js = await readFile(new URL('../calendar/calendar.js', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../calendar/calendar-v2.css', import.meta.url), 'utf8');
+
+  assert.match(js, /deleteButton\.dataset\.action = 'delete-event'/);
+  assert.match(js, /deleteButton\.textContent = 'Delete'/);
+  assert.match(js, /function confirmAndDeleteEvent\(id\)/);
+  assert.match(js, /window\.confirm\(`/);
+  assert.match(js, /handleCalendarDetailsClick[\s\S]*?confirmAndDeleteEvent\(eventId\)/);
+  assert.match(css, /\.calendar-view__details-delete/);
+});
+
 test('calendar keeps event creation and advanced settings progressive', async () => {
   const html = await readFile(new URL('../calendar/index.html', import.meta.url), 'utf8');
   const js = await readFile(new URL('../calendar/calendar.js', import.meta.url), 'utf8');


### PR DESCRIPTION
Adds a clear Delete button beside Edit in the selected-day event details.

- confirms before deletion
- reuses the same confirmation from the expanded event list
- styles the destructive action clearly
- adds regression coverage

Tests: 14 calendar UI/layout/prefill tests pass.