### PR TITLE
Make the Core Labs Legacy map visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Run `npm test` for the portal, `npm run test:agent` for the agent, or `npm run t
 
 The ecosystem-wide simplification and shipping plan is tracked in [`docs/ecosystem-consolidation.md`](docs/ecosystem-consolidation.md). Its operating rule is simple: keep the public story clear, route users through a few strong intents, and move experiments behind stable core products.
 
+### Ecosystem map
+
+- **Core** — maintained public paths: `3dvr.tech`, Portal, 3DVR OS, 3DVR Calendar, and `tmsteph.com`.
+- **Labs** — experiments and research such as TommyOS / Daedalos, AI Systems Lab, browser-computing prototypes, characters, hardware concepts, and interactive experiments.
+- **Legacy** — superseded projects kept for history. Their README files should point visitors to the current Core replacement.
+
+Default rule: extend a Core path when possible; use Labs when the work is intentionally experimental; do not revive Legacy as a competing product line.
+
 ## What is here now?
 
 - Portal Home and installable web apps

--- a/docs/ecosystem-consolidation.md
+++ b/docs/ecosystem-consolidation.md
@@ -118,7 +118,7 @@ The open-source contribution ledger is high-value proof and should be easy to re
 
 ### P1 — make the ecosystem legible
 
-- [ ] Add Core / Labs / Legacy guidance to relevant public/project indexes.
+- [x] Add Core / Labs / Legacy guidance to relevant public/project indexes.
 - [ ] Label or archive superseded 3DVR repositories and point them to active replacements.
 - [x] Canonize TommyOS as a research prototype and 3DVR OS as the product path.
 - [ ] Reduce Portal first-screen emphasis on individual tools; keep the four intents dominant.
@@ -153,3 +153,4 @@ This consolidation phase is successful when:
 - Added a deployment-budget regression test so future API growth fails locally/CI before it breaks production.
 - Verified the merged `main` deployment reached READY with 12 Node.js functions, and `https://portal.3dvr.tech/` returned HTTP 200.
 - Started P1 consolidation by defining 3DVR OS as the maintained Core product and TommyOS / Daedalos as Labs research lineage; future user-facing OS work should default to 3DVR OS while experimental ideas can graduate into it.
+- Made the Core / Labs / Legacy map visible in the Portal project README and the active `3dvr-web` README, so contributors can identify the maintained public paths without opening the full roadmap.


### PR DESCRIPTION
Advances the P1 ecosystem consolidation roadmap.

- adds a concise Core / Labs / Legacy map to the Portal README
- gives contributors a simple default for where new work belongs
- records the public/project-index guidance item as complete in the living roadmap

Documentation-only; no runtime or billing behavior changes.