### PR TITLE
Block over-budget Vercel production releases

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Enforce Vercel Hobby function budget
+        run: node --test tests/vercel-function-budget.test.js
+
       - name: Install Vercel CLI
         run: npm install --global vercel
 

--- a/tests/vercel-production-policy.test.js
+++ b/tests/vercel-production-policy.test.js
@@ -21,7 +21,12 @@ test('GitHub Actions production workflow is manual fallback only', async () => {
   assert.doesNotMatch(workflow, /\n\s*pull_request:/);
   assert.match(workflow, /VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z/);
   assert.match(workflow, /VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch/);
-  assert.match(workflow, /vercel deploy --prebuilt --prod/);
+
+  const budgetGuard = workflow.indexOf('node --test tests/vercel-function-budget.test.js');
+  const productionDeploy = workflow.indexOf('vercel deploy --prebuilt --prod');
+  assert.ok(budgetGuard >= 0, 'production workflow must enforce the Vercel function budget');
+  assert.ok(productionDeploy > budgetGuard, 'function-budget guard must run before production deploy');
+
   assert.match(workflow, /https:\/\/portal\.3dvr\.tech\//);
   assert.match(workflow, /data-portal-swirl-logo/);
   assert.match(workflow, /homeOperatorForm/);


### PR DESCRIPTION
## What changed
- run the existing Vercel Hobby function-budget test inside the canonical production deployment workflow before any Vercel build/deploy step
- add a policy regression test that requires that guard to remain present and before the production deploy command
- fast-forwarded the already-merged 3DVR Girl feature branch to current `main` so it can no longer redeploy the stale 13-function tree

## Why
The function-count regression test already existed on `main`, but a stale feature branch was deployed directly with the Vercel CLI and bypassed it. This closes the gap in the official production release lane.

Expected behavior: deployments exceeding the Hobby 12-function ceiling fail locally in GitHub Actions before consuming a Vercel production deployment attempt.