### PR TITLE
Link deployed pages back to Projects

### DIFF
--- a/projects/app.js
+++ b/projects/app.js
@@ -458,7 +458,9 @@ function buildProjectPage(slug) {
       : 'Explain the project clearly and give visitors one useful next step.',
     audience: project.category && project.category !== 'project'
       ? `People interested in ${project.category}.`
-      : 'People this project is meant to help.'
+      : 'People this project is meant to help.',
+    projectSlug: project.slug,
+    projectName: project.name
   };
 
   try {

--- a/tests/projects-launchpad.test.js
+++ b/tests/projects-launchpad.test.js
@@ -55,6 +55,8 @@ describe('3DVR Seed Deck', () => {
     assert.match(js, /window\.location\.href = '\.\.\/growth-operator\/\?from=project'/);
     assert.match(js, /buildPage\.textContent = 'Build page'/);
     assert.match(js, /sessionStorage\.setItem\(WEB_BUILDER_PREFILL_KEY/);
+    assert.match(js, /projectSlug: project\.slug/);
+    assert.match(js, /projectName: project\.name/);
     assert.match(js, /window\.location\.href = '\.\.\/web-builder-app\/'/);
     assert.match(js, /Page draft prepared\. Opening Web Builder for review/);
     assert.match(js, /new URLSearchParams\(window\.location\.search\)/);

--- a/tests/web-builder-defaults.test.js
+++ b/tests/web-builder-defaults.test.js
@@ -67,6 +67,12 @@ test('web builder accepts homepage owned-app handoff', async () => {
   const app = await readFile(new URL('../web-builder-app/app.js', import.meta.url), 'utf8');
 
   assert.match(app, /builderPrefillStorageKey = 'web-builder-prefill-request'/);
+  assert.match(app, /builderProjectContextStorageKey = 'web-builder-project-context'/);
+  assert.match(app, /currentProjectContext = \{ projectSlug, projectName: projectName \|\| projectSlug \}/);
+  assert.match(app, /function recordProjectDeployment/);
+  assert.match(app, /portalRoot\.get\('projectLaunchpad'\)\.get\('nodes'\)\.get\(project\.projectSlug\)/);
+  assert.match(app, /title: 'Project page deployed'/);
+  assert.match(app, /await recordProjectDeployment\(deployedUrl\)/);
   assert.match(app, /hydrateBuilderPrefill\(\)/);
   assert.match(app, /builderRequestInput\.value = request/);
   assert.match(app, /siteTitleInput\.value = title/);

--- a/web-builder-app/app.js
+++ b/web-builder-app/app.js
@@ -55,6 +55,7 @@ let currentSources = [];
 let currentSearchUsage = null;
 let generateStatusAnimationTimer = null;
 let billingStatusSyncPromise = null;
+let currentProjectContext = null;
 let resolveDefaultsFirstRecord = null;
 const defaultsFirstRecordPromise = new Promise(resolve => {
   resolveDefaultsFirstRecord = resolve;
@@ -77,6 +78,7 @@ const vercelStorageKey = 'web-builder-vercel';
 const githubStorageKey = 'web-builder-github';
 const modelStorageKey = 'web-builder-model';
 const builderPrefillStorageKey = 'web-builder-prefill-request';
+const builderProjectContextStorageKey = 'web-builder-project-context';
 
 const STATUS_TONE_CLASSES = ['status--info', 'status--success', 'status--warning', 'status--error'];
 const LOAD_DEFAULTS_LABEL = 'Reload shared defaults';
@@ -386,7 +388,18 @@ function hydrateBuilderPrefill() {
   const raw = safeRead(localStorage, builderPrefillStorageKey) || safeRead(sessionStorage, builderPrefillStorageKey);
   const prefill = safeParseJson(raw);
   if (!prefill || typeof prefill !== 'object') {
+    const storedProjectContext = safeParseJson(safeRead(sessionStorage, builderProjectContextStorageKey));
+    if (storedProjectContext?.projectSlug) {
+      currentProjectContext = storedProjectContext;
+    }
     return;
+  }
+
+  const projectSlug = String(prefill.projectSlug || '').trim();
+  const projectName = String(prefill.projectName || '').trim();
+  if (projectSlug) {
+    currentProjectContext = { projectSlug, projectName: projectName || projectSlug };
+    safeWrite(sessionStorage, builderProjectContextStorageKey, JSON.stringify(currentProjectContext));
   }
 
   const request = String(prefill.request || '').trim();
@@ -1617,6 +1630,65 @@ async function handleIterate() {
   await requestGeneration(prompt, 'iterate');
 }
 
+function normalizePublicUrl(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  try {
+    const url = new URL(raw.includes('://') ? raw : `https://${raw}`);
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url.href : '';
+  } catch (_error) {
+    return '';
+  }
+}
+
+function putGunRecord(node, payload) {
+  return new Promise((resolve, reject) => {
+    if (!node || typeof node.put !== 'function') {
+      reject(new Error('Project graph is unavailable.'));
+      return;
+    }
+    const timer = window.setTimeout(() => resolve({ timedOut: true }), 5000);
+    node.put(payload, ack => {
+      window.clearTimeout(timer);
+      if (ack?.err) reject(new Error(String(ack.err)));
+      else resolve(ack || {});
+    });
+  });
+}
+
+async function recordProjectDeployment(rawUrl) {
+  const project = currentProjectContext;
+  const url = normalizePublicUrl(rawUrl);
+  if (!project?.projectSlug || !url) return;
+
+  const now = Date.now();
+  const updateId = `page-${project.projectSlug}-${now.toString(36)}`;
+  try {
+    await Promise.all([
+      putGunRecord(
+        portalRoot.get('projectLaunchpad').get('nodes').get(project.projectSlug),
+        { support: url, updatedAt: now }
+      ),
+      putGunRecord(
+        portalRoot.get('projectLaunchpad').get('updates').get(updateId),
+        {
+          id: updateId,
+          projectId: project.projectSlug,
+          projectSlug: project.projectSlug,
+          title: 'Project page deployed',
+          body: `Live page: ${url}`,
+          createdAt: now
+        }
+      )
+    ]);
+    safeRemove(sessionStorage, builderProjectContextStorageKey);
+    currentProjectContext = null;
+    logMessage(`Linked deployed page back to project ${project.projectName || project.projectSlug}.`);
+  } catch (error) {
+    logMessage(`Site deployed, but project link-back did not sync: ${error.message || 'Gun sync failed.'}`);
+  }
+}
+
 async function handleDeploy() {
   if (!currentHtml) {
     setGenerateStatus('Generate a site first, then deploy from the Publish panel.', 'warning');
@@ -1655,8 +1727,10 @@ async function handleDeploy() {
       return;
     }
 
-    setGenerateStatus(`Deployed: ${result.url || result.inspectUrl}`, 'success');
-    logMessage(`Deployment ready at ${result.url || 'Vercel inspect panel'}`);
+    const deployedUrl = result.url || '';
+    setGenerateStatus(`Deployed: ${deployedUrl || result.inspectUrl}`, 'success');
+    logMessage(`Deployment ready at ${deployedUrl || 'Vercel inspect panel'}`);
+    await recordProjectDeployment(deployedUrl);
   } catch (error) {
     setGenerateStatus('Unable to reach the Vercel deploy API.', 'error');
     logMessage(error.message || 'Network error');


### PR DESCRIPTION
Completes the Project → Page loop by linking successful Web Builder deployments back to the originating Project.

- includes project identity in the existing Web Builder prefill contract
- remembers project context only for project-launched builds
- after a successful user-triggered Vercel deploy, writes the deployed URL back to the Project support/page field
- adds a `Project page deployed` update to the Project timeline
- does not auto-generate or auto-deploy anything

Focused validation: `node --test tests/projects-launchpad.test.js tests/web-builder-defaults.test.js` — 10/10 passing; `git diff --check` passes.