### PR TITLE
Fix legacy Messenger history across browsers

### DIFF
--- a/chat/index.html
+++ b/chat/index.html
@@ -1073,7 +1073,36 @@ function loadRoom(roomName) {
     }
   };
 
-  roomStream.on(ingestMessage);
+  const legacyBackfillCandidates = new Map();
+  const durableMessageIds = new Set();
+  const legacyBackfillsInFlight = new Set();
+  const LEGACY_BACKFILL_MIN_AGE_MS = 30_000;
+
+  const ingestGunMessage = (message, id) => {
+    const normalizedId = normalizeMessageId(id);
+    const createdAt = Number(message?.createdAt) || 0;
+    const sender = typeof message?.sender === 'string' ? message.sender.trim() : '';
+    const text = typeof message?.text === 'string' ? message.text.trim() : '';
+    if (normalizedId && normalizedId !== '_latest' && sender && text && createdAt > 0 &&
+        createdAt <= Date.now() - LEGACY_BACKFILL_MIN_AGE_MS) {
+      legacyBackfillCandidates.set(normalizedId, { ...message, sender, text, createdAt });
+    }
+    ingestMessage(message, id);
+  };
+
+  const backfillLegacyMessages = () => {
+    if (roomName !== currentRoom) return;
+    legacyBackfillCandidates.forEach((message, messageId) => {
+      if (durableMessageIds.has(messageId) || legacyBackfillsInFlight.has(messageId)) return;
+      legacyBackfillsInFlight.add(messageId);
+      publishChatMessageToServer(roomName, messageId, message, { backfill: true })
+        .then(() => durableMessageIds.add(messageId))
+        .catch(error => console.warn('Legacy chat backfill failed; will retry', error))
+        .finally(() => legacyBackfillsInFlight.delete(messageId));
+    });
+  };
+
+  roomStream.on(ingestGunMessage);
 
   const followedMessageIds = new Set();
   const followMessageChain = (messageId, remaining = 50) => {
@@ -1082,7 +1111,7 @@ function loadRoom(roomName) {
     const messageNode = chat.get(messageId);
     messageNode.on(message => {
       if (!message || typeof message.text !== 'string' || !message.text.trim()) return;
-      ingestMessage(message, messageId);
+      ingestGunMessage(message, messageId);
       if (typeof messageNode.off === 'function') {
         messageNode.off();
       }
@@ -1097,7 +1126,7 @@ function loadRoom(roomName) {
       try {
         const recentMessages = JSON.parse(pointer.recent);
         if (Array.isArray(recentMessages)) {
-          recentMessages.forEach(entry => ingestMessage(entry?.message, entry?.id));
+          recentMessages.forEach(entry => ingestGunMessage(entry?.message, entry?.id));
         }
       } catch (error) {
         console.warn('Unable to reconcile recent chat messages', error);
@@ -1109,10 +1138,17 @@ function loadRoom(roomName) {
 
   const reconcileRoom = () => {
     if (roomName !== currentRoom) return;
-    chat.map().once(ingestMessage);
+    chat.map().once(ingestGunMessage);
     chat.get('_latest').once(ingestLatestPointer);
     syncChatMessagesFromServer(roomName)
-      .then(entries => entries.forEach(entry => ingestMessage(entry?.message, entry?.id)))
+      .then(entries => {
+        entries.forEach(entry => {
+          const messageId = normalizeMessageId(entry?.id);
+          if (messageId) durableMessageIds.add(messageId);
+          ingestMessage(entry?.message, entry?.id);
+        });
+        backfillLegacyMessages();
+      })
       .catch(error => console.warn('Durable chat sync unavailable; using GUN fallback', error));
   };
   currentRoomReconcile = reconcileRoom;
@@ -1200,14 +1236,15 @@ async function callChatMessageApi(action, payload = {}) {
   return response.json();
 }
 
-async function publishChatMessageToServer(room, messageId, message) {
+async function publishChatMessageToServer(room, messageId, message, { backfill = false } = {}) {
   return callChatMessageApi('publish', {
     room,
     messageId,
     senderId: message.sender,
     username: message.username,
     text: message.text,
-    createdAt: message.createdAt
+    createdAt: message.createdAt,
+    backfill: backfill === true
   });
 }
 

--- a/services/newsletter-store/chat-message-policy.mjs
+++ b/services/newsletter-store/chat-message-policy.mjs
@@ -1,0 +1,3 @@
+export function shouldNotifyForChatPublish(input = {}) {
+  return input.backfill !== true;
+}

--- a/services/newsletter-store/server.mjs
+++ b/services/newsletter-store/server.mjs
@@ -3,6 +3,7 @@ import http from 'node:http';
 import Gun from 'gun';
 import { Pool } from 'pg';
 import webpush from 'web-push';
+import { shouldNotifyForChatPublish } from './chat-message-policy.mjs';
 import { sendChatPushProof } from './chat-push-proof.mjs';
 
 const port = Number.parseInt(process.env.PORT || '8787', 10);
@@ -183,8 +184,11 @@ async function publishChatMessage(input) {
     ON CONFLICT (room, message_id) DO NOTHING
   `, [room, messageId, senderId, username || null, text, createdAt.toISOString()]);
 
-  if (rowCount === 1 && await claimChatMessage(room, messageId)) {
-    await sendChatNotifications({ room, messageId, senderId, username, text });
+  if (rowCount === 1) {
+    const claimed = await claimChatMessage(room, messageId);
+    if (claimed && shouldNotifyForChatPublish(input)) {
+      await sendChatNotifications({ room, messageId, senderId, username, text });
+    }
   }
 
   return listChatMessages({ room });

--- a/tests/chat-cross-browser.e2e.test.js
+++ b/tests/chat-cross-browser.e2e.test.js
@@ -22,7 +22,7 @@ async function waitForServer() {
   throw new Error('Chat test server did not start.');
 }
 
-async function openRandomRoom(browser, durableMessages) {
+async function openRandomRoom(browser, durableMessages, publishCalls = []) {
   const context = await browser.newContext({
     viewport: { width: 390, height: 844 },
     serviceWorkers: 'block'
@@ -37,6 +37,7 @@ async function openRandomRoom(browser, durableMessages) {
     }
     const body = request.postDataJSON();
     if (body.kind === 'chat-message' && body.action === 'publish') {
+      publishCalls.push(body);
       if (!durableMessages.some(entry => entry.id === body.messageId)) {
         durableMessages.push({
           id: body.messageId,
@@ -125,6 +126,54 @@ describe('Chat cross-browser delivery', () => {
     await waitForMessage(chromePage, message);
 
     assert.match(await chromePage.locator('.message').filter({ hasText: message }).first().textContent(), /Cross-browser sync test/);
+    await Promise.all([chromeContext.close(), firefoxContext.close()]);
+  });
+
+  it('backfills legacy cached history so a fresh browser can see it', async () => {
+    const durableMessages = [{
+      id: 'durable-baseline',
+      message: {
+        sender: 'server-user',
+        username: 'Server User',
+        text: 'Already durable',
+        createdAt: Date.now() - 180_000
+      }
+    }];
+    const publishCalls = [];
+    const { context: chromeContext, page: chromePage } =
+      await openRandomRoom(chromiumBrowser, durableMessages, publishCalls);
+    const legacyId = `legacy-cached-${Date.now()}`;
+    const legacyText = `Legacy cached history ${Date.now()}`;
+    const legacyMessage = {
+      sender: 'legacy-user',
+      username: 'Legacy User',
+      text: legacyText,
+      createdAt: Date.now() - 120_000
+    };
+
+    await chromePage.evaluate(({ messageId, message }) => new Promise(resolve => {
+      chat.get(messageId).put(message, () => resolve());
+    }), { messageId: legacyId, message: legacyMessage });
+
+    const deadline = Date.now() + 10_000;
+    while (!durableMessages.some(entry => entry.id === legacyId) && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    assert.ok(durableMessages.some(entry => entry.id === legacyId), 'legacy message was not backfilled');
+    const backfillCalls = publishCalls.filter(call => call.messageId === legacyId);
+    assert.equal(backfillCalls.length, 1);
+    assert.equal(backfillCalls[0].backfill, true);
+    assert.equal(publishCalls.some(call => call.messageId === 'durable-baseline'), false);
+
+    const { context: firefoxContext, page: firefoxPage } =
+      await openRandomRoom(firefoxBrowser, durableMessages);
+    await waitForMessage(firefoxPage, legacyText);
+
+    await new Promise(resolve => setTimeout(resolve, 1_500));
+    assert.equal(publishCalls.filter(call => call.messageId === legacyId).length, 1);
+    assert.equal(durableMessages.filter(entry => entry.id === legacyId).length, 1);
+
     await Promise.all([chromeContext.close(), firefoxContext.close()]);
   });
 

--- a/tests/chat-message-policy.test.js
+++ b/tests/chat-message-policy.test.js
@@ -1,0 +1,14 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldNotifyForChatPublish } from '../services/newsletter-store/chat-message-policy.mjs';
+
+describe('chat message publish policy', () => {
+  it('notifies for normal live publishes', () => {
+    assert.equal(shouldNotifyForChatPublish({}), true);
+    assert.equal(shouldNotifyForChatPublish({ backfill: false }), true);
+  });
+
+  it('suppresses notifications for legacy history backfills', () => {
+    assert.equal(shouldNotifyForChatPublish({ backfill: true }), false);
+  });
+});


### PR DESCRIPTION
Closes #1956.

Backfills legacy GUN/browser-cached messages into the durable chat store after reconciliation, preserving message IDs and timestamps. Backfill publishes are idempotent and silent: the server records their delivery claim without sending old-message push notifications.

Safety:
- does not clear or rewrite browser storage
- ignores messages newer than 30 seconds for migration
- keeps room/message IDs intact
- does not republish messages already returned by the durable store

Verification:
- focused chat/unit suite: 10/10 passed
- new Chromium -> durable store -> fresh Firefox legacy-history regression passed on Linux
- existing burst cross-browser regression passed when rerun independently