### PR TITLE
Point Vercel fallback at canonical Portal project

### DIFF
--- a/.github/workflows/vercel-production-prebuilt.yml
+++ b/.github/workflows/vercel-production-prebuilt.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VERCEL_ORG_ID: team_KXuVUd00RMnDsjoqwdREcZ7J
-  VERCEL_PROJECT_ID: prj_V49UqQXH0kmkYcL0NZFBkklzsbuy
+  VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z
+  VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 jobs:

--- a/tests/workspace-sync.test.js
+++ b/tests/workspace-sync.test.js
@@ -45,8 +45,8 @@ test('production keeps Vercel main closed plus opt-in preview bridges with a def
   assert.match(workflow, /workflow_dispatch:/);
   assert.doesNotMatch(workflow, /^\s*push:/m);
   assert.doesNotMatch(workflow, /^\s*pull_request:/m);
-  assert.match(workflow, /VERCEL_ORG_ID: team_KXuVUd00RMnDsjoqwdREcZ7J/);
-  assert.match(workflow, /VERCEL_PROJECT_ID: prj_V49UqQXH0kmkYcL0NZFBkklzsbuy/);
+  assert.match(workflow, /VERCEL_ORG_ID: team_xxJGO7S7h1ZP4BHidYV0CX9Z/);
+  assert.match(workflow, /VERCEL_PROJECT_ID: prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch/);
   assert.match(workflow, /Enforce Vercel Hobby function budget/);
   assert.match(workflow, /Detect direct Vercel credentials/);
   assert.match(workflow, /skipping the optional Vercel fallback deployment/);


### PR DESCRIPTION
Fixes a release-target split discovered while auditing the current Vercel failure.

`portal.3dvr.tech` is owned by the canonical personal-team Portal project (`team_xxJGO7S7h1ZP4BHidYV0CX9Z` / `prj_rAhxzdSdrK9MwKjUMeAXGxk8z8Ch`), which is also what `docs/VERCEL-PRODUCTION.md` documents. The manual fallback workflow had drifted to the newer `3dvr` project, which does not own the production domain.

This change:
- restores the manual production fallback to the project that actually owns `portal.3dvr.tech`
- aligns the workspace deployment-policy regression test with the canonical-project policy test and documentation
- leaves routine `main` Git deploys disabled and opt-in previews unchanged
- does not deploy by itself

Validation: 10/10 focused Vercel/workspace/function-budget tests pass; `/api` remains at the Hobby 12-function limit; `git diff --check` passes.