### PR TITLE
Connect Projects to Web Builder

### DIFF
--- a/projects/app.js
+++ b/projects/app.js
@@ -1,6 +1,7 @@
 const PROJECT_LAUNCHPAD_ROOT = 'projectLaunchpad';
 const LOCAL_KEY = '3dvr-project-launchpad';
 const LAUNCH_ROOM_PREFILL_KEY = '3dvr.launch-room.project-prefill.v1';
+const WEB_BUILDER_PREFILL_KEY = 'web-builder-prefill-request';
 
 const seedProjects = [
   {
@@ -348,6 +349,12 @@ function renderProjects() {
       actions.append(support);
     }
 
+    const buildPage = document.createElement('button');
+    buildPage.type = 'button';
+    buildPage.dataset.buildPage = project.slug;
+    buildPage.textContent = 'Build page';
+    actions.append(buildPage);
+
     const follow = document.createElement('button');
     follow.type = 'button';
     follow.dataset.follow = project.slug;
@@ -423,6 +430,39 @@ function followProject(slug) {
   els.status.textContent = 'Follow saved.';
 }
 
+function buildProjectPage(slug) {
+  const project = state.nodes.get(slug);
+  if (!project) return;
+
+  const firstOffer = project.offers[0] || '';
+  const request = [
+    `Create a simple launch page for ${project.name}.`,
+    project.mission ? `Mission: ${project.mission}` : '',
+    firstOffer ? `First offer or invitation: ${firstOffer}` : '',
+    project.needs.length ? `Current needs: ${project.needs.join('; ')}.` : '',
+    'Keep the page focused on one clear next step and make it work well on mobile.'
+  ].filter(Boolean).join(' ');
+
+  const prefill = {
+    request,
+    siteTitle: project.name,
+    siteGoal: firstOffer
+      ? `Help visitors understand the project and take this first step: ${firstOffer}`
+      : 'Explain the project clearly and give visitors one useful next step.',
+    audience: project.category && project.category !== 'project'
+      ? `People interested in ${project.category}.`
+      : 'People this project is meant to help.'
+  };
+
+  try {
+    window.sessionStorage.setItem(WEB_BUILDER_PREFILL_KEY, JSON.stringify(prefill));
+    els.status.textContent = 'Page draft prepared. Opening Web Builder for review…';
+    window.location.href = '../web-builder-app/';
+  } catch (_error) {
+    els.status.textContent = 'Could not prepare the Web Builder draft in this browser.';
+  }
+}
+
 function bindFilters() {
   els.filters.forEach(button => {
     button.addEventListener('click', () => {
@@ -459,9 +499,15 @@ function bindGun() {
 els.form.addEventListener('submit', saveNode);
 els.updateForm.addEventListener('submit', saveUpdate);
 els.list.addEventListener('click', event => {
-  const button = event.target.closest('[data-follow]');
-  if (!button) return;
-  followProject(button.dataset.follow);
+  const buildPageButton = event.target.closest('[data-build-page]');
+  if (buildPageButton) {
+    buildProjectPage(buildPageButton.dataset.buildPage);
+    return;
+  }
+
+  const followButton = event.target.closest('[data-follow]');
+  if (!followButton) return;
+  followProject(followButton.dataset.follow);
 });
 
 loadSeeds();

--- a/tests/projects-launchpad.test.js
+++ b/tests/projects-launchpad.test.js
@@ -48,6 +48,11 @@ describe('3DVR Seed Deck', () => {
     assert.match(js, /PROJECT_LAUNCHPAD_ROOT = 'projectLaunchpad'/);
     assert.match(js, /LOCAL_KEY = '3dvr-project-launchpad'/);
     assert.match(js, /LAUNCH_ROOM_PREFILL_KEY = '3dvr\.launch-room\.project-prefill\.v1'/);
+    assert.match(js, /WEB_BUILDER_PREFILL_KEY = 'web-builder-prefill-request'/);
+    assert.match(js, /buildPage\.textContent = 'Build page'/);
+    assert.match(js, /sessionStorage\.setItem\(WEB_BUILDER_PREFILL_KEY/);
+    assert.match(js, /window\.location\.href = '\.\.\/web-builder-app\/'/);
+    assert.match(js, /Page draft prepared\. Opening Web Builder for review/);
     assert.match(js, /new URLSearchParams\(window\.location\.search\)/);
     assert.match(js, /sessionStorage\.getItem\(LAUNCH_ROOM_PREFILL_KEY\)/);
     assert.match(js, /sessionStorage\.removeItem\(LAUNCH_ROOM_PREFILL_KEY\)/);


### PR DESCRIPTION
Continues the post-consolidation launch path by connecting existing Core surfaces.

- adds `Build page` to each Project card
- translates the project mission, first offer, needs, and category into the Web Builder's existing `web-builder-prefill-request` contract
- uses one-time session storage and opens the existing Web Builder
- does not generate, deploy, or publish anything automatically; the Web Builder remains the review/action boundary

Focused validation: `node --test tests/projects-launchpad.test.js tests/web-builder-defaults.test.js` — 10/10 passing; `git diff --check` passes.