### PR TITLE
Fix chat E2E isolation from live Gun relay

### DIFF
--- a/gun-init.js
+++ b/gun-init.js
@@ -9,7 +9,11 @@
   const existingPeers = Array.isArray(global.__GUN_PEERS__)
     ? global.__GUN_PEERS__
     : [];
-  const mergedPeers = Array.from(new Set([...defaultPeers, ...existingPeers].filter(Boolean)))
+  const disableDefaultPeers = global.__DISABLE_GUN_DEFAULT_PEERS__ === true;
+  const mergedPeers = Array.from(new Set([
+    ...(disableDefaultPeers ? [] : defaultPeers),
+    ...existingPeers
+  ].filter(Boolean)))
     .filter(peer => !disabledPeers.has(peer));
   global.__GUN_PEERS__ = mergedPeers;
 

--- a/tests/chat-cross-browser.e2e.test.js
+++ b/tests/chat-cross-browser.e2e.test.js
@@ -28,6 +28,7 @@ async function openRandomRoom(browser, durableMessages, publishCalls = []) {
     serviceWorkers: 'block'
   });
   await context.addInitScript(() => {
+    window.__DISABLE_GUN_DEFAULT_PEERS__ = true;
     window.__GUN_PEERS__ = [];
   });
   await context.route('**/api/trial', async route => {

--- a/tests/gun-peer-config.test.js
+++ b/tests/gun-peer-config.test.js
@@ -40,6 +40,15 @@ describe('Gun peer configuration', () => {
     }
   });
 
+  it('lets isolated browser tests disable the default Gun relays', async () => {
+    const sharedInit = await read('gun-init.js');
+    const chatE2e = await read('tests/chat-cross-browser.e2e.test.js');
+
+    assert.match(sharedInit, /__DISABLE_GUN_DEFAULT_PEERS__/);
+    assert.match(sharedInit, /disableDefaultPeers \? \[\] : defaultPeers/);
+    assert.match(chatE2e, /__DISABLE_GUN_DEFAULT_PEERS__ = true/);
+  });
+
   it('does not let Chat try the dead relay before the working Fly relay', async () => {
     const source = await read('chat/index.html');
 


### PR DESCRIPTION
$## What changed\n- make the shared Gun initializer honor an explicit no-default-peers test flag\n- set that flag in the cross-browser chat E2E\n- add a regression check\n\n## Cleanup\n- leaked burst/sync/legacy test chat records were removed separately from the live Gun graph\n\n## Verification\n- `node --test tests/gun-peer-config.test.js`\n- initializer smoke check returns an empty peer list in isolated mode