### PR TITLE
Keep Vercel fallback green without optional credentials

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -11,24 +11,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
-  VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch
+  VERCEL_ORG_ID: team_KXuVUd00RMnDsjoqwdREcZ7J
+  VERCEL_PROJECT_ID: prj_V49UqQXH0kmkYcL0NZFBkklzsbuy
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 jobs:
   deploy:
-    name: Deploy canonical production fallback
+    name: Validate and deploy canonical production fallback
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Require direct Vercel credentials
-        shell: bash
-        run: |
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "::error::VERCEL_TOKEN is not configured."
-            exit 1
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -44,16 +36,31 @@ jobs:
       - name: Enforce Vercel Hobby function budget
         run: node --test tests/vercel-function-budget.test.js
 
+      - name: Detect direct Vercel credentials
+        id: vercel-creds
+        shell: bash
+        run: |
+          if [ -n "$VERCEL_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::VERCEL_TOKEN is not configured; skipping the optional Vercel fallback deployment."
+          fi
+
       - name: Install Vercel CLI
+        if: ${{ steps.vercel-creds.outputs.enabled == 'true' }}
         run: npm install --global vercel
 
       - name: Pull production environment
+        if: ${{ steps.vercel-creds.outputs.enabled == 'true' }}
         run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build production artifact
+        if: ${{ steps.vercel-creds.outputs.enabled == 'true' }}
         run: vercel build --prod --token="$VERCEL_TOKEN"
 
       - name: Deploy production artifact
+        if: ${{ steps.vercel-creds.outputs.enabled == 'true' }}
         id: deploy
         shell: bash
         run: |

--- a/tests/workspace-sync.test.js
+++ b/tests/workspace-sync.test.js
@@ -45,8 +45,11 @@ test('production keeps Vercel main closed plus opt-in preview bridges with a def
   assert.match(workflow, /workflow_dispatch:/);
   assert.doesNotMatch(workflow, /^\s*push:/m);
   assert.doesNotMatch(workflow, /^\s*pull_request:/m);
-  assert.match(workflow, /VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z/);
-  assert.match(workflow, /VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch/);
+  assert.match(workflow, /VERCEL_ORG_ID: team_KXuVUd00RMnDsjoqwdREcZ7J/);
+  assert.match(workflow, /VERCEL_PROJECT_ID: prj_V49UqQXH0kmkYcL0NZFBkklzsbuy/);
+  assert.match(workflow, /Enforce Vercel Hobby function budget/);
+  assert.match(workflow, /Detect direct Vercel credentials/);
+  assert.match(workflow, /skipping the optional Vercel fallback deployment/);
   assert.match(workflow, /vercel deploy --prebuilt --prod/);
   assert.match(workflow, /https:\/\/portal\.3dvr\.tech\//);
   assert.doesNotMatch(workflow, /German worker/i);


### PR DESCRIPTION
Fixes the noisy Vercel fallback failure while preserving the deployment guardrail.

- updates the fallback to the current 3dvr Vercel team/project IDs
- runs the Hobby serverless-function budget test before credential handling
- treats missing VERCEL_TOKEN as an optional fallback skip instead of a hard failure
- always verifies the canonical self-hosted portal is healthy