### PR TITLE
Focus Work Agent on AV contacts

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -86,6 +86,20 @@
     </div>
   </div>
 
+  <div id="avNetworkBanner" class="hidden max-w-6xl mx-auto px-4 pt-4">
+    <div class="rounded-xl border border-teal-400/25 bg-teal-950/30 p-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.28em] text-teal-300">First market · live-event AV</p>
+        <h1 class="text-xl font-semibold">AV Network</h1>
+        <p class="text-sm text-gray-300">Production companies, labor coordinators, PMs, crew chiefs, venues, and technicians in one worker-owned network.</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <a href="../work-agent/" class="bg-teal-600 hover:bg-teal-500 px-4 py-2 rounded text-sm font-medium">Open Work Agent</a>
+        <a href="./" class="bg-white/10 hover:bg-white/20 px-4 py-2 rounded text-sm font-medium border border-white/10">All contacts</a>
+      </div>
+    </div>
+  </div>
+
   <main class="max-w-6xl mx-auto p-4 grid gap-6 md:grid-cols-[320px,1fr]">
 
     <!-- Settings / Space / Backup -->
@@ -183,9 +197,14 @@
             <label class="text-sm text-gray-300" for="search">Search contacts</label>
             <input id="search" placeholder="Name, email, company, tags…" class="w-full p-2 rounded text-black" />
           </div>
-          <a href="https://portal.3dvr.tech/crm/index.html" class="bg-white/10 hover:bg-white/20 px-4 py-2 rounded text-sm font-medium text-center border border-white/10">
-            Search CRM
-          </a>
+          <div class="grid grid-cols-2 gap-2">
+            <a href="?view=av" class="bg-teal-900/60 hover:bg-teal-800/70 px-3 py-2 rounded text-sm font-medium text-center border border-teal-400/20">
+              AV Network
+            </a>
+            <a href="https://portal.3dvr.tech/crm/index.html" class="bg-white/10 hover:bg-white/20 px-3 py-2 rounded text-sm font-medium text-center border border-white/10">
+              Search CRM
+            </a>
+          </div>
         </div>
       </div>
 
@@ -903,6 +922,8 @@ let lastFocusedBeforeAuth = null;
 const urlParams = new URLSearchParams(window.location.search);
 const requestedSpace = urlParams.get('space');
 const focusContactId = urlParams.get('contact');
+const avNetworkView = (urlParams.get('view') || '').trim().toLowerCase() === 'av';
+const shouldOpenPrefill = ['1', 'true', 'yes'].includes((urlParams.get('new') || '').trim().toLowerCase());
 const cellContextId = (urlParams.get('cellId') || urlParams.get('cell') || '').trim();
 const focusClasses = ['ring-2', 'ring-emerald-400', 'ring-offset-2', 'ring-offset-gray-900'];
 let focusScrollDone = false;
