### PR TITLE
Fix standalone Calendar issue launcher asset

### DIFF
--- a/.github/workflows/calendar-production.yml
+++ b/.github/workflows/calendar-production.yml
@@ -113,6 +113,15 @@ jobs:
           grep -q 'data-calendar-view-title' /tmp/calendar-live.html
           grep -q '3DVR Portal – Calendar' /tmp/calendar-live.html
           ! grep -q '<title>3DVR Portal</title>' /tmp/calendar-live.html
+
+          # The standalone deployment has its own root, so every root-relative
+          # asset referenced by calendar/index.html must ship with calendar/.
+          curl --fail --silent --show-error --location \
+            --retry 6 --retry-delay 2 --retry-all-errors \
+            "https://$CALENDAR_DOMAIN/issue-launcher.js" -o /tmp/calendar-issue-launcher.js
+          grep -q 'calendarIssueLauncherSource' /tmp/calendar-issue-launcher.js
+          grep -q 'portal.3dvr.tech/issue-launcher.js' /tmp/calendar-issue-launcher.js
+
           echo "Calendar is live at https://$CALENDAR_DOMAIN/"
           REMOTE
 

--- a/calendar/issue-launcher.js
+++ b/calendar/issue-launcher.js
@@ -1,0 +1,13 @@
+(() => {
+  if (typeof document === 'undefined') return;
+  if (document.querySelector('script[data-calendar-issue-launcher-source]')) return;
+
+  const script = document.createElement('script');
+  script.src = 'https://portal.3dvr.tech/issue-launcher.js';
+  script.async = true;
+  script.dataset.calendarIssueLauncherSource = 'portal';
+  script.addEventListener('error', () => {
+    console.warn('3DVR issue launcher could not be loaded from portal.3dvr.tech.');
+  });
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
Fixes the standalone calendar's `/issue-launcher.js` 404. The Calendar Vercel project deploys only the `calendar/` directory, so this lightweight bridge loads the canonical issue launcher from `portal.3dvr.tech` while preserving the existing same-origin path used by the page.