### PR TITLE
Connect Projects to Growth Operator

### DIFF
--- a/growth-operator/app.js
+++ b/growth-operator/app.js
@@ -1,5 +1,6 @@
 const STORAGE_KEY = '3dvr.growthOperator.items.v1';
 const TOKEN_STORAGE_KEY = '3dvr.growthOperator.operatorEmailToken.v1';
+const PROJECT_LEAD_BRIEF_KEY = '3dvr.growthOperator.project-lead-brief.v1';
 const ROOT_KEY = '3dvr-portal';
 const OPERATOR_NODE = 'growthOperator';
 const AGENT_OWNER_ALIAS = '3dvr-managed';
@@ -64,7 +65,8 @@ const STAGE_LABELS = Object.freeze({
 const state = {
   items: loadItems(),
   sendingId: '',
-  queueing: false
+  queueing: false,
+  projectLeadBrief: null
 };
 
 const gun = typeof Gun === 'function' ? Gun(window.__GUN_PEERS__ || DEFAULT_PEERS) : null;
@@ -153,6 +155,44 @@ function readStorageText(key) {
     return normalizeText(window.localStorage.getItem(key));
   } catch (_error) {
     return '';
+  }
+}
+
+function hydrateProjectLeadBrief() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('from') !== 'project') return;
+
+  try {
+    const raw = window.sessionStorage.getItem(PROJECT_LEAD_BRIEF_KEY);
+    if (!raw) return;
+    const brief = JSON.parse(raw);
+    const projectName = normalizeText(brief?.projectName);
+    if (!projectName) return;
+
+    state.projectLeadBrief = {
+      projectName,
+      projectSlug: normalizeText(brief.projectSlug),
+      mission: normalizeText(brief.mission),
+      category: normalizeText(brief.category),
+      offer: normalizeText(brief.offer),
+      needs: Array.isArray(brief.needs) ? brief.needs.map(normalizeText).filter(Boolean).slice(0, 8) : [],
+      support: normalizeText(brief.support)
+    };
+    window.sessionStorage.removeItem(PROJECT_LEAD_BRIEF_KEY);
+
+    if (els.itemOffer && state.projectLeadBrief.offer) {
+      els.itemOffer.value = state.projectLeadBrief.offer;
+    }
+    if (els.itemContext) {
+      els.itemContext.value = [
+        `Project: ${state.projectLeadBrief.projectName}`,
+        state.projectLeadBrief.mission,
+        state.projectLeadBrief.category ? `Audience/category: ${state.projectLeadBrief.category}` : ''
+      ].filter(Boolean).join('\n');
+    }
+    updateStatus(`Loaded ${projectName}. Review the target, then use Find leads when you want research queued.`);
+  } catch (_error) {
+    updateStatus('Project people brief could not be loaded. Nothing was queued or sent.');
   }
 }
 
