### PR TITLE
Restore username and points on latest Portal home

### DIFF
--- a/home-operator.js
+++ b/home-operator.js
@@ -24,8 +24,22 @@ function readAccountState() {
   const username = (localStorage.getItem('username') || shared.username || '').trim();
   return {
     signedIn,
+    alias,
     displayName: signedIn ? username || aliasToDisplay(alias) || 'User' : ''
   };
+}
+
+function readCachedPoints(state) {
+  if (!state.signedIn || !state.alias) return 0;
+  try {
+    const key = `3dvr:score:user:${state.alias.toLowerCase()}`;
+    return [key, `${key}:pending`, `${key}:portalPending`]
+      .map(cacheKey => Number(localStorage.getItem(cacheKey) || 0))
+      .filter(Number.isFinite)
+      .reduce((best, value) => Math.max(best, Math.max(0, Math.round(value))), 0);
+  } catch {
+    return 0;
+  }
 }
 
 function installAccountStatus() {
@@ -35,9 +49,10 @@ function installAccountStatus() {
   const render = () => {
     const state = readAccountState();
     if (state.signedIn) {
+      const points = readCachedPoints(state);
       authEntry.href = '/profile.html#profile';
-      authEntry.textContent = 'Profile';
-      authEntry.setAttribute('aria-label', `Open profile for ${state.displayName}`);
+      authEntry.textContent = `${state.displayName} · ⭐ ${points}`;
+      authEntry.setAttribute('aria-label', `Open profile for ${state.displayName}. ${points} points.`);
       return;
     }
 

--- a/tests/homepage-account-ux.test.js
+++ b/tests/homepage-account-ux.test.js
@@ -14,9 +14,13 @@ test('homepage account entry follows portal auth state', async () => {
   assert.match(html, /data-auth-entry>Sign in<\/a>/);
   assert.match(app, /syncStorageFromSharedIdentity\?\.\(localStorage\)/);
   assert.match(app, /authEntry\.href = '\/profile\.html#profile'/);
-  assert.match(app, /authEntry\.textContent = 'Profile'/);
+  assert.match(app, /3dvr:score:user:/);
+  assert.match(app, /:pending/);
+  assert.match(app, /:portalPending/);
+  assert.match(app, /authEntry\.textContent = `\$\{state\.displayName\} · ⭐ \$\{points\}`/);
   assert.match(app, /authEntry\.href = '\/sign-in\.html\?redirect=%2F'/);
   assert.match(app, /authEntry\.textContent = 'Sign in'/);
+  assert.match(app, /installOsLauncher/);
   assert.doesNotMatch(app, /signInLink\.hidden/);
 });
 


### PR DESCRIPTION
Exact-base replacement for stale #1834 / diverged #1971.

This commit is built directly on the current `main` tree after #1830 and reuses the exact two file blobs that already passed Playwright on #1971:
- `home-operator.js`: signed-in `username · ⭐ points`, preserving the newer 3DVR OS launcher
- `tests/homepage-account-ux.test.js`: account cache assertions plus OS-launcher regression guard

No other files or concurrent work are changed. Merge only after the fresh exact-base Playwright run passes.