### PR TITLE
Add multi-account Google connector core

### DIFF
--- a/apps/agent/connectors/accounts/registry.js
+++ b/apps/agent/connectors/accounts/registry.js
@@ -1,0 +1,159 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function normalizeProvider(value) {
+  const provider = normalizeText(value).toLowerCase();
+  if (provider === 'gmail') return 'google';
+  return provider;
+}
+
+function normalizeAlias(value) {
+  const alias = normalizeText(value).toLowerCase();
+  if (!alias) throw new Error('Account alias is required.');
+  if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(alias)) {
+    throw new Error('Account alias may contain letters, numbers, dots, underscores, and hyphens.');
+  }
+  return alias;
+}
+
+function normalizeEmail(value) {
+  const email = normalizeText(value).toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw new Error('A valid account email is required.');
+  }
+  return email;
+}
+
+function defaultRegistryPath() {
+  return process.env.THREEDVR_CONNECTOR_ACCOUNTS_FILE
+    || path.join(os.homedir(), '.3dvr', 'connectors', 'accounts.json');
+}
+
+function readStore(filePath = defaultRegistryPath()) {
+  try {
+    if (!fs.existsSync(filePath)) return { version: 1, accounts: {} };
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return {
+      version: 1,
+      accounts: parsed && typeof parsed.accounts === 'object' ? parsed.accounts : {},
+    };
+  } catch {
+    return { version: 1, accounts: {} };
+  }
+}
+
+function writeStore(store, filePath = defaultRegistryPath()) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const payload = {
+    version: 1,
+    accounts: store.accounts || {},
+    updatedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Some Android/Termux filesystems ignore chmod.
+  }
+}
+
+function makeAccountId(provider) {
+  const suffix = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+  return `acct_${normalizeProvider(provider)}_${suffix}`;
+}
+
+function normalizeScopes(scopes) {
+  return [...new Set((Array.isArray(scopes) ? scopes : [])
+    .map((scope) => normalizeText(scope))
+    .filter(Boolean))].sort();
+}
+
+function sanitizeAccount(account) {
+  if (!account) return null;
+  return {
+    id: account.id,
+    provider: account.provider,
+    alias: account.alias,
+    email: account.email,
+    scopes: [...(account.scopes || [])],
+    status: account.status || 'connected',
+    credentialRef: account.credentialRef || '',
+    createdAt: account.createdAt || '',
+    updatedAt: account.updatedAt || '',
+  };
+}
+
+function listAccounts({ provider, filePath } = {}) {
+  const store = readStore(filePath);
+  const normalizedProvider = provider ? normalizeProvider(provider) : '';
+  return Object.values(store.accounts)
+    .filter((account) => !normalizedProvider || account.provider === normalizedProvider)
+    .map(sanitizeAccount)
+    .sort((a, b) => a.alias.localeCompare(b.alias));
+}
+
+function getAccount(identifier, { provider, filePath } = {}) {
+  const wanted = normalizeText(identifier).toLowerCase();
+  if (!wanted) throw new Error('Account id or alias is required.');
+  const normalizedProvider = provider ? normalizeProvider(provider) : '';
+  const account = listAccounts({ provider: normalizedProvider, filePath }).find((candidate) => (
+    candidate.id.toLowerCase() === wanted || candidate.alias === wanted
+  ));
+  if (!account) throw new Error(`Connector account not found: ${identifier}`);
+  return account;
+}
+
+function upsertAccount(input, { filePath } = {}) {
+  const provider = normalizeProvider(input?.provider || 'google');
+  const alias = normalizeAlias(input?.alias);
+  const email = normalizeEmail(input?.email);
+  const store = readStore(filePath);
+  const existing = Object.values(store.accounts).find((account) => (
+    account.id === input?.id
+    || (account.provider === provider && account.email === email)
+    || (account.provider === provider && account.alias === alias)
+  ));
+
+  for (const account of Object.values(store.accounts)) {
+    if (existing && account.id === existing.id) continue;
+    if (account.provider === provider && account.alias === alias) {
+      throw new Error(`Account alias already exists for ${provider}: ${alias}`);
+    }
+    if (account.provider === provider && account.email === email) {
+      throw new Error(`Account email already exists for ${provider}: ${email}`);
+    }
+  }
+
+  const now = new Date().toISOString();
+  const account = {
+    id: existing?.id || input?.id || makeAccountId(provider),
+    provider,
+    alias,
+    email,
+    scopes: normalizeScopes(input?.scopes ?? existing?.scopes),
+    status: normalizeText(input?.status || existing?.status || 'connected').toLowerCase(),
+    credentialRef: normalizeText(input?.credentialRef ?? existing?.credentialRef),
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+  };
+  store.accounts[account.id] = account;
+  writeStore(store, filePath);
+  return sanitizeAccount(account);
+}
+
+module.exports = {
+  defaultRegistryPath,
+  getAccount,
+  listAccounts,
+  makeAccountId,
+  normalizeAlias,
+  normalizeEmail,
+  normalizeProvider,
+  upsertAccount,
+};

