### PR TITLE
Connect Launch Room briefs to Projects

### DIFF
--- a/launch-room/app.js
+++ b/launch-room/app.js
@@ -1,12 +1,14 @@
 import { buildModeBrief, getLaunchRoomMode } from './modes.js';
 
 const STORAGE_KEY = '3dvr.launch-room.movement-brief.v1';
+const PROJECT_PREFILL_KEY = '3dvr.launch-room.project-prefill.v1';
 
 const form = document.getElementById('movementBriefForm');
 const clearButton = document.querySelector('[data-action="clear"]');
 const copyButton = document.querySelector('[data-action="copy"]');
 const downloadButton = document.querySelector('[data-action="download"]');
 const buildLaunchPageButton = document.querySelector('[data-action="build-launch-page"]');
+const createProjectButton = document.querySelector('[data-action="create-project"]');
 const copyLaunchPageButton = document.querySelector('[data-action="copy-launch-page"]');
 const status = document.getElementById('draftStatus');
 const modeSelect = document.getElementById('launchMode');
@@ -294,6 +296,33 @@ async function copyLaunchPage() {
   status.textContent = 'Launch Page Draft copied to clipboard.';
 }
 
+function createProjectDraft() {
+  const brief = buildBrief(getState());
+  const audience = asClause(brief.audience);
+  const projectDraft = {
+    name: brief.movementName,
+    slug: slugify(brief.movementName),
+    stage: 'seed',
+    category: 'movement / project',
+    mission: brief.mission,
+    needs: [
+      `Feedback from ${audience}`,
+      'One person willing to try the first version'
+    ],
+    offers: [brief.tinyProject],
+    contact: '',
+    support: ''
+  };
+
+  try {
+    window.sessionStorage.setItem(PROJECT_PREFILL_KEY, JSON.stringify(projectDraft));
+    status.textContent = 'Project draft prepared. Opening Projects for review…';
+    window.location.href = '../projects/?from=launch-room';
+  } catch {
+    status.textContent = 'Could not prepare the project draft in this browser.';
+  }
+}
+
 const storedDraft = loadDraft();
 const requestedMode = new URLSearchParams(window.location.search).get('mode');
 const initialMode = getLaunchRoomMode(requestedMode || storedDraft.mode || 'start-project');
@@ -344,5 +373,7 @@ copyButton.addEventListener('click', copyBrief);
 downloadButton.addEventListener('click', downloadBrief);
 
 buildLaunchPageButton.addEventListener('click', generateLaunchPage);
+
+createProjectButton.addEventListener('click', createProjectDraft);
 
 copyLaunchPageButton.addEventListener('click', copyLaunchPage);

--- a/launch-room/index.html
+++ b/launch-room/index.html
@@ -114,6 +114,7 @@
               <button class="cta ghost" type="button" data-action="copy">Copy Brief</button>
               <button class="cta ghost" type="button" data-action="download">Download Markdown</button>
               <button class="cta ghost" type="button" data-action="build-launch-page">Build Launch Page</button>
+              <button class="cta ghost" type="button" data-action="create-project">Create Project Draft</button>
             </div>
 
             <div class="brief-stack" aria-live="polite">

--- a/projects/app.js
+++ b/projects/app.js
@@ -1,5 +1,6 @@
 const PROJECT_LAUNCHPAD_ROOT = 'projectLaunchpad';
 const LOCAL_KEY = '3dvr-project-launchpad';