@@ -1502,6 +1523,7 @@ const btnImportGoogleContacts = document.getElementById('btnImportGoogleContacts
 const btnImportMicrosoftContacts = document.getElementById('btnImportMicrosoftContacts');
 const contactsImportStatus = document.getElementById('contactsImportStatus');
 const createContactOverlay = document.getElementById('createContactOverlay');
+const avNetworkBanner = document.getElementById('avNetworkBanner');
 const contactDetailOverlay = document.getElementById('contactDetailOverlay');
 const contactDetailName = document.getElementById('contactDetailName');
 const contactDetailSummary = document.getElementById('contactDetailSummary');
@@ -1532,10 +1554,48 @@ if (bulkImport) {
 
 refreshCellContextBanner();
 
+function prefillContactFromUrl() {
+  const fieldMap = {
+    name: 'name',
+    email: 'email',
+    phone: 'phone',
+    company: 'company',
+    role: 'role',
+    status: 'status',
+    notes: 'notes',
+  };
+  Object.entries(fieldMap).forEach(([param, id]) => {
+    const value = (urlParams.get(param) || '').trim().slice(0, param === 'notes' ? 2000 : 300);
+    const field = document.getElementById(id);
+    if (field && value) field.value = value;
+  });
+  const tagsField = document.getElementById('tags');
+  if (tagsField) {
+    const requestedTags = (urlParams.get('tags') || '').trim();
+    const tags = requestedTags.split(',').map(item => item.trim()).filter(Boolean);
+    if (avNetworkView && !tags.some(tag => tag.toLowerCase() === 'industry/av')) tags.unshift('industry/av');
+    if (tags.length) tagsField.value = Array.from(new Set(tags)).join(', ');
+  }
+}
+
+function initializeAvNetworkView() {
+  if (!avNetworkView) return;
+  avNetworkBanner?.classList.remove('hidden');
+  document.title = 'AV Network | 3DVR Contacts';
+  openCreateContactBtn && (openCreateContactBtn.textContent = 'Add AV contact');
+}
+
+prefillContactFromUrl();
+initializeAvNetworkView();
+
 let lastFocusedBeforeCreate = null;
 
 function openCreateContact(){
   if(!createContactOverlay) return;
+  if (avNetworkView) {
+    const tagsInput = document.getElementById('tags');
+    if (tagsInput && !tagsInput.value.trim()) tagsInput.value = 'industry/av';
+  }
   lastFocusedBeforeCreate = document.activeElement;
   createContactOverlay.classList.remove('hidden');
   setTimeout(()=>{
@@ -1553,6 +1613,7 @@ function closeCreateContact(){
 
 openCreateContactBtn?.addEventListener('click', openCreateContact);
 closeCreateContactBtn?.addEventListener('click', closeCreateContact);
+if (shouldOpenPrefill) setTimeout(openCreateContact, 0);
 createContactOverlay?.addEventListener('click', evt=>{
   if(evt.target === createContactOverlay) closeCreateContact();
 });
@@ -2921,6 +2982,10 @@ function applyFilters(items){
   return items.filter(c=>{
     const hay = `${c.name||''} ${c.email||''} ${c.phone||''} ${c.company||''} ${c.role||''} ${c.tags||''} ${c.notes||''}`.toLowerCase();
     if(q && !hay.includes(q)) return false;
+    if(avNetworkView){
+      const tags = String(c.tags || '').toLowerCase().split(',').map(tag => tag.trim());
+      if(!tags.includes('industry/av')) return false;
+    }
     if(fS && (c.status||'') !== fS) return false;
     if(fC === 'linked' && !c.crmId) return false;
     if(fC === 'unlinked' && c.crmId) return false;

--- a/tests/av-contacts-market.test.js
+++ b/tests/av-contacts-market.test.js
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('AV contacts first market', () => {
+  it('gives Contacts an AV network view and URL-prefilled contact handoff', async () => {
+    const html = await readFile(new URL('../contacts/index.html', import.meta.url), 'utf8');
+    assert.match(html, /AV Network/);
+    assert.match(html, /avNetworkView/);
+    assert.match(html, /industry\/av/);
+    assert.match(html, /shouldOpenPrefill/);
+    assert.match(html, /prefillContactFromUrl/);
+  });
+
+  it('models Work Agent leads as AV contacts and hands them to canonical Contacts', async () => {
+    const html = await readFile(new URL('../work-agent/index.html', import.meta.url), 'utf8');
+    const app = await readFile(new URL('../work-agent/app.js', import.meta.url), 'utf8');
+    assert.match(html, /AV contacts/);
+    assert.match(html, /Labor coordinator \/ scheduler/);
+    assert.match(html, /Open AV Contacts/);
+    assert.match(app, /AV_CONTACT_KIND_LABELS/);
+    assert.match(app, /avContactHref/);
+    assert.match(app, /industry\/av, av\/network/);
+    assert.match(app, /Save to AV Contacts/);
+  });
+
+  it('documents AV contacts as the deliberate first vertical', async () => {
+    const readme = await readFile(new URL('../work-agent/README.md', import.meta.url), 'utf8');
+    assert.match(readme, /First market: AV contacts/);
+    assert.match(readme, /Contacts is the canonical network/);
+    assert.match(readme, /labor coordinators/);
+  });
+});

--- a/work-agent/README.md
+++ b/work-agent/README.md
@@ -2,6 +2,26 @@
 
 A worker-owned freelance booking agent for AV technicians and stagehands.
 
+## First market: AV contacts
+
+The first vertical is intentionally narrow: live-event AV workers and the people who book them. Contacts is the canonical network; Work Agent is the operator that acts on those records.
+
+Use `industry/av` as the durable vertical tag. More specific tags can describe the relationship without creating separate databases:
+
+```text
+industry/av
+av/network
+av/type/production-company
+av/type/labor-coordinator
+av/type/pm-td
+av/type/crew-chief
+av/type/technician
+av/type/venue
+source/work-agent
+```
+
+The initial network should favor high-leverage contacts who can directly create or fill calls: labor coordinators, production-company schedulers, PMs/TDs, crew chiefs, and trusted technicians. Generic CRM expansion comes after this AV loop produces repeat work.
+
 ## First useful loop
 
 1. Worker signs in and connects their own email.

--- a/work-agent/app.js
+++ b/work-agent/app.js
@@ -803,37 +803,69 @@
     addActivity('Rate and booking rules updated.');
   }
 
+  const AV_CONTACT_KIND_LABELS = {
+    'production-company': 'Production company',
+    'labor-coordinator': 'Labor coordinator / scheduler',
+    'pm-td': 'PM / technical director',
+    'crew-chief': 'Crew chief / lead',
+    technician: 'Freelance technician',
+    venue: 'Venue / property AV contact',
+    other: 'Other AV contact',
+  };
+
+  function avContactKindLabel(kind) {
+    return AV_CONTACT_KIND_LABELS[kind] || AV_CONTACT_KIND_LABELS.other;
+  }
+
+  function avContactHref(company) {
+    const params = new URLSearchParams({
+      view: 'av',
+      new: '1',
+      name: company.contactName || '',
+      email: company.email || '',
+      company: company.name || '',
+      role: avContactKindLabel(company.kind),
+      tags: `industry/av, av/network, av/type/${company.kind || 'other'}, source/work-agent`,
+      status: company.relationship === 'warm' ? 'Active' : 'Prospect',
+      notes: `Added from 3DVR Work Agent. Relationship: ${company.relationship || 'unknown'}.`,
+    });
+    return `/contacts/?${params.toString()}`;
+  }
+
   function outreachDraft(company) {
     const profile = state.profile;
     const rate = Number(state.rules.targetRate) || 0;
     const role = profile.roles || 'AV technician';
     const market = profile.market || 'my market';
     const name = profile.name || '—';
+    const firstName = String(company.contactName || '').trim().split(/\s+/)[0];
+    const greeting = firstName ? `Hi ${firstName}` : `Hi ${company.name} team`;
     if (company.relationship === 'warm') {
-      return `Hi ${company.name} team — I’m opening up more freelance availability for ${role} work around ${market}. I’d be glad to work together again. My current day rate is $${rate}. If you have upcoming calls, feel free to send dates and show details.\n\nThanks,\n${name}`;
+      return `${greeting} — I’m opening up more freelance availability for ${role} work around ${market}. I’d be glad to work together again. My current day rate is $${rate}. If you have upcoming calls, feel free to send dates and show details.\n\nThanks,\n${name}`;
     }
     if (company.relationship === 'referred') {
-      return `Hi ${company.name} team — I was referred your way and wanted to introduce myself. I’m a freelance ${role} based around ${market}. My current day rate is $${rate}. I’d be happy to send availability and a resume for your technician pool.\n\nThanks,\n${name}`;
+      return `${greeting} — I was referred your way and wanted to introduce myself. I’m a freelance ${role} based around ${market}. My current day rate is $${rate}. I’d be happy to send availability and a resume for your technician pool.\n\nThanks,\n${name}`;
     }
-    return `Hi ${company.name} team — I’m a freelance ${role} based around ${market} and I’d like to be considered for your technician pool. My current day rate is $${rate}. If useful, I can send current availability and a resume.\n\nThanks,\n${name}`;
+    return `${greeting} — I’m a freelance ${role} based around ${market} and I’d like to be considered for your technician pool. My current day rate is $${rate}. If useful, I can send current availability and a resume.\n\nThanks,\n${name}`;
   }
 
   function renderCompanies() {
     const container = $('company-list');
     if (!state.companies.length) {
-      container.innerHTML = '<div class="empty">Add a production company to start a small, intentional call list.</div>';
+      container.innerHTML = '<div class="empty">Add an AV contact to start a small, intentional network. Production companies and labor coordinators are the best first records.</div>';
       return;
     }
     container.innerHTML = state.companies.map(company => `
       <article class="company-card" data-company-id="${escapeHtml(company.id)}">
         <div class="company-top">
-          <div><h3>${escapeHtml(company.name)}</h3><div class="company-meta">${escapeHtml(company.email)} · ${escapeHtml(company.relationship)}</div></div>
+          <div><h3>${escapeHtml(company.contactName || company.name)}</h3><div class="company-meta">${escapeHtml(company.contactName ? `${company.name} · ` : '')}${escapeHtml(avContactKindLabel(company.kind))} · ${escapeHtml(company.email)} · ${escapeHtml(company.relationship)}</div></div>
           <span class="pill">Explicit send</span>
         </div>
         <label>Outreach draft<textarea data-company-draft>${escapeHtml(company.draft || outreachDraft(company))}</textarea></label>
         <div class="company-actions">
           <button class="button compact" type="button" data-company-action="refresh">Refresh draft</button>
           <button class="button compact" type="button" data-company-action="send">Send resume + outreach</button>
+          <a class="button compact" href="${escapeHtml(avContactHref(company))}">Save to AV Contacts</a>
           <button class="button compact" type="button" data-company-action="remove">Remove</button>
         </div>
       </article>
@@ -1017,8 +1049,10 @@
     event.preventDefault();
     const company = {
       id: uniqueId('company'),
+      contactName: $('company-contact-name').value.trim(),
       name: $('company-name').value.trim(),
       email: $('company-email').value.trim().toLowerCase(),
+      kind: $('company-kind').value,
       relationship: $('company-relationship').value,
       draft: '',
       createdAt: Date.now(),
@@ -1028,7 +1062,7 @@
     state.companies.push(company);
     saveState();
     renderCompanies();
-    addActivity(`Added ${company.name} to the freelance call list.`);
+    addActivity(`Added ${company.contactName || company.name} to the AV network.`);
     $('company-form').reset();
   });
 

--- a/work-agent/index.html
+++ b/work-agent/index.html
@@ -39,7 +39,7 @@
       <a href="#schedule">Schedule</a>
       <a href="#inbox">Inbox</a>
       <a href="#profile">Resume</a>
-      <a href="#companies">Companies</a>
+      <a href="#companies">AV network</a>
       <a href="#rules">Rules</a>
     </nav>
 
@@ -142,14 +142,29 @@
     <section id="companies" class="panel">
       <div class="section-heading">
         <div>
-          <p class="eyebrow">4 · Build the call list</p>
-          <h2>Freelance companies</h2>
-          <p>Add companies you want to work with. The agent drafts outreach from your profile and attaches the generated resume; sending remains explicit.</p>
+          <p class="eyebrow">4 · Build the AV network</p>
+          <h2>AV contacts</h2>
+          <p>Start with the people who can create or fill calls: production companies, labor coordinators, PMs, crew chiefs, venues, and other technicians. Outreach is personalized and sending remains explicit.</p>
         </div>
       </div>
+      <div class="actions">
+        <a class="button" href="/contacts/?view=av">Open AV Contacts</a>
+      </div>
       <form id="company-form" class="company-form">
+        <label>Contact name <span class="optional">optional</span><input id="company-contact-name" placeholder="Labor coordinator or PM" /></label>
         <label>Company<input id="company-name" required placeholder="Production company" /></label>
         <label>Email<input id="company-email" type="email" required placeholder="labor@example.com" /></label>
+        <label>AV contact type
+          <select id="company-kind">
+            <option value="production-company">Production company</option>
+            <option value="labor-coordinator">Labor coordinator / scheduler</option>
+            <option value="pm-td">PM / technical director</option>
+            <option value="crew-chief">Crew chief / lead</option>
+            <option value="technician">Freelance technician</option>
+            <option value="venue">Venue / property AV contact</option>
+            <option value="other">Other AV contact</option>
+          </select>
+        </label>
         <label>Relationship
           <select id="company-relationship">
             <option value="warm">They know my work</option>
@@ -157,7 +172,7 @@
             <option value="cold">New company</option>
           </select>
         </label>
-        <button class="button" type="submit">Add company</button>
+        <button class="button" type="submit">Add AV contact</button>
       </form>
       <div id="company-list" class="company-list"></div>
     </section>


### PR DESCRIPTION
## What changed
- makes live-event AV contacts the deliberate first Work Agent market
- adds an AV Network view to the existing Contacts app using the durable industry/av tag
- adds AV-specific contact types: production company, labor coordinator, PM/TD, crew chief, technician, venue
- lets Work Agent hand a contact into canonical Contacts with prefilled person/company/type/source tags
- preserves explicit-send outreach behavior and existing Gmail safety boundaries
- documents Contacts as the canonical network and Work Agent as the operator

## Verification
- 31 focused tests passed
- browser verified AV Network banner, Work Agent handoff, prefilled contact fields, and AV tags
- no new serverless functions