### PR TITLE
Controlled Vercel release gate — August 29

### DIFF
--- a/tests/vercel-main-only.test.js
+++ b/tests/vercel-main-only.test.js
@@ -4,10 +4,10 @@ import { readFile } from 'node:fs/promises';
 
 const vercel = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'));
 
-test('Vercel skips routine main builds and ordinary branches while allowing opt-in preview bridges', () => {
+test('Vercel temporarily enables main for the controlled production release', () => {
   assert.deepEqual(vercel.git?.deploymentEnabled, {
     '**': false,
-    main: false,
+    main: true,
     'preview-pr-*': true,
   });
   assert.equal(vercel.ignoreCommand, undefined);

--- a/tests/vercel-production-policy.test.js
+++ b/tests/vercel-production-policy.test.js
@@ -4,11 +4,11 @@ import { readFile } from 'node:fs/promises';
 
 const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
 
-test('Vercel Git keeps production closed by default and allows explicit preview bridge branches', async () => {
+test('Vercel Git temporarily opens main for the controlled production release', async () => {
   const config = JSON.parse(await read('vercel.json'));
   assert.deepEqual(config.git?.deploymentEnabled, {
     '**': false,
-    main: false,
+    main: true,
     'preview-pr-*': true,
   });
   assert.equal(config.ignoreCommand, undefined);

--- a/tests/workspace-sync.test.js
+++ b/tests/workspace-sync.test.js
@@ -34,11 +34,11 @@ test('relay timeout never auto-saves empty startup state', async () => {
   assert.doesNotMatch(timeoutBlock, /\bsave\s*\(/, 'timeout must not overwrite unknown remote state');
 });
 
-test('production keeps Vercel main closed plus opt-in preview bridges with a default deny rule', async () => {
+test('controlled production release temporarily enables Vercel main while preserving preview/default-deny rules', async () => {
   const workflow = await read('.github/workflows/vercel-production-prebuilt.yml');
   const vercelConfig = JSON.parse(await read('vercel.json'));
 
-  assert.equal(vercelConfig.git?.deploymentEnabled?.main, false);
+  assert.equal(vercelConfig.git?.deploymentEnabled?.main, true);
   assert.equal(vercelConfig.git?.deploymentEnabled?.['preview-pr-*'], true);
   assert.equal(vercelConfig.git?.deploymentEnabled?.['**'], false);
   assert.equal(vercelConfig.ignoreCommand, undefined);

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "git": {
     "deploymentEnabled": {
       "**": false,
-      "main": false,
+      "main": true,
       "preview-pr-*": true
     }
   },


### PR DESCRIPTION
Temporary controlled-release commit following `docs/VERCEL-PRODUCTION.md`.

Purpose: allow exactly one intentional `main` Git deployment so the canonical Vercel production site can advance from the older #1981-era deployment to current main after the function-budget/import/release-target repairs.

Changes:
- temporarily set `git.deploymentEnabled.main=true`
- adjust only the deployment-policy tests to describe this temporary gate
- preserve default-deny for all ordinary branches and opt-in preview bridges
- preserve the 12-function Hobby ceiling

Validation: 10/10 focused Vercel/workspace/function-budget tests pass; `git diff --check` passes.

After the production deployment is verified on `portal.3dvr.tech`, a follow-up commit will immediately restore `main=false`.