### PR TITLE
Add the 3DVR launch loop roadmap

### DIFF
--- a/docs/launch-loop.md
+++ b/docs/launch-loop.md
@@ -1,0 +1,66 @@
+# 3DVR Launch Loop
+
+Status: active
+
+Started: 2026-08-29
+
+## North star
+
+Turn a real need into a small project, get it in front of real people, earn a real customer, deliver something useful, and turn the result into proof that makes the next customer easier.
+
+**Brief → Project → Page → People → Customer → Delivery → Proof → Referral / Repeat**
+
+This phase is about completing that loop repeatedly. Do not add another app unless an existing Core surface cannot reasonably own the step.
+
+## Safety and trust rules
+
+- Research may be automated; contacting people remains review/approval-gated.
+- Marking a customer never charges them or sends a message.
+- Delivery work may be prepared automatically, but customer-facing actions require explicit intent.
+- Record outcomes as facts. Do not invent metrics, testimonials, revenue, or customer satisfaction.
+- Prefer one-time handoffs between existing apps over duplicate data models.
+
+## Shipped loop
+
+- [x] **Movement Brief → Project** — Launch Room creates a reviewable Projects draft; nothing is saved until submit.
+- [x] **Project → Page** — Projects hands mission, offer, audience, and identity into Web Builder.
+- [x] **Page → Project** — successful user-triggered Vercel deploys write the live page URL back to the Project.
+- [x] **Project → People** — Projects opens Growth Operator with project-specific targeting context.
+- [x] **People → Customer** — Growth Operator keeps research, draft, approve, and send boundaries; customer wins require explicit confirmation.
+- [x] **Customer → Delivery** — confirmed wins create a first-delivery work item without sending or queueing agent work.
+- [x] **Delivery → Proof signal** — marking delivery complete writes a factual project update and points to outcome capture.
+
+## Next work
+
+### P0 — prove one complete real loop
+
+- [ ] Run one real project from Launch Room through customer and delivery.
+- [ ] Record where the user has to retype information or leave the intended flow.
+- [ ] Fix only the friction encountered in that real run.
+
+### P1 — turn outcomes into credible proof
+
+- [ ] Add a structured outcome capture after delivery: what shipped, what changed, source/evidence, customer quote only when actually provided.
+- [ ] Let an approved outcome become a case-study draft without publishing automatically.
+- [ ] Link approved proof back to the public 3dvr.tech case-study surface.
+
+### P2 — make the next customer easier
+
+- [ ] Add a reviewable referral / testimonial follow-up after a successful delivery.
+- [ ] Let proven project language improve the next lead-search brief.
+- [ ] Track conversion milestones without pretending a lead, customer, paid customer, and delivered customer are the same thing.
+
+## Definition of done
+
+This phase is successful when one person can move through the whole loop without understanding the internal app catalog, and the system preserves evidence at each step:
+
+1. a real brief,
+2. a real project,
+3. a real public page,
+4. real people considered,
+5. a real customer decision,
+6. a real delivered result,
+7. credible proof,
+8. a clear path to the next customer.
+
+The measure is not number of apps or commits. The measure is completed useful loops.


### PR DESCRIPTION
Starts the post-consolidation operating roadmap around completed useful loops rather than more apps.

The new roadmap defines:
- Brief → Project → Page → People → Customer → Delivery → Proof → Referral / Repeat
- explicit safety/trust boundaries
- the handoffs already shipped
- P0: prove one real end-to-end loop
- P1: structured, evidence-based proof
- P2: earned referral/repeat-customer follow-up

The core rule is simple: measure completed useful loops, not surface area or commit count.