### PR TITLE
Add safe Website Upgrade fulfillment orchestrator

### DIFF
--- a/apps/agent/test/website-upgrade-fulfillment-worker.test.js
+++ b/apps/agent/test/website-upgrade-fulfillment-worker.test.js
@@ -1,0 +1,266 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  deliveryKey,
+  processUpgradeOrder,
+  publicationKey,
+} = require('../thomas-agent/node/website-upgrade-fulfillment-worker');
+
+function order(overrides = {}) {
+  return {
+    sessionId: 'cs_live_upgrade_123',
+    businessName: 'Example Studio',
+    mainAction: 'Book a consultation',
+    siteUrl: 'https://3dvr.tech/free-sites/example-studio/',
+    slug: 'example-studio',
+    customerEmail: 'buyer@example.com',
+    ...overrides,
+  };
+}
+
+function createState() {
+  const records = new Map();
+  const calls = [];
+
+  const api = {
+    calls,
+    records,
+    async receiveOrder(input) {
+      calls.push(['receive', input.sessionId]);
+      const existing = records.get(input.sessionId);
+      if (existing) {
+        return {
+          record: { ...existing },
+          created: false,
+          terminal: ['delivered', 'blocked'].includes(existing.status),
+        };
+      }
+      const record = {
+        ...input,
+        status: 'received',
+        attempts: 0,
+        deliveryState: 'pending',
+        deliveryReservedAt: null,
+        deliveryReservationId: null,
+        deliverySentAt: null,
+      };
+      records.set(input.sessionId, record);
+      return { record: { ...record }, created: true, terminal: false };
+    },
+    async transitionOrder(sessionId, status, details = {}) {
+      calls.push(['transition', sessionId, status, details]);
+      const current = records.get(sessionId);
+      if (!current) throw new Error(`missing ${sessionId}`);
+      if (['delivered', 'blocked'].includes(current.status) && current.status !== status) {
+        return { ...current };
+      }
+      const next = { ...current, ...details, status };
+      if (status === 'processing') next.attempts = Number(current.attempts || 0) + 1;
+      if (status === 'delivered') {
+        next.deliveryState = 'sent';
+        next.deliverySentAt = next.deliverySentAt || '2026-08-30T00:00:00.000Z';
+      }
+      records.set(sessionId, next);
+      return { ...next };
+    },
+    async reserveDelivery(sessionId, reservationId) {
+      calls.push(['reserve', sessionId, reservationId]);
+      const current = records.get(sessionId);
+      if (!current) throw new Error(`missing ${sessionId}`);
+      if (
+        ['delivered', 'blocked'].includes(current.status)
+        || current.deliveryReservedAt
+        || current.deliverySentAt
+      ) {
+        return { record: { ...current }, reserved: false };
+      }
+      const next = {
+        ...current,
+        deliveryState: 'reserved',
+        deliveryReservedAt: '2026-08-30T00:00:00.000Z',
+        deliveryReservationId: reservationId,
+      };
+      records.set(sessionId, next);
+      return { record: { ...next }, reserved: true };
+    },
+  };
+
+  return api;
+}
+
+function adapters(overrides = {}) {
+  const calls = { publish: [], verify: [], send: [] };
+  return {
+    calls,
+    publishUpgrade: overrides.publishUpgrade || (async (input) => {
+      calls.publish.push(input);
+      return { siteUrl: input.order.siteUrl, prUrl: 'https://github.com/tmsteph/3dvr-web/pull/123' };
+    }),
+    verifyUpgrade: overrides.verifyUpgrade || (async (input) => {
+      calls.verify.push(input);
+      return true;
+    }),
+    sendDelivery: overrides.sendDelivery || (async (input) => {
+      calls.send.push(input);
+      return { accepted: true };
+    }),
+  };
+}
+
+test('success publishes, verifies, reserves delivery, sends once, then marks delivered', async () => {
+  const state = createState();
+  const sideEffects = adapters();
+  const input = order();
+
+  const result = await processUpgradeOrder(input, { state, ...sideEffects });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'delivered');
+  assert.equal(sideEffects.calls.publish.length, 1);
+  assert.equal(sideEffects.calls.verify.length, 1);
+  assert.equal(sideEffects.calls.send.length, 1);
+  assert.equal(sideEffects.calls.publish[0].idempotencyKey, publicationKey(input.sessionId));
+  assert.equal(sideEffects.calls.send[0].idempotencyKey, deliveryKey(input.sessionId));
+  assert.equal(result.record.finalUrl, input.siteUrl);
+  assert.equal(result.record.deliveryState, 'sent');
+});
+
+test('delivered replay performs no publish, verify, or delivery side effects', async () => {
+  const state = createState();
+  const sideEffects = adapters();
+  const input = order();
+
+  await processUpgradeOrder(input, { state, ...sideEffects });
+  const replay = await processUpgradeOrder(input, { state, ...sideEffects });
+
+  assert.equal(replay.status, 'delivered');
+  assert.equal(replay.replay, true);
+  assert.equal(sideEffects.calls.publish.length, 1);
+  assert.equal(sideEffects.calls.verify.length, 1);
+  assert.equal(sideEffects.calls.send.length, 1);
+});
+
+test('missing or malformed customer email blocks before publishing', async () => {
+  for (const customerEmail of ['', 'not-an-email']) {
+    const state = createState();
+    const sideEffects = adapters();
+    const result = await processUpgradeOrder(order({ customerEmail }), { state, ...sideEffects });
+
+    assert.equal(result.status, 'blocked');
+    assert.match(result.record.reason, /valid customer email/);
+    assert.equal(sideEffects.calls.publish.length, 0);
+    assert.equal(sideEffects.calls.verify.length, 0);
+    assert.equal(sideEffects.calls.send.length, 0);
+  }
+});
+
+test('invalid or external target is blocked before publishing', async () => {
+  const state = createState();
+  const sideEffects = adapters();
+  const result = await processUpgradeOrder(order({
+    siteUrl: 'https://example.com/free-sites/example-studio/',
+  }), { state, ...sideEffects });
+
+  assert.equal(result.status, 'blocked');
+  assert.match(result.record.reason, /validated 3DVR-hosted free-site URL/);
+  assert.equal(sideEffects.calls.publish.length, 0);
+  assert.equal(sideEffects.calls.send.length, 0);
+});
+
+test('publisher cannot redirect delivery to a different URL', async () => {
+  const state = createState();
+  const calls = { publish: 0, verify: 0, send: 0 };
+  const result = await processUpgradeOrder(order(), {
+    state,
+    publishUpgrade: async () => {
+      calls.publish += 1;
+      return { siteUrl: 'https://evil.example/' };
+    },
+    verifyUpgrade: async () => {
+      calls.verify += 1;
+      return true;
+    },
+    sendDelivery: async () => {
+      calls.send += 1;
+    },
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.stage, 'publish');
+  assert.equal(calls.publish, 1);
+  assert.equal(calls.verify, 0);
+  assert.equal(calls.send, 0);
+});
+
+test('verification failure records failed state and never reserves or sends delivery', async () => {
+  const state = createState();
+  const sideEffects = adapters({
+    verifyUpgrade: async (input) => {
+      sideEffects.calls.verify.push(input);
+      return false;
+    },
+  });
+
+  const result = await processUpgradeOrder(order(), { state, ...sideEffects });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.stage, 'verify');
+  assert.equal(sideEffects.calls.publish.length, 1);
+  assert.equal(sideEffects.calls.verify.length, 1);
+  assert.equal(sideEffects.calls.send.length, 0);
+  assert.equal(state.calls.filter((entry) => entry[0] === 'reserve').length, 0);
+});
+
+test('delivery failure leaves durable reservation uncertain and retry never sends again', async () => {
+  const state = createState();
+  const calls = { publish: 0, verify: 0, send: 0 };
+  const opts = {
+    state,
+    publishUpgrade: async ({ order: input }) => {
+      calls.publish += 1;
+      return { siteUrl: input.siteUrl };
+    },
+    verifyUpgrade: async () => {
+      calls.verify += 1;
+      return true;
+    },
+    sendDelivery: async () => {
+      calls.send += 1;
+      throw new Error('smtp outcome unknown');
+    },
+  };
+
+  const first = await processUpgradeOrder(order(), opts);
+  const replay = await processUpgradeOrder(order(), opts);
+
+  assert.equal(first.status, 'delivery_uncertain');
+  assert.equal(first.record.deliveryState, 'uncertain');
+  assert.ok(first.record.deliveryReservedAt);
+  assert.equal(replay.status, 'delivery_uncertain');
+  assert.equal(calls.publish, 1);
+  assert.equal(calls.verify, 1);
+  assert.equal(calls.send, 1);
+});
+
+test('publish failure can retry with the same stable publication idempotency key', async () => {
+  const state = createState();
+  const keys = [];
+  let attempts = 0;
+  const sideEffects = adapters({
+    publishUpgrade: async (input) => {
+      keys.push(input.idempotencyKey);
+      attempts += 1;
+      if (attempts === 1) throw new Error('temporary git failure');
+      return { siteUrl: input.order.siteUrl };
+    },
+  });
+
+  const first = await processUpgradeOrder(order(), { state, ...sideEffects });
+  const second = await processUpgradeOrder(order(), { state, ...sideEffects });
+
+  assert.equal(first.status, 'failed');
+  assert.equal(first.stage, 'publish');
+  assert.equal(second.status, 'delivered');
+  assert.deepEqual(keys, [publicationKey(order().sessionId), publicationKey(order().sessionId)]);
+  assert.equal(sideEffects.calls.send.length, 1);
+});

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-worker.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-worker.js
@@ -14,6 +14,11 @@ function defaultStateApi() {
   return require('./website-upgrade-fulfillment-state');
 }
 
