### PR TITLE
Fix trial service imports outside Vercel API budget

### DIFF
--- a/api/trial.js
+++ b/api/trial.js
@@ -1,7 +1,6 @@
 import Stripe from 'stripe';
 import nodemailer from 'nodemailer';
-import { saveNewsletterSubscriber } from './_lib/newsletter-store.js';
-import { callChatPushStore } from './_lib/chat-push-store.js';
+import { saveNewsletterSubscriber, callChatPushStore } from '../src/services/newsletter-store-client.js';
 import {
   createBusinessCardOrderHandler,
   getBusinessCardCheckoutConfig,

--- a/src/services/newsletter-store-client.js
+++ b/src/services/newsletter-store-client.js
@@ -1,0 +1,33 @@
+function value(input) {
+  return String(input || '').trim();
+}
+
+function storeConfig(config = process.env) {
+  const baseUrl = value(config.NEWSLETTER_STORE_URL).replace(/\/$/, '');
+  const token = value(config.NEWSLETTER_STORE_TOKEN);
+  if (!baseUrl || !token) throw new Error('Newsletter store is not configured.');
+  return { baseUrl, token };
+}
+
+async function postStore(path, input, config = process.env, fetchImpl = fetch) {
+  const { baseUrl, token } = storeConfig(config);
+  const response = await fetchImpl(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(input),
+    signal: AbortSignal.timeout(8_000)
+  });
+  if (!response.ok) throw new Error(`Newsletter store returned ${response.status}.`);
+  return response.json();
+}
+
+export function saveNewsletterSubscriber(input, config = process.env, fetchImpl = fetch) {
+  return postStore('/v1/subscribers', input, config, fetchImpl);
+}
+
+export function callChatPushStore(path, input, config = process.env, fetchImpl = fetch) {
+  return postStore(`/v1/chat/${path}`, input, config, fetchImpl);
+}

--- a/tests/chat-push-store.test.js
+++ b/tests/chat-push-store.test.js
@@ -1,6 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { callChatPushStore } from '../api/_lib/chat-push-store.js';
+import { callChatPushStore, saveNewsletterSubscriber } from '../src/services/newsletter-store-client.js';
 
 describe('chat push store client', () => {
   it('keeps the DigitalOcean bearer token server-side', async () => {
@@ -19,4 +19,22 @@ describe('chat push store client', () => {
     assert.equal(options.headers.authorization, 'Bearer server-secret');
     assert.equal(JSON.parse(options.body).userId, 'guest_123');
   });
+
+  it('stores newsletter subscribers through the same non-API helper', async () => {
+    const fetchImpl = mock.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true })
+    }));
+
+    await saveNewsletterSubscriber({ email: 'reader@example.com' }, {
+      NEWSLETTER_STORE_URL: 'https://selfhost.3dvr.tech/api/newsletter/',
+      NEWSLETTER_STORE_TOKEN: 'server-secret'
+    }, fetchImpl);
+
+    const [url, options] = fetchImpl.mock.calls[0].arguments;
+    assert.equal(url, 'https://selfhost.3dvr.tech/api/newsletter/v1/subscribers');
+    assert.equal(options.headers.authorization, 'Bearer server-secret');
+    assert.equal(JSON.parse(options.body).email, 'reader@example.com');
+  });
+
 });

--- a/tests/trial.test.js
+++ b/tests/trial.test.js
@@ -91,12 +91,14 @@ describe('trial handler', () => {
     await handler(req, res);
 
     assert.equal(res.statusCode, 200);
-    assert.deepEqual(res.body, {
-      stripeConfigured: true,
-      priceConfigured: true,
-      mailConfigured: true,
-      chatPushPublicKey: 'public-vapid-key',
-    });
+    assert.equal(res.body.stripeConfigured, true);
+    assert.equal(res.body.priceConfigured, true);
+    assert.equal(res.body.mailConfigured, true);
+    assert.equal(res.body.chatPushPublicKey, 'public-vapid-key');
+    assert.equal(res.body.businessCardCheckout?.stripeConfigured, true);
+    assert.equal(res.body.businessCardCheckout?.artworkUploadConfigured, true);
+    assert.ok(Array.isArray(res.body.businessCardCheckout?.products));
+    assert.ok(res.body.businessCardCheckout.products.length > 0);
     assert.equal(stripe.customers.list.mock.calls.length, 0);
     assert.equal(stripe.subscriptions.create.mock.calls.length, 0);
   });

--- a/tests/vercel-function-budget.test.js
+++ b/tests/vercel-function-budget.test.js
@@ -11,7 +11,6 @@ async function listApiEntries(dir = API_ROOT) {
   const files = [];
 
   for (const entry of entries) {
-    if (entry.name === '_lib') continue;
     const child = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, dir);
     if (entry.isDirectory()) files.push(...await listApiEntries(child));
     else if (entry.isFile() && entry.name.endsWith('.js')) files.push(child);


### PR DESCRIPTION
Repairs a current-main regression introduced by the Hobby function-count cleanup.

What broke:
- `api/_lib/newsletter-store.js` and `api/_lib/chat-push-store.js` were deleted to reduce Vercel function count
- `api/trial.js` and `tests/chat-push-store.test.js` still imported those deleted files
- a clean runtime therefore failed before `api/trial` could load

What this does:
- moves the newsletter/chat store client into `src/services/newsletter-store-client.js`, outside Vercel's `/api` function discovery tree
- updates `api/trial.js` and the store-client tests to use the shared helper
- updates the stale trial GET assertion to preserve the already-shipped business-card checkout diagnostics
- removes the `_lib` exemption from the function-budget test so any future JavaScript helper placed under `/api` is counted just like Vercel counts it

Validation:
- 14/14 focused trial/chat/function-budget tests pass
- `node --check` passes
- `git diff --check` passes
- `/api` remains at 12 JS entries on Hobby

This is a repair only; no pricing, email policy, or customer-facing checkout behavior changes.