--- a/apps/agent/connectors/google/gmail.js
+++ b/apps/agent/connectors/google/gmail.js
@@ -1,0 +1,129 @@
+const { getGoogleAccessToken } = require('./oauth');
+
+const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function requireAccount(identifier) {
+  const value = normalizeText(identifier);
+  if (!value) throw new Error('accountId is required for Gmail actions.');
+  return value;
+}
+
+function headerValue(value, field) {
+  const text = normalizeText(value);
+  if (!text) throw new Error(`${field} is required.`);
+  if (/\r|\n/.test(text)) throw new Error(`${field} contains invalid newline characters.`);
+  return text;
+}
+
+function base64Url(value) {
+  return Buffer.from(value, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function buildRawMessage({ from, to, subject, body }) {
+  const headers = [
+    `From: ${headerValue(from, 'from')}`,
+    `To: ${headerValue(to, 'to')}`,
+    `Subject: ${headerValue(subject, 'subject')}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset=UTF-8',
+    'Content-Transfer-Encoding: 8bit',
+  ];
+  return base64Url(`${headers.join('\r\n')}\r\n\r\n${String(body || '')}`);
+}
+
+async function authorizedRequest(accountId, url, request = {}, options = {}) {
+  const identifier = requireAccount(accountId);
+  const tokenResolver = options.tokenResolver || getGoogleAccessToken;
+  const fetchImpl = options.fetchImpl || fetch;
+  const tokenOptions = options.tokenOptions || options;
+  const { account, accessToken } = await tokenResolver(identifier, tokenOptions);
+  const response = await fetchImpl(url, {
+    ...request,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      ...(request.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(request.headers || {}),
+    },
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload?.error?.message || payload?.error || `Gmail API request failed: ${response.status}`);
+  }
+  return { account, payload };
+}
+
+async function searchMessages({ accountId, query = '', maxResults = 25 } = {}, options = {}) {
+  const params = new URLSearchParams();
+  if (normalizeText(query)) params.set('q', normalizeText(query));
+  params.set('maxResults', String(Math.min(100, Math.max(1, Number(maxResults) || 25))));
+  const { account, payload } = await authorizedRequest(
+    accountId,
+    `${GMAIL_API_BASE}/messages?${params.toString()}`,
+    {},
+    options,
+  );
+  return {
+    account,
+    messages: Array.isArray(payload.messages) ? payload.messages : [],
+    nextPageToken: payload.nextPageToken || '',
+    resultSizeEstimate: Number(payload.resultSizeEstimate) || 0,
+  };
+}
+
+async function readMessage({ accountId, messageId, format = 'full' } = {}, options = {}) {
+  const id = encodeURIComponent(headerValue(messageId, 'messageId'));
+  const allowedFormats = new Set(['minimal', 'full', 'raw', 'metadata']);
+  const resolvedFormat = allowedFormats.has(format) ? format : 'full';
+  const { account, payload } = await authorizedRequest(
+    accountId,
+    `${GMAIL_API_BASE}/messages/${id}?format=${encodeURIComponent(resolvedFormat)}`,
+    {},
+    options,
+  );
+  return { account, message: payload };
+}
+
+async function createDraft({ accountId, to, subject, body, threadId } = {}, options = {}) {
+  const identifier = requireAccount(accountId);
+  const tokenResolver = options.tokenResolver || getGoogleAccessToken;
+  const tokenOptions = options.tokenOptions || options;
+  const auth = await tokenResolver(identifier, tokenOptions);
+  const raw = buildRawMessage({
+    from: auth.account.email,
+    to,
+    subject,
+    body,
+  });
+  const message = { raw };
+  if (normalizeText(threadId)) message.threadId = normalizeText(threadId);
+
+  const fetchImpl = options.fetchImpl || fetch;
+  const response = await fetchImpl(`${GMAIL_API_BASE}/drafts`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ message }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload?.error?.message || payload?.error || `Unable to create Gmail draft: ${response.status}`);
+  }
+  return { account: auth.account, draft: payload };
+}
+
+module.exports = {
+  buildRawMessage,
+  createDraft,
+  readMessage,
+  searchMessages,
+};

--- a/apps/agent/connectors/google/oauth-vault.js
+++ b/apps/agent/connectors/google/oauth-vault.js
@@ -1,0 +1,146 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function defaultVaultPath() {
+  return process.env.THREEDVR_CONNECTOR_GOOGLE_VAULT_FILE
+    || path.join(os.homedir(), '.3dvr', 'connectors', 'google-oauth.enc.json');
+}
+
+function masterKeyMaterial(explicit) {
+  const value = normalizeText(explicit || process.env.THREEDVR_CONNECTOR_MASTER_KEY);
+  if (!value) {
+    throw new Error('THREEDVR_CONNECTOR_MASTER_KEY is required for connector credential storage.');
+  }
+  return value;
+}
+
+function deriveKey(keyMaterial) {
+  return crypto.createHash('sha256').update(masterKeyMaterial(keyMaterial), 'utf8').digest();
+}
+
+function readStore(filePath = defaultVaultPath()) {
+  try {
+    if (!fs.existsSync(filePath)) return { version: 1, secrets: {} };
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return {
+      version: 1,
+      secrets: parsed && typeof parsed.secrets === 'object' ? parsed.secrets : {},
+    };
+  } catch {
+    return { version: 1, secrets: {} };
+  }
+}
+
+function writeStore(store, filePath = defaultVaultPath()) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify({
+    version: 1,
+    secrets: store.secrets || {},
+    updatedAt: new Date().toISOString(),
+  }, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Some Android/Termux filesystems ignore chmod.
+  }
+}
+
+function credentialRef(accountId) {
+  const id = normalizeText(accountId);
+  if (!/^acct_google_[a-z0-9]+$/i.test(id)) {
+    throw new Error('A valid Google connector account id is required.');
+  }
+  return `google-oauth:${id}`;
+}
+
+function encrypt(value, ref, keyMaterial) {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', deriveKey(keyMaterial), iv);
+  cipher.setAAD(Buffer.from(ref, 'utf8'));
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(value), 'utf8'),
+    cipher.final(),
+  ]);
+  return {
+    algorithm: 'aes-256-gcm',
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    ciphertext: ciphertext.toString('base64'),
+  };
+}
+
+function decrypt(record, ref, keyMaterial) {
+  if (!record || record.algorithm !== 'aes-256-gcm') {
+    throw new Error(`Unsupported or missing credential record: ${ref}`);
+  }
+  const decipher = crypto.createDecipheriv(
+    'aes-256-gcm',
+    deriveKey(keyMaterial),
+    Buffer.from(record.iv, 'base64'),
+  );
+  decipher.setAAD(Buffer.from(ref, 'utf8'));
+  decipher.setAuthTag(Buffer.from(record.tag, 'base64'));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(record.ciphertext, 'base64')),
+    decipher.final(),
+  ]).toString('utf8');
+  return JSON.parse(plaintext);
+}
+
+function normalizeCredential(input = {}) {
+  const refreshToken = normalizeText(input.refreshToken || input.refresh_token);
+  if (!refreshToken) throw new Error('Google OAuth refresh token is required.');
+  return {
+    accessToken: normalizeText(input.accessToken || input.access_token),
+    refreshToken,
+    scope: normalizeText(input.scope),
+    scopeKey: normalizeText(input.scopeKey || input.scope_key || 'mail').toLowerCase() || 'mail',
+    expiresAt: Math.max(0, Number(input.expiresAt || input.expires_at) || 0),
+    updatedAt: Date.now(),
+  };
+}
+
+function saveGoogleCredential(accountId, input, { filePath, keyMaterial } = {}) {
+  const ref = credentialRef(accountId);
+  const credential = normalizeCredential(input);
+  const store = readStore(filePath);
+  store.secrets[ref] = {
+    ...encrypt(credential, ref, keyMaterial),
+    updatedAt: new Date().toISOString(),
+  };
+  writeStore(store, filePath);
+  return ref;
+}
+
+function loadGoogleCredential(refOrAccountId, { filePath, keyMaterial } = {}) {
+  const ref = normalizeText(refOrAccountId).startsWith('google-oauth:')
+    ? normalizeText(refOrAccountId)
+    : credentialRef(refOrAccountId);
+  const store = readStore(filePath);
+  const record = store.secrets[ref];
+  if (!record) throw new Error(`Google OAuth credential not found: ${ref}`);
+  return normalizeCredential(decrypt(record, ref, keyMaterial));
+}
+
+function removeGoogleCredential(refOrAccountId, { filePath } = {}) {
+  const ref = normalizeText(refOrAccountId).startsWith('google-oauth:')
+    ? normalizeText(refOrAccountId)
+    : credentialRef(refOrAccountId);
+  const store = readStore(filePath);
+  delete store.secrets[ref];
+  writeStore(store, filePath);
+}
+
+module.exports = {
+  credentialRef,
+  defaultVaultPath,
+  loadGoogleCredential,
+  removeGoogleCredential,
+  saveGoogleCredential,
+};

--- a/apps/agent/connectors/google/oauth.js
+++ b/apps/agent/connectors/google/oauth.js
@@ -1,0 +1,121 @@
+const {
+  getAccount,
+  upsertAccount,
+} = require('../accounts/registry');
+const {
+  loadGoogleCredential,
+  saveGoogleCredential,
+} = require('./oauth-vault');
+
+const DEFAULT_PORTAL_URL = 'https://portal.3dvr.tech';
+const TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000;
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function refreshEndpoint() {
+  const explicit = normalizeText(process.env.THREEDVR_OAUTH_REFRESH_ENDPOINT);
+  if (explicit) return explicit;
+  const portalUrl = normalizeText(process.env.THREEDVR_PORTAL_URL) || DEFAULT_PORTAL_URL;
+  return `${portalUrl.replace(/\/+$/, '')}/api/oauth/google`;
+}
+
+function registerGoogleAccount(input, options = {}) {
+  const pending = upsertAccount({
+    id: input?.id,
+    provider: 'google',
+    alias: input?.alias,
+    email: input?.email,
+    scopes: input?.scopes,
+    status: 'pending_credentials',
+  }, { filePath: options.registryFilePath });
+
+  const credentialRef = saveGoogleCredential(pending.id, input, {
+    filePath: options.vaultFilePath,
+    keyMaterial: options.keyMaterial,
+  });
+
+  return upsertAccount({
+    ...pending,
+    status: 'connected',
+    credentialRef,
+  }, { filePath: options.registryFilePath });
+}
+
+function resolveGoogleAccount(identifier, options = {}) {
+  const account = getAccount(identifier, {
+    provider: 'google',
+    filePath: options.registryFilePath,
+  });
+  if (!account.credentialRef) {
+    throw new Error(`Google account has no credential reference: ${account.id}`);
+  }
+  return account;
+}
+
+function loadGoogleAccountCredential(identifier, options = {}) {
+  const account = resolveGoogleAccount(identifier, options);
+  const credential = loadGoogleCredential(account.credentialRef, {
+    filePath: options.vaultFilePath,
+    keyMaterial: options.keyMaterial,
+  });
+  return { account, credential };
+}
+
+async function refreshGoogleCredential(account, credential, options = {}) {
+  const fetchImpl = options.fetchImpl || fetch;
+  const response = await fetchImpl(refreshEndpoint(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      action: 'refresh',
+      refreshToken: credential.refreshToken,
+      scopeKey: credential.scopeKey || 'mail',
+    }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload?.error || `Unable to refresh Google OAuth token: ${response.status}`);
+  }
+
+  const updated = {
+    ...credential,
+    accessToken: payload.accessToken,
+    refreshToken: payload.refreshToken || credential.refreshToken,
+    scope: payload.scope || credential.scope,
+    scopeKey: payload.scopeKey || credential.scopeKey,
+    expiresAt: payload.expiresAt || 0,
+  };
+  saveGoogleCredential(account.id, updated, {
+    filePath: options.vaultFilePath,
+    keyMaterial: options.keyMaterial,
+  });
+  return updated;
+}
+
+async function getGoogleAccessToken(identifier, options = {}) {
+  const { account, credential } = loadGoogleAccountCredential(identifier, options);
+  const now = Number(options.now || Date.now());
+  let current = credential;
+  if (!current.accessToken || (current.expiresAt && current.expiresAt <= now + TOKEN_REFRESH_SKEW_MS)) {
+    current = await refreshGoogleCredential(account, current, options);
+  }
+  if (!current.accessToken) {
+    throw new Error(`Google OAuth access token unavailable for ${account.alias}.`);
+  }
+  return {
+    account,
+    accessToken: current.accessToken,
+  };
+}
+
+module.exports = {
+  getGoogleAccessToken,
+  loadGoogleAccountCredential,
+  refreshGoogleCredential,
+  registerGoogleAccount,
+  resolveGoogleAccount,
+};

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -9,7 +9,8 @@
   "files": [
     "README.md",
     "install.sh",
-    "thomas-agent"
+    "thomas-agent",
+    "connectors"
   ],
   "engines": {
     "node": ">=22.13"

--- a/apps/agent/test/connectors-google.test.js
+++ b/apps/agent/test/connectors-google.test.js
@@ -33,6 +33,17 @@ function fixturePaths() {
   };
 }
 
+function registryOptions(options) {
+  return { filePath: options.registryFilePath };
+}
+
+function vaultOptions(options) {
+  return {
+    filePath: options.vaultFilePath,
+    keyMaterial: options.keyMaterial,
+  };
+}
+
 function futureExpiry() {
   return Date.now() + (60 * 60 * 1000);
 }
@@ -45,14 +56,14 @@ test('account registry keeps two Google identities distinct and addressable by a
     email: 'person@example.com',
     scopes: ['gmail.readonly'],
     credentialRef: 'google-oauth:test-personal',
-  }, options);
+  }, registryOptions(options));
   const work = upsertAccount({
     provider: 'google',
     alias: 'work',
     email: 'work@example.com',
     scopes: ['gmail.compose', 'gmail.readonly'],
     credentialRef: 'google-oauth:test-work',
-  }, options);
+  }, registryOptions(options));
 
   assert.notEqual(personal.id, work.id);
   assert.deepEqual(listAccounts({ provider: 'google', filePath: options.registryFilePath }).map((account) => account.alias), [
@@ -68,17 +79,17 @@ test('Google OAuth vault encrypts refresh tokens at rest', () => {
     provider: 'google',
     alias: 'personal',
     email: 'person@example.com',
-  }, options);
+  }, registryOptions(options));
   const secret = 'refresh-token-that-must-not-be-plaintext';
   const ref = saveGoogleCredential(account.id, {
     refreshToken: secret,
     accessToken: 'access-token',
     expiresAt: futureExpiry(),
-  }, options);
+  }, vaultOptions(options));
 
   const rawVault = fs.readFileSync(options.vaultFilePath, 'utf8');
   assert.equal(rawVault.includes(secret), false);
-  assert.equal(loadGoogleCredential(ref, options).refreshToken, secret);
+  assert.equal(loadGoogleCredential(ref, vaultOptions(options)).refreshToken, secret);
 });
 
 test('registered Google accounts resolve separate access tokens', async () => {

--- a/apps/agent/test/connectors-google.test.js
+++ b/apps/agent/test/connectors-google.test.js
@@ -1,0 +1,177 @@
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const {
+  getAccount,
+  listAccounts,
+  upsertAccount,
+} = require('../connectors/accounts/registry');
+const {
+  loadGoogleCredential,
+  saveGoogleCredential,
+} = require('../connectors/google/oauth-vault');
+const {
+  getGoogleAccessToken,
+  registerGoogleAccount,
+} = require('../connectors/google/oauth');
+const {
+  buildRawMessage,
+  createDraft,
+  searchMessages,
+} = require('../connectors/google/gmail');
+
+function fixturePaths() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), '3dvr-connectors-'));
+  return {
+    root,
+    registryFilePath: path.join(root, 'accounts.json'),
+    vaultFilePath: path.join(root, 'google.enc.json'),
+    keyMaterial: 'test-only-master-key',
+  };
+}
+
+function futureExpiry() {
+  return Date.now() + (60 * 60 * 1000);
+}
+
+test('account registry keeps two Google identities distinct and addressable by alias', () => {
+  const options = fixturePaths();
+  const personal = upsertAccount({
+    provider: 'google',
+    alias: 'personal',
+    email: 'person@example.com',
+    scopes: ['gmail.readonly'],
+    credentialRef: 'google-oauth:test-personal',
+  }, options);
+  const work = upsertAccount({
+    provider: 'google',
+    alias: 'work',
+    email: 'work@example.com',
+    scopes: ['gmail.compose', 'gmail.readonly'],
+    credentialRef: 'google-oauth:test-work',
+  }, options);
+
+  assert.notEqual(personal.id, work.id);
+  assert.deepEqual(listAccounts({ provider: 'google', filePath: options.registryFilePath }).map((account) => account.alias), [
+    'personal',
+    'work',
+  ]);
+  assert.equal(getAccount('work', { provider: 'google', filePath: options.registryFilePath }).email, 'work@example.com');
+});
+
+test('Google OAuth vault encrypts refresh tokens at rest', () => {
+  const options = fixturePaths();
+  const account = upsertAccount({
+    provider: 'google',
+    alias: 'personal',
+    email: 'person@example.com',
+  }, options);
+  const secret = 'refresh-token-that-must-not-be-plaintext';
+  const ref = saveGoogleCredential(account.id, {
+    refreshToken: secret,
+    accessToken: 'access-token',
+    expiresAt: futureExpiry(),
+  }, options);
+
+  const rawVault = fs.readFileSync(options.vaultFilePath, 'utf8');
+  assert.equal(rawVault.includes(secret), false);
+  assert.equal(loadGoogleCredential(ref, options).refreshToken, secret);
+});
+
+test('registered Google accounts resolve separate access tokens', async () => {
+  const options = fixturePaths();
+  const personal = registerGoogleAccount({
+    alias: 'personal',
+    email: 'person@example.com',
+    scopes: ['gmail.readonly'],
+    refreshToken: 'personal-refresh',
+    accessToken: 'personal-access',
+    expiresAt: futureExpiry(),
+  }, options);
+  const work = registerGoogleAccount({
+    alias: 'work',
+    email: 'work@example.com',
+    scopes: ['gmail.readonly'],
+    refreshToken: 'work-refresh',
+    accessToken: 'work-access',
+    expiresAt: futureExpiry(),
+  }, options);
+
+  const personalAuth = await getGoogleAccessToken(personal.id, options);
+  const workAuth = await getGoogleAccessToken('work', options);
+
+  assert.equal(personalAuth.accessToken, 'personal-access');
+  assert.equal(workAuth.accessToken, 'work-access');
+  assert.equal(workAuth.account.id, work.id);
+});
+
+test('Gmail search requires an explicit account and uses its token', async () => {
+  const calls = [];
+  const tokenResolver = async (accountId) => {
+    calls.push(['token', accountId]);
+    return {
+      account: { id: accountId, alias: accountId, email: `${accountId}@example.com` },
+      accessToken: `token-${accountId}`,
+    };
+  };
+  const fetchImpl = async (url, request) => {
+    calls.push(['fetch', url, request.headers.Authorization]);
+    return {
+      ok: true,
+      json: async () => ({ messages: [{ id: 'm1' }], resultSizeEstimate: 1 }),
+    };
+  };
+
+  await assert.rejects(() => searchMessages({ query: 'from:test' }, { tokenResolver, fetchImpl }), /accountId is required/);
+  const result = await searchMessages({ accountId: 'work', query: 'from:test', maxResults: 5 }, { tokenResolver, fetchImpl });
+
+  assert.equal(result.messages[0].id, 'm1');
+  assert.deepEqual(calls[0], ['token', 'work']);
+  assert.match(calls[1][1], /messages\?q=from%3Atest&maxResults=5/);
+  assert.equal(calls[1][2], 'Bearer token-work');
+});
+
+test('Gmail draft is prepared in the selected mailbox without sending', async () => {
+  let captured;
+  const tokenResolver = async (accountId) => ({
+    account: { id: accountId, alias: 'work', email: 'work@example.com' },
+    accessToken: 'work-access',
+  });
+  const fetchImpl = async (url, request) => {
+    captured = { url, request };
+    return {
+      ok: true,
+      json: async () => ({ id: 'draft-1', message: { id: 'message-1' } }),
+    };
+  };
+
+  const result = await createDraft({
+    accountId: 'work',
+    to: 'customer@example.com',
+    subject: 'Hello',
+    body: 'Prepared, not sent.',
+  }, { tokenResolver, fetchImpl });
+
+  assert.equal(captured.url, 'https://gmail.googleapis.com/gmail/v1/users/me/drafts');
+  assert.equal(captured.request.method, 'POST');
+  assert.equal(captured.request.headers.Authorization, 'Bearer work-access');
+  assert.equal(result.draft.id, 'draft-1');
+
+  const raw = JSON.parse(captured.request.body).message.raw;
+  const decoded = Buffer.from(raw.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
+  assert.match(decoded, /From: work@example.com/);
+  assert.match(decoded, /To: customer@example.com/);
+  assert.match(decoded, /Prepared, not sent\./);
+});
+
+test('raw message builder rejects header injection', () => {
+  assert.throws(() => buildRawMessage({
+    from: 'work@example.com',
+    to: 'customer@example.com\r\nBcc: attacker@example.com',
+    subject: 'Hello',
+    body: 'Nope',
+  }), /invalid newline/);
+});


### PR DESCRIPTION
Implements the first functional slice of the provider-neutral connector gateway under `apps/agent`.

Includes:
- metadata-only connector account registry with explicit aliases/IDs
- multiple simultaneous Google identities
- AES-256-GCM encrypted local OAuth vault keyed by `THREEDVR_CONNECTOR_MASTER_KEY`
- Google token resolver and refresh path through the existing portal OAuth endpoint
- Gmail search/read/create-draft adapter requiring an explicit account
- no send capability yet; consequential send remains reserved for the approval/audit layer
- tests for account separation, encrypted-at-rest refresh tokens, explicit Gmail account scoping, draft preparation, and header injection

No credentials or secrets are committed.