### PR TITLE
Route paid Auto Business orders into fulfillment

### DIFF
--- a/api/webhooks/stripe.js
+++ b/api/webhooks/stripe.js
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer';
+import { dispatchPaidCheckout } from '../../src/money/fulfillment-router.js';
 import {
   BILLING_ACTIVE_STATUSES,
   getBillingPlan,
@@ -445,6 +446,26 @@ async function notifyTeamOfOneTimePayment(email, details = {}, { transporter, co
   }
 }
 
+async function notifyFulfillmentQueue(dispatch, { transporter, config } = {}) {
+  const order = dispatch?.order;
+  if (!order) return;
+  const gmailUser = String(config?.GMAIL_USER || '').trim();
+  const target = String(config?.AUTO_BUSINESS_OWNER_EMAIL || config?.STRIPE_LOG_EMAIL || gmailUser).trim();
+  if (!gmailUser || !target || !transporter?.sendMail) return;
+  const ticket = dispatch?.ticket || {};
+  const ticketLine = ticket.url ? `\nTask: ${ticket.url}` : `\nTask queue: ${ticket.status || 'unknown'}${ticket.reason ? ` — ${ticket.reason}` : ''}`;
+  try {
+    await sendMailSafely(transporter, {
+      from: `"3DVR Auto Business" <${gmailUser}>`,
+      to: target,
+      subject: `[FULFILLMENT:${order.lane}] ${order.offer} ${order.amount}`,
+      text: `${order.privateSummary}${ticketLine}`
+    });
+  } catch (error) {
+    console.error('Failed to notify fulfillment queue:', error?.message || error);
+  }
+}
+
 function readCheckoutPlan(session = {}) {
   const metadataPlan = normalizeBillingPlan(session?.metadata?.plan || session?.subscription_details?.metadata?.plan || '');
   if (metadataPlan && getBillingPlan(metadataPlan)?.kind === 'subscription') {
@@ -569,6 +590,7 @@ export function createStripeWebhookHandler(options = {}) {
     ? createTransporter(runtimeConfig)
     : options.transporter;
   const readRawBodyImpl = options.readRawBody || getRawBody;
+  const fulfillmentDispatcher = options.fulfillmentDispatcher || (event => dispatchPaidCheckout(event, { config: runtimeConfig, fetchImpl: options.fetchImpl || globalThis.fetch }));
   const constructEvent = options.constructEvent || ((payload, signature) => {
     if (!stripeClient?.webhooks?.constructEvent) {
       throw new Error('Stripe webhook verification is not configured.');
@@ -629,6 +651,14 @@ export function createStripeWebhookHandler(options = {}) {
       transporter,
       config: runtimeConfig
     });
+
+    if (['checkout.session.completed', 'checkout.session.async_payment_succeeded'].includes(event.type)) {
+      const fulfillment = await fulfillmentDispatcher(event);
+      if (fulfillment?.order) {
+        await notifyFulfillmentQueue(fulfillment, { transporter, config: runtimeConfig });
+        console.log('Auto Business fulfillment:', fulfillment.order.eventId, fulfillment.order.lane, fulfillment.ticket?.status);
+      }
+    }
 
     if (event.type === 'checkout.session.completed') {
       const session = event.data.object;

--- a/src/money/fulfillment-router.js
+++ b/src/money/fulfillment-router.js
@@ -1,0 +1,125 @@
+const OFFERS = new Set(['website-upgrade', 'automation-quick-win', 'business-sites']);
+const OWNER = /\b(legal|lawyer|tax|irs|refund|chargeback|bank transfer|wire transfer|password|credential|secret|api key|medical|hipaa|regulated)\b/i;
+const LOCAL = /\b(on[- ]?site|in person|physical install|mount|wiring|cabling|repair|delivery|moving|event setup|stagehand|hardware install|field service)\b/i;
+const CONTRACTOR = /\b(logo|graphic design|illustration|photography|video edit|3d model|3d modeling|cad|copywriting|translation|voiceover)\b/i;
+
+const clean = value => String(value || '').trim();
+const lower = value => clean(value).toLowerCase();
+
+function money(cents, code = 'usd') {
+  const amount = Number(cents || 0);
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency', currency: clean(code).toUpperCase() || 'USD'
+    }).format((Number.isFinite(amount) ? amount : 0) / 100);
+  } catch {
+    return `${((Number.isFinite(amount) ? amount : 0) / 100).toFixed(2)} USD`;
+  }
+}
+
+export function readCheckoutFieldMap(session = {}) {
+  return Object.fromEntries((Array.isArray(session.custom_fields) ? session.custom_fields : [])
+    .map(field => [clean(field?.key || field?.label?.custom), clean(field?.text?.value ?? field?.numeric?.value ?? field?.dropdown?.value)])
+    .filter(([key, value]) => key && value));
+}
+export function isAutoBusinessCheckout(session = {}) {
+  const metadata = session?.metadata && typeof session.metadata === 'object' ? session.metadata : {};
+  const offer = lower(metadata.offer || metadata.offer_id || metadata.custom_label);
+  const source = lower(metadata.source);
+  return OFFERS.has(offer) || source === 'autobusiness' || source === 'free-site-campaign';
+}
+
+export function chooseFulfillmentLane({ offer = '', fields = {}, metadata = {} } = {}) {
+  const text = [offer, ...Object.values(fields), metadata.custom_description, metadata.description].map(clean).join(' ');
+  if (OWNER.test(text)) return { lane: 'owner-review', reason: 'High-impact money, credential, legal, or regulated boundary.' };
+  if (LOCAL.test(text)) return { lane: 'local-worker', reason: 'Physical or on-site fulfillment appears necessary.' };
+  if (CONTRACTOR.test(text)) return { lane: 'contractor', reason: 'Specialist production work is better scoped to a contractor.' };
+  return { lane: 'agent', reason: 'Digital work defaults to agent-first fulfillment.' };
+}
+
+function checklist(lane) {
+  if (lane === 'local-worker') return ['Retrieve private Stripe intake.', 'Scope the local task and acceptance criteria.', 'Use approved marketplace/partner channels only.', 'Require approval before spend or booking.', 'Record delivery and margin.'];
+  if (lane === 'contractor') return ['Retrieve private Stripe intake.', 'Complete automatable prep first.', 'Scope only the remaining specialist work.', 'Require approval before contractor spend.', 'QA delivery and record margin.'];
+  if (lane === 'owner-review') return ['Retrieve private Stripe intake.', 'Prepare the high-impact decision without executing it.', 'Wait for owner approval.', 'Continue agent fulfillment after approval.', 'Record delivery and margin.'];
+  return ['Retrieve private Stripe intake.', 'Build the smallest working deliverable.', 'Use 3DVR agents/code before outsourcing.', 'Escalate only blocked specialist/physical/high-impact steps.', 'Deliver and record margin.'];
+}
+
+export function buildFulfillmentOrder(event = {}) {
+  const session = event?.data?.object || {};
+  if (!['checkout.session.completed', 'checkout.session.async_payment_succeeded'].includes(clean(event.type))) return null;
+  if (!isAutoBusinessCheckout(session)) return null;
+  const paymentStatus = lower(session.payment_status);
+  if (event.type === 'checkout.session.completed' && paymentStatus && !['paid', 'no_payment_required'].includes(paymentStatus)) return null;
+
+  const metadata = session?.metadata && typeof session.metadata === 'object' ? session.metadata : {};
+  const fields = readCheckoutFieldMap(session);
+  const offer = lower(metadata.offer || metadata.offer_id || metadata.custom_label) || 'autobusiness-order';
+  const route = chooseFulfillmentLane({ offer, fields, metadata });
+  const eventId = clean(event.id);
+  const sessionId = clean(session.id);
+  const marker = `3dvr-fulfillment:${eventId || sessionId}`;
+  const amount = money(session.amount_total, session.currency);
+  const laneSteps = checklist(route.lane);
+  const publicBody = [
+    `<!-- ${marker} -->`, '## Paid fulfillment order', '',
+    `- **Offer:** ${offer}`, `- **Amount:** ${amount}`,
+    `- **Routing lane:** ${route.lane}`, `- **Why:** ${route.reason}`,
+    `- **Stripe event:** ${eventId || 'unknown'}`, `- **Checkout session:** ${sessionId || 'unknown'}`,
+    '', '> Customer identity and checkout intake stay private in Stripe/email.', '',
+    '## Fulfillment checklist', ...laneSteps.map(item => `- [ ] ${item}`), '',
+    '## Close the loop', '- [ ] Customer received the result', '- [ ] Revenue, direct spend, and gross margin recorded',
+    '- [ ] Reusable automation/template extracted', '- [ ] Decide: kill, keep, or scale'
+  ].join('\n');
+  const customerEmail = lower(session.customer_details?.email || session.customer_email || metadata.billing_email);
+  const intake = Object.entries(fields).map(([key, value]) => `${key}: ${value}`).join('\n');
+  const privateSummary = [`Paid Auto Business order: ${offer}`, `Route: ${route.lane} — ${route.reason}`,
+    `Amount: ${amount}`, `Stripe event: ${eventId || 'unknown'}`, `Checkout session: ${sessionId || 'unknown'}`,
+    customerEmail ? `Email: ${customerEmail}` : '', intake ? `\nIntake:\n${intake}` : '', `\nNext: ${laneSteps[0]}`].filter(Boolean).join('\n');
+  return {
+    marker, offer, lane: route.lane, routeReason: route.reason, amount,
+    eventId, sessionId, customerEmail, fields, privateSummary,
+    safeTitle: `[Fulfillment:${route.lane}] ${offer.replace(/[-_]+/g, ' ')} — ${amount}`,
+    publicBody
+  };
+}
+
+function githubSettings(config = process.env) {
+  const token = clean(config.AUTO_BUSINESS_FULFILLMENT_GITHUB_TOKEN || config.MONEY_AUTOPILOT_GH_TOKEN || config.GITHUB_TOKEN || config.GH_PAT);
+  const repository = clean(config.AUTO_BUSINESS_FULFILLMENT_REPO || config.GITHUB_REPOSITORY
+    || (config.GITHUB_OWNER && config.GITHUB_REPO ? `${config.GITHUB_OWNER}/${config.GITHUB_REPO}` : '')) || 'tmsteph/3dvr-portal';
+  return { token, repository };
+}
+
+async function githubJson(fetchImpl, url, token, options = {}) {
+  const response = await fetchImpl(url, { ...options, headers: {
+    Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28',
+    Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...(options.headers || {})
+  }});
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(`GitHub fulfillment request failed (${response.status}): ${payload?.message || 'unknown error'}`);
+  return payload;
+}
+
+export async function createOrFindFulfillmentIssue(order, { config = process.env, fetchImpl = globalThis.fetch } = {}) {
+  if (!order) return { status: 'skipped' };
+  const { token, repository } = githubSettings(config);
+  if (!token || typeof fetchImpl !== 'function') return { status: 'private-queue-only', repository, reason: 'GitHub write token is not configured' };
+  const query = encodeURIComponent(`repo:${repository} is:issue in:body \"${order.marker}\"`);
+  const search = await githubJson(fetchImpl, `https://api.github.com/search/issues?q=${query}`, token);
+  const existing = Array.isArray(search.items) ? search.items[0] : null;
+  if (existing) return { status: 'existing', repository, issueNumber: existing.number, url: existing.html_url || '' };
+  const created = await githubJson(fetchImpl, `https://api.github.com/repos/${repository}/issues`, token, {
+    method: 'POST', body: JSON.stringify({ title: order.safeTitle, body: order.publicBody })
+  });
+  return { status: 'created', repository, issueNumber: created.number, url: created.html_url || '' };
+}
+
+export async function dispatchPaidCheckout(event, options = {}) {
+  const order = buildFulfillmentOrder(event);
+  if (!order) return { order: null, ticket: { status: 'skipped' } };
+  try {
+    return { order, ticket: await createOrFindFulfillmentIssue(order, options) };
+  } catch (error) {
+    return { order, ticket: { status: 'error', reason: error?.message || String(error) } };
+  }
+}

--- a/tests/fulfillment-router.test.js
+++ b/tests/fulfillment-router.test.js
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildFulfillmentOrder,
+  chooseFulfillmentLane,
+  createOrFindFulfillmentIssue
+} from '../src/money/fulfillment-router.js';
+
+function checkoutEvent(overrides = {}) {
+  return {
+    id: 'evt_auto_1',
+    type: 'checkout.session.completed',
+    data: { object: {
+      id: 'cs_auto_1', mode: 'payment', payment_status: 'paid',
+      amount_total: 29900, currency: 'usd', payment_link: 'plink_auto',
+      customer_details: { email: 'private@example.com' },
+      metadata: { offer: 'automation-quick-win', source: 'autobusiness' },
+      custom_fields: [{ key: 'problem', type: 'text', text: { value: 'Automate lead follow-up' } }],
+      ...overrides
+    }}
+  };
+}
+
+test('paid Auto Business checkout becomes a privacy-safe agent task', () => {
+  const order = buildFulfillmentOrder(checkoutEvent());
+  assert.equal(order.lane, 'agent');
+  assert.equal(order.offer, 'automation-quick-win');
+  assert.match(order.privateSummary, /private@example\.com/);
+  assert.doesNotMatch(order.publicBody, /private@example\.com/);
+  assert.doesNotMatch(order.publicBody, /Automate lead follow-up/);
+});
+test('routing escalates physical, specialist, and high-impact work', () => {
+  assert.equal(chooseFulfillmentLane({ fields: { problem: 'Need on-site hardware install' } }).lane, 'local-worker');
+  assert.equal(chooseFulfillmentLane({ fields: { problem: 'Need a CAD model' } }).lane, 'contractor');
+  assert.equal(chooseFulfillmentLane({ fields: { problem: 'Need bank transfer automation' } }).lane, 'owner-review');
+});
+
+test('unpaid checkout does not start fulfillment', () => {
+  const event = checkoutEvent({ payment_status: 'unpaid' });
+  assert.equal(buildFulfillmentOrder(event), null);
+});
+
+test('async payment success starts fulfillment', () => {
+  const event = checkoutEvent({ payment_status: 'paid' });
+  event.type = 'checkout.session.async_payment_succeeded';
+  assert.equal(buildFulfillmentOrder(event).lane, 'agent');
+});
+
+test('GitHub task creation is idempotent by Stripe event marker', async () => {
+  const order = buildFulfillmentOrder(checkoutEvent());
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url, options });
+    return { ok: true, json: async () => ({ items: [{ number: 42, html_url: 'https://github.com/tmsteph/3dvr-portal/issues/42' }] }) };
+  };
+  const ticket = await createOrFindFulfillmentIssue(order, { config: { GITHUB_TOKEN: 'test', GITHUB_REPOSITORY: 'tmsteph/3dvr-portal' }, fetchImpl });
+  assert.equal(ticket.status, 'existing');
+  assert.equal(ticket.issueNumber, 42);
+  assert.equal(calls.length, 1);
+});
+test('GitHub task body contains no private checkout fields', async () => {
+  const order = buildFulfillmentOrder(checkoutEvent());
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url, options });
+    if (String(url).includes('/search/issues')) return { ok: true, json: async () => ({ items: [] }) };
+    return { ok: true, json: async () => ({ number: 77, html_url: 'https://github.com/tmsteph/3dvr-portal/issues/77' }) };
+  };
+  const ticket = await createOrFindFulfillmentIssue(order, {
+    config: { GITHUB_TOKEN: 'test', GITHUB_REPOSITORY: 'tmsteph/3dvr-portal' }, fetchImpl
+  });
+  assert.equal(ticket.status, 'created');
+  const createdBody = JSON.parse(calls[1].options.body);
+  assert.match(createdBody.body, /3dvr-fulfillment:evt_auto_1/);
+  assert.doesNotMatch(createdBody.body, /private@example\.com|Automate lead follow-up/);
+});

