### PR TITLE
Land Website Upgrade fulfillment safety on current main

### DIFF
--- a/apps/agent/test/website-upgrade-fulfillment-state.test.js
+++ b/apps/agent/test/website-upgrade-fulfillment-state.test.js
@@ -1,0 +1,117 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const gunDbPath = require.resolve('../thomas-agent/node/gun-db');
+const fulfillmentPath = require.resolve('../thomas-agent/node/website-upgrade-fulfillment-state');
+delete require.cache[gunDbPath];
+delete require.cache[fulfillmentPath];
+
+const {
+  readNode,
+  receiveOrder,
+  reserveDelivery,
+  shouldDeliver,
+  transitionOrder,
+} = require(fulfillmentPath);
+
+function order() {
+  return {
+    sessionId: 'cs_live_upgrade_123',
+    businessName: 'Example Studio',
+    mainAction: 'Book a consultation',
+    siteUrl: 'https://3dvr.tech/free-sites/example-studio/',
+    slug: 'example-studio',
+    customerEmail: 'buyer@example.com',
+  };
+}
+
+function memoryNodeFactory() {
+  const records = new Map();
+  const node = sessionId => ({
+    once(callback) {
+      callback(records.get(sessionId) || null);
+    },
+    put(value, callback) {
+      records.set(sessionId, structuredClone(value));
+      callback({ ok: 1 });
+    },
+  });
+  node.records = records;
+  return node;
+}
+
+test('importing fulfillment state does not open the real Gun client', () => {
+  assert.equal(require.cache[gunDbPath], undefined);
+});
+
+test('receives each Stripe Checkout Session only once', async () => {
+  const node = memoryNodeFactory();
+  const first = await receiveOrder(order(), { node });
+  const replay = await receiveOrder({ ...order(), businessName: 'Changed on replay' }, { node });
+
+  assert.equal(first.created, true);
+  assert.equal(replay.created, false);
+  assert.equal(node.records.size, 1);
+  assert.equal(replay.record.businessName, 'Example Studio');
+});
+
+test('fails closed on malformed shared fulfillment state', async () => {
+  const malformedNode = {
+    once(callback) {
+      callback('corrupt-existing-record');
+    },
+  };
+
+  await assert.rejects(
+    readNode(malformedNode),
+    /Malformed Website Upgrade fulfillment state/
+  );
+});
+
+test('tracks processing attempts and safe retry state', async () => {
+  const node = memoryNodeFactory();
+  await receiveOrder(order(), { node });
+  await transitionOrder(order().sessionId, 'processing', {}, { node });
+  await transitionOrder(order().sessionId, 'failed', { reason: 'verification timeout' }, { node });
+  const retry = await transitionOrder(order().sessionId, 'processing', {}, { node });
+
+  assert.equal(retry.attempts, 2);
+  assert.equal(retry.status, 'processing');
+});
+
+test('delivery reservation survives restart and prevents duplicate send', async () => {
+  const node = memoryNodeFactory();
+  const { record } = await receiveOrder(order(), { node });
+  assert.equal(shouldDeliver(record), true);
+
+  const first = await reserveDelivery(order().sessionId, 'delivery-attempt-1', { node });
+  assert.equal(first.reserved, true);
+  assert.equal(first.record.deliveryState, 'reserved');
+  assert.ok(first.record.deliveryReservedAt);
+  assert.equal(shouldDeliver(first.record), false);
+
+  const restartedWorker = await reserveDelivery(order().sessionId, 'delivery-attempt-2', { node });
+  assert.equal(restartedWorker.reserved, false);
+  assert.equal(restartedWorker.record.deliveryReservationId, 'delivery-attempt-1');
+  assert.equal(shouldDeliver(restartedWorker.record), false);
+
+  const delivered = await transitionOrder(order().sessionId, 'delivered', {
+    finalUrl: order().siteUrl,
+  }, { node });
+  assert.equal(delivered.deliveryState, 'sent');
+  assert.ok(delivered.deliverySentAt);
+  assert.equal(shouldDeliver(delivered), false);
+});
+
+test('blocked orders remain terminal and cannot pass the delivery guard', async () => {
+  const node = memoryNodeFactory();
+  await receiveOrder(order(), { node });
+  const blocked = await transitionOrder(order().sessionId, 'blocked', { reason: 'target rejected' }, { node });
+  const replay = await transitionOrder(order().sessionId, 'processing', {}, { node });
+
+  assert.equal(blocked.status, 'blocked');
+  assert.equal(replay.status, 'blocked');
+  assert.equal(shouldDeliver(blocked), false);
+  const reservation = await reserveDelivery(order().sessionId, 'should-not-reserve', { node });
+  assert.equal(reservation.reserved, false);
+});

