### PR TITLE
Add reusable customer experiment engine

### DIFF
--- a/api/growth/homepage-hero-cron.js
+++ b/api/growth/homepage-hero-cron.js
@@ -1,4 +1,6 @@
 import { runHomepageHeroCronCycle } from '../../src/growth/homepage-hero-cron.js';
+import { runExperimentCronCycle } from '../../src/growth/experiment-cron.js';
+import { AV_FREELANCE_HERO_EXPERIMENT } from '../../src/growth/experiments.js';
 
 function parseBoolean(value, fallback) {
   if (typeof value === 'boolean') {
@@ -53,6 +55,7 @@ function setHeaders(res) {
 
 export function createHomepageHeroGrowthCronHandler(options = {}) {
   const runCycleImpl = options.runCycleImpl || runHomepageHeroCronCycle;
+  const runExperimentImpl = options.runExperimentImpl || runExperimentCronCycle;
   const config = options.config || process.env;
 
   return async function handler(req, res) {
@@ -84,10 +87,18 @@ export function createHomepageHeroGrowthCronHandler(options = {}) {
     );
 
     try {
-      const result = await runCycleImpl({
+      const cycleOptions = {
         dryRun,
         gunPeers: config.GROWTH_GUN_PEERS,
-      });
+      };
+      const result = await runCycleImpl(cycleOptions);
+      let avFreelance = null;
+      let avFreelanceError = '';
+      try {
+        avFreelance = await runExperimentImpl(AV_FREELANCE_HERO_EXPERIMENT, cycleOptions);
+      } catch (error) {
+        avFreelanceError = error?.message || 'AV freelance experiment evaluation failed.';
+      }
 
       return res.status(200).json({
         ok: true,
@@ -107,6 +118,11 @@ export function createHomepageHeroGrowthCronHandler(options = {}) {
         stats: result.stats,
         totals: result.totals,
         reason: result.reason,
+        experiments: {
+          homepageHero: result,
+          avFreelanceHero: avFreelance,
+        },
+        experimentErrors: avFreelanceError ? { avFreelanceHero: avFreelanceError } : {},
       });
     } catch (error) {
       return res.status(500).json({

--- a/av-freelance/experiment.js
+++ b/av-freelance/experiment.js
@@ -1,0 +1,106 @@
+import {
+  assignVariant,
+  experimentPath,
+  normalizeExperimentDefinition,
+} from '../src/growth/experiment-engine.js';
+import { AV_FREELANCE_HERO_EXPERIMENT } from '../src/growth/experiments.js';
+import { DEFAULT_GUN_PEERS, getNode } from '../src/growth/homepage-hero.js';
+
+const definition = normalizeExperimentDefinition(AV_FREELANCE_HERO_EXPERIMENT);
+const visitorKey = `3dvr.experiment.${definition.id}.visitor.v1`;
+const visitorId = getVisitorId();
+const source = getSource();
+const gun = createGun();
+const configNode = gun ? getNode(gun, experimentPath(definition.id, 'config')) : null;
+const eventsNode = gun ? getNode(gun, experimentPath(definition.id, 'events')) : null;
+let finalized = false;
+
+function getVisitorId() {
+  try {
+    const existing = window.localStorage.getItem(visitorKey);
+    if (existing) return existing;
+    const generated = `visitor-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    window.localStorage.setItem(visitorKey, generated);
+    return generated;
+  } catch (_error) {
+    return `visitor-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+}
+
+function getSource() {
+  const params = new URLSearchParams(window.location.search);
+  return String(params.get('utm_source') || params.get('source') || params.get('ref') || 'direct')
+    .trim()
+    .slice(0, 80) || 'direct';
+}
+
+function createGun() {
+  if (typeof window.Gun !== 'function') return null;
+  try {
+    return window.Gun({ peers: window.__GUN_PEERS__ || DEFAULT_GUN_PEERS });
+  } catch (error) {
+    console.warn('AV freelance experiment Gun init failed.', error);
+    return null;
+  }
+}
+
+function getVariant(key) {
+  return AV_FREELANCE_HERO_EXPERIMENT.variants.find((variant) => variant.key === key)
+    || AV_FREELANCE_HERO_EXPERIMENT.variants[0];
+}
+
+function applyVariant(key) {
+  const variant = getVariant(key);
+  const title = document.getElementById('heroTitle');
+  const copy = document.getElementById('heroCopy');
+  const primary = document.querySelector('[data-primary-work-agent]');
+  if (title) title.textContent = variant.headline;
+  if (copy) copy.textContent = variant.copy;
+  if (primary) primary.textContent = variant.cta;
+  document.documentElement.dataset.experimentVariant = variant.key;
+  window.__3DVR_EXPERIMENT__ = { id: definition.id, variant: variant.key };
+  return variant.key;
+}
+
+function recordEvent(variant, eventType, cta = '') {
+  if (!eventsNode || !variant || !eventType) return;
+  const timestamp = new Date().toISOString();
+  const id = `${Date.now()}-${visitorId}-${eventType}-${Math.random().toString(36).slice(2, 8)}`;
+  eventsNode.get(id).put({
+    id,
+    experimentId: definition.id,
+    page: definition.page,
+    visitorId,
+    variant,
+    eventType,
+    cta,
+    source,
+    timestamp,
+  });
+}
+
+function bindClicks(variant) {
+  document.querySelectorAll('[data-work-agent-cta]').forEach((link) => {
+    link.addEventListener('click', () => recordEvent(variant, 'work-agent-open', link.dataset.workAgentCta || 'work-agent'));
+  });
+  document.querySelectorAll('[data-starter-kit-cta]').forEach((link) => {
+    link.addEventListener('click', () => recordEvent(variant, 'starter-kit-click', link.dataset.starterKitCta || 'starter-kit'));
+  });
+}
+
+function finalize(config = {}) {
+  if (finalized) return;
+  finalized = true;
+  const winner = String(config?.winner || '').trim();
+  const assigned = assignVariant(definition, visitorId, winner);
+  const variant = applyVariant(assigned);
+  bindClicks(variant);
+  recordEvent(variant, 'view');
+}
+
+if (configNode && typeof configNode.once === 'function') {
+  configNode.once((data) => finalize(data || {}));
+  window.setTimeout(() => finalize({}), 700);
+} else {
+  finalize({});
+}

--- a/av-freelance/index.html
+++ b/av-freelance/index.html
@@ -26,13 +26,13 @@
       <section class="hero" aria-labelledby="heroTitle">
         <p class="eyebrow">AV Freelance Launchpad</p>
         <h1 id="heroTitle">You already know how to run the show. Build work that belongs to you.</h1>
-        <p class="hero-copy">
+        <p class="hero-copy" id="heroCopy">
           For event technicians who are good at the work but want more control over their time, clients,
           rates, and direction. Keep your income stable while you build a freelance runway one relationship at a time.
         </p>
         <div class="hero-actions">
-          <a class="button button--primary" href="../work-agent/">Use the free Work Agent</a>
-          <a class="button" href="https://buy.stripe.com/00w8wPeua4lR5gPcMAc7u0n">Get the $9 templates</a>
+          <a class="button button--primary" href="../work-agent/" data-primary-work-agent data-work-agent-cta="hero">Use the free Work Agent</a>
+          <a class="button" href="https://buy.stripe.com/00w8wPeua4lR5gPcMAc7u0n" data-starter-kit-cta="hero">Get the $9 templates</a>
         </div>
         <p class="hero-note">
           Start free: connect your schedule, build your worker profile, review work-email signals, and set your rate boundaries before buying anything. 3DVR is not affiliated with Encore.
@@ -60,7 +60,7 @@
           </article>
         </div>
         <div class="hero-actions">
-          <a class="button button--primary" href="../work-agent/">Open Work Agent — free</a>
+          <a class="button button--primary" href="../work-agent/" data-work-agent-cta="product">Open Work Agent — free</a>
         </div>
       </section>
 
@@ -85,7 +85,7 @@
           </article>
         </div>
         <div class="hero-actions">
-          <a class="button button--primary" href="https://buy.stripe.com/00w8wPeua4lR5gPcMAc7u0n">Buy once — instant access</a>
+          <a class="button button--primary" href="https://buy.stripe.com/00w8wPeua4lR5gPcMAc7u0n" data-starter-kit-cta="kit">Buy once — instant access</a>
         </div>
       </section>
 
@@ -108,6 +108,8 @@
       <a href="../index.html">Back to Portal</a>
     </footer>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script type="module" src="./experiment.js"></script>
   <script defer src="/issue-launcher.js"></script>
 </body>
 </html>

--- a/docs/growth-plan.md
+++ b/docs/growth-plan.md
@@ -57,6 +57,16 @@ Then:
 - Target staffing coordinators, labor coordinators, production managers, technical directors, venue AV managers, and other public business contacts.
 - Use public listings only; never guess names, emails, phone numbers, or business facts.
 
+## Auto-development experiment loop
+
+- Treat customer behavior as the deciding signal for low-risk product changes.
+- Assign visitors deterministically so the same person keeps seeing the same variant until a winner is promoted.
+- Use Gun at `3dvr-portal/growth/experiments/<experiment>/...` as the shared event/config source of truth.
+- Compare unique visitors, not raw repeated clicks. Require minimum sample size, minimum conversions, meaningful lift, and a statistical confidence threshold before promotion.
+- Auto-promote only allowlisted low-risk classes such as copy, layout, CTA wording, and discovery flows. Pricing, billing, privacy, auth, security, legal, or destructive changes require explicit review.
+- Optimize for the deepest reliable customer outcome available. Revenue/paid conversion beats qualified leads, which beat activation, which beat engagement.
+- First live reusable experiment: `av-freelance-hero`, optimizing visits from the AV Freelance Launchpad into the free Work Agent. The existing daily growth cron evaluates it alongside the homepage experiment.
+
 ## Product principles
 
 - A third grader should understand the next action.

--- a/src/growth/experiment-cron.js
+++ b/src/growth/experiment-cron.js
@@ -1,0 +1,121 @@
+import {
+  canAutoPromote,
+  computeConversionStats,
+  experimentPath,
+  normalizeExperimentDefinition,
+  normalizeExperimentEvent,
+  pickConversionWinner,
+} from './experiment-engine.js';
+import { DEFAULT_GUN_PEERS, getNode } from './homepage-hero.js';
+import { parseGunPeers, readGunMap } from './homepage-hero-cron.js';
+
+function onceNode(node) {
+  return new Promise((resolve) => {
+    if (!node || typeof node.once !== 'function') return resolve(undefined);
+    node.once((value) => resolve(value));
+  });
+}
+
+function putNode(node, value) {
+  return new Promise((resolve, reject) => {
+    if (!node || typeof node.put !== 'function') return reject(new Error('Experiment config node is not writable.'));
+    node.put(value, (ack) => ack?.err ? reject(new Error(String(ack.err))) : resolve(ack || {}));
+  });
+}
+
+async function loadGun(explicitImpl) {
+  if (explicitImpl) return explicitImpl;
+  const moduleResult = await import('gun');
+  return moduleResult?.default || moduleResult;
+}
+
+export async function createExperimentGrowthClient(definition, options = {}) {
+  const normalized = normalizeExperimentDefinition(definition);
+  const GunImpl = await loadGun(options.GunImpl);
+  const peers = parseGunPeers(options.peers || options.gunPeers, DEFAULT_GUN_PEERS);
+  const gun = options.gun || GunImpl({
+    peers,
+    localStorage: false,
+    radisk: false,
+    file: false,
+    multicast: false,
+    axe: false,
+  });
+  const configNode = getNode(gun, experimentPath(normalized.id, 'config'));
+  const eventsNode = getNode(gun, experimentPath(normalized.id, 'events'));
+
+  return {
+    async readConfig() {
+      const data = await onceNode(configNode) || {};
+      const winner = normalized.variants.some((variant) => variant.key === data.winner)
+        ? String(data.winner)
+        : '';
+      return {
+        autoMode: typeof data.autoMode === 'boolean' ? data.autoMode : true,
+        winner,
+        winnerReason: String(data.winnerReason || '').trim(),
+        updatedAt: String(data.updatedAt || '').trim(),
+        updatedBy: String(data.updatedBy || '').trim(),
+      };
+    },
+    async readEvents(readOptions = {}) {
+      return readGunMap(
+        eventsNode,
+        (data, id) => normalizeExperimentEvent(normalized, data, id),
+        readOptions
+      );
+    },
+    async writeConfig(value) {
+      await putNode(configNode, value);
+    },
+  };
+}
+
+export async function runExperimentCronCycle(definition, options = {}) {
+  const normalized = normalizeExperimentDefinition(definition);
+  const client = options.client || await createExperimentGrowthClient(normalized, options);
+  const generatedAt = typeof options.now === 'function' ? options.now() : new Date().toISOString();
+  const dryRun = Boolean(options.dryRun);
+  const [config, events] = await Promise.all([client.readConfig(), client.readEvents(options)]);
+  const stats = computeConversionStats(normalized, events);
+  const recommended = pickConversionWinner(normalized, stats, options);
+  const safe = canAutoPromote(normalized);
+  const wouldPromote = Boolean(safe && config.autoMode && recommended && config.winner !== recommended.key);
+  let promoted = false;
+  let winnerAfter = config.winner;
+
+  if (wouldPromote) {
+    winnerAfter = recommended.key;
+    if (!dryRun) {
+      await client.writeConfig({
+        ...config,
+        winner: recommended.key,
+        winnerReason: recommended.reason,
+        updatedAt: generatedAt,
+        updatedBy: 'growth-cron',
+      });
+      promoted = true;
+    }
+  }
+
+  return {
+    experiment: normalized.id,
+    generatedAt,
+    dryRun,
+    autoMode: config.autoMode,
+    safeToAutoPromote: safe,
+    winnerBefore: config.winner,
+    winnerAfter,
+    recommendedWinner: recommended?.key || '',
+    recommendedReason: recommended?.reason || '',
+    wouldPromote,
+    promoted,
+    action: !safe ? 'approval-required'
+      : !config.autoMode ? 'auto-mode-disabled'
+        : !recommended ? 'insufficient-data'
+          : config.winner === recommended.key ? 'winner-already-current'
+            : dryRun ? 'dry-run'
+              : promoted ? 'promoted' : 'no-change',
+    stats,
+  };
+}

--- a/src/growth/experiment-engine.js
+++ b/src/growth/experiment-engine.js
@@ -1,0 +1,170 @@
+export const SAFE_AUTO_PROMOTION_RISK_CLASSES = Object.freeze([
+  'copy',
+  'layout',
+  'cta',
+  'discovery',
+]);
+
+export const DEFAULT_MIN_VIEWS_PER_VARIANT = 25;
+export const DEFAULT_MIN_CONVERSIONS = 3;
+export const DEFAULT_MIN_RELATIVE_LIFT = 0.1;
+export const DEFAULT_Z_THRESHOLD = 1.96;
+
+function valuesOf(input) {
+  if (Array.isArray(input)) return input;
+  if (!input || typeof input !== 'object') return [];
+  return Object.values(input);
+}
+
+function hashUnitInterval(value) {
+  let hash = 2166136261;
+  const text = String(value || '');
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 4294967296;
+}
+
+export function normalizeExperimentDefinition(definition = {}) {
+  const variants = Array.isArray(definition.variants)
+    ? definition.variants.filter((variant) => variant?.key)
+    : [];
+
+  return {
+    id: String(definition.id || '').trim(),
+    page: String(definition.page || '').trim(),
+    riskClass: String(definition.riskClass || '').trim(),
+    conversionEvent: String(definition.conversionEvent || '').trim(),
+    variants: variants.map((variant) => ({
+      ...variant,
+      key: String(variant.key).trim(),
+      weight: Math.max(1, Number(variant.weight) || 1),
+    })),
+    minViewsPerVariant: Math.max(
+      1,
+      Number(definition.minViewsPerVariant) || DEFAULT_MIN_VIEWS_PER_VARIANT
+    ),
+    minConversions: Math.max(
+      1,
+      Number(definition.minConversions) || DEFAULT_MIN_CONVERSIONS
+    ),
+    minRelativeLift: Math.max(
+      0,
+      Number(definition.minRelativeLift) || DEFAULT_MIN_RELATIVE_LIFT
+    ),
+    zThreshold: Math.max(
+      0,
+      Number(definition.zThreshold) || DEFAULT_Z_THRESHOLD
+    ),
+  };
+}
+
+export function canAutoPromote(definition = {}) {
+  const normalized = normalizeExperimentDefinition(definition);
+  return SAFE_AUTO_PROMOTION_RISK_CLASSES.includes(normalized.riskClass);
+}
+
+export function experimentPath(experimentId, section) {
+  return ['3dvr-portal', 'growth', 'experiments', String(experimentId || '').trim(), section];
+}
+
+export function assignVariant(definition, visitorId, winner = '') {
+  const normalized = normalizeExperimentDefinition(definition);
+  const winnerKey = String(winner || '').trim();
+  if (normalized.variants.some((variant) => variant.key === winnerKey)) {
+    return winnerKey;
+  }
+  if (!normalized.variants.length) return '';
+
+  const totalWeight = normalized.variants.reduce((sum, variant) => sum + variant.weight, 0);
+  let cursor = hashUnitInterval(`${normalized.id}:${visitorId}`) * totalWeight;
+  for (const variant of normalized.variants) {
+    cursor -= variant.weight;
+    if (cursor < 0) return variant.key;
+  }
+  return normalized.variants.at(-1)?.key || '';
+}
+
+export function normalizeExperimentEvent(definition, data = {}, id = '') {
+  const normalized = normalizeExperimentDefinition(definition);
+  const variant = String(data.variant || '').trim();
+  return {
+    id: String(id || data.id || '').trim(),
+    visitorId: String(data.visitorId || '').trim(),
+    page: String(data.page || '').trim(),
+    experimentId: String(data.experimentId || '').trim(),
+    eventType: String(data.eventType || '').trim(),
+    variant: normalized.variants.some((item) => item.key === variant) ? variant : '',
+    cta: String(data.cta || '').trim(),
+    source: String(data.source || '').trim(),
+    timestamp: String(data.timestamp || '').trim(),
+  };
+}
+
+export function computeConversionStats(definition, events = {}) {
+  const normalized = normalizeExperimentDefinition(definition);
+  const visitorSets = Object.fromEntries(normalized.variants.map((variant) => [
+    variant.key,
+    { views: new Set(), conversions: new Set() },
+  ]));
+
+  valuesOf(events).forEach((entry) => {
+    if (!entry || entry.experimentId !== normalized.id || entry.page !== normalized.page) return;
+    if (!visitorSets[entry.variant]) return;
+    const visitorKey = String(entry.visitorId || entry.id || '').trim();
+    if (!visitorKey) return;
+    if (entry.eventType === 'view') visitorSets[entry.variant].views.add(visitorKey);
+    if (entry.eventType === normalized.conversionEvent) visitorSets[entry.variant].conversions.add(visitorKey);
+  });
+
+  return Object.fromEntries(Object.entries(visitorSets).map(([key, sets]) => {
+    const views = sets.views.size;
+    const conversions = [...sets.conversions].filter((visitorId) => sets.views.has(visitorId)).length;
+    return [key, {
+      views,
+      conversions,
+      conversionRate: views ? conversions / views : 0,
+    }];
+  }));
+}
+
+function twoProportionZScore(best, second) {
+  const pooledViews = best.views + second.views;
+  if (!pooledViews) return 0;
+  const pooledRate = (best.conversions + second.conversions) / pooledViews;
+  const standardError = Math.sqrt(
+    pooledRate * (1 - pooledRate) * ((1 / best.views) + (1 / second.views))
+  );
+  if (!standardError) return 0;
+  return (best.conversionRate - second.conversionRate) / standardError;
+}
+
+export function pickConversionWinner(definition, stats = {}, options = {}) {
+  const normalized = normalizeExperimentDefinition({ ...definition, ...options });
+  const entries = Object.entries(stats)
+    .map(([key, stat]) => ({ key, ...stat }))
+    .filter((entry) => entry.views >= normalized.minViewsPerVariant)
+    .sort((left, right) => right.conversionRate - left.conversionRate);
+
+  if (entries.length < 2) return null;
+  const [best, second] = entries;
+  if (best.conversions < normalized.minConversions) return null;
+  if (best.conversionRate <= second.conversionRate) return null;
+
+  const relativeLift = second.conversionRate > 0
+    ? (best.conversionRate - second.conversionRate) / second.conversionRate
+    : 1;
+  const zScore = twoProportionZScore(best, second);
+  if (relativeLift < normalized.minRelativeLift || zScore < normalized.zThreshold) return null;
+
+  return {
+    key: best.key,
+    best,
+    second,
+    relativeLift,
+    zScore,
+    signature: `${best.key}:${best.views}:${best.conversions}:${second.key}:${second.views}:${second.conversions}`,
+    reason: `Auto-promoted ${best.key}: ${(best.conversionRate * 100).toFixed(1)}% vs ${(second.conversionRate * 100).toFixed(1)}% on ${normalized.conversionEvent}.`,
+  };
+}

--- a/src/growth/experiments.js
+++ b/src/growth/experiments.js
@@ -1,0 +1,28 @@
+export const AV_FREELANCE_HERO_EXPERIMENT = Object.freeze({
+  id: 'av-freelance-hero',
+  page: 'av-freelance',
+  riskClass: 'copy',
+  conversionEvent: 'work-agent-open',
+  minViewsPerVariant: 25,
+  minConversions: 3,
+  minRelativeLift: 0.1,
+  zThreshold: 1.96,
+  variants: Object.freeze([
+    Object.freeze({
+      key: 'ownership',
+      label: 'Ownership-first',
+      weight: 1,
+      headline: 'You already know how to run the show. Build work that belongs to you.',
+      copy: 'For event technicians who are good at the work but want more control over their time, clients, rates, and direction. Keep your income stable while you build a freelance runway one relationship at a time.',
+      cta: 'Use the free Work Agent',
+    }),
+    Object.freeze({
+      key: 'outcome',
+      label: 'Outcome-first',
+      weight: 1,
+      headline: 'Turn your AV experience into better freelance calls — without quitting first.',
+      copy: 'Use your real schedule, experience, and rate boundaries to build a freelance pipeline while keeping the work you already have. Start with the next good client, not a dramatic career leap.',
+      cta: 'Build my freelance profile — free',
+    }),
+  ]),
+});

--- a/tests/av-freelance-experiment.test.js
+++ b/tests/av-freelance-experiment.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+
+test('AV Freelance Launchpad runs a Gun-backed copy experiment on the free Work Agent CTA', async () => {
+  const html = await readFile(new URL('../av-freelance/index.html', import.meta.url), 'utf8');
+  const js = await readFile(new URL('../av-freelance/experiment.js', import.meta.url), 'utf8');
+  assert.match(html, /id="heroCopy"/);
+  assert.match(html, /data-work-agent-cta="hero"/);
+  assert.match(html, /data-starter-kit-cta="hero"/);
+  assert.match(html, /cdn\.jsdelivr\.net\/npm\/gun\/gun\.js/);
+  assert.match(html, /type="module" src="\.\/experiment\.js"/);
+  assert.match(js, /AV_FREELANCE_HERO_EXPERIMENT/);
+  assert.match(js, /assignVariant/);
+  assert.match(js, /experimentPath/);
+  assert.match(js, /recordEvent\(variant, 'view'\)/);
+  assert.match(js, /'work-agent-open'/);
+});

--- a/tests/experiment-cron.test.js
+++ b/tests/experiment-cron.test.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runExperimentCronCycle } from '../src/growth/experiment-cron.js';
+import { AV_FREELANCE_HERO_EXPERIMENT } from '../src/growth/experiments.js';
+
+function createEvents() {
+  const events = {};
+  for (const variant of ['ownership', 'outcome']) {
+    for (let index = 0; index < 100; index += 1) {
+      events[`${variant}-view-${index}`] = {
+        id: `${variant}-view-${index}`,
+        experimentId: AV_FREELANCE_HERO_EXPERIMENT.id,
+        page: AV_FREELANCE_HERO_EXPERIMENT.page,
+        variant,
+        eventType: 'view',
+        visitorId: `${variant}-visitor-${index}`,
+      };
+    }
+  }
+  for (let index = 0; index < 20; index += 1) {
+    events[`ownership-conversion-${index}`] = {
+      id: `ownership-conversion-${index}`,
+      experimentId: AV_FREELANCE_HERO_EXPERIMENT.id,
+      page: AV_FREELANCE_HERO_EXPERIMENT.page,
+      variant: 'ownership',
+      eventType: 'work-agent-open',
+      visitorId: `ownership-visitor-${index}`,
+    };
+  }
+  for (let index = 0; index < 8; index += 1) {
+    events[`outcome-conversion-${index}`] = {
+      id: `outcome-conversion-${index}`,
+      experimentId: AV_FREELANCE_HERO_EXPERIMENT.id,
+      page: AV_FREELANCE_HERO_EXPERIMENT.page,
+      variant: 'outcome',
+      eventType: 'work-agent-open',
+      visitorId: `outcome-visitor-${index}`,
+    };
+  }
+  return events;
+}
+
+function createClient(definition = AV_FREELANCE_HERO_EXPERIMENT) {
+  const writes = [];
+  return {
+    writes,
+    client: {
+      async readConfig() {
+        return { autoMode: true, winner: '', winnerReason: '', updatedAt: '', updatedBy: '' };
+      },
+      async readEvents() {
+        return createEvents(definition);
+      },
+      async writeConfig(value) {
+        writes.push(value);
+      },
+    },
+  };
+}
+
+test('generic experiment cron promotes a statistically supported low-risk winner', async () => {
+  const { client, writes } = createClient();
+  const result = await runExperimentCronCycle(AV_FREELANCE_HERO_EXPERIMENT, {
+    client,
+    now: () => '2026-08-30T02:00:00.000Z',
+  });
+  assert.equal(result.action, 'promoted');
+  assert.equal(result.promoted, true);
+  assert.equal(result.winnerAfter, 'ownership');
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].updatedBy, 'growth-cron');
+});
+
+test('generic experiment cron refuses to auto-promote pricing experiments', async () => {
+  const { client, writes } = createClient();
+  const result = await runExperimentCronCycle(
+    { ...AV_FREELANCE_HERO_EXPERIMENT, riskClass: 'pricing' },
+    { client }
+  );
+  assert.equal(result.action, 'approval-required');
+  assert.equal(result.promoted, false);
+  assert.equal(writes.length, 0);
+});

--- a/tests/experiment-engine.test.js
+++ b/tests/experiment-engine.test.js
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  assignVariant,
+  canAutoPromote,
+  computeConversionStats,
+  pickConversionWinner,
+} from '../src/growth/experiment-engine.js';
+import { AV_FREELANCE_HERO_EXPERIMENT } from '../src/growth/experiments.js';
+
+function makeEvents({ ownershipViews = 0, ownershipConversions = 0, outcomeViews = 0, outcomeConversions = 0 } = {}) {
+  const events = {};
+  const add = (variant, eventType, index) => {
+    const id = `${variant}-${eventType}-${index}`;
+    events[id] = {
+      id,
+      experimentId: AV_FREELANCE_HERO_EXPERIMENT.id,
+      page: AV_FREELANCE_HERO_EXPERIMENT.page,
+      variant,
+      eventType,
+      visitorId: `${variant}-visitor-${index}`,
+    };
+  };
+  for (let i = 0; i < ownershipViews; i += 1) add('ownership', 'view', i);
+  for (let i = 0; i < ownershipConversions; i += 1) add('ownership', 'work-agent-open', i);
+  for (let i = 0; i < outcomeViews; i += 1) add('outcome', 'view', i);
+  for (let i = 0; i < outcomeConversions; i += 1) add('outcome', 'work-agent-open', i);
+  return events;
+}
+
+test('experiment assignment is stable per visitor and a promoted winner overrides the split', () => {
+  const first = assignVariant(AV_FREELANCE_HERO_EXPERIMENT, 'visitor-123');
+  const second = assignVariant(AV_FREELANCE_HERO_EXPERIMENT, 'visitor-123');
+  assert.equal(first, second);
+  assert.ok(['ownership', 'outcome'].includes(first));
+  assert.equal(assignVariant(AV_FREELANCE_HERO_EXPERIMENT, 'visitor-123', 'outcome'), 'outcome');
+});
+
+test('conversion stats ignore unrelated events and calculate per-variant rates', () => {
+  const events = makeEvents({ ownershipViews: 10, ownershipConversions: 3, outcomeViews: 10, outcomeConversions: 1 });
+  events.other = { id: 'other', visitorId: 'other', experimentId: 'other', page: 'av-freelance', variant: 'ownership', eventType: 'view' };
+  events.duplicate = { ...events['ownership-work-agent-open-0'], id: 'duplicate-click' };
+  const stats = computeConversionStats(AV_FREELANCE_HERO_EXPERIMENT, events);
+  assert.deepEqual(stats.ownership, { views: 10, conversions: 3, conversionRate: 0.3 });
+  assert.deepEqual(stats.outcome, { views: 10, conversions: 1, conversionRate: 0.1 });
+});
+
+test('winner selection waits for enough evidence and then requires a significant lift', () => {
+  const tooEarly = computeConversionStats(
+    AV_FREELANCE_HERO_EXPERIMENT,
+    makeEvents({ ownershipViews: 20, ownershipConversions: 8, outcomeViews: 20, outcomeConversions: 1 })
+  );
+  assert.equal(pickConversionWinner(AV_FREELANCE_HERO_EXPERIMENT, tooEarly), null);
+
+  const enough = computeConversionStats(
+    AV_FREELANCE_HERO_EXPERIMENT,
+    makeEvents({ ownershipViews: 100, ownershipConversions: 20, outcomeViews: 100, outcomeConversions: 8 })
+  );
+  const winner = pickConversionWinner(AV_FREELANCE_HERO_EXPERIMENT, enough);
+  assert.equal(winner?.key, 'ownership');
+  assert.ok(winner.zScore >= 1.96);
+  assert.match(winner.reason, /20\.0% vs 8\.0%/);
+});
+
+test('auto promotion is allowlisted to low-risk experiment classes', () => {
+  assert.equal(canAutoPromote(AV_FREELANCE_HERO_EXPERIMENT), true);
+  assert.equal(canAutoPromote({ ...AV_FREELANCE_HERO_EXPERIMENT, riskClass: 'pricing' }), false);
+  assert.equal(canAutoPromote({ ...AV_FREELANCE_HERO_EXPERIMENT, riskClass: 'privacy' }), false);
+});

--- a/tests/homepage-growth-cron-api.test.js
+++ b/tests/homepage-growth-cron-api.test.js
@@ -111,7 +111,13 @@ test('homepage growth cron handler runs the cycle and returns diagnostics', asyn
         },
         reason: 'Auto-promoted clarity from stronger click and clarity signals.',
       };
-    }
+    },
+    runExperimentImpl: async (definition, payload) => ({
+      experiment: definition.id,
+      dryRun: payload.dryRun,
+      action: 'insufficient-data',
+      promoted: false,
+    })
   });
 
   const req = {
@@ -132,4 +138,5 @@ test('homepage growth cron handler runs the cycle and returns diagnostics', asyn
   assert.equal(res.body.recommendedWinner, 'clarity');
   assert.equal(res.body.action, 'dry-run');
   assert.equal(res.body.totals.totalViews, 12);
+  assert.equal(res.body.experiments.avFreelanceHero.experiment, 'av-freelance-hero');
 });


### PR DESCRIPTION
## What this changes
- adds a reusable Gun-backed A/B experiment engine with stable visitor assignment
- compares unique visitors and primary conversions, not repeated raw clicks
- requires minimum sample size, conversions, relative lift, and a two-proportion significance threshold before auto-promotion
- auto-promotion is allowlisted to low-risk copy/layout/CTA/discovery experiments; pricing, billing, privacy, auth, security, legal, and destructive changes require review
- launches the first reusable customer test on `/av-freelance/`, optimizing the free Work Agent open event
- reuses the existing homepage growth cron instead of creating another Vercel function
- documents the auto-development learning loop

## Verification
- 32/32 impacted growth/cron/config tests passed before sync with main
- 13/13 focused tests passed after merging the latest production-budget guard
- dev server verified on an isolated port; `/av-freelance/` and `/av-freelance/experiment.js` both returned 200

## Known unrelated baseline
`tests/market-lab.test.js` still contains a stale assertion that the redesigned portal homepage directly links Market Lab; current `main` no longer does. This branch does not touch that homepage behavior.

Stripe/pricing impact: none. The existing $9 payment link and checkout verification are unchanged.