--- a/tests/stripe-webhook-cleanup.test.js
+++ b/tests/stripe-webhook-cleanup.test.js
@@ -707,3 +707,37 @@ test('stripe webhook does not email on later automatic retry failures', async ()
   assert.equal(res.statusCode, 200);
   assert.equal(transporter.sendMail.mock.calls.length, 0);
 });
+test('stripe webhook dispatches paid Auto Business fulfillment and queues a private handoff', async () => {
+  const transporter = { sendMail: mock.fn(async payload => payload) };
+  const fulfillmentDispatcher = mock.fn(async () => ({
+    order: {
+      eventId: 'evt_autobusiness_paid', lane: 'agent', offer: 'automation-quick-win', amount: '$299.00',
+      privateSummary: 'Paid order\nPrivate intake stays here.'
+    },
+    ticket: { status: 'created', url: 'https://github.com/tmsteph/3dvr-portal/issues/2000' }
+  }));
+  const handler = createStripeWebhookHandler({
+    stripeClient: createStripeState().stripe,
+    config: { ...baseConfig, GMAIL_USER: 'billing@3dvr.tech', STRIPE_LOG_EMAIL: '' },
+    transporter, fulfillmentDispatcher,
+    readRawBody: async () => Buffer.from('{}'),
+    constructEvent: () => ({
+      id: 'evt_autobusiness_paid', type: 'checkout.session.completed', created: 1700000000,
+      data: { object: {
+        id: 'cs_autobusiness_paid', mode: 'payment', payment_status: 'paid', amount_total: 29900, currency: 'usd',
+        customer_details: {}, metadata: { offer: 'automation-quick-win', source: 'autobusiness' }
+      }}
+    })
+  });
+  const req = { method: 'POST', headers: { 'stripe-signature': 'sig_test' } };
+  const res = createMockRes();
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(fulfillmentDispatcher.mock.calls.length, 1);
+  assert.equal(transporter.sendMail.mock.calls.length, 1);
+  const handoff = transporter.sendMail.mock.calls[0].arguments[0];
+  assert.equal(handoff.to, 'billing@3dvr.tech');
+  assert.equal(handoff.subject, '[FULFILLMENT:agent] automation-quick-win $299.00');
+  assert.match(handoff.text, /Private intake stays here/);
+  assert.match(handoff.text, /issues\/2000/);
+});


### PR DESCRIPTION
## What changed
- Detect paid Auto Business Stripe checkouts for website upgrade / automation quick win / business-sites
- Route each order to agent, contractor, local-worker, or owner-review based on the work
- Create an idempotent GitHub fulfillment issue when a server-side GitHub token is available
- Keep customer identity and checkout intake out of public GitHub issues
- Send the private intake/routing handoff to the configured owner/Stripe log inbox
- Handle async payment success without starting work on an unpaid checkout

## Guardrails
- Agent-first for digital work
- Human approval required before contractor/local-worker spend
- Marketplace workers stay on approved platform/partner channels
- High-impact money/legal/credential work routes to owner review

## Tests
`node --test tests/fulfillment-router.test.js tests/stripe-webhook-cleanup.test.js` — 14/14 passing on the 3DVR server.