--- a/apps/agent/thomas-agent/node/gun-db.js
+++ b/apps/agent/thomas-agent/node/gun-db.js
@@ -38,6 +38,10 @@ function autopilotStateNode() {
   return gun.get(APP_ROOT).get(OPS_ROOT).get(AUTOPILOT_ROOT).get('state');
 }
 
+function websiteUpgradeFulfillmentNode() {
+  return gun.get(APP_ROOT).get(OPS_ROOT).get(AUTOPILOT_ROOT).get('website-upgrade-fulfillment');
+}
+
 function portalAgentOpsNode() {
   return gun.get(PORTAL_ROOT).get('agentOps');
 }
@@ -64,6 +68,7 @@ module.exports = {
   outreachArtifactsNode,
   autopilotRunsNode,
   autopilotStateNode,
+  websiteUpgradeFulfillmentNode,
   portalAgentOpsNode,
   portalCrmNode,
   portalCrmTouchLogNode,

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-state.js
@@ -1,0 +1,140 @@
+const TERMINAL_STATUSES = new Set(['delivered', 'blocked']);
+const VALID_STATUSES = new Set(['received', 'processing', 'delivered', 'blocked', 'failed']);
+
+function nowIso(now = () => new Date()) {
+  return now().toISOString();
+}
+
+function requireSessionId(order) {
+  const sessionId = String(order?.sessionId || '').trim();
+  if (!sessionId) throw new Error('Website Upgrade fulfillment requires a Stripe Checkout Session ID.');
+  return sessionId;
+}
+
+function sessionNode(sessionId) {
+  // Keep the real Gun client lazy. Unit tests inject a node factory and should
+  // not open a persistent relay connection merely by importing this module.
+  const { websiteUpgradeFulfillmentNode } = require('./gun-db');
+  return websiteUpgradeFulfillmentNode().get(sessionId);
+}
+
+function readNode(node, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out reading Website Upgrade fulfillment state from GunJS.')), timeoutMs);
+    node.once((data) => {
+      clearTimeout(timer);
+      if (data === null || data === undefined) {
+        resolve(null);
+        return;
+      }
+      if (typeof data !== 'object' || Array.isArray(data)) {
+        reject(new Error('Malformed Website Upgrade fulfillment state in GunJS.'));
+        return;
+      }
+      resolve(data);
+    });
+  });
+}
+
+function writeNode(node, value, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out writing Website Upgrade fulfillment state to GunJS.')), timeoutMs);
+    node.put(value, (ack) => {
+      clearTimeout(timer);
+      if (ack && ack.err) reject(new Error(`GunJS fulfillment write failed: ${ack.err}`));
+      else resolve(value);
+    });
+  });
+}
+
+async function receiveOrder(order, options = {}) {
+  const sessionId = requireSessionId(order);
+  const node = (options.node || sessionNode)(sessionId);
+  const existing = await readNode(node, options.timeoutMs);
+  if (existing) return { record: existing, created: false, terminal: TERMINAL_STATUSES.has(existing.status) };
+
+  const at = nowIso(options.now);
+  const record = {
+    sessionId,
+    status: 'received',
+    slug: String(order.slug || '').trim(),
+    siteUrl: String(order.siteUrl || '').trim(),
+    customerEmail: String(order.customerEmail || '').trim(),
+    businessName: String(order.businessName || '').trim(),
+    mainAction: String(order.mainAction || '').trim(),
+    receivedAt: at,
+    updatedAt: at,
+    attempts: 0,
+    deliveryState: 'pending',
+    deliveryReservedAt: null,
+    deliveryReservationId: null,
+    deliverySentAt: null,
+  };
+  await writeNode(node, record, options.timeoutMs);
+  return { record, created: true, terminal: false };
+}
+
+async function reserveDelivery(sessionId, reservationId, options = {}) {
+  const id = String(reservationId || '').trim();
+  if (!id) throw new Error('Website Upgrade delivery reservation requires an ID.');
+
+  const node = (options.node || sessionNode)(sessionId);
+  const record = await readNode(node, options.timeoutMs);
+  if (!record) throw new Error(`Unknown Website Upgrade fulfillment session: ${sessionId}`);
+
+  if (
+    TERMINAL_STATUSES.has(record.status)
+    || record.deliverySentAt
+    || record.deliveryReservedAt
+  ) {
+    return { record, reserved: false };
+  }
+
+  const at = nowIso(options.now);
+  const next = {
+    ...record,
+    deliveryState: 'reserved',
+    deliveryReservedAt: at,
+    deliveryReservationId: id,
+    updatedAt: at,
+  };
+  await writeNode(node, next, options.timeoutMs);
+  return { record: next, reserved: true };
+}
+
+async function transitionOrder(sessionId, status, details = {}, options = {}) {
+  if (!VALID_STATUSES.has(status)) throw new Error(`Invalid Website Upgrade fulfillment status: ${status}`);
+  const node = (options.node || sessionNode)(sessionId);
+  const record = await readNode(node, options.timeoutMs);
+  if (!record) throw new Error(`Unknown Website Upgrade fulfillment session: ${sessionId}`);
+  if (TERMINAL_STATUSES.has(record.status) && record.status !== status) return record;
+
+  const at = nowIso(options.now);
+  const next = { ...record, ...details, status, updatedAt: at };
+  if (status === 'processing') next.attempts = Number(record.attempts || 0) + 1;
+  if (status === 'delivered') {
+    if (!next.deliverySentAt) next.deliverySentAt = at;
+    next.deliveryState = 'sent';
+  }
+  await writeNode(node, next, options.timeoutMs);
+  return next;
+}
+
+function shouldDeliver(record) {
+  return Boolean(
+    record
+    && !TERMINAL_STATUSES.has(record.status)
+    && !record.deliveryReservedAt
+    && !record.deliverySentAt
+  );
+}
+
+module.exports = {
+  TERMINAL_STATUSES,
+  readNode,
+  receiveOrder,
+  reserveDelivery,
+  shouldDeliver,
+  transitionOrder,
+  writeNode,
+};


### PR DESCRIPTION
Exact-current-main reconstruction of #1900 after its fully hardened branch passed both Agent Checks and Playwright.

This PR carries only the three intended files onto current `main`:
- shared canonical Gun root for Website Upgrade fulfillment
- durable fulfillment state keyed by Stripe Checkout Session ID
- focused fulfillment safety tests

Safety properties preserved from #1900:
- received → processing → delivered/blocked/failed transitions
- malformed shared state fails closed
- terminal blocked/delivered records cannot re-enter delivery
- retries track attempts
- delivery is durably reserved before the customer-facing side effect, preventing automatic duplicate sends after worker restart
- importing the fulfillment module does not open the real Gun relay during tests (the CI hang root cause found on #1900)

The source branch #1900 passed the full Agent Checks and Playwright after the lazy-Gun fix. This exact-base PR gets one final fresh run before merge.

#1873 remains open for the later end-to-end paid-order → publish → verify → delivery wiring.