### PR TITLE
Add send-only Google OAuth scopes

### DIFF
--- a/src/oauth/provider-api.js
+++ b/src/oauth/provider-api.js
@@ -385,11 +385,14 @@ function createGoogleProvider(config = process.env) {
       if (scopeKey === 'contacts' || scopeKey === 'contacts-calendar') {
         scopes.add('https://www.googleapis.com/auth/contacts.readonly');
       }
-      if (scopeKey === 'calendar' || scopeKey === 'contacts-calendar') {
+      if (scopeKey === 'calendar' || scopeKey === 'contacts-calendar' || scopeKey === 'calendar-gmail-send') {
         scopes.add('https://www.googleapis.com/auth/calendar.events');
       }
       if (scopeKey === 'mail' || scopeKey === 'gmail') {
         scopes.add('https://www.googleapis.com/auth/gmail.readonly');
+        scopes.add('https://www.googleapis.com/auth/gmail.send');
+      }
+      if (scopeKey === 'gmail-send' || scopeKey === 'calendar-gmail-send') {
         scopes.add('https://www.googleapis.com/auth/gmail.send');
       }
       const params = new URLSearchParams({
@@ -630,7 +633,7 @@ function createMicrosoftProvider(config = process.env) {
       if (scopeKey === 'contacts' || scopeKey === 'contacts-calendar') {
         scopes.add('Contacts.Read');
       }
-      if (scopeKey === 'calendar' || scopeKey === 'contacts-calendar') {
+      if (scopeKey === 'calendar' || scopeKey === 'contacts-calendar' || scopeKey === 'calendar-gmail-send') {
         scopes.add('Calendars.ReadWrite');
       }
       if (scopeKey === 'mail' || scopeKey === 'outlook') {
@@ -861,6 +864,8 @@ function isScopeSupported(provider, scopeKey = 'identity') {
   if (normalized === 'contacts') return Boolean(provider.supports.contacts);
   if (normalized === 'calendar') return Boolean(provider.supports.calendar);
   if (normalized === 'contacts-calendar') return Boolean(provider.supports.contacts && provider.supports.calendar);
+  if (normalized === 'gmail-send') return Boolean(provider.supports.mail);
+  if (normalized === 'calendar-gmail-send') return Boolean(provider.supports.calendar && provider.supports.mail);
   if (normalized === 'mail' || normalized === 'gmail' || normalized === 'outlook') return Boolean(provider.supports.mail);
   return false;
 }

--- a/tests/oauth-provider-api.test.js
+++ b/tests/oauth-provider-api.test.js
@@ -128,6 +128,45 @@ describe('oauth provider api', () => {
     assert.doesNotMatch(scopes, /https:\/\/www\.googleapis\.com\/auth\/calendar(?:\s|$)/);
   });
 
+  it('supports send-only Google Gmail access without mailbox read permission', async () => {
+    const handler = createOAuthProviderHandler({
+      config: { GOOGLE_OAUTH_CLIENT_ID: 'client.apps.googleusercontent.com', GOOGLE_OAUTH_CLIENT_SECRET: 'secret' },
+    });
+    const res = createMockRes();
+
+    await handler({
+      method: 'GET',
+      headers: { host: 'portal.3dvr.tech', 'x-forwarded-proto': 'https' },
+      query: { provider: 'google', action: 'start', scopeKey: 'gmail-send', returnTo: '/sd-day-traders-admin/' },
+    }, res);
+
+    assert.equal(res.statusCode, 302);
+    const location = new URL(res.headers.Location);
+    const scopes = location.searchParams.get('scope') || '';
+    assert.match(scopes, /https:\/\/www\.googleapis\.com\/auth\/gmail\.send/);
+    assert.doesNotMatch(scopes, /https:\/\/www\.googleapis\.com\/auth\/gmail\.readonly/);
+  });
+
+  it('supports Calendar plus Gmail send without mailbox read permission', async () => {
+    const handler = createOAuthProviderHandler({
+      config: { GOOGLE_OAUTH_CLIENT_ID: 'client.apps.googleusercontent.com', GOOGLE_OAUTH_CLIENT_SECRET: 'secret' },
+    });
+    const res = createMockRes();
+
+    await handler({
+      method: 'GET',
+      headers: { host: 'portal.3dvr.tech', 'x-forwarded-proto': 'https' },
+      query: { provider: 'google', action: 'start', scopeKey: 'calendar-gmail-send', returnTo: '/sd-day-traders-admin/' },
+    }, res);
+
+    assert.equal(res.statusCode, 302);
+    const location = new URL(res.headers.Location);
+    const scopes = location.searchParams.get('scope') || '';
+    assert.match(scopes, /https:\/\/www\.googleapis\.com\/auth\/calendar\.events/);
+    assert.match(scopes, /https:\/\/www\.googleapis\.com\/auth\/gmail\.send/);
+    assert.doesNotMatch(scopes, /https:\/\/www\.googleapis\.com\/auth\/gmail\.readonly/);
+  });
+
   it('renders copyable CLI OAuth result instead of redirecting immediately', async () => {
     const handler = createOAuthProviderHandler({
       config: {},


### PR DESCRIPTION
Implements issue #2000 without changing existing Work Agent mail access.

- adds `gmail-send` for identity + Gmail send only
- adds `calendar-gmail-send` for Calendar events + Gmail send, still without mailbox read
- keeps existing `mail` / `gmail` behavior unchanged for Work Agent schedule scanning
- preserves the selected scope key in the existing OAuth connection record path
- adds regression coverage proving `gmail.readonly` is absent from both narrow scopes

Validation: 16/16 focused OAuth, Work Agent mail, and Vercel function-budget tests pass; `git diff --check` passes; no new serverless function.