### PR TITLE
Clarify 3DVR OS as the Core product path

### DIFF
--- a/3dvr-os/README.md
+++ b/3dvr-os/README.md
@@ -1,6 +1,13 @@
 # 3DVR OS
 
-Daedalos / TommyOS browser-native desktop.
+**Core product:** 3DVR OS is the maintained open personal-computing path for the 3DVR ecosystem.
+
+It grows out of the Daedalos / TommyOS browser-native desktop experiments, but the naming boundary is now explicit:
+
+- **3DVR OS** — Core product and supported public path.
+- **TommyOS / Daedalos experiments** — Labs lineage for research, prototypes, and ideas that may graduate into 3DVR OS.
+
+New user-facing operating-system work should land in 3DVR OS unless it is intentionally experimental. Proven Labs work can be absorbed here without requiring users to understand the internal experiment history.
 
 ## Deployment
 

--- a/docs/ecosystem-consolidation.md
+++ b/docs/ecosystem-consolidation.md
@@ -120,7 +120,7 @@ The open-source contribution ledger is high-value proof and should be easy to re
 
 - [ ] Add Core / Labs / Legacy guidance to relevant public/project indexes.
 - [ ] Label or archive superseded 3DVR repositories and point them to active replacements.
-- [ ] Canonize TommyOS as a research prototype and 3DVR OS as the product path.
+- [x] Canonize TommyOS as a research prototype and 3DVR OS as the product path.
 - [ ] Reduce Portal first-screen emphasis on individual tools; keep the four intents dominant.
 
 ### P2 — increase proof and conversion
@@ -152,3 +152,4 @@ This consolidation phase is successful when:
 - Reduced Portal API entry files from 13 to 12 by removing the redundant Workboard deployment wrapper while keeping the shared implementation intact.
 - Added a deployment-budget regression test so future API growth fails locally/CI before it breaks production.
 - Verified the merged `main` deployment reached READY with 12 Node.js functions, and `https://portal.3dvr.tech/` returned HTTP 200.
+- Started P1 consolidation by defining 3DVR OS as the maintained Core product and TommyOS / Daedalos as Labs research lineage; future user-facing OS work should default to 3DVR OS while experimental ideas can graduate into it.


### PR DESCRIPTION
Advances the P1 ecosystem-consolidation roadmap.

- defines 3DVR OS as the maintained Core product
- defines TommyOS / Daedalos as Labs research lineage
- gives contributors a simple default: user-facing OS work goes to 3DVR OS; experimental work may graduate into it
- records the completed roadmap item in the living consolidation plan

Documentation-only; no runtime or billing behavior changes.