### PR TITLE
Allow full agent test suite to finish

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -27,7 +27,10 @@ jobs:
   test:
     name: Run agent tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The full agent syntax + Node test suite now routinely exceeds 15 minutes.
+    # Keep a finite cap, but allow healthy runs to finish instead of being
+    # reported as cancelled midway through otherwise passing tests.
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: apps/agent


### PR DESCRIPTION
The Agent Checks job currently hard-stops after 15 minutes. Recent runs reached hundreds of passing tests and were then reported as cancelled, which blocks otherwise safe PRs without surfacing a failing assertion.

This is CI-only:
- raises only the `Run agent tests` timeout from 15 to 30 minutes
- keeps a finite timeout
- does not change product/runtime/deployment behavior

The PR itself exercises the updated workflow. Merge if the full Agent Checks run completes successfully under the new cap.