+function validEmail(value) {
+  const email = text(value).toLowerCase();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : '';
+}
+
 function validateBoundedOrder(order) {
   const sessionId = text(order?.sessionId);
   const slug = text(order?.slug).toLowerCase();
@@ -29,7 +34,9 @@ function validateBoundedOrder(order) {
     throw new Error('Website Upgrade target must be the validated 3DVR-hosted free-site URL.');
   }
   if (!businessName) throw new Error('Website Upgrade order is missing businessName.');
+  if (businessName.length > 160) throw new Error('Website Upgrade businessName is too long.');
   if (!mainAction) throw new Error('Website Upgrade order is missing mainAction.');
+  if (mainAction.length > 240) throw new Error('Website Upgrade mainAction is too long.');
 
   return { sessionId, slug, siteUrl, businessName, mainAction };
 }
@@ -92,9 +99,10 @@ async function processUpgradeOrder(order, options = {}) {
     };
   }
 
-  if (!text(order.customerEmail)) {
+  const customerEmail = validEmail(order.customerEmail);
+  if (!customerEmail) {
     record = await state.transitionOrder(bounded.sessionId, 'blocked', {
-      reason: 'Website Upgrade order is missing customer email.',
+      reason: 'Website Upgrade order is missing a valid customer email.',
     });
     return { ok: false, status: 'blocked', record };
   }
@@ -106,7 +114,7 @@ async function processUpgradeOrder(order, options = {}) {
   let publication;
   try {
     publication = await publishUpgrade({
-      order,
+      order: { ...order, customerEmail },
       record,
       idempotencyKey: publicationKey(bounded.sessionId),
     });
@@ -118,7 +126,16 @@ async function processUpgradeOrder(order, options = {}) {
     return { ok: false, status: 'failed', stage: 'publish', record: failed };
   }
 
-  const finalUrl = text(publication?.siteUrl || order.siteUrl);
+  const finalUrl = text(publication?.siteUrl || bounded.siteUrl);
+  if (finalUrl !== bounded.siteUrl) {
+    const failed = await failOrder(state, bounded.sessionId, 'Website Upgrade publisher returned an unexpected target URL.', {
+      stage: 'publish',
+      publicationKey: publicationKey(bounded.sessionId),
+      attemptedFinalUrl: finalUrl || null,
+    });
+    return { ok: false, status: 'failed', stage: 'publish', record: failed };
+  }
+
   const publicationDetails = {
     publicationKey: publicationKey(bounded.sessionId),
     prUrl: text(publication?.prUrl) || null,
@@ -128,7 +145,7 @@ async function processUpgradeOrder(order, options = {}) {
   let verified = false;
   try {
     verified = Boolean(await verifyUpgrade({
-      order,
+      order: { ...order, customerEmail },
       record,
       publication,
       siteUrl: finalUrl,
@@ -169,7 +186,7 @@ async function processUpgradeOrder(order, options = {}) {
 
   try {
     await sendDelivery({
-      order,
+      order: { ...order, customerEmail },
       record,
       siteUrl: finalUrl,
       idempotencyKey: deliveryKey(bounded.sessionId),
@@ -213,4 +230,5 @@ module.exports = {
   processUpgradeOrders,
   publicationKey,
   validateBoundedOrder,
+  validEmail,
 };

--- a/apps/agent/thomas-agent/node/website-upgrade-fulfillment-worker.js
+++ b/apps/agent/thomas-agent/node/website-upgrade-fulfillment-worker.js
@@ -1,0 +1,216 @@
+function text(value) {
+  return String(value || '').trim();
+}
+
+function publicationKey(sessionId) {
+  return `website-upgrade:publish:${text(sessionId)}`;
+}
+
+function deliveryKey(sessionId) {
+  return `website-upgrade:delivery:${text(sessionId)}`;
+}
+
+function defaultStateApi() {
+  return require('./website-upgrade-fulfillment-state');
+}
+
+function validateBoundedOrder(order) {
+  const sessionId = text(order?.sessionId);
+  const slug = text(order?.slug).toLowerCase();
+  const siteUrl = text(order?.siteUrl);
+  const businessName = text(order?.businessName);
+  const mainAction = text(order?.mainAction);
+
+  if (!sessionId) throw new Error('Website Upgrade order is missing sessionId.');
+  if (!/^[a-z0-9][a-z0-9-]{0,79}$/.test(slug)) {
+    throw new Error('Website Upgrade target slug is invalid.');
+  }
+  if (siteUrl !== `https://3dvr.tech/free-sites/${slug}/`) {
+    throw new Error('Website Upgrade target must be the validated 3DVR-hosted free-site URL.');
+  }
+  if (!businessName) throw new Error('Website Upgrade order is missing businessName.');
+  if (!mainAction) throw new Error('Website Upgrade order is missing mainAction.');
+
+  return { sessionId, slug, siteUrl, businessName, mainAction };
+}
+
+async function failOrder(state, sessionId, reason, details = {}) {
+  return state.transitionOrder(sessionId, 'failed', {
+    ...details,
+    reason: text(reason).slice(0, 500),
+  });
+}
+
+async function processUpgradeOrder(order, options = {}) {
+  const state = options.state || defaultStateApi();
+  const publishUpgrade = options.publishUpgrade;
+  const verifyUpgrade = options.verifyUpgrade;
+  const sendDelivery = options.sendDelivery;
+
+  if (typeof publishUpgrade !== 'function') throw new Error('publishUpgrade adapter is required.');
+  if (typeof verifyUpgrade !== 'function') throw new Error('verifyUpgrade adapter is required.');
+  if (typeof sendDelivery !== 'function') throw new Error('sendDelivery adapter is required.');
+
+  let bounded;
+  try {
+    bounded = validateBoundedOrder(order);
+  } catch (error) {
+    const sessionId = text(order?.sessionId);
+    if (!sessionId) throw error;
+    const received = await state.receiveOrder(order);
+    if (!received.terminal) {
+      const blocked = await state.transitionOrder(sessionId, 'blocked', {
+        reason: text(error?.message || error).slice(0, 500),
+      });
+      return { ok: false, status: 'blocked', record: blocked };
+    }
+    return { ok: false, status: received.record.status, record: received.record, replay: true };
+  }
+
+  const received = await state.receiveOrder(order);
+  let record = received.record;
+
+  if (record.status === 'delivered' || record.status === 'blocked') {
+    return {
+      ok: record.status === 'delivered',
+      status: record.status,
+      record,
+      replay: true,
+    };
+  }
+
+  // Once an email delivery has been durably reserved, never automatically try
+  // the customer-facing side effect again. A crash after SMTP acceptance but
+  // before the final state write is intentionally treated as uncertain rather
+  // than risking a duplicate customer email.
+  if (record.deliveryReservedAt && !record.deliverySentAt) {
+    return {
+      ok: false,
+      status: 'delivery_uncertain',
+      record,
+      replay: !received.created,
+    };
+  }
+
+  if (!text(order.customerEmail)) {
+    record = await state.transitionOrder(bounded.sessionId, 'blocked', {
+      reason: 'Website Upgrade order is missing customer email.',
+    });
+    return { ok: false, status: 'blocked', record };
+  }
+
+  record = await state.transitionOrder(bounded.sessionId, 'processing', {
+    publicationKey: publicationKey(bounded.sessionId),
+  });
+
+  let publication;
+  try {
+    publication = await publishUpgrade({
+      order,
+      record,
+      idempotencyKey: publicationKey(bounded.sessionId),
+    });
+  } catch (error) {
+    const failed = await failOrder(state, bounded.sessionId, error?.message || error, {
+      stage: 'publish',
+      publicationKey: publicationKey(bounded.sessionId),
+    });
+    return { ok: false, status: 'failed', stage: 'publish', record: failed };
+  }
+
+  const finalUrl = text(publication?.siteUrl || order.siteUrl);
+  const publicationDetails = {
+    publicationKey: publicationKey(bounded.sessionId),
+    prUrl: text(publication?.prUrl) || null,
+    finalUrl,
+  };
+
+  let verified = false;
+  try {
+    verified = Boolean(await verifyUpgrade({
+      order,
+      record,
+      publication,
+      siteUrl: finalUrl,
+    }));
+  } catch (error) {
+    const failed = await failOrder(state, bounded.sessionId, error?.message || error, {
+      ...publicationDetails,
+      stage: 'verify',
+    });
+    return { ok: false, status: 'failed', stage: 'verify', record: failed };
+  }
+
+  if (!verified) {
+    const failed = await failOrder(state, bounded.sessionId, 'Website Upgrade publication could not be verified.', {
+      ...publicationDetails,
+      stage: 'verify',
+    });
+    return { ok: false, status: 'failed', stage: 'verify', record: failed };
+  }
+
+  const reservation = await state.reserveDelivery(
+    bounded.sessionId,
+    deliveryKey(bounded.sessionId),
+  );
+  record = reservation.record;
+
+  if (!reservation.reserved) {
+    if (record.status === 'delivered') {
+      return { ok: true, status: 'delivered', record, replay: true };
+    }
+    return {
+      ok: false,
+      status: 'delivery_uncertain',
+      record,
+      replay: true,
+    };
+  }
+
+  try {
+    await sendDelivery({
+      order,
+      record,
+      siteUrl: finalUrl,
+      idempotencyKey: deliveryKey(bounded.sessionId),
+    });
+  } catch (error) {
+    const failed = await failOrder(state, bounded.sessionId, error?.message || error, {
+      ...publicationDetails,
+      stage: 'delivery',
+      deliveryState: 'uncertain',
+    });
+    return { ok: false, status: 'delivery_uncertain', stage: 'delivery', record: failed };
+  }
+
+  record = await state.transitionOrder(bounded.sessionId, 'delivered', {
+    ...publicationDetails,
+    stage: 'delivered',
+  });
+  return { ok: true, status: 'delivered', record };
+}
+
+async function processUpgradeOrders(orders, options = {}) {
+  const results = [];
+  for (const order of Array.isArray(orders) ? orders : []) {
+    try {
+      results.push(await processUpgradeOrder(order, options));
+    } catch (error) {
+      results.push({
+        ok: false,
+        status: 'error',
+        sessionId: text(order?.sessionId) || null,
+        error: text(error?.message || error).slice(0, 500),
+      });
+    }
+  }
+  return results;
+}
+
+module.exports = {
+  deliveryKey,
+  processUpgradeOrder,
+  processUpgradeOrders,
+  publicationKey,
+  validateBoundedOrder,
+};


### PR DESCRIPTION
Next bounded slice of #1873 after the durable fulfillment state landed.

Adds an orchestration layer only; real GitHub/Gmail publishing adapters are still injected, so this PR cannot accidentally publish or email during tests.

Safety behavior:
- re-validates the exact `https://3dvr.tech/free-sites/<slug>/` target before publishing
- blocks missing/malformed customer email before publishing
- bounds business name and main action length
- uses stable publish and delivery idempotency keys derived from Stripe Checkout Session ID
- refuses publisher output that points at any different URL
- requires verification before delivery reservation/email
- reserves delivery durably before customer email
- if SMTP outcome is uncertain, preserves the reservation and **will not automatically send again** on retry
- delivered/blocked replays have no side effects
- publish failures can retry using the same stable publication key

Focused tests cover success, delivered replay, missing/invalid email, external target, publisher redirect, verification failure, uncertain delivery/restart, and publish retry idempotency.

This does not change Vercel policy or activate live paid fulfillment yet. A follow-up adapter slice will wire the existing `3dvr-web` publish/verify and Gmail delivery primitives behind this tested contract.