+const LAUNCH_ROOM_PREFILL_KEY = '3dvr.launch-room.project-prefill.v1';
 
 const seedProjects = [
   {
@@ -164,6 +165,34 @@ function normalizeNode(node) {
     createdAt: Number(node.createdAt || Date.now()),
     updatedAt: Number(node.updatedAt || Date.now()),
   };
+}
+
+function applyLaunchRoomPrefill() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('from') !== 'launch-room') return;
+
+  try {
+    const raw = window.sessionStorage.getItem(LAUNCH_ROOM_PREFILL_KEY);
+    if (!raw) return;
+    const draft = JSON.parse(raw);
+
+    els.name.value = clean(draft.name);
+    els.stage.value = clean(draft.stage) || 'seed';
+    els.slug.value = clean(draft.slug) || slugify(draft.name);
+    els.category.value = clean(draft.category) || 'movement / project';
+    els.mission.value = clean(draft.mission);
+    els.needs.value = Array.isArray(draft.needs) ? draft.needs.map(clean).filter(Boolean).join('\n') : clean(draft.needs);
+    els.offers.value = Array.isArray(draft.offers) ? draft.offers.map(clean).filter(Boolean).join('\n') : clean(draft.offers);
+    els.contact.value = clean(draft.contact);
+    els.support.value = clean(draft.support);
+
+    window.sessionStorage.removeItem(LAUNCH_ROOM_PREFILL_KEY);
+    els.status.textContent = 'Project draft prefilled from Launch Room. Review it, then save when ready.';
+    els.form.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    els.name.focus({ preventScroll: true });
+  } catch (_error) {
+    els.status.textContent = 'Launch Room project draft could not be loaded. Nothing was saved.';
+  }
 }
 
 function saveLocalBackup() {
@@ -440,3 +469,4 @@ loadLocalBackup();
 bindFilters();
 renderProjects();
 bindGun();
+applyLaunchRoomPrefill();

--- a/tests/launch-room.test.js
+++ b/tests/launch-room.test.js
@@ -33,6 +33,8 @@ test('launch room ships a local-first Movement Brief flow', async () => {
   assert.match(html, /Download Markdown/);
   assert.match(html, /Build Launch Page/);
   assert.match(html, /data-action="build-launch-page"/);
+  assert.match(html, /Create Project Draft/);
+  assert.match(html, /data-action="create-project"/);
   assert.match(html, /Movement Brief/);
   assert.match(html, /Launch Checklist/);
   assert.match(html, /Next 3 Actions/);
@@ -53,6 +55,10 @@ test('launch room ships a local-first Movement Brief flow', async () => {
   assert.match(html, /data-mode-tools/);
 
   assert.match(app, /STORAGE_KEY = '3dvr\.launch-room\.movement-brief\.v1'/);
+  assert.match(app, /PROJECT_PREFILL_KEY = '3dvr\.launch-room\.project-prefill\.v1'/);
+  assert.match(app, /sessionStorage\.setItem\(PROJECT_PREFILL_KEY/);
+  assert.match(app, /window\.location\.href = '\.\.\/projects\/\?from=launch-room'/);
+  assert.match(app, /createProjectButton\.addEventListener\('click', createProjectDraft\)/);
   assert.match(app, /function buildBrief/);
   assert.match(app, /function briefToMarkdown/);
   assert.match(app, /function buildLaunchPage/);

--- a/tests/projects-launchpad.test.js
+++ b/tests/projects-launchpad.test.js
@@ -47,6 +47,12 @@ describe('3DVR Seed Deck', () => {
 
     assert.match(js, /PROJECT_LAUNCHPAD_ROOT = 'projectLaunchpad'/);
     assert.match(js, /LOCAL_KEY = '3dvr-project-launchpad'/);
+    assert.match(js, /LAUNCH_ROOM_PREFILL_KEY = '3dvr\.launch-room\.project-prefill\.v1'/);
+    assert.match(js, /new URLSearchParams\(window\.location\.search\)/);
+    assert.match(js, /sessionStorage\.getItem\(LAUNCH_ROOM_PREFILL_KEY\)/);
+    assert.match(js, /sessionStorage\.removeItem\(LAUNCH_ROOM_PREFILL_KEY\)/);
+    assert.match(js, /Project draft prefilled from Launch Room\. Review it, then save when ready\./);
+    assert.match(js, /applyLaunchRoomPrefill\(\)/);
     assert.match(js, /gun\.get\('3dvr-portal'\)\.get\(PROJECT_LAUNCHPAD_ROOT\)/);
     assert.match(js, /root\?\.get\('nodes'\)\.get\(node\.slug\)\.put\(node\)/);
     assert.match(js, /root\?\.get\('updates'\)\.get\(update\.id\)\.put\(update\)/);
@@ -59,10 +65,9 @@ describe('3DVR Seed Deck', () => {
   it('keeps Projects registered in the portal dock as the launchpad entry', async () => {
     const html = await readFile(new URL('../index.html', baseDir), 'utf8');
 
-    assert.match(html, /href="projects\/index\.html"/);
-    assert.match(html, /<span class="app-card__title">Projects<\/span>/);
-    assert.match(html, /Open Seed Deck to plant ideas with pages, updates, needs, offers, and support links/);
-    assert.match(html, /data-app-keywords="[^"]*\bseed deck\b[^"]*"/);
-    assert.match(html, /data-app-keywords="[^"]*\blaunchpad\b[^"]*"/);
+    assert.match(html, /href="\/projects\/"/);
+    assert.match(html, /<strong>Projects<\/strong>/);
+    assert.match(html, /Active work and next steps\./);
+    assert.match(html, /data-app="[^"]*\bprojects\b[^"]*"/);
   });
 });


### PR DESCRIPTION
Starts the next roadmap connection without creating another app.

- adds `Create Project Draft` beside the existing Launch Room brief actions
- hands the brief to Projects through one-time same-origin `sessionStorage`
- pre-fills the existing Projects form with name, slug, mission, first offer, and initial needs
- requires explicit review + normal form submit before anything is saved to Gun/local storage
- removes the one-time handoff after it is consumed
- updates the stale Projects homepage regression expectation to match the already-shipped `/projects/` app entry

Focused validation: `node --test tests/launch-room.test.js tests/projects-launchpad.test.js` — 4/4 passing; `git diff --check` passes.