### PR TITLE
Make Vercel an intentional release lane

### DIFF
--- a/docs/VERCEL-PRODUCTION.md
+++ b/docs/VERCEL-PRODUCTION.md
@@ -1,13 +1,19 @@
 # Canonical Vercel production
 
-3DVR Portal uses one production lane to avoid duplicate builds and Hobby-plan quota churn.
+3DVR Portal uses Vercel as a controlled public release lane while self-host production tracks `main` continuously. This avoids duplicate builds and Hobby-plan quota churn.
 
-- Native Vercel Git deployment is the normal production path.
-- `vercel.json` explicitly enables `main` and disables the `*` branch pattern.
-- A short `ignoreCommand` is the safety net for branch names containing `/`: non-main refs exit successfully and skip the build, while `main` continues.
-- The canonical project that owns `portal.3dvr.tech` is team `team_xxJGO7S7h1ZP4BHidYV0CX9Z`, project `prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch`.
-- Pull-request previews remain opt-in through the dedicated preview workflow.
-- `.github/workflows/vercel-production-prebuilt.yml` is manual fallback only and requires the `VERCEL_TOKEN` repository secret before it can run.
-- Production verification should confirm the live portal contains the interactive spinner and inline Operator form.
+- `vercel.json` disables automatic Vercel production builds from `main` by default.
+- Pull-request previews remain opt-in through the dedicated `vercel-preview` bridge workflow.
+- The canonical Vercel project that owns `portal.3dvr.tech` is team `team_xxJGO7S7h1ZP4BHidYV0CX9Z`, project `prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch`.
+- Self-host production remains the continuous deployment/canary path for every `main` merge.
+- `.github/workflows/vercel-production-prebuilt.yml` remains a manual fallback when its Vercel token is configured.
 
-Normal path: merge or push to `main`, Vercel builds production once. Non-main branches are disabled where the branch rule matches and otherwise stopped by the ignored-build check before a real build runs.
+## Controlled public release
+
+1. Start from current `main` after self-host checks are green.
+2. In a release branch, temporarily change `git.deploymentEnabled.main` to `true`.
+3. Merge that single release-gate change to `main`. Vercel performs the production build.
+4. Verify `portal.3dvr.tech` serves the expected commit/features.
+5. Immediately restore `git.deploymentEnabled.main` to `false`; that guard commit itself should not trigger another Vercel deployment.
+
+This deliberately spends Vercel quota only when we intend to change the public Vercel production site. Routine development stays on the self-host lane.

--- a/tests/vercel-main-only.test.js
+++ b/tests/vercel-main-only.test.js
@@ -4,10 +4,10 @@ import { readFile } from 'node:fs/promises';
 
 const vercel = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'));
 
-test('Vercel builds main and opt-in preview bridges while skipping ordinary branches', () => {
+test('Vercel skips routine main builds and ordinary branches while allowing opt-in preview bridges', () => {
   assert.deepEqual(vercel.git?.deploymentEnabled, {
     '**': false,
-    main: true,
+    main: false,
     'preview-pr-*': true,
   });
   assert.equal(vercel.ignoreCommand, undefined);

--- a/tests/vercel-production-policy.test.js
+++ b/tests/vercel-production-policy.test.js
@@ -4,11 +4,11 @@ import { readFile } from 'node:fs/promises';
 
 const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
 
-test('native Vercel Git deploys production plus explicit preview bridge branches', async () => {
+test('Vercel Git keeps production closed by default and allows explicit preview bridge branches', async () => {
   const config = JSON.parse(await read('vercel.json'));
   assert.deepEqual(config.git?.deploymentEnabled, {
     '**': false,
-    main: true,
+    main: false,
     'preview-pr-*': true,
   });
   assert.equal(config.ignoreCommand, undefined);

--- a/tests/workspace-sync.test.js
+++ b/tests/workspace-sync.test.js
@@ -34,11 +34,11 @@ test('relay timeout never auto-saves empty startup state', async () => {
   assert.doesNotMatch(timeoutBlock, /\bsave\s*\(/, 'timeout must not overwrite unknown remote state');
 });
 
-test('production uses main plus opt-in Vercel preview bridges with a default deny rule', async () => {
+test('production keeps Vercel main closed plus opt-in preview bridges with a default deny rule', async () => {
   const workflow = await read('.github/workflows/vercel-production-prebuilt.yml');
   const vercelConfig = JSON.parse(await read('vercel.json'));
 
-  assert.equal(vercelConfig.git?.deploymentEnabled?.main, true);
+  assert.equal(vercelConfig.git?.deploymentEnabled?.main, false);
   assert.equal(vercelConfig.git?.deploymentEnabled?.['preview-pr-*'], true);
   assert.equal(vercelConfig.git?.deploymentEnabled?.['**'], false);
   assert.equal(vercelConfig.ignoreCommand, undefined);

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "git": {
     "deploymentEnabled": {
       "**": false,
-      "main": true,
+      "main": false,
       "preview-pr-*": true
     }
   },


### PR DESCRIPTION
Prevents routine Portal merges from exhausting the Vercel Hobby deployment quota now that self-host production tracks `main` continuously.

- disables automatic Vercel production builds from `main` by default
- preserves explicitly requested `preview-pr-*` preview builds
- documents the controlled release pattern: temporarily enable `main`, merge one release gate, verify public production, then restore the guard
- keeps the existing manual prebuilt workflow as a fallback
- updates deployment-policy regression tests

Validation: `node --test tests/vercel-production-policy.test.js tests/vercel-main-only.test.js tests/workspace-sync.test.js` — 8/8 passing; `git diff --check` passes.

Context: the current public Vercel project is rate-limited for 24 hours while self-host production is healthy and current.