@@ -460,7 +500,21 @@ function buildAgentTask(kind, item = null) {
   ];
 
   if (kind === 'find-leads') {
-    taskLines.push('Find 10 likely-fit 3dvr.tech leads from public sources, existing CRM gaps, market research, and referral context.');
+    const project = state.projectLeadBrief;
+    if (project) {
+      taskLines.push(
+        '',
+        `Target project: ${project.projectName}${project.projectSlug ? ` (${project.projectSlug})` : ''}`,
+        project.mission ? `Project mission: ${project.mission}` : '',
+        project.category ? `Audience/category: ${project.category}` : '',
+        project.offer ? `First offer or invitation: ${project.offer}` : '',
+        project.needs.length ? `Current needs: ${project.needs.join('; ')}` : '',
+        project.support ? `Project/support page: ${project.support}` : '',
+        'Find 10 likely-fit people or organizations for this project from public sources, existing CRM gaps, market research, and referral context. Prefer plausible first customers, collaborators, or introducers. Do not contact them; return candidates and draft next steps for review.'
+      );
+    } else {
+      taskLines.push('Find 10 likely-fit 3dvr.tech leads from public sources, existing CRM gaps, market research, and referral context.');
+    }
   }
   if (kind === 'draft-outreach') {
     taskLines.push('Draft the next approved outreach note for each lead with an email or clear contact path.');
@@ -795,6 +849,7 @@ function init() {
   }
   bindEvents();
   render();
+  hydrateProjectLeadBrief();
   subscribeGun();
   subscribeAutopilotState();
   subscribeCrm();

--- a/projects/app.js
+++ b/projects/app.js
@@ -2,6 +2,7 @@ const PROJECT_LAUNCHPAD_ROOT = 'projectLaunchpad';
 const LOCAL_KEY = '3dvr-project-launchpad';
 const LAUNCH_ROOM_PREFILL_KEY = '3dvr.launch-room.project-prefill.v1';
 const WEB_BUILDER_PREFILL_KEY = 'web-builder-prefill-request';
+const GROWTH_OPERATOR_PROJECT_BRIEF_KEY = '3dvr.growthOperator.project-lead-brief.v1';
 
 const seedProjects = [
   {
@@ -355,6 +356,12 @@ function renderProjects() {
     buildPage.textContent = 'Build page';
     actions.append(buildPage);
 
+    const findPeople = document.createElement('button');
+    findPeople.type = 'button';
+    findPeople.dataset.findPeople = project.slug;
+    findPeople.textContent = 'Find people';
+    actions.append(findPeople);
+
     const follow = document.createElement('button');
     follow.type = 'button';
     follow.dataset.follow = project.slug;
@@ -463,6 +470,29 @@ function buildProjectPage(slug) {
   }
 }
 
+function findProjectPeople(slug) {
+  const project = state.nodes.get(slug);
+  if (!project) return;
+
+  const brief = {
+    projectName: project.name,
+    projectSlug: project.slug,
+    mission: project.mission,
+    category: project.category,
+    offer: project.offers[0] || '',
+    needs: project.needs,
+    support: project.support || ''
+  };
+
+  try {
+    window.sessionStorage.setItem(GROWTH_OPERATOR_PROJECT_BRIEF_KEY, JSON.stringify(brief));
+    els.status.textContent = 'People brief prepared. Opening Growth Operator for review…';
+    window.location.href = '../growth-operator/?from=project';
+  } catch (_error) {
+    els.status.textContent = 'Could not prepare the Growth Operator brief in this browser.';
+  }
+}
+
 function bindFilters() {
   els.filters.forEach(button => {
     button.addEventListener('click', () => {
@@ -502,6 +532,12 @@ els.list.addEventListener('click', event => {
   const buildPageButton = event.target.closest('[data-build-page]');
   if (buildPageButton) {
     buildProjectPage(buildPageButton.dataset.buildPage);
+    return;
+  }
+
+  const findPeopleButton = event.target.closest('[data-find-people]');
+  if (findPeopleButton) {
+    findProjectPeople(findPeopleButton.dataset.findPeople);
     return;
   }
 

--- a/tests/growth-operator.test.js
+++ b/tests/growth-operator.test.js
@@ -45,6 +45,12 @@ test('growth operator app queues agent work and can send approved outreach throu
   const js = await readFile(new URL('app.js', baseDir), 'utf8');
 
   assert.match(js, /OPERATOR_NODE = 'growthOperator'/);
+  assert.match(js, /PROJECT_LEAD_BRIEF_KEY = '3dvr\.growthOperator\.project-lead-brief\.v1'/);
+  assert.match(js, /function hydrateProjectLeadBrief/);
+  assert.match(js, /sessionStorage\.getItem\(PROJECT_LEAD_BRIEF_KEY\)/);
+  assert.match(js, /Review the target, then use Find leads when you want research queued/);
+  assert.match(js, /Find 10 likely-fit people or organizations for this project/);
+  assert.match(js, /Do not contact them; return candidates and draft next steps for review/);
   assert.match(js, /AGENT_OWNER_ALIAS = '3dvr-managed'/);
   assert.match(js, /AUDIENCE_LEAD_SOURCES = Object\.freeze/);
   assert.match(js, /key: 'forge-revenue-sprint'/);

--- a/tests/projects-launchpad.test.js
+++ b/tests/projects-launchpad.test.js
@@ -49,6 +49,10 @@ describe('3DVR Seed Deck', () => {
     assert.match(js, /LOCAL_KEY = '3dvr-project-launchpad'/);
     assert.match(js, /LAUNCH_ROOM_PREFILL_KEY = '3dvr\.launch-room\.project-prefill\.v1'/);
     assert.match(js, /WEB_BUILDER_PREFILL_KEY = 'web-builder-prefill-request'/);
+    assert.match(js, /GROWTH_OPERATOR_PROJECT_BRIEF_KEY = '3dvr\.growthOperator\.project-lead-brief\.v1'/);
+    assert.match(js, /findPeople\.textContent = 'Find people'/);
+    assert.match(js, /sessionStorage\.setItem\(GROWTH_OPERATOR_PROJECT_BRIEF_KEY/);
+    assert.match(js, /window\.location\.href = '\.\.\/growth-operator\/\?from=project'/);
     assert.match(js, /buildPage\.textContent = 'Build page'/);
     assert.match(js, /sessionStorage\.setItem\(WEB_BUILDER_PREFILL_KEY/);
     assert.match(js, /window\.location\.href = '\.\.\/web-builder-app\/'/);


### PR DESCRIPTION
Continues the post-consolidation path toward first customers by connecting Projects to the existing Growth Operator.

- adds `Find people` to each Project card
- hands project mission, category, first offer, needs, and support page into Growth Operator through one-time session storage
- preloads the targeting context without creating a lead or queueing work automatically
- keeps `Find leads` as the explicit action that queues research
- scopes targeted research to plausible first customers, collaborators, or introducers
- explicitly instructs the agent not to contact candidates; return candidates and draft next steps for review
- preserves Growth Operator's existing draft → approve → send boundary

Focused validation: `node --test tests/projects-launchpad.test.js tests/growth-operator.test.js` — 6/6 passing; `git diff